### PR TITLE
Enable link to binary sensor overview

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -33,7 +33,7 @@
     </div>
   {% endif %}
 
-  {% if is_platform and parent_name != 'sensor' and parent_name != 'binary_sensor' %}
+  {% if is_platform and parent_name != 'sensor' %}
     <div class='section'>
       This is a platform for
       <a href='{{parent_component.url}}'>the {{parent_component.title}} component</a>.


### PR DESCRIPTION
**Description:**
To make it simpler to find the sensor classes which are documented on the binary sensor overview.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


