### PR TITLE
s/sensor/switch/ in mfi docs

### DIFF
--- a/source/_components/switch.mfi.markdown
+++ b/source/_components/switch.mfi.markdown
@@ -18,7 +18,7 @@ To add this platform to your installation, add the following to your `configurat
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
+switch:
   - platform: mfi
     host: IP_ADDRESS
     username: USERNAME


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>


This appears to be a copy & paste error; it does need to both switch and sensor stanzas to work in my installation.