### PR TITLE
Added a note on ios app discovery

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -28,7 +28,7 @@ Configuration variables:
 - **api_password** (*Optional*): Protect Home Assistant with a password.
 - **server_host** (*Optional*): Only listen to incoming requests on specific ip/host (default: accept all)
 - **server_port** (*Optional*): Let you set a port to use. Defaults to 8123.
-- **base_url** (*Optional*): The url that Home Assistant is available on the internet. For example: `hass-example.duckdns.org:8123`. Defaults to local IP address.
+- **base_url** (*Optional*): The url that Home Assistant is available on the internet. For example: `hass-example.duckdns.org:8123`. Defaults to local IP address. The IOS app finds local installations, if you have a outside url use this so that you can auto fill when discovered in the app.
 - **development** (*Optional*): Disable caching and load unvulcanized assets. Useful for Frontend development.
 - **ssl_certificate** (*Optional*): Path to your TLS/SSL certificate to serve Home Assistant over a secure connection.
 - **ssl_key** (*Optional*): Path to your TLS/SSL key to serve Home Assistant over a secure connection.


### PR DESCRIPTION
**Description:**
Ios app discovers local installations, if you set base_url correctly then you can click your local installation and will automaticly use the outside url of your install.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

