### PR TITLE
Adding doc for extend efergy component

### DIFF
--- a/source/_components/sensor.efergy.markdown
+++ b/source/_components/sensor.efergy.markdown
@@ -28,6 +28,8 @@ sensor:
       - type: cost
         period: day
         currency: $
+      - type: amount
+        period: day
 ```
 
 Configuration variables:
@@ -37,6 +39,10 @@ Configuration variables:
 negative number of minutes your timezone is ahead/behind UTC time.
 - **monitored_variables** array (*Required*): Variables to monitor.
   - **type** (*Required*): Name of the variable.
+      - **instant_readings**: Instant energy consumption.
+      - **budget**: Monthly budget.
+      - **cost**: The cost for energy consumption (with the tariff that has been set in Efergy) over a given period.
+      - **amount**: The amount of energy consumed over a given period.
   - **period** (*Optional*): Some variables take a period argument. Valid options are "day", "week", "month", and "year".
   - **currency** (*Optional*): This is used to display the cost/period as the unit when monitoring the cost. It should correspond to the actual currency used in your dashboard.
 


### PR DESCRIPTION
**Description:**
Documentation for the PR about extend energy component (get the amount of energy consumed in a period) and also i have extended the explanation about the configuration.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4202

