### PR TITLE
Revert "correct value_template format for command_state"

### DIFF
--- a/source/_components/switch.command_line.markdown
+++ b/source/_components/switch.command_line.markdown
@@ -59,7 +59,7 @@ switch:
       command_on: "/usr/bin/curl -X GET http://192.168.1.10/digital/4/1"
       command_off: "/usr/bin/curl -X GET http://192.168.1.10/digital/4/0"
       command_state: "/usr/bin/curl -X GET http://192.168.1.10/digital/4"
-      value_template: '{% raw %}{{ value == "1" }}{% endraw %}'
+      value_template: '{% raw %}{{ return_value == "1" }}{% endraw %}'
       friendly_name: Kitchen Lightswitch
 ```
 


### PR DESCRIPTION
Reverts home-assistant/home-assistant.github.io#1868