### PR TITLE
Updated keyring link

### DIFF
--- a/source/_docs/configuration/secrets.markdown
+++ b/source/_docs/configuration/secrets.markdown
@@ -59,7 +59,7 @@ This will print all your secrets
 
 ### {% linkable_title Storing passwords in a keyring managed by your OS %}
 
-Using [Keyring](https://pypi.python.org/pypi/keyring/10.3.2) is an alternative way to `secrets.yaml`. They can be managed from the command line via the keyring script.
+Using [Keyring](https://github.com/jaraco/keyring) is an alternative way to `secrets.yaml`. They can be managed from the command line via the keyring script.
 
 ```bash
 $ hass --script keyring --help

--- a/source/_docs/configuration/secrets.markdown
+++ b/source/_docs/configuration/secrets.markdown
@@ -59,7 +59,7 @@ This will print all your secrets
 
 ### {% linkable_title Storing passwords in a keyring managed by your OS %}
 
-Using [Keyring](http://pythonhosted.org/keyring/) is an alternative way to `secrets.yaml`. They can be managed from the command line via the keyring script.
+Using [Keyring](https://pypi.python.org/pypi/keyring/10.3.2) is an alternative way to `secrets.yaml`. They can be managed from the command line via the keyring script.
 
 ```bash
 $ hass --script keyring --help


### PR DESCRIPTION
New link: https://pypi.python.org/pypi/keyring/10.3.2

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

