### PR TITLE
Fix markdown in WOL Switch

### DIFF
--- a/source/_components/switch.wake_on_lan.markdown
+++ b/source/_components/switch.wake_on_lan.markdown
@@ -51,6 +51,7 @@ from Home Assistant running on another Linux computer (the **server**).
 6. On the **target**, we need to let the hass user execute the program needed to suspend/shut down the target computer. I'm using `pm-suspend`, use `poweroff` to turn off the computer. First, get the full path: `which pm-suspend`. On my system, this is `/usr/sbin/pm-suspend`.
 7. On the **target**, using an account with sudo access (typically your main account), `sudo visudo`. Add this line last in the file: `hass ALL=NOPASSWD:/usr/sbin/pm-suspend`, where you replace `hass` with the name of your user on the target, if different, and `/usr/sbin/pm-suspend` with the command of your choice, if different.
 8. On the **server**, add the following to your configuration, replacing TARGET with the target's name:
+
 ```yaml
 switch:
   - platform: wake_on_lan


### PR DESCRIPTION
Currently the final code example is garbled on the home assistant website (but not github). I suspect it needs a line of whitespace before the code block.

