### PR TITLE
Fix typo in "python-OpenZWace".

### DIFF
--- a/source/getting-started/z-wave.markdown
+++ b/source/getting-started/z-wave.markdown
@@ -13,7 +13,7 @@ footer: true
 
 There is currently support for climate, covers, lights, locks, sensors, switches and thermostats. All will be picked up automatically after configuring this platform.
 
-### {% linkable_title Installation in Virtualenv (python-OpenZWace) %}
+### {% linkable_title Installation in Virtualenv (python-OpenZWave) %}
 
 If you installed Home Assistant using a virtual environment then please read the instructions on [Installing python-OpenZWave in a virtualenv](https://home-assistant.io/getting-started/installation-virtualenv/#installing-python-openzwave-in-a-virtualenv).
 


### PR DESCRIPTION
**Description:** Changed "python-OpenZWace" to "python-OpenZWave"


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant# Not applicable.

