### PR TITLE
Updating nginx docs for clarity

### DIFF
--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -59,6 +59,10 @@ sudo openssl dhparam -out dhparams.pem 2048
 
 Create a new file `/etc/nginx/sites-available/hass` and copy the configuration file at the bottom of the page into it.
 
+<p class='note'>
+Some Linux distributions (including CentOS and Fedora) will not have the `/etc/nginx/sites-available/` directory. In this case, remove the default server {} block from the `/etc/nginx/nginx.conf` file and paste the contents from the bottom of the page in its place. If doing this, proceed to step 7.
+</p>
+
 ### {% linkable_title 6. Enable the Home Assistant configuration. %}
 
 ```

--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -40,6 +40,7 @@ If you do not own your own domain, you may generate a self-signed certificate. T
 
 ```
 openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 9999
+openssl rsa -in key.pem -out key.pem
 sudo cp key.pem cert.pem /etc/nginx/ssl
 sudo chmod 600 /etc/nginx/ssl/key.pem /etc/nginx/ssl/cert.pem
 sudo chown root:root /etc/nginx/ssl/key.pem /etc/nginx/ssl/cert.pem
@@ -78,56 +79,54 @@ Forward ports 443 and 80 to your server on your router. Do not forward port 8123
 ### {% linkable_title NGINX Config %}
 
 ```
-http {
-    map $http_upgrade $connection_upgrade {
-        default upgrade;
-        ''      close;
-    }
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
 
-    server {
-        # Update this line to be your domain
-        server_name example.com;
+server {
+    # Update this line to be your domain
+    server_name example.com;
 
-        # These shouldn't need to be changed
-        listen [::]:80 default_server ipv6only=off;
-        return 301 https://$host$request_uri;
-    }
+    # These shouldn't need to be changed
+    listen [::]:80 default_server ipv6only=off;
+    return 301 https://$host$request_uri;
+}
 
-    server {
-        # Update this line to be your domain
-        server_name example.com;
+server {
+    # Update this line to be your domain
+    server_name example.com;
 
-        # Ensure these lines point to your SSL certificate and key
-        ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
-        # Use these lines instead if you created a self-signed certificate
-        # ssl_certificate /etc/nginx/ssl/cert.pem;
-        # ssl_certificate_key /etc/nginx/ssl/key.pem;
+    # Ensure these lines point to your SSL certificate and key
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+    # Use these lines instead if you created a self-signed certificate
+    # ssl_certificate /etc/nginx/ssl/cert.pem;
+    # ssl_certificate_key /etc/nginx/ssl/key.pem;
 
-        # Ensure this line points to your dhparams file
-        ssl_dhparam /etc/nginx/ssl/dhparams.pem;
+    # Ensure this line points to your dhparams file
+    ssl_dhparam /etc/nginx/ssl/dhparams.pem;
 
 
-        # These shouldn't need to be changed
-        listen [::]:443 default_server ipv6only=off; # if your nginx version is >= 1.9.5 you can also add the "http2" flag here
-        add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-        ssl on;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
-        ssl_prefer_server_ciphers on;
-        ssl_session_cache shared:SSL:10m;
+    # These shouldn't need to be changed
+    listen [::]:443 default_server ipv6only=off; # if your nginx version is >= 1.9.5 you can also add the "http2" flag here
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+    ssl on;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
 
-        proxy_buffering off;
+    proxy_buffering off;
 
-        location / {
-            proxy_pass http://localhost:8123;
-            proxy_set_header Host $host;
-            proxy_redirect http:// https://;
-            proxy_http_version 1.1;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-        }
+    location / {
+        proxy_pass http://localhost:8123;
+        proxy_set_header Host $host;
+        proxy_redirect http:// https://;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
     }
 }
 ```


### PR DESCRIPTION
**Description:**
Fixing a couple of issues in the nginx docs after seeing recurring questions in the gitter chat.
- Added a step to remove the PEM passphrase from the private key when generating a self-signed keypair. Otherwise nginx will error out upon starting up.
- Removed the `http` block in the given config since available sites are included inside the `http` block already. I confirmed this is the case by checking the nginx.conf file in the packages from the last 3 releases of Debian, Ubuntu, and Raspbian.
- Adding a note about the `sites-available` directory not being present in all distros.