### PR TITLE
Better to use extra brackets in template

### DIFF
--- a/source/_topics/templating.markdown
+++ b/source/_topics/templating.markdown
@@ -123,7 +123,7 @@ Print out a list of all the sensor states.
 
 {{ states.sensor.temperature | float + 1 }}
 
-{{ states.sensor.temperature | float * 10 | round(2) }}
+{{ (states.sensor.temperature | float * 10) | round(2) }}
 
 {% if states('sensor.temperature') | float > 20 %}
   It is warm!


### PR DESCRIPTION
Current explanation is unclear. Had a problem when trying to convert pressure in mb to pressure in mm according to example: {{ states.sensor.pws_pressure_mb.state | float * 0.720064 | round(0) }}. Problem gone after correction of template to: {{ ( states.sensor.pws_pressure_mb.state | float * 0.720064 ) | round(0) }}

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

