### PR TITLE
Small bug in initial developer docs modifying a variable out of scope

### DIFF
--- a/source/developers/development_events.markdown
+++ b/source/developers/development_events.markdown
@@ -46,6 +46,7 @@ def setup(hass, config):
 
     # Listener to handle fired events
     def handle_event(event):
+        nonlocal count
         count += 1
         print('Total events received:', count)
 


### PR DESCRIPTION
Fixes `NameError: name 'count' is not defined` when going through the development:events tutorial