### PR TITLE
[HASS Configurator] Update documentation, add link in menu

### DIFF
--- a/source/_docs/ecosystem/hass-configurator.markdown
+++ b/source/_docs/ecosystem/hass-configurator.markdown
@@ -24,7 +24,8 @@ Essentially this is a browser-based alternative to modifying your configuration 
 - Check valid configuration and restart Home Assistant directly with the click of a button
 - SSL support
 - Optional authentication and IP filtering for additional security
-- Direct links to Home Assistant documentation
+- Direct links to Home Assistant documentation and icons
+- Execute shell commands
 - Runs on pretty much any machine Home Assistant can run on
 
 <p class='note warning'>
@@ -33,7 +34,7 @@ Consider running the configurator as a user with limited privileges to limit pos
 
 ### {% linkable_title Installation (Linux, OS X) %}
 There are no dependencies on Python modules that are not part of the standard library. And all the fancy JavaScript libraries are loaded from CDN (which means this doesn't work when you're offline).  
-- Copy [configurator.py](https://github.com/danielperna84/hass-poc-configurator/blob/master/configurator.py) to your Home Assistant configuration directory (e.g /home/homeassistant/.homeassistant)
+- Copy [configurator.py](https://github.com/danielperna84/hass-configurator/blob/master/configurator.py) to your Home Assistant configuration directory (e.g /home/homeassistant/.homeassistant)
 - Make it executable: `sudo chmod 755 configurator.py`
 - (Optional) Set the `GIT` variable in configurator.py to `True` if [GitPython](https://gitpython.readthedocs.io/) is installed on your system. This is required if you want to make use of the Git integration.
 - Execute it: `sudo ./configurator.py`
@@ -41,7 +42,7 @@ There are no dependencies on Python modules that are not part of the standard li
 
 ### {% linkable_title Configuration %}
 Near the top of the configurator.py-file you will find some global variables you can change to customize the configurator. If you are unfamiliar with Python: when setting variables of the type _string_, you have to write that within quotation marks. The default settings are fine for just checking out the configurator quickly. With more customized setups you should change some settings though.  
-To keep your settings across updates it is also possible to save settings in an external file. In that case copy [settings.conf](https://github.com/danielperna84/hass-poc-configurator/blob/master/settings.conf) whereever you like and append the full path to the file to the command when starting the configurator. E.g. `sudo .configurator.py /home/homeassistant/.homeassistant/mysettings.conf`. This file is in JSON format. So make sure it has a valid syntax (you can set the editor to JSON to get syntax highlighting for the settings). The major difference to the settings in the py-file is, that `None` becomes `null`.
+To keep your settings across updates it is also possible to save settings in an external file. In that case copy [settings.conf](https://github.com/danielperna84/hass-configurator/blob/master/settings.conf) whereever you like and append the full path to the file to the command when starting the configurator. E.g. `sudo .configurator.py /home/homeassistant/.homeassistant/mysettings.conf`. This file is in JSON format. So make sure it has a valid syntax (you can set the editor to JSON to get syntax highlighting for the settings). The major difference to the settings in the py-file is, that `None` becomes `null`.
 
 #### LISTENIP (string)
 The IP the service is listening on. By default it is binding to `0.0.0.0`, which is every interface on the system.
@@ -99,11 +100,11 @@ Since the configurator script on its own is no service, you will have to take so
 
 1. Fork the process into the background with the command:  
 `nohup sudo ./configurator.py &`
-2. If your system is using systemd (that's usually what you'll find on a Raspberry PI), there's a [template file](https://github.com/danielperna84/hass-poc-configurator/blob/master/hass-poc-configurator.systemd) you can use and then apply the same process to integrate it as mentioned in the [Home Assistant documentation](https://home-assistant.io/docs/autostart/systemd/). If you use this method you have to set the `BASEPATH` variable according to your environment.
-3. If you have [supervisor](http://supervisord.org/) running on your system, [hass-poc-configurator.supervisor](https://github.com/danielperna84/hass-poc-configurator/blob/master/hass-poc-configurator.supervisor) would be an example configuration you could use to control the configurator.
+2. If your system is using systemd (that's usually what you'll find on a Raspberry PI), there's a [template file](https://github.com/danielperna84/hass-configurator/blob/master/hass-poc-configurator.systemd) you can use and then apply the same process to integrate it as mentioned in the [Home Assistant documentation](https://home-assistant.io/docs/autostart/systemd/). If you use this method you have to set the `BASEPATH` variable according to your environment.
+3. If you have [supervisor](http://supervisord.org/) running on your system, [hass-poc-configurator.supervisor](https://github.com/danielperna84/hass-configurator/blob/master/hass-poc-configurator.supervisor) would be an example configuration you could use to control the configurator.
 4. A tool called [tmux](https://tmux.github.io/), which should be pre-installed with [HASSbian](https://home-assistant.io/docs/hassbian/).
 5. A tool called [screen](http://ss64.com/bash/screen.html) (alternative to tmux). If it's not already installed on your system, you can do `sudo apt-get install screen` or `sudo yum install screen` to get it. When it's installed, start a screen session by executing `screen`. Then navigate to your Home Assistant directory and start the configurator like described above. Put the screen session into the background by pressing `CTRL+A` and then `CTRL+D`. It is now safe to disconnect from your SSH session.
 To resume the screen session, log in to your machine and execute `screen -r`.
 
 ### {% linkable_title Troubleshooting, Issues etc. %}
-If you encounter difficulties setting up the configurator or stumble upon a possible bug, head over to the [Issues](https://github.com/danielperna84/hass-poc-configurator/issues) section of the configurator repository. Additionally there is a thread at the [Home Assistant Community](https://community.home-assistant.io/t/simplistic-configuration-ui/10175) where common problems may have been discussed already. And if not, there are always friendly people around to help finding solutions.
+If you encounter difficulties setting up the configurator or stumble upon a possible bug, head over to the [Issues](https://github.com/danielperna84/hass-configurator/issues) section of the configurator repository. Additionally there is a thread at the [Home Assistant Community](https://community.home-assistant.io/t/simplistic-configuration-ui/10175) where common problems may have been discussed already. And if not, there are always friendly people around to help finding solutions.

--- a/source/_includes/asides/docs_navigation.html
+++ b/source/_includes/asides/docs_navigation.html
@@ -195,6 +195,7 @@
           <li>{% active_link /docs/ecosystem/scenegen/ scenegen %}</li>
           <li>{% active_link /docs/ecosystem/synology/ Synology %}</li>
           <li>{% active_link /docs/ecosystem/backup/backup_github/ Backup to GitHub %}</li>
+          <li>{% active_link /docs/ecosystem/hass-configurator/ HASS Configurator %}</li>
         </ul>
     </ul>
   </div>


### PR DESCRIPTION
**Description:**
Minor update of the documentation for the HASS Configurator. On top of that, the link to the documentation is missing in the menu on the right on ecosystem-sites. Both issues are being addressed with this PR.

