### PR TITLE
media_player.kodi: add ssl option

### DIFF
--- a/source/_components/media_player.kodi.markdown
+++ b/source/_components/media_player.kodi.markdown
@@ -31,6 +31,7 @@ Configuration variables:
 - **host** (*Required*): The host name or address of the device that is running XBMC/Kodi
 - **port** (*Optional*): The http port number. Defaults to 8080.
 - **name** (*Optional*): The name of the device used in the frontend.
+- **ssl** (*Optional*): Connect to kodi with HTTPS. Defaults to false
 - **username** (*Optional*): The XBMC/Kodi HTTP username.
 - **password** (*Optional*): The XBMC/Kodi HTTP password.
 - **turn_off_action** (*Optional*): The desired turn off action. Options are `none`, `quit`, `hibernate`, `suspend`, `reboot`, or `shutdown`. Default `none`.


### PR DESCRIPTION
**Description:**
Add SSL option to support https for kodi as a media player.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5531

