### PR TITLE
GPMDP expects an IP address in "host" (not "address")

### DIFF
--- a/source/_components/media_player.gpmdp.markdown
+++ b/source/_components/media_player.gpmdp.markdown
@@ -24,12 +24,12 @@ Then just add the following to your `configuration.yaml` file:
 # Example configuration.yaml entry
 media_player:
   platform: gpmdp
-  address: IP_ADDRESS
+  host: IP_ADDRESS
   name: NAME
 ```
 
 Configuration variables:
 
-- **address** (*Required*): IP address of the computer running GPMDP
+- **host** (*Required*): IP address of the computer running GPMDP
 - **name** (*Optional*): Name of the player
 


### PR DESCRIPTION
Here's a documentation fix -- the GPMDP component uses homeassistant.const's CONF_HOST to figure out which configuration variable ("host") to use for the IP address.

The documentation currently has "address" instead.  The component ignores this field, defaults to localhost, and (if GPMDP isn't running on the same computer as Home Assistant) gives an error saying that the connection was refused.