### PR TITLE
Added warning and link to how to ssh

### DIFF
--- a/source/getting-started/installation-raspberry-pi.markdown
+++ b/source/getting-started/installation-raspberry-pi.markdown
@@ -26,7 +26,7 @@ There's currently three documented ways to install Home Assistant on a Raspberry
 This installation of Home Assistant requires the Raspberry Pi to run [Raspbian Lite](https://www.raspberrypi.org/downloads/raspbian/).
 The installation will be installed in a [Virtual Environment](/getting-started/installation-virtualenv) with minimal overhead. Instructions assume this is a new installation of Raspbian Lite.
 
-Connect to the Raspberry Pi over ssh. Default password is `raspberry`.
+Connect to the Raspberry Pi over ssh. Default password is `raspberry`. If you are using the Raspberry Pi 3, you will need to enable ssh access. The raspberry pi website has instructions [here](https://www.raspberrypi.org/documentation/remote-access/ssh/)
 ```bash
 $ ssh pi@ipadress
 ```

--- a/source/getting-started/installation-raspberry-pi.markdown
+++ b/source/getting-started/installation-raspberry-pi.markdown
@@ -26,7 +26,7 @@ There's currently three documented ways to install Home Assistant on a Raspberry
 This installation of Home Assistant requires the Raspberry Pi to run [Raspbian Lite](https://www.raspberrypi.org/downloads/raspbian/).
 The installation will be installed in a [Virtual Environment](/getting-started/installation-virtualenv) with minimal overhead. Instructions assume this is a new installation of Raspbian Lite.
 
-Connect to the Raspberry Pi over ssh. Default password is `raspberry`. If you are using the Raspberry Pi 3, you will need to enable ssh access. The raspberry pi website has instructions [here](https://www.raspberrypi.org/documentation/remote-access/ssh/)
+Connect to the Raspberry Pi over ssh. Default password is `raspberry`. You will need to enable ssh access. The raspberry pi website has instructions [here](https://www.raspberrypi.org/documentation/remote-access/ssh/)
 ```bash
 $ ssh pi@ipadress
 ```

--- a/source/getting-started/installation-raspberry-pi.markdown
+++ b/source/getting-started/installation-raspberry-pi.markdown
@@ -26,7 +26,8 @@ There's currently three documented ways to install Home Assistant on a Raspberry
 This installation of Home Assistant requires the Raspberry Pi to run [Raspbian Lite](https://www.raspberrypi.org/downloads/raspbian/).
 The installation will be installed in a [Virtual Environment](/getting-started/installation-virtualenv) with minimal overhead. Instructions assume this is a new installation of Raspbian Lite.
 
-Connect to the Raspberry Pi over ssh. Default password is `raspberry`. You will need to enable ssh access. The raspberry pi website has instructions [here](https://www.raspberrypi.org/documentation/remote-access/ssh/)
+Connect to the Raspberry Pi over ssh. Default password is `raspberry`. 
+You will need to enable ssh access. The raspberry pi website has instructions [here](https://www.raspberrypi.org/documentation/remote-access/ssh/).
 ```bash
 $ ssh pi@ipadress
 ```


### PR DESCRIPTION
**Description:**
When I was going through the raspberry pi manual tutorial I ran into a problem when wanting to ssh into the pi. I've added a notice for raspberry pi 3 that you need to enable ssh access as it is disabled by default for the raspberry pi 3.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

