### PR TITLE
input_select: documentation for services and scene

### DIFF
--- a/source/_components/input_select.markdown
+++ b/source/_components/input_select.markdown
@@ -43,3 +43,39 @@ Configuration variables:
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your input and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.
 
+### {% linkable_title Services %}
+
+This components provide three services to modify the state of the `input_select`:
+
+- `input_select.select_option`: This can be used to select a specific option. The option is passed as `option` attribute in the service data.
+- `input_select.select_previous`: Select the previous option.
+- `input_select.select_next`: Select the next option.
+
+The following example shows the usage of the `input_select.select_option` service in an automation:
+
+```yaml
+# Example configuration.yaml entry
+automation:
+  - alias: example automation
+    trigger:
+      platform: event
+      event_type: MY_CUSTOM_EVENT
+    action:
+      - service: input_select.select_option
+        data:
+          entity_id: input_select.who_cooks
+          option: Paulus
+```
+
+### {% linkable_title Scenes %}
+
+To specify a target option in a [Scene](/components/scene/) you have to specify the target as `option` attribute:
+
+```yaml
+# Example configuration.yaml entry
+scene:
+  - name: Example1
+    entities:
+      input_select.who_cooks:
+        option: Paulus
+```


### PR DESCRIPTION
**Description:**

This adds documentation on how to use the input_select component
services and how to use it in a scene.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4674


This adds documentation on how to use the input_select component
services and how to use it in a scene.

This is related to bug home-assistant/home-assistant#4673

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>