### PR TITLE
Fixed a typo in the config tool name

### DIFF
--- a/source/_docs/hassbian/installation.markdown
+++ b/source/_docs/hassbian/installation.markdown
@@ -26,7 +26,7 @@ The following extras are included on the image:
  - GPIO pins are ready to use.
  - Bluetooth is ready to use (supported models only, no Bluetooth LE).
  - SSH server is enabled.
- - A tool called `hassbian_config`. 
+ - A tool called `hassbian-config`. 
 
 ### {% linkable_title Technical Details %}
 


### PR DESCRIPTION
**Description:**

The tool name appears to be `hassbian-config` when I'm on the device.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

