### PR TITLE
Clarify docs for binary_sensor class 'opening'

### DIFF
--- a/source/_components/binary_sensor.markdown
+++ b/source/_components/binary_sensor.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 ---
 
-Binary sensors are gathering information about state of switches, contacts, pins, and alike. The return value of those sensors is usually digital (1/0). This means that those sensors knows only two states: **0/off/low/open/false** and **1/on/high/closed/true**.
+Binary sensors are gathering information about state of switches, contacts, pins, and alike. The return value of those sensors is usually digital (1/0). This means that those sensors knows only two states: **0/off/low/closed/false** and **1/on/high/open/true**.
 
 Knowing that there are only two states allows Home Assistant to represent the sensor better in the frontend.
 
@@ -25,7 +25,7 @@ The display style of each entity can be modified in the [customize section](/get
 - **motion**: Motion sensor
 - **moving**: On means moving, Off means stopped
 - **occupancy**: On means occupied, Off means not occupied
-- **opening**: Door, window, etc
+- **opening**: Door, window, etc. On means open, Off means closed
 - **power**: Power, over-current, etc
 - **safety**: On means unsafe, Off means safe
 - **smoke**: Smoke detector


### PR DESCRIPTION
**Description:**

The documentation for the 'opening' class of binary_sensor left the
interpretation of On and Off undefined.  Additionally, the intro paragraph
claimed that "On" is "Closed" and "Off" is "Open" which is the opposite of
common usage that I've seen in example configurations.

This commit explicitly states that On==Open and Off=Closed and amends the
examples in the leading paragraph.

Confirmed in Gitter chat that this is appropriate:

@balloob: "I would assume that “on” is open as it’s the special case.
           Assuming doors/windows etc are usually closed.
           With smoke, detecting smoke is the special case"
