### PR TITLE
[ecosystem/appdaemon/api]Fixed wrong syntax for example

### DIFF
--- a/source/_ecosystem/appdaemon/api.markdown
+++ b/source/_ecosystem/appdaemon/api.markdown
@@ -1160,7 +1160,7 @@ Each service has different parameter requirements. This argument allows you to s
 #### {% linkable_title Examples %}
 
 ```python
-self.call_service("light.turn_on", entity_id = "light/office_lamp", color_name = "red")
+self.call_service("light/turn_on", entity_id = "light.office_lamp", color_name = "red")
 self.call_service("notify/notify", title = "Hello", message = "Hello World")
 ```
 ### {% linkable_title turn_on() %}


### PR DESCRIPTION
**Description:**
The example code uses invalid syntax that wouldn't work when just copied.