### PR TITLE
Document new sensor.zoneminder "include_archived" option

### DIFF
--- a/source/_components/sensor.zoneminder.markdown
+++ b/source/_components/sensor.zoneminder.markdown
@@ -13,7 +13,7 @@ ha_release: 0.31
 ---
 
 
-The `zoneminder` sensor platform let you monitor the current state of your zoneminder install including the number of events and the current state of the cameras.
+The `zoneminder` sensor platform let you monitor the current state of your ZoneMinder install including the number of events and the current state of the cameras.
 
 <p class='note'>
 You must have the [ZoneMinder component](/components/zoneminder/) configured to use those sensors.
@@ -25,4 +25,9 @@ To set it up, add the following information to your `configuration.yaml` file:
 # Example configuration.yaml entry
 sensor:
   - platform: zoneminder
+    include_archived: false
 ```
+
+Configuration variables:
+
+- **include_archived** (*Optional*): Whether to include archived ZoneMinder events in event counts. Default is `false`.


### PR DESCRIPTION
**Description:**
Document the new option to control whether archived ZoneMinder events are included in the zoneminder sensor.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4445