### PR TITLE
bind HTTPS to ipv6 port in NGINX example configuration

### DIFF
--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -111,6 +111,7 @@ http {
 
         # These shouldn't need to be changed
         listen 443 default_server;
+        listen [::]:443 default_server ipv6only=on;
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
         ssl on;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;

--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -89,8 +89,7 @@ http {
         server_name example.com;
 
         # These shouldn't need to be changed
-        listen 80 default_server;
-        listen [::]:80 default_server ipv6only=on;
+        listen [::]:80 default_server ipv6only=off;
         return 301 https://$host$request_uri;
     }
 
@@ -110,8 +109,7 @@ http {
 
 
         # These shouldn't need to be changed
-        listen 443 default_server;
-        listen [::]:443 default_server ipv6only=on;
+        listen [::]:443 default_server ipv6only=off; # if your nginx version is >= 1.9.5 you can also add the "http2" flag here
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
         ssl on;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;


### PR DESCRIPTION
**Description:**

The nginx configuration does not bind port 443 with IPv6 (but does so for 80).



Another thing I could change is the fact that (in my setup), the `sites-available/hass` file must not include the `http {... }` wrapping. I was not sure whether that is specific to my setup (fresh nginx installation via `apt-get`) so I did not change it yet.

