### PR TITLE
Added documentation for notify.twilio_call component

### DIFF
--- a/source/_components/notify.twilio_call.markdown
+++ b/source/_components/notify.twilio_call.markdown
@@ -1,0 +1,56 @@
+yout: page
+title: "Twilio Call"
+description: "Instructions how to add user notifications to Home Assistant."
+date: 2017-01-27 00:09
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: twilio.png
+ha_category: Notifications
+ha_release: "0.36.1"
+---
+
+The `twilio` notification platform enables sending notifications via Voice, powered by [Twilio](https://twilio.com).
+Passed message will be read by Text-To-Speech service.
+
+This component is just an adaptation from the Twilio SMS notification platform and won't exist without it.
+
+To use this notification platform in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+notify:
+  - name: NOTIFIER_NAME
+    platform: twilio_call
+    account_sid: ACCOUNT_SID_FROM_TWILIO
+    auth_token: AUTH_TOKEN_FROM_TWILIO
+    from_number: E164_PHONE_NUMBER
+```
+
+Configuration variables:
+
+- **account_sid** (*Required*): Your Twilio Account SID which can be found in your [console](https://www.twilio.com/console). It starts with the letters `AC`.
+- **auth_token** (*Required*): Your Twilio Account SID which can be found in your [console](https://www.twilio.com/console). It should be directly under where you found the `account_sid`.
+- **from_number** (*Required*): An [E.164](https://en.wikipedia.org/wiki/E.164) formatted phone number, like +14151234567. See [Twilio's guide to formatting phone numbers](https://www.twilio.com/help/faq/phone-numbers/how-do-i-format-phone-numbers-to-work-internationally) for more information.
+- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+
+### {% linkable_title Usage %}
+
+Twilio is a notify platform and thus can be controlled by calling the notify service [as described here](/components/notify/). It will send a notification to all E.164 phone numbers in the notification **target**. See the notes above regarding the `from_number` configuration variable for information about formatting phone numbers.
+
+```yaml
+# Example automation notification entry
+automation:
+  - alias: The sun has set
+    trigger:
+      platform: sun
+      event: sunset
+    action:
+      service: notify.twilio_sms
+      data:
+        message: 'The sun has set'
+        target:
+          - +14151234567
+          - +15105555555
+```

--- a/source/_components/notify.twilio_call.markdown
+++ b/source/_components/notify.twilio_call.markdown
@@ -19,7 +19,7 @@ This component is just an adaptation from the Twilio SMS notification platform a
 Free trial account is available at [Twilio](https://twilio.com) website providing free calls to verified phone numbers.
 Calls are limited to 10 minutes and will play a short trial message before your message runs.
 
-Upgraded accounts have no limitation.t
+Upgraded accounts have no limitation.
 
 To use this notification platform in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/notify.twilio_call.markdown
+++ b/source/_components/notify.twilio_call.markdown
@@ -19,7 +19,7 @@ This component is just an adaptation from the Twilio SMS notification platform a
 Free trial account is available at [Twilio](https://twilio.com) website providing free calls to verified phone numbers.
 Calls are limited to 10 minutes and will play a short trial message before your message runs.
 
-Upgraded accounts have no limitation.
+Upgraded accounts have no limitation.t
 
 To use this notification platform in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/notify.twilio_call.markdown
+++ b/source/_components/notify.twilio_call.markdown
@@ -8,7 +8,7 @@ sharing: true
 footer: true
 logo: twilio.png
 ha_category: Notifications
-ha_release: "0.36.1"
+ha_release: "0.37"
 ---
 
 The `twilio` notification platform enables sending notifications via Voice, powered by [Twilio](https://twilio.com).

--- a/source/_components/notify.twilio_call.markdown
+++ b/source/_components/notify.twilio_call.markdown
@@ -16,6 +16,11 @@ Passed message will be read by Text-To-Speech service.
 
 This component is just an adaptation from the Twilio SMS notification platform and won't exist without it.
 
+Free trial account is available at [Twilio](https://twilio.com) website providing free calls to verified phone numbers.
+Calls are limited to 10 minutes and will play a short trial message before your message runs.
+
+Upgraded accounts have no limitation.
+
 To use this notification platform in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
**Description:**
Documentation for the twilio notification platform enables sending notifications via Voice Phone Call, powered by Twilio (https://twilio.com). Passed message will be read by Text-To-Speech service provided by Twilio.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5580

