### PR TITLE
Update installation-virtualenv.markdown

### DIFF
--- a/source/getting-started/installation-virtualenv.markdown
+++ b/source/getting-started/installation-virtualenv.markdown
@@ -19,8 +19,8 @@ Virtualenvs are pretty easy to setup. This example will walk through one method 
 $ sudo apt-get update
 $ sudo apt-get upgrade
 $ sudo apt-get install python-pip python3-dev
-$ sudo pip install --upgrade virtualenv
-```
+$ sudo pip3 install virtualenv
+$ sudo pip install --upgrade virtualenv```
 
 ### {% linkable_title Step 1: Create a Home Assistant user %}
 


### PR DESCRIPTION
I am using raspbian lite (debian) on a raspberry pi 3b, and in order to use the $ virtualenv -p python3 /srv/homeassistant command, i first had to install virtualenv as the normal user.  after that, this guide worked perfectly for installing home assistant and the open z-wave plugin.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

