### PR TITLE
show a template switch example for harmony

### DIFF
--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -67,7 +67,7 @@ switch:
   - platform: template
     switches:
       tv:
-        value_template: "{% if is_state('remote.family_room', 'on') %}on{% else %}off{% endif %}"
+        value_template: "{% raw %}{% if is_state('remote.family_room', 'on') %}on{% else %}off{% endif %}{% endraw %}"
         turn_on:
           service: remote.turn_on
           entity_id: remote.family_room

--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -60,6 +60,22 @@ Supported services:
 
 ### {% linkable_title Examples %}
 
+A template switch can be used to display and control the state of an activity in the frontend.
+
+```yaml
+switch:
+  - platform: template
+    switches:
+      tv:
+        value_template: "{% if is_state('remote.family_room', 'on') %}on{% else %}off{% endif %}"
+        turn_on:
+          service: remote.turn_on
+          entity_id: remote.family_room
+        turn_off:
+          service: remote.turn_off
+          entity_id: remote.family_room
+```
+
 Template sensors can be utilized to display current activity in the frontend.
 
 ```yaml


### PR DESCRIPTION
**Description:**
I thought this ought to be included in these docs.  Describes how to use a template switch to view and control the state of a harmony activity.

