### PR TITLE
configuration: Fix broken link

### DIFF
--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -20,7 +20,7 @@ sensor:
   - platform: random
 ```
 
-The [Setting up devices part](/docs/configuration/devices/) contains of the documentation additional details about adding device and services and [customization](docs/configuration/customizing-devices/).
+The [Setting up devices part](/docs/configuration/devices/) contains of the documentation additional details about adding device and services and [customization](/docs/configuration/customizing-devices/).
 
 For further details about configuration, please take a look at the [configuration documentation](/docs/configuration/).
 


### PR DESCRIPTION
**Description:**

The linked URL did not have a leading '/' therefore it resolved into a 404 error.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** none

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>