### PR TITLE
Fix ambiguous wording

### DIFF
--- a/source/_components/joaoapps_join.markdown
+++ b/source/_components/joaoapps_join.markdown
@@ -37,7 +37,7 @@ Configuration variables:
 - **device_id** (*Required*): The Id of your device.
 - **api_key** (*Required*): The API key for Join.
 
-The notify service has 2 optional parameters: icon and small icon.  You can use them like so:
+The notify service has two optional parameters: `icon` and `small icon`.  You can use them like so:
 
 ```json
 {"message":"Hello!","title":"From Hass","data":{"icon":"https://goo.gl/KVqcYi","smallicon":"http://goo.gl/AU4Wf1"}}

--- a/source/_components/joaoapps_join.markdown
+++ b/source/_components/joaoapps_join.markdown
@@ -37,7 +37,7 @@ Configuration variables:
 - **device_id** (*Required*): The Id of your device.
 - **api_key** (*Required*): The API key for Join.
 
-The notify service has a few optional parameters such as icon and small icon.  You can use them like so:
+The notify service has 2 optional parameters: icon and small icon.  You can use them like so:
 
 ```json
 {"message":"Hello!","title":"From Hass","data":{"icon":"https://goo.gl/KVqcYi","smallicon":"http://goo.gl/AU4Wf1"}}


### PR DESCRIPTION
The line made it seem like there may be more optional parameters, but there isn't any.

**Description:** Changed line to make it more obvious there is only 2 optional parameters.

NOTE: The table on this page overlaps the navigation links to the right on my screen. Not sure how to fix that, but someone who does should look into it.



