### PR TITLE
Remove unnecessary environment variable setup from systemd service

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -49,7 +49,6 @@ After=network.target
 [Service]
 Type=simple
 User=%i
-# Make sure the virtualenv Python binary is used
 ExecStart=/srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
 
 [Install]

--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -48,7 +48,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=homeassistant
+User=%i
 # Make sure the virtualenv Python binary is used
 ExecStart=/srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
 

--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -39,7 +39,7 @@ ExecStart=/usr/bin/hass
 WantedBy=multi-user.target
 ```
 
-If you've setup Home Assistant in `virtualenv` following our [python installation guide](https://home-assistant.io/getting-started/installation-virtualenv/) or [manual installation guide for raspberry pi](https://home-assistant.io/getting-started/installation-raspberry-pi/), the following template should work for you.  If Home Assistant install is not located at `/srv/homeassistant`, please modify the `Enviroment=` and `ExecStart=` lines appropriately.  
+If you've setup Home Assistant in `virtualenv` following our [python installation guide](https://home-assistant.io/getting-started/installation-virtualenv/) or [manual installation guide for raspberry pi](https://home-assistant.io/getting-started/installation-raspberry-pi/), the following template should work for you.  If Home Assistant install is not located at `/srv/homeassistant`, please modify the `ExecStart=` line appropriately.  
 
 ```
 [Unit]
@@ -49,7 +49,7 @@ After=network.target
 [Service]
 Type=simple
 User=%i
-ExecStart=/srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
+ExecStart=/srv/homeassistant/bin/hass -c "/home/%i/.homeassistant"
 
 [Install]
 WantedBy=multi-user.target

--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -50,8 +50,6 @@ After=network.target
 Type=simple
 User=homeassistant
 # Make sure the virtualenv Python binary is used
-Environment=VIRTUAL_ENV="/srv/homeassistant"
-Environment=PATH="$VIRTUAL_ENV/bin:$PATH"
 ExecStart=/srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
 
 [Install]

--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -49,7 +49,7 @@ After=network.target
 [Service]
 Type=simple
 User=%i
-ExecStart=/srv/homeassistant/bin/hass -c "/home/%i/.homeassistant"
+ExecStart=/srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The environment variables are not needed and are actually overriding the system PATH variable and were causing trouble in certain circumstances.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

