### PR TITLE
switch.zoneminder: Note that system:edit permission is required

### DIFF
--- a/source/_components/switch.zoneminder.markdown
+++ b/source/_components/switch.zoneminder.markdown
@@ -16,7 +16,7 @@ ha_release: 0.31
 The `zoneminder` switch platform allows you to toggle the current function of all cameras attached to your [ZoneMinder](https://www.zoneminder.com) instance.
 
 <p class='note'>
-You must have the [ZoneMinder component](/components/zoneminder/) configured to use this.
+You must have the [ZoneMinder component](/components/zoneminder/) configured to use this and if ZoneMinder authentication is enabled the account specified in the component configuration must have "Edit" permission for "System".
 </p>
 
 To enable this switch, add the following lines to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**
The switch won't work if the account used to authenticate to ZM doesn't have the system permission set to "edit". See https://github.com/ZoneMinder/ZoneMinder/blob/48e2c5f6ecea2499f37985485c9c650b552abe89/web/api/app/Controller/MonitorsController.php#L125