### PR TITLE
Update systemd template used in manual installs

### DIFF
--- a/source/getting-started/autostart-systemd.markdown
+++ b/source/getting-started/autostart-systemd.markdown
@@ -35,7 +35,7 @@ WantedBy=multi-user.target
 EOF'
 ```
 
-If you've setup Home Assistant in `virtualenv` following the guide the following template should work for you.
+If you've setup Home Assistant in `virtualenv` following our [manual installation guide](https://home-assistant.io/getting-started/installation-raspberry-pi/), the following template should work for you.
 
 ```
 [Unit]
@@ -44,9 +44,9 @@ After=network.target
 
 [Service]
 Type=simple
-User=hass
-ExecStartPre=source /srv/hass/bin/activate
-ExecStart=/srv/hass/bin/hass -c "/home/hass/.homeassistant"
+User=homeassistant
+ExecStartPre=source /srv/homeassistant/homeassistant_venv/bin/activate
+ExecStart=/srv/homeassistant/homeassistant_venv/bin/hass -c "/home/homeassistant/.homeassistant"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Description:** The systemd template included on the "Getting Started" guide assumes that the user running Home Assistant is called 'hass', however the [Manual Installation guide](https://home-assistant.io/getting-started/installation-raspberry-pi/) uses the username 'homeassistant'.

Testing:
- Installed the new template and ran `sudo systemctl start home-assistant@homeassistant`.  Verified  that `hass` is running and that Home Assistant is accessible via port 8123. 
