### PR TITLE
Fixed restriction for MQTT Eventstream config

### DIFF
--- a/source/_components/mqtt_eventstream.markdown
+++ b/source/_components/mqtt_eventstream.markdown
@@ -25,8 +25,8 @@ mqtt_eventstream:
 
 Configuration variables:
 
-- **publish_topic** (*Required*): Topic for publishing local events
-- **subscribe_topic** (*Required*): Topic to receive events from the remote server.
+- **publish_topic** (*Optional*): Topic for publishing local events
+- **subscribe_topic** (*Optional*): Topic to receive events from the remote server.
 
 ## Multiple Instances
 


### PR DESCRIPTION
Required -> Optional for MQTT Eventstream config parameters to be like in code https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mqtt_eventstream.py#L32