### PR TITLE
Fix code block syntax on notify.webostv doc page

### DIFF
--- a/source/_components/notify.webostv.markdown
+++ b/source/_components/notify.webostv.markdown
@@ -56,7 +56,7 @@ The icon can be overridden for individual notifications by providing a path to a
 ```yaml
 automation:
   - alias: Front door motion
-    trigger: 
+    trigger:
       platform: state
       entity_id: binary_sensor.front_door_motion
       state: 'on'
@@ -66,4 +66,4 @@ automation:
         message: "Movement detected: Front Door"
         data:
           icon: "/home/homeassistant/images/doorbell.png"
- ```
+```


### PR DESCRIPTION
**Description:**
The [current doc page](https://home-assistant.io/components/notify.webostv/) renders the last example improperly due to a space before the closing ` ``` ` of the code block.

Tested this works by generating docs locally.