### PR TITLE
Add in to and from

### DIFF
--- a/source/_cookbook/dim_lights_when_playing_media.markdown
+++ b/source/_cookbook/dim_lights_when_playing_media.markdown
@@ -56,6 +56,7 @@ automation:
       - platform: state
         entity_id: media_player.htpc
         from: 'playing'
+        to: 'idle'
     condition:
       - condition: state
         entity_id: sun.sun
@@ -69,6 +70,7 @@ automation:
       - platform: state
         entity_id: media_player.htpc
         to: 'playing'
+        from: 'idle'
     condition:
       - condition: state
         entity_id: sun.sun


### PR DESCRIPTION
I think due to the rapid changes/reporting of states, a clear delimiter is needed for examples.

