### PR TITLE
Docs for Zengge bulbs

### DIFF
--- a/source/_components/light.zengge.markdown
+++ b/source/_components/light.zengge.markdown
@@ -1,30 +1,31 @@
 ---
 layout: page
-title: "Zengge"
-description: "Instructions how to integrate Zengge Bluetooth bulbs into Home Assistant."
-date: 2017-01-14 08:00
+title: "Zennge"
+description: "Instructions on how to setup Zengge Bluetooth LED bulbs within Home Assistant."
+date: 2017-01-15 10:46
 sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: zengge.png
 ha_category: Light
 ha_iot_class: "Local Polling"
+featured: false
 ha_release: 0.36
 ---
 
-The `zengge` platform allows you to integrate your [Zengge Bluetooth bulbs](http://www.zengge.com/) into Home Assistant.
+Support for the Bluetooth smart bulb from [Zengge](http://www.enledcontroller.com/), also sold under brands like Flux. If your bulb works with the Magic Light - BLE app, it should be supported by this component. To enable these lights, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 light:
   - platform: zengge
     devices:
-      C4:BE:84:51:54:8B:
-        name: Living Room
+      00:21:4D:00:00:01:
+        name: Bulb 1
+      00:22:4D:00:00:fe:
+        name: Bulb 2
 ```
+
 Configuration variables:
 
-- **devices** array (*Required*): List of your devices/bulbs.
-  - **MAC address** (*Required*): The MAC address of the bulb.
-    - **MAC address** (*Optional*): Friendly name for the frontend.
+- **devices**: A list of devices with their bluetooth address and a custom name to use in the frontend.


### PR DESCRIPTION
Add documentation for the Zengge Bluetooth bulb component

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5196

