### PR TITLE
Link virtualenv to z-wave documentation

### DIFF
--- a/source/getting-started/installation-virtualenv.markdown
+++ b/source/getting-started/installation-virtualenv.markdown
@@ -105,7 +105,7 @@ The [autostart instructions](/getting-started/autostart/) will work just fine, j
 
 ### {% linkable_title Installing python-openzwave %}
 
-If you want to use Z-Wave devices, you will need to install `python-openzwave` in your virtualenv. This requires a small tweak to the instructions on home-assistant.io
+If you want to use Z-Wave devices, you will need to install `python-openzwave` in your virtualenv. This requires a small tweak to the instructions in [the Z-Wave Getting Started documentation](/getting-started/z-wave/)
 
 Install the dependencies as normal (Note: you will need to do this as your normal user, since `hass` isn't a sudoer).
 


### PR DESCRIPTION
It looks like this documentation may have originated somewhere else,
since it refers to documentation on home-assistant.io. This is
home-assistant.io, so may as well just link to it.