### PR TITLE
Pine64 offical Z-wave module setup

### DIFF
--- a/source/getting-started/z-wave-device-specific.markdown
+++ b/source/getting-started/z-wave-device-specific.markdown
@@ -92,3 +92,13 @@ Here's a handy configuration for the Aeon Labs Minimote that defines all possibl
        object_id: aeon_labs_minimote_1
        scene_id: 8
 ```
+
+##### Pine64 Z-wave Module
+
+The following configuration works for the offical Pine64 Z-Wave module:
+
+```
+zwave:
+  usb_path: /dev/ttyS2
+
+```


### PR DESCRIPTION
Extended the docs for the Pine64 Z-wave module (which arrived for me on Friday from the Kickstarter), so there maybe an influx of people to try this due to the AMD64 Serial Port OpenHAB JAR not being AMD64 compatible.