### PR TITLE
Updated the docs for rest_command

### DIFF
--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -35,6 +35,7 @@ Configuration variables:
   - **username** (*Optional*): The username for HTTP authentication.
   - **password** (*Optional*): The password for HTTP authentication.
   - **timeout** (*Optional*): Timeout for requests. Defaults to 10 seconds.
+  - **content_type** (*Optional*): Content type for the request. Defaults to 'text/plain'.
 
 The commands can be dynamic, using templates to insert values of other entities. Service call support variables for template stuff.
 

--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -35,7 +35,7 @@ Configuration variables:
   - **username** (*Optional*): The username for HTTP authentication.
   - **password** (*Optional*): The password for HTTP authentication.
   - **timeout** (*Optional*): Timeout for requests. Defaults to 10 seconds.
-  - **content_type** (*Optional*): Content type for the request. Defaults to 'text/plain'.
+  - **content_type** (*Optional*): Content type for the request.
 
 The commands can be dynamic, using templates to insert values of other entities. Service call support variables for template stuff.
 


### PR DESCRIPTION
Added the optional content_type config value, used to specify the request content type.

**Description:**
Currently, there is no way to set the request content type of the rest_command, and in some scenarios (with Kodi for instance), API requests will be rejected if the proper content-type

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7101

