### PR TITLE
Inform users that Docker now includes ffmpeg

### DIFF
--- a/source/_posts/2017-01-14-iss-usps-images-packages.markdown
+++ b/source/_posts/2017-01-14-iss-usps-images-packages.markdown
@@ -56,6 +56,7 @@ The new [image processing component][image] currently works with [number plates]
 - Media player - SqueezeBox: Switch to JSON-RPC ([@dasos])
 - Scripts: Support for `last_triggered` ([@Danielhiversen])
 - Media player: Support for `SUPPORT_PLAY` flag ([@armills])
+- Docker: `ffmpeg` is now included by default ([@colinodell])
 - Minor and not so minor features and bug fixes by [@balloob], [@pvizeli], [@fabaff], [@mezz64], [@andrey-git], [@aequitas], [@abmantis], [@turbokongen], [@jabesq], [@michaelarnauts], [@kellerza], [@titilambert], [@btorresgil], [@henworth], [@armills], [@mjg59], [@Giannie], [@n8henrie], [@magicus], [@florianholzapfel], [@MrMep], [@bah2830], [@happyleavesaoc], [@lwis], [@glance-], [@markferry], and [@nikdoof].
 
 ### {% linkable_title Breaking Changes %}
@@ -85,6 +86,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [@balloob]: https://github.com/balloob
 [@brandonweeks]: https://github.com/brandonweeks
 [@btorresgil]: https://github.com/btorresgil
+[@colinodell]: https://github.com/colinodell
 [@Danielhiversen]: https://github.com/Danielhiversen
 [@danieljkemp]: https://github.com/danieljkemp
 [@danielperna84]: https://github.com/danielperna84


### PR DESCRIPTION
**Description:**

Prior to this release, some people may have extended the base Docker image to install `ffmpeg` or `libav` themselves. This is no longer necessary.  We should therefore alert these users to this change so they're not installing extra/conflicting packages.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5322
