### PR TITLE
Replaces 'sudo su' with 'sudo -s'

### DIFF
--- a/source/getting-started/installation-raspberry-pi-all-in-one.markdown
+++ b/source/getting-started/installation-raspberry-pi-all-in-one.markdown
@@ -53,7 +53,7 @@ The All-In-One Installer script will do the following automatically:
 To upgrade the All-In-One setup manually:
 
 *  Login to Raspberry Pi `ssh pi@your_raspberry_pi_ip`
-*  Change to hass user `sudo su -s /bin/bash hass`
+*  Change to hass user `sudo -u hass -H -s`
 *  Change to virtual enviroment `source /srv/hass/hass_venv/bin/activate`
 *  Update HA `pip3 install --upgrade homeassistant`
 *  Type `exit` to logout the hass user and return to the `pi` user.

--- a/source/getting-started/installation-raspberry-pi.markdown
+++ b/source/getting-started/installation-raspberry-pi.markdown
@@ -62,7 +62,7 @@ $ sudo chown homeassistant:homeassistant homeassistant
 
 Next up is to create and change to a virtual environment for Home Assistant. This will be done as the `homeassistant` account.
 ```bash
-$ sudo su -s /bin/bash homeassistant 
+$ sudo -u homeassistant -s -H
 $ cd /srv/homeassistant
 $ python3 -m venv homeassistant_venv
 $ source /srv/homeassistant/homeassistant_venv/bin/activate

--- a/source/getting-started/installation-virtualenv.markdown
+++ b/source/getting-started/installation-virtualenv.markdown
@@ -52,7 +52,7 @@ $ sudo chown hass /srv/hass
 This is obviously only necessary if you created a `hass` user, but if you did, be sure to switch to that user whenever you install things in your virtualenv, otherwise you'll end up with mucked up permissions.
 
 ```bash
-$ sudo su -s /bin/bash hass
+$ sudo -u hass -s -H
 ```
 
 The `su` command means 'switch' user. We use the '-s' flag because the `hass` user is a system user and doesn't have a default shell by default (to prevent attackers from being able to log in as that user).


### PR DESCRIPTION
**Description:**

There's no need to use `sudo su -s ...` as this invokes first sudo, becoming super-user and then again as super-user invoking `su`.

To replicate the functionality it's sufficient to invoke `sudo` with the follogin parameters
- `-u USERNAME` execute as the given username
- `-s` start a shell
- `-H` set HOME environment variable