### PR TITLE
Update sensor.rflink.markdown

### DIFF
--- a/source/_components/sensor.rflink.markdown
+++ b/source/_components/sensor.rflink.markdown
@@ -53,7 +53,7 @@ Configuration variables:
 Device configuration variables:
 
 - **name** (*Optional*): Name for the device, defaults to Rflink ID.
-- **sensor_type_** (*Optional*): Override automatically detected type of sensor.
+- **sensor_type** (*Required*): Override automatically detected type of sensor.
 - **unit_of_measurement** (*Optional*): Override automatically detected unit of sensor.
 - **aliasses** (*Optional*): Alternative Rflink ID's this device is known by.
 


### PR DESCRIPTION
According to the source code  of the rflink sensor component the value 'sensor_type' is required.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

