### PR TITLE
Fix typo

### DIFF
--- a/source/_components/lock.nuki.markdown
+++ b/source/_components/lock.nuki.markdown
@@ -14,7 +14,7 @@ ha_release: 0.38
 ha_iot_class: "Local Polling"
 ---
 
-The `nuki` platform allows you to control [Nuki Smart Locks](https://nuki.io/en/smart-lock/) via either a [sofware bridge](https://play.google.com/store/apps/details?id=io.nuki.bridge) or a [physical bridge](https://nuki.io/en/bridge/).
+The `nuki` platform allows you to control [Nuki Smart Locks](https://nuki.io/en/smart-lock/) via either a [software bridge](https://play.google.com/store/apps/details?id=io.nuki.bridge) or a [physical bridge](https://nuki.io/en/bridge/).
 
 To add a Nuki bridge to your installation, you need to enable developper mode on your bridge and define a port and an access token. This can be achieved using the [Android app](https://play.google.com/store/apps/details?id=io.nuki). Please note that the API token should be 6-20 characters long, even though the app allows you to set a longer one.
 Then add the following to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**
There is a typo in `lock.nuki`. This fixes it.

TLDR: sofware -> sofTware
