### PR TITLE
Changed order of instructions.

### DIFF
--- a/source/getting-started/autostart-systemd.markdown
+++ b/source/getting-started/autostart-systemd.markdown
@@ -35,6 +35,12 @@ WantedBy=multi-user.target
 EOF'
 ```
 
+There is also another [sample service file](https://raw.githubusercontent.com/home-assistant/home-assistant/master/script/home-assistant%40.service) available. To use this one, just download it.
+
+```bash
+$ sudo wget https://raw.githubusercontent.com/home-assistant/home-assistant/master/script/home-assistant%40.service -O /etc/systemd/system/home-assistant@[your user].service
+```
+
 If you've setup Home Assistant in virtualenv following the guide the following template should work for you.
 
 ```
@@ -50,12 +56,6 @@ ExecStart=/srv/hass/bin/hass -c "/home/hass/.homeassistant"
 
 [Install]
 WantedBy=multi-user.target
-```
-
-There is also another [sample service file](https://raw.githubusercontent.com/home-assistant/home-assistant/master/script/home-assistant%40.service) available. To use this one, just download it.
-
-```bash
-$ sudo wget https://raw.githubusercontent.com/home-assistant/home-assistant/master/script/home-assistant%40.service -O /etc/systemd/system/home-assistant@[your user].service
 ```
 
 You need to reload `systemd` to make the daemon aware of the new configuration. Enable and launch Home Assistant after that.


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


Order of the instructions suggested that the sample service file could be used if you installed Hass in a virtual environment. Which isn't the case.