### PR TITLE
Update z-wave docs to correctly format alt cmds

### DIFF
--- a/source/getting-started/z-wave.markdown
+++ b/source/getting-started/z-wave.markdown
@@ -43,13 +43,12 @@ $ sudo PYTHON_EXEC=$(which python3) make install
 
 <p class='note'>
 Instead of `make install`, you can alternatively build your own python-openzwave package which can be easily uninstalled:
+</p>
 
 ```bash
 $ sudo apt-get install -y checkinstall
 $ sudo PYTHON_EXEC=$(which python3) checkinstall --pkgname python-openzwave --pkgversion 1.0 --provides python-openzwave
 ```
-
-</p>
 
 With this installation, your `config_path` needed below will resemble:
 


### PR DESCRIPTION
The alternate pyopenzwave build commands were all on one line causing users to think multiple commands was actually one.

Should really just fix the p.note css to allow for multiline code blocks

Thanks to @mikenolet for pointing this one out.