### PR TITLE
Added sudo on the make install command

### DIFF
--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -27,7 +27,7 @@ $ cd libcoap
 $ ./autogen.sh
 $ ./configure --disable-documentation --disable-shared --without-debug CFLAGS="-D COAP_DEBUG_FD=stderr"
 $ make
-$ make install
+$ sudo make install
 ```
 
 To enable these lights, add the following lines to your `configuration.yaml` file:


### PR DESCRIPTION
The make install of the coap failed for me when ran without sudo

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

