### PR TITLE
Include units to description of elevation config

### DIFF
--- a/source/getting-started/basic.markdown
+++ b/source/getting-started/basic.markdown
@@ -19,7 +19,7 @@ homeassistant:
   latitude: 32.87336
   longitude: 117.22743
 
-  # Impacts weather/sunrise data (altitude above sea level) 
+  # Impacts weather/sunrise data (altitude above sea level in meters) 
   elevation: 430
 
   # 'metric' for Metric, 'imperial' for Imperial


### PR DESCRIPTION
The elevation units have never been specified.  The example configuration file sent with Home Assistant should be updated to include the elevation units also.
https://pythonhosted.org/astral/module.html#astral.Location.elevation