### PR TITLE
Telldus link

### DIFF
--- a/source/_components/media_player.yamaha.markdown
+++ b/source/_components/media_player.yamaha.markdown
@@ -29,6 +29,8 @@ To add a Yamaha Network Receiver to your installation, add the following to your
 # Example configuration.yaml entry
 media_player:
   - platform: yamaha
+    host: 192.168.1.100
+    name: 'Basement Receiver'
 ```
 Configuration variables:
 

--- a/source/_components/tellstick.markdown
+++ b/source/_components/tellstick.markdown
@@ -12,7 +12,7 @@ ha_category: Hub
 ---
 
 
-The `tellstick` component integrates [TellStick](http://www.telldus.se/products/tellstick) devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 Mhz. There are a number of vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [compatibility list](http://developer.telldus.com/wiki/TellStick_conf).
+The `tellstick` component integrates [TellStick](http://www.telldus.se/products/tellstick) devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 Mhz. There are a number of vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [protocol list](http://developer.telldus.com/wiki/TellStick_conf).
 
 To get started, add the devices to your `configuration.yaml` file.
 

--- a/source/_components/tellstick.markdown
+++ b/source/_components/tellstick.markdown
@@ -12,7 +12,7 @@ ha_category: Hub
 ---
 
 
-The `tellstick` component integrates [TellStick](http://www.telldus.se/products/tellstick) devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 Mhz. There are a number of vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [protocol definition list](http://developer.telldus.com/wiki/TellStick_conf).
+The `tellstick` component integrates [TellStick](http://www.telldus.se/products/tellstick) devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 Mhz. There are a number of vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [compatibility list](http://developer.telldus.com/wiki/TellStick_conf).
 
 To get started, add the devices to your `configuration.yaml` file.
 

--- a/source/_components/tellstick.markdown
+++ b/source/_components/tellstick.markdown
@@ -12,7 +12,7 @@ ha_category: Hub
 ---
 
 
-The `tellstick` component integrates [TellStick](http://www.telldus.se/products/tellstick) devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 Mhz. There are a number of vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [compatibility list](http://telldus.se/products/compability).
+The `tellstick` component integrates [TellStick](http://www.telldus.se/products/tellstick) devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 Mhz. There are a number of vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [protocol definition list](http://developer.telldus.com/wiki/TellStick_conf).
 
 To get started, add the devices to your `configuration.yaml` file.
 


### PR DESCRIPTION
The link to the compatiblity list on https://home-assistant.io/components/tellstick/ leads to a 404 page, since telldus started to move away from 433MHz radio technology towards zwave technology. 
The best resource to get hardware compatibility is the protocol example list in the telldus developer wiki, so i changed the dead link to this list. 

Please note the 2 commits from Sep 19, which are basically handled in https://github.com/home-assistant/home-assistant.github.io/pull/959. Somehow i got a merge conflict between my origin and upstream and fixed it - and they ended up appearing in this branch as well. I'm sorry for that. 
You will notice that there is no difference between these commits in this pull request and the ones already merged in #959, so git should just ignore these commits when merging. 