### PR TITLE
Fixes mismatch between code and docs.

### DIFF
--- a/source/_components/device_tracker.mqtt_json.markdown
+++ b/source/_components/device_tracker.mqtt_json.markdown
@@ -20,7 +20,7 @@ To use this device tracker in your installation, add the following to your `conf
 ```yaml
 # Example configuration.yaml entry
 device_tracker:
-  - platform: mqtt
+  - platform: mqtt_json
     devices:
       paulus_oneplus: location/paulus
       annetherese_n4: location/annetherese


### PR DESCRIPTION
**Description:**

The configuration example in the docs has been updated to correct platform name.   

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

