### PR TITLE
Add logos to "native" Home Assistant components

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -7,6 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category: Hub
 ha_release: 0.27
 ha_iot_class: "Local Push"

--- a/source/_components/plant.markdown
+++ b/source/_components/plant.markdown
@@ -7,6 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category: Other
 ha_release: 0.44
 ---

--- a/source/_components/rss_feed_template.markdown
+++ b/source/_components/rss_feed_template.markdown
@@ -7,6 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category: Front end
 ha_release: 0.44
 ---

--- a/source/_components/sensor.dnsip.markdown
+++ b/source/_components/sensor.dnsip.markdown
@@ -7,6 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category: Sensor
 ha_iot_class: "Cloud Polling"
 ha_release: "0.40"


### PR DESCRIPTION
**Description:**
Adds the Home Assistant Logo to "native" Home Assistant components. 

Open to discussion but these are the ones who are not connected to any brand or device (as far as I can tell) and that doesn't have a better option for logo.