### PR TITLE
Rewriting of installation guide for Raspberry Pi

### DIFF
--- a/source/_components/binary_sensor.rpi_gpio.markdown
+++ b/source/_components/binary_sensor.rpi_gpio.markdown
@@ -12,7 +12,6 @@ ha_category: Binary Sensor
 ha_release: pre 0.7
 ---
 
-
 The `rpi_gpio` binary sensor platform allows you to read sensor values of the GPIOs of your [Raspberry Pi](https://www.raspberrypi.org/).
 
 To use your Raspberry Pi's GPIO in your installation, add the following to your `configuration.yaml` file:
@@ -39,10 +38,3 @@ Configuration variables:
 
 For more details about the GPIO layout, visit the Wikipedia [article](https://en.wikipedia.org/wiki/Raspberry_Pi#GPIO_connector) about the Raspberry Pi.
 
-<p class='note warning'>
-If you are not running Raspbian Jessie, you will need to run Home Assistant as root.
-</p>
-
-<p class='note warning'>
-To avoid having to run Home Assistant as root when using this component, run a Raspbian version released at or after September 29, 2015.
-</p>

--- a/source/_components/camera.rpi_camera.markdown
+++ b/source/_components/camera.rpi_camera.markdown
@@ -14,7 +14,7 @@ ha_release: 0.17
 ---
 
 
-The `rpi` platform allows you to integrate the Raspberry Pi camera into Home Assistant. This component uses the application [`raspistill`](https://www.raspberrypi.org/documentation/usage/camera/raspicam/raspistill.md) to store the image from camera.
+The `rpi_camera` platform allows you to integrate the Raspberry Pi camera into Home Assistant. This component uses the application [`raspistill`](https://www.raspberrypi.org/documentation/usage/camera/raspicam/raspistill.md) to store the image from camera.
 
 To enable this camera in your installation, add the following to your `configuration.yaml` file:
 
@@ -46,10 +46,4 @@ Configuration variables:
  - **file_path** (*Optional*): Save the picture in a custom file path (default: camera components folder)
  
 The given **file_path** must be an existing file because the camera platform setup make a writeable check on it.
-
-Ensure that the user who is running Home Assistant is in the video group. Eg. for the user `hass`:
-
-```bash
-$ sudo usermod -a -G video hass
-```
 

--- a/source/_components/device_tracker.bluetooth_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_tracker.markdown
@@ -16,10 +16,6 @@ ha_release: 0.18
 This tracker discovers new devices on boot and tracks bluetooth devices periodically based on interval_seconds value. It is not required to pair the devices with each other! 
 Devices discovered are stored with 'bt_' as the prefix for device mac addresses in `known_devices.yaml`.
 
-<p class='note'>
-Requires PyBluez. If you are on Raspbian, make sure you first install `bluetooth` and `libbluetooth-dev` by running `sudo apt install bluetooth libbluetooth-dev`
-</p>
-
 To use the Bluetooth tracker in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_components/switch.rpi_gpio.markdown
+++ b/source/_components/switch.rpi_gpio.markdown
@@ -35,6 +35,3 @@ Configuration variables:
 
 For more details about the GPIO layout, visit the Wikipedia [article](https://en.wikipedia.org/wiki/Raspberry_Pi#GPIO_connector) about the Raspberry Pi.
 
-<p class='note warning'>
-If you are not running Raspbian Jessie, you will need to run Home Assistant as root.
-</p>

--- a/source/getting-started/installation-raspberry-pi.markdown
+++ b/source/getting-started/installation-raspberry-pi.markdown
@@ -1,29 +1,152 @@
 ---
 layout: page
-title: "Installation on a Raspberry Pi"
-description: "Instructions to install Home Assistant on a Raspberry Pi."
-date: 2016-04-16 11:36
+title: "Raspbian Lite on a Raspberry Pi"
+description: "Instructions to install Home Assistant on a Raspberry Pi runnning Raspbian Lite."
+date: 2016-09-05 16:00
 sidebar: true
 comments: false
 sharing: true
 footer: true
 ---
 
-Home Assistant requires the Raspberry Pi to run [Raspbian Jessie](https://www.raspberrypi.org/downloads/raspbian/). This version was released on September 24, 2015 and comes by default with Python 3.4 which is required for Home Assistant.
+### {% linkable_title Installation %}
 
-Execute the following code in a console:
+This installation of Home Assistant requires the Raspberry Pi to run [Raspbian Lite](https://www.raspberrypi.org/downloads/raspbian/).
+The installation will be installed in a [Virtual Environment](/getting-started/installation-virtualenv) with minimal overhead. Instructions assume this is a new installation of Raspbian Lite.
 
+Connect to the Raspberry Pi over ssh. Default password is `raspberry`.
 ```bash
-$ sudo pip3 install homeassistant
-$ hass
+$ ssh pi@ipadress
 ```
 
-Running these commands will:
+Changing the default password is encouraged.
+```bash
+$ passwd
+```
 
- - Install Home Assistant
- - Launch Home Assistant and serve the web interface on [http://localhost:8123](http://localhost:8123)
+Update the system.
+```bash
+$ sudo apt-get update
+$ sudo apt-get upgrade -y
+```
 
-There is also a [video tutorial](https://www.youtube.com/watch?v=GjzOXkPb7XE) created by [brusc](https://github.com/brusc).
+Install the dependencies.
+```bash
+$ sudo apt-get install python3 python3-venv python3-pip
+```
+
+Add an account for Home Assistant called `homeassistant`.  
+Since this account is only for running Home Assistant the extra arguments of `-rm` is added to create a system account and create a home directory.
+```bash
+$ sudo useradd -rm homeassistant
+```
+
+Next we will create a directory for the installation of Home Assistant and change the owner to the `homeassistant` account.
+```bash
+$ cd /srv
+$ sudo mkdir homeassistant
+$ sudo chown homeassistant:homeassistant homeassistant
+```
+
+Next up is to create and change to a virtual environment for Home Assistant. This will be done as the `homeassistant` account.
+```bash
+$ sudo su -s /bin/bash homeassistant 
+$ cd /srv/homeassistant
+$ python3 -m venv homeassistant_venv
+$ source /srv/homeassistant/homeassistant_venv/bin/activate
+```
+Once you have activated the virtual environment you will notice the prompt change and then you can install Home Assistant.
+```bash
+(homeassistant_venv) homeassistant@raspberrypi:/srv/homeassistant $ pip3 install homeassistant
+```
+
+Start Home Assistant for the first time. This will complete the installation, create the `.homeasssistant` configuration directory in the `/home/homeassistant` directory and install any basic dependencies.
+```bash
+(homeassistant_venv) $ hass
+```
+
+You can now reach your installation on your raspberry pi over the web interface on [http://ipaddress:8123](http://ipaddress:8123). 
+For instruction on how to configure Home Assistant continue on with [Configuring Home Assistant](/getting-started/configuration/).
+
+### {% linkable_title Raspberry Pi Hardware Specific Components %}
+
+Some components that are specific for the Raspberry Pi can require some further configuration outside of Home Assistant. All commands below are assumed to be executed with the `pi` account. For full documentation of these components refer to the [components](/components) page.
+
+### {% linkable_title Bluetooth Tracker %}
+The Bluetooth tracker will work on a Raspberry Pi 3 with the built-in Bluetooth module or with a USB Bluetooth device on any of the other Raspberry Pi's.   
+
+Install the following external dependencies.
+```bash
+$ sudo apt-get install bluetooth libbluetooth-dev
+```
+After this follow the [Bluetooth Tracker component](/components/device_tracker.bluetooth_tracker/) and [Device Tracker page](/components/device_tracker/) pages.
+
+
+### {% linkable_title Raspberry Pi Camera %}
+The Raspberry Pi Camera is a specific camera for the Raspberry Pi boards. For more information about the camera I suggest reading the [documentation](https://www.raspberrypi.org/documentation/usage/camera/) from the Raspberry Pi foundation.  
+
+To use the camera it needs to be enabled with the `raspi-config` utility.
+```bash
+$ sudo raspi-config
+```
+Select `Enable camera` choose `<Yes>` and hit `Enter`, then go to `Finish` and you'll be prompted to reboot.  
+After reboot add your `homeassistant` account to the `video` group.
+```bash
+$ sudo adduser homeassistant video
+```
+After this follow the [Raspberry Pi Camera component](/components/camera.rpi_camera/) page.
+
+### {% linkable_title Raspberry Pi GPIO %}
+Each of the following devices are connected to the GPIO pins on the Raspberry Pi.
+For more details about the GPIO layout, visit the [documentation](https://www.raspberrypi.org/documentation/usage/gpio/) from the Raspberry 
+Pi foundation.  
+Since these are not normally used some extra permission will need to be added.
+In general the permission that is needed is granted by adding the `homeassistant` account to the `gpio` group.
+
+
+#### {% linkable_title Raspberry Pi Cover %}
+Add your `homeassistant` account to the `gpio` group
+```bash
+$ sudo adduser homeassistant gpio
+```
+After this follow the [Raspberry Pi Cover component](/components/cover.rpi_gpio/) page.
+
+#### {% linkable_title DHT Sensor %}
+Add your `homeassistant` account to the `gpio` group
+```bash
+$ sudo adduser homeassistant gpio
+```
+After this follow the [DHT Sensor component](/components/sensor.dht/) page.
+
+
+#### {% linkable_title Raspberry PI GPIO Binary Sensor %}
+Add your `homeassistant` account to the `gpio` group
+```bash
+$ sudo adduser homeassistant gpio
+```
+After this follow the [Raspberry PI GPIO Binary Sensor component](/components/binary_sensor.rpi_gpio/) page.
+
+#### {% linkable_title Raspberry PI GPIO Switch %}
+Add your `homeassistant` account to the `gpio` group.
+```bash
+$ sudo adduser homeassistant gpio
+```
+After this follow the [Raspberry PI GPIO Switch component](/components/switch.rpi_gpio/) page.
+
+#### {% linkable_title Raspberry Pi RF Switch %}
+Add your `homeassistant` account to the `gpio` group
+```bash
+$ sudo adduser homeassistant gpio
+```
+After this follow the [Raspberry Pi RF Switch component](/components/switch.rpi_rf/) page.
+
+#### {% linkable_title One wire Sensor %}
+The One wire sensor requires that support for it is enabled on the Raspberry Pi and that the One Wire device is connected to GPIO pin 4.
+To enable One Wire support add the following line to the end of `/boot/config.txt`
+```yaml
+dtoverlay=w1-gpio
+```
+After this follow the [One Wire Sensor component](/components/sensor.onewire/) page.
 
 ### {% linkable_title Troubleshooting %}
 


### PR DESCRIPTION
Associated with #891 
- Rewrite of installation guide for Raspberry Pi.Installation based on Raspbian Lite with separate part for Raspberry Pi specific hardware.  
- Incorrect and outdated information removed from components where appropriate. 

