### PR TITLE
switch.anel_pwrctrl: correct ha_release type

### DIFF
--- a/source/_components/switch.anel_pwrctrl.markdown
+++ b/source/_components/switch.anel_pwrctrl.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: anel.png
 ha_category: Switch
 ha_iot_class: "Local Polling"
-ha_release: 0.30
+ha_release: "0.30"
 ---
 
 The `anel_pwrctrl` switch platform allows you to control [ANEL PwrCtrl](http://anel-elektronik.de/SITE/produkte/produkte.htm) devices.


### PR DESCRIPTION
The release version is being treated as float and presented as `0.3` instead of `0.30`, converting it to string should prevent that.
