### PR TITLE
media_player/vlc: More details about inner working

### DIFF
--- a/source/_components/media_player.vlc.markdown
+++ b/source/_components/media_player.vlc.markdown
@@ -28,3 +28,6 @@ Configuration variables:
 
 - **name** (*Optional*): The name to use in the frontend.
 
+Only "music" media type is supported for now.
+
+This service will control a background VLC instance, therefore you cannot use this to control a VLC instance launched on your desktop, unlike the Kodi media player for example.


### PR DESCRIPTION
- Say that only music is supported
- Explain that it launches a VLC in background and this does not allow to control a GUI instance.

@fabaff this maybe not the better phrasing, but I think this bit of documentation is needed.