### PR TITLE
Added D6300SF to the working model list for Samsung Smart TVs

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -47,6 +47,7 @@ Currently known supported models:
 - EH5600
 - F6400AF
 - D6505
+- D6300SF
 
 Currently tested but not working models:
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


I would create a new section ("Currently known partially supported models") for the D6300SF as I am able to control state, play/pause, media_next_track, media_previous_track, volume_down, volume_up, volume_mute; HOWEVER, there are no controls for changing input/source, or up down left right(D-pad) with enter, or channel buttons.

Note: I am unsure how many controls HA supports, so that's why i put it in the working models.  if any of the other supported models works with input/source, up down left right(D-pad) with enter, or channel buttons, then it should not get placed in the unsupported section but in a new partially supported models section.