### PR TITLE
Add a note about timezones and alerts

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -16,6 +16,8 @@ The `alert` component is designed to notify you when problematic issues arise. F
 
 Alerts will add an entity to the front end only when they are firing. This entity allows you to silence an alert until it is resolved.
 
+When using the `alert` component it is important that the timezone used for Home Assistant and the underlying operating system match. Failing to do so may result in multiple alerts being sent at the same time (such as when Home Assistant is set to the `America/Detroit` timezone but the operating system uses `UTC`).
+
 ### {% linkable_title Basic Example %}
 
 The `alert` component makes use of any of the `notifications` components. To setup the `alert` component, first, you must setup a `notification` component. Then, add the following to your configuration file:


### PR DESCRIPTION
Add a note about timezones, because otherwise `repeat` breaks if the timezones arent' the same.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

