### PR TITLE
Adding port proxy instructions for Windows

### DIFF
--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -28,6 +28,17 @@ Additionally, if your expectation is that you will be able to browse directly to
 $ docker run -d --name="home-assistant" -v /path/to/your/config:/config -e "TZ=America/Los_Angeles" -p 8123:8123 homeassistant/home-assistant
 ```
 
+### {% linkable_title Windows %}
+
+When running Home Assistant in Docker on Windows, you may have some difficulty getting ports to map for routing (since the `--net=host` switch actually applies to the hypervisor's network interface). To get around this, you will need to add port proxy ipv4 rules to your local Windows machine, like so (Replacing '192.168.1.10' with whatever your Windows IP is, and '10.0.50.2' with whatever your Docker container's IP is):
+```
+netsh interface portproxy add v4tov4 listenaddress=192.168.1.10 listenport=8123 connectaddress=10.0.50.2 connectport=8123
+netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=8123 connectaddress=10.0.50.2 connectport=8123
+```
+
+This will let you access your Home Assistant portal from http://localhost:8123, and if you forward port 8123 on your router to your machine IP, the traffic will be forwarded on through to the docker container.
+
+
 ### {% linkable_title Restart %}
 
 This will launch Home Assistant and serve the web interface from port 8123 on your Docker host.


### PR DESCRIPTION
**Description:**
Adds instructions for Windows machines running home assistant within Docker, showing how to set up the port proxies.

I wrestled with this problem for hours until I figured it out. Hopefully we can save others some trouble by adding these instructions to the documentation.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/2120

