### PR TITLE
Fix pacaur invocation in Arch installation instructions

### DIFF
--- a/source/_docs/installation/archlinux.markdown
+++ b/source/_docs/installation/archlinux.markdown
@@ -27,5 +27,5 @@ $ pip3 install homeassistant
 Home Assistant is part of the [AUR](https://aur.archlinux.org/packages/home-assistant/). This means that it can be installed  with `pacaur`:
 
 ```bash
-$ sudo pacaur -S home-assistant
+$ pacaur -S home-assistant
 ```


### PR DESCRIPTION
Pacaur does not work with root privileges for security reasons:

```
$ sudo pacaur -S home-assistant
[sudo] password for zoresvit: 
:: you cannot perform this operation as root
```
It will only ask for a password interactively when invoking `makepkg`.