### PR TITLE
Fix binary_sensor.command_line example

### DIFF
--- a/source/_components/binary_sensor.command_line.markdown
+++ b/source/_components/binary_sensor.command_line.markdown
@@ -73,7 +73,7 @@ An alternative solution could look like this:
 binary_sensor:
   platform: command_line
   name: Printer
-  command: ping -c 1 192.168.1.10 &> /dev/null && echo success || echo fail
+  command: ping -W 1 -c 1 192.168.1.10 > /dev/null 2>&1 && echo success || echo fail
   sensor_class: connectivity
   payload_on: "success"
   payload_off: "fail"


### PR DESCRIPTION
The example to check if an IP is alive didn't work. It seems that the `&> /dev/null` redirector didn't work. `> /dev/null 2>&1` works fine however.

This can be verified with the following config:
```yaml
- platform: command_line
  name: "testtrue1"
  command: "true &> /dev/null && echo success || echo fail"
  scan_interval: 5
  payload_on: "success"
  payload_off: "fail"

- platform: command_line
  name: "testfalse1"
  command: "false &> /dev/null && echo success || echo fail"
  scan_interval: 5
  payload_on: "success"
  payload_off: "fail"

- platform: command_line
  name: "testtrue2"
  command: "true > /dev/null 2>&1 && echo success || echo fail"
  scan_interval: 5
  payload_on: "success"
  payload_off: "fail"

- platform: command_line
  name: "testfalse2"
  command: "false > /dev/null 2>&1 && echo success || echo fail"
  scan_interval: 5
  payload_on: "success"
  payload_off: "fail"
```

Also a `-W 1` lowers the timeout to one second.