### PR TITLE
Update sensor.fritzbox_callmonitor.markdown

### DIFF
--- a/source/_components/sensor.fritzbox_callmonitor.markdown
+++ b/source/_components/sensor.fritzbox_callmonitor.markdown
@@ -73,13 +73,13 @@ automation:
         data:
           title: "Phone"
           message: >-
-            {% if is_state("sensor.phone", "idle") %}
-              Idle
+            {% raw %}{% if is_state("sensor.phone", "idle") %}
+              Phone is idle
             {% elif is_state("sensor.phone", "dialing") %}
-              {{ states.sensor.phone.attributes.to_name }} ({{ states.sensor.phone.attributes.to }})
+              Calling {{ states.sensor.phone.attributes.to_name }} ({{ states.sensor.phone.attributes.to }})
             {% elif is_state("sensor.phone", "ringing") %}
-              {{ states.sensor.phone.attributes.from_name }} ({{ states.sensor.phone.attributes.from }})
+              Incoming call from {{ states.sensor.phone.attributes.from_name }} ({{ states.sensor.phone.attributes.from }})
             {% else %}
-              {{ states.sensor.phone.attributes.with_name }} ({{ states.sensor.phone.attributes.with }})
-            {% endif %}
+              Talking to {{ states.sensor.phone.attributes.with_name }} ({{ states.sensor.phone.attributes.with }})
+            {% endif %}{% endraw %}
 ```

--- a/source/_components/sensor.fritzbox_callmonitor.markdown
+++ b/source/_components/sensor.fritzbox_callmonitor.markdown
@@ -56,3 +56,30 @@ sensor:
       - '+4989'
       - '089'
 ```
+
+### {% linkable_title Send notifications on state change %}
+
+This example shows how to send notifications whenever the sensor's state changes. You will get notified both when you receive a call and also when a call is placed.
+
+```yaml
+# Example configuration.yml entry.
+automation:
+  - alias: "Notify about phone state"
+    trigger:
+      - platform: state
+        entity_id: sensor.phone
+    action:
+      - service: notify.notify
+        data:
+          title: "Phone"
+          message: >-
+            {% if is_state("sensor.phone", "idle") %}
+              Idle
+            {% elif is_state("sensor.phone", "dialing") %}
+              {{ states.sensor.phone.attributes.to_name }} ({{ states.sensor.phone.attributes.to }})
+            {% elif is_state("sensor.phone", "ringing") %}
+              {{ states.sensor.phone.attributes.from_name }} ({{ states.sensor.phone.attributes.from }})
+            {% else %}
+              {{ states.sensor.phone.attributes.with_name }} ({{ states.sensor.phone.attributes.with }})
+            {% endif %}
+```


### PR DESCRIPTION
Added a configuration example for callmonitor push notifications

**Description:**
The Fritz!Box Callmonitor documentation was a bit rough so I decided to add this example since it cost me some time to find out how this works.

