### PR TITLE
Removed duplicate configuration variable 'effect'

### DIFF
--- a/source/_components/light.mqtt_json.markdown
+++ b/source/_components/light.mqtt_json.markdown
@@ -54,7 +54,6 @@ Configuration variables:
 - **brightness** (*Optional*): Flag that defines if the light supports brightness. Default is false.
 - **color_temperature** (*Optional*): Flag that defines if the light supports color temperature. Default is false.
 - **effect** (*Optional*): Flag that defines if the light supports effects. Default is false.
-- **effect** (*Optional*): Flag that defines if the light supports effects. Default is false.
 - **effect_list** (*Optional*): The list of effects the light supports.
 - **flash_time_long** (*Optional*): The duration, in seconds, of a "long" flash. Default is 10.
 - **flash_time_short** (*Optional*): The duration, in seconds, of a "short" flash. Default is 2.


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

