### PR TITLE
Update z-wave.markdown

### DIFF
--- a/source/getting-started/z-wave.markdown
+++ b/source/getting-started/z-wave.markdown
@@ -23,10 +23,10 @@ Make sure you have the correct dependencies installed before running the script:
 $ sudo apt-get install cython3 libudev-dev python3-sphinx python3-setuptools
 ```
 
-Make sure you have at least version 0.23 of cython.
+Make sure you have at least version 0.23 and at the most 0.24.1 of cython.
 
 ```bash
-$ sudo pip3 install --upgrade cython
+$ sudo pip3 install --upgrade cython==0.24.1
 ```
 
 Then get the OpenZWave files and switch to the `python3` branch:


### PR DESCRIPTION
**Description:**
Specify version of cython that installed.
Currently version 0.24.1 is the latest usable version to compile OpenZWave.