### PR TITLE
Added "round" to battery percentage

### DIFF
--- a/source/_cookbook/track_battery_level.markdown
+++ b/source/_cookbook/track_battery_level.markdown
@@ -22,7 +22,7 @@ sensor:
         unit_of_measurement: '%'
         value_template: >-
             {% raw %}{%- if states.device_tracker.iphone.attributes.battery %}
-                {{ states.device_tracker.iphone.attributes.battery }}
+                {{ states.device_tracker.iphone.attributes.battery|round }}
             {% else %}
                 {{ states.sensor.battery_iphone.state }}
             {%- endif %}{% endraw %}


### PR DESCRIPTION
Sometimes the battery will be show as a long string like: 28.99999999996%.. [Picture](https://i.gyazo.com/60f67935c1ebc5fe18f2c0ebefee266a.png)
By adding "|round" this will be shown as 29%

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

