### PR TITLE
Removed additional spaces in the yaml

### DIFF
--- a/source/_components/ifttt.markdown
+++ b/source/_components/ifttt.markdown
@@ -58,7 +58,7 @@ You need to setup a unique trigger for each event you sent to IFTTT.
 ```yaml
 # Example configuration.yaml Automation entry
 automation:
-  - alias: Startup Notification
+  alias: Startup Notification
   trigger:
     platform: event
     event_type: homeassistant_start


### PR DESCRIPTION
The yaml entry is incorrect. The additional spaces give an error:
`expected <block end>, but found '?' in "/root/.homeassistant/configuration.yaml"`