### PR TITLE
Add EH5300 as supported Samsung TV for Samsung remote component

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -44,6 +44,7 @@ Currently known supported models:
 - ES6800
 - F6300
 - F6500
+- EH5300
 - EH5600
 - F6400AF
 - D6505


### PR DESCRIPTION
Addition of the Samsung EH5300 TV as supported TV for the Samsung TV Remote component.

