### PR TITLE
List Python3 version of Gstreamer bindings

### DIFF
--- a/source/_components/media_player.gstreamer.markdown
+++ b/source/_components/media_player.gstreamer.markdown
@@ -37,7 +37,7 @@ And then install the following system dependencies:
 Debian/Ubuntu/Rasbian:
 
 ```bash
-sudo apt-get install python-gst-1.0 \
+sudo apt-get install python3-gst-1.0 \
     gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 \
     gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
     gstreamer1.0-tools


### PR DESCRIPTION
**Description:**

On Raspian Jessie `python-gst-1.0` installs Gstreamer with Python2.7 bindings. 

Relevant discussion [here](https://community.home-assistant.io/t/snapcast-tts/10824).

