### PR TITLE
Fix over 100 typos/spelling mistakes :P

### DIFF
--- a/source/_components/alarm_control_panel.concord232.markdown
+++ b/source/_components/alarm_control_panel.concord232.markdown
@@ -25,5 +25,5 @@ alarm_control_panel:
 Configuration variables:
 
 - **host** (*Optional*): The host where the concord232 server process is running. Defaults to localhost.
-- **port** (*Optional*): The port where the Alarm panel ist listening. Defaults to 5007.
+- **port** (*Optional*): The port where the Alarm panel is listening. Defaults to 5007.
 

--- a/source/_components/alarm_control_panel.nx584.markdown
+++ b/source/_components/alarm_control_panel.nx584.markdown
@@ -25,5 +25,5 @@ alarm_control_panel:
 Configuration variables:
 
 - **host** (*Optional*): The host where the nx584 server process is running. Defaults to `localhost`.
-- **port** (*Optional*): The port where the Alarm panel ist listening. Defaults to `5007`.
+- **port** (*Optional*): The port where the Alarm panel is listening. Defaults to `5007`.
 

--- a/source/_components/binary_sensor.concord232.markdown
+++ b/source/_components/binary_sensor.concord232.markdown
@@ -25,5 +25,5 @@ binary_sensor:
 Configuration variables:
 
 - **host** (*Optional*): The host where the concord232 server process is running. Defaults to `localhost`.
-- **port** (*Optional*): The port where the Alarm panel ist listening. Defaults to 5007.
+- **port** (*Optional*): The port where the Alarm panel is listening. Defaults to 5007.
 

--- a/source/_components/binary_sensor.enocean.markdown
+++ b/source/_components/binary_sensor.enocean.markdown
@@ -13,7 +13,7 @@ ha_release: 0.21
 ha_iot_class: "Local Push"
 ---
 
-This can typically be one of those batteryless wall switches. Currently only one type has been tested: Eltako FT55. Other devices will most likely not work without changing the Home Asisstant code.
+This can typically be one of those batteryless wall switches. Currently only one type has been tested: Eltako FT55. Other devices will most likely not work without changing the Home Assistant code.
 
 To use your EnOcean device, you first have to set up your [EnOcean hub](/components/enocean/) and then add the following to your `configuration.yaml` file:
 
@@ -27,5 +27,5 @@ binary_sensor:
 Configuration variables:
 
 - **id** (*Required*): The ID of the device. This is the 4 bytes long number written on the dimmer.
-- **name** (*Optional*): An identifier for the Ligh in the frontend.
+- **name** (*Optional*): An identifier for the light in the frontend.
 - **sensor_class** (*Optional*): The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.

--- a/source/_components/binary_sensor.enocean.markdown
+++ b/source/_components/binary_sensor.enocean.markdown
@@ -27,5 +27,5 @@ binary_sensor:
 Configuration variables:
 
 - **id** (*Required*): The ID of the device. This is the 4 bytes long number written on the dimmer.
-- **name** (*Optional*): An identifier for the light in the frontend.
+- **name** (*Optional*): An identifier for the switch in the frontend.
 - **sensor_class** (*Optional*): The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.

--- a/source/_components/binary_sensor.modbus.markdown
+++ b/source/_components/binary_sensor.modbus.markdown
@@ -34,5 +34,5 @@ Configuration variables:
 
 - **coils** array (*Required*): The array contains a list of coils to read from.
   - **name** (*Required*): Name of the sensor.
-  - **slave** (*Required*): The number of the slave (Optional for tcp and upd Modbus).
+  - **slave** (*Required*): The number of the slave (Optional for TCP and UDP Modbus).
   - **coil** (*Required*): Coil number.

--- a/source/_components/binary_sensor.netatmo.markdown
+++ b/source/_components/binary_sensor.netatmo.markdown
@@ -40,7 +40,7 @@ Configuration variables:
 
 - **home** (*Optional*): Will use the cameras of this home only.
 - **timeout** (*Optional*): The binary sensors will reflect the events from the last X minutes (default: 15)
-- **cameras** array (*Optional*): Cameras to use. Multiple enties allowed.
+- **cameras** array (*Optional*): Cameras to use. Multiple entities allowed.
     - 'camera_name': Name of the camera to display.
 - **monitored_conditions** array (*Optional*): List of monitored conditions.
     - 'Someone known'

--- a/source/_components/binary_sensor.rest.markdown
+++ b/source/_components/binary_sensor.rest.markdown
@@ -54,7 +54,7 @@ Configuration variables:
 - **name** (*Optional*): Name of the REST binary sensor.
 - **sensor_class** (*Optional*): The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
 - **value_template** (*Optional*): Defines a [template](/topics/templating/) to extract the value.
-- **payload** (*Optional*): The payload to send with a POST request. Usualy formed as a dictionary.
+- **payload** (*Optional*): The payload to send with a POST request. Usually formed as a dictionary.
 - **verify_ssl** (*Optional*): Verify the certification of the endpoint. Default to True.
 - **authentication** (*Optional*): Type of the HTTP authentication. `basic` or `digest`.
 - **username** (*Optional*): The username for accessing the REST endpoint.

--- a/source/_components/binary_sensor.trend.markdown
+++ b/source/_components/binary_sensor.trend.markdown
@@ -33,7 +33,7 @@ Configuration variables:
   - **sensor_class** (*Optional*): The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
   - **entity_id** (*Required*): The entity that this sensor tracks.
   - **attribute** (*Optional*): The attribute of the entity that this sensor tracks. If no attribute is specified then the sensor will track the state.
-  - **invert** (*Optional*): Invert the result (so `true` means decending rather than ascending)
+  - **invert** (*Optional*): Invert the result (so `true` means descending rather than ascending)
 
 ## {% linkable_title Examples %}
 

--- a/source/_components/binary_sensor.zigbee.markdown
+++ b/source/_components/binary_sensor.zigbee.markdown
@@ -27,8 +27,8 @@ binary_sensor:
 
 Configuration variables:
 
-- **name** (*Required*): The name you wouldd like to give the binary sensor in Home Assistant.
+- **name** (*Required*): The name you would like to give the binary sensor in Home Assistant.
 - **pin** (*Required*): The number identifying which pin to use.
-- **address** (*Optional*): The long 64bit address of the remote ZigBee device whose digital input pin you'd like to sample. Do not include this variable if you want to sample the local ZigBee device's pins.
+- **address** (*Optional*): The long 64-bit address of the remote ZigBee device whose digital input pin you'd like to sample. Do not include this variable if you want to sample the local ZigBee device's pins.
 - **on_state** (*Optional*): Either `high` (default) or `low`, depicting whether the binary sensor is considered `on` when the pin is `high` or `low`.
 

--- a/source/_components/camera.ffmpeg.markdown
+++ b/source/_components/camera.ffmpeg.markdown
@@ -13,7 +13,7 @@ ha_release: 0.26
 ---
 
 
-The `ffmpeg` platform allows you to use any video feed as a camera in Home Assistant via [FFmpeg](http://www.ffmpeg.org/). This video source must support multiple simultaenous reads, because for every concurrent Home Assistant user, a connection will be made to the source every 10 seconds. Normally this should not be a problem.
+The `ffmpeg` platform allows you to use any video feed as a camera in Home Assistant via [FFmpeg](http://www.ffmpeg.org/). This video source must support multiple simultaneous reads, because for every concurrent Home Assistant user, a connection will be made to the source every 10 seconds. Normally this should not be a problem.
 
 To enable your FFmpeg feed in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/camera.netatmo.markdown
+++ b/source/_components/camera.netatmo.markdown
@@ -31,7 +31,7 @@ camera:
 Configuration variables:
 
 - **home** (*Optional*): Will display the cameras of this home only.
-- **cameras** array (*Optional*): Cameras to use. Multiple enties allowed.
+- **cameras** array (*Optional*): Cameras to use. Multiple entities allowed.
     - **camera_name**: Name of the camera to display.
 
 If **home** and **cameras** are not provided, all cameras will be displayed. For more control over your cameras check the configuration sample below.

--- a/source/_components/camera.synology.markdown
+++ b/source/_components/camera.synology.markdown
@@ -31,7 +31,7 @@ Configuration variables:
 - **url** (*Required*): The URL to your synology, including port.
 - **username** (*Required*): The username for accessing surveillance station.
 - **password** (*Required*): The password for accessing surveillance station.
-- **whitelist** (*Optional*): A list of which cameras you want to add, the names must be the same as in Surveillance Station.  If omited all cameras are added.
+- **whitelist** (*Optional*): A list of which cameras you want to add, the names must be the same as in Surveillance Station.  If omitted all cameras are added.
 - **verify_ssl** (*Optional*): True to require a valid certificate, False to disable certificate checking. Defaults to `True`.
 
 A full sample configuration for the `synology` platform is shown below:

--- a/source/_components/climate.generic_thermostat.markdown
+++ b/source/_components/climate.generic_thermostat.markdown
@@ -31,7 +31,7 @@ Configuration variables:
 - **target_sensor** (*Required*): `entity_id` for a temperature sensor, target_sensor.state must be temperature.
 - **min_temp** (*Optional*): Set minimum set point available (default: 7)
 - **max_temp** (*Optional*): Set maximum set point available (default: 35)
-- **target_temp** (*Optional*): Set intital target temperature. Failure to set this variable will result in target temperature being set to null on startup.
+- **target_temp** (*Optional*): Set initial target temperature. Failure to set this variable will result in target temperature being set to null on startup.
 - **ac_mode** (*Optional*): Set the switch specified in the *heater* option to be treated as a cooling device instead of a heating device.
 - **min_cycle_duration** (*Optional*): Set a minimum amount of time that the switch specified in the *heater* option must be in it's current state prior to being switched either off or on.
 

--- a/source/_components/climate.heatmiser.markdown
+++ b/source/_components/climate.heatmiser.markdown
@@ -38,4 +38,4 @@ Configuration variables:
 - **port** (*Required*): The port that the interface is listening on.
 - **tstats** (*Required*): A list of thermostats activated on the gateway.
 - **id** (*Required*): The id of the thermostat as configured on the device itself
-- **name** (*Required*): A friendly name for the themostat
+- **name** (*Required*): A friendly name for the thermostat

--- a/source/_components/climate.proliphix.markdown
+++ b/source/_components/climate.proliphix.markdown
@@ -31,7 +31,7 @@ climate:
 
 Configuration variables:
 
-- **host** (*Required*): Adress of your thermostat, eg. 192.168.1.32
+- **host** (*Required*): Address of your thermostat, eg. 192.168.1.32
 - **username** (*Required*): Username for the thermostat.
 - **password** (*Required*): Password for the thermostat.
 

--- a/source/_components/climate.radiotherm.markdown
+++ b/source/_components/climate.radiotherm.markdown
@@ -14,7 +14,7 @@ ha_category: Climate
 
 The `radiotherm` climate platform let you control a thermostat from [Radio Thermostat](http://www.radiothermostat.com/).
 
-The underlaying library supports:
+The underlying library supports:
 
 - CT50 V1.09
 - CT50 V1.88
@@ -36,7 +36,7 @@ Configuration variables:
 
 Temperature settings from Home Assistant will be sent to thermostat and then hold at that temperature. Set to `False` if you set a thermostat schedule on the thermostat itself and just want Home Assistant to send temporary temperature changes.
 
-Multiple thermostats could be assigned by using `host:` if auto-detetion is not used.
+Multiple thermostats could be assigned by using `host:` if auto-detection is not used.
 
 ```yaml
 climate:

--- a/source/_components/demo.markdown
+++ b/source/_components/demo.markdown
@@ -12,7 +12,7 @@ ha_category: Other
 ---
 
 
-The `demo` platform allows you to use components which are providing a demo of their implementation. The demo entities are dummies but show you how the acutal platform looks like. This way you can run own demonstration instance like the online [Home Assistant demo](https://home-assistant.io/demo/) or `hass --demo-mode` but combined with your own real/functional platforms.
+The `demo` platform allows you to use components which are providing a demo of their implementation. The demo entities are dummies but show you how the actual platform looks like. This way you can run own demonstration instance like the online [Home Assistant demo](https://home-assistant.io/demo/) or `hass --demo-mode` but combined with your own real/functional platforms.
 
 Available demo platforms:
 

--- a/source/_components/device_tracker.bluetooth_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_tracker.markdown
@@ -23,6 +23,6 @@ device_tracker:
   - platform: bluetooth_tracker
 ```
 
-In some cases it can be that your device is not discovered. In that case let your phone scan for BT devices while you restart Home Assistant. Just hit `Scan` on your phone all the time until Home Assisstant is fully restarted and the device should appear in `known_devices.yaml`.
+In some cases it can be that your device is not discovered. In that case let your phone scan for BT devices while you restart Home Assistant. Just hit `Scan` on your phone all the time until Home Assistant is fully restarted and the device should appear in `known_devices.yaml`.
 
 For additional configuration variables check the [Device tracker page](/components/device_tracker/).

--- a/source/_components/device_tracker.owntracks.markdown
+++ b/source/_components/device_tracker.owntracks.markdown
@@ -32,7 +32,7 @@ Configuration variables:
 - **waypoints** (*Optional*): Owntracks users can define [waypoints](http://owntracks.org/booklet/features/waypoints/) (a.k.a regions) which are similar in spirit to Home Assistant zones. If this configuration variable is `True`, the Owntracks users who are in `waypoint_whitelist` can export waypoints from the device and Home Assistant will import them as zone definitions. Defaults to `True`.
 - **waypoint_whitelist** (*Optional*): A list of user names (as defined for [Owntracks](https://home-assistant.io/components/device_tracker.owntracks/)) who can export their waypoints from Owntracks to Home Assistant. Defaults to all users who are connected to Home Assistant via Owntracks.
 
-A full sample configuration for the `owntracks` plaftfrom is shown below:
+A full sample configuration for the `owntracks` platform is shown below:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/device_tracker.tplink.markdown
+++ b/source/_components/device_tracker.tplink.markdown
@@ -16,7 +16,7 @@ ha_release: pre 0.7
 The `tplink` platform allows you to detect presence by looking at connected devices to a [TP-Link](https://www.tp-link.com) device. This includes the ArcherC9 line.
 
 <p class='note'>
-TP-Link devices typically only allow one login at a time to the admin console.  This component will count torwards your one allowed login. Depending on how aggressively you configure device_tracker you may not be able to access the admin console of your TP-Link device without first stopping Home Assistant (and waiting a few minutes for the session to timeout) before you'll be able to login.
+TP-Link devices typically only allow one login at a time to the admin console.  This component will count towards your one allowed login. Depending on how aggressively you configure device_tracker you may not be able to access the admin console of your TP-Link device without first stopping Home Assistant (and waiting a few minutes for the session to timeout) before you'll be able to login.
 </p>
 
 
@@ -38,7 +38,7 @@ Configuration variables:
 For Archer C9 models running firmware version 150811 or later please use the encrypted password you can retrieve like this:
 
 1. Go to the login page of your router. (default: 192.168.0.1)
-2. Type in the password you use to login into the passsword field.
+2. Type in the password you use to login into the password field.
 3. Click somewhere else on the page so that the password field is not selected anymore.
 4. Open the JavaScript console of your browser (usually by pressing F12 and then clicking on "Console").
 5. Type ```document.getElementById("login-password").value;```.

--- a/source/_components/ecobee.markdown
+++ b/source/_components/ecobee.markdown
@@ -54,7 +54,7 @@ ecobee:
 
 Configuration variables:
 
-- **api_key** (*Required*): Your ecobee API key. This is only needed for the inital setup of the component. Once registered it can be removed. If you revoke the key in the ecobee portal you will need to update this again and remove the ecobee.conf file in the `.homeassistant` configuration path.
+- **api_key** (*Required*): Your ecobee API key. This is only needed for the initial setup of the component. Once registered it can be removed. If you revoke the key in the ecobee portal you will need to update this again and remove the ecobee.conf file in the `.homeassistant` configuration path.
 - **hold_temp** (*Optional*): True/False whether or not to hold changes indefinitely (True) or until the next scheduled event. Defaults to `False`.
 
 <p class='img'>

--- a/source/_components/emoncms_history.markdown
+++ b/source/_components/emoncms_history.markdown
@@ -35,4 +35,4 @@ Configuration variables:
 - **url** (*Required*): The root URL of your Emoncms installation. (Use https://emoncms.org for the cloud based version)
 - **inputnode** (*Required*): Input node that will be used inside emoncms. Please make sure you use a dedicated, not used before, node for this component!
 - **whitelist** (*Required*): List of entity IDs you want to publish.
-- **scan_interval** (*Optional*): Defines, in seconds, how reguarly the states of the whitelisted entities are being gathered and send to emoncms. Default is 30 seconds.
+- **scan_interval** (*Optional*): Defines, in seconds, how regularly the states of the whitelisted entities are being gathered and send to emoncms. Default is 30 seconds.

--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -41,7 +41,7 @@ Configuration variables:
   - `script`
   - `scene`
 
-- **expose_by_default** (*Optional*): Whether or not entities should be exposed via the bridge by default instead of explicitly (see the 'emulated_hue' customization below). If not specified, this defaults to true.  Warning: If you have a lot of devices (more than 49 total across all exposed domains), you should be careful with this option.  Exposing more devices than Alexa supports can result in it not seeing any of them.  If you are having trouble getting any devices to show up, try disabling this, and explicitly exposing just a few devices at a time to see if that fixes it.
+- **expose_by_default** (*Optional*): Whether or not entities should be exposed via the bridge by default instead of explicitly (see the 'emulated_hue' customization below). If not specified, this defaults to true. Warning: If you have a lot of devices (more than 49 total across all exposed domains), you should be careful with this option. Exposing more devices than Alexa supports can result in it not seeing any of them.  If you are having trouble getting any devices to show up, try disabling this, and explicitly exposing just a few devices at a time to see if that fixes it.
 
 - **exposed_domains** (*Optional*): The domains that are exposed by default if `expose_by_default` is set to true. If not specified, this defaults to the following list:
   - `switch`

--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -16,7 +16,7 @@ The `emulated_hue` component provides a virtual Philips Hue bridge, written enti
 entities. The driving use case behind this functionality is to allow Home Assistant to work with an Amazon Echo with no set up cost outside of configuration changes.
 
 <p class='note'>
-  It is recommended to assign a static IP address to the computer running Home Assistant. This is because the Amazon Echo discovers devices by IP addresss, and if the IP changes, the Echo won't be able to control it. This is easiest done from your router, see your router's manual for details.
+  It is recommended to assign a static IP address to the computer running Home Assistant. This is because the Amazon Echo discovers devices by IP addresses, and if the IP changes, the Echo won't be able to control it. This is easiest done from your router, see your router's manual for details.
 </p>
 
 ### {% linkable_title Configuration %}
@@ -41,7 +41,7 @@ Configuration variables:
   - `script`
   - `scene`
 
-- **expose_by_default** (*Optional*): Whether or not entities should be exposed via the bridge by default instead of explicitly (see the 'emulated_hue' customization below). If not specified, this defaults to true.  Warning: If you have a lot of devices (more than 49 total across all exposed domains), you should be careful with this opton.  Exposing more devices than Alexa supports can result in it not seeing any of them.  If you are having trouble getting any devices to show up, try disabling this, and explicitly exposing just a few devices at a time to see if that fixes it.
+- **expose_by_default** (*Optional*): Whether or not entities should be exposed via the bridge by default instead of explicitly (see the 'emulated_hue' customization below). If not specified, this defaults to true.  Warning: If you have a lot of devices (more than 49 total across all exposed domains), you should be careful with this option.  Exposing more devices than Alexa supports can result in it not seeing any of them.  If you are having trouble getting any devices to show up, try disabling this, and explicitly exposing just a few devices at a time to see if that fixes it.
 
 - **exposed_domains** (*Optional*): The domains that are exposed by default if `expose_by_default` is set to true. If not specified, this defaults to the following list:
   - `switch`

--- a/source/_components/ffmpeg.markdown
+++ b/source/_components/ffmpeg.markdown
@@ -14,7 +14,7 @@ ha_category: Hub
 The FFmpeg component allows other Home Assistant components to process video and audio streams. This component supports all FFmpeg versions since 3.0.0; if you have a older version, please update.
 
 <p class='note'>
-You need the `ffmpeg` binary in your system path. On Debian 8 or Raspbian (Jessie) you can install it from [debian-backports](https://backports.debian.org/Instructions/). If you want [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) support on a Raspberry Pi, you will need to build from source by yourself. Windows binaries are avilable on the [FFmpeg](http://www.ffmpeg.org/) website.
+You need the `ffmpeg` binary in your system path. On Debian 8 or Raspbian (Jessie) you can install it from [debian-backports](https://backports.debian.org/Instructions/). If you want [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) support on a Raspberry Pi, you will need to build from source by yourself. Windows binaries are available on the [FFmpeg](http://www.ffmpeg.org/) website.
 </p>
 
 To set it up, add the following information to your `configuration.yaml` file:

--- a/source/_components/hdmi_cec.markdown
+++ b/source/_components/hdmi_cec.markdown
@@ -40,7 +40,7 @@ $ ln -s /usr/local/lib/python3.4/dist-packages/cec /srv/hass/hass_venv/lib/pytho
 ```
 
 <p class='note'>If after symlinking and adding `hdmi_cec:` to your configuration you are getting the following error in your logs, 
-`* failed to open vchiq instance` you will also need to add the user account Home Assistant runs under, to the `video` group. To add the Home Assisstant user account to the `video` group, run the following command. `$ usermod -a -G video <hass_user_account>`
+`* failed to open vchiq instance` you will also need to add the user account Home Assistant runs under, to the `video` group. To add the Home Assistant user account to the `video` group, run the following command. `$ usermod -a -G video <hass_user_account>`
 </p>
 
 ## {% linkable_title Testing your installation %}

--- a/source/_components/hdmi_cec.markdown
+++ b/source/_components/hdmi_cec.markdown
@@ -40,7 +40,7 @@ $ ln -s /usr/local/lib/python3.4/dist-packages/cec /srv/hass/hass_venv/lib/pytho
 ```
 
 <p class='note'>If after symlinking and adding `hdmi_cec:` to your configuration you are getting the following error in your logs, 
-`* failed to open vchiq instance` you will also need to add the user account Home Asssistant runs under, to the `video` group. To add the Home Assistant user account to the `video` group, run the following command. `$ usermod -a -G video <hass_user_account>`
+`* failed to open vchiq instance` you will also need to add the user account Home Assistant runs under, to the `video` group. To add the Home Assisstant user account to the `video` group, run the following command. `$ usermod -a -G video <hass_user_account>`
 </p>
 
 ## {% linkable_title Testing your installation %}

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -24,7 +24,7 @@ Device support is currently available for most of:
 - Sensors (shutter contacts, motion detectors, power meters and more)
 - Simple remote controls
 
-If you want to see if a specific device you have is supported, head over to the [pyhomematic](https://github.com/danielperna84/pyhomematic/tree/master/pyhomematic/devicetypes) repository and browse through the sourcecode. A dictionary with the device identifiers (e.g. HM-Sec-SC-2) can be found within the relevant modules near the bottom.
+If you want to see if a specific device you have is supported, head over to the [pyhomematic](https://github.com/danielperna84/pyhomematic/tree/master/pyhomematic/devicetypes) repository and browse through the source code. A dictionary with the device identifiers (e.g. HM-Sec-SC-2) can be found within the relevant modules near the bottom.
 
 We automatically detect all devices we currently support and try to generate useful names. If you enable name-resolving, we try to fetch names from Metadata (Homegear), via JSON-RPC or the XML-API you may have installed on your CCU. Since this may fail this is disabled by default.
 You can manually override the created entities be using Home Assistants [Customizing](https://home-assistant.io/getting-started/customizing-devices/) feature. With it you are able to hide entities you don't need to see within the UI.
@@ -45,7 +45,7 @@ Configuration variables:
 - **resolvenames** (*Optional*): <metadata, json, xml> Try to fetch device names. Defaults to `False` if not specified.
 - **username** (*Optional*): When fetching names via JSON-RPC, you need to specify a user with guest-access to the CCU.
 - **password** (*Optional*): When fetching names via JSON-RPC, you need to specify the password of the user you have configured above.
-- **delay** (*Optional*): <Float> Delay fetching of current state per deivce on startup. Used to prevent overloading of the CCU. Defaults to 0.5.
+- **delay** (*Optional*): <Float> Delay fetching of current state per device on startup. Used to prevent overloading of the CCU. Defaults to 0.5.
 - **variables** (*Optional*): True or False if you want use CCU2/Homegear variables. Default False.
 
 To further explain the `resolvenames` option:

--- a/source/_components/input_select.markdown
+++ b/source/_components/input_select.markdown
@@ -12,7 +12,7 @@ ha_category: Automation
 ha_release: 0.13
 ---
 
-The `input_select` component allows the user to define a list of values that can be selected via the frontend and can be used within conditions of automation. When a user selectes a new item, a state transition event is generated. This state event can be used in an `automation` trigger. 
+The `input_select` component allows the user to define a list of values that can be selected via the frontend and can be used within conditions of automation. When a user selects a new item, a state transition event is generated. This state event can be used in an `automation` trigger.
 
 To enable this platform, add the following lines to your `configuration.yaml`:
 

--- a/source/_components/isy994.markdown
+++ b/source/_components/isy994.markdown
@@ -36,7 +36,7 @@ Configuration variables:
 - **password** (*Required*): The password that used to access the ISY interface.
 - **sensor_string** (*Optional*): This is the string that is used to identify which devices are to be assumed to be sensors instead of lights of switches. By default, this string is 'sensor'. If this string is found in the device name or folder, Home Assistant will assume it is as a sensor or binary sensor (if the device has on/off or true/false states).
 - **hidden_string** (*Optional*): The HIDDEN_STRING is a string that is used to identify which devices are to be hidden on Home Assistant's front page. This string will be stripped from the device's name before being used. By default, this value is '{HIDE ME}'.
-- **tls** (*Optional*): This entry should refelct the version of TLS that the ISY controller is using for HTTPS encryption. This value can be either 1.1 or 1.2. If this value is not set, it is assumed to be version 1.1. This is the default for most users. ISY994 Pro users may likely be using 1.2. When using HTTPS in the host entry, it is best practice to set this value.
+- **tls** (*Optional*): This entry should reflect the version of TLS that the ISY controller is using for HTTPS encryption. This value can be either 1.1 or 1.2. If this value is not set, it is assumed to be version 1.1. This is the default for most users. ISY994 Pro users may likely be using 1.2. When using HTTPS in the host entry, it is best practice to set this value.
 
 Once the ISY controller is configured, it will automatically import any binary sensors, covers, fans, lights, locks, sensors and switches it can locate.
 
@@ -109,7 +109,7 @@ The *actions* program indicates what should be performed for the following devic
  * *cover* the THEN clause is evaluated for the open_cover service, the ELSE clause is evaluated for the close_cover service
  * *fan* the THEN clause is evaluated for the turn_on service, the ELSE clause is evaluated for the turn_off service
  * *lock* the THEN clause is evaluated for the lock service, the ELSE clause is evaluated for the unlock service
- * *switch* the THEN clause is evaluated for the turn_on srevice, the ELSE clause is evaluated for the turn_off service
+ * *switch* the THEN clause is evaluated for the turn_on service, the ELSE clause is evaluated for the turn_off service
 
 <p class='img'>
   <img src='{{site_root}}/images/isy994/isy994_SwitchActionsExample.png' />

--- a/source/_components/light.hyperion.markdown
+++ b/source/_components/light.hyperion.markdown
@@ -14,7 +14,7 @@ ha_release: 0.7.6
 
 This platform allows you to integrate your [Hyperion](https://hyperion-project.org/wiki) into Home Assistant.
 
-Hyperion is an opensource Ambilight implementation which runs on many platforms.
+Hyperion is an open source Ambilight implementation which runs on many platforms.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -35,8 +35,8 @@ Turns one light on or multiple lights on using [groups]({{site_root}}/components
 | `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Else targets all.
 | `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds. *not supported by Wink
 | `profile` | yes | String with the name of one of the built-in profiles (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory.  Light profiles define a xy color and a brightness. If a profile is given and a brightness or xy color then the profile values will be overwritten.
-| `xy_color` | yes | A list containing two floats representing the xy color you want the light to be. Two comma seperated floats that represent the color in XY.
-| `rgb_color` | yes | A list containing three integers representing the rgb color you want the light to be. Three comma seperated integers that represent the color in RGB.  You can find a great chart here: [Hue Color Chart](http://www.developers.meethue.com/documentation/hue-xy-values)
+| `xy_color` | yes | A list containing two floats representing the xy color you want the light to be. Two comma separated floats that represent the color in XY.
+| `rgb_color` | yes | A list containing three integers representing the rgb color you want the light to be. Three comma separated integers that represent the color in RGB.  You can find a great chart here: [Hue Color Chart](http://www.developers.meethue.com/documentation/hue-xy-values)
 | `color_temp` | yes | An INT in mireds representing the color temperature you want the light to be.
 | `color_name` | yes | A human readable string of a color name, such as `blue` or `goldenrod` or [`chucknorris`](http://stackoverflow.com/questions/8318911/why-does-html-think-chucknorris-is-a-color). If your browser can display it, so can Home Assistant.
 | `brightness` | yes | Integer between 0 and 255 for how bright the color should be.

--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -36,7 +36,7 @@ Determine your bulb ip (using router, software, ping ...)
 </p>
 
 <p class='note warning'>
-Tests are only made with a YLDP03YL model. Because it's the only hardware developer owns. If you have bugs with another kind of model, you could open an issue on [Home Assitant Github](https://github.com/home-assistant/home-assistant)
+Tests are only made with a YLDP03YL model. Because it's the only hardware developer owns. If you have bugs with another kind of model, you could open an issue on [Home Assistant Github](https://github.com/home-assistant/home-assistant)
 </p>
 
 

--- a/source/_components/light.zigbee.markdown
+++ b/source/_components/light.zigbee.markdown
@@ -28,5 +28,5 @@ Configuration variables:
 
 - **name** (*Required*): The name you would like to give the light in Home Assistant.
 - **pin** (*Required*): The number identifying which pin to use.
-- **address** (*Optional*): The long 64 bit address of the remote ZigBee device whose digital output pin you wouldd like to switch. Do not include this variable if you want to switch the local ZigBee device's pins.
+- **address** (*Optional*): The long 64 bit address of the remote ZigBee device whose digital output pin you would like to switch. Do not include this variable if you want to switch the local ZigBee device's pins.
 - **on_state** (*Optional*): Either `high` (default) or `low`, depicting whether the digital output pin is pulled `high` or `low` when the light is turned on.

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -27,7 +27,7 @@ Steps to configure your Amazon Fire TV stick with Home Assistant:
 - Find Amazon Fire TV device IP:
   - From the main (Launcher) screen, select Settings.
   - Select System > About > Network.
-- The following commands must be run in a Python 2.x environment. They will allow the component to function in an Ubuntu 16.04/Hassbian enviorment.
+- The following commands must be run in a Python 2.x environment. They will allow the component to function in an Ubuntu 16.04/Hassbian environment.
   - `apt-get install swig libssl-dev python-dev libusb-1.0-0`
   - `pip install flask`
   - `pip install https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-0.24.0.tar.gz`

--- a/source/_components/media_player.mpd.markdown
+++ b/source/_components/media_player.mpd.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Polling"
 ---
 
 
-The `mpd` platform allows you to control a [Music Player Daemon](http://www.musicpd.org/) from Home Assistant. Unfortunatly you will not be able to manipulate the playlist (add or delete songs) or add transitions between the songs. 
+The `mpd` platform allows you to control a [Music Player Daemon](http://www.musicpd.org/) from Home Assistant. Unfortunately you will not be able to manipulate the playlist (add or delete songs) or add transitions between the songs. 
 
 Even though no playlist manipulation is possible, it is possible to use the play_media service to load an existing saved playlist as part of an automation or scene.
 

--- a/source/_components/media_player.sonos.markdown
+++ b/source/_components/media_player.sonos.markdown
@@ -64,7 +64,7 @@ Take a snapshot of what is currently playing on one or more speakers. This servi
 
 ### {% linkable_title Service `sonos_restore` %}
 
-Restore a previosly taken snapshot of one or more speakers. If no `entity_id` is provided, all speakers are restored.
+Restore a previously taken snapshot of one or more speakers. If no `entity_id` is provided, all speakers are restored.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |

--- a/source/_components/media_player.universal.markdown
+++ b/source/_components/media_player.universal.markdown
@@ -58,7 +58,7 @@ The universal media player will primarily imitate one of its *children*. The fir
 
 It is recommended that the command *turn_on*, the command *turn_off*, and the attribute *state* all be provided together. The *state* attribute indicates if the Media Player is on or off. If *state* indicates the media player is off, this status will take precedent over the states of the children. If all the children are idle/off and *state* is on, the universal media player's state will be on.
 
-It is also recomended that the command *volume_up*, the command *volume_down*, the command *volume_mute*, and the attribute *is_volume_muted* all be provided together. The attribute *is_volume_muted* should return either True or the on state when the volume is muted. The *volume_mute* service should toggle the mute setting.
+It is also recommended that the command *volume_up*, the command *volume_down*, the command *volume_mute*, and the attribute *is_volume_muted* all be provided together. The attribute *is_volume_muted* should return either True or the on state when the volume is muted. The *volume_mute* service should toggle the mute setting.
 
 Below is an example configuration.
 

--- a/source/_components/media_player.yamaha.markdown
+++ b/source/_components/media_player.yamaha.markdown
@@ -41,7 +41,7 @@ A few notes:
 
 - Not specifying the host variable will result in automatically searching your network for Yamaha Receivers. It will add a media player device for each one.
 - For receivers that support more than one zone, Home Assistant will add one media player per zone supported by the player, named "$name Zone 2" and "$name Zone 3".
-- In some cases, autodiscovery fails due to a known bug in the receiver's firmware. It is possible to manually specify the reveiver's IP address or via it's hostname (if it is discoverably by your DNS) then.
+- In some cases, autodiscovery fails due to a known bug in the receiver's firmware. It is possible to manually specify the receiver's IP address or via it's hostname (if it is discoverably by your DNS) then.
 - Please note: If adding the IP address or hostname manually, you **must** enable network standby on your receiver, or else startup of Home Assistant will hang if you have your receiver switched off.
 - Currently, this component supports powering on/off, mute, volume control and source selection. Playback controls, for instance play and stop are available for sources that supports it.
 

--- a/source/_components/mqtt.markdown
+++ b/source/_components/mqtt.markdown
@@ -211,7 +211,7 @@ logger:
 
 ## {% linkable_title Testing your setup %}
 
-The `mosquitto` broker package ships commandline tools to send and recieve MQTT messages. As an alternative have a look at [hbmqtt_pub](http://hbmqtt.readthedocs.org/en/latest/references/hbmqtt_pub.html) and [hbmqtt_sub](http://hbmqtt.readthedocs.org/en/latest/references/hbmqtt_sub.html) which are provied by HBMQTT. For sending test messages to a broker running on localhost check the example below:
+The `mosquitto` broker package ships commandline tools to send and receive MQTT messages. As an alternative have a look at [hbmqtt_pub](http://hbmqtt.readthedocs.org/en/latest/references/hbmqtt_pub.html) and [hbmqtt_sub](http://hbmqtt.readthedocs.org/en/latest/references/hbmqtt_sub.html) which are provided by HBMQTT. For sending test messages to a broker running on localhost check the example below:
 
 ```bash
 $ mosquitto_pub -h 127.0.0.1 -t home-assistant/switch/1/on -m "Switch is ON"

--- a/source/_components/mqtt_eventstream.markdown
+++ b/source/_components/mqtt_eventstream.markdown
@@ -25,6 +25,6 @@ mqtt_eventstream:
 
 Configuration variables:
 
-- **publish_topic** (*Required*): Topic for pushlishing local events
-- **subscribe_topic** (*Required*): Topic to recieve events from the remote server.
+- **publish_topic** (*Required*): Topic for publishing local events
+- **subscribe_topic** (*Required*): Topic to receive events from the remote server.
 

--- a/source/_components/notify.group.markdown
+++ b/source/_components/notify.group.markdown
@@ -33,4 +33,4 @@ Configuration variables:
 - **name** (*Required*): Setting the parameter `name` sets the name of the group.
 - **services** (*Required*): A list of all the services to be included in the group.
   - **service** (*Required*): The service part of an entity ID, i.e. if you use `notify.html5` normally, just put `html5`.
-  - **data** (*Optional*): A dictonary containing parameters to add to all notify payloads. This can be anything that is valid to use in a payload, such as `data`, `message`, `target`, `title`.
+  - **data** (*Optional*): A dictionary containing parameters to add to all notify payloads. This can be anything that is valid to use in a payload, such as `data`, `message`, `target`, `title`.

--- a/source/_components/notify.pushetta.markdown
+++ b/source/_components/notify.pushetta.markdown
@@ -33,7 +33,7 @@ Configuration variables:
 - **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
 - **api_key** (*Required*): Your API key for Pushetta.
 - **channel_name** (*Required*): The name of your channel.
-- **send_test_msg** (*Optional*): Disable/enable the test message send on Home Asssitant's startup to test the API key and the existance of the channel. Default to `False`.
+- **send_test_msg** (*Optional*): Disable/enable the test message send on Home Assistant's startup to test the API key and the existence of the channel. Default to `False`.
 
 It's easy to test your Pushetta setup outside of Home Assistant. Assuming you have a channel *home-assistant*, just fire a request and check the channel page in the dashboard for a new message.
 

--- a/source/_components/notify.rest.markdown
+++ b/source/_components/notify.rest.markdown
@@ -28,7 +28,7 @@ notify:
 Configuration variables:
 
 - **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **resource** (*Required*): The resource or endpoint that will recieve the value.
+- **resource** (*Required*): The resource or endpoint that will receive the value.
 - **method** (*Optional*): The method of the request. Default is GET.
 - **message_param_name** (*Optional*): Parameter name for the message. Defaults to `message`.
 - **title_param_name** (*Optional*): Parameter name for the title. Defaults to none.

--- a/source/_components/notify.slack.markdown
+++ b/source/_components/notify.slack.markdown
@@ -21,7 +21,7 @@ It is also possible to use Slack bots as users. Just create a new bot at https:/
 
 Don't forget to invite the bot to the room where you want to get the notifications.
 
-To enable the slack notification in your installation, add the following to your `configuration.yaml` file:
+To enable the Slack notification in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -35,10 +35,10 @@ notify:
 Configuration variables:
 
 - **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **api_key** (*Required*): The slack API token to use for sending slack messages.
+- **api_key** (*Required*): The Slack API token to use for sending Slack messages.
 - **default_channel** (*Required*): The default channel to post to if no channel is explicitly specified when sending the notification message.
-- **username** (*Optional*): Setting username will allow homeassistant to post to slack using the username specified. By default not setting this will post to slack using the user account or botname that you generated the api_key as.
-- **icon** (*Optional*): Use one of the slack emoji's as an Icon for the supplied username.  Slack uses the standard emoji sets used [here](http://www.webpagefx.com/tools/emoji-cheat-sheet/).
+- **username** (*Optional*): Setting username will allow Home Assistant to post to Slack using the username specified. By default not setting this will post to Slack using the user account or botname that you generated the api_key as.
+- **icon** (*Optional*): Use one of the Slack emoji's as an Icon for the supplied username.  Slack uses the standard emoji sets used [here](http://www.webpagefx.com/tools/emoji-cheat-sheet/).
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
 

--- a/source/_components/notify.syslog.markdown
+++ b/source/_components/notify.syslog.markdown
@@ -54,6 +54,6 @@ The table contains values to use in your `configuration.yaml` file.
 | local6    |         |           |
 | local7    |         |           |
 
-For details about facility, option, and priority please consult the [wikpedia article](http://en.wikipedia.org/wiki/Syslog) and [RFC 3164](http://tools.ietf.org/html/rfc3164).
+For details about facility, option, and priority please consult the [wikipedia article](http://en.wikipedia.org/wiki/Syslog) and [RFC 3164](http://tools.ietf.org/html/rfc3164).
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).

--- a/source/_components/openalpr.markdown
+++ b/source/_components/openalpr.markdown
@@ -24,7 +24,7 @@ If you want use a video stream. You need setup the [ffmpeg](/components/ffmpeg) 
 
 If you want process all data local you need the command line tool `alpr` in version > 2.3.1
 
-If you don't found binarys for you distribution you can compile from source. A documention how to build a openalpr is found [here](https://github.com/openalpr/openalpr/wiki).
+If you don't find binaries for your distribution you can compile from source. Documention of how to build openalpr is found [here](https://github.com/openalpr/openalpr/wiki).
 
 On a debian system you can use this cmake command to build only the command line tool (which second part on linux build instruction - ubuntu 14.04+):
 ```bash
@@ -63,7 +63,7 @@ Configuration variables:
 - **region** (*Required*): Country or region. List of Supported [value](https://github.com/openalpr/openalpr/tree/master/runtime_data/config).
 - **confidence** (*Optional*): Default 80. The minimum of confidence in percent to process with Home-Assistant.
 - **entities** (*Required*): A list of device to add in Home-Assistant.
-- **name** (*Optional*): This parameter allows you to override the name of your openalpr entitie.
+- **name** (*Optional*): This parameter allows you to override the name of your openalpr entity.
 - **interval** (*Optional*): Default 2. Time in seconds to poll a picture. If the interval is 0 It don't poll and it only process data with `openalpr.scan` service.
 - **render** (*Optional*): default is with ffmpeg. How is Home-Assistant to get a picture from. It support `ffmpeg` for video streams and `image` for a still image.
 - **input** (*Required*): The source from getting pictures. With ffmpeg it could by all supported input. Image only support a url.

--- a/source/_components/pilight.markdown
+++ b/source/_components/pilight.markdown
@@ -55,8 +55,8 @@ pilight:
 
 ## {% linkable_title Troubleshooting %}
 
-- A list of tested RF transceiver hardware is available [here](https://wiki.pilight.org/doku.php/electronics). This might be usefull before buying.
-- Sending commands is simple when the protocol is known by pilight, but receiving commands can be rather difficult. It can happend that the code is not correctly recognized due to different timings in the sending hardware or the RF receiver. If this happens follow these steps:
+- A list of tested RF transceiver hardware is available [here](https://wiki.pilight.org/doku.php/electronics). This might be useful before buying.
+- Sending commands is simple when the protocol is known by pilight, but receiving commands can be rather difficult. It can happen that the code is not correctly recognized due to different timings in the sending hardware or the RF receiver. If this happens follow these steps:
 
 1. [Install](https://www.pilight.org/get-started/installation/) pilight from source (do not worry that is very easy) and only activate the protocols you are expecting in the pop up menu. This reduces false positives.
 2. Check the real timings of your device + RF receiver by running `pilight-debug`. Remember the `pulslen` parameter.

--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -48,7 +48,7 @@ recorder:
 
 ## {% linkable_title Installation notes %}
 
-Not all Python bindings for the choosen database engine can be installed directly. This section contains additional details which should help you to get it working. 
+Not all Python bindings for the chosen database engine can be installed directly. This section contains additional details which should help you to get it working.
 
 ### {% linkable_title MYSQL %}
 

--- a/source/_components/rfxtrx.markdown
+++ b/source/_components/rfxtrx.markdown
@@ -26,8 +26,8 @@ Configuration variables:
 
 - **device** (*Required*): The path to your device, e.g. `/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0`
 - **debug** (*Optional*): If you want to receive debug output.
-- **dummy** (*Optional*): Then you have need a connected drive to test your settings. Can be usefull for debugging and testing.
+- **dummy** (*Optional*): Then you have need a connected drive to test your settings. Can be useful for debugging and testing.
 
 Supported protocols
 
-Not all protocols as advertised are enabled on inital setup of your transceiver. Enabling all protocols is not recommmended either. Your 433.92 product not showing in the logs? Visit the RFXtrx website to [download RFXmgmr](http://www.rfxcom.com/epages/78165469.sf/nl_NL/?ObjectPath=/Shops/78165469/Categories/Downloads) and enable the required protocol.
+Not all protocols as advertised are enabled on initial setup of your transceiver. Enabling all protocols is not recommended either. Your 433.92 product not showing in the logs? Visit the RFXtrx website to [download RFXmgmr](http://www.rfxcom.com/epages/78165469.sf/nl_NL/?ObjectPath=/Shops/78165469/Categories/Downloads) and enable the required protocol.

--- a/source/_components/sensor.arwn.markdown
+++ b/source/_components/sensor.arwn.markdown
@@ -21,4 +21,4 @@ sensor:
   platform: arwn
 ```
 
-Currently all temperature, barometer, and wind sensors will be displayed. Support for rain guage sensors will happen in the future.
+Currently all temperature, barometer, and wind sensors will be displayed. Support for rain gauge sensors will happen in the future.

--- a/source/_components/sensor.bbox.markdown
+++ b/source/_components/sensor.bbox.markdown
@@ -37,5 +37,5 @@ Configuration variables:
   - **down_max_bandwidth**: Maximum bandwidth available for download.
   - **up_max_bandwidth**: Maximum bandwidth available for upload.
   - **current_down_bandwidth**: Instant measure of the current used bandwidth for download.
-  - **current_up_bandwidth**: Instant measure of the current used bandwidthfor upload.
+  - **current_up_bandwidth**: Instant measure of the current used bandwidth for upload.
 

--- a/source/_components/sensor.deutsche_bahn.markdown
+++ b/source/_components/sensor.deutsche_bahn.markdown
@@ -14,7 +14,7 @@ ha_release: 0.14
 ---
 
 
-The `deutsche_bahn` sensor will give you the departure time of the next train for the given connection. In case of a delay, the delay is also shown. Additional details are used to inform about eg. the type of the train, price, and if it is ontime.
+The `deutsche_bahn` sensor will give you the departure time of the next train for the given connection. In case of a delay, the delay is also shown. Additional details are used to inform about eg. the type of the train, price, and if it is on time.
 
 To enable this sensor, add the following lines to your `configuration.yaml` file:
 
@@ -31,7 +31,7 @@ Configuration variables:
 - **from** (*Required*): The name of the start station.
 - **to** (*Required*): The name of the end/destination station.
 
-As already mentioned this sensor contains a lot of information to access those a [template senosr](/components/sensor.template/) can come handy.
+This sensor stores a lot of attributes which can be accessed by other sensors eg. a [template sensor](/components/sensor.template/).
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/sensor.emoncms.markdown
+++ b/source/_components/sensor.emoncms.markdown
@@ -113,7 +113,7 @@ sensor:
       - 106
 ```
 
-Display feeds from the same Emoncms instance with 2 groups of feeds, diffrent `scan_interval` and a diffrent `unit_of_measurement`.
+Display feeds from the same Emoncms instance with 2 groups of feeds, different `scan_interval` and a different `unit_of_measurement`.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/sensor.gpsd.markdown
+++ b/source/_components/sensor.gpsd.markdown
@@ -45,7 +45,7 @@ To setup a GPSD sensor in your installation, add the following to your `configur
 
 ```yaml
 # Example configuration.yaml entry
-senosr:
+sensor:
   - platform: gpsd
 ```
 

--- a/source/_components/sensor.imap_email_content.markdown
+++ b/source/_components/sensor.imap_email_content.markdown
@@ -37,7 +37,7 @@ Configuration variables:
 - **name** (*Optional*): Name of the IMAP sensor to use in the frontend.
 - **username** (*Required*): Username for the IMAP server.
 - **password** (*Required*): Password for the IMAP server.
-- **senders** (*Required*): A list of sender email addresses that are allowed to report state via email. Only emails recieved from these addresses will be processed.
+- **senders** (*Required*): A list of sender email addresses that are allowed to report state via email. Only emails received from these addresses will be processed.
 - **value_template** (*Optional*): If specified this template will be used to render the state of sensor. If a template is not supplied the raw message body will be used for the sensor value. The following attributes will be supplied to the template:
 
    * **from**: The from address of the email

--- a/source/_components/sensor.knx.markdown
+++ b/source/_components/sensor.knx.markdown
@@ -50,5 +50,5 @@ Configuration variables:
 - **address** (*Required*): The address of the sensor on the bus.
 - **name** (*Optional*): The name to use in the frontend.
 - **minimum** (*Optional*): Minimum sensor value who gets processed. Defaults to a hardcoded default values.
-- **maxmimum** (*Optional*): Maxmimum sensor value who gets processed. Defaults to a hardcoded default.
+- **maximum** (*Optional*): Maximum sensor value who gets processed. Defaults to a hardcoded default.
 

--- a/source/_components/sensor.min_max.markdown
+++ b/source/_components/sensor.min_max.markdown
@@ -14,7 +14,7 @@ ha_release: "0.31"
 ---
 
 
-The `min_max` sensor platform is consuming the state from other sensors and determine the minimum, maximum, and the mean of the collected states. The sensor will always show you the highest/lowest value which was received from your all monitored sensors. If you have spikes in your values, it's recommanded filter/equalize your values with a [statistics sensor](/components/sensor.statistics/) first.
+The `min_max` sensor platform is consuming the state from other sensors and determine the minimum, maximum, and the mean of the collected states. The sensor will always show you the highest/lowest value which was received from your all monitored sensors. If you have spikes in your values, it's recommended filter/equalize your values with a [statistics sensor](/components/sensor.statistics/) first.
 
 It's an alternative to the [template sensor](/components/sensor.template/)'s `value_template:` to get the average of multiple sensors.
 

--- a/source/_components/sensor.mqtt_room.markdown
+++ b/source/_components/sensor.mqtt_room.markdown
@@ -34,7 +34,7 @@ Configuration variables:
 - **device_id** (*Required*): The device id to track for this sensor.
 - **name** (*Optional*): The name of the sensor.
 - **state_topic** (*Optional*): The topic that contains all subtopics for the rooms.
-- **timeout** (*Optional*): The time in seconds after which a room presence state is considered old. An example: device1 is reported at scanner1 with a distance of 1. No further updates are sent from scanner1. After 5 secoonds scanner2 reports device with a distance of 2. The old location info is discarded in favor of the new scanner2 information as the timeout has passed.
+- **timeout** (*Optional*): The time in seconds after which a room presence state is considered old. An example: device1 is reported at scanner1 with a distance of 1. No further updates are sent from scanner1. After 5 seconds scanner2 reports device with a distance of 2. The old location info is discarded in favor of the new scanner2 information as the timeout has passed.
 - **away_timeout** (*Optional*): The time in seconds after which the state should be set to `away` if there were no updates. `0` disables the check and is the default.
 
 Example JSON that should be published to the room topics:

--- a/source/_components/sensor.pilight.markdown
+++ b/source/_components/sensor.pilight.markdown
@@ -14,7 +14,7 @@ ha_iot_class: depends
 ---
 
 
-This `pilight` sensor platform for 433 MHz devices uses a value in the message payload as the sensor value. Unique identifiers (e.g. _uuid_) can be set to distinguish between multile pilight devices. To use a pilight sensor the pilight home assistant hub has to be set up.
+This `pilight` sensor platform for 433 MHz devices uses a value in the message payload as the sensor value. Unique identifiers (e.g. _uuid_) can be set to distinguish between multiple pilight devices. To use a pilight sensor the pilight home assistant hub has to be set up.
 
 To use your sensor via pilight, make sure it is [supported](https://wiki.pilight.org/doku.php/protocols) and add the following to your `configuration.yaml` file:
 

--- a/source/_components/sensor.rest.markdown
+++ b/source/_components/sensor.rest.markdown
@@ -137,7 +137,7 @@ User-Agent: Home Assistant
 
 ### {% linkable_title Use GitHub to get the latest release of Home Assistant %}
 
-This sample is very similar to the [`updater`](/components/updater/) component but the information is recieved from GitHub.
+This sample is very similar to the [`updater`](/components/updater/) component but the information is received from GitHub.
 
 ```yaml
 sensor:

--- a/source/_components/sensor.sabnzbd.markdown
+++ b/source/_components/sensor.sabnzbd.markdown
@@ -36,7 +36,7 @@ sensor:
 Configuration variables:
 
 - **host** (*Required*): The host where your SABnzbd instance is running, eg. 192.168.1.32
-- **port** (*Optional*): The port to use whith SABnzbd instance. Defaults to `8080`.
+- **port** (*Optional*): The port to use with SABnzbd instance. Defaults to `8080`.
 - **api_key** (*Required*): Name that will be used in the frontend for the pin.
 - **name** (*Optional*): The name to use when displaying this SABnzbd instance.
 - **ssl** (*Optional*): Use `https` instead of `http` to connect. Defaults to False.
@@ -46,7 +46,7 @@ Configuration variables:
   - **queue_size**: Size of the queue
   - **queue_remaining**: Remaining elements in the queue
   - **disk_size**: Disk size of the storage location
-  - **disk_free**: Free disk space at the sotrage location
+  - **disk_free**: Free disk space at the storage location
 
 Note that this will create sensors under the name 'sab' and NOT 'sabnzbd' as follows:
 

--- a/source/_components/sensor.statistics.markdown
+++ b/source/_components/sensor.statistics.markdown
@@ -16,7 +16,7 @@ ha_release: "0.30"
 
 The `statistics` sensor platform is consuming the state from other sensors. Beside the maximal and the minimal value also the total, the mean, the median, the variance, and the standard deviation are as attributes available. If it's a binary sensor then only the state changes are counted.
 
-It can take time till the sensor starts to work because a couple of atrributes need more than one value to do the calculation.
+It can take time till the sensor starts to work because a couple of attributes need more than one value to do the calculation.
 
 To enable the statistics sensor, add the following lines to your `configuration.yaml`:
 

--- a/source/_components/sensor.ted5000.markdown
+++ b/source/_components/sensor.ted5000.markdown
@@ -33,7 +33,7 @@ Configuration variables:
 - **port** (*Optional*): The port of your ted gateway. Defaults to 80.
 - **name** (*Optional*): Name of the ted gateway. Defaults to ted.
 
-For each plugged MTU, using an index starting at 1, the platorm creates 2 sensors:
+For each plugged MTU, using an index starting at 1, the platform creates 2 sensors:
 ```yaml
 sensor.<name>_mtu<MTU id>_power
 sensor.<name>_mtu<MTU id>_voltage

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -118,7 +118,7 @@ sensor:
 Please note the blank line to close the multi-line template.
 </p>
 
-### {% linkable_title Change the unit of measurment %}
+### {% linkable_title Change the unit of measurement %}
 
 With a template sensor it's easy to convert given values into others if the unit of measurement don't fit your needs.
 

--- a/source/_components/sensor.thinkingcleaner.markdown
+++ b/source/_components/sensor.thinkingcleaner.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Thinking Cleaner sensor"
-description: "Instructions how to integrate a ThinkingCleaner senosrs within Home Assistant."
+description: "Instructions how to integrate a ThinkingCleaner sensor within Home Assistant."
 date: 2016-04-10 17:24
 sidebar: true
 comments: false

--- a/source/_components/sensor.yweather.markdown
+++ b/source/_components/sensor.yweather.markdown
@@ -46,7 +46,7 @@ Configuration variables:
 - **name** (*Optional*): The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option. Defaults to `Yweather`. 
 - **monitored_conditions** array (*Required*): Conditions to display in the frontend.
   - **weather**: A human-readable text summary with picture from yahoo.
-  - **weather_current**: A human-readable text summary with picture from yahoo from current conditon.
+  - **weather_current**: A human-readable text summary with picture from yahoo from current condition.
   - **temperature**: The current temperature.
   - **temp_min**: The minimal temperature of this day.
   - **temp_max**: The maximum temperature of this day.

--- a/source/_components/simple_alarm.markdown
+++ b/source/_components/simple_alarm.markdown
@@ -12,7 +12,7 @@ ha_category: Alarm
 ---
 
 
-The component `simple_alarm` is capable of detecting intruders. It does so by checking if lights are being turned on while there is no one at home. When this happens it will turn the lights red, flash them for 30 seconds and send a message via [the notifiy component]({{site_root}}/components/notify/). It will also flash a specific light when a known person comes home.
+The component `simple_alarm` is capable of detecting intruders. It does so by checking if lights are being turned on while there is no one at home. When this happens it will turn the lights red, flash them for 30 seconds and send a message via [the notify component]({{site_root}}/components/notify/). It will also flash a specific light when a known person comes home.
 
 This component depends on the components [device_tracker]({{site_root}}/components/device_tracker/) and [light]({{site_root}}/components/light/) being setup.
 

--- a/source/_components/splunk.markdown
+++ b/source/_components/splunk.markdown
@@ -12,7 +12,7 @@ ha_category: "History"
 ha_release: 0.13
 ---
 
-The `splunk` component makes it possible to log all state changes to an external [Splunk](http://splunk.com/) database using Splunk's HTTP Event Collector feature. You can either use this alone, or with the HomeAssistant for Splunk [app](https://github.com/miniconfig/splunk-homeassistant). Since the HEC feature is new to Splunk, you will need to use at least version 6.3.
+The `splunk` component makes it possible to log all state changes to an external [Splunk](http://splunk.com/) database using Splunk's HTTP Event Collector feature. You can either use this alone, or with the Home Assistant for Splunk [app](https://github.com/miniconfig/splunk-homeassistant). Since the HEC feature is new to Splunk, you will need to use at least version 6.3.
 
 To use the `splunk` component in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/sun.markdown
+++ b/source/_components/sun.markdown
@@ -22,7 +22,7 @@ sun:
 
 Configuration variables:
 
-- **elevation** (*Optional*): The (physical) elevation of your location, in metres above sea level. If ommitted will be retrieved from Google Maps.
+- **elevation** (*Optional*): The (physical) elevation of your location, in metres above sea level. If omitted will be retrieved from Google Maps.
 
 <p class='img'>
 <img src='/images/screenshots/more-info-dialog-sun.png' />

--- a/source/_components/switch.command_line.markdown
+++ b/source/_components/switch.command_line.markdown
@@ -48,7 +48,7 @@ In this section you find some real life examples of how to use this switch.
 
 ### {% linkable_title aREST device %}
 
-The example below is doing the same as the [aREST switch](/components/switch.arest/). The commandline tool [`curl`](http://curl.haxx.se/) is used to toogle a pin which is controllable through REST.
+The example below is doing the same as the [aREST switch](/components/switch.arest/). The commandline tool [`curl`](http://curl.haxx.se/) is used to toggle a pin which is controllable through REST.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/switch.dlink.markdown
+++ b/source/_components/switch.dlink.markdown
@@ -37,6 +37,6 @@ Configuration variables:
 - **host** (*Required*): The IP address of your D-Link plug, eg. http://192.168.1.32
 - **name** (*Optional*): The name to use when displaying this switch.
 - **username** (*Required*): The username for your plug. Defaults to `admin`.
-- **password** (*Required*): The password for your plug. Default password is the `PIN` inlcuded on the configuration card.
+- **password** (*Required*): The password for your plug. Default password is the `PIN` included on the configuration card.
 - **use_legacy_protocol** (*Optional*): Enable limited support for legacy firmware protocols (Tested with v1.24).
 

--- a/source/_components/switch.hikvision.markdown
+++ b/source/_components/switch.hikvision.markdown
@@ -31,7 +31,7 @@ switch:
 Configuration variables:
 
 - **host** (*Required*): The IP address of your Hikvision camera, eg. `192.168.1.32`.
-- **port** (*Optional*): The port to connec to your Hikvision camera. Defaults to `80`.
+- **port** (*Optional*): The port to connect to your Hikvision camera. Defaults to `80`.
 - **name** (*Optional*): This parameter allows you to override the name of your camera.
 - **username** (*Optional*): The username for accessing your Hikvision camera. Defaults to `admin`.
 - **password** (*Optional*): The password to access your Hikvision camera. Defaults to `12345`.

--- a/source/_components/switch.knx.markdown
+++ b/source/_components/switch.knx.markdown
@@ -28,6 +28,6 @@ switch:
 
 - **name** (*Optional*): A name for this devices used within Home assistant
 - **address** (*Required*): The KNX group address that is used to turn on/off this actuator channel
-- **state_address** (*Optional*): Some KNX devices can change their state internally without any messages on the KXN bus, e.g. if you configure a timer on a channel. The optional `state_address` can be used to inform Home Assistant about these state changes. If a KNX message is seen on the bus addressed to the given state address, this wil overwrite the state of the switch object.
-For switching actuators that are only controlled by a single group address and can't change their state internally, you don't have to configrue the state address.
+- **state_address** (*Optional*): Some KNX devices can change their state internally without any messages on the KXN bus, e.g. if you configure a timer on a channel. The optional `state_address` can be used to inform Home Assistant about these state changes. If a KNX message is seen on the bus addressed to the given state address, this will overwrite the state of the switch object.
+For switching actuators that are only controlled by a single group address and can't change their state internally, you don't have to configure the state address.
 

--- a/source/_components/switch.pilight.markdown
+++ b/source/_components/switch.pilight.markdown
@@ -55,7 +55,7 @@ Variables for the different codes:
 - **'off'** (*Optional*): `1` or `0`
 - **'on'** (*Optional*): `1` or `0`
 
-For possible code entries look at the [pilight API](https://www.pilight.org/development/api/). All commands allowed by [pilight-send](https://wiki.pilight.org/doku.php/psend) can be used. Which means that if for a certain protocol there are different parameters used, you should be able to replace the variables above by the proper ones required by the specific protocol. When using the `elro_800_switch` or `mumbi` protocol for example, you will have to replace the variable `unit` with `unitcode` or there will be errors occuring.
+For possible code entries look at the [pilight API](https://www.pilight.org/development/api/). All commands allowed by [pilight-send](https://wiki.pilight.org/doku.php/psend) can be used. Which means that if for a certain protocol there are different parameters used, you should be able to replace the variables above by the proper ones required by the specific protocol. When using the `elro_800_switch` or `mumbi` protocol for example, you will have to replace the variable `unit` with `unitcode` or there will be errors occurring.
 
 
 ## {% linkable_title Examples %}

--- a/source/_components/switch.pulseaudio_loopback.markdown
+++ b/source/_components/switch.pulseaudio_loopback.markdown
@@ -32,7 +32,7 @@ switch:
 
 Configuration variables:
 
-- **sink_name** (*Required*): The name of the Pulseaudio sink that will recieve the audio.
+- **sink_name** (*Required*): The name of the Pulseaudio sink that will receive the audio.
 - **source_name** (*Required*): The name of the Pulseaudio source that will supply the audio.
 - **name** (*Optional*): Name of the switch.
 - **host** (*Optional*): The IP address or host name of the PulseAudio server.  If not specified, 127.0.0.1 is used.

--- a/source/_components/switch.rfxtrx.markdown
+++ b/source/_components/switch.rfxtrx.markdown
@@ -52,7 +52,7 @@ Configuration variables:
 
 Generate codes:
 
-If you need to generate codes for switches you can use a template (usefull for example COCO switches).
+If you need to generate codes for switches you can use a template (useful for example COCO switches).
 
 - Go to home-assistant-IP:8123/dev-template
 - Use this code to generate a code:
@@ -64,7 +64,7 @@ If you need to generate codes for switches you can use a template (usefull for e
 - Use this code to add a new switch in your configuration.yaml
 - Launch your homeassistant and go the website.
 - Enable learning mode on your switch (i.e. push learn button or plug it in a wall socket)
-- Toggle your new switch in the homeassisant interface
+- Toggle your new switch in the Home Assistant interface
 
 ## {% linkable_title Examples %}
 

--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -13,7 +13,7 @@ ha_category: Other
 
 The `updater` component will check daily for new releases. It will show a badge in the frontend if a new version was found.
 
-The updater component will also collect basic information about Home Assistant and its environment. The information includes the current Home Assistant version, the timezone, Python version and operating system infomation. No identifiable information (i.e. IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/updater.py#L91).
+The updater component will also collect basic information about Home Assistant and its environment. The information includes the current Home Assistant version, the timezone, Python version and operating system information. No identifiable information (i.e. IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/updater.py#L91).
 
 To integrate this into Home Assistant, add the following section to your `configuration.yaml` file:
 

--- a/source/_components/wink.markdown
+++ b/source/_components/wink.markdown
@@ -44,7 +44,7 @@ wink:
   client_secret: YOUR_WINK_CLIENT_SECRET
 ```
 
-The following can also be provied to allow access to the Wink Relay sensors. This value could change at any time.
+The following can also be provided to allow access to the Wink Relay sensors. This value could change at any time.
 
 ```yaml
 wink:
@@ -54,10 +54,10 @@ wink:
 Configuration variables:
 
 - **access_token** (*Required if the below aren't present.*): The retrieved access token.
-- **email** (*Required if access token isn't provied*): Your Wink login email.
-- **password** (*Required if access token isn't provied*): Your Wink loging password.
-- **client_id** (*Required if access token isn't provied*): Your provided Wink client_id.
-- **client_secret** (*Required if access token isn't provied*): Your provided Wink client_secret.
+- **email** (*Required if access token isn't provided*): Your Wink login email.
+- **password** (*Required if access token isn't provided*): Your Wink login password.
+- **client_id** (*Required if access token isn't provided*): Your provided Wink client_id.
+- **client_secret** (*Required if access token isn't provided*): Your provided Wink client_secret.
 - **user_agent** (*Optional*): The user-agent passed in the API calls to Wink.
 
 This will connect to the Wink hub and automatically set up any lights, switches and sensors that it finds.

--- a/source/getting-started/z-wave.markdown
+++ b/source/getting-started/z-wave.markdown
@@ -222,7 +222,7 @@ The `zwave` component exposes multiple services to help maintain the network.
 | ------- | ----------- |
 | add_node | Put the Z-Wave controller in inclusion mode. Allows one to add a new device to the Z-Wave network.|
 | add_node_secure | Put the Z-Wave controller in secure inclusion mode. Allows one to add a new device with secure communications to the Z-Wave network. |
-| change_association | Add or remove an association in th Z-Wave network
+| change_association | Add or remove an association in the Z-Wave network
 | cancel_command | Cancels a running Z-Wave command. If you have started a add_node or remove_node command, and decides you are not going to do it, then this must be used to stop the inclusion/exclusion command. |
 | heal_network | Tells the controller to "heal" the Z-Wave network. Basically asks the nodes to tell the controller all of their neighbors so the controller can refigure out optimal routing. |
 | remove_node | Put the Z-Wave controller in exclusion mode. Allows one to remove a device from the Z-Wave network.|


### PR DESCRIPTION
**Description:**
Partially automated identification of words not in the aspell dictionary followed by manual correction. I was a bit bored while waiting for reviews on my code pull requests and noticed quite a few documentation spelling mistakes in the last week since I started using hass so decided to help fix the problem in a larger way than my single-word fixes.

Some of the tools:
`find source/_components -name "*.markdown" -exec cat {} \; | aspell list | sort | uniq -c | sort -n # list non-dictionary words`
`function f { grep -w -R "$1" source/_components/; } # show the typo in context`
`function r { grep -w -l -R "$1" source/_components/ | xargs -n1 sed -E -i'' "s/\b$1\b/$2/g"; } # replace the typo` 