### PR TITLE
Rename "Enviro pHat" to "Raspberry Pi Enviro pHat"

### DIFF
--- a/source/_components/sensor.envirophat.markdown
+++ b/source/_components/sensor.envirophat.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Enviro pHAT"
+title: "Raspberry Pi Enviro pHAT"
 description: "Instructions how to integrate the Enviro pHAT within Home Assistant."
 date: 2017-05-03 17:00
 sidebar: true


### PR DESCRIPTION
When searching the components for "Pi" or "Raspberry" I'd expect the Enviro pHat to be included in those search results.
