### PR TITLE
Fix binary_sensor.threshold sample

### DIFF
--- a/source/_components/binary_sensor.threshold.markdown
+++ b/source/_components/binary_sensor.threshold.markdown
@@ -26,7 +26,7 @@ To enable the threshold sensor, add the following lines to your `configuration.y
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
+binary_sensor:
   - platform: threshold
     threshold: 15
     type: lower


### PR DESCRIPTION
**Description:**

The `binary_sensor.threshold` documentation contained a mistake: the sample was referring to `sensor.threshold`.

