### PR TITLE
pip3 install should be executed with sudo

### DIFF
--- a/source/_docs/installation/armbian.markdown
+++ b/source/_docs/installation/armbian.markdown
@@ -21,5 +21,5 @@ $ sudo apt-get install python3-dev python3-pip
 Install Home Assistant.
 
 ```bash
-$ pip3 install homeassistant
+$ sudo pip3 install homeassistant
 ```


### PR DESCRIPTION
Installation will fail if not sudo-ed.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

