### PR TITLE
Add undocumented comm_type

### DIFF
--- a/source/_components/switch.mochad.markdown
+++ b/source/_components/switch.mochad.markdown
@@ -29,4 +29,5 @@ Configuration variables:
 
 - **address** (*Required*): The X10 address of the switch.
 - **name** (*Optional*): The name of the switch. Default is: x10_switch_dev_*address*.
+- **comm_type** (*Optional*): pl (powerline) or rf (radio frequency). Default is pl.
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


The CM19A is an RF device and will not work unless the correct comm_type is added to the configuration.  Support for comm_type  is already implemented in homeassistant/components/switch/mochad.py, but it is undocumented.