### PR TITLE
Fix typo in configuration variables for TP-Link Smart Switches

### DIFF
--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -33,7 +33,7 @@ switch:
 
 Configuration variables:
 
-- **host** (*Required*): The IP address of your myStrom switch, eg. `http://192.168.1.32`.
+- **host** (*Required*): The IP address of your TP-Link switch, eg. `http://192.168.1.32`.
 - **name** (*Optional*): The name to use when displaying this switch.
 
 


### PR DESCRIPTION
Page had indicated [MyStrom)(https://mystrom.ch/en/), however, this appears to be another smart switch option, not TP-Link as the page is about.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

