### PR TITLE
Add cover to emulated hue default exposed devices

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -59,6 +59,7 @@ Configuration variables:
   - `group`
   - `input_boolean`
   - `media_player`
+  - `cover`
 
 A full configuration sample looks like the one below.
 


### PR DESCRIPTION
**Description:**
Add cover component to the list of default exposed devices


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#5050

