### PR TITLE
Fixed typo in OpenALPR

### DIFF
--- a/source/_components/openalpr.markdown
+++ b/source/_components/openalpr.markdown
@@ -91,7 +91,7 @@ Configuration variables:
 ```yaml
 # Example configuration.yaml entry
 openalpr:
-  engine: local
+  engine: cloud
   region: eu
   api_key: SK_AAABBBBCCCEEEE
   entities:


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


