### PR TITLE
Update Tado device tracker documentation to include home_id

### DIFF
--- a/source/_components/device_tracker.tado.markdown
+++ b/source/_components/device_tracker.tado.markdown
@@ -32,7 +32,7 @@ Configuration variables:
 
 - **username** (*Required*): The username for your Tado account.
 - **password** (*Required*): The password for your Tado account.
-- **home_id** (*Required*): The id of your home of which you want to track devices. See below how to find it.
+- **home_id** (*Optional*): The id of your home of which you want to track devices. If provided, the Tado device tracker will tack *all* devices known to Tado associated with this home. See below how to find it.
 
 After configuration, your device has to be at home at least once before showing up as *home* or *away*.
 Polling Tado API for presence information will happen at most once every 30 seconds.

--- a/source/_components/device_tracker.tado.markdown
+++ b/source/_components/device_tracker.tado.markdown
@@ -15,6 +15,7 @@ ha_release: 0.37
 The `tado` device tracker is using the [Tado Smart Thermostat](https://www.tado.com/) and it's support for person presence detection based on smartphone location by geofencing.
 
 This tracker uses the Tado API to determine if a mobile device is at home.
+It tracks all devices in your home that Tado knows about.
 
 To use the Tado platform in your installation, add the following to your `configuration.yaml` file:
 
@@ -24,14 +25,27 @@ device_tracker:
   - platform: tado
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
+    home_id: YOUR_HOME_ID
 ```
 
 Configuration variables:
 
 - **username** (*Required*): The username for your Tado account.
 - **password** (*Required*): The password for your Tado account.
+- **home_id** (*Required*): The id of your home of which you want to track devices. See below how to find it.
 
-After configuration, your device has to be at home at least once before showing up as 'home' or 'away'.
-Polling Tado API for presence information will occure at most once every 30 seconds.
+After configuration, your device has to be at home at least once before showing up as *home* or *away*.
+Polling Tado API for presence information will happen at most once every 30 seconds.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.
+
+### {% linkable_title Finding your `home_id` %}
+Find your `home_id` by browsing to `https://my.tado.com/api/v2/me?username=YOUR_USERNAME&password=YOUR_PASSWORD`. There you'll see something like the following:
+
+```json
+{"name":"Mark","email":"your@email.tld","username":"your@email.tld",
+"homes":[{"id":12345,"name":"Home Sweet Home"}],"locale":"en_US",
+"mobileDevices":[]}
+```
+
+In this example `12345` is the `home_id` you'll need to configure.


### PR DESCRIPTION
**Description:**
The Tado device tracker only tracked devices that belonged to the primary Tado account. A PR on Home Assistant is proposed to change this to track all devices in a home.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5810

