### PR TITLE
Update installation-virtualenv.markdown

### DIFF
--- a/source/getting-started/installation-virtualenv.markdown
+++ b/source/getting-started/installation-virtualenv.markdown
@@ -116,7 +116,7 @@ $ sudo apt-get install cython3 libudev-dev python3-sphinx python3-setuptools
 Then, activate your virtualenv (steps 3 and 5 above) and upgrade cython.
 
 ```bash
-(hass)$ pip3 install --upgrade cython
+(hass)$ pip3 install --upgrade cython==0.24.1
 ```
 
 Finally, get and install `python-openzwave`.


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


Updated to include maximum version of cython, otherwise will download v25.x causing 'make build' to fail