### PR TITLE
Restore input_* states on startup

### DIFF
--- a/source/_components/input_boolean.markdown
+++ b/source/_components/input_boolean.markdown
@@ -19,6 +19,7 @@ input_boolean:
   notify_home:
     name: Notify when someone arrives home
     initial: off
+    restore: startup
     icon: mdi:car
 ```
 
@@ -27,6 +28,7 @@ Configuration variables:
 - **[alias]** (*Required*): Alias for the input.
 - **name** (*Optional*): Friendly name of the input.
 - **initial** (*Optional*): Initial value when Home Assistant starts.
+- **restore** (*Optional*): Restore last know state on startup (possible values: 'startup')
 - **icon** (*Optional*): Icon for entry.
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your input and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.

--- a/source/_components/input_select.markdown
+++ b/source/_components/input_select.markdown
@@ -25,6 +25,7 @@ input_select:
      - Paulus
      - Anne Therese
     initial: Anne Therese
+    restore: startup
     icon: mdi:panda
   living_room_preset:
     options:
@@ -39,6 +40,7 @@ Configuration variables:
 - **name** (*Optional*): Friendly name of the input.
 - **options** array: List of options to choose from
 - **initial** (*Optional*): Initial value when Home Assistant starts.
+- **restore** (*Optional*): Restore last know state on startup (possible values: 'startup')
 - **icon** (*Optional*): Icon for entry.
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your input and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.

--- a/source/_components/input_slider.markdown
+++ b/source/_components/input_slider.markdown
@@ -20,6 +20,7 @@ input_slider:
   slider1:
     name: Slider 1
     initial: 30
+    restore: startup
     min: -20
     max: 35
     step: 1
@@ -32,6 +33,7 @@ Configuration variables:
 - **max** (*Required*): Maximum value for the slider.
 - **name** (*Optional*): Friendly name of the slider input.
 - **initial** (*Optional*): Initial value when Home Assistant starts.
+- **restore** (*Optional*): Restore last know state on startup (possible values: 'startup')
 - **step** (*Optional*): Step value for the slider.
 
 ## {% linkable_title Automation Examples %}


### PR DESCRIPTION
**Description:**
This PR enables HASS to restore the last state of an input_boolean, an input_slider and an input_select on a restart.
This is pretty useful if you have e.g. input booleans or sliders for dynamic settings on your HASS.

See PR on main repository

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5622
