### PR TITLE
Documentation for the emoncms_history component.

### DIFF
--- a/source/_components/emoncms_history.markdown
+++ b/source/_components/emoncms_history.markdown
@@ -14,14 +14,14 @@ ha_release: 0.29
 ---
 
 
-The `emoncms` component makes it possible to transfer details collected with Home Assistant to [Emoncms.org](https://emoncms.org/) or your local running Emoncms instance. 
+The `emoncms_history` component makes it possible to transfer details collected with Home Assistant to [Emoncms.org](https://emoncms.org/) or your local running Emoncms instance. 
 It will send the data to a specific input node on emoncms with the entity id's as a key. Afterwards you can create feeds and dashboards in Emoncms with the collected data.
 
 <p class='note warning'>
   The publishing interval is limited to 1 second. This means that it's possible to miss fast changes.
 </p>
 
-To use the `emoncms` component in your installation, add the following to your `configuration.yaml` file:
+To use the `emoncms_history` component in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/emoncms_history.markdown
+++ b/source/_components/emoncms_history.markdown
@@ -16,11 +16,6 @@ ha_release: 0.30
 
 The `emoncms_history` component makes it possible to transfer details collected with Home Assistant to [Emoncms.org](https://emoncms.org/) or your local running Emoncms instance. 
 It will send the data to a specific input node on emoncms with the entity id's as a key. Afterwards you can create feeds and dashboards in Emoncms with the collected data.
-
-<p class='note warning'>
-  The publishing interval is limited to 1 second. This means that it's possible to miss fast changes.
-</p>
-
 To use the `emoncms_history` component in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_components/emoncms_history.markdown
+++ b/source/_components/emoncms_history.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: emoncms.png
 ha_category: History
 featured: false
-ha_release: 0.29
+ha_release: 0.30
 ---
 
 

--- a/source/_components/emoncms_history.markdown
+++ b/source/_components/emoncms_history.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: emoncms.png
 ha_category: History
 featured: false
-ha_release: 0.30
+ha_release: 0.31
 ---
 
 
@@ -40,3 +40,4 @@ Configuration variables:
 - **url** (*Required*): The root url of your emoncms installation. (Use https://emoncms.org for the cloud based version)
 - **inputnode** (*Required*): Input node that will be used inside emoncms. Please make sure you use a dedicated, not used before, node for this component!
 - **whitelist** (*Required*): List of entity ID's you want to publish.
+- **scan_interval** (*Optional*): Defines, in seconds, how reguarly the states of the whitelisted entities are being gathered and send to emoncms. Default is 30 seconds.

--- a/source/_components/emoncms_history.markdown
+++ b/source/_components/emoncms_history.markdown
@@ -1,0 +1,47 @@
+---
+layout: page
+title: "Emoncms history"
+description: "Record events in emoncms."
+date: 2016-09-25 12:50
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: emoncms.png
+ha_category: History
+featured: false
+ha_release: 0.29
+---
+
+
+The `emoncms` component makes it possible to transfer details collected with Home Assistant to [Emoncms.org](https://emoncms.org/) or your local running Emoncms instance. 
+It will send the data to a specific input node on emoncms with the entity id's as a key. Afterwards you can create feeds and dashboards in Emoncms with the collected data.
+
+<p class='note warning'>
+  The publishing interval is limited to 1 second. This means that it's possible to miss fast changes.
+</p>
+
+To use the `emoncms` component in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+emoncms_history:
+  api_key: put your emoncms WRITE api key here
+  url: https://emoncms.org
+  inputnode: 19
+  whitelist:
+    - sensor.owm_temperature
+    - sensor.owm_wind_speed
+    - sensor.owm_humidity
+    - sensor.mold_indicator
+    - sensor.emoncms1_feedid_29
+    - sensor.cpu_use
+    - binary_sensor.pir_motion
+```
+
+Configuration variables:
+
+- **api_key** (*Required*): Your emoncms write api key
+- **url** (*Required*): The root url of your emoncms installation. (Use https://emoncms.org for the cloud based version)
+- **inputnode** (*Required*): Input node that will be used inside emoncms. Please make sure you use a dedicated, not used before, node for this component!
+- **whitelist** (*Required*): List of entity ID's you want to publish.


### PR DESCRIPTION
it's a history component just like / based on the dweet.io history component and has the same functionality but sends the data to emoncms.

This would for example let people push there power readings from zwave power devices to emoncms for further processing. 

But can be used to send any (numerical) data to emoncms.