### PR TITLE
Update Sonarr docs for new optional urlbase option

### DIFF
--- a/source/_components/sensor.sonarr.markdown
+++ b/source/_components/sensor.sonarr.markdown
@@ -38,6 +38,7 @@ Configuration variables:
   - **diskspace**: Available disk space.
 - **host** (*Optional*): The host Sonarr is running on (Default: localhost).
 - **port** (*Optional*): The port Sonarr is running on (Default: 8989).
+- **urlbase** (*Optional*): The base URL Sonarr is running under (Default: /).
 - **days** (*Optional*): How many days to look ahead for the upcoming sensor, 1 means today only (Default: 1).
 - **included_paths** (*Optional*): Array of filepaths to include when calculating diskspace. Leave blank to include all.
 - **unit**: (*Optional*): The unit to display disk space in (Default: GB).


### PR DESCRIPTION
**Description:**
For those of us who have sonarr hidden behind reverse proxy under a path, we need to be able to pass the path

Adds urlbase: XXX to the sonarr yaml... Match it to what you have set in Sonarr (Settings>General>URL Base)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4975
