### PR TITLE
Clarification of formatting and options

### DIFF
--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -18,10 +18,13 @@ To enable those lights, add the following lines to your `configuration.yaml` fil
 
 ```yaml
 # Example configuration.yaml entry
-  - platform: yeelight
+light:
+  platform: yeelight
     devices:
       192.168.1.25:
-        name: palier
+        name: Front Door
+      192.168.1.13
+        name: Living Room
 ```
 
 Configuration variables:


### PR DESCRIPTION
Added main component (light:) as many are missing this requirement when adding the yeelights to their config files.  Also expanded the example config to include two entries, also to demonstrate proper config setup for this platform.

**Description:**
See above

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

