### PR TITLE
Update history.markdown

### DIFF
--- a/source/_components/history.markdown
+++ b/source/_components/history.markdown
@@ -13,7 +13,7 @@ ha_release: pre 0.7
 ---
 
 
-The `history` component will track everything that is going on within Home Assistant and allows the user to browse through it. It depends on the `recorder` component for storing the data. This means that if the `recorder` component is set up to use e.g. mySQL as data store, the `history` component does not use the default SQLite database to store data.
+The `history` component will track everything that is going on within Home Assistant and allows the user to browse through it. It depends on the `recorder` component for storing the data and uses the same database setting. If any entities are excluded from being recorded, no history will be available for these entities as well.
 
 To enable the history option in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/history.markdown
+++ b/source/_components/history.markdown
@@ -13,7 +13,7 @@ ha_release: pre 0.7
 ---
 
 
-The `history` component will track everything that is going on within Home Assistant and allows the user to browse through it.
+The `history` component will track everything that is going on within Home Assistant and allows the user to browse through it. It depends on the `recorder` component for storing the data. This means that if the `recorder` component is set up to use e.g. mySQL as data store, the `history` component does not use the default SQLite database to store data.
 
 To enable the history option in your installation, add the following to your `configuration.yaml` file:
 
@@ -89,7 +89,7 @@ history:
 
 #### {% linkable_title Implementation details %}
 
-The history is stored in a SQLite database `home-assistant_v2.db` within your configuration directory.
+The history is stored in a SQLite database `home-assistant_v2.db` within your configuration directory if the `recorder` component is not set up differently.
 
  - events table is all events except `time_changed` that happened while recorder component was running.
  - states table contains all the `new_state` values of `state_changed` events.


### PR DESCRIPTION
Elaborated the fact that the "recorder" component storage settings have an effect on the "history" component. It was unclear to me before. See https://community.home-assistant.io/t/history-with-mysql/10027 for details.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

