### PR TITLE
Quotes added to example

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -35,7 +35,7 @@ automation 2:
     service_template: >{% raw %}
       notify.{{ trigger.topic.split('/')[-1] }}{% endraw %}
     data_template:
-      message: {% raw %}{{ trigger.payload }}{% endraw %}
+      message: {% raw %}'{{ trigger.payload }}'{% endraw %}
 ```
 
 ## {% linkable_title Important Template Rules %}


### PR DESCRIPTION
The automation 2 / action / data_template example does not adhere to the **must** directive to wrap single line templates in some form of quote.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

