### PR TITLE
Corrected second example, removing URL path content for pin

### DIFF
--- a/source/_components/binary_sensor.arest.markdown
+++ b/source/_components/binary_sensor.arest.markdown
@@ -45,7 +45,7 @@ An example for Pin 9 inspired by the command above could look like this:
 # Example configuration.yaml entry
 binary_sensor:
   - platform: arest
-    resource: http://192.168.0.5/digital/9
+    resource: http://192.168.0.5
     pin: 9
     name: Office
 ```


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


Second example included full URL path.  Current implementation of aRest automatically adds /digital/X to URL, and specifying it in the configuration file causes the component not to load properly