### PR TITLE
Add hvac_state property to nest sensors

### DIFF
--- a/source/_components/sensor.nest.markdown
+++ b/source/_components/sensor.nest.markdown
@@ -43,6 +43,7 @@ The following conditions are available by device:
   - operation\_mode
   - temperature
   - target
+  - hvac\_state: The currently active state of the HVAC system, `heating`, `cooling`, or `off`.
 - Nest Protect:
   - co\_status
   - smoke\_status 


### PR DESCRIPTION
**Description:** Adding information about the Nest `hvac_state` property


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4810

