### PR TITLE
Update BloomSky conditions

### DIFF
--- a/source/_components/sensor.bloomsky.markdown
+++ b/source/_components/sensor.bloomsky.markdown
@@ -25,11 +25,9 @@ sensor:
   monitored_conditions:
     - Temperature
     - Humidity
-    - Rain
     - Pressure
     - UVIndex
     - Luminance
-    - Night
     - Voltage
 ```
 
@@ -38,9 +36,10 @@ Configuration variables:
 - **monitored_conditions** array (*Required*): The sensors that you wish to monitor on all of your devices. Select from these options:
   - Humidity
   - Luminance
-  - Night
   - Pressure
-  - Rain
   - Temperature
   - UVIndex
   - Voltage
+
+
+More conditions are available using the [BloomSky binary sensor](/components/binary_sensor.bloomsky) component.


### PR DESCRIPTION
The rain and night conditions are binary sensors and can not be used in the main Bloomsky sensor component. I have removed them from this list and added a note referring people to the BloomSky binary sensor component.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

