### PR TITLE
Move Nest sensor configuration to Nest component

### DIFF
--- a/source/_components/binary_sensor.nest.markdown
+++ b/source/_components/binary_sensor.nest.markdown
@@ -16,18 +16,18 @@ ha_release: pre 0.7
 The `nest` binary sensor platform lets you monitor various states of your [Nest](https://nest.com) devices.
 
 <p class='note'>
-You must have the [Nest component](/components/nest/) configured to use these sensors.  The `nest` binary sensor will automatically be setup when you do.
+You must have the [Nest component](/components/nest/) configured to use these sensors. The binary sensors will be setup if the `nest` component is configured and the required configuration for the `nest binary sensor` is set.
 </p>
 
-To customize which binary sensors are enabled, you can add the following to your `configuration.yaml` file:
+To enable binary sensors and customize which sensors are setup, you can extend the [Nest component](/components/nest/) configuration in your `configuration.yaml` file with the following settings:
 
 ```yaml
 # Example configuration.yaml entry
-binary_sensor:
-  - platform: nest
+nest:
+  binary_sensors:
     monitored_conditions:
       - 'fan'
-      - 'is_using_emergency_heat'
+      - 'target'
 ```
 
 If you leave `monitored_conditions` blank, all sensors that are available for your devices will be used.
@@ -35,14 +35,6 @@ If you leave `monitored_conditions` blank, all sensors that are available for yo
 Configuration variables:
 
 - **monitored_conditions** array (*Optional*): States to monitor.
-  - online
-  - fan
-  - is\_using\_emergency\_heat
-  - is\_locked
-  - has\_leaf
-  - motion\_detected
-  - person\_detected
-  - sound\_detected
 
 The following conditions are available by device:
 

--- a/source/_components/binary_sensor.nest.markdown
+++ b/source/_components/binary_sensor.nest.markdown
@@ -30,6 +30,8 @@ nest:
       - 'target'
 ```
 
+By default all binary sensors for your available Nest devices will be monitored. Leave `monitored_conditions` blank to disable all binary sensors for the [Nest component](/components/nest/).
+
 Configuration variables:
 
 - **monitored_conditions** array (*Optional*): States to monitor.

--- a/source/_components/binary_sensor.nest.markdown
+++ b/source/_components/binary_sensor.nest.markdown
@@ -30,8 +30,6 @@ nest:
       - 'target'
 ```
 
-If you leave `monitored_conditions` blank, all sensors that are available for your devices will be used.
-
 Configuration variables:
 
 - **monitored_conditions** array (*Optional*): States to monitor.

--- a/source/_components/sensor.nest.markdown
+++ b/source/_components/sensor.nest.markdown
@@ -16,15 +16,14 @@ ha_release: pre 0.7
 The `nest` sensor platform lets you monitor sensors connected to your [Nest](https://nest.com) devices.
 
 <p class='note'>
-You must have the [Nest component](/components/nest/) configured to use these sensors.  The `nest` binary sensor will automatically be setup when you do.
+You must have the [Nest component](/components/nest/) configured to use these sensors. The sensors will be setup if the `nest` component is configured and the required configuration for the `nest sensor` is set.
 </p>
 
-To customize which sensors are enabled, you can add the following to your `configuration.yaml` file:
-
+To enable sensors and customize which sensors are setup, you can extend the [Nest component](/components/nest/) configuration in your `configuration.yaml` file with the following settings:
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: nest
+nest:
+  sensors:
     monitored_conditions:
       - 'temperature'
       - 'target'
@@ -46,6 +45,7 @@ The following conditions are available by device:
   - hvac\_state: The currently active state of the HVAC system, `heating`, `cooling`, or `off`.
 - Nest Protect:
   - co\_status
-  - smoke\_status 
+  - smoke\_status
+  - batter\_health
 - Nest Camera: none
 

--- a/source/_components/sensor.nest.markdown
+++ b/source/_components/sensor.nest.markdown
@@ -29,8 +29,6 @@ nest:
       - 'target'
 ```
 
-If you leave `monitored_conditions` blank, all sensors that are available for your devices will be included.
-
 Configuration variables:
 
 - **monitored_conditions** array (*Optional*): States to monitor.

--- a/source/_components/sensor.nest.markdown
+++ b/source/_components/sensor.nest.markdown
@@ -29,6 +29,8 @@ nest:
       - 'target'
 ```
 
+By default all sensors for your available Nest devices will be monitored. Leave `monitored_conditions` blank to disable all sensors for the [Nest component](/components/nest/).
+
 Configuration variables:
 
 - **monitored_conditions** array (*Optional*): States to monitor.


### PR DESCRIPTION
**Description:**
Components added via discovery are not initialized with information from the config file. The sensors and binary sensors for Nest devices are added via discovery so they are not configurable as described on the website. To set this right, the configuration for the sensors needs to be set via the Nest component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#4983