### PR TITLE
Make manual installation docs consistent with AIO

### DIFF
--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -58,8 +58,8 @@ Next up is to create and change to a virtual environment for Home Assistant. Thi
 ```bash
 $ sudo su -s /bin/bash homeassistant
 $ cd /srv/homeassistant
-$ python3 -m venv .
-$ source bin/activate
+$ python3 -m venv homeassistant_venv
+$ source homeassistant_venv/bin/activate
 ```
 Once you have activated the virtual environment you will notice the prompt change and then you can install Home Assistant.
 


### PR DESCRIPTION
**Description:**
Minor change to the manual installation instructions that places the virtualenv in the same location used by the AIO installer.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>
