### PR TITLE
Add flic service documentation links for windows and OS X.

### DIFF
--- a/source/_components/binary_sensor.flic.markdown
+++ b/source/_components/binary_sensor.flic.markdown
@@ -15,7 +15,7 @@ ha_release: 0.33.4
 
 The `flic` platform allows you to connect with multiple [flic](https://flic.io) smart buttons.
 
-The platform does not directly interact with the buttons, but communicates with the flic service that manages the buttons. The service can run on the same instance as home assistant or any other reachable machine. For setup instructions visit the [GitHub repository](https://github.com/50ButtonsEach/fliclib-linux-hci#quick-start) of the service.
+The platform does not directly interact with the buttons, but communicates with the flic service that manages the buttons. The service can run on the same instance as home assistant or any other reachable machine. For setup instructions visit the GitHub repository of the service for [Linux](https://github.com/50ButtonsEach/fliclib-linux-hci), [OS X](https://github.com/50ButtonsEach/flic-service-osx) or [Windows](https://github.com/50ButtonsEach/fliclib-windows).
 
 ### {% linkable_title Configuration %}
 


### PR DESCRIPTION
**Description:**
Added missing links for flic service documentation for windows and OS X.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


