### PR TITLE
Add known issues for the pilight.send service

### DIFF
--- a/source/_components/pilight.markdown
+++ b/source/_components/pilight.markdown
@@ -53,6 +53,11 @@ pilight:
       - 42
 ```
 
+## {% linkable_title Known issues %}
+
+- You always have to use the correct types for service data for the `pilight.send` service, as all data is sent unchecked and unchanged to the daemon. If you choose the wrong type, your call gets rejected and all you get is a `insufficient number of arguments` in the pilight log. To retrieve the right argument type, read the [implementation of your protocol](https://github.com/pilight/pilight/tree/master/libs/pilight/protocols).
+- The `pilight.send` does **NOT WORK** if you specify the service data with `data_template` instead of `data`. It does not matter if you use an actual template or not. But choosing `data_template` converts all data to strings which gets rejected by the pilight daemon.
+
 ## {% linkable_title Troubleshooting %}
 
 - A list of tested RF transceiver hardware is available [here](https://wiki.pilight.org/doku.php/electronics). This might be useful before buying.


### PR DESCRIPTION
**Description:**

As we don't implement the pilight api but only provide a transport to
the daemon, we should inform the user, that its their responsibility to
choose the correct data type.

As we convert all the users data to string if it specifies it in a
data_template without giving them an option to change it back, we
should put a warning, that templating will not work at all with the
send service of pilight.

I think, these warnings should be persisted in the documentation,
as we're not intended to fix the issues.
