### PR TITLE
Add Pushbullet and Home Assistant version to update notification

### DIFF
--- a/source/_cookbook/notify_if__new_ha_release.markdown
+++ b/source/_cookbook/notify_if__new_ha_release.markdown
@@ -30,3 +30,24 @@ automation:
       data:
         message: 'There is a new Home Assistant release available.'
 ```
+
+You can use [templates](/topics/templating/) to include the release number of Home Assistant if you prefer. The following example sends a notification via [Pushbullet](/components/notify.pushbullet/) with the Home Assistant version in the message.
+
+```yaml
+notify:
+  platform: pushbullet
+  api_key: 'YOUR_KEY_HERE'
+  name: pushbullet
+
+automation:
+  - alias: Update notifications
+  trigger:
+    - platform: state
+      entity_id: updater.updater
+  action:
+    service: notify.pushbullet
+    data: 
+      title: 'New Home Assistant Release'
+      target: 'YOUR_TARGET_HERE' #See Pushbullet component for usage
+      message: "Home Assistant {{ states.updater.updater.state }} is now available."
+```

--- a/source/_cookbook/notify_if__new_ha_release.markdown
+++ b/source/_cookbook/notify_if__new_ha_release.markdown
@@ -51,3 +51,4 @@ automation:
       target: 'YOUR_TARGET_HERE' #See Pushbullet component for usage
       message: "Home Assistant {{ states.updater.updater.state }} is now available."
 ```
+


### PR DESCRIPTION
Adds an example configuration for someone who wants to be alerted when a
new Home Assistant is released, and they would like the notification to
include the new Home Assistant version in the message.