### PR TITLE
Create page for dublin bus transport sensor

### DIFF
--- a/source/_components/sensor.dublin_bus_transport.markdown
+++ b/source/_components/sensor.dublin_bus_transport.markdown
@@ -1,0 +1,40 @@
+---
+layout: page
+title: "Dublin Bus Transport"
+description: "Instructions how to integrate timetable data for travelling on Dublin Bus within Home Assistant."
+date: 2017-01-09 21:45
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: train.png
+ha_category: Transport
+ha_iot_class: "Cloud Polling"
+ha_release: 0.35.4
+---
+
+
+The `dublin_bus_transport` sensor will give you the time until the next two departures from a Dublin bus stop using the RTPI information.
+
+The [Dublin Bus](https://www.dublinbus.ie/RTPI/) website can help to determine the id of your bus stop. You can check if this is correct by going to 
+
+https://data.dublinked.ie/cgi-bin/rtpi/realtimebusinformation?stopid=[Stop ID]
+
+Then add the data to your `configuration.yaml` file as shown in the example:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: dublin_bus_transport
+    stopid: [Stop ID]
+    route: [Route]
+    name: [Friendly Name]
+```
+
+Configuration variables:
+
+- **stopid** (*Required*): The ID of the bust stop to get the informaion for.
+- **route** (*Optional*): Only show a single bus route at the stop. This is the same as the bus number, e.g. 83
+- **name** (*Optional*): A friendly name for this sensor.
+
+The public RTPI information is coming from [Dub Linked](https://data.dublinked.ie/).


### PR DESCRIPTION
**Description:**
Adds a sensor for the Dublin Bus real time information so that you can trigger an action based on a bus being due in a certain timeframe


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5257

PR name is "add dublin bus RTPI sensor". 
