### PR TITLE
Update device_tracker.nmap_tracker.markdown

### DIFF
--- a/source/_components/device_tracker.nmap_tracker.markdown
+++ b/source/_components/device_tracker.nmap_tracker.markdown
@@ -32,7 +32,7 @@ Configuration variables:
 
 - **hosts** (*Required*): The network address to scan (in any supported NMap format). Mixing subnets and IPs is possible.
 - **home_interval** (*Optional*): The number of minutes nmap will not scan this device, assuming it is home, in order to preserve the device battery.
-- **exclude** (*Optional*): Hosts not to include in nmap scanning.
+- **exclude** (*Optional*): Hosts not to include in nmap scanning. Scanning the host where Home Assistant is running can cause problems (websocket error), so excluding that host is a good idea.
 - **scan_options** (*Optional*): Configurable scan options for nmap. Default to `-F --host-timeout 5s`
 
 


### PR DESCRIPTION
Added a note to exclude the HA host from scanning as it may cause verbose errors to be generated due to websocket error caused by the scanning.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

