### PR TITLE
Remove superfluous -

### DIFF
--- a/source/_components/light.lifx.markdown
+++ b/source/_components/light.lifx.markdown
@@ -19,7 +19,7 @@ The `lifx` platform allows you to integrate your [LIFX](http://www.lifx.com) int
 # Example configuration.yaml entry
 light:
   - platform: lifx
-  - broadcast: 192.168.1.255
+    broadcast: 192.168.1.255
 ```
 Configuration variables:
 


### PR DESCRIPTION
Documentation fix.
Lifx broadcast doesn't need -

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

