### PR TITLE
Update climate.markdown

### DIFF
--- a/source/_components/climate.markdown
+++ b/source/_components/climate.markdown
@@ -54,12 +54,17 @@ automation:
 
 ### {% linkable_title Service `climate.set_away_mode` %}
 
-Turn away mode on/off for climate device
+This service has been deprecated. Use `climate.set_hold_mode` instead.
+
+
+### {% linkable_title Service `climate.set_hold_mode` %}
+
+Set hold mode for climate device
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
-| `away_mode` | no | New value of away mode.
+| `hold_mode` | no | New value of hold mode.
 
 #### {% linkable_title Automation example  %}
 
@@ -69,10 +74,10 @@ automation:
     platform: time
     after: "07:15:00"
   action:
-    - service: climate.set_away_mode
+    - service: climate.set_hold_mode
       data:
         entity_id: climate.kitchen
-        away_mode: true
+        hold_mode: 'away'
 ```
 
 ### {% linkable_title Service `climate.set_temperature` %}


### PR DESCRIPTION
Add documentation for hold_mode.

**Description:**

Hold mode has been introduced to represent various modes that a climate device could hold the temperature. Examples (to be implemented in particular devices) are away mode, home mode, temperature hold, vacation hold. This feature subsumes away mode which has been deprecated. The documentation is updated accordingly.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5586

