### PR TITLE
Add note about emulated_hue on port 80 as non-root

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -103,6 +103,11 @@ You can verify that the `emulated_hue` component has been loaded and is respondi
  - `http://<HA IP Address>:8300/description.xml` - This URL should return a descriptor file in the form of an XML file.
  - `http://<HA IP Address>:8300/api/pi/lights` - This will return a list of devices, lights, scenes, groups, etc.. that `emulated_hue` is exposing to Alexa.
 
+An additional step is required to run Home Assistant as non-root user and use port 80 when using the AiO script.  Execute the following command to allow `emulated_hue` to use port 80 as non-root user.
+
+```bash
+sudo setcap 'cap_net_bind_service=+ep' /srv/homeassistant/homeassistant_venv/bin/python3
+```
 
 ### {% linkable_title License %}
 


### PR DESCRIPTION
Added a note to the troubleshooting section showing hot to setup emulated_hue on port 80 when running as a non-root user.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

