### PR TITLE
Added example for raw/endraw

### DIFF
--- a/source/developers/website.markdown
+++ b/source/developers/website.markdown
@@ -88,7 +88,14 @@ You can use the default markdown syntax to generate syntax highlighted code. For
 
 Note that you can replace `yaml` next to \`\`\` with the language that is within the block.
 
-Please add `{% raw %} ... {% endraw %}` around variables and other things that should not be rendered on the website:
+When you're writing code that is to be executed on the terminal, prefix it with `$`.
+
+### {% linkable_title Templates %}
+
+For the [configuration templating](/topics/templating/) is [Jinja](http://jinja.pocoo.org/) used.
+
+If you are using templates then those parts needs to be [escaped](http://stackoverflow.com/a/24102537). Otherwise they will be rendered and appear blank on the website:
+
 ```yaml
 # Example configuration.yml entry.
 automation:
@@ -105,14 +112,6 @@ automation:
               Example notification
              {% endif %}{% endraw %}
 ```
-
-When you're writing code that is to be executed on the terminal, prefix it with `$`.
-
-### {% linkable_title Templates %}
-
-For the [configuration templating](/topics/templating/) is [Jinja](http://jinja.pocoo.org/) used.
-
-If you are using templates then those parts needs to be [escaped](http://stackoverflow.com/a/24102537). Otherwise they will be rendered and appear blank on the website.
 
 ### {% linkable_title HTML %}
 

--- a/source/developers/website.markdown
+++ b/source/developers/website.markdown
@@ -88,6 +88,24 @@ You can use the default markdown syntax to generate syntax highlighted code. For
 
 Note that you can replace `yaml` next to \`\`\` with the language that is within the block.
 
+Please add `{% raw %} ... {% endraw %}` around variables and other things that should not be rendered on the website:
+```yaml
+# Example configuration.yml entry.
+automation:
+  - alias: "Example notification"
+    trigger:
+      - platform: state
+        entity_id: sensor.example
+    action:
+      - service: notify.notify
+        data:
+          title: "Test"
+          message: >-
+            {% raw %}{% if is_state("sensor.example", "test") %}
+              Example notification
+             {% endif %}{% endraw %}
+```
+
 When you're writing code that is to be executed on the terminal, prefix it with `$`.
 
 ### {% linkable_title Templates %}


### PR DESCRIPTION
Added "raw/endraw" example with my learnings from https://github.com/home-assistant/home-assistant.github.io/pull/2685. I found the docs not intuitive enough and eventually got it by looking at the source code...

**Description:**
The docs now show an explicit example of how to avoid parsing of YAML variables in docs.
