### PR TITLE
Add http.use_x_forwarded_for option

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -32,6 +32,7 @@ Configuration variables:
 - **ssl_certificate** (*Optional*): Path to your TLS/SSL certificate to serve Home Assistant over a secure connection.
 - **ssl_key** (*Optional*): Path to your TLS/SSL key to serve Home Assistant over a secure connection.
 - **cors_allowed_origins** (*Optional*): A list of origin domain names to allow [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) requests from. Enabling this will set the `Access-Control-Allow-Origin` header to the Origin header if it is found in the list, and the `Access-Control-Allow-Headers` header to `Origin, Accept, X-Requested-With, Content-type, X-HA-access`. You must provide the exact Origin, i.e. `https://home-assistant.io` will allow requests from `https://home-assistant.io` but __not__ `http://home-assistant.io`.
+- **use_x_forwarded_for** (*Optional*): Enable parsing of the `X-Forwarded-For` header, passing on the client's correct IP address in proxied setups. You should only enable this in a trustworthy network environment, as clients passing that header could easily spoof their source IP address.
 - **trusted_networks** (*Optional*): List of trusted networks, consisting of IP addresses or networks, that are allowed to bypass password protection when accessing Home Assistant.
 
 The sample below shows a configuration entry with possible values: 


### PR DESCRIPTION
Documents the `http.use_x_forwarded_for` configuration option.

Relates to https://github.com/home-assistant/home-assistant/pull/4355

Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>