### PR TITLE
Update raspberry-pi-all-in-one.markdown

### DIFF
--- a/source/_docs/installation/raspberry-pi-all-in-one.markdown
+++ b/source/_docs/installation/raspberry-pi-all-in-one.markdown
@@ -22,7 +22,7 @@ Irrespective of whether  you use SSH to connect to the Pi from another computer 
 *  Run the following command
 
 ```bash
-$ curl -O https://raw.githubusercontent.com/home-assistant/fabric-home-assistant/master/hass_rpi_installer.sh && sudo chown pi:pi hass_rpi_installer.sh && bash hass_rpi_installer.sh
+curl -O https://raw.githubusercontent.com/home-assistant/fabric-home-assistant/master/hass_rpi_installer.sh && sudo chown pi:pi hass_rpi_installer.sh && bash hass_rpi_installer.sh
 ```
 <p class='note warning'>
   Note this command is one-line and not run as sudo.


### PR DESCRIPTION
Remove the leading command prompt from the installer command, since it keeps causing confusion in people who're not experienced with command lines.

The latest thread showing this is https://community.home-assistant.io/t/all-in-one-installer-and-hassbian-not-working-help/15413 - however it's not the first and I'm pretty sure I remember catching a few of these on Gitter too.