### PR TITLE
Fixed a dead link

### DIFF
--- a/source/_components/tellstick.markdown
+++ b/source/_components/tellstick.markdown
@@ -12,7 +12,7 @@ ha_category: Hub
 ---
 
 
-The `tellstick` component integrates [TellStick](http://www.telldus.se/products/tellstick) devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 Mhz. There are a number of vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [compatibility list](http://telldus.se/products/compability).
+The `tellstick` component integrates [TellStick](http://www.telldus.se/products/tellstick) devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 Mhz. There are a number of vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [protocol list](http://developer.telldus.com/wiki/TellStick_conf).
 
 To get started, add the devices to your `configuration.yaml` file.
 


### PR DESCRIPTION
The link to the compatiblity list on https://home-assistant.io/components/tellstick/ leads to a 404 page, since telldus started to move away from 433MHz radio technology towards zwave technology. 
The best resource to get hardware compatibility is the protocol example list in the telldus developer wiki, so i changed the dead link to this list.