### PR TITLE
Recommend setting static IP for Vera controller

### DIFF
--- a/source/_components/vera.markdown
+++ b/source/_components/vera.markdown
@@ -22,6 +22,10 @@ vera:
   vera_controller_url: http://192.168.1.161:3480/
 ```
 
+<p class='note'>
+  It is recommended to assign a static IP address to your Vera Controller. This ensures that it won't change IP addresses, so you won't have to change the `vera_controller_url` if it reboots and comes up with a different IP address. See your router's manual for details on how to set this up.
+</p>
+
 By default your switches will be added to HA as switches, however if some of them are light switches, you can tell HA this using the optional ```lights``` parameter as shown below.
 
 Vera imports detailed zwave devices into HA - this can include system devices and other devices that you don't use, you can tell HA not to load these devices using the ```exclude:``` parameter as shown below.

--- a/source/_components/vera.markdown
+++ b/source/_components/vera.markdown
@@ -23,7 +23,7 @@ vera:
 ```
 
 <p class='note'>
-  It is recommended to assign a static IP address to your Vera Controller. This ensures that it won't change IP addresses, so you won't have to change the `vera_controller_url` if it reboots and comes up with a different IP address. See your router's manual for details on how to set this up.
+  It is recommended to assign a static IP address to your Vera Controller. This ensures that it won't change IP addresses, so you won't have to change the `vera_controller_url` if it reboots and comes up with a different IP address. See your router's manual for details on how to set this up. If you need the MAC address of your Vera, check the label on the bottom.
 </p>
 
 By default your switches will be added to HA as switches, however if some of them are light switches, you can tell HA this using the optional ```lights``` parameter as shown below.


### PR DESCRIPTION
I suggested something similar in https://github.com/home-assistant/home-assistant.github.io/pull/890 . It might be worth documenting assigning static IPs or hostnames to your devices so you don't have to worry about them changing, and link it up to any component that uses local IPs or hostnames.