### PR TITLE
Update sensor.vasttrafik.markdown

### DIFF
--- a/source/_components/sensor.vasttrafik.markdown
+++ b/source/_components/sensor.vasttrafik.markdown
@@ -39,7 +39,7 @@ Configuration variables:
 - **secret** (*Required*): The API secret to access your Västtrafik account.
 - **departures** array (*Required*): List of travelling routes.
   - **name** (*Optional*): Name of the route.
-  - **from** (*Optional*): The start station.
+  - **from** (*Required*): The start station.
   - **heading** (*Optional*): Direction of the travelling.
   - **delay** (*Optional*): Delay in minutes.
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


Apparently, **from** is required.
Proves:
16-11-21 23:06:40 homeassistant.bootstrap: Invalid config for [sensor.vasttrafik]: required key not provided @ data['departures'][0]['from']. Got None. (See ?:?). Please check the docs at https://home-assistant.io/components/sensor.vasttrafik/