### PR TITLE
Fix typo in Concord232 Binary Sensor description (sensor -> Sensor)

### DIFF
--- a/source/_components/binary_sensor.concord232.markdown
+++ b/source/_components/binary_sensor.concord232.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: interlogix.png
-ha_category: Binary sensor
+ha_category: Binary Sensor
 ha_release: 0.31
 ---
 


### PR DESCRIPTION
**Description:**
Sorry for the spam... I should not do pr first thing in the morning... Doing pr #1343 again...

This typo is responsible for the duplicate categories in the component page :
Binary Sensor (29)
Binary sensor (1)


