### PR TITLE
Replace customize with device_config

### DIFF
--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -80,7 +80,7 @@ Configuration variables:
 - **config_path** (*Optional*): The path to the Python OpenZWave configuration files. Defaults to the folder `config` in your Python OpenZWave install directory.
 - **autoheal** (*Optional*): Allows disabling auto Z-Wave heal at midnight. Defaults to True.
 - **polling_interval** (*Optional*): The time period in milliseconds between polls of a nodes value. Be careful about using polling values below 30000 (30 seconds) as polling can flood the zwave network and cause problems.
-- **customize** (*Optional*): This attribute contains node-specific override values. See [Customizing devices and services](https://home-assistant.io/getting-started/customizing-devices/) for format:
+- **device_config** (*Optional*): This attribute contains node-specific override values. See [Customizing devices and services](https://home-assistant.io/getting-started/customizing-devices/) for format:
   - **polling_intensity** (*Optional*): Enables polling of a value and sets the frequency of polling (0=none, 1=every time through the list, 2=every other time, etc). If not specified then your device will not be polled.
   - **ignored** (*Optional*): Ignore this entitiy completely. It won't be shown in the Web Interface and no events are generated for it.
   - **refresh_value** (*Optional*): Enable refreshing of the node value. Only the light component uses this. Defaults to False.


### PR DESCRIPTION
In version 0.39 of Home Assistant, `zwave:`-> `customize:` was renamed to `zwave:` -> `device_config:`

When I have more time, I might submit another PR to elaborate on `device_config_domain:` and `device_config_glob:` but right now, this minor change should go through to avoid confusion.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#5933

