### PR TITLE
provide detail for correct user in hassbian

### DIFF
--- a/source/getting-started/z-wave.markdown
+++ b/source/getting-started/z-wave.markdown
@@ -93,6 +93,9 @@ Or, on some other systems (such as Raspberry Pi), use:
 
 ```bash
 $ ls /dev/ttyACM*
+
+# If `hass` runs with another user (e.g. *homeassistant* on Hassbian) give access to the stick with:
+$ sudo usermod -a -G dialout homeassistant
 ```
 
 Or, on some other systems (such as Pine 64), use:


### PR DESCRIPTION
**Description:**
If installing openzwave with Hassbian the user needs to give the correct rights to access USB-Sticks.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

