### PR TITLE
Update lets_encrypt.markdown

### DIFF
--- a/source/_docs/ecosystem/certificates/lets_encrypt.markdown
+++ b/source/_docs/ecosystem/certificates/lets_encrypt.markdown
@@ -247,7 +247,7 @@ $ sudo adduser hass sudo
 If you did not already log in as the user that currently runs Home Assistant, change to that user (usually `hass` or `homeassistant` - you may have used a command similar to this in the past):
 
 ```bash
-$ su -s /bin/bash hass 
+$ sudo su -s /bin/bash hass 
 ```
 
 Make sure you are in the home directory for the HA user:


### PR DESCRIPTION
Corrected command to change user, as the default position for most users is not to have a password for HA user.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

