### PR TITLE
Fix typo in Synology DSM docs

### DIFF
--- a/source/_components/sensor.synologydsm.markdown
+++ b/source/_components/sensor.synologydsm.markdown
@@ -14,7 +14,7 @@ ha_iot_class: depends
 ---
 
 
-This `synologydms` sensor allows getting various statistics from your [Synology NAS](https://www.synology.com). Please note that using this sensor wakes up your synology if in hibernation mode.
+This `synologydsm` sensor allows getting various statistics from your [Synology NAS](https://www.synology.com). Please note that using this sensor wakes up your synology if in hibernation mode.
 
 To use the SynologyDSM sensor in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:** There's a slight typo in the docs for the new Synology DSM component.


