### PR TITLE
Fixed sensor/Nest documentation to reflect the new mode attribute

### DIFF
--- a/source/_components/sensor.nest.markdown
+++ b/source/_components/sensor.nest.markdown
@@ -29,7 +29,7 @@ sensor:
     - 'temperature'
     - 'target'
     - 'humidity'
-    - 'operation_mode'
+    - 'mode'
     - 'last_connection'
     - 'co_status' # Nest Protect only
     - 'smoke_status' # Nest Protect only
@@ -41,7 +41,7 @@ Configuration variables:
   - 'temperature'
   - 'target'
   - 'humidity'
-  - 'operation_mode'
+  - 'mode'
   - 'last_ip'
   - 'local_ip'
   - 'last_connection'


### PR DESCRIPTION
Fixed sensor/Nest documentation to reflect the new 'mode' attribute. 

```yaml
sensor:
  - platform: nest
    monitored_conditions:
      - 'temperature'
      - 'target'
      - 'humidity'
      - 'last_ip'
      - 'local_ip'
      - 'last_connection'
      - 'battery_level'
      - 'mode'
      - 'weather_condition'
      - 'weather_temperature'
      - 'weather_humidity'
      - 'wind_speed'
      - 'wind_direction'
      - 'co_status'
      - 'smoke_status'
```

Home Assistant PR https://github.com/home-assistant/home-assistant/pull/3665