### PR TITLE
Updated pygments.rb to latest to make it build under ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 group :development do
   gem 'rake', '~> 10.0'
   gem 'jekyll', '~> 3.0'
-  gem 'pygments.rb', '~> 0.6.3'
+  gem 'pygments.rb', '~> 1.1.2'
   gem 'rdiscount', '~> 2.0'
   gem 'RedCloth', '~> 4.2'
   gem 'haml', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
     method_source (0.8.2)
+    multi_json (1.12.1)
     octopress (3.0.11)
       jekyll (>= 2.0)
       mercenary (~> 0.3.2)
@@ -71,14 +72,12 @@ GEM
       jekyll (>= 2.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.11)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pygments.rb (0.6.3)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
+    pygments.rb (1.1.2)
+      multi_json (>= 1.0.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -107,7 +106,6 @@ GEM
       ref
     tilt (2.0.5)
     titlecase (0.1.1)
-    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
@@ -127,7 +125,7 @@ DEPENDENCIES
   octopress-filters
   octopress-include-tag
   pry
-  pygments.rb (~> 0.6.3)
+  pygments.rb (~> 1.1.2)
   rake (~> 10.0)
   rb-fsevent (~> 0.9)
   rdiscount (~> 2.0)
@@ -138,4 +136,4 @@ DEPENDENCIES
   therubyracer
 
 BUNDLED WITH
-   1.10.6
+   1.14.6


### PR DESCRIPTION
**Description:**

On latest OS X, default ruby is 2.4. Older version of Pygments.rb depends on a version of yajl-ruby that is not buildable on latest ruby 2.4. Updated pygments to latest version. Issue #1887 seems to refer to this issue. 



