### PR TITLE
Added a note about formats for mediaplayers

### DIFF
--- a/source/_components/tts.voicerss.markdown
+++ b/source/_components/tts.voicerss.markdown
@@ -43,3 +43,5 @@ tts:
     codec: mp3
     format: 8khz_8bit_mono
 ```
+
+Please note, some media_players require a certain format. For example the Sonos requires a format of '44khz_16bit_stereo'


### PR DESCRIPTION
Note points out sonos, since it is widely used and actual

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

