### PR TITLE
Added some clarifying information

### DIFF
--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Polling"
 ha_release: 0.43
 ---
 
-The `tradfri` component supports for the IKEA Trådfri (Tradfri) gateway. The gateway can control lights connected to it.
+The `tradfri` component supports for the IKEA Trådfri (Tradfri) gateway, The gateway can control lights connected to it and Home Assistant will automatically discover its presents on your network. 
 
 For this to work, you need to install a modified lib-coap library:
 
@@ -29,8 +29,13 @@ $ ./configure --disable-documentation --disable-shared --without-debug CFLAGS="-
 $ make
 $ make install
 ```
+You will be prompted to configure the gateway through the Home Assistant interface, Enter the security key when prompted and click configure
 
-To enable these lights, add the following lines to your `configuration.yaml` file:
+<p class='note'>
+If you see an "Unable to connect" message, restart the gateway and try again
+</p>
+ 
+The gateway can also be manually configured by adding the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -42,4 +47,4 @@ tradfri:
 Configuration variables:
 
  - **host** (*Required*): The IP address or hostname of your Trådfri gateway.
- - **api_key** (*Required*): Can be found on the back of the Trådfri gateway.
+ - **api_key** (*Required*): Can be found listed as Security Key on the back of the Trådfri gateway.

--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Polling"
 ha_release: 0.43
 ---
 
-The `tradfri` component supports for the IKEA Trådfri (Tradfri) gateway, The gateway can control lights connected to it and Home Assistant will automatically discover its presents on your network. 
+The `tradfri` component supports for the IKEA Trådfri (Tradfri) gateway. The gateway can control lights connected to it and Home Assistant will automatically discover its presence on your network. 
 
 For this to work, you need to install a modified lib-coap library:
 
@@ -32,7 +32,7 @@ $ make install
 You will be prompted to configure the gateway through the Home Assistant interface, Enter the security key when prompted and click configure
 
 <p class='note'>
-If you see an "Unable to connect" message, restart the gateway and try again
+If you see an "Unable to connect" message, restart the gateway and try again.
 </p>
  
 The gateway can also be manually configured by adding the following lines to your `configuration.yaml` file:


### PR DESCRIPTION
Added additional details about automatic discovery of the gateway on the network and how to configure it, found that many user have had to restart the gateway to get the configurator working, so also added a note about that

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

