### PR TITLE
Fix configuration variable name in sonarr sensor : included_paths → include_paths

### DIFF
--- a/source/_components/sensor.sonarr.markdown
+++ b/source/_components/sensor.sonarr.markdown
@@ -40,7 +40,7 @@ Configuration variables:
 - **port** (*Optional*): The port Sonarr is running on (Default: 8989).
 - **urlbase** (*Optional*): The base URL Sonarr is running under (Default: /).
 - **days** (*Optional*): How many days to look ahead for the upcoming sensor, 1 means today only (Default: 1).
-- **included_paths** (*Optional*): Array of filepaths to include when calculating diskspace. Leave blank to include all.
+- **include_paths** (*Optional*): Array of filepaths to include when calculating diskspace. Leave blank to include all.
 - **unit**: (*Optional*): The unit to display disk space in (Default: GB).
 - **ssl**:  boolean (*Optional*): Whether or not to use SSL for Sonarr.
 

--- a/source/_components/sensor.sonarr.markdown
+++ b/source/_components/sensor.sonarr.markdown
@@ -102,7 +102,7 @@ sensor:
     host: 192.168.1.8
     monitored_conditions:
       - diskspace
-    included_paths:
+    include_paths:
       - /tank/plex
 ```
 


### PR DESCRIPTION
Fix configuration variable name in sonarr sensor : included_paths → include_paths

**Description:**

Fix a typo in the name of the variable include_paths for the sonarr sensor

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** Not applicable

