### PR TITLE
Necessary quotation in Matrix room id or alias

### DIFF
--- a/source/_components/notify.matrix.markdown
+++ b/source/_components/notify.matrix.markdown
@@ -36,6 +36,6 @@ Configuration variables:
 - **default_room** (*Required*): The room all messages will be sent to, when no other target is given.
 - **verify_ssl** (*Optional*): Verify the homeservers certificate. Defaults to `true`.
 
-The target room has to be precreated, the room id can be obtained from the rooms settings dialog. Rooms by default have a canonical id of the form `!<randomid>:homeserver.tld`, but can also be allocated aliases like `#roomname:homeserver.tld`. The notifying account may need to be invited to the room, depending on the individual rooms policies.
+The target room has to be precreated, the room id can be obtained from the rooms settings dialog. Rooms by default have a canonical id of the form `"!<randomid>:homeserver.tld"`, but can also be allocated aliases like `"#roomname:homeserver.tld"`. Make sure to use quotes around the id or alias to escape special characters (`!`, and `#`) in YAML. The notifying account may need to be invited to the room, depending on the individual rooms policies.
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).

--- a/source/_components/notify.matrix.markdown
+++ b/source/_components/notify.matrix.markdown
@@ -36,6 +36,6 @@ Configuration variables:
 - **default_room** (*Required*): The room all messages will be sent to, when no other target is given.
 - **verify_ssl** (*Optional*): Verify the homeservers certificate. Defaults to `true`.
 
-The target room has to be precreated, the room id can be obtained from the rooms settings dialog. Rooms by default have a canonical id of the form `"!<randomid>:homeserver.tld"`, but can also be allocated aliases like `"#roomname:homeserver.tld"`. Make sure to use quotes around the id or alias to escape special characters (`!`, and `#`) in YAML. The notifying account may need to be invited to the room, depending on the individual rooms policies.
+The target room has to be precreated, the room id can be obtained from the rooms settings dialog. Rooms by default have a canonical id of the form `"!<randomid>:homeserver.tld"`, but can also be allocated aliases like `"#roomname:homeserver.tld"`. Make sure to use quotes around the room id or alias to escape special characters (`!`, and `#`) in YAML. The notifying account may need to be invited to the room, depending on the individual rooms policies.
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).


### PR DESCRIPTION
**Description:**

[YAML syntax](https://symfony.com/doc/current/components/yaml/yaml_format.html) suggests that strings containing `!` and `#` should be wrapped in single or double quotes. Otherwise it will be recognised as an inline comment.
