### PR TITLE
input_boolean supports 'input_boolean.toggle' as well.

### DIFF
--- a/source/_components/input_boolean.markdown
+++ b/source/_components/input_boolean.markdown
@@ -51,7 +51,7 @@ automation:
       message: "Honey, I'm home!"
 ```
 
-You can also set or change the status of an `input_boolean` by using `input_boolean.turn_on` and `input_boolean.turn_off` in your automations.
+You can also set or change the status of an `input_boolean` by using `input_boolean.turn_on`, `input_boolean.turn_off` or `input_boolean.toggle` in your automations.
 
 ```yaml
     - service: input_boolean.turn_on


### PR DESCRIPTION
**Description:**
`input_boolean` supports `input_boolean.toggle` as well since the related pull request from last September.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#3432
