### PR TITLE
Added documentation for the rpi_pfio platform.

### DIFF
--- a/source/_components/binary_sensor.rpi_pfio.markdown
+++ b/source/_components/binary_sensor.rpi_pfio.markdown
@@ -1,0 +1,40 @@
+---
+layout: page
+title: "PiFace Digital I/O Binary Sensor"
+description: "Instructions how to integrate the PiFace Digital I/O module into Home Assistant as a binary sensor."
+date: 2016-05-08 15:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: raspberry-pi.png
+ha_category: Binary Sensor
+ha_release: 0.44.3
+---
+
+The `rpi_pfio` binary sensor platform allows you to read sensor values of the [PiFace Digital I/O](https://www.element14.com/community/docs/DOC-69001) .
+
+To use your PiFace Digital I/O module in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+  - platform: rpi_pfio
+    ports:
+      0:
+        name: PIR Office
+        invert_logic: true
+      1:
+        name: Doorbell
+        settle_time: 50
+```
+
+Configuration variables:
+
+- **ports** array (*Required*): Array of used ports.
+  - **num** (*Required*): Port number.
+    - **name** (*Required*): Port name.
+    - **pull_mode** (*Optional*): The internal pull to use (UP or DOWN). Default is UP.
+    - **settle_time** (*Optional*): The time in milliseconds for port debouncing. Default is 20ms.
+    - **invert_logic** (*Optional*): If true, inverts the output logic to ACTIVE LOW. Default is false (ACTIVE HIGH).
+

--- a/source/_components/binary_sensor.rpi_pfio.markdown
+++ b/source/_components/binary_sensor.rpi_pfio.markdown
@@ -34,7 +34,6 @@ Configuration variables:
 - **ports** array (*Required*): Array of used ports.
   - **num** (*Required*): Port number.
     - **name** (*Required*): Port name.
-    - **pull_mode** (*Optional*): The internal pull to use (UP or DOWN). Default is UP.
     - **settle_time** (*Optional*): The time in milliseconds for port debouncing. Default is 20ms.
     - **invert_logic** (*Optional*): If true, inverts the output logic to ACTIVE LOW. Default is false (ACTIVE HIGH).
 

--- a/source/_components/binary_sensor.rpi_pfio.markdown
+++ b/source/_components/binary_sensor.rpi_pfio.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: raspberry-pi.png
 ha_category: Binary Sensor
-ha_release: 0.44.3
+ha_release: 0.45
 ---
 
 The `rpi_pfio` binary sensor platform allows you to read sensor values of the [PiFace Digital I/O](https://www.element14.com/community/docs/DOC-69001) .

--- a/source/_components/rpi_pfio.markdown
+++ b/source/_components/rpi_pfio.markdown
@@ -1,0 +1,16 @@
+---
+layout: page
+title: "PiFace Digital I/O"
+description: "Instructions how to integrate the PiFace Digital I/O module into Home Assistant."
+date: 2016-05-08 15:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: raspberry-pi.png
+ha_category: DIY
+ha_release: 0.44.3
+---
+
+The `rpi_pfio` component is the base for all related PFIO platforms in Home Assistant. There is no setup needed for the component itself, for the platforms please check their corresponding pages.
+

--- a/source/_components/rpi_pfio.markdown
+++ b/source/_components/rpi_pfio.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: raspberry-pi.png
 ha_category: DIY
-ha_release: 0.44.3
+ha_release: 0.45
 ---
 
 The `rpi_pfio` component is the base for all related PFIO platforms in Home Assistant. There is no setup needed for the component itself, for the platforms please check their corresponding pages.

--- a/source/_components/switch.rpi_pfio.markdown
+++ b/source/_components/switch.rpi_pfio.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: raspberry-pi.png
 ha_category: Switch
-ha_release: 0.44.3
+ha_release: 0.45
 ---
 
 The `rpi_pfio` switch platform allows you to control the [PiFace Digital I/O](https://www.element14.com/community/docs/DOC-69001) module.

--- a/source/_components/switch.rpi_pfio.markdown
+++ b/source/_components/switch.rpi_pfio.markdown
@@ -1,0 +1,37 @@
+---
+layout: page
+title: "PiFace Digital I/O Switch"
+description: "Instructions how to integrate the PiFace Digital I/O module into Home Assistant as a switch."
+date: 2016-05-08 15:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: raspberry-pi.png
+ha_category: Switch
+ha_release: 0.44.3
+---
+
+The `rpi_pfio` switch platform allows you to control the [PiFace Digital I/O](https://www.element14.com/community/docs/DOC-69001) module.
+
+To use your PiFace Digital I/O module in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: rpi_pfio
+    ports:
+      0:
+        name: Doorlock
+        invert_logic: true
+      1:
+        name: Light Desk
+```
+
+Configuration variables:
+
+- **ports** array (*Required*): Array of used ports.
+  - **num** (*Required*): Port number.
+    - **name** (*Required*): Port name.
+    - **invert_logic** (*Optional*): If true, inverts the output logic to ACTIVE LOW. Default is false (ACTIVE HIGH).
+


### PR DESCRIPTION
**Description:**
Support for the PiFace Digital I/O module (Raspberry Pi add on board)
This is basically a port of the rpi_gpio component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7494

