### PR TITLE
Fix example automation syntax in light.flux_led.markdown

### DIFF
--- a/source/_components/light.flux_led.markdown
+++ b/source/_components/light.flux_led.markdown
@@ -63,7 +63,7 @@ light:
         name: flux_living_room_lamp
 
 automation:
-  random_flux_living_room_lamp:
+  alias: random_flux_living_room_lamp
   trigger:
     platform: time
     seconds: '/45'


### PR DESCRIPTION
**Description:**
Tried to follow this example and the configuration syntax was invalid.  Fixed.


