### PR TITLE
Error in binary_sensor.nx584.markdown

### DIFF
--- a/source/_components/binary_sensor.nx584.markdown
+++ b/source/_components/binary_sensor.nx584.markdown
@@ -48,3 +48,4 @@ binary_sensor:
     2: opening
     4: motion
     6: moisture
+```


### PR DESCRIPTION
The final `yaml` code snippet was not closed properly and causing a rendering error on https://home-assistant.io/components/binary_sensor.nx584/

