### PR TITLE
Update example to use metric unit_system instead of the legacy temperature unit

### DIFF
--- a/source/getting-started/customizing-devices.markdown
+++ b/source/getting-started/customizing-devices.markdown
@@ -15,7 +15,7 @@ By default, all of your devices will be visible and have a default icon determin
 # Example configuration.yaml entry
 homeassistant:
   name: Home
-  unit_system: celsius
+  unit_system: metric
   # etc
 
   customize:


### PR DESCRIPTION
Update the example in the getting started guide, to reflect the metric system instead of the old temperature based unit.