### PR TITLE
Document forecast sensor update_interval option

### DIFF
--- a/source/_components/sensor.forecast.markdown
+++ b/source/_components/sensor.forecast.markdown
@@ -84,5 +84,17 @@ Configuration variables:
   - **precip_intensity_max**: Today's expected maximum intensity of precipitation.
 - **units** (*Optional*): Specify the unit system. Default to `si` or `us` based on the temperature preference in Home Assistant. Other options are `auto`, `us`, `si`, `ca`, and `uk2`.
 `auto` will let forecast.io decide the unit system based on location.
+- **update_inverval** (*Optional*): Minimum time interval between updates. Default is 2 minutes. Supported formats:
+  - `update_interval: 'HH:MM:SS'`
+  - `update_interval: 'HH:MM'`
+  - Time period dictionary, e.g.:
+ <pre>update_interval:
+        # At least one of these must be specified:
+        days: 0
+        hours: 0
+        minutes: 3
+        seconds: 30
+        milliseconds: 0
+    </pre>
 
 Details about the API are available in the [Forecast.io documentation](https://developer.forecast.io/docs/v2).


### PR DESCRIPTION
Documentation of new `update_interval` parameter for the forecast.io sensor.  home-assistant/home-assistant#3520