### PR TITLE
Add undocumented properties to REST binary sensor doc

### DIFF
--- a/source/_components/binary_sensor.rest.markdown
+++ b/source/_components/binary_sensor.rest.markdown
@@ -56,9 +56,13 @@ Configuration variables:
 - **value_template** (*Optional*): Defines a [template](/topics/templating/) to extract the value.
 - **payload** (*Optional*): The payload to send with a POST request. Usualy formed as a dictionary.
 - **verify_ssl** (*Optional*): Verify the certification of the endpoint. Default to True.
+- **authentication** (*Optional*): Type of the HTTP authentication. `basic` or `digest`.
+- **username** (*Optional*): The username for accessing the REST endpoint.
+- **password** (*Optional*): The password for accessing the REST endpoint.
+- **headers** (*Optional*): The headers for the requests.
 
 <p class='note warning'>
-Make sure that the URL matches exactly your endpoint or resource.
+Make sure that the URL exactly matches your endpoint or resource.
 </p>
 
 
@@ -68,7 +72,7 @@ In this section you find some real life examples of how to use this sensor.
 
 ### {% linkable_title aREST sensor %}
 
-Instead of using an [aREST](/components/binary_sensor.arest/) binary sensor could the value of a device supporting aREST directly retrieved with a REST binary sensor.
+Instead of using an [aREST](/components/binary_sensor.arest/) binary sensor, you could retrieve the value of a device supporting aREST directly with a REST binary sensor.
 
 ```yaml
 binary_sensor:
@@ -77,6 +81,31 @@ binary_sensor:
     method: GET
     name: Light
     sensor_class: light
-    value_template: '{{ value_json.return_value }}'
+    value_template: {% raw %}'{{ value_json.return_value }}'{% endraw %}
 ```
 
+### {% linkable_title Accessing an HTTP authentication protected endpoint %}
+
+The REST sensor supports HTTP authentication and customized headers.
+
+```yaml
+binary_sensor:
+  - platform: rest
+    resource: http://IP_ADDRESS:5000/binary_sensor
+    username: ha1
+    password: test1
+    authentication: basic
+    headers:
+      User-Agent: Home Assistant
+      Content-Type: application/json
+```
+
+The headers will contain all relevant details. This will also give you the ability to access endpoints that are protected by tokens. 
+
+```bash
+Content-Length: 1024
+Host: IP_ADDRESS1:5000
+Authorization: Basic aGExOnRlc3Qx
+Accept-Encoding: identity
+Content-Type: application/json
+User-Agent: Home Assistant


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


Added docs for the HTTP auth properties (authentication, username, password) and headers, and added an example to bring this more in line with the REST sensor doc