### PR TITLE
Add instructions for setting using discovery with the Harmony hub

### DIFF
--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -26,26 +26,24 @@ Supported units:
 
 The preferred way to setup the Harmony remote is by enabling the [discovery component](/components/discovery/).
 
-You can override some discovered values (e.g. the `port` or `activity`) by adding a `configuration.yaml` setting.
-In this case the `name` used in the config must match exactly the name you have chosen for your hub. You must also leave the `host`
-setting empty to force the platform to discover the host IP automatically.
-
-If you want to manually configure all device settings, you will need to add its settings to your `configuration.yaml`.
+However, if you want to manually configure the device, you will need to add its settings to your `configuration.yaml`.
 
 ```yaml
-# Example configuration.yaml entry if you need any manual configuration
 remote:
-  # Specifying a hub manually, without discovery
   - platform: harmony
     name: Bedroom
-    host: 10.168.1.13
+    host: 10.168.1.13   # The IP of your hub
+```
 
-  # Overriding some discovered settings, note no host setting!
+You can override some default configuration values on a discovered hub (e.g. the `port` or `activity`) by adding
+a `configuration.yaml` setting. In this case leave the `host` setting empty so the platform will
+discover the host IP automatically, but set the `name` in the config to match exactly the name you have
+set for your Hub so the platform knows what Hub you are trying to configure.
+
+```yaml
   - platform: harmony
-    # name - This name must match the name you have set on the Hub
-    name: Living Room
-    # activity - The setting we want to use for the discovered Hub
-    activity: Watch TV
+    name: Living Room    # This name must match the name you have set on the Hub
+    activity: Watch TV   # Overriding the 'activity' setting for this discovered hub
 ```
 
 Configuration variables:

--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -49,7 +49,7 @@ set for your Hub so the platform knows what Hub you are trying to configure.
 Configuration variables:
 
 - **name** (*Required*): The hub's name to display in the frontend.
-- **host** (*Required*): The Harmony device's IP address.
+- **host** (*Optional*): The Harmony device's IP address. Leave empty for the IP to be discovered automatically.
 - **port** (*Optional*): The Harmony device's port. Defaults to 5222.
 - **activity** (*Optional*): Activity to use when turnon service is called without any data.
 - **scan_interval** (*Optional*): Amount in seconds in between polling for device's current activity. Defaults to 30 seconds.

--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -29,6 +29,7 @@ The preferred way to setup the Harmony remote is by enabling the [discovery comp
 However, if you want to manually configure the device, you will need to add its settings to your `configuration.yaml`.
 
 ```yaml
+# Example configuration.yaml entry
 remote:
   - platform: harmony
     name: Bedroom
@@ -41,7 +42,7 @@ discover the host IP automatically, but set the `name` in the config to match ex
 set for your Hub so the platform knows what Hub you are trying to configure.
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry with discovery
   - platform: harmony
     name: Living Room    # This name must match the name you have set on the Hub
     activity: Watch TV   # Overriding the 'activity' setting for this discovered hub

--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -24,14 +24,28 @@ Supported units:
 - Harmony Elite
 
 
-To use your Harmony remote in your installation, add the following to your `configuration.yaml` file:
+The preferred way to setup the Harmony remote is by enabling the [discovery component](/components/discovery/).
+
+You can override some discovered values (e.g. the `port` or `activity`) by adding a `configuration.yaml` setting.
+In this case the `name` used in the config must match exactly the name you have chosen for your hub. You must also leave the `host`
+setting empty to force the platform to discover the host IP automatically.
+
+If you want to manually configure all device settings, you will need to add its settings to your `configuration.yaml`.
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry if you need any manual configuration
 remote:
+  # Specifying a hub manually, without discovery
   - platform: harmony
     name: Bedroom
     host: 10.168.1.13
+
+  # Overriding some discovered settings, note no host setting!
+  - platform: harmony
+    # name - This name must match the name you have set on the Hub
+    name: Living Room
+    # activity - The setting we want to use for the discovered Hub
+    activity: Watch TV
 ```
 
 Configuration variables:
@@ -134,12 +148,12 @@ automation:
       data_template:
       # using a data template to have if brances for relavant device
         # Always the same entity_id - the harmony hub
-        entity_id: remote.bedroom 
+        entity_id: remote.bedroom
         # Always the same command - the Pause key
         command: Pause
         # select device based upon the activity being undertaken.
         device: >
-          # when in WATCH TV activity, the pause key relates to a TiVo, which is device 22987101 
+          # when in WATCH TV activity, the pause key relates to a TiVo, which is device 22987101
           {% raw %}{% if is_state("sensor.bedroom", "WATCH TV") %}{% raw %}
             22987101
           # when in WATCH APPLE TV activity, the pause key relates to an Apple TV, which is device 23002316

--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -41,6 +41,7 @@ discover the host IP automatically, but set the `name` in the config to match ex
 set for your Hub so the platform knows what Hub you are trying to configure.
 
 ```yaml
+# Example configuration.yaml entry
   - platform: harmony
     name: Living Room    # This name must match the name you have set on the Hub
     activity: Watch TV   # Overriding the 'activity' setting for this discovered hub


### PR DESCRIPTION
**Description:**

Adds additional information about using new netdisco discovery feature to find a [Harmony Hub](https://home-assistant.io/components/remote.harmony/)
 
**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7741

