### PR TITLE
Fixed service name for alarm keypress

### DIFF
--- a/source/_components/envisalink.markdown
+++ b/source/_components/envisalink.markdown
@@ -77,4 +77,4 @@ The following services are supported by Envisalink and can be used to script or 
 - **alarm_arm_home**: Arms the alarm in home mode.
 - **alarm_arm_away**: Arms the alarm in standard away mode.
 - **alarm_trigger**: Trigger an alarm on the Envisalink connected alarm system. For example, a newer zwave/zigbee sensor can now be integrated into a legacy alarm system using a Home Assistant automation.
-- **alarm_keypress**: Sends a string of up to 6 characters to the alarm. *DSC alarms only*
+- **envisalink_alarm_keypress**: Sends a string of up to 6 characters to the alarm. *DSC alarms only*


### PR DESCRIPTION
**Description:**
Missed that the new service was called envisalink_alarm_keypress instead of alarm_keypress