### PR TITLE
Updated Configuration variables text

### DIFF
--- a/source/_components/light.hyperion.markdown
+++ b/source/_components/light.hyperion.markdown
@@ -24,5 +24,5 @@ light:
 
 Configuration variables:
 
-- **host** (*Optional*): To enable the automatic addition of lights on startup.
-- **port** (*Optional*): A list of devices with their ip address and a custom name to use in the frontend.
+- **host** (*Optional*): IP Address of the device the Hyperion service is running on.
+- **port** (*Optional*): The Port used to comunicate with the Hyperion service (defualt is 19444).


### PR DESCRIPTION
The text for the configuration variables was not relevant to the listed variables.

i have updated it in my own words, happy for this to be changed to conform to other documents, are there other variables to be added?

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

