### PR TITLE
Updating development environment setup guide

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -28,15 +28,64 @@ recorder:
 Configuration variables:
 
 - **purge_days** (*Optional*): Delete events and states older than x days.
+- **exclude** (*Optional*): Configure which components should be excluded from recordings.
+  - **entities** (*Optional*): The list of entity ids to be excluded from recordings.
+  - **domains** (*Optional*): The list of domains to be excluded from recordings.
+- **include** (*Optional*): Configure which components should be included in recordings. If set, all other entities will not be recorded.
+  - **entities** (*Optional*): The list of entity ids to be included from the history.
+  - **domains** (*Optional*): The list of domains to be included from the history.
 - **db_url** (*Optional*): The URL which point to your database. 
 
 
+Define domains and entities to `exclude` (aka. blacklist). This is convenient when you are basically happy with the information recorded, but just want to remove some entities or domains. Usually these are entities/domains which do not change (like `weblink`) or rarely change (`updater` or `automation`).
+
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry with exclude
 recorder:
   purge_days: 5
   db_url: sqlite:///home/user/.homeassistant/test
+  exclude:
+    domains:
+      - automation
+      - weblink
+      - updater
+    entities:
+      - sun.sun   # Don't record sun data
+      - sensor.last_boot
+      - sensor.date
 ```
+
+Define domains and entities to record by using the `include` configuration (aka. whitelist). If you have a lot of entities in your system and your `exclude` lists possibly get very large, it might be better just to define the entities or domains to record.
+
+```yaml
+# Example configuration.yaml entry with include
+history:
+  include:
+    domains:
+      - sensor
+      - switch
+      - media_player
+```
+
+Use the `include` list to define the domains/entities to record, and exclude some of them with in the `exclude` list. This makes sense if you for instance include the `sensor` domain, but want to exclude some specific sensors. Instead of adding every sensor entity to the `include` `entities` list just include the `sensor` domain and exclude the sensor entities you are not interested in.
+
+```yaml
+# Example configuration.yaml entry with include and exclude
+history:
+  include:
+    domains:
+      - sensor
+      - switch
+      - media_player
+  exclude:
+    entities:
+     - sensor.last_boot
+     - sensor.date
+```
+
+If you only want to hide events from e.g. your history, take a look at the [`history` component](/components/history/). Same goes for logbook. But if you have privacy concerns about certain events or neither want them in history or logbook, you should use the `exclude`/`include` options of the `recorder` component, that they aren't even in your database. That way you can save storage and keep the database small by excluding certain often-logged events (like `sensor.last_boot`).
+
+## Custom database engines
 
 | Database engine | `db_url`                                                 | 
 | :---------------|:---------------------------------------------------------|

--- a/source/developers/development_environment.markdown
+++ b/source/developers/development_environment.markdown
@@ -62,7 +62,7 @@ $ script/setup
 
 * On Windows, you can use `python setup.py develop` instead of the setup script.
 
-* Run `hass` to invoke your local installation of the backend server or `hass --open-ui` to start the server and serve the web interface on http://localhost:8123
+* Run `hass` to invoke your local installation.
 
 ### {% linkable_title Logging %}
 

--- a/source/developers/development_environment.markdown
+++ b/source/developers/development_environment.markdown
@@ -33,12 +33,7 @@ $ sudo apt-get install python3-pip python3-dev libssl-dev
 Different distributions have different package installation mechanisms and sometimes packages names as well. For example Centos would use: `sudo yum install epel-release python34 python34-devel mysql-devel`
 </p>
 
-#### {% linkable_title Frontend dependencies (optional) %} 
-
-In order to run or develop the [Frontend](https://home-assistant.io/developers/frontend/) you will need node.js. The preferred method of installing node is [nvm](https://github.com/creationix/nvm). Install nvm using the instructions in the [README](https://github.com/creationix/nvm#install-script), and install node.js by running the following command:
-```bash
-$ nvm install node
-```
+Additional dependencies exist if you you plan to perform Frontend Development, please read the [Frontend](https://home-assistant.io/developers/frontend/) section to learn more.
 
 #### {% linkable_title Setting up virtual environment (optional) %} 
 

--- a/source/developers/development_environment.markdown
+++ b/source/developers/development_environment.markdown
@@ -29,6 +29,9 @@ Install the core dependencies.
 ```bash
 $ sudo apt-get install python3-pip python3-dev libssl-dev
 ```
+<p class='note'>
+Different distributions have different package installation mechanisms and sometimes packages names as well. For example Centos would use: `sudo yum install epel-release python34 python34-devel mysql-devel`
+</p>
 
 #### {% linkable_title Frontend dependencies (optional) %} 
 
@@ -51,7 +54,7 @@ $ source venv/bin/activate
 
 ### {% linkable_title Setup and Run %}
 
-* On Mac OS X and Linux 
+* On Mac OS X and Linux (remember to activate your virtual environment before running setup, if you are using one):
 ```bash
 $ cd home-assistant
 $ script/setup

--- a/source/developers/development_environment.markdown
+++ b/source/developers/development_environment.markdown
@@ -42,13 +42,18 @@ $ nvm install node
 
 #### {% linkable_title Setting up virtual environment (optional) %} 
 
-If you plan on providing isolation to your environment using [`venv`](https://docs.python.org/3.4/library/venv.html). You'll need to install the python3-venv package:
+If you plan on providing isolation to your environment using [`venv`](https://docs.python.org/3.4/library/venv.html). Within the `home-assistant` directory, create and activate your virtual environment.
+
+If using Python < 3.6 `pyvenv` is the recommended method of setting up virtual environments, you'll need to install the `python3-venv` package.
 ```bash
 $ sudo apt-get install python3-venv
-```
-Within the `home-assistant` directory, create and activate your virtual environment using the commands:
-```bash
 $ pyvenv venv
+$ source venv/bin/activate
+```
+
+If using Python 3.6 `pyvenv` has been deprecated:
+```bash
+$ python3 -m venv venv
 $ source venv/bin/activate
 ```
 

--- a/source/developers/development_environment.markdown
+++ b/source/developers/development_environment.markdown
@@ -30,7 +30,7 @@ Install the core dependencies.
 $ sudo apt-get install python3-pip python3-dev libssl-dev
 ```
 <p class='note'>
-Different distributions have different package installation mechanisms and sometimes packages names as well. For example Centos would use: `sudo yum install epel-release python34 python34-devel mysql-devel`
+Different distributions have different package installation mechanisms and sometimes packages names as well. For example Centos would use: `sudo yum install epel-release && sudo yum install python34 python34-devel mysql-devel`
 </p>
 
 Additional dependencies exist if you you plan to perform Frontend Development, please read the [Frontend](https://home-assistant.io/developers/frontend/) section to learn more.


### PR DESCRIPTION
**Description:**
Added more complete instructions for setting up a development environment for Home Assistant. Including details of dependencies, setting up venv. This is based on notes captured from setting up a dedicated hass dev environment on Debian 8.6.0

