### PR TITLE
Import Owntracks waypoints into HA as zone definitions

### DIFF
--- a/source/_components/device_tracker.owntracks.markdown
+++ b/source/_components/device_tracker.owntracks.markdown
@@ -25,14 +25,17 @@ To integrate Owntracks in Home Assistant, add the following section to your `con
 device_tracker:
   platform: owntracks
   max_gps_accuracy: 200
-  waypoint_import_user: jon
+  waypoints: True
+  waypoint_whitelist:
+  - jon
+  - ram
 ```
 
 Configuration variables:
 
 - **max_gps_accuracy** (*Optional*): Sometimes Owntracks can report GPS location with a very low accuracy (few kilometers). That can trigger false zoning in your Home Assistant installation. With the parameter, you can filter these GPS reports. The number has to be in meter. For example, if you put 200 only GPS report with an accuracy under 200 will be take in account.
-
-- **waypoint_import_user** (*Optional*): Owntracks users can define [waypoints](http://owntracks.org/booklet/features/waypoints/) which are similar in spirit to Home Assistant zones. If this configuration variable is defined, the Owntracks user matching user name specified here can export waypoints from the device and Home Assistant will import them as zone definitions.
+- **waypoints** (*Optional*): Owntracks users can define [waypoints](http://owntracks.org/booklet/features/waypoints/) (a.k.a regions) which are similar in spirit to Home Assistant zones. If this configuration variable is `True`, the Owntracks users who are in `waypoint_whitelist` can export waypoints from the device and Home Assistant will import them as zone definitions. Defaults to `True`.
+- **waypoint_whitelist** (*Optional*): A list of user names (as defined for [Owntracks](https://home-assistant.io/components/device_tracker.owntracks/)) who can export their waypoints from Owntracks to Home Assistant. Defaults to all users who are connected to Home Assistant via Owntracks.
 
 ### {% linkable_title Using Owntracks with other device trackers %}
 Owntracks can also be used with other device trackers, such as [Nmap](/components/device_tracker.nmap_scanner/) or [Netgear](/components/device_tracker.netgear/). To do this, fill in the `mac` field to the Owntracks entry in `known_devices.yaml` with the MAC address of the device you want to track. This way the state of the device will be determined by the source that reported last. The naming convention for known device list is `<username>_<device-id>` and could be set in app configuration. More details about this config can found in [device tracker](/components/device_tracker/).
@@ -67,3 +70,8 @@ This allows you to write zone automations for devices that can't track themselve
 ### {% linkable_title Using mobile and fixed iBeacons together %}
 You can use iBeacons of both types together, so if you have a Zone `drive` with an iBeacon region called `-drive` and you arrive home with a mobile iBeacon called `-car`, then `device_tracker.beacon_car` will be set to a state of `drive`.
 
+### {% linkable_title Importing Owntracks waypoints as zones %}
+By default, any Owntracks user connected to Home Assistant can export their waypoint definitions (from the `Export - Export to Endpoint` menu item) which will then be translated to zone definitions in Home Assistant. The zones will be named `<user>-<device> - <waypoint name>`. This functionality can be controlled in 2 ways:
+
+1. The configuration variable `waypoints` can be set to `False` which will disable importing waypoints for all users.
+2. The configuration variable `waypoint_whitelist` can contain a list of users who are allowed to import waypoints.

--- a/source/_components/device_tracker.owntracks.markdown
+++ b/source/_components/device_tracker.owntracks.markdown
@@ -25,11 +25,14 @@ To integrate Owntracks in Home Assistant, add the following section to your `con
 device_tracker:
   platform: owntracks
   max_gps_accuracy: 200
+  waypoint_import_user: jon
 ```
 
 Configuration variables:
 
 - **max_gps_accuracy** (*Optional*): Sometimes Owntracks can report GPS location with a very low accuracy (few kilometers). That can trigger false zoning in your Home Assistant installation. With the parameter, you can filter these GPS reports. The number has to be in meter. For example, if you put 200 only GPS report with an accuracy under 200 will be take in account.
+
+- **waypoint_import_user** (*Optional*): Owntracks users can define [waypoints](http://owntracks.org/booklet/features/waypoints/) which are similar in spirit to Home Assistant zones. If this configuration variable is defined, the Owntracks user matching user name specified here can export waypoints from the device and Home Assistant will import them as zone definitions.
 
 ### {% linkable_title Using Owntracks with other device trackers %}
 Owntracks can also be used with other device trackers, such as [Nmap](/components/device_tracker.nmap_scanner/) or [Netgear](/components/device_tracker.netgear/). To do this, fill in the `mac` field to the Owntracks entry in `known_devices.yaml` with the MAC address of the device you want to track. This way the state of the device will be determined by the source that reported last. The naming convention for known device list is `<username>_<device-id>` and could be set in app configuration. More details about this config can found in [device tracker](/components/device_tracker/).


### PR DESCRIPTION
Configuration variable waypoint_import_user for enabling importing waypoints from Owntracks as zone definitions in HA.