### PR TITLE
ELTA platform

### DIFF
--- a/source/_components/sensor.elta.markdown
+++ b/source/_components/sensor.elta.markdown
@@ -19,8 +19,7 @@ To enable this sensor, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: Elta
+c_Elta:
     code: YOUR_TRACKING_CODE
 ```
 

--- a/source/_components/sensor.elta.markdown
+++ b/source/_components/sensor.elta.markdown
@@ -1,31 +1,30 @@
 ---
 layout: page
-title: USPS Sensor
-description: "Instructions on how to set up USPS sensors within Home Assistant."
-date: 2017-01-06 08:00
+title: ELTA Sensor
+description: "Instructions on how to set up Elta sensors within Home Assistant."
+date: 2017-02-05 08:00
 sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: usps.png
+logo: http://www.elta.gr/Portals/0/elta.jpg
 ha_category: Sensor
 ha_release: 0.36
 ---
 
-The `usps` platform allows one to track deliveries by the [US Postal Service (USPS)](https://www.usps.com/).
-In addition to having a USPS account, you will need to complete the "Opt-In" process by clicking "Get Started Now" on [this page](https://my.usps.com/mobileWeb/pages/intro/start.action). Currently, you also will need to have a package listed in the "Package Dashboard" in order for the component to complete set-up.
+The `elta` platform allows one to track deliveries by the [Hellenic Postal Service (ELTA)](https://www.elta.gr/en-us/home.aspx).
+TO ADD @@@@@@@@@@@.
 
 To enable this sensor, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
 sensor:
-  - platform: usps
-    username: YOUR_USERNAME
-    password: YOUR_PASSWORD
+  - platform: Elta
+    code: YOUR_TRACKING_CODE
 ```
 
-Configuration options for the USPS Sensor:
+TO BE EDITED @@@@Configuration options for the ELTA Sensor:
 
 - **username** (*Required*): The username to access the MyUSPS service.
 - **password** (*Required*): The password for the given username.
@@ -44,5 +43,5 @@ Configuration options for the USPS Sensor:
     </pre>
 
 <p class='note warning'>
-The USPS sensor logs into the MyUSPS website to scrape package data. It does not use an API.
+The ELTA sensor is in BETA and currently only show tracking from ELTA.
 </p>

--- a/source/_components/sensor.elta.markdown
+++ b/source/_components/sensor.elta.markdown
@@ -28,12 +28,21 @@ Configuration options for the ELTA Sensor:
 
 - **code** (*Required*): The tracking code of the pacage.
 
+The ELTA platform will only accept tracking code in the below format.
+Two letters followed by nine numbers and ending with two letters (total thirteen characters).
 
 ELTA Hellenic Post number rules :  ( # Letter, * Digit, ! Letter Or Digit )
   ( R# *** *** *** GR )   ( V# *** *** *** GR )
   ( A# *** *** *** GR )   ( C# *** *** *** GR )
   ( E# *** *** *** GR )   ( L# *** *** *** GR )
   ( N# *** *** *** GR )   ( I# *** *** *** GR )
+
+Troubleshooting:
+The tracking number has to end in “GR” or have destination country Greece.
+
+If the tracking code does not meet the above format, there will be log entry in this format.
+Invalid key YOUR_TRACKING_CODE . Key must be 13 characters.
+
 
 <p class='note warning'>
 The ELTA sensor is in BETA and currently only show tracking from ELTA.

--- a/source/_components/sensor.elta.markdown
+++ b/source/_components/sensor.elta.markdown
@@ -9,10 +9,10 @@ sharing: true
 footer: true
 logo: http://www.elta.gr/Portals/0/elta.jpg
 ha_category: Sensor
-ha_release: 0.36
+ha_release: 0.39
 ---
 
-The `elta` platform allows one to track deliveries by the [Hellenic Postal Service (ELTA)](https://www.elta.gr/en-us/home.aspx).
+The `elta` platform allows you to track deliveries by the [Hellenic Postal Service (ELTA)](https://www.elta.gr/en-us/home.aspx).
 Track ELTA Hellenic Post Packages on your dashboard get Origin (limited)/destinations(full) tracking information
 
 To enable this sensor, add the following lines to your `configuration.yaml`:

--- a/source/_components/sensor.elta.markdown
+++ b/source/_components/sensor.elta.markdown
@@ -13,7 +13,7 @@ ha_release: 0.36
 ---
 
 The `elta` platform allows one to track deliveries by the [Hellenic Postal Service (ELTA)](https://www.elta.gr/en-us/home.aspx).
-TO ADD @@@@@@@@@@@.
+Track ELTA Hellenic Post Packages on your dashboard get Origin (limited)/destinations(full) tracking information
 
 To enable this sensor, add the following lines to your `configuration.yaml`:
 
@@ -24,23 +24,16 @@ sensor:
     code: YOUR_TRACKING_CODE
 ```
 
-TO BE EDITED @@@@Configuration options for the ELTA Sensor:
+Configuration options for the ELTA Sensor:
 
-- **username** (*Required*): The username to access the MyUSPS service.
-- **password** (*Required*): The password for the given username.
-- **name** (*Optional*): Name the sensor (default: your mailing address).
-- **update_inverval** (*Optional*): Minimum time interval between updates. Default is 1 hour. Supported formats:
-  - `update_interval: 'HH:MM:SS'`
-  - `update_interval: 'HH:MM'`
-  - Time period dictionary, e.g.:
-    <pre>update_interval:
-        # At least one of these must be specified:
-        days: 0
-        hours: 0
-        minutes: 3
-        seconds: 30
-        milliseconds: 0
-    </pre>
+- **code** (*Required*): The tracking code of the pacage.
+
+
+ELTA Hellenic Post number rules :  ( # Letter, * Digit, ! Letter Or Digit )
+  ( R# *** *** *** GR )   ( V# *** *** *** GR )
+  ( A# *** *** *** GR )   ( C# *** *** *** GR )
+  ( E# *** *** *** GR )   ( L# *** *** *** GR )
+  ( N# *** *** *** GR )   ( I# *** *** *** GR )
 
 <p class='note warning'>
 The ELTA sensor is in BETA and currently only show tracking from ELTA.

--- a/source/_components/sensor.elta.markdown
+++ b/source/_components/sensor.elta.markdown
@@ -1,0 +1,48 @@
+---
+layout: page
+title: USPS Sensor
+description: "Instructions on how to set up USPS sensors within Home Assistant."
+date: 2017-01-06 08:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: usps.png
+ha_category: Sensor
+ha_release: 0.36
+---
+
+The `usps` platform allows one to track deliveries by the [US Postal Service (USPS)](https://www.usps.com/).
+In addition to having a USPS account, you will need to complete the "Opt-In" process by clicking "Get Started Now" on [this page](https://my.usps.com/mobileWeb/pages/intro/start.action). Currently, you also will need to have a package listed in the "Package Dashboard" in order for the component to complete set-up.
+
+To enable this sensor, add the following lines to your `configuration.yaml`:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: usps
+    username: YOUR_USERNAME
+    password: YOUR_PASSWORD
+```
+
+Configuration options for the USPS Sensor:
+
+- **username** (*Required*): The username to access the MyUSPS service.
+- **password** (*Required*): The password for the given username.
+- **name** (*Optional*): Name the sensor (default: your mailing address).
+- **update_inverval** (*Optional*): Minimum time interval between updates. Default is 1 hour. Supported formats:
+  - `update_interval: 'HH:MM:SS'`
+  - `update_interval: 'HH:MM'`
+  - Time period dictionary, e.g.:
+    <pre>update_interval:
+        # At least one of these must be specified:
+        days: 0
+        hours: 0
+        minutes: 3
+        seconds: 30
+        milliseconds: 0
+    </pre>
+
+<p class='note warning'>
+The USPS sensor logs into the MyUSPS website to scrape package data. It does not use an API.
+</p>


### PR DESCRIPTION
Documentation for the ELTA postal tracking
 Allow tracking from the ELTA system .
like USPS service but for all the ELTA partners.
BETA files https://github.com/apo-mak/courier 

**Description:**
**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5888

