### PR TITLE
Added spotify shuffle to Media Player page

### DIFF
--- a/source/_components/media_player.markdown
+++ b/source/_components/media_player.markdown
@@ -64,3 +64,11 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | ---------------------- | -------- | ---------------------------------------------------- |
 | `entity_id`            |      yes | Target a specific media player. Defaults to all.     |
 | `source`               |       no | Name of the source to switch to. Platform dependent. |
+
+#### {% linkable_title Service `media_player/shuffle_set` %}
+Currently only supports Spotify.
+
+| Service data attribute | Optional | Description                                          |
+| ---------------------- | -------- | ---------------------------------------------------- |
+| `entity_id`            |       no | Target a specific media player. For example `media_player.spotify`|
+| `source`               |       no | `true`/`false` for enabling/disabling shuffle            |


### PR DESCRIPTION
entity_id is not optional as it seems like it doesn't work if not included. Throws NotImplementedError() otherwise.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7339

