### PR TITLE
Add note about new default Raspbian behavior

### DIFF
--- a/source/getting-started/installation-raspberry-pi-all-in-one.markdown
+++ b/source/getting-started/installation-raspberry-pi-all-in-one.markdown
@@ -11,7 +11,7 @@ The [Raspberry Pi All-In-One Installer](https://github.com/home-assistant/fabric
 
 The only requirement is that you have a Raspberry Pi with a fresh installation of [Raspbian](https://www.raspberrypi.org/downloads/raspbian/) connected to your network.
 
-<p class='note note'>
+<p class='note'>
 Note that as of 2016-11-30 SSH is disabled by default in the official Raspbian images.  Adding an empty file called `ssh` to `/boot/` or the FAT32 partition will enable it.  More information is on the Raspberry Pi Foundation [Blog](https://www.raspberrypi.org/blog/page/2/?fish#a-security-update-for-raspbian-pixel)
 </p>
 

--- a/source/getting-started/installation-raspberry-pi-all-in-one.markdown
+++ b/source/getting-started/installation-raspberry-pi-all-in-one.markdown
@@ -11,6 +11,10 @@ The [Raspberry Pi All-In-One Installer](https://github.com/home-assistant/fabric
 
 The only requirement is that you have a Raspberry Pi with a fresh installation of [Raspbian](https://www.raspberrypi.org/downloads/raspbian/) connected to your network.
 
+<p class='note note'>
+Note that as of 2016-11-30 SSH is disabled by default in the official Raspbian images.  Adding an empty file called `ssh` to `/boot/` or the FAT32 partition will enable it.  More information is on the Raspberry Pi Foundation [Blog](https://www.raspberrypi.org/blog/page/2/?fish#a-security-update-for-raspbian-pixel)
+</p>
+
 *  Login to Raspberry Pi. For example with `ssh pi@your_raspberry_pi_ip`
 *  Run the following command
 


### PR DESCRIPTION
figured this note should be present to save some facedesking.

apologies for the bad markdown (assuming it fails to render correctly.)

**Description:**

Since I had to go digging (read: somewhat obscure blog post) to find out why I couldn't SSH in to a fresh image, and it's a reasonable assumption that users doing this will be running headless, it might be a good idea to include this.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

