### PR TITLE
Example usage of square bracket notation in value_json

### DIFF
--- a/source/_topics/templating.markdown
+++ b/source/_topics/templating.markdown
@@ -199,4 +199,7 @@ It depends per component or platform but it is common to be able to define a tem
 # Timestamps
 {% raw %}{{ value_json.tst | timestamp_local }}{% endraw %}
 {% raw %}{{ value_json.tst | timestamp_utc }}{% endraw %}
+
+# Square bracket notation
+{% raw %}{{ value_json["001"] }}{% endraw %}
 ```


### PR DESCRIPTION
Shows example how to extract values from a key that normally isn't allowed in dot notation.