### PR TITLE
Renamed service in description

### DIFF
--- a/source/_components/sensor.darksky.markdown
+++ b/source/_components/sensor.darksky.markdown
@@ -84,7 +84,7 @@ Configuration variables:
   - **apparent_temperature_min**: Today's expected apparent low temperature.
   - **precip_intensity_max**: Today's expected maximum intensity of precipitation.
 - **units** (*Optional*): Specify the unit system. Default to `si` or `us` based on the temperature preference in Home Assistant. Other options are `auto`, `us`, `si`, `ca`, and `uk2`.
-`auto` will let forecast.io decide the unit system based on location.
+`auto` will let Dark Sky decide the unit system based on location.
 - **update_inverval** (*Optional*): Minimum time interval between updates. Default is 2 minutes. Supported formats:
   - `update_interval: 'HH:MM:SS'`
   - `update_interval: 'HH:MM'`


### PR DESCRIPTION
Units variable description still referred to forecast.io rather than Dark Sky

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

