### PR TITLE
Added required dependency

### DIFF
--- a/source/_components/sensor.apcupsd.markdown
+++ b/source/_components/sensor.apcupsd.markdown
@@ -105,3 +105,5 @@ sensor:
       - loadpct
       - itemp
 ```
+
+**NOTE:** Before using above sensor, you must enable  [apcupsd](https://home-assistant.io/components/apcupsd/) in configuration file

--- a/source/_components/sensor.apcupsd.markdown
+++ b/source/_components/sensor.apcupsd.markdown
@@ -11,9 +11,9 @@ logo: apcupsd.png
 ha_category: Sensor
 ---
 
-The `apcupsd` sensor platform to allow you to monitor a UPS (battery backup) by using data from the [apcaccess](http://linux.die.net/man/8/apcaccess) command.
+The `apcupsd` sensor platform allows you to monitor a UPS (battery backup) by using data from the [apcaccess](http://linux.die.net/man/8/apcaccess) command.
 
-To add this platform to your installation, add the following to your `configuration.yaml` file:
+To use this sensor platform, you first have to set up [apcupsd](https://home-assistant.io/components/apcupsd/) and add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -105,5 +105,3 @@ sensor:
       - loadpct
       - itemp
 ```
-
-**NOTE:** Before using above sensor, you must enable  [apcupsd](https://home-assistant.io/components/apcupsd/) in configuration file


### PR DESCRIPTION
Since release 0.27.1 it became mandatory to define apcupsd and associated server and port. Missing configuration was not caught by validation script and it prevented all other sensors from loading. See more here:
https://community.home-assistant.io/t/0-27-1-broke-customize