### PR TITLE
remove redundant dash from check config command line

### DIFF
--- a/source/_topics/splitting_configuration.markdown
+++ b/source/_topics/splitting_configuration.markdown
@@ -182,8 +182,8 @@ If you have issues checkout `home-assistant.log` in the configuration directory 
 ### {% linkable_title Debugging multiple configuration files %}
 
 If you have many configuration files, the `check_config` script allows you to see how Home Assistant interprets them:
-- Listing all loaded files: `hass --script --check_config --files`
-- Viewing a component's config: `hass --script --check_config --info light`
+- Listing all loaded files: `hass --script check_config --files`
+- Viewing a component's config: `hass --script check_config --info light`
 - Or all components' config:  `hass --script check_config --info all`
 
 You can get help from the command line using: `hass --script check_config --help`


### PR DESCRIPTION
---

***DELETE EVERYTHING BEFORE SUBMITTING YOUR PULL REQUEST!***

If you are submitting docs that depend on a pull request to be merged in Home Assistant please reference the PR like so:

`home-assistant/home-assistant#<home-assistant PR number goes here>`

Thanks for submitting!

---

