### PR TITLE
Add documentation for pushbuller url push

### DIFF
--- a/source/_components/notify.pushbullet.markdown
+++ b/source/_components/notify.pushbullet.markdown
@@ -53,3 +53,22 @@ If using targets, your own account's email address functions as 'send to all dev
   ]
 }
 ```
+
+To use notifications, please see the [getting started with automation page](/getting-started/automation/).
+
+### {% linkable_title URL support %}
+
+```yaml
+...
+
+action:
+  service: notify.NOTIFIER_NAME
+  data:
+    title: Send URL
+    message: This is an url
+    data:
+      url: google.com
+```
+
+- **url** (*Required*): Page URL to send with pushbullet.
+


### PR DESCRIPTION
Add documentation on how to send an url note with pushbullet

`home-assistant/home-assistant#3758`


