### PR TITLE
Update the second configuration example

### DIFF
--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -51,6 +51,8 @@ light:
   name: "Office light"
   state_topic: "office/rgb1/light/status"
   command_topic: "office/rgb1/light/switch"
+  brightness_state_topic: 'office/rgb1/light/brightness'
+  brightness_command_topic: 'office/rgb1/light/brightness/set'
   qos: 0
   payload_on: "ON"
   payload_off: "OFF"


### PR DESCRIPTION
For the second example, the brightness functionality was mentioned, but it doesn't include the "brightness_state_topic" and the "brightness_command_topic" instructions.