### PR TITLE
Add "Enabling the web interface" section

### DIFF
--- a/source/getting-started/basic.markdown
+++ b/source/getting-started/basic.markdown
@@ -32,10 +32,15 @@ homeassistant:
   # Name of the location where Home Assistant is running
   name: Home
 ```
+### {% linkable_title Enabling the web interface %}
+To enable the frontend, add a `frontend` section to `configuration.yaml`:
+```yaml
+frontend:
+```
 
 ### {% linkable_title Password protecting the web interface %}
 
-First, you'll want to add a password for the Home Assistant web interface. Use your favourite text editor to open `configuration.yaml` and edit the `http` section:
+You will probably want to add a password for the Home Assistant web interface. Use your favourite text editor to open `configuration.yaml` and edit the `http` section:
 
 ```yaml
 http:


### PR DESCRIPTION
See #1768

**Description:**
Add a very simple section in the getting started/basic configuration for how to enable the frontend, which apparently is not enabled by default in 0.35.3 and later.

