### PR TITLE
Remove references to deprecated `new_devices_group`

### DIFF
--- a/source/_components/light.rflink.markdown
+++ b/source/_components/light.rflink.markdown
@@ -90,6 +90,7 @@ By default new lights are assigned the `switchable` type. Protocol supporting di
 
 Lights are added automatically when the RFLink gateway intercepts a wireless command in the ether. To prevent cluttering the frontend use any of these methods:
 
+- Disable automatically adding of unconfigured new sensors (set `automatic_add` to `false`).
 - Hide unwanted devices using [customizations](/getting-started/customizing-devices/)
 - [Ignore devices on a platform level](/components/rflink/#ignoring-devices)
 

--- a/source/_components/light.rflink.markdown
+++ b/source/_components/light.rflink.markdown
@@ -38,6 +38,7 @@ light:
 
 Configuration variables:
 
+- **automatic_add** (*Optional*): Automatically add new/unconfigured devices to HA if detected (default: True).
 - **devices**  (*Optional*): A list of devices with their name to use in the frontend.
 - **device_defaults**: (*Optional*)
   - **fire_event** (*Optional*): Set default `fire_event` for Rflink switch devices (see below).

--- a/source/_components/light.rflink.markdown
+++ b/source/_components/light.rflink.markdown
@@ -18,17 +18,6 @@ First you have to set up your [rflink hub](/components/rflink/).
 
 After configuring the RFLink hub lights will be automatically discovered and added.
 
-New/unknown lights can be assigned to a default group automatically by specifying the `new_devices_group` option with a group name. If the group doesn't exist it will be created.
-
-For example:
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  platform: rflink
-  new_devices_group: "New Rflink Lights"
-```
-
 RFLink switch/light ID's are composed of: protocol, id, switch. For example: `newkaku_0000c6c2_1`.
 
 Once the ID of a light is known it can be used to configure the light in HA, for example to add it to a different group, hide it or configure a nice name.
@@ -50,7 +39,6 @@ light:
 Configuration variables:
 
 - **devices**  (*Optional*): A list of devices with their name to use in the frontend.
-- **new_devices_group** (*Optional*): Create group to add new/unknown devices to.
 - **device_defaults**: (*Optional*)
   - **fire_event** (*Optional*): Set default `fire_event` for Rflink switch devices (see below).
   - **signal_repetitions** (*Optional*): Set default `signal_repetitions` for Rflink switch devices (see below).
@@ -101,7 +89,6 @@ By default new lights are assigned the `switchable` type. Protocol supporting di
 
 Lights are added automatically when the RFLink gateway intercepts a wireless command in the ether. To prevent cluttering the frontend use any of these methods:
 
-- Configure a `new_devices_group` for lights and optionally add it to a different `view`.
 - Hide unwanted devices using [customizations](/getting-started/customizing-devices/)
 - [Ignore devices on a platform level](/components/rflink/#ignoring-devices)
 

--- a/source/_components/sensor.rflink.markdown
+++ b/source/_components/sensor.rflink.markdown
@@ -36,6 +36,7 @@ sensor:
 
 Configuration variables:
 
+- **automatic_add** (*Optional*): Automatically add new/unconfigured devices to HA if detected (default: True).
 - **devices**  (*Optional*): A list of devices with their name to use in the frontend.
 
 Device configuration variables:

--- a/source/_components/sensor.rflink.markdown
+++ b/source/_components/sensor.rflink.markdown
@@ -50,6 +50,7 @@ Device configuration variables:
 
 Sensors are added automatically when the RFLink gateway intercepts a wireless command in the ether. To prevent cluttering the frontend use any of these methods:
 
+- Disable automatically adding of unconfigured new sensors (set `automatic_add` to `false`).
 - Hide unwanted devices using [customizations](/getting-started/customizing-devices/)
 - [Ignore devices on a platform level](/components/rflink/#ignoring-devices)
 

--- a/source/_components/sensor.rflink.markdown
+++ b/source/_components/sensor.rflink.markdown
@@ -18,17 +18,6 @@ First you have to set up your [rflink hub](/components/rflink/).
 
 After configuring the RFLink hub sensors will be automatically discovered and added.
 
-New/unknown sensors can be assigned to a default group automatically by specifying the `new_devices_group` option with a group name. If the group doesn't exist it will be created.
-
-For example:
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  platform: rflink
-  new_devices_group: "New RFLink Sensors"
-```
-
 RFLink sensor ID's are composed of: protocol, id and type (optional). For example: `alectov1_0334_temp`. Some sensors emit multiple types of data. Each will be created as its own
 
 Once the ID of a sensor is known it can be used to configure the sensor in HA, for example to add it to a different group, hide it or configure a nice name.
@@ -48,7 +37,6 @@ sensor:
 Configuration variables:
 
 - **devices**  (*Optional*): A list of devices with their name to use in the frontend.
-- **new_devices_group** (*Optional*): Create group to add new/unknown devices to.
 
 Device configuration variables:
 
@@ -61,7 +49,6 @@ Device configuration variables:
 
 Sensors are added automatically when the RFLink gateway intercepts a wireless command in the ether. To prevent cluttering the frontend use any of these methods:
 
-- Configure a `new_devices_group` for sensors and optionally add it to a different `view`.
 - Hide unwanted devices using [customizations](/getting-started/customizing-devices/)
 - [Ignore devices on a platform level](/components/rflink/#ignoring-devices)
 


### PR DESCRIPTION
**Description:** Remove references to deprecated `new_devices_group`


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/issues/6735 https://github.com/home-assistant/home-assistant/pull/6580