### PR TITLE
Running bluetooth LE device tracker as non root

### DIFF
--- a/source/_components/device_tracker.bluetooth_le_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_le_tracker.markdown
@@ -32,4 +32,12 @@ Some BTLE devices (e.g. fitness trackers) are only visible to the devices that t
 
 BTLE tracking requires root privileges.
 
+For running Home Assistant as non root user we can give python3 the missing capabilities to access the bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](http://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
+```bash
+sudo apt-get install libcap2-bin
+sudo setcap 'cap_net_raw,cap_net_admin+eip' `readlink -f \`which python3\``
+```
+A restard of Home Assistant is required.
+
+
 For additional configuration variables check the [Device tracker page](/components/device_tracker/).

--- a/source/_components/device_tracker.bluetooth_le_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_le_tracker.markdown
@@ -37,7 +37,7 @@ For running Home Assistant as non root user we can give python3 the missing capa
 sudo apt-get install libcap2-bin
 sudo setcap 'cap_net_raw,cap_net_admin+eip' `readlink -f \`which python3\``
 ```
-A restard of Home Assistant is required.
+A restart of Home Assistant is required.
 
 
 For additional configuration variables check the [Device tracker page](/components/device_tracker/).


### PR DESCRIPTION
Added information how to run HA as non root, but give python3 the required capabilities to access the bluetooth stack.