### PR TITLE
add manual mode to speedtests

### DIFF
--- a/source/_components/sensor.fastdotcom.markdown
+++ b/source/_components/sensor.fastdotcom.markdown
@@ -46,5 +46,6 @@ Configuration variables:
 - **minute** (*Optional*): Specify the minute(s) of the hour to schedule the speedtest. Use a list for multiple entries. Default is 0.
 - **hour** (*Optional*): Specify the hour(s) of the day to schedule the speedtest. Use a list for multiple entries. Default is None.
 - **day** (*Optional*): Specify the day(s) of the month to schedule the speedtest. Use a list for multiple entries. Default is None.
+- **manual** (*Optional*): True or False to turn manual mode on or off.  Manual mode will disable scheduled speedtests.
 
-There is also a service named `sensor.update_fastdotcom` that you can use to run a fast.com speedtest on demand.
+There is also a service named `sensor.update_fastdotcom` that you can use to run a fast.com speedtest on demand.  You can turn on manual mode to disable the scheduled speedtests.

--- a/source/_components/sensor.speedtest.markdown
+++ b/source/_components/sensor.speedtest.markdown
@@ -41,10 +41,12 @@ Configuration variables:
 - **minute** (*Optional*): Specify the minute(s) of the hour to schedule the speedtest. Use a list for multiple entries. Default is 0.
 - **hour** (*Optional*): Specify the hour(s) of the day to schedule the speedtest. Use a list for multiple entries. Default is None.
 - **day** (*Optional*): Specify the day(s) of the month to schedule the speedtest. Use a list for multiple entries. Default is None.
+- **manual** (*Optional*): True or False to turn manual mode on or off.  Manual mode will disable scheduled speedtests.
 
 This component uses [speedtest-cli](https://github.com/sivel/speedtest-cli) to gather network performance data from Speedtest.net. Please be aware of the potential [inconsistencies](https://github.com/sivel/speedtest-cli#inconsistency) that this component may display.
 
-When Home Assistant first starts up, the values of the speedtest will show as `Unknown`. You can use the service `sensor.update_speedtest` to run a manual speedtest and populate the data or just wait for the next regularly scheduled test.
+When Home Assistant first starts up, the values of the speedtest will show as `Unknown`. You can use the service `sensor.update_speedtest` to run a manual speedtest and populate the data or just wait for the next regularly scheduled test.  You can turn on manual mode to disable the scheduled speedtests.
+
 
 ## {% linkable_title Examples %}
 


### PR DESCRIPTION
**Description:**
add manual mode to docs for fast.com and speedtest.net sensors

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


