### PR TITLE
Update switch.command_line.markdown

### DIFF
--- a/source/_components/switch.command_line.markdown
+++ b/source/_components/switch.command_line.markdown
@@ -73,7 +73,7 @@ This switch will shutdown your host immediately, there will be no confirmation.
 switch:
   platform: command_line
   switches:
-    Home Assistant system shutdown:
+    home_assistant_system_shutdown:
       command_off: "/usr/sbin/poweroff"
 ```
 
@@ -87,7 +87,7 @@ This switch will control a local VLC media player ([Source](https://community.ho
 switch:
   platform: command_line
   switches:
-    VLC:
+    vlc:
       command_on: "cvlc 1.mp3 vlc://quit &"
       command_off: "pkill vlc"
 ```


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


There are several mistakes in the examples: upper case and spaces are not allowed in `identifier`.
See the issue [here](https://community.home-assistant.io/t/command-line-switch-possible-documentation-issue/6218/3)