### PR TITLE
Dont Merge - Add /bin to PATH variable for virtualenv installations

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -48,7 +48,7 @@ Type=simple
 User=homeassistant
 # Make sure the virtualenv Python binary is used
 Environment=VIRTUAL_ENV="/srv/homeassistant"
-Environment=PATH="$VIRTUAL_ENV/bin:$PATH"
+Environment=PATH="$VIRTUAL_ENV/bin:/bin:$PATH"
 ExecStart=/srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
 
 [Install]


### PR DESCRIPTION
Add /bin to PATH variable for virtualenv installations to enable home assistant to find e.g. the ping command which is located in /bin. This was a problem on ubuntu which caused the WOL switch to not report the correct state of the computer.

See https://github.com/home-assistant/home-assistant/issues/5930 and https://community.home-assistant.io/t/wake-on-lan-switch-status-not-working/11700 for reference.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

