### PR TITLE
Update apache.markdown

### DIFF
--- a/source/_docs/ecosystem/apache.markdown
+++ b/source/_docs/ecosystem/apache.markdown
@@ -55,7 +55,7 @@ If you don't want HTTPS, you can change `<VirtualHost *:443>` to `<VirtualHost *
 
 <p class='note'>
 In case you are getting occasional HTTP 504 error messages ("Gateway Timeout") when accessing the Web UI through your proxy, try adding disablereuse=on to both ProxyPass directives:
-
+</p>
 ```text
 <VirtualHost *:443>
   [...]
@@ -65,7 +65,6 @@ In case you are getting occasional HTTP 504 error messages ("Gateway Timeout") w
   [...]
 </VirtualHost>
 ```
-</p>
 
 #### {% linkable_title Multiple Instance %}
 


### PR DESCRIPTION
Placed config snippet for HTTP 504 error workaround outside of class=note paragraph as it aparently doesn't format well inside a note.
