### PR TITLE
Update state fields

### DIFF
--- a/source/_topics/state_object.markdown
+++ b/source/_topics/state_object.markdown
@@ -17,6 +17,7 @@ All states will always have an entity id, a state and a timestamp when last upda
 
 Field | Description
 ----- | -----------
+`states.state` | String representation of the current state of the entity. Example `off`
 `state.entity_id` | Entity ID. Format: `<domain>.<object_id>`. Example: `light.kitchen`.
 `state.domain` | Domain of the entity. Example: `light`.
 `state.object_id` | Object ID of entity. Example: `kitchen`.
@@ -24,7 +25,6 @@ Field | Description
 `state.last_updated` | Time the state was written to the state machine. Note that writing the exact same state including attributes will not result in this field being updated. Example: `14:10:03 13-03-2016`.
 `state.last_changed` | Time the state changed. This is not updated when there are only updated attributes. Example: `14:10:03 13-03-2016`.
 `state.attributes` | A dictionary with extra attributes related to the current state.
-`states.state` | String representation of the current state of the entity. Example `"off"`
 
 The attributes of an entity are optional. There are a few attributes that are used by Home Assistant for representing the entity in a specific way. Each component will also have it's own attributes to represent extra state data about the entity. For example, the light component has attributes for the current brightness and color of the light. When an attribute is not available, Home Assistant will not write it to the state.
 

--- a/source/_topics/state_object.markdown
+++ b/source/_topics/state_object.markdown
@@ -17,7 +17,7 @@ All states will always have an entity id, a state and a timestamp when last upda
 
 Field | Description
 ----- | -----------
-`states.state` | String representation of the current state of the entity. Example `off`
+`state.state` | String representation of the current state of the entity. Example `off`
 `state.entity_id` | Entity ID. Format: `<domain>.<object_id>`. Example: `light.kitchen`.
 `state.domain` | Domain of the entity. Example: `light`.
 `state.object_id` | Object ID of entity. Example: `kitchen`.

--- a/source/_topics/state_object.markdown
+++ b/source/_topics/state_object.markdown
@@ -24,6 +24,7 @@ Field | Description
 `state.last_updated` | Time the state was written to the state machine. Note that writing the exact same state including attributes will not result in this field being updated. Example: `14:10:03 13-03-2016`.
 `state.last_changed` | Time the state changed. This is not updated when there are only updated attributes. Example: `14:10:03 13-03-2016`.
 `state.attributes` | A dictionary with extra attributes related to the current state.
+`states.state` | String representation of the current state of the entity. Example `"off"`
 
 The attributes of an entity are optional. There are a few attributes that are used by Home Assistant for representing the entity in a specific way. Each component will also have it's own attributes to represent extra state data about the entity. For example, the light component has attributes for the current brightness and color of the light. When an attribute is not available, Home Assistant will not write it to the state.
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


Added missing `state` field, which gives the current state of the entity