### PR TITLE
Update upgrading.markdown

### DIFF
--- a/source/_docs/hassbian/upgrading.markdown
+++ b/source/_docs/hassbian/upgrading.markdown
@@ -24,12 +24,12 @@ $ sudo apt-get -y upgrade
 To update the Home Assistant installation execute the following command as the `pi` user.
 
 ```bash
-$ sudo systemctl stop homeassistant@homeassistant.service
+$ sudo systemctl stop home-assistant@homeassistant.service
 $ sudo su -s /bin/bash homeassistant
 $ source /srv/homeassistant/bin/activate
 $ pip3 install --upgrade homeassistant
 $ exit
-$ sudo systemctl start homeassistant@homeassistant.service
+$ sudo systemctl start home-assistant@homeassistant.service
 ```
 
 #### {% linkable_title Upgrading the hassbian-scripts %}


### PR DESCRIPTION
Fix command line to start and stop Home Assistant

**Description:**
The command line to start/stop Home Assistant in the upgrade instructions for Hassbian does not work on current installations. This PR corrects the command line.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) (if applicable):** home-assistant/home-assistant.github.io#2190

