### PR TITLE
IP address without protocol, otherwise it errors

### DIFF
--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -33,7 +33,7 @@ switch:
 
 Configuration variables:
 
-- **host** (*Required*): The IP address of your TP-Link switch, eg. `http://192.168.1.32`.
+- **host** (*Required*): The IP address of your TP-Link switch, eg. `192.168.1.32`.
 - **name** (*Optional*): The name to use when displaying this switch.
 
 


### PR DESCRIPTION
This is the error if you provide http://IP_ADDRESS as the example shows.
```ERROR:homeassistant.components.switch:Error while setting up platform tplink
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/homeassistant/helpers/entity_component.py", line 151, in _async_setup_platform
    entity_platform.add_entities, discovery_info
  File "/usr/lib/python3.5/asyncio/futures.py", line 361, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.5/asyncio/tasks.py", line 296, in _wakeup
    future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.5/dist-packages/homeassistant/components/switch/tplink.py", line 40, in setup_platform
    add_devices([SmartPlugSwitch(SmartPlug(host), name)], True)
  File "/home/ged/.homeassistant/deps/pyHS100/pyHS100.py", line 78, in __init__
    socket.inet_pton(socket.AF_INET, ip_address)
OSError: illegal IP address string passed to inet_pton```

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

