### PR TITLE
Update sensor.sabnzbd.markdown

### DIFF
--- a/source/_components/sensor.sabnzbd.markdown
+++ b/source/_components/sensor.sabnzbd.markdown
@@ -48,3 +48,14 @@ Configuration variables:
   - **queue_remaining**: Remaining elements in the queue
   - **disk_size**: Disk size of the storage location
   - **disk_free**: Free disk space at the sotrage location
+
+Note that this will create sensors under the name 'sab' and NOT 'sabnzbd' as follows:
+```
+ - sensor.sab_status
+ - sensor.sab_speed
+ - sensor.sab_queue
+ - sensor.sab_left
+ - sensor.sab_disk
+ - sensor.sab_disk_free
+```
+As always, you can determine the names of sensors by looking at the dev-state page `< >` in the web interface.


### PR DESCRIPTION
Added clarification about the name of the sensors created to help new users who might expect the sensor name and component name to match.

Also, it would seem that after 0.27, configuration of this component may have changed.  Using "http" or "https" as indicated in the documentation seems to raise an exception.  Using the port number on the host line also causes an error.  Omitting this (at least without SSL) seems to fix the issue.  I don't know enough about how this component work to troubleshoot, so I left that part as-is.  Maybe someone who knows this component better could take a look?