### PR TITLE
iCloud depency fail, manual install notice

### DIFF
--- a/source/_components/device_tracker.icloud.markdown
+++ b/source/_components/device_tracker.icloud.markdown
@@ -17,6 +17,9 @@ The `icloud` platform allows you to detect presence using the [iCloud](https://w
 
 It does require that your device is registered with "Find My iPhone".
 
+If automatic install does not install it, use `pip3 install pyicloud`
+The erro will look like: `Not initializing device_tracker.icloud because could not install dependency pyicloud==0.9.1`
+
 To integrate iCloud in Home Assistant, add the following section to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_components/device_tracker.icloud.markdown
+++ b/source/_components/device_tracker.icloud.markdown
@@ -18,7 +18,7 @@ The `icloud` platform allows you to detect presence using the [iCloud](https://w
 It does require that your device is registered with "Find My iPhone".
 
 If automatic install does not install it, use `pip3 install pyicloud`
-The erro will look like: `Not initializing device_tracker.icloud because could not install dependency pyicloud==0.9.1`
+The error will look like: `Not initializing device_tracker.icloud because could not install dependency pyicloud==0.9.1`
 
 To integrate iCloud in Home Assistant, add the following section to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


This will explain the user when the auto install of the depency fails the user can manually install it using the command in the text.