### PR TITLE
proposed change for issue #1939

### DIFF
--- a/source/_components/hdmi_cec.markdown
+++ b/source/_components/hdmi_cec.markdown
@@ -30,13 +30,13 @@ The computer running Home Assistant must support CEC, and of course be connected
 Create a symlink to the `cec` installation.
  
 ```bash
-$ ln -s /usr/local/lib/python3.4/dist-packages/cec /path/to/your/venv/lib/python3.4/site-packages
+$ ln -s /usr/local/lib/python3.4/site-packages/cec /path/to/your/venv/lib/python3.4/site-packages
 ```
 
 For the default virtual environment of a [Raspberry Pi All-In-One installation](/getting-started/installation-raspberry-pi-all-in-one/) the command would be as follows.
 
 ```bash
-$ ln -s /usr/local/lib/python3.4/dist-packages/cec /srv/hass/hass_venv/lib/python3.4/site-packages
+$ ln -s /usr/local/lib/python3.4/site-packages/cec /srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages
 ```
 
 <p class='note'>If after symlinking and adding `hdmi_cec:` to your configuration you are getting the following error in your logs, 

--- a/source/_components/hdmi_cec.markdown
+++ b/source/_components/hdmi_cec.markdown
@@ -27,10 +27,17 @@ The computer running Home Assistant must support CEC, and of course be connected
 
 #### {% linkable_title Symlinking into virtual environment %}
 
-Create a symlink to the `cec` installation.
+Create a symlink to the `cec` installation. Keep in mind different installation methods will result in different locations of cec.
  
 ```bash
-$ ln -s /usr/local/lib/python3.4/site-packages/cec /path/to/your/venv/lib/python3.4/site-packages
+$ ln -s /path/to/your/installation/of/cec /path/to/your/venv/lib/python3.4/site-packages
+```
+##### {% linkable_title Symlinking examples: %}
+
+For the default virtual environment of a [HASSbian Image for Raspberry Pi](/getting-started/installation-raspberry-pi-image/) the command would be as follows.
+
+```bash
+$ ln -s /usr/local/lib/python3.4/dist-packages/cec /srv/homeassistant/lib/python3.4/site-packages
 ```
 
 For the default virtual environment of a [Raspberry Pi All-In-One installation](/getting-started/installation-raspberry-pi-all-in-one/) the command would be as follows.


### PR DESCRIPTION
changed link target to point to correct location of libcec in system site-packages
included latest default location for the virtual env in a Raspberry Pi All-In-One installation

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

