### PR TITLE
Updated sensor.min_max to include missing configuration variable

### DIFF
--- a/source/_components/sensor.min_max.markdown
+++ b/source/_components/sensor.min_max.markdown
@@ -38,7 +38,6 @@ sensor:
     type: min
     name: "Lowest House Temperature"
     unit_of_measurement: '°C'
-    
 ```
 
 Configuration variables:

--- a/source/_components/sensor.min_max.markdown
+++ b/source/_components/sensor.min_max.markdown
@@ -35,6 +35,10 @@ sensor:
       - sensor.kitchen_temperature
       - sensor.living_room_temperature
       - sensor.office_temperature
+    type: min
+    name: "Lowest House Temperature"
+    unit_of_measurement: '°C'
+    
 ```
 
 Configuration variables:
@@ -42,4 +46,5 @@ Configuration variables:
 - **entity_ids** (*Required*): At least two entities to monitor
 - **type** (*Optional*): The type of sensor: `min`, `max` or `mean`. Defaults to `max`.
 - **name** (*Optional*): Name of the sensor to use in the frontend.
+- **unit_of_measurement** (*Optional*): Defines the units of measurement of the sensor, if any.
 - **round_digits** (*Optional*): Round mean value to specified number of digits. Defaults to 2.


### PR DESCRIPTION
Updated example and added extra missing  **unit_of_measurement** configuration variable.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

