### PR TITLE
Fix "cameras" hyperlink which was invalid markdown

### DIFF
--- a/source/_components/image_processing.markdown
+++ b/source/_components/image_processing.markdown
@@ -10,7 +10,7 @@ footer: true
 ha_release: 0.36
 ---
 
-Image processing enables Home Assistant to process images from [cameras][/components/#camera]. Only camera entities are supported as sources.
+Image processing enables Home Assistant to process images from [cameras](/components/#camera). Only camera entities are supported as sources.
 
 For interval control, use `scan_interval` in platform.
 


### PR DESCRIPTION
Simply documentation fix.
