### PR TITLE
for compring and review on local

### DIFF
--- a/source/getting-started/z-wave.markdown
+++ b/source/getting-started/z-wave.markdown
@@ -68,7 +68,7 @@ zwave:
 Configuration variables:
 
 - **usb_path** (*Required*): The port where your device is connected to your Home Assistant host.
-- **config_path** (*Optional*): The path to the Python Open Z-Wave configuration files.
+- **config_path** (*Optional*): The path to the Python OpenZWave configuration files.
 - **autoheal** (*Optional*): Allows disabling auto ZWave heal at midnight. Defaults to True.
 - **polling_interval** (*Optional*): The time period in milliseconds between polls of a nodes value. Be careful about using polling values below 30000 (30 seconds) as polling can flood the zwave network and cause problems.
 - **customize** (*Optional*): This attribute contains node-specific override values:
@@ -115,40 +115,40 @@ You can replace these values with your own 16 byte network key. For more informa
 ### {% linkable_title Events %}
 
 #### {% linkable_title zwave.network_complete %}
-HomeAssistant will trigger a event when the zwave network is complete. Meaning all of the nodes on the network have been queried. This can take quite som time, depending on wakeup intervals on the battery powered devices on the network.
+HomeAssistant will trigger a event when the Z-Wave network is complete. Meaning all of the nodes on the network have been queried. This can take quite som time, depending on wakeup intervals on the battery powered devices on the network.
 
 ```yaml
- - alias: ZWave network is complete
+ - alias: Z-Wave network is complete
    trigger:
      platform: event
      event_type: zwave.network_complete
 ```
 
 #### {% linkable_title zwave.network_ready %}
-HomeAssistant will trigger a event when the zwave network is ready for use. Between `zwave.network_start` and `zwave.network_ready` HomeAssistant will feel sluggish when trying to send commands to zwave nodes. This is because the controller is requesting information from all of the nodes on the network. When this is triggered all awake nodes have been queried and sleeping nodes will be queried when they awake.
+HomeAssistant will trigger a event when the Z-Wave network is ready for use. Between `zwave.network_start` and `zwave.network_ready` HomeAssistant will feel sluggish when trying to send commands to Z-Wave nodes. This is because the controller is requesting information from all of the nodes on the network. When this is triggered all awake nodes have been queried and sleeping nodes will be queried when they awake.
 
 ```yaml
- - alias: ZWave network is ready
+ - alias: Z-Wave network is ready
    trigger:
      platform: event
      event_type: zwave.network_ready
 ```
 
 #### {% linkable_title zwave.network_start %}
-HomeAssistant will trigger a event when the zwave network is set up to be started.
+HomeAssistant will trigger a event when the Z-Wave network is set up to be started.
 
 ```yaml
- - alias: ZWave network is starting
+ - alias: Z-Wave network is starting
    trigger:
      platform: event
      event_type: zwave.network_start
 ```
 
 #### {% linkable_title zwave.network_stop %}
-HomeAssistant will trigger a event when the zwave network stopping.
+HomeAssistant will trigger a event when the Z-Wave network stopping.
 
 ```yaml
- - alias: ZWave network is stopping
+ - alias: Z-Wave network is stopping
    trigger:
      platform: event
      event_type: zwave.network_stop
@@ -192,21 +192,20 @@ The *object_id* and *scene_id* of all triggered events can be seen in the consol
 
 ### {% linkable_title Services %}
 
-The Z-Wave component exposes seven services to help maintain the network.
+The `zwave` component exposes seven services to help maintain the network.
 
 | Service | Description |
 | ------- | ----------- |
-| add_node | Put the zwave controller in inclusion mode. Allows one to add a new device to the zwave network.|
-| add_node_secure | Put the zwave controller in secure inclusion mode. Allows one to add a new device with secure communications to the zwave network. |
-| cancel_command | Cancels a running zwave command. If you have started a add_node or remove_node command, and decides you are not going to do it, then this must be used to stop the inclusion/exclusion command. |
-| heal_network | Tells the controller to "heal" the network. Bascially asks the nodes to tell the controller all of their neighbors so the controller can refigure out optimal routing. |
-| remove_node | Put the zwave controller in exclusion mode. Allows one to remove a device from the zwave network.|
+| add_node | Put the Z-Wave controller in inclusion mode. Allows one to add a new device to the Z-Wave network.|
+| add_node_secure | Put the Z-Wave controller in secure inclusion mode. Allows one to add a new device with secure communications to the Z-Wave network. |
+| cancel_command | Cancels a running Z-Wave command. If you have started a add_node or remove_node command, and decides you are not going to do it, then this must be used to stop the inclusion/exclusion command. |
+| heal_network | Tells the controller to "heal" the Z-Wave network. Bascially asks the nodes to tell the controller all of their neighbors so the controller can refigure out optimal routing. |
+| remove_node | Put the Z-Wave controller in exclusion mode. Allows one to remove a device from the zwave network.|
 | soft_reset | Tells the controller to do a "soft reset". This is not supposed to lose any data, but different controllers can behave differently to a "soft reset" command.|
 | test_network | Tells the controller to send no-op commands to each node and measure the time for a response. In theory, this can also bring back nodes which have been marked "presumed dead".|
 | rename_node | Sets a node's name. Requires an `entity_id` and `name` field. |
 
-The soft_reset and heal_network commands can be used as part of an automation script
-to help keep a zwave network running relliably. For example:
+The `soft_reset` and `heal_network` commands can be used as part of an automation script to help keep a Z-Wave network running reliably as shown in the example below.  By default, Home Assistant will run a `heal_network` at midnight.  This is a configuration option for the `zwave` component, the option defaults to `true` but can be disabled by setting `auto_heal` to false.  Using the `soft_reset` function with some Z-Wave controllers can cause the Z-Wave network to hang. If you're having issues with your Z-Wave network try disabling this automation.
 
 ```yaml
 # Example configuration.yaml automation entry


### PR DESCRIPTION
- Notes added to Z-wave `soft-reset` about known issues by @sgauche 
- Fixed usage of `zwave` component, Z-Wave for references to a Z-Wave network, and OpenZWave as a project name by @sgauche