### PR TITLE
Wrong indentation.

### DIFF
--- a/source/_components/climate.eq3btsmart.markdown
+++ b/source/_components/climate.eq3btsmart.markdown
@@ -58,7 +58,7 @@ to the start function of /etc/init.d/hass-daemon.
 # Example configuration.yaml entry
 climate:
   platform: eq3btsmart
-    devices:
-      room1:
-        mac: '00:11:22:33:44:55'
+  devices:
+    room1:
+      mac: '00:11:22:33:44:55'
 ```


### PR DESCRIPTION
Indentation from devices was wrong.
See https://community.home-assistant.io/t/mapping-values-are-not-allowed-here-when-using-eq3-thermostat-climate-component/3999/5?u=michel.settembrino