### PR TITLE
Change condition example to use the lowercase 'on' state

### DIFF
--- a/source/getting-started/automation-condition.markdown
+++ b/source/getting-started/automation-condition.markdown
@@ -11,7 +11,7 @@ footer: true
 
 Conditions are an optional part of an automation rule and can be used to prevent an action from happening when triggered. Conditions look very similar to triggers but are very different. A trigger will look at events happening in the system while a condition only looks at how the system looks right now. A trigger can observe that a switch is being turned on. A condition can only see if a switch is currently on or off.
 
-The available conditions for an automation are the same as for the script syntax. So see that page for a [full list of available conditions][script-condition].
+The available conditions for an automation are the same as for the script syntax so see that page for a [full list of available conditions][script-condition].
 
 Example of using condition:
 
@@ -20,7 +20,7 @@ Example of using condition:
   trigger:
     platform: state
     entity_id: sensor.mini_despacho
-    to: 'ON'
+    to: 'on'
   condition:
     condition: or
     conditions:


### PR DESCRIPTION
**Description:**
The condition example used an uppercase 'ON' state which is confusing because HA normally uses a lowercase 'on' state: https://github.com/home-assistant/home-assistant/blob/32ffd006facea907b2013da19336cf81bd16e6d3/homeassistant/const.py#L160

I confirmed in my setup that using an uppercase 'ON' for a state trigger `to` didn't work but a lowercase 'on' did.