### PR TITLE
Fixed 3 typo's in the code

### DIFF
--- a/source/developers/frontend_creating_custom_panels.markdown
+++ b/source/developers/frontend_creating_custom_panels.markdown
@@ -27,7 +27,7 @@ The `hello.html` contains the needed building blocks to create the elements insi
   </template>
 </dom-module>
 
-</script>
+<script>
 Polymer({
   is: 'ha-panel-hello',
   properties: {
@@ -67,11 +67,10 @@ Create an entry for the new panel in your `configuration.yaml` file:
 
 ```yaml
 panel_custom:
-  - name: hello_world
+  - name: hello
     sidebar_title: Hello World
     sidebar_icon: mdi:hand-pointing-right
-    url_path: hello_world
-    webcomponent_path: <config dir>/panels/hello.html
+    url_path: hello
 ```
 
 For more examples, see the [Custom panel Examples](/cookbook#custom-panel-examples) on our examples page.


### PR DESCRIPTION
Fixed 3 typo's which prevented the script from working out of the box.
- 2nd </script> tag should have been <script>
- changed: "name: hello_world" to "name: hello"
- changed: "url_path: hello_world" to "url_path: hello"
- removed: "webcomponent_path: <config dir>/panels/hello.html"