### PR TITLE
fix error in switch/turn_on example

### DIFF
--- a/source/developers/rest_api.markdown
+++ b/source/developers/rest_api.markdown
@@ -418,7 +418,7 @@ Sample `curl` command:
 ```bash
 $ curl -X POST -H "x-ha-access: YOUR_PASSWORD" \
        -H "Content-Type: application/json" \
-       -d '{"entity_id": "switch.christmas_lights", "state": "on"}' \
+       -d '{"entity_id": "switch.christmas_lights"}' \
        http://localhost:8123/api/services/switch/turn_on
 ```
 


### PR DESCRIPTION
Corrected CURL bash command ( thanks to David):

'$ curl -X POST -H "x-ha-access: YOUR_PASSWORD" \
       -H "Content-Type: application/json" \
       -d '{"entity_id": "switch.christmas_lights", "state": "on"}' \
       http://localhost:8123/api/services/switch/turn_on'

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

