### PR TITLE
Added the ability to Weather Underground to track severe weather alerts

### DIFF
--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -56,6 +56,7 @@ sensor:
       - precip_today_metric
       - precip_today_string
       - solarradiation
+      - alerts
 
 ```
 
@@ -90,6 +91,7 @@ Configuration variables:
   - **precip_today_metric**: Total precipitation in metric units
   - **precip_today_string**: Text summary of precipitation today
   - **solarradiation**: Current levels of solar radiation
+  - **alerts**: Current severe weather advisories
 
 Additional details about the API are available [here](https://www.wunderground.com/weather/api/d/docs).
 


### PR DESCRIPTION
This patch updates the documentation with a new monitored_condition called `alerts` which monitors the current severe weather advisories issued for the configured location. 
```yaml
sensor:
    platform: wunderground
    api_key: your_api_key
    pws_id: enter_pws_id
    monitored_conditions:
      - weather
      - temp_f
      - alerts
```
![screenshot at 2016-09-24 01-07-46](https://cloud.githubusercontent.com/assets/809840/18806518/686b9854-81fd-11e6-8486-f5fe0841d4d3.png)


![screenshot at 2016-09-24 01-08-10](https://cloud.githubusercontent.com/assets/809840/18806521/7231af4a-81fd-11e6-9a20-dbfb781d67d6.png)

