### PR TITLE
Added RTSP documentation to Amcrest camera

### DIFF
--- a/source/_components/camera.amcrest.markdown
+++ b/source/_components/camera.amcrest.markdown
@@ -34,7 +34,6 @@ Configuration variables:
 - **port** (*Optional*): The port that the camera is running on. The default is 80.
 - **resolution** (*Optional*): This parameter allows you to specify the camera resolution. For a high resolution (1080/720p), specify the option `high`. For VGA resolution (640x480p), specify the option `low`. If omitted, it defaults to *high*.
 - **stream_source** (*Optional*): The data source for the live stream. `mjpeg` will use the camera's native MJPEG stream, whereas `snapshot` will use the camera's snapshot API to create a stream from still images. You can also set the `rtsp` option to generate the streaming via RTSP protocol. If omitted, it defaults to *mjpeg*.
-- **ffmpeg_binary**: (*Optional*): Specify the `ffmpeg` binary path.  It defaults to `/usr/bin/ffmpeg`.
 - **ffmpeg_arguments**: (*Optional*): Extra options to pass to ffmpeg, e.g. image quality or video filter options.
 
 **Note:** Amcrest cameras with newer firmwares no longer have the ability to stream `high` definition video with MJPEG encoding. You may need to use `low` resolution stream or the `snapshot` stream source instead.  If the quality seems too poor, lower the `Frame Rate (FPS)` and max out the `Bit Rate` settings in your camera's configuration manager.

--- a/source/_components/camera.amcrest.markdown
+++ b/source/_components/camera.amcrest.markdown
@@ -33,8 +33,13 @@ Configuration variables:
 - **name** (*Optional*): This parameter allows you to override the name of your camera. The default is "Amcrest Camera".
 - **port** (*Optional*): The port that the camera is running on. The default is 80.
 - **resolution** (*Optional*): This parameter allows you to specify the camera resolution. For a high resolution (1080/720p), specify the option `high`. For VGA resolution (640x480p), specify the option `low`. If omitted, it defaults to *high*.
-- **stream_source** (*Optional*): The data source for the live stream. `mjpeg` will use the camera's native MJPEG stream, whereas `snapshot` will use the camera's snapshot API to create a stream from still images. If omitted, it defaults to *mjpeg*.
+- **stream_source** (*Optional*): The data source for the live stream. `mjpeg` will use the camera's native MJPEG stream, whereas `snapshot` will use the camera's snapshot API to create a stream from still images. You can also set the `rtsp` option to generate the streaming via RTSP protocol. If omitted, it defaults to *mjpeg*.
+- **ffmpeg_binary**: (*Optional*): Specify the `ffmpeg` binary path.  It defaults to `/usr/bin/ffmpeg`.
+- **ffmpeg_arguments**: (*Optional*): Extra options to pass to ffmpeg, e.g. image quality or video filter options.
 
 **Note:** Amcrest cameras with newer firmwares no longer have the ability to stream `high` definition video with MJPEG encoding. You may need to use `low` resolution stream or the `snapshot` stream source instead.  If the quality seems too poor, lower the `Frame Rate (FPS)` and max out the `Bit Rate` settings in your camera's configuration manager.
+
+**Note:** If you set the `stream_source` option to `rtsp`, make sure to follow the steps mentioned at
+[FFMPEG](https://home-assistant.io/components/ffmpeg/) documentation to install the `ffmpeg`.
 
 To check if your Amcrest camera is supported/tested, visit the [supportability matrix](https://github.com/tchellomello/python-amcrest#supportability-matrix) link from the `python-amcrest` project.


### PR DESCRIPTION
**Description:**

Added RTSP documentation to Amcrest camera.

```yaml
#cameras.yaml
- platform: amcrest
  name: "Amcrest Backyard"
  host: !secret amcrest_backyard_host
  username: !secret amcrest_backyard_username
  password: !secret amcrest_backyard_password
  port: 80
  resolution: low
  stream_source: rtsp

- platform: amcrest
  name: "Amcrest Driveway"
  host: !secret amcrest_driveway_host
  username: !secret amcrest_driveway_username
  password: !secret amcrest_driveway_password
  port: 80
  resolution: high
  stream_source: rtsp
```


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7646

