### PR TITLE
Added glances CPU temperature doc.

### DIFF
--- a/source/_components/sensor.glances.markdown
+++ b/source/_components/sensor.glances.markdown
@@ -54,6 +54,7 @@ sensor:
       - 'process_total'
       - 'process_thread'
       - 'process_sleeping'
+      - 'cpu_temp'
 ```
 
 Configuration variables:
@@ -76,4 +77,5 @@ Configuration variables:
   - **process_total**: Total number of processes
   - **process_thread**: Number of threads
   - **process_sleeping**: Number of sleeping processes
+  - **cpu_temp**: CPU Temperature
 


### PR DESCRIPTION
**Description:**

Added documentation about the new metric available in glances sensor.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):**

https://github.com/home-assistant/home-assistant/pull/6433