### PR TITLE
Update with `repeats` config variable

### DIFF
--- a/source/_components/switch.rpi_rf.markdown
+++ b/source/_components/switch.rpi_rf.markdown
@@ -37,7 +37,7 @@ switch:
       protocol: 5
       code_on: 654321
       code_off: 654320
-      repeats: 15
+      signal_repetitions: 15
 ```
 
 Configuration variables:
@@ -49,4 +49,4 @@ Configuration variables:
     - **code_off** (*Required*): Decimal code to switch the device off.
     - **protocol** (*Optional*): RF Protocol (Default is `1`).
     - **pulselength** (*Optional*): Pulselength (Default is the protocol default).
-    - **repeats** (*Optional*): Number of times to repeat transmission (default is 10, can increase to try to improve reliability).
+    - **signal_repetitions** (*Optional*): Number of times to repeat transmission (default is 10, can increase to try to improve reliability).

--- a/source/_components/switch.rpi_rf.markdown
+++ b/source/_components/switch.rpi_rf.markdown
@@ -37,6 +37,7 @@ switch:
       protocol: 5
       code_on: 654321
       code_off: 654320
+      repeats: 15
 ```
 
 Configuration variables:
@@ -48,4 +49,4 @@ Configuration variables:
     - **code_off** (*Required*): Decimal code to switch the device off.
     - **protocol** (*Optional*): RF Protocol (Default is `1`).
     - **pulselength** (*Optional*): Pulselength (Default is the protocol default).
-
+    - **repeats** (*Optional*): Number of times to repeat transmission (default is 10, can increase to try to improve reliability).


### PR DESCRIPTION
See https://github.com/home-assistant/home-assistant/issues/5069

**Description:** Adds `repeats` config variable to leverage `rpi_rf`'s ability to set custom number of transmission repeats.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5070