### PR TITLE
Add exit to All-In-One upgrade

### DIFF
--- a/source/getting-started/installation-raspberry-pi-all-in-one.markdown
+++ b/source/getting-started/installation-raspberry-pi-all-in-one.markdown
@@ -56,6 +56,7 @@ To upgrade the All-In-One setup manually:
 *  Change to hass user `sudo su -s /bin/bash hass`
 *  Change to virtual enviroment `source /srv/hass/hass_venv/bin/activate`
 *  Update HA `pip3 install --upgrade homeassistant`
+*  Type `exit` to get out of hass user and change to normal user.
   
 To upgrade with fabric:
 
@@ -67,7 +68,6 @@ After upgrading, you can restart Home Assistant a few different ways:
 
 * Restarting the Raspberry Pi `sudo reboot`
 * Restarting the Home-Assistant Service `sudo systemctl restart home-assistant.service`
-
 
 ### {% linkable_title Using the OZWCP web application %}
 

--- a/source/getting-started/installation-raspberry-pi-all-in-one.markdown
+++ b/source/getting-started/installation-raspberry-pi-all-in-one.markdown
@@ -56,7 +56,8 @@ To upgrade the All-In-One setup manually:
 *  Change to hass user `sudo su -s /bin/bash hass`
 *  Change to virtual enviroment `source /srv/hass/hass_venv/bin/activate`
 *  Update HA `pip3 install --upgrade homeassistant`
-*  Type `exit` to get out of hass user and change to normal user.
+*  Type `exit` to logout the `hass` user and return to the `pi` user.
+
   
 To upgrade with fabric:
 


### PR DESCRIPTION
After upgrading via All-In-One upgrade, I kept typing sudo reboot and the command window kept asking me password for hass user. 
After posting in gitter, I came to realize hass has no password and first I have to type exit to get out and change to normal user. Then I was able to reboot.

I know this is a obvious one. But I have seen many beginners post the same problem elsewhere.