### PR TITLE
SMTP notify enhancements: full HTML emails and custom `product_name` in email headers

### DIFF
--- a/source/_components/notify.smtp.markdown
+++ b/source/_components/notify.smtp.markdown
@@ -35,8 +35,9 @@ Configuration variables:
 - **sender** (*Optional*): E-mail address of the sender.
 - **username** (*Optional*): Username for the SMTP account.
 - **password** (*Optional*): Password for the SMTP server that belongs to the given username. If the password contains a colon it need to be wrapped in apostrophes.
-- **recipient** (*Required*): E-mail address of the recipient of the notification. This can be a recpient address or a list of addresses for multiple recipients.
+- **recipient** (*Required*): E-mail address of the recipient of the notification. This can be a recipient address or a list of addresses for multiple recipients.
 - **starttls** (*Optional*): Enables STARTTLS, eg. True or False. Defaults to False.
+- **product_name** (*Optional*): Sets a custom 'product name' in the emails headers (*From*: Custom name <example@mail.com>, *X-Mailer*: Custom name).
 - **debug** (*Optional*): Enables Debug, eg. True or False. Defaults to False.
 
 A sample configuration entry for Google Mail.
@@ -56,6 +57,7 @@ notify:
     recipient:
       - james@gmail.com
       - bob@gmail.com
+    product_name: My Home
 ```
 
 Keep in mind that Google has some extra layers of protection which need special attention (Hint: 'Less secure apps').
@@ -63,7 +65,7 @@ Keep in mind that Google has some extra layers of protection which need special 
 To use the SMTP notification, refer to it in an automation or script like in this example:
 
 ```yaml
-  burglar: 
+  burglar:
     alias: Burglar Alarm
     sequence:
       - service: shell_command.snapshot
@@ -74,12 +76,79 @@ To use the SMTP notification, refer to it in an automation or script like in thi
             title: 'Intruder alert'
             message: 'Intruder alert at apartment!!'
             data:
-                images: 
+                images:
                     - /home/pi/snapshot1.jpg
                     - /home/pi/snapshot2.jpg
 ```
 
 The optional `images` field adds in-line image attachments to the email. This sends a text/HTML multi-part message instead of the plain text default.
+
+The optional `html` field makes a custom text/HTML multi-part message, allowing total freedom for sending rich html emails. In them, if you need to attach images, you can pass both arguments (`html` and `images`), the attachments will be joined with the basename of the images, so they can be included in the html page with `src="cid:image_name.ext"`.
+
+```yaml
+  burglar:
+    alias: Burglar Alarm
+    sequence:
+      - service: shell_command.snapshot
+      - delay:
+            seconds: 1
+      - service: notify.NOTIFIER_NAME
+        data_template:
+            message: 'Intruder alert at apartment!!'
+            data:
+              images:
+                - /home/pi/snapshot1.jpg
+                - /home/pi/snapshot2.jpg
+              html: >
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+                <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+                    <head>
+                        <meta charset="UTF-8">
+                        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+                        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                        <title>Intruder alert</title>
+                        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css">
+                        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+                        <style type="text/css">
+                            @font-face {
+                              font-family: 'Open Sans';
+                              font-style: normal;
+                              font-weight: 300;
+                              src: local('Open Sans Light'), local('OpenSans-Light'), url(http://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTZS3E-kSBmtLoNJPDtbj2Pk.ttf) format('truetype');
+                            }
+                            h1,h2,h3,h4,h5,h6 {
+                                font-family:'Open Sans',Arial,sans-serif;
+                                font-weight:400;
+                                margin:10px 0
+                            }
+                        </style>
+                    </head>
+                    <body>
+                      <div class="jumbotron jumbotron-fluid" style="background-color: #f00a2d; color: white;">
+                          <div class="container py-0">
+                              <h1>Intruder alert at apartment!!</h1>
+                          </div>
+                      </div>
+                      <div class="container-fluid">
+                        <div class="row">
+                          <div class="col-xs-12 col-md-6 px-0">
+                            <img class="rounded" style="width: 100%;"
+                                alt="snapshot1" src="cid:snapshot1.jpg" />
+                          </div>
+                          <div class="col-xs-12 col-md-6 px-0">
+                            <img class="rounded" style="width: 100%;"
+                                alt="snapshot2" src="cid:snapshot2.jpg" />
+                          </div>
+                        </div>
+                        <br>
+                      </div>
+                    </body>
+                    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+                    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js"></script>
+                </html>
+
+```
+Obviously, this kind of complex html email reporting is done much more conveniently using Jinja2 templating from an [AppDaemon app](https://home-assistant.io/docs/ecosystem/appdaemon/tutorial/), for example.
 
 This platform is fragile and not able to catch all exceptions in a smart way because of the large number of possible configuration combinations.
 

--- a/source/_components/notify.smtp.markdown
+++ b/source/_components/notify.smtp.markdown
@@ -37,7 +37,7 @@ Configuration variables:
 - **password** (*Optional*): Password for the SMTP server that belongs to the given username. If the password contains a colon it need to be wrapped in apostrophes.
 - **recipient** (*Required*): E-mail address of the recipient of the notification. This can be a recipient address or a list of addresses for multiple recipients.
 - **starttls** (*Optional*): Enables STARTTLS, eg. True or False. Defaults to False.
-- **product_name** (*Optional*): Sets a custom 'product name' in the emails headers (*From*: Custom name <example@mail.com>, *X-Mailer*: Custom name).
+- **sender_name** (*Optional*): Sets a custom 'sender name' in the emails headers (*From*: Custom name <example@mail.com>).
 - **debug** (*Optional*): Enables Debug, eg. True or False. Defaults to False.
 
 A sample configuration entry for Google Mail.
@@ -57,7 +57,7 @@ notify:
     recipient:
       - james@gmail.com
       - bob@gmail.com
-    product_name: My Home
+    sender_name: My Home Assistant
 ```
 
 Keep in mind that Google has some extra layers of protection which need special attention (Hint: 'Less secure apps').


### PR DESCRIPTION
**Description:**
- Ability to send full HTML emails, with or without inline attached images.
- Customize `product_name` identifier in the `FROM` and `X-MAILER` email headers.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7533
