### PR TITLE
correct quotation mark to work correct

### DIFF
--- a/source/_components/sensor.miflora.markdown
+++ b/source/_components/sensor.miflora.markdown
@@ -21,7 +21,7 @@ To use your Mi Flora plant sensor in your installation, add the following to you
 # Example configuration.yaml entry
 sensor:
   - platform: miflora
-    mac: "xx:xx:xx:xx:xx:xx"
+    mac: 'xx:xx:xx:xx:xx:xx'
     monitored_conditions:
       - temperature
 ```
@@ -50,7 +50,7 @@ A full configuration example could looks the one below:
 # Example configuration.yaml entry
 sensor:
   - platform: miflora
-    mac: "xx:xx:xx:xx:xx:xx"
+    mac: 'xx:xx:xx:xx:xx:xx'
     name: Flower 1
     force_update: false
     median: 3


### PR DESCRIPTION
**Description:**

The example doesn't work because of quotation marks.
Changes this to make it work right away with copy and paste.

