### PR TITLE
Document new token auth option for Hook switch

### DIFF
--- a/source/_components/switch.hook.markdown
+++ b/source/_components/switch.hook.markdown
@@ -20,11 +20,19 @@ In short, Hook is an RF to Wi-Fi bridge, controlling devices that recieve comman
 
 Hook provides a simple [REST API](https://app.swaggerhub.com/api/rahilj/GetHook_RestAPI/v1). This Home Assistant component reads in devices that have been set up in the official app.
 
+Configure with either your username/password or your API token for the official app.
+
 ```yaml
 # Example configuration.yaml entry
 -  platform: hook
    username: <email address>
    password: !secret hook
+```
+OR
+```yaml
+# Example configuration.yaml entry
+-  platform: hook
+   token: <your API token>
 ```
 
 Extra debug logging is available, if you need it.

--- a/source/_components/switch.hook.markdown
+++ b/source/_components/switch.hook.markdown
@@ -28,7 +28,7 @@ Configure with either your username/password or your API token for the official 
    username: <email address>
    password: !secret hook
 ```
-OR
+Or
 ```yaml
 # Example configuration.yaml entry
 -  platform: hook


### PR DESCRIPTION
**Description:**

Reflect new option to configure Hook switch with API token rather than username/password.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#6922

