### PR TITLE
Update keyboard_remote.markdown

### DIFF
--- a/source/_components/keyboard_remote.markdown
+++ b/source/_components/keyboard_remote.markdown
@@ -23,13 +23,13 @@ The `evdev` package is used to interface with the keyboard and thus this is Linu
 ```yaml
 # Example configuration.yaml entry
 keyboard_remote:
-  device_descriptor: '/dev/input/by-id/foo'
+  device_descriptor: '/dev/input/event12'
   type: 'key_up'
 ```
 
 Configuration variables:
 
-- **device_descriptor** (*Required*): List of URLS for your feeds.
+- **device_descriptor** (*Required*): Path to the local event input device file that corresponds to the keyboard.
 - **type** (*Required*): Possible values are `key_up`, `key_down`, and `key_hold`. Be careful, `key_hold` will fire a lot of events.
 
 And an automation rule to breathe life into it:
@@ -45,4 +45,51 @@ automation:
   action:
     service: light.turn_on
     entity_id: light.all
+```
+
+This component manages disconnections and re-connections of the keyboard, for example in the case of a bluetooth device that turns off automatically to preserve battery.
+
+If the keyboard disconnects, the component will fire an event `keyboard_remote_disconnected`.
+When the keyboard reconnects an event `keyboard_remote_connected` will be fired.
+
+Here's an automation example that plays a sound through a media player whenever the keyboard connects/disconnects:
+```yaml
+automation:
+  - alias: Keyboard Connected
+    trigger:
+      platform: event
+      event_type: keyboard_remote_connected
+    action:
+      - service: media_player.play_media
+        data:
+          entity_id: media_player.speaker
+          media_content_id: keyboard_connected.wav
+          media_content_type: music
+  - alias: Keyboard Disconnected
+    trigger:
+      platform: event
+      event_type: keyboard_remote_disconnected
+    action:
+      - service: media_player.play_media
+        data:
+          entity_id: media_player.speaker
+          media_content_id: keyboard_disconnected.wav
+          media_content_type: music
+```
+
+
+There might be permissions problems with the event input device file. If this is the case, the user that hass runs as must be allowed read and write permissions with:
+```
+sudo setfacl -m u:HASS_USER:rw /dev/input/event*
+```
+where `HASS_USER` is the user hass runs as and `event*` is the event input device file your keyboard is connected to.
+
+If you want to make this permanent, you can use a udev rule that sets it for your event input device. Add a file `/etc/udev/rules.d/99-userdev-input.rules` containing:
+```
+KERNEL=="event*", SUBSYSTEM=="input", RUN+="/usr/bin/setfacl -m u:HASS_USER:rw $env{DEVNAME}"
+```
+
+You can check the ACLs permission with
+```
+getfacl /dev/input/event*
 ```

--- a/source/_components/keyboard_remote.markdown
+++ b/source/_components/keyboard_remote.markdown
@@ -47,7 +47,7 @@ automation:
     entity_id: light.all
 ```
 
-{% linkable_title Disconnections %}
+## {% linkable_title Disconnections %}
 This component manages disconnections and re-connections of the keyboard, for example in the case of a bluetooth device that turns off automatically to preserve battery.
 
 If the keyboard disconnects, the component will fire an event `keyboard_remote_disconnected`.
@@ -78,7 +78,7 @@ automation:
           media_content_type: music
 ```
 
-{% linkable_title Permissions %}
+## {% linkable_title Permissions %}
 There might be permissions problems with the event input device file. If this is the case, the user that hass runs as must be allowed read and write permissions with:
 ```
 sudo setfacl -m u:HASS_USER:rw /dev/input/event*

--- a/source/_components/keyboard_remote.markdown
+++ b/source/_components/keyboard_remote.markdown
@@ -47,6 +47,7 @@ automation:
     entity_id: light.all
 ```
 
+{% linkable_title Disconnections %}
 This component manages disconnections and re-connections of the keyboard, for example in the case of a bluetooth device that turns off automatically to preserve battery.
 
 If the keyboard disconnects, the component will fire an event `keyboard_remote_disconnected`.
@@ -77,7 +78,7 @@ automation:
           media_content_type: music
 ```
 
-
+{% linkable_title Permissions %}
 There might be permissions problems with the event input device file. If this is the case, the user that hass runs as must be allowed read and write permissions with:
 ```
 sudo setfacl -m u:HASS_USER:rw /dev/input/event*

--- a/source/_components/keyboard_remote.markdown
+++ b/source/_components/keyboard_remote.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Keyboard"
+title: "Keyboard Remote"
 description: "Instructions how to use a keyboard to remote control Home Assistant."
 date: 2016-09-28 14:39
 sidebar: true


### PR DESCRIPTION
Added info and examples on events when keyboard disconnects or reconnects.
Added info on how to set permissions on the event input device file.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5341

