### PR TITLE
Revert "Revert "Added documentation changes for ZM external trigger""

### DIFF
--- a/source/_components/switch.zoneminder.markdown
+++ b/source/_components/switch.zoneminder.markdown
@@ -34,6 +34,23 @@ Configuration variables:
 - **command_on** (*Required*): The function you want the camera to run when turned on.
 - **command_off** (*Required*): The function you want the camera to run when turned off.
 
+External trigger mode:
+
+Zoneminder supports "External Trigger", where recording is triggered out-of-band (not with ZM's built-in motion detector).
+This is useful if your camera takes a while to 'warmup' and you use some external sensor like PIR motion detector.
+In this case camera can be kept in 'Nodect' state so it is warm and ready to capture. Once external trigger is activated camera starts recording immediately.
+This way you will not lose any frames and actually see how your S.W.A.T team deals with the intruder stepped into your nuclear facility.
+
+Configuration variables:
+
+- **ext_trigger_enable** (*Optional*): Enable external trigger switch. This will create 'trigger' switch for each of your monitors.
+- **ext_trigger_time** (*Optional*): How long ZM is to record once switch is triggered.
+- **ext_trigger_cause** (*Optional*): Text that will appear as 'cause' in ZM event log.
+
+Please note:
+* If you use trigger mode, it is recommended to keep camera in 'Nodect' state, so set both **command_on** and **command_off** to Nodect.
+* Make sure OPT_TRIGGER is enabled in ZM
+* If your trigger source can generate "no motion" event, you may want to set **ext_trigger_time** to some large value.
 
 <p class='note'>
 The default functions installed by ZoneMinder are: None, Monitor, Modect, Record, Mocord, Nodect.

--- a/source/_components/zoneminder.markdown
+++ b/source/_components/zoneminder.markdown
@@ -28,6 +28,7 @@ Configuration variables:
 - **ssl** (*Optional*): Set to `True` if your ZoneMinder installation is using SSL. Default to `False`.
 - **username** (*Optional*): Your ZoneMinder username.
 - **password** (*Optional*): Your ZoneMinder password. Required if `OPT_USE_AUTH` is enabled in ZM.
+- **trigger_port** (*Optional*): ZM's external trigger port. Default is 6802
 
 ### {% linkable_title Full configuration %}
 


### PR DESCRIPTION
The docs got merged too soon. This PR should only be merged when the PR In the main repo has been merged: https://github.com/home-assistant/home-assistant/pull/6836

Reverts home-assistant/home-assistant.github.io#2359