### PR TITLE
fix link to customizing-devices

### DIFF
--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -20,7 +20,7 @@ sensor:
   - platform: random
 ```
 
-The [Setting up devices part](/docs/configuration/devices/) contains of the documentation additional details about adding device and services and [customization](docs/configuration/customizing-devices/).
+The [Setting up devices part](/docs/configuration/devices/) contains of the documentation additional details about adding device and services and [customization](/docs/configuration/customizing-devices/).
 
 For further details about configuration, please take a look at the [configuration documentation](/docs/configuration/).
 


### PR DESCRIPTION
fix link to customizing-devices

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

