### PR TITLE
Update perform_actions_based_on_input_select.markdown

### DIFF
--- a/source/_cookbook/perform_actions_based_on_input_select.markdown
+++ b/source/_cookbook/perform_actions_based_on_input_select.markdown
@@ -43,8 +43,8 @@ automation:
       service: media_player.play_media
       data:
         entity_id: media_player.nursery
-        media_id: http://fileserver/rain.mp3
-        media_type: audio/mp4
+        media_content_id: http://fileserver/rain.mp3
+        media_content_type: audio/mp4
 
 
   # If you select "Babbling Brook", play the "babbling_brook.mp3" file
@@ -59,8 +59,8 @@ automation:
       service: media_player.play_media
       data:
         entity_id: media_player.nursery
-        media_id: http://fileserver/babbling_brook.mp3
-        media_type: audio/mp4
+        media_content_id: http://fileserver/babbling_brook.mp3
+        media_content_type: audio/mp4
 
   # If you select "None, turn the Chromecast off
   - alias: Stop the Lullaby


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


In the first example the media to play was identified as media_id and media_type. That did not work for me, but changing it to "media_content_id" and "media_content_type" did (on version 0.33.4).