### PR TITLE
Update the platform start trigger

### DIFF
--- a/source/_docs/configuration/group_visibility.markdown
+++ b/source/_docs/configuration/group_visibility.markdown
@@ -124,8 +124,8 @@ automation:
     trigger:
       - platform: state
         entity_id: sensor.occasion
-      - platform: event
-        event_type: homeassistant_start
+      - platform: homeassistant
+        event: start
     action:
       service: script.group_visibility
       data:
@@ -169,8 +169,8 @@ automation:
     trigger:
       - platform: state
         entity_id: sensor.occasion
-      - platform: event
-        event_type: homeassistant_start
+      - platform: homeassistant
+        event: start
     action:
       service: script.group_visibility
       data:


### PR DESCRIPTION
This event no longer works as it's changed: https://home-assistant.io/docs/automation/trigger/#home-assistant-trigger

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

