### PR TITLE
Thermostat-link is broken - Knx Thermostat in meny points to climate.knx

### DIFF
--- a/source/_components/knx.markdown
+++ b/source/_components/knx.markdown
@@ -20,7 +20,7 @@ There is currently support for the following device types within Home Assistant:
 - [Binary Sensor](/components/binary_sensor.knx)
 - [Sensor](/components/sensor.knx)
 - [Switch](/components/switch.knx)
-- [Thermostat](/components/thermostat.knx)
+- [Thermostat](/components/climate.knx)
 
 A `knx` section must be present in the `configuration.yaml` file and contain the following options as required:
 


### PR DESCRIPTION
**Description:**
Thermostat-link is broken - Knx Thermostat in meny points to climate.knx
Link updated to point to climate.knx

