### PR TITLE
Update climate.generic_thermostat.markdown

### DIFF
--- a/source/_components/climate.generic_thermostat.markdown
+++ b/source/_components/climate.generic_thermostat.markdown
@@ -35,8 +35,9 @@ Configuration variables:
 - **ac_mode** (*Optional*): Set the switch specified in the *heater* option to be treated as a cooling device instead of a heating device.
 - **min_cycle_duration** (*Optional*): Set a minimum amount of time that the switch specified in the *heater* option must be in it's current state prior to being switched either off or on.
 - **tolerance** (*Optional*): Set a minimum amount of difference between the temperature read by the sensor specified in the *target_sensor* option and the target temperature that must change prior to being switched either off or on. For example, if the target temperature is 25 and the tolerance is 0.5 the heater will start when the sensor goes below 24.5 and it will stop when the sensor goes above 25.5.
+- **keep_alive** (*Optional*): Set a keep-alive interval. If set, the switch specified in the *heater* option will be  triggered every time the interval elapses. Use with heaters and A/C units that shut off if they don't receive a signal from their remote for a while.
 
-A full configuration example looks like the one below. `min_cycle_duration` must contains at least one of the following entries: `days:`, `hours:`, `minutes:`, `seconds:` or `milliseconds:`.
+A full configuration example looks like the one below. `min_cycle_duration` and `keep_alive` must contain at least one of the following entries: `days:`, `hours:`, `minutes:`, `seconds:` or `milliseconds:`.
 
 ```yaml
 # Full example configuration.yaml entry
@@ -51,4 +52,6 @@ climate:
     tolerance: 0.3
     min_cycle_duration:
       seconds: 5
+    keep_alive:
+      minutes: 3
 ```


### PR DESCRIPTION
Add explanation for the new `keep_alive` field of `generic_thermostat`.

**Description:**

My A/C unit depends on a thermostat residing inside the remote control to get updates on the current room temperature, as well as decide when to switch from heating/cooling to idle, and vice versa. I tried using generic_thermostat in order to control it, which worked fine. However, I noticed that the A/C unit stops working after a while, even if the desired temperature hasn't been reached (and no stop signals have been sent by Home Assistant). My assumption is that it has some sort of failsafe, turning off after a certain amount of time without temperature updates from the remote.

In order to try and resolve this issue, I came up with the keep-alive feature for generic_thermostat. This simple feature basically resends the turn on/turn off signal to the A/C unit to reiterate its state and prevent the unit shutting off prematurely.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#6040
