### PR TITLE
Fix volvooncall.markdown external website link

### DIFF
--- a/source/_components/device_tracker.volvooncall.markdown
+++ b/source/_components/device_tracker.volvooncall.markdown
@@ -13,7 +13,7 @@ ha_release: "0.30"
 ---
 
 
-The `volvooncall` platform offers presence detection by retrieving your car's information from the [Volvo On Call](http://www.volvocars.com/intl/own/owner-info/volvo-on-call#) cloud service.
+The `volvooncall` platform offers presence detection by retrieving your car's information from the [Volvo On Call](http://www.volvocars.com/intl/own/connectivity/volvo-on-call) cloud service.
 
 To use Volvo On Call in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
Volvo on call website is now found at: device_tracker.volvooncall.markdown

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

