### PR TITLE
Reference to outdated "echo" attribute

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -49,7 +49,7 @@ Configuration variables:
   - `script`
   - `scene`
 
-- **expose_by_default** (*Optional*): Whether or not entities should be exposed via the bridge by default instead of explicitly (see the 'echo' attribute later on). If not specified, this defaults to true.
+- **expose_by_default** (*Optional*): Whether or not entities should be exposed via the bridge by default instead of explicitly (see the 'emulated_hue' customization below). If not specified, this defaults to true.
 
 - **exposed_domains** (*Optional*): The domains that are exposed by default if `expose_by_default` is set to true. If not specified, this defaults to the following list:
   - `switch`


### PR DESCRIPTION
Reworded the "expose_by_default" information. It used the "echo" attribute, which if I'm not mistaken, is deprecated.