### PR TITLE
Added supportability matrix link from the github page of python-amcrest project

### DIFF
--- a/source/_components/camera.amcrest.markdown
+++ b/source/_components/camera.amcrest.markdown
@@ -36,3 +36,5 @@ Configuration variables:
 - **stream_source** (*Optional*): The data source for the live stream. `mjpeg` will use the camera's native MJPEG stream, whereas `snapshot` will use the camera's snapshot API to create a stream from still images. If omitted, it defaults to *mjpeg*.
 
 **Note:** Amcrest cameras with newer firmwares no longer have the ability to stream `high` definition video with MJPEG encoding. You may need to use `low` resolution stream or the `snapshot` stream source instead.  If the quality seems too poor, lower the `Frame Rate (FPS)` and max out the `Bit Rate` settings in your camera's configuration manager.
+
+To check if your Amcrest camera is supported/tested, visit the [supportability matrix](https://github.com/tchellomello/python-amcrest#supportability-matrix) link from the `python-amcrest` project.

--- a/source/_components/sensor.amcrest.markdown
+++ b/source/_components/sensor.amcrest.markdown
@@ -41,3 +41,5 @@ Configuration variables:
   - **motion_detector**: Return True/False when a motion is detected
   - **sdcard**: Return the SD card usage by reporting the total and used space
   - **ptz_preset**: Return the number of PTZ preset positions configured for the given camera
+
+To check if your Amcrest camera is supported/tested, visit the [supportability matrix](https://github.com/tchellomello/python-amcrest#supportability-matrix) link from the `python-amcrest` project.


### PR DESCRIPTION
**Description:**

Added supportability matrix link from the github page of python-amcrest project .

Should be a quick reference to users to identify if their camera model as been tested on the backend python module `amcrest`.



