### PR TITLE
Update sensor.mhz19.markdown

### DIFF
--- a/source/_components/sensor.mhz19.markdown
+++ b/source/_components/sensor.mhz19.markdown
@@ -11,7 +11,7 @@ ha_category: sensor
 ha_release: 0.27
 ---
 
-The MH-Z19 is a small nondispersive infrared sensor that can measure CO2 sensors. High CO2 levels can lead to drowsiness, poor concentration, loss of attention or increased heart rate. Outside CO2 levels are usually between 250 and 350ppm, but inside levels can reach between 1000 and 5000 ppm. High CO2 levels indicate that you should increase ventilation.
+The MH-Z19 is a small nondispersive infrared sensor that can measure CO2 sensors. High CO2 levels can lead to drowsiness, poor concentration, loss of attention or increased heart rate. The CO2 level outside is around 400ppm, but inside levels can reach between 1000 and 5000 ppm. High CO2 levels indicate that you should increase ventilation.
 
 Check out the [Open Home Automation web site](https://www.open-homeautomation.com/2016/08/24/monitor-co2-levels-in-your-house/) for a quick guide how to connect the sensor to your PC or Raspberry Pi.
 


### PR DESCRIPTION
CO2 level outside isn't 250 - 350pmm, but assumed to be 400ppm. It has risen over the years, due to global warming :-(
Most sensors that do automatic calibration assume 400ppm as lowest.

See also https://www.co2.earth/ for actual CO2 level on the earth.