### PR TITLE
Corrected automation part: event_type and event_data

### DIFF
--- a/source/_components/openalpr.markdown
+++ b/source/_components/openalpr.markdown
@@ -114,8 +114,8 @@ automation:
 - alias: Open garage door
   trigger:
     platform: event
-    Event_type: openalpr.found
-    Event_data:
+    event_type: openalpr.found
+    event_data:
       entity_id: openalpr.camera_garage_1
       plate: BE2183423
 ...


### PR DESCRIPTION
automation:
- alias: Open garage door
  trigger:
    platform: event
    event_type: openalpr.found
    event_data:
      entity_id: openalpr.camera_garage_1
      plate: XXXXXXXX

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

