### PR TITLE
Setting proper variables for specific protocols.

### DIFF
--- a/source/_components/switch.pilight.markdown
+++ b/source/_components/switch.pilight.markdown
@@ -55,7 +55,7 @@ Variables for the different codes:
 - **'off'** (*Optional*): `1` or `0`
 - **'on'** (*Optional*): `1` or `0`
 
-For possible code entries look at the [pilight API](https://www.pilight.org/development/api/). All commands allowed by [pilight-send](https://wiki.pilight.org/doku.php/psend) can be used.
+For possible code entries look at the [pilight API](https://www.pilight.org/development/api/). All commands allowed by [pilight-send](https://wiki.pilight.org/doku.php/psend) can be used. Which means that if for a certain protocol there are different parameters used, you should be able to replace the variables above by the proper ones required by the specific protocol. When using the `elro_800_switch` or `mumbi` protocol for example, you will have to replace the variable `unit` with `unitcode` or there will be errors occuring.
 
 
 ## {% linkable_title Examples %}


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


For some PiLight protocols there are different parameters used and therefore the variables have to be replaced in order to have the pilight_switch component working with HASS.