### PR TITLE
AiO install requires "pip install lxml"

### DIFF
--- a/source/_components/device_tracker.fritz.markdown
+++ b/source/_components/device_tracker.fritz.markdown
@@ -17,7 +17,7 @@ The `fritz` platform offers presence detection by looking at connected devices t
 
 <p class='note warning'>
 It might be necessary to install additional packages: <code>$ sudo apt-get install libxslt-dev libxml2-dev python3-lxml</code>
-</p>
+If you are working with the All-in-One installation, you may also need to execute also within your virtual environment the command <code> pip install lxml</code>; be patient this will take a while.</p>
 
 To use an Fritz!Box router in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
In addition to the added packages, it is necessary to install lxml within the virtual environment if AiO install has been chosen (I did not verify with other installs). Otherwise HASS will not start and not give any error messages when device_tracker with Fritz is used.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

