### PR TITLE
Expose media volume as emulated Hue brightness

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -13,7 +13,8 @@ ha_iot_class: "Local Push"
 ---
 
 The `emulated_hue` component provides a virtual Philips Hue bridge, written entirely in software, that allows services that work with the Hue API to interact with Home Assistant
-entities. The driving use case behind this functionality is to allow Home Assistant to work with an Amazon Echo with no set up cost outside of configuration changes.
+entities. The driving use case behind this functionality is to allow Home Assistant to work with an Amazon Echo or Google Home with no set up cost outside of configuration changes.
+The virtual bridge has the ability to turn entities on or off, or change the brightness of dimmable lights. The volume level of media players can be controlled as brightness.
 
 <p class='note'>
   It is recommended to assign a static IP address to the computer running Home Assistant. This is because the Amazon Echo discovers devices by IP addresses, and if the IP changes, the Echo won't be able to control it. This is easiest done from your router, see your router's manual for details.


### PR DESCRIPTION
**Description:**
This exposes volume control of media_player devices as brightness via the emulated Hue bridge. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4869


