### PR TITLE
value is needed instead of return_value

### DIFF
--- a/source/_components/switch.command_line.markdown
+++ b/source/_components/switch.command_line.markdown
@@ -59,7 +59,7 @@ switch:
       command_on: "/usr/bin/curl -X GET http://192.168.1.10/digital/4/1"
       command_off: "/usr/bin/curl -X GET http://192.168.1.10/digital/4/0"
       command_state: "/usr/bin/curl -X GET http://192.168.1.10/digital/4"
-      value_template: '{% raw %}{{ return_value == "1" }}{% endraw %}'
+      value_template: '{% raw %}{{ value == "1" }}{% endraw %}'
       friendly_name: Kitchen Lightswitch
 ```
 


### PR DESCRIPTION
**Description:**
The documentation is wrong. To use the returned value of the state command in the value_template you need to use `value` instead of `return_value`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

