### PR TITLE
explain value extraction via template

### DIFF
--- a/source/_components/mqtt.markdown
+++ b/source/_components/mqtt.markdown
@@ -280,7 +280,7 @@ It is also possible to extract JSON values by using a value template:
 ```yaml
 switch:
   platform: mqtt
-  value_template: '{{ value_json.somekey[0].value }}'
+  value_template: '{% raw %}{{ value_json.somekey[0].value }}{% endraw %}'
 ```
 
 More information about the full JSONPath syntax can be found [here][JSONPath syntax].

--- a/source/_components/mqtt.markdown
+++ b/source/_components/mqtt.markdown
@@ -275,6 +275,13 @@ switch:
   platform: mqtt
   state_format: 'json:somekey[0].value'
 ```
+It is also possible to extract JSON values by using a value template:
+
+```yaml
+switch:
+  platform: mqtt
+  value_template: '{{ value_json.somekey[0].value }}'
+```
 
 More information about the full JSONPath syntax can be found [here][JSONPath syntax].
 


### PR DESCRIPTION
Getting values from a JSON variable via `state_format` did not work for me, but using `value_template` worked. I added some explanation on how to use it.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

