### PR TITLE
Corrected configuration variable for color temp

### DIFF
--- a/source/_components/light.mqtt_json.markdown
+++ b/source/_components/light.mqtt_json.markdown
@@ -52,7 +52,7 @@ Configuration variables:
 
 - **command_topic** (*Required*): The MQTT topic to publish commands to change the light's state.
 - **brightness** (*Optional*): Flag that defines if the light supports brightness. Default is false.
-- **color_temperature** (*Optional*): Flag that defines if the light supports color temperature. Default is false.
+- **color_temp** (*Optional*): Flag that defines if the light supports color temperature. Default is false.
 - **effect** (*Optional*): Flag that defines if the light supports effects. Default is false.
 - **effect_list** (*Optional*): The list of effects the light supports.
 - **flash_time_long** (*Optional*): The duration, in seconds, of a "long" flash. Default is 10.


### PR DESCRIPTION
The documented configuration variable for color temperature is in fact named "color_temp" (not "color_temperature" as described). It took me some time to figure out this in my home assistant configuration :)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

