### PR TITLE
Remove extra backticks for syntax rendering

### DIFF
--- a/source/_components/device_tracker.gpslogger.markdown
+++ b/source/_components/device_tracker.gpslogger.markdown
@@ -40,8 +40,9 @@ Set the URL under "General Options -> Logging details":
 - Log to KML: no
 - Log to custom URL: yes and set 
 ```yaml
-http://<ha_server>/api/gpslogger?latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT` (be sure you include API password (`&api_password=<password>`) if needed, or you can also use HTTP Basic authentication `http://<username>:<password>@<ha_server>/api/gpslogger...)
+http://<ha_server>/api/gpslogger?latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT
 ```
+(be sure you include API password (`&api_password=<password>`) if needed, or you can also use HTTP Basic authentication `http://<username>:<password>@<ha_server>/api/gpslogger...`)
 - Log to OpenGTS Server: no
 - Log to Plain Text: no
 - Log to NMEA: no

--- a/source/_components/device_tracker.gpslogger.markdown
+++ b/source/_components/device_tracker.gpslogger.markdown
@@ -27,7 +27,7 @@ device_tracker:
 
 To configure GPSLogger, you must set up the app to send a `GET` request to your Home Assistant server at 
 ```yaml
-`http://<ha_server>/api/gpslogger?latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT`
+http://<ha_server>/api/gpslogger?latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT
 ```
 . Make sure to include the API password if you have configured a password in Home Assistant (add `&api_password=<password>` to the end of the URL). Configure that options under "General Options":
 
@@ -40,7 +40,7 @@ Set the URL under "General Options -> Logging details":
 - Log to KML: no
 - Log to custom URL: yes and set 
 ```yaml
-`http://<ha_server>/api/gpslogger?latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT` (be sure you include API password (`&api_password=<password>`) if needed, or you can also use HTTP Basic authentication `http://<username>:<password>@<ha_server>/api/gpslogger...`)
+http://<ha_server>/api/gpslogger?latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT` (be sure you include API password (`&api_password=<password>`) if needed, or you can also use HTTP Basic authentication `http://<username>:<password>@<ha_server>/api/gpslogger...)
 ```
 - Log to OpenGTS Server: no
 - Log to Plain Text: no


### PR DESCRIPTION

It looks like 2 out of the 3 example configs are incorrect on this page. This should fix them.

###Example of extra backticks 


<img width="718" alt="screenshot-248" src="https://cloud.githubusercontent.com/assets/6786817/23336558/286edde0-fb99-11e6-99f4-aec6ed2fbc5a.png">

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

