### PR TITLE
Adding documentation for Sense HAT lights

### DIFF
--- a/source/_components/light.sensehat.markdown
+++ b/source/_components/light.sensehat.markdown
@@ -8,8 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: sense-hat.png
+ha_version: 0.44
 ha_category: Light
-ha_iot_class: "Local Push"
+ha_iot_class: "Assumed State"
 ---
 
 The `sensehat` light platform lets you control the [Sense HAT](https://www.raspberrypi.org/products/sense-hat/) board's 8x8 RGB LED matrix on your Raspberry Pi from within Home Assistant.

--- a/source/_components/light.sensehat.markdown
+++ b/source/_components/light.sensehat.markdown
@@ -1,0 +1,26 @@
+---
+layout: page
+title: "Sense HAT Light"
+description: "Instructions how to setup Sense HAT LED lights within Home Assistant."
+date: 2017-04-29 16:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: sense-hat.png
+ha_category: Light
+ha_iot_class: "Local Push"
+---
+
+The `sensehat` light platform lets you control the [Sense HAT](https://www.raspberrypi.org/products/sense-hat/) board's 8x8 RGB LED matrix on your Raspberry Pi from within Home Assistant.
+
+To add `sensehat` to your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+light:
+  platform: sensehat
+  name: SenseHAT
+```
+
+For setting up the Sense HAT sensors, please see the [Sense HAT sensor component](/components/sensor.sensehat/).

--- a/source/_components/sensor.sensehat.markdown
+++ b/source/_components/sensor.sensehat.markdown
@@ -150,3 +150,5 @@ This fix has been tested with a clean install of:
 and
  
 * [Home-Assistant 0.37.1](https://home-assistant.io/getting-started/installation-raspberry-pi-all-in-one/)
+
+For setting up the Sense HAT's RGB LED matrix as lights within Home Assistant, please see the [Sense HAT light component](/components/light.sensehat/).


### PR DESCRIPTION
**Description:**

Adding documentation for Sense HAT lights platform, to use the Sense HAT's 8x8 RGB LED matrix with Home Assistant. Lights component page plus cross referencing from the Sense HAT
sensors component page.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7365