### PR TITLE
Updated device_tracker.unifi documentation to cover the option 'verify_ssl'.

### DIFF
--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -32,5 +32,6 @@ Configuration variables:
 - **username** (*Required*: The username of an user with administrative privileges, usually `admin`.
 - **password** (*Required*): The password for your given admin account.
 - **site_id** (*Optional*): Allows you to specify a `site_id` for device tracking. Defaults to `default`. Found in the URL of the controller (i.e. https://CONTROLLER:PORT/manage/site/SITE_ID/dashboard)
+- **verify_ssl** (*Optional*): Controls if the SSL certificate running on your Unifi webserver must be trusted by a known Certificate Authority on the server running Home Assistant. Defaults to 'True'.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
**Description:**

Updated device_tracker.unifi documentation to cover the option 'verify_ssl'. If the SSL certificate is not imported on the system, the traceback below is displayed.

```python
17-03-15 01:41:05 INFO (MainThread) [homeassistant.components.device_tracker] Setting up device_tracker.unifi
17-03-15 01:41:05 ERROR (MainThread) [homeassistant.components.device_tracker] Error setting up platform unifi
Traceback (most recent call last):
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 345, in _make_request
    self._validate_conn(conn)
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 844, in _validate_conn
    conn.connect()
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/packages/urllib3/connection.py", line 326, in connect
    ssl_context=context)
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/packages/urllib3/util/ssl_.py", line 324, in ssl_wrap_socket
    return context.wrap_socket(sock, server_hostname=server_hostname)
  File "/usr/lib64/python3.5/ssl.py", line 377, in wrap_socket
    _context=self)
  File "/usr/lib64/python3.5/ssl.py", line 752, in __init__
    self.do_handshake()
  File "/usr/lib64/python3.5/ssl.py", line 988, in do_handshake
    self._sslobj.do_handshake()
  File "/usr/lib64/python3.5/ssl.py", line 633, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/adapters.py", line 423, in send
    timeout=timeout
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 630, in urlopen
    raise SSLError(e)
requests.packages.urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/homeassistant/components/device_tracker/__init__.py", line 152, in async_setup_platform
    None, platform.get_scanner, hass, {DOMAIN: p_config})
  File "/usr/lib64/python3.5/asyncio/futures.py", line 361, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib64/python3.5/asyncio/tasks.py", line 296, in _wakeup
    future.result()
  File "/usr/lib64/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/lib64/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/homeassistant/components/device_tracker/unifi.py", line 53, in get_scanner
    site_id=site_id, ssl_verify=verify_ssl)
  File "/opt/srv/homeassistant/.homeassistant/deps/pyunifi/controller.py", line 65, in __init__
    self._login(version)
  File "/opt/srv/homeassistant/.homeassistant/deps/pyunifi/controller.py", line 123, in _login
    r = self.session.post(login_url, params)
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/sessions.py", line 535, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/sessions.py", line 488, in request
    resp = self.send(prep, **send_kwargs)
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/sessions.py", line 609, in send
    r = adapter.send(request, **kwargs)
  File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/requests/adapters.py", line 497, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)
```

The `verify_ssl` option was introduced to `unifi` by PR https://github.com/home-assistant/home-assistant/pull/6490

