### PR TITLE
Added documentation to Weather Underground to support language codes

### DIFF
--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -73,6 +73,7 @@ sensor:
 Configuration variables:
 - **api_key** (Required): See above.
 - **pws_id** (Optional): You can enter a Personal Weather Station ID. The current list of Wunderground PWS stations is available [here](https://www.wunderground.com/weatherstation/ListStations.asp). If you do not enter a PWS ID, the current location information (latitude and longitude) from your `configuration.yaml` will be used to display weather conditions. 
+- **lang** (Optional): Specify the language that the API returns. The current list of all Wunderground language codes is available [here](https://www.wunderground.com/weather/api/d/docs?d=language-support). If not specified, it defaults to English (EN).
 - **monitored_conditions** array (*Required*): Conditions to display in the frontend. The following conditions can be monitored.
   - **alerts**: Current severe weather advisories
   - **dewpoint_c**: Temperature in Celsius below which water droplets begin to condense and dew can form


### PR DESCRIPTION
**Description:**

Added documentation to support language codes on WU

```yaml
### sensor in Czech
sensor:
  - platform: wunderground
    api_key: !secret wu_key
    pws_id: KNCHOLLY21
    lang: CZ
    monitored_conditions:
      - alerts
      - weather
      - temp_c
```

![image](https://cloud.githubusercontent.com/assets/809840/21002562/70053606-bcf4-11e6-8ccb-92af41ec5893.png)


```yaml
### sensor in Brazilian portuguese
sensor:
  - platform: wunderground
    api_key: !secret wu_key
    pws_id: KNCHOLLY21
    lang: BR
    monitored_conditions:
      - alerts
      - weather
      - temp_c
```

![image](https://cloud.githubusercontent.com/assets/809840/21002536/5d3a1320-bcf4-11e6-88c4-52857fa23000.png)

```yaml
### sensor in French
sensor:
  - platform: wunderground
    api_key: !secret wu_key
    pws_id: KNCHOLLY21
    lang: FR
    monitored_conditions:
      - alerts
      - weather
      - temp_c
```
![image](https://cloud.githubusercontent.com/assets/809840/21002638/ccef02ac-bcf4-11e6-9d9f-061b9c553285.png)


**Supported Language Codes**

AF	Afrikaans
AL	Albanian
AR	Arabic
HY	Armenian
AZ	Azerbaijani
EU	Basque
BY	Belarusian
BU	Bulgarian
LI	British English
MY	Burmese
CA	Catalan
CN	Chinese - Simplified
TW	Chinese - Traditional
CR	Croatian
CZ	Czech
DK	Danish
DV	Dhivehi
NL	Dutch
EN	English
EO	Esperanto
ET	Estonian
FA	Farsi
FI	Finnish
FR	French
FC	French Canadian
GZ	Galician
DL	German
KA	Georgian
GR	Greek
GU	Gujarati
HT	Haitian Creole
IL	Hebrew
HI	Hindi
HU	Hungarian
IS	Icelandic
IO	Ido
ID	Indonesian
IR	Irish Gaelic
IT	Italian
JP	Japanese
JW	Javanese
KM	Khmer
KR	Korean
KU	Kurdish
LA	Latin
LV	Latvian
LT	Lithuanian
ND	Low German
MK	Macedonian
MT	Maltese
GM	Mandinka
MI	Maori
MR	Marathi
MN	Mongolian
NO	Norwegian
OC	Occitan
PS	Pashto
GN	Plautdietsch
PL	Polish
BR	Portuguese
PA	Punjabi
RO	Romanian
RU	Russian
SR	Serbian
SK	Slovak
SL	Slovenian
SP	Spanish
SI	Swahili
SW	Swedish
CH	Swiss
TL	Tagalog
TT	Tatarish
TH	Thai
TR	Turkish
TK	Turkmen
UA	Ukrainian
UZ	Uzbek
VU	Vietnamese
CY	Welsh
SN	Wolof
JI	Yiddish - transliterated
YI	Yiddish - unicode

All supported languages are listed at https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4815

