### PR TITLE
nfandroidtv interrupt explanation

### DIFF
--- a/source/_components/notify.nfandroidtv.markdown
+++ b/source/_components/notify.nfandroidtv.markdown
@@ -35,7 +35,7 @@ Configuration variables:
 - **position** (*Optional*): Has to be one of: bottom-right (default), bottom-left, top-right, top-left, center
 - **color** (*Optional*): Has to be one of: grey (default), black, indigo, green, red, cyan, teal, amber, pink
 - **transparency** (*Optional*): Has to be one of: 0%, 25% (default), 50%, 75%, 100%
-- **interrupt** (*Optional*): If set to true, 1, on etc., the notification is interactive and can be dismissed or selected to display more details.
+- **interrupt** (*Optional*): If set to true, 1, on etc., the notification is interactive and can be dismissed or selected to display more details. Depending on the running app (e.g. Netflix), this may stop playback.
 
 The configuration will be used to configure the default values for the notification for the host specified by the IP. However, you can override most of the settings by passing them with the data-attribute when calling the service.
 This is a fully customized JSON you can use to test how the final notification will look like:


### PR DESCRIPTION
**Description:**
The author of the Notifications for AndroidTV application asked me to explicitly point out, that the interrupt option available to HASS is capable of stopping the currently playing media, depending on the app. Netflix is the example he mentioned.

This PR should satisfy his request.