### PR TITLE
Invalid syntax in Automation Trigger example

### DIFF
--- a/source/getting-started/automation-trigger.markdown
+++ b/source/getting-started/automation-trigger.markdown
@@ -98,7 +98,7 @@ Template triggers work by evaluating a [template] on each state change. The trig
 automation:
   trigger:
     platform: template
-    value_template: '{% raw %}{% if is_state('device_tracker.paulus', 'home') %}true{% endif %}{% endraw %}'
+    value_template: "{% raw %}{% if is_state('device_tracker.paulus', 'home') %}true{% endif %}{% endraw %}"
 ```
 
 ### {% linkable_title Time trigger %}


### PR DESCRIPTION
Contains single quotes on inside and outside. 

Fix uses double quotes on outside and single on inside.