### PR TITLE
Updated documentation to match with voluptuous config validation

### DIFF
--- a/source/_components/sensor.imap.markdown
+++ b/source/_components/sensor.imap.markdown
@@ -23,7 +23,7 @@ sensor:
     server: imap.gmail.com
     port: 993
     name: Emails
-    user: USERNAME
+    username: USERNAME
     password: PASSWORD
 ```
 
@@ -32,6 +32,6 @@ Configuration variables:
 - **server** (*Required*): The IP address or hostname of the IMAP server.
 - **port** (*Required*): The port where the server is accessible.
 - **name** (*Optional*): Name of the IMAP sensor.
-- **user** (*Required*): Username for the IMAP server.
+- **username** (*Required*): Username for the IMAP server.
 - **password** (*Required*): Password for the IMAP server.
 


### PR DESCRIPTION
--
After the upgrade to use voluptuous to parse the configuration, sensor.imap needs to pass username instead user. Note that user also works, but to keep it coherent, we are updating the documentation.

```
(home_assistant) ↪ hass --script check_config
Testing configuration at /home/hass/.homeassistant
16-08-28 00:49:35 ERROR (MainThread) [homeassistant.bootstrap] Invalid config for [sensor.imap]: required key not provided @ data['username']. Got None
Failed config
  sensor.imap:
    user: <redacted>
    port: 993
    platform: imap
    password: <redacted>
    server: imap.gmail.com
    name: Gmail Alerts

Successful config (partial)
  sensor.imap:
```

   After replacing ```user``` by ```username```, ```hass --script check_config``` works as expected.