### PR TITLE
Add more info about the /api/history/period route

### DIFF
--- a/source/developers/rest_api.markdown
+++ b/source/developers/rest_api.markdown
@@ -202,6 +202,12 @@ $ curl -X GET -H "x-ha-access: YOUR_PASSWORD" \
 #### {% linkable_title GET /api/history/period/&lt;timestamp> %}
 Returns an array of state changes in the past. Each object contains further details for the entities.
 
+The `<timestamp>` is optional and defaults to 1 day before the time of the request. It determines the beginning of the period.
+
+You can pass the following optional GET parameters:
+  - `filter_entity_id=<entity_id>` to filter on a single entity
+  - `end_time=<timestamp>` to choose the end of the period (defaults to 1 day)
+
 ```json
 [
     [


### PR DESCRIPTION
**Description:**

The [documentation](https://home-assistant.io/developers/rest_api/#get-apihistoryperiodlttimestamp) about the `/api/history/period` route is too light:

 - we don't know if `<timestamp>` is the beginning or the end of the period
 - the `end_time` parameter is in the code but nowhere in the doc
 - we don't know the default period length

I added some precisions

