### PR TITLE
Update sensor.imap.markdown

### DIFF
--- a/source/_components/sensor.imap.markdown
+++ b/source/_components/sensor.imap.markdown
@@ -23,7 +23,7 @@ sensor:
     server: imap.gmail.com
     port: 993
     name: Emails
-    user: USERNAME
+    username: USERNAME
     password: PASSWORD
 ```
 
@@ -32,6 +32,6 @@ Configuration variables:
 - **server** (*Required*): The IP address or hostname of the IMAP server.
 - **port** (*Required*): The port where the server is accessible.
 - **name** (*Optional*): Name of the IMAP sensor.
-- **user** (*Required*): Username for the IMAP server.
+- **username** (*Required*): Username for the IMAP server.
 - **password** (*Required*): Password for the IMAP server.
 


### PR DESCRIPTION
After this PR https://github.com/home-assistant/home-assistant/pull/2903 'user' changed to 'username' for imap.
Should maybe be added as a breaking change to the release note?