### PR TITLE
Added fritzbox_netmonitor documentation

### DIFF
--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -34,7 +34,7 @@ Configuration variables:
 
 The following statistics will be exposed as attributes.
 
-|attribute         |description                                                  |
+|Attribute         |Description                                                  |
 |:-----------------|:------------------------------------------------------------|
 |is_linked         |True if the FritzBox is physically linked to the provider    |
 |is_connected      |True if the FritzBox has established an internet-connection  |

--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -31,3 +31,19 @@ sensor:
 Configuration variables:
 
 - **host** (*Optional*): The IP address of your router, eg. 192.168.1.1. It is optional since every fritzbox is also reachable by using the IP address 169.254.1.1.
+
+The following statistics will be exposed as attributes.
+
+|attribute         |description                                                  |
+|:-----------------|:------------------------------------------------------------|
+|is_linked         |True if the FritzBox is physically linked to the provider    |
+|is_connected      |True if the FritzBox has established an internet-connection  |
+|wan_access_type   |Connection-type, can be `DSL` or `Cable`                     |
+|external_ip       |External ip address                                          |
+|uptime            |Uptime in seconds                                            |
+|bytes_sent        |Bytes sent                                                   |
+|bytes_received    |Bytes received                                               |
+|max_byte_rate_up  |Maximum upstream-rate in bytes/s                             |
+|max_byte_rate_down|Maximum downstream-rate in bytes/s                           |
+
+The sensor's state corresponds to the `is_linked` attribute and is either `online`, `offline`, or `unavailable` (in case connection to the router is lost).

--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -1,0 +1,48 @@
+---
+layout: page
+title: "FRITZ!Box"
+description: "Instructions how to integrate an AVM FRITZ!Box monitor into Home Assistant."
+date: 2017-01-17 22:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: avm.png
+ha_category: System Monitor
+ha_release: 0.36
+ha_iot_class: "Local Polling"
+---
+
+
+The `fritzbox_netmonitor` sensor monitors the network statistics exposed by [AVM Fritz!Box](http://avm.de/produkte/fritzbox/) routers.
+
+<p class='note warning'>
+It might be necessary to install additional packages: <code>$ sudo apt-get install libxslt-dev libxml2-dev python3-lxml</code>
+If you are working with the All-in-One installation, you may also need to execute also within your virtual environment the command <code> pip install lxml</code>; be patient this will take a while.</p>
+
+To use the Fritz!Box network monitor in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: fritzbox_netmonitor
+    host: 192.168.1.1
+    resources:
+      - type: is_linked
+      - type: is_connected
+      - type: wan_access_type
+      - type: external_ip
+      - type: uptime
+      - type: bytes_sent
+      - type: bytes_received
+      - type: transmission_rate_up
+      - type: transmission_rate_down
+      - type: max_byte_rate_up
+      - type: max_byte_rate_down
+      - type: max_bit_rate_up
+      - type: max_bit_rate_down
+```
+
+Configuration variables:
+
+- **host** (*Optional*): The IP address of your router, eg. 192.168.1.1. It is optional since every fritzbox is also reachable by using the IP address 169.254.1.1.

--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -26,21 +26,6 @@ To use the Fritz!Box network monitor in your installation, add the following to 
 # Example configuration.yaml entry
 sensor:
   - platform: fritzbox_netmonitor
-    host: 192.168.1.1
-    resources:
-      - type: is_linked
-      - type: is_connected
-      - type: wan_access_type
-      - type: external_ip
-      - type: uptime
-      - type: bytes_sent
-      - type: bytes_received
-      - type: transmission_rate_up
-      - type: transmission_rate_down
-      - type: max_byte_rate_up
-      - type: max_byte_rate_down
-      - type: max_bit_rate_up
-      - type: max_bit_rate_down
 ```
 
 Configuration variables:


### PR DESCRIPTION
**Description:**
Documentation for new system-monitor sensor that provides various network related statistics of AVM Fritz!Box routers.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5469

