### PR TITLE
Transition updated

### DIFF
--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -33,7 +33,7 @@ Turns one light on or multiple lights on using [groups]({{site_root}}/components
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Else targets all.
-| `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds. *not supported by Wink
+| `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds. *Currently only supported on Philips Hue
 | `profile` | yes | String with the name of one of the built-in profiles (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory.  Light profiles define a xy color and a brightness. If a profile is given and a brightness or xy color then the profile values will be overwritten.
 | `xy_color` | yes | A list containing two floats representing the xy color you want the light to be. Two comma separated floats that represent the color in XY.
 | `rgb_color` | yes | A list containing three integers representing the rgb color you want the light to be. Three comma separated integers that represent the color in RGB.  You can find a great chart here: [Hue Color Chart](http://www.developers.meethue.com/documentation/hue-xy-values)

--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -33,14 +33,14 @@ Turns one light on or multiple lights on using [groups]({{site_root}}/components
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Else targets all.
-| `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds. *Currently only supported on Philips Hue
+| `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds. *Not supported by all lights.
 | `profile` | yes | String with the name of one of the built-in profiles (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory.  Light profiles define a xy color and a brightness. If a profile is given and a brightness or xy color then the profile values will be overwritten.
 | `xy_color` | yes | A list containing two floats representing the xy color you want the light to be. Two comma separated floats that represent the color in XY.
 | `rgb_color` | yes | A list containing three integers representing the rgb color you want the light to be. Three comma separated integers that represent the color in RGB.  You can find a great chart here: [Hue Color Chart](http://www.developers.meethue.com/documentation/hue-xy-values)
 | `color_temp` | yes | An INT in mireds representing the color temperature you want the light to be.
 | `color_name` | yes | A human readable string of a color name, such as `blue` or `goldenrod`. All [CSS3 color names](https://www.w3.org/TR/2010/PR-css3-color-20101028/#svg-color) are supported.
 | `brightness` | yes | Integer between 0 and 255 for how bright the color should be.
-| `flash` | yes | Tell light to flash, can be either value `short` or `long`. *not supported by Wink
+| `flash` | yes | Tell light to flash, can be either value `short` or `long`. *Not supported by all lights.
 | `effect`| yes | Applies an effect such as `colorloop` or `random`.
 
 ### {% linkable_title Service `light.turn_off` %}


### PR DESCRIPTION
According to this https://home-assistant.io/cookbook/automation_sun/ (and my own experience) transition appears to only be supported on Hue bulbs - so I have updated the Transition note.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

