### PR TITLE
Add SSL support to NZBGet sensor

### DIFF
--- a/source/_components/sensor.nzbget.markdown
+++ b/source/_components/sensor.nzbget.markdown
@@ -32,6 +32,7 @@ Configuration variables:
 
 - **host** (*Required*): IP address where your NZBGet installation is running.
 - **port** (*Optional*): The port of your NZBGet installation. Defaults to 6789.
+- **ssl** (*Optional*): Whether or not to use SSL to access NZBGet. Defaults to false.
 - **name** (*Optional*): The prefix to use for your sensor. Defaults to NZBGet.
 - **username** (*Optional*): The username to access your NZBGet installation.
 - **password** (*Optional*): The password to access your NZBGet installation.


### PR DESCRIPTION
**Description:**
Adds documentation for the SSL option of the NZBGet sensor.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7553

