### PR TITLE
Change name of apns notify service

### DIFF
--- a/source/_components/notify.apns.markdown
+++ b/source/_components/notify.apns.markdown
@@ -22,17 +22,19 @@ notify:
   name: NOTIFIER_NAME
   platform: apns
   cert_file: cert_file.pem
+  topic: topic
 ```
 
 Configuration variables:
 
 - **name** (*Required*): The name of the notifier. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **sandbox** (*Optional*): If true notifications will be sent to the sandbox (test) notification service. Default false.
 - **cert_file** (*Required*): The certificate to use to authenticate with the APNS service.
+- **topic** (*Required*): The app bundle ID specified in the certificate.
+- **sandbox** (*Optional*): If true notifications will be sent to the sandbox (test) notification service. Default false.
 
-The APNS platform will register two services, `notify.NOTIFIER_NAME` and `apns.NOTIFIER_NAME`.
+The APNS platform will register two services, `notify.NOTIFIER_NAME` and `notify.apns_NOTIFIER_NAME`.
 
-### apns.NOTIFIER_NAME
+### notify.apns_NOTIFIER_NAME
 
 This service will register device id's with home assistant. In order to receive a notification a device must be registered. The app on the device can use this service to send an ID to Home Assistant during startup, the ID will be stored in `[NOTIFIER_NAME]_apns.yaml`.
 
@@ -47,7 +49,7 @@ This service will send messages to a registered device. The following parameters
 - **target**: The desired state of the device, only devices that match the state will receive messages. To enable state tracking a registered device must have a `tracking_device_id` attribute added to the `[NOTIFIER_NAME]_apns.yaml` file. If this ID matches a device in `known_devices.yaml` the device state will be tracked.
 
 - **data**:
-	* **badge**: The number to display as the badge of the app ic.
-	* **sound**: The name of a sound file in the app bundle or in the Library/Sounds folder.
-	* **category**: Provide this key with a string value that represents the identifier property of the UIMutableUserNotificationCategory.
-	* **content_available**: Provide this key with a value of 1 to indicate that new content is available.
+  * **badge**: The number to display as the badge of the app ic.
+  * **sound**: The name of a sound file in the app bundle or in the Library/Sounds folder.
+  * **category**: Provide this key with a string value that represents the identifier property of the UIMutableUserNotificationCategory.
+  * **content_available**: Provide this key with a value of 1 to indicate that new content is available.


### PR DESCRIPTION
**Description:**
* Both apns notify services are now found under the notify domain.
* Update required configuration.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>
https://github.com/home-assistant/home-assistant/pull/5219
