### PR TITLE
Introduce parameter 'delay' for component tts.

### DIFF
--- a/source/_components/tts.markdown
+++ b/source/_components/tts.markdown
@@ -29,6 +29,7 @@ The following optional parameters can be used with any platform. However the TTS
 | `cache` | True    | Allow TTS to cache voice file to local storage. |
 | `cache_dir`  | tts      | Foldername or path to folder for caching files. |
 | `time_memory`     | 300     | Time to hold the voice data inside memory for fast play on media player. Minimum is 60 s and the maximum 57600 s (16 hours). |
+| `delay`      | 0        | Time in ms to delay audio by inserting silence at the beginning. |
 
 The extended example from above would look like the following sample:
 
@@ -39,6 +40,7 @@ tts:
     cache: true
     cache_dir: /tmp/tts
     time_memory: 300
+    delay: 200
 ```
 
 <p class='note'>


### PR DESCRIPTION
**Description:**

A delay can be necessary if the beginning of the audio is missing when streaming via Bluetooth.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#6541

