### PR TITLE
Update typos, path fix, & grammar in logger.markdown

### DIFF
--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -68,8 +68,8 @@ data:
   homeassistant.components.media_player.yamaha: debug
 ```
 
-The log information are stored in the [configuration directory](/docs/configuration/) as `home-assistant.log` and you can read it with the command-line tool `cat` or follow it dynamicly with `tail -f`. If you are a Rasbian user then like the example below:
+The log information are stored in the [configuration directory](/docs/configuration/) as `home-assistant.log` and you can read it with the command-line tool `cat` or follow it dynamically with `tail -f`. If you are a Hassbian user you can use the example below:
 
 ```bash
-$ tail -f /home/pi/.homeassistant/home-assistant.log
+$ tail -f /home/homeassistant/.homeassistant/home-assistant.log
 ```


### PR DESCRIPTION
* Fix path for `tail -f ` for reading `home-assistant.log`
* Fix typo (spelling)
* Fix sentence structure regarding using the `tail` command.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

