### PR TITLE
Scene component: describe limitations wrt states

### DIFF
--- a/source/_components/scene.markdown
+++ b/source/_components/scene.markdown
@@ -53,3 +53,7 @@ automation:
     service: scene.turn_on
     entity_id: scene.romantic
 ```
+
+<p class='note'>
+Please note that the scene component currently only supports one service call per entity to achieve the state. Due to this limitation you cannot set states belonging to different services.
+</p>


### PR DESCRIPTION
**Description:**
Currently the scene component only allows setting states of a single service per component. Document this limitation.

references https://github.com/home-assistant/home-assistant/issues/5123