### PR TITLE
Display template tags in Pushbullet Home Assistant release example

### DIFF
--- a/source/_cookbook/notify_if__new_ha_release.markdown
+++ b/source/_cookbook/notify_if__new_ha_release.markdown
@@ -49,6 +49,6 @@ automation:
     data: 
       title: 'New Home Assistant Release'
       target: 'YOUR_TARGET_HERE' #See Pushbullet component for usage
-      message: "Home Assistant {{ states.updater.updater.state }} is now available."
+      message: "Home Assistant {% raw %} {{ states.updater.updater.state }} {% raw %} is now available."
 ```
 


### PR DESCRIPTION
The template example introduced in #1100 needs some tags around the
template tags so that Jekyll doesn't try to interpret the code.

Rebase of #1193 