### PR TITLE
Use Wake-on-LAN to turn on LG webOS TV

### DIFF
--- a/source/_components/media_player.webostv.markdown
+++ b/source/_components/media_player.webostv.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "LG WebOS TV"
-description: "Instructions how to integrate a LG WebOS TV within Home Assistant."
+title: "LG webOS Smart TV"
+description: "Instructions how to integrate a LG webOS Smart TV within Home Assistant."
 date: 2016-04-18 23:24
 sidebar: true
 comments: false
@@ -13,7 +13,7 @@ ha_iot_class: "Local Polling"
 ha_release: 0.18
 ---
 
-The `webostv` platform allows you to control a [LG](http://www.lg.com) WebOS Smart TV.
+The `webostv` platform allows you to control a [LG](http://www.lg.com/) webOS Smart TV.
 
 When the TV is first connected, you will need to accept Home Assistant on the TV to allow communication.
 
@@ -27,12 +27,14 @@ media_player:
 
 Configuration variables:
 
-- **host** (*Optional*): The IP of the LG WebOS Smart TV, eg. 192.168.0.10
-- **name** (*Optional*): The name you would like to give to the LG WebOS Smart TV.
+- **host** (*Optional*): The IP of the LG webOS Smart TV, e.g. `192.168.0.10`.
+- **mac** (*Optional*): The MAC address of the TV, e.g. `C8:08:E9:99:99:1A`.
+- **name** (*Optional*): The name you would like to give to the LG webOS Smart TV.
 - **customize** array (*Optional*): List of options to customize.
   - ***sources** array (*Optional*): List of hardware inputs.
 
-If you do not provide a host name, all LG WebOS Smart TV's within your network will be auto-discovered if your TV network name is set to `[LG] webOS TV`.
+If you do not specify `host:`, all LG webOS Smart TVs within your network will be auto-discovered if they use the default name setting of `[LG] webOS TV`.
+Home Assistant is able to turn on a LG webOS Smart TV if you specify its MAC address with `mac:`. Some models require the **Mobile TV On** setting and/or a wired network connection to use Wake-on-LAN.
 
 A full configuration example will look like the sample below:
 
@@ -41,6 +43,7 @@ A full configuration example will look like the sample below:
 media_player:
   - platform: webostv
     host: 192.168.0.10
+    mac: C8:08:E9:99:99:1A
     name: Living Room TV
     customize:
       sources:


### PR DESCRIPTION
**Description:**
This adds support to media_player.webostv for Wake-on-LAN.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4808


