### PR TITLE
Workday automation example, condition state

### DIFF
--- a/source/_components/binary_sensor.workday.markdown
+++ b/source/_components/binary_sensor.workday.markdown
@@ -43,7 +43,7 @@ automation:
   condition:
     condition: state
     entity_id: 'binary_sensor.workday_sensor'
-    state: 'off'
+    state: 'on'
   action:
     service: switch.turn_on
     entity_id: switch.heater


### PR DESCRIPTION
Sensor in 'on' for workday, 'off' for non-workday. Corrected automation example to reflect that.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

