### PR TITLE
Corrected grammar / removed additional 'the'

### DIFF
--- a/source/_cookbook/automation_flashing_lights.markdown
+++ b/source/_cookbook/automation_flashing_lights.markdown
@@ -12,7 +12,7 @@ ha_category: Automation Examples
 
 #### {% linkable_title Flashing lights triggered by an alarm %}
 
-For flashing regular lights in case the the triggering of an alarm.
+For flashing regular lights in case an alarm is triggered.
 
 ```yaml
 # AlmAct1 - switch to activate the alarm in Room1


### PR DESCRIPTION
Corrected spelling mistake in instruction text.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

