### PR TITLE
Tomato only tracks wireless devices

### DIFF
--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -15,6 +15,8 @@ ha_release: pre 0.7
 
 The `tomato` platform requires an extra config variable called `http_id`. The value can be obtained by logging in to the Tomato admin interface and search for `http_id` in the page source code.
 
+Because of a limitation in Tomato's API, this platform will only track wireless devices. If tracking wired devices like a Philips Hue Hub is necessary, it is possible to use another platform like [NMAP](/components/device_tracker.nmap_tracker/).
+
 To use this device tracker in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
**Description:**
Explicitly state that Tomato only tracks wireless devices. I have NMAP configured to track the IPs of my wired devices and an automation that sends a notification if my media server or Hue Hub go down.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


