### PR TITLE
Added quotes around states in examples

### DIFF
--- a/source/getting-started/automation-create-first.markdown
+++ b/source/getting-started/automation-create-first.markdown
@@ -37,7 +37,7 @@ automation:
   condition:
     condition: state
     entity_id: group.all_devices
-    state: home
+    state: 'home'
   action:
     service: light.turn_on
 ```
@@ -66,7 +66,7 @@ automation:
   condition:
     condition: state
     entity_id: group.all_devices
-    state: home
+    state: 'home'
   action:
     service: light.turn_on
     entity_id: group.living_room
@@ -93,7 +93,7 @@ automation:
   condition:
     condition: state
     entity_id: group.all_devices
-    state: home
+    state: 'home'
   action:
     service: homeassistant.turn_on
     entity_id: group.living_room


### PR DESCRIPTION
These examples in the tutorial didn't actually work - adding the quote marks around the state names fixed it.