### PR TITLE
Broken link - file header link to documentation

### DIFF
--- a/source/_cookbook/python_component_basic_state.markdown
+++ b/source/_cookbook/python_component_basic_state.markdown
@@ -23,7 +23,7 @@ To get started, create the file `<config dir>/custom_components/hello_state.py` 
 Support for showing text in the frontend.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/hello_state/
+https://home-assistant.io/cookbook/python_component_basic_state/
 """
 import logging
 


### PR DESCRIPTION
Found a broken link: file header link to documentation.
Suggest to update the link from: https://home-assistant.io/components/hello_state/ to 
https://home-assistant.io/cookbook/python_component_basic_state/

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

