### PR TITLE
Fix formatting error in Samsung TV component docs

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -29,7 +29,7 @@ media_player:
 
 Configuration variables:
 
-- **host** (*Required*): The IP of the Samsung Smart TV, eg. `192.168.0.10^.
+- **host** (*Required*): The IP of the Samsung Smart TV, eg. `192.168.0.10`.
 - **port** (*Optional*): The port of the Samsung Smart TV. Defaults to 55000.
 - **name** (*Optional*): The name you would like to give to the Samsung Smart TV.
 - **timeout** (*Optional*): The time-out for the communication with the TV. Defaults to 0.


### PR DESCRIPTION
I assume this was meant to be in backticks, also open to just removing the backtick and carat. :)