### PR TITLE
Deprecate automation trigger "state"

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -72,7 +72,7 @@ automation:
 
 ### {% linkable_title State trigger %}
 
-Triggers when the state of tracked entities change. If only entity_id given will match all state changes.
+Triggers when the state of tracked entities change. If only entity_id given will match all state changes, even if only state attributes change.
 
 ```yaml
 automation:
@@ -81,10 +81,8 @@ automation:
     entity_id: device_tracker.paulus, device_tracker.anne_therese
     # Optional
     from: 'not_home'
+    # Optional
     to: 'home'
-
-    # Alias for 'to'
-    state: 'home'
 
     # If given, will trigger when state has been the to state for X time.
     for:
@@ -95,6 +93,9 @@ automation:
 
 <p class='note warning'>
   Use quotes around your values for `from` and `to` to avoid the YAML parser interpreting values as booleans.
+</p>
+<p class='note warning'>
+  Using `state` as an alias for `to` is deprecated.
 </p>
 
 ### {% linkable_title Sun trigger %}


### PR DESCRIPTION
**Description:**

Even though the parent PR is a breaking change, the documentation does not change anything around. This is because the previous way of working was not documented.

The new meaning matches what one would expect from reading the example, so further elaboration is hopefully not needed.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7651

