### PR TITLE
Add documentation for Hue Groups

### DIFF
--- a/source/_components/light.hue.markdown
+++ b/source/_components/light.hue.markdown
@@ -35,7 +35,38 @@ Configuration variables:
 - **allow_unreachable** (*Optional*):  This will allow unreachable bulbs to report their state correctly. By default *name* from the device is used.
 - **filename** (*Optional*): Make this unique if specifying multiple Hue hubs.
 
-### {% linkable_title Using Hue Scenes in Home Assistant %} ###
+### {% linkable_title Using Hue Groups in Home Assistant %}
+
+The Hue API allows you to group lights. Home Assistant also supports grouping of entities natively, but sometimes it can be usefull to use Hue Groups to group light bulbs. By doing so, Home Assistant only needs to send one API call to change the state of all the bulbs in those groups instead of one call for every light in the group. This causes all the bulbs to change state simultaniously.
+
+These Hue Groups can be a `Luminaire`, `Lightsource`, `LightGroup` or `Room`. The `Luminaire` and `Lightsource` can't be created manually since the Hue bridge manages these automatically based on the discovered bulbs. The `Room` and `LightGroup` can be created manually trough the API, or the mobile app. A bulb can only exist in one `Room`, but can exist in multiple `LightGroup`. The `LightGroup` can be usefull to link certain bulbs together since.
+
+The 2nd generation Hue app only allows to create a `Room`. You need to use the first generation app or the API to create a `LightGroup`.
+
+Example:
+
+To create a `LightGroup` named `Ceiling lights` that contains the lights 1, 2 and 3, execute the following command:
+```shell
+$ curl -XPOST -d '{"name": "Ceiling lights", "lights": ["1", "2", "3"]}' http://<bridge>/api/<username>/groups
+```
+
+The `<username>` is the string that is used to register Home Assistant on the bridge, you can find it in the `phue.conf` file in your configuration path. `<bridge>` is the IP address or hostname of your Hue bridge.
+
+You can find out the ids of your lights by executing the following command:
+```shell
+$ curl http://<bridge>/api/<username>/lights
+```
+
+Home Assistant will automatically detect your new `LightGroup` and add it to the interface.
+
+<p class='note warning'>
+  To support Hue Light Groups, your bridge needs to have at least firmware 1.13 (released on June 3, 2016).
+</p>
+
+More information can be found on the [Philips Hue API documentation](https://www.developers.meethue.com/documentation/groups-api#22_create_group) website.
+
+
+### {% linkable_title Using Hue Scenes in Home Assistant %}
 
 The Hue platform has it's own concept of Scenes for setting the colors
 of a group of lights at once. Hue Scenes are very cheap, get created
@@ -46,11 +77,11 @@ used, almost all very poorly named.
 
 To avoid user interface overload we don't expose Scenes
 directly. Instead there is a
-[light.hue_activate_scene]/(/components/light/#service-lighthue_activate_scene)
+[light.hue_activate_scene](/components/light/#service-lighthue_activate_scene)
 service which can be used by `automation` or `script` components. For
 instance:
 
-```
+```yaml
 script:
   porch_on:
     sequence:


### PR DESCRIPTION
**Description:**
The code for Hue Groups was included in hass, but there was no documentation for it yet. This contains some information on how to add those groups manually since the official app doesn't support adding `LightGroups` (yet?).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4744

