### PR TITLE
Fix notify_if__new_ha_release.markdown

### DIFF
--- a/source/_cookbook/notify_if__new_ha_release.markdown
+++ b/source/_cookbook/notify_if__new_ha_release.markdown
@@ -46,7 +46,7 @@ automation:
       entity_id: updater.updater
   action:
     service: notify.pushbullet
-    data: 
+    data_template: 
       title: 'New Home Assistant Release'
       target: 'YOUR_TARGET_HERE' #See Pushbullet component for usage
       message: "Home Assistant {% raw %} {{ states.updater.updater.state }} {% endraw %} is now available."


### PR DESCRIPTION
**Description:**

A template requires the use of `data_template` instead of `data` for the template to be rendered (instead of resulting in an error).