### PR TITLE
Add verify_ssl config option to Unifi device-tracker docs

### DIFF
--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -32,5 +32,6 @@ Configuration variables:
 - **username** (*Required*: The username of an user with administrative privileges, usually `admin`.
 - **password** (*Required*): The password for your given admin account.
 - **site_id** (*Optional*): Allows you to specify a `site_id` for device tracking. Defaults to `default`. Found in the URL of the controller (i.e. https://CONTROLLER:PORT/manage/site/SITE_ID/dashboard)
+- **verify_ssl** (*Optional*): Allows you to enable or disable verification of the SSL certificate presented by the Unifi controller. Defaults to `true`. Valid values are `true` and `false`.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
**Description:**
Add documentation entry for the `verify_ssl` configuration option in the Unifi device-tracker component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

