### PR TITLE
added scan_interval

### DIFF
--- a/source/_components/climate.honeywell.markdown
+++ b/source/_components/climate.honeywell.markdown
@@ -24,12 +24,13 @@ climate:
   scan_interval: 600
 ```
 <p class='note'>
-Scan interval is expressed in seconds. Omitting scan_interval may result in too-frequent polling and cause you to rate-limited by Honewell.
+Scan interval is expressed in seconds. Omitting scan_interval may result in too-frequent polling and cause you to rate-limited by Honeywell.
 </p>
 
 Configuration variables:
 
 - **username** (*Required*): The username of an user with access.
 - **password** (*Required*): The password for your given admin account.
-- **away_temperature** (*optional*): Heating setpoint when away mode is on. If omitted it defaults to 16.0 deg C.
-- **region** (*optional*): Region identifier (either 'eu' or 'us'). Defaults to 'eu' if not provided.
+- **away_temperature** (*Optional*): Heating setpoint when away mode is on. If omitted it defaults to 16.0 deg C.
+- **region** (*Optional*): Region identifier (either 'eu' or 'us'). Defaults to 'eu' if not provided.
+- **scan_interval**(*Optional*): Scan interval is expressed in seconds. Recommended value of 600 seconds. Default value is 120 seconds. Omitting scan_interval may result in too-frequent polling and cause you to rate-limited by Honeywell.

--- a/source/_components/climate.honeywell.markdown
+++ b/source/_components/climate.honeywell.markdown
@@ -21,7 +21,11 @@ climate:
   platform: honeywell
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
+  scan_interval: 600
 ```
+<p class='note'>
+Scan interval is expressed in seconds. Omitting scan_interval may result in too-frequent polling and cause you to rate-limited by Honewell.
+</p>
 
 Configuration variables:
 


### PR DESCRIPTION
**Description:**
Added scan_interval to docs. Default scan_interval for climate platform causes you to be rate-limited by Honeywell API.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

