### PR TITLE
Change turn on/off lights example to use 'state'

### DIFF
--- a/source/_cookbook/turn_on_light_for_10_minutes_when_motion_detected.markdown
+++ b/source/_cookbook/turn_on_light_for_10_minutes_when_motion_detected.markdown
@@ -20,7 +20,7 @@ automation:
   trigger:
     platform: state
     entity_id: sensor.motion_sensor
-    to: 'on'
+    state: 'on'
   action:
     service: homeassistant.turn_on
     entity_id: light.kitchen
@@ -29,7 +29,7 @@ automation:
   trigger:
     platform: state
     entity_id: sensor.motion_sensor
-    to: 'off'
+    state: 'off'
     for:
       minutes: 10
   action:


### PR DESCRIPTION
The example in the current documentation does not appear to work in hass 0.43.2. A trigger containing 'to' without a 'from' doesn't fire, however one that uses 'state' does.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

