### PR TITLE
Update switch.kankun.markdown

### DIFF
--- a/source/_components/switch.kankun.markdown
+++ b/source/_components/switch.kankun.markdown
@@ -25,9 +25,9 @@ To enable it, add the following lines to your `configuration.yaml`:
 # Example configuration.yaml entry
 switch:
   platform: kankun
-    switches:
-      bedroom_heating:
-        host: hostname_or_ipaddr
+  switches:
+    bedroom_heating:
+      host: hostname_or_ipaddr
 ```
 
 Configuration variables:


### PR DESCRIPTION
Fixed indentation errors in the configuration.yaml example.
switches should be on the same level as platform.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

