### PR TITLE
Fixed Typo

### DIFF
--- a/source/_components/input_slider.markdown
+++ b/source/_components/input_slider.markdown
@@ -111,7 +111,7 @@ automation:
 ```
 
 
-Exampleof `input_slider` being used in a bidirectional manner, both being set by and controlled by an MQTT action in an automation.
+Example of `input_slider` being used in a bidirectional manner, both being set by and controlled by an MQTT action in an automation.
 
 ```yaml
 {% raw %}


### PR DESCRIPTION
Fixed "Exampleof" typo.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

