### PR TITLE
Cache expiration is cache_value

### DIFF
--- a/source/_components/sensor.miflora.markdown
+++ b/source/_components/sensor.miflora.markdown
@@ -38,7 +38,7 @@ sensor:
 - **median** (*Optional*): Sometimes the sensor measurements show spikes. Using this parameter, the poller will report the median of the last 3 (you can also use larger values) measurements. This filters out single spikes. Median: 5 will also filter double spikes. If you never have problems with spikes, `median: 1` will work fine. 
 - **timeout** (*Optional*): Define the timeout value in seconds when polling (defaults to 10 if not defined)
 - **retries** (*Optional*): Define the number of retries when polling (defaults to 2 if not defined)
-- **cache** (*Optional*): Define cache expiration value in seconds (defaults to 1200 if not defined)
+- **cache_value** (*Optional*): Define cache expiration value in seconds (defaults to 1200 if not defined)
 - **adapter** (*Optional*): Define the bluetooth adapter to use (defaults to hci0). Run `hciconfig` to get a list of available adapters.
 
 Note that by default the sensor is only polled once every 15 minutes. This means with the `median: 3` setting will take as least 30 minutes before the sensor will report a value after a Home Assistant restart. As the values usually change very slowly, this isn't a big problem. 


### PR DESCRIPTION
If I put in the config file cache: 3600 it still used 1200. After looking at the code it turned out cache_value: 3600 is what should be used in the config file.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

