### PR TITLE
Update telegram_webhooks.markdown

### DIFF
--- a/source/_components/telegram_webhooks.markdown
+++ b/source/_components/telegram_webhooks.markdown
@@ -63,7 +63,7 @@ telegram_webhooks:
 
 ### {% linkable_title Configuration samples %}
 
-Telegram webhooks raise an event `telegram.command` with a payload.
+Telegram webhooks raise an event `telegram_command` with a payload.
 
 ```json
 {

--- a/source/_components/telegram_webhooks.markdown
+++ b/source/_components/telegram_webhooks.markdown
@@ -80,7 +80,7 @@ alias: 'telegram bot that reply pong to ping'
 hide_entity: true
 trigger:
   platform: event
-  event_type: telegram.command
+  event_type: telegram_command
   event_data:
     command: '/ping'
 action:
@@ -94,7 +94,7 @@ Example that show keyboard interaction with `notify.telegram`
 ```yaml
 trigger:
   platform: event
-  event_type: telegram.command
+  event_type: telegram_command
   event_data:
     command: '/start'
 action:
@@ -112,7 +112,7 @@ and an automation to trigger a related command "/siren".
 ```yaml
 trigger:
   platform: event
-  event_type: telegram.command
+  event_type: telegram_command
   event_data:
     command: '/siren'
 action:


### PR DESCRIPTION
The telegram.command is the wrong syntax and should be telegram_command. This took me 3 days to figure out so I hope it'll save somebody else the time.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

