### PR TITLE
Fix typo

### DIFF
--- a/source/developers/development_guidelines.markdown
+++ b/source/developers/development_guidelines.markdown
@@ -17,7 +17,7 @@ Summary of the most relevant points:
 - Use 4 spaces per indentation level. We don't use tabs.
 - Comments should be full sentences and end with a period.
 - [Imports](https://www.python.org/dev/peps/pep-0008/#imports) should be ordered.
-- Constants and the content of lists and directories should be in alphabetical order.
+- Constants and the content of lists and dictionaries should be in alphabetical order.
 - Avoid trailing whitespace but surround binary operators with a single space.
 - Line separator should be set to `LF`.
 


### PR DESCRIPTION
At least I think it's a typo?

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

