### PR TITLE
Update z-wave.markdown

### DIFF
--- a/source/getting-started/z-wave.markdown
+++ b/source/getting-started/z-wave.markdown
@@ -58,7 +58,7 @@ With this installation, your `config_path` needed below will resemble:
 
 If you followed along with setting up a virtual environment, your path will be:
 ```bash
-/srv/hass/python-openzwave/openzwave/config
+/srv/hass/src/python-openzwave/openzwave/config
 ```
 
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


The config path was missing "src" along the way. At least my installation required it.