### PR TITLE
Document macOS zwave device path

### DIFF
--- a/source/getting-started/z-wave.markdown
+++ b/source/getting-started/z-wave.markdown
@@ -86,6 +86,12 @@ Or, on some other systems (such as Raspberry Pi), use:
 $ ls /dev/ttyACM*
 ```
 
+Or, on macOS, use:
+
+```bash
+$ ls /dev/cu.usbmodem*
+```
+
 <p class='note'>
 Depending on what's plugged into your USB ports, the name found above may change. You can lock in a name, such as `/dev/zwave`, by following [these instructions](http://hintshop.ludvig.co.nz/show/persistent-names-usb-serial-devices/). 
 </p>


### PR DESCRIPTION
I had to file a support ticket with Aeotec to track down how to find the path to a Z-Stick. Even with that, I was getting errors like:


```
WARNING:homeassistant.components.zwave:zwave not ready after 30 seconds, continuing anyway
```

I came across https://github.com/home-assistant/home-assistant/issues/2064 which pointed out the correct path for macOS. This PR documents that.