### PR TITLE
Update step 1 to add group

### DIFF
--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -23,12 +23,13 @@ $ sudo apt-get install python-pip python3-dev
 $ sudo pip install --upgrade virtualenv
 ```
 
-### {% linkable_title Step 1: Create a Home Assistant user %}
+### {% linkable_title Step 1: Create a Home Assistant user & group %}
 
 This step is optional, but it's a good idea to give services like Home Assistant their own user. It gives you more granular control over permissions, and reduces the exposure to the rest of your system in the event there is a security related bug in Home Assistant. This is a reasonably Linux oriented step, and will look different on other operating systems (or even other Linux distributions).
 
 ```bash
 $ sudo adduser --system homeassistant
+$ sudo addgroup homeassistant
 ```
 
 Home Assistant stores its configuration in `$HOME/.homeassistant` by default, so in this case, it would be in `/home/homeassistant/.homeassistant`


### PR DESCRIPTION
Following the directions as is yielded an error at step 2 when running `sudo chown homeassistant:homeassistant /srv/homeassistant` since there are no directions prior to make a group.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

