### PR TITLE
Fix AutoStart links

### DIFF
--- a/source/_includes/asides/docs_navigation.html
+++ b/source/_includes/asides/docs_navigation.html
@@ -112,13 +112,13 @@
         {% active_link /docs/ecosystem/ Ecosystem %}
         <ul>
           <li>
-            {% active_link /docs/ecosystem/autostart/ Autostart %}
+            {% active_link /docs/autostart/ Autostart %}
             <ul>
-              <li>{% active_link /docs/ecosystem/autostart/systemd/ systemd (Linux) %}</li>
-              <li>{% active_link /docs/ecosystem/autostart/upstart/ Upstart (Linux) %}</li>
-              <li>{% active_link /docs/ecosystem/autostart/init.d/ init.d (Linux) %}</li>
-              <li>{% active_link /docs/ecosystem/autostart/macos/ macOS %}</li>
-              <li>{% active_link /docs/ecosystem/autostart/synology/ Synology NAS %}</li>
+              <li>{% active_link /docs/autostart/systemd/ systemd (Linux) %}</li>
+              <li>{% active_link /docs/autostart/upstart/ Upstart (Linux) %}</li>
+              <li>{% active_link /docs/autostart/init.d/ init.d (Linux) %}</li>
+              <li>{% active_link /docs/autostart/macos/ macOS %}</li>
+              <li>{% active_link /docs/autostart/synology/ Synology NAS %}</li>
             </ul>
           </li>
           <li>


### PR DESCRIPTION
There is no 'ecosystem/' part on the URL (is this intended ?)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

