### PR TITLE
Update sensor.cert_expiry.markdown

### DIFF
--- a/source/_components/sensor.cert_expiry.markdown
+++ b/source/_components/sensor.cert_expiry.markdown
@@ -27,6 +27,7 @@ Configuration variables:
 
 - **host** (*Required*): The host FQDN (or IP) to retrieve certificate from.
 - **port** (*Optional*): The port number where the server is running. Defaults to `443`.
+- **name** (*Optional*): The friendly name for the certificate.
 
 <p class='note warning'>
 Make sure that the URL exactly matches your endpoint or resource.


### PR DESCRIPTION
`name` is an optional variable for `cert_expiry`. If you don't use it all your certs just show up as "SSL Certificate Expiry" as their name.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

