### PR TITLE
Add base_url documentation

### DIFF
--- a/source/_components/tts.google.markdown
+++ b/source/_components/tts.google.markdown
@@ -34,3 +34,11 @@ tts:
   - platform: google
     language: 'de'
 ```
+
+Note: If you are using SSL certificate or Docker, you may need to add the `base_url` configuration variable to your `html` component as follows:
+```yaml
+#Example configuration.yaml entry
+html:
+  base_url: example.duckdns.org
+```
+The `base_url` configuration variable was added in 0.35.1, so make sure your Home Assistant version is **0.35.1 or above.**


### PR DESCRIPTION
**Description:**
Updating documentation to add a note and example of the base_url property as it is needed for users using SSL or Docker.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant

