### PR TITLE
All in One documentation - WinSCP section update

### DIFF
--- a/source/getting-started/installation-raspberry-pi-all-in-one.markdown
+++ b/source/getting-started/installation-raspberry-pi-all-in-one.markdown
@@ -109,4 +109,6 @@ The (**homeassistant**)user is added to the GPIO group as part of the install no
 
 ### {% linkable_title WinSCP %}
 
-If you are Windows users who is using [WinSCP](https://winscp.net/), please note that after running the installer, you will need to modify settings allowing you to "switch users" to edit your configuration files. The needed change within WinSCP is: **Environment** -> **SCP/Shell** -> **Shell** and set it to `sudo su -`.
+If you are Windows users who is using [WinSCP](https://winscp.net/), please note that after running the installer, you will need to modify settings allowing you to "switch users" to edit your configuration files. 
+
+First create a new session on WinSCP using Protocol **SCP** pointing to your Pi IP address and port 22 and then modify the needed setting by click on **Advanced...** -> **Environment** -> **SCP/Shell** -> **Shell** and selecting `sudo su -`.


### PR DESCRIPTION
Added some more verbiage as how to properly configure WinSCP to be able to access the folder structure under .homeassistant with the ability to edit the config files using WinSCP. It took me a bit to find that SCP protocol needed to be selected when creating a new session, so I edited the last paragraph to add that requirement and make it easier for first time installers.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

