### PR TITLE
Correct iot class

### DIFF
--- a/source/_components/sensor.loop_energy.markdown
+++ b/source/_components/sensor.loop_energy.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: loop.png
 ha_category: Energy
 ha_release: 0.17
-ha_iot_class: "Local Polling"
+ha_iot_class: "Cloud Push"
 ---
 
 


### PR DESCRIPTION
**Description:**
Just notices this wasn't correct. It's always been cloud push.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

