### PR TITLE
Fixed Formatting issue in Mixed Conditions Section

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -58,12 +58,12 @@ condition:
       state: 'home'
     - condition: or
       conditions:
-      - condition: state
-        entity_id: sensor.weather_precip
-        state: 'rain'
-      - condition: numeric_state
-        entity_id: 'sensor.temperature'
-        below: '20'
+        - condition: state
+          entity_id: sensor.weather_precip
+          state: 'rain'
+        - condition: numeric_state
+          entity_id: 'sensor.temperature'
+          below: '20'
 ```
 
 ### {% linkable_title Numeric state condition %}


### PR DESCRIPTION
Mixed conditions had improper formatting after the 'or' condition
