### PR TITLE
Fixing customize example for customize_glob icon

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -38,7 +38,7 @@ homeassistant:
       icon: mdi:home
   customize_glob:
     "light.kitchen_*":
-      icon: mid:description
+      icon: mdi:description
 
 ```
 


### PR DESCRIPTION
Icons should be `icon: mdi:icon-name` not `icon: mid:icon-name`.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

