### PR TITLE
Add missing 'update_interval' variable to darksky sensor documentation

### DIFF
--- a/source/_components/sensor.darksky.markdown
+++ b/source/_components/sensor.darksky.markdown
@@ -85,6 +85,18 @@ Configuration variables:
   - **precip_intensity_max**: Today's expected maximum intensity of precipitation.
 - **units** (*Optional*): Specify the unit system. Default to `si` or `us` based on the temperature preference in Home Assistant. Other options are `auto`, `us`, `si`, `ca`, and `uk2`.
 `auto` will let forecast.io decide the unit system based on location.
+- **update_inverval** (*Optional*): Minimum time interval between updates. Default is 2 minutes. Supported formats:
+  - `update_interval: 'HH:MM:SS'`
+  - `update_interval: 'HH:MM'`
+  - Time period dictionary, e.g.:
+    <pre>update_interval:
+        # At least one of these must be specified:
+        days: 0
+        hours: 0
+        minutes: 3
+        seconds: 30
+        milliseconds: 0
+    </pre>
 
 <p class='note warning'>
 Note: While the platform is called "darksky" the sensors will show up in Home Assistant as "dark_sky" (eg: sensor.dark_sky_summary).


### PR DESCRIPTION
**Description:**

The darksky sensor documentation is currently missing the 'update_interval' variable that has already been added with version 0.30.0 (as the forecast platform). I only copied the old text from the forecast documentation as it is still valid (see https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/sensor/darksky.py).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

home-assistant/home-assistant#3520
