### PR TITLE
camera.zoneminder: Document MJPEG stream support

### DIFF
--- a/source/_components/camera.zoneminder.markdown
+++ b/source/_components/camera.zoneminder.markdown
@@ -1,0 +1,28 @@
+---
+layout: page
+title: "ZoneMinder Camera"
+description: "View ZoneMinder camera streams within Home Assistant."
+date: 2017-02-19 18:11
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: zoneminder.png
+ha_category: Camera
+ha_release: 0.39
+---
+
+
+The `zoneminder` camera platform lets you monitor the current stream of your [ZoneMinder](https://www.zoneminder.com) cameras.
+
+<p class='note'>
+You must have the [ZoneMinder component](/components/zoneminder/) configured to view the camera stream.
+</p>
+
+To set it up, add the following information to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+camera:
+  - platform: zoneminder
+```

--- a/source/_components/sensor.zoneminder.markdown
+++ b/source/_components/sensor.zoneminder.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "ZoneMinder Sensor"
-description: "Instructions how to integrate ZoneMinder sensors within Home Assistant."
+description: "How to view ZoneMinder monitor functions and events within Home Assistant."
 date: 2016-10-13 22:57
 sidebar: true
 comments: false
@@ -13,10 +13,10 @@ ha_release: 0.31
 ---
 
 
-The `zoneminder` sensor platform let you monitor the current state of your ZoneMinder install including the number of events and the current state of the cameras.
+The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of events and the current state of the cameras.
 
 <p class='note'>
-You must have the [ZoneMinder component](/components/zoneminder/) configured to use those sensors.
+You must have the [ZoneMinder component](/components/zoneminder/) configured to use this sensor.
 </p>
 
 To set it up, add the following information to your `configuration.yaml` file:

--- a/source/_components/switch.zoneminder.markdown
+++ b/source/_components/switch.zoneminder.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "ZoneMinder Switch"
-description: "Instructions how to integrate ZoneMinder switches into Home Assistant."
+description: "How to toggle the function of ZoneMinder monitors in Home Assistant."
 date: 2016-10-13 22:57
 sidebar: true
 comments: false
@@ -13,7 +13,7 @@ ha_release: 0.31
 ---
 
 
-The `zoneminder` switch platform allows you to toggle the current function of cameras attached to your ZoneMinder instance.
+The `zoneminder` switch platform allows you to toggle the current function of all cameras attached to your [ZoneMinder](https://www.zoneminder.com) instance.
 
 <p class='note'>
 You must have the [ZoneMinder component](/components/zoneminder/) configured to use this.
@@ -38,4 +38,3 @@ Configuration variables:
 <p class='note'>
 The default functions installed by ZoneMinder are: None, Monitor, Modect, Record, Mocord, Nodect.
 </p>
-

--- a/source/_components/zoneminder.markdown
+++ b/source/_components/zoneminder.markdown
@@ -1,19 +1,19 @@
 ---
 layout: page
 title: "ZoneMinder"
-description: "Instructions how to integrate ZoneMinder into Home Assistant."
+description: "How to integrate ZoneMinder into Home Assistant."
 date: 2016-10-13 22:57
 sidebar: true
 comments: false
 sharing: true
 footer: true
 logo: zoneminder.png
-ha_category: Camera
+ha_category: Hub
 featured: false
 ha_release: 0.31
 ---
 
-The ZoneMinder component is the main component to integrate all the sensors and switches for controlling your ZoneMinder instance.
+The ZoneMinder component sets up the integration with your [ZoneMinder](https://www.zoneminder.com) instance so that [cameras](/components/camera.zoneminder/), [sensors](/components/sensor.zoneminder/), and [switches](/components/switch.zoneminder) can use it.
 
 ```yaml
 # Example configuration.yaml entry
@@ -22,11 +22,12 @@ zoneminder:
 ```
 
 Configuration variables:
-- **host** (*Required*): Your ZoneMinder server.
+- **host** (*Required*): Your ZoneMinder server's host (and optional port), not including the scheme.
 - **path** (*Optional*): Path to your ZoneMinder install. Defaults to `/zm/`.
+- **path_zms** (*Optional*): Path to the CGI script for streaming. This should match `PATH_ZMS` in ZM's "Paths" settings. Defaults to `/zm/cgi-bin/nph-zms`.
 - **ssl** (*Optional*): Set to `True` if your ZoneMinder installation is using SSL. Default to `False`.
 - **username** (*Optional*): Your ZoneMinder username.
-- **password** (*Optional*): Your ZoneMinder password.
+- **password** (*Optional*): Your ZoneMinder password. Required if `OPT_USE_AUTH` is enabled in ZM.
 
 ### {% linkable_title Full configuration %}
 
@@ -35,6 +36,7 @@ Configuration variables:
 zoneminder:
   host: ZM_HOST
   path: ZM_PATH
+  path_zms: ZM_PATH_ZMS
   ssl: False
   username: USERNAME
   password: PASSWORD


### PR DESCRIPTION
**Description:**
Documents the new `camera.zoneminder` platform and moves the `zoneminder` component from a camera to a hub. Other assorted cleanup and linking done.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#6098

