### PR TITLE
D-Link switch added legacy protocol variable

### DIFF
--- a/source/_components/switch.dlink.markdown
+++ b/source/_components/switch.dlink.markdown
@@ -31,6 +31,7 @@ switch:
   name: D-Link plug
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
+  use_legacy_protocol: False
 ```
 
 Configuration variables:
@@ -39,4 +40,5 @@ Configuration variables:
 - **name** (*Optional*): The name to use when displaying this switch.
 - **username** (*Required*): The username for your plug. Defaults to `admin`.
 - **password** (*Required*): The password for your plug. Default password is the `PIN` inlcuded on the configuration card.
+- **use_legacy_protocol** (*Optional*): Enable limited support for legacy firmware protocols (Tested with v1.24).
 


### PR DESCRIPTION
Added information about the upcoming use_legacy_protocol flag which adds support for older firmware versions of the smart plug. The setting is only tested with version v1.24 of the plug but may work for other pre-v2.0 releases.