### PR TITLE
New config parameter for min_max sensor

### DIFF
--- a/source/_components/sensor.min_max.markdown
+++ b/source/_components/sensor.min_max.markdown
@@ -40,6 +40,6 @@ sensor:
 Configuration variables:
 
 - **entity_ids** (*Required*): At least two entities to monitor
-- **type** (*Optional*): The type of sensor. Defaults to `max`.
+- **type** (*Optional*): The type of sensor: `min`, `max` or `mean`. Defaults to `max`.
 - **name** (*Optional*): Name of the sensor to use in the frontend.
 - **round_digits** (*Optional*): Round mean value to specified number of digits. Defaults to 2.

--- a/source/_components/sensor.min_max.markdown
+++ b/source/_components/sensor.min_max.markdown
@@ -42,4 +42,4 @@ Configuration variables:
 - **entity_ids** (*Required*): At least two entities to monitor
 - **type** (*Optional*): The type of sensor. Defaults to `max`.
 - **name** (*Optional*): Name of the sensor to use in the frontend.
-
+- **round_digits** (*Optional*): Round mean value to specified number of digits. Defaults to 2.


### PR DESCRIPTION
**Description:**
Documenting new configuration parameter (`round_digits`) for min_max sensor.
Documenting the available sensor types.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4237

