### PR TITLE
Add dependency libsqlite3-dev as bundle command fails without it.

### DIFF
--- a/source/_ecosystem/hadashboard/installation.markdown
+++ b/source/_ecosystem/hadashboard/installation.markdown
@@ -109,6 +109,7 @@ Note: Prereqs will vary across different machines. So far users have reported re
 
 - ruby-dev - `sudo apt-get install ruby-dev`
 - node-js - `sudo apt-get install nodejs`
+- libsqlite3-dev - `sudo apt-get install libsqlite3-dev`
 - execjs gem - `gem install execjs`
 
 You will need to research what works on your particular architecture and also bear in mind that version numbers may change over time.


### PR DESCRIPTION
**Description:**

Add dependency libsqlite3-dev as bundle command fails without it.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

