### PR TITLE
Update MQTT Eventstream documentation to demonstrate multiple instances

### DIFF
--- a/source/_components/mqtt_eventstream.markdown
+++ b/source/_components/mqtt_eventstream.markdown
@@ -42,7 +42,7 @@ mqtt_eventstream:
 For a multiple instance setup, each slave would publish to their own topic.
 
 ```yaml
-# Example master instance configuration.yaml entry
+# Example slave instance configuration.yaml entry
 mqtt_eventstream:
   publish_topic: slaves/upstairs
   subscribe_topic: master/topic
@@ -51,6 +51,6 @@ mqtt_eventstream:
 ```yaml
 # Example slave instance configuration.yaml entry
 mqtt_eventstream:
-  publish_topic: master/downstairs
+  publish_topic: slaves/downstairs
   subscribe_topic: master/topic
 ```

--- a/source/_components/mqtt_eventstream.markdown
+++ b/source/_components/mqtt_eventstream.markdown
@@ -12,7 +12,7 @@ ha_category: Other
 ha_release: 0.11
 ---
 
-The `mqtt_eventstream` components connects two Home Assistant instances via MQTT.
+The `mqtt_eventstream` component connects two Home Assistant instances via MQTT.
 
 To integrate MQTT Eventstream into Home Assistant, add the following section to your `configuration.yaml` file:
 
@@ -28,3 +28,29 @@ Configuration variables:
 - **publish_topic** (*Required*): Topic for publishing local events
 - **subscribe_topic** (*Required*): Topic to receive events from the remote server.
 
+## Multiple Instances
+
+Events from multiple instances can be aggregated to a single master instance by subscribing to a wildcard topic from the master instance.
+
+```yaml
+# Example master instance configuration.yaml entry
+mqtt_eventstream:
+  publish_topic: master/topic
+  subscribe_topic: slaves/#
+```
+
+For a multiple instance setup, each slave would publish to their own topic.
+
+```yaml
+# Example master instance configuration.yaml entry
+mqtt_eventstream:
+  publish_topic: slaves/upstairs
+  subscribe_topic: master/topic
+```
+
+```yaml
+# Example slave instance configuration.yaml entry
+mqtt_eventstream:
+  publish_topic: master/downstairs
+  subscribe_topic: master/topic
+```


### PR DESCRIPTION
**Description:**
Clarifies how to use MQTT Eventstream for one-to-many master to slave bidirectional event streaming.

