### PR TITLE
fix inconsistent virtual env location in guides

### DIFF
--- a/source/getting-started/autostart-systemd.markdown
+++ b/source/getting-started/autostart-systemd.markdown
@@ -35,7 +35,7 @@ WantedBy=multi-user.target
 EOF'
 ```
 
-If you've setup Home Assistant in `virtualenv` following our [manual installation guide](https://home-assistant.io/getting-started/installation-raspberry-pi/), the following template should work for you.
+If you've setup Home Assistant in `virtualenv` following our [python installation guide](https://home-assistant.io/getting-started/installation-virtualenv/) or [manual installation guide for raspberry pi](https://home-assistant.io/getting-started/installation-raspberry-pi/), the following template should work for you.
 
 ```
 [Unit]
@@ -46,9 +46,9 @@ After=network.target
 Type=simple
 User=homeassistant
 #make sure the virtualenv python binary is used
-Environment=VIRTUAL_ENV="/srv/homeassistant/homeassistant_venv"
+Environment=VIRTUAL_ENV="/srv/homeassistant"
 Environment=PATH="$VIRTUAL_ENV/bin:$PATH"
-ExecStart=/srv/homeassistant/homeassistant_venv/bin/hass -c "/home/homeassistant/.homeassistant"
+ExecStart=/srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
 
 [Install]
 WantedBy=multi-user.target

--- a/source/getting-started/installation-raspberry-pi.markdown
+++ b/source/getting-started/installation-raspberry-pi.markdown
@@ -12,7 +12,7 @@ footer: true
 This installation of Home Assistant requires the Raspberry Pi to run [Raspbian Lite](https://www.raspberrypi.org/downloads/raspbian/).
 The installation will be installed in a [Virtual Environment](/getting-started/installation-virtualenv) with minimal overhead. Instructions assume this is a new installation of Raspbian Lite.
 
-Connect to the Raspberry Pi over ssh. Default password is `raspberry`. 
+Connect to the Raspberry Pi over ssh. Default password is `raspberry`.
 You will need to enable ssh access. The raspberry pi website has instructions [here](https://www.raspberrypi.org/documentation/remote-access/ssh/).
 ```bash
 $ ssh pi@ipadress
@@ -51,17 +51,17 @@ Next up is to create and change to a virtual environment for Home Assistant. Thi
 ```bash
 $ sudo su -s /bin/bash homeassistant
 $ cd /srv/homeassistant
-$ python3 -m venv homeassistant_venv
-$ source /srv/homeassistant/homeassistant_venv/bin/activate
+$ python3 -m venv .
+$ source bin/activate
 ```
 Once you have activated the virtual environment you will notice the prompt change and then you can install Home Assistant.
 ```bash
-(homeassistant_venv) homeassistant@raspberrypi:/srv/homeassistant $ pip3 install homeassistant
+(homeassistant) homeassistant@raspberrypi:/srv/homeassistant $ pip3 install homeassistant
 ```
 
 Start Home Assistant for the first time. This will complete the installation, create the `.homeasssistant` configuration directory in the `/home/homeassistant` directory and install any basic dependencies.
 ```bash
-(homeassistant_venv) $ hass
+(homeassistant) $ hass
 ```
 
 You can now reach your installation on your raspberry pi over the web interface on [http://ipaddress:8123](http://ipaddress:8123).


### PR DESCRIPTION
**Description:**
Some small changes to align installation guides with consistent `virtualenv` location.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

