### PR TITLE
Corrected Sensor "threshold yaml" mistakes on example Template Binary Sensor Component page 

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -46,8 +46,8 @@ sensor:
   - platform: template
     sensors:
       furnace_on:
-        value_template: {% raw %}{{ states.sensor.furnace.state > 2.5 }}{% endraw %}
-        friendly_name: 'Furnace Running
+        value_template: '{{ states.sensor.furnace.state > 2.5 }}'
+        friendly_name: 'Furnace Running'
         sensor_class: heat
 ```
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


