### PR TITLE
Include ignore_cec in cast documentation

### DIFF
--- a/source/_components/media_player.cast.markdown
+++ b/source/_components/media_player.cast.markdown
@@ -28,3 +28,4 @@ media_player:
 Configuration variables:
 
 - **host** (*Optional*): Use only if you don't want to scan for devices.
+- **ignore_cec** (*Optional*) A list of chromecasts that should ignore CEC data for determining the active input. [See the upstream documentation for more information.](https://github.com/balloob/pychromecast#ignoring-cec-data)


### PR DESCRIPTION
**Description:**
This was never added to the documentation.