### PR TITLE
Added resolution support to Amcrest camera component

### DIFF
--- a/source/_components/camera.amcrest.markdown
+++ b/source/_components/camera.amcrest.markdown
@@ -32,5 +32,5 @@ Configuration variables:
 - **password** (*Required*): The password for accessing your camera.
 - **name** (*Optional*): This parameter allows you to override the name of your camera. The default is "Amcrest Camera".
 - **port** (*Optional*): The port that the camera is running on. The default is 80.
-- **resolution** (*Optional*): This parameter allows you to specify the camera resolution. For a high resolution (1080/720p), specify the option `high`. For VGA resolution (640x480p), specify the option `low`. If ommitted, it defaults to *high*.
+- **resolution** (*Optional*): This parameter allows you to specify the camera resolution. For a high resolution (1080/720p), specify the option `high`. For VGA resolution (640x480p), specify the option `low`. If omitted, it defaults to *high*.
 

--- a/source/_components/camera.amcrest.markdown
+++ b/source/_components/camera.amcrest.markdown
@@ -32,4 +32,5 @@ Configuration variables:
 - **password** (*Required*): The password for accessing your camera.
 - **name** (*Optional*): This parameter allows you to override the name of your camera. The default is "Amcrest Camera".
 - **port** (*Optional*): The port that the camera is running on. The default is 80.
+- **resolution** (*Optional*): This parameter allows you to specify the camera resolution. For a high resolution (1080/720p), specify the option `high`. For VGA resolution (640x480p), specify the option `low`. If ommitted, it defaults to *high*.
 


### PR DESCRIPTION
**Description:**

Added documentation to Amcrest camera to support high/low camera resolution. 

```yaml
camera:
  - platform: amcrest
    name: Living Room
    host: 192.168.0.11
    port: 80
    username: admin
    password: secret
    resolution: high

  - platform: amcrest
    name: Patio
    host: 192.168.0.10
    port: 80
    username: admin
    password: password
    resolution: low 
```

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4860
