### PR TITLE
Update group_visibility.markdown

### DIFF
--- a/source/_docs/configuration/group_visibility.markdown
+++ b/source/_docs/configuration/group_visibility.markdown
@@ -103,6 +103,10 @@ sensor:
     name: Occasion
     command: "python3 occasion.py"
 ```
+<p class='note'>
+If you are using docker to run home assistant then the occasion.py script will be placed under /config. Your command should instead be: command: "python3 /command/occasion.py"
+</p>
+
 
 To simplify things, we create a Home Assistant script that changes the visibility of a group, but also verifies that an entity is in a specific state:
 
@@ -124,8 +128,8 @@ automation:
     trigger:
       - platform: state
         entity_id: sensor.occasion
-      - platform: event
-        event_type: homeassistant_start
+      - platform: homeassistant
+        event: start
     action:
       service: script.group_visibility
       data:
@@ -169,8 +173,8 @@ automation:
     trigger:
       - platform: state
         entity_id: sensor.occasion
-      - platform: event
-        event_type: homeassistant_start
+      - platform: homeassistant
+        event: start
     action:
       service: script.group_visibility
       data:


### PR DESCRIPTION
This event no longer works as it's changed: https://home-assistant.io/docs/automation/trigger/#home-assistant-trigger

Also added a hint for docker users... I understand if you don't want that added though!

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

