### PR TITLE
Update systemd unit file for virtualenv

### DIFF
--- a/source/getting-started/autostart-systemd.markdown
+++ b/source/getting-started/autostart-systemd.markdown
@@ -45,7 +45,9 @@ After=network.target
 [Service]
 Type=simple
 User=homeassistant
-ExecStartPre=source /srv/homeassistant/homeassistant_venv/bin/activate
+#make sure the virtualenv python binary is used
+Environment=VIRTUAL_ENV="/srv/homeassistant/homeassistant_venv"
+Environment=PATH="$VIRTUAL_ENV/bin:$PATH"
 ExecStart=/srv/homeassistant/homeassistant_venv/bin/hass -c "/home/homeassistant/.homeassistant"
 
 [Install]


### PR DESCRIPTION
**Description:**
The current systemd unit file will provoke an error because the 'ExecPre' line calls a shell built-in function and all systemd Execs need to use an absolute path. The proposed change sets the python environment using the provided 'Environment' calls as used by systemd.


