### PR TITLE
Remove link to component initialization

### DIFF
--- a/source/_includes/asides/developers_navigation.html
+++ b/source/_includes/asides/developers_navigation.html
@@ -47,7 +47,6 @@
           <li>{% active_link /developers/code_review_component/ Checklist creating a component %}</li>
           <li>{% active_link /developers/component_loading/ Loading components %}</li>
           <li>{% active_link /developers/component_deps_and_reqs/ Requirements & Dependencies %}</li>
-          <li>{% active_link /developers/component_initialization/ Initialization %}</li>
           <li>{% active_link /developers/component_events/ Handling events %}</li>
           <li>{% active_link /developers/component_states/ States %}</li>
           <li>{% active_link /developers/component_visibility/ Visibility %}</li>

--- a/source/developers/development_hass_object.markdown
+++ b/source/developers/development_hass_object.markdown
@@ -7,6 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+redirect_from: /developers/component_initialization/
 ---
 
 While developing Home Assistant you will see a variable that is everywhere: `hass`. This is the Home Assistant instance that will give you access to all the various parts of the system.


### PR DESCRIPTION
**Description:**
Remove link to component initialization. Left-over from the update to "Development 101".

**Related issue (if applicable):** fixes #2659


