### PR TITLE
add the other possibility of leave

### DIFF
--- a/source/getting-started/automation-trigger.markdown
+++ b/source/getting-started/automation-trigger.markdown
@@ -141,5 +141,5 @@ automation:
     entity_id: device_tracker.paulus
     zone: zone.home
     # Event is either enter or leave
-    event: enter
+    event: enter  # or "leave"
 ```


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


I spent about 20 minutes searching around.  Didn't know if it was leaving, leave, exit, etc.  Figured this might save someone time later on.