### PR TITLE
Extended installation instructions for Armbian

### DIFF
--- a/source/_docs/installation/armbian.markdown
+++ b/source/_docs/installation/armbian.markdown
@@ -18,8 +18,17 @@ $ sudo apt-get update
 $ sudo apt-get install python3-dev python3-pip
 ```
 
-Install Home Assistant.
-
+Now that you installed python, there are two ways to install Home Assistant:
+1. It is recommended to install Home Assistant in a virtual environment to avoid using `root`, using the [VirtualEnv instructions](/docs/installation/virtualenv/
+2. Alternatively, you can install Home Assistant for the user you created when first booting Armbian:
 ```bash
 $ sudo pip3 install homeassistant
+$ hass --open-ui
 ```
+Running these commands will:
+
+ - Install Home Assistant
+ - Launch Home Assistant and serve the web interface on [http://localhost:8123](http://localhost:8123)
+ - the configuration files will be created in /home/<user>/.homeassistant
+ 
+ 


### PR DESCRIPTION
Though not incorrect, the instructions for installing HA on Armbian are very sparse. This proposed change provides a better way to help users get Home Assistant properly installed on Armbian (linking to existing docs for setting up in a venv)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

