### PR TITLE
Include notes about entity_ids that start with a number

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -89,6 +89,11 @@ Home Assistant adds extensions to allow templates to access all of the current s
 
 [strp-format]: https://docs.python.org/3.4/library/datetime.html#strftime-and-strptime-behavior
 
+<p class='note warning'>
+If your template uses an entity_id that begins with a number (example: device_tracker.2008_gmc) you must use a bracket syntax to avoid errors caused by rendering the entity_id improperly.  In the example given, the correct syntax for the device tracker would be: device_tracker['2008_gmc']
+</p>
+
+
 ## {% linkable_title Examples %}
 
 ### {% linkable_title States %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -90,7 +90,7 @@ Home Assistant adds extensions to allow templates to access all of the current s
 [strp-format]: https://docs.python.org/3.4/library/datetime.html#strftime-and-strptime-behavior
 
 <p class='note warning'>
-If your template uses an entity_id that begins with a number (example: device_tracker.2008_gmc) you must use a bracket syntax to avoid errors caused by rendering the entity_id improperly.  In the example given, the correct syntax for the device tracker would be: device_tracker['2008_gmc']
+If your template uses an entity_id that begins with a number (example: states.device_tracker.2008_gmc) you must use a bracket syntax to avoid errors caused by rendering the entity_id improperly.  In the example given, the correct syntax for the device tracker would be: states.device_tracker['2008_gmc']
 </p>
 
 

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -90,7 +90,7 @@ Home Assistant adds extensions to allow templates to access all of the current s
 [strp-format]: https://docs.python.org/3.4/library/datetime.html#strftime-and-strptime-behavior
 
 <p class='note warning'>
-If your template uses an entity_id that begins with a number (example: states.device_tracker.2008_gmc) you must use a bracket syntax to avoid errors caused by rendering the entity_id improperly.  In the example given, the correct syntax for the device tracker would be: states.device_tracker['2008_gmc']
+If your template uses an `entity_id` that begins with a number (example: `states.device_tracker.2008_gmc`) you must use a bracket syntax to avoid errors caused by rendering the `entity_id` improperly. In the example given, the correct syntax for the device tracker would be: `states.device_tracker['2008_gmc']`
 </p>
 
 


### PR DESCRIPTION
Based on info discovered by @armills in forum thread:  https://community.home-assistant.io/t/google-maps-as-a-card/9382/40

Wanted to update the docs as I had never run into this before nor had I seen it in the docs.



