### PR TITLE
Add icon to device_tracker; misc cleanup.

### DIFF
--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -62,7 +62,6 @@ devicename:
   name: Friendly Name
   mac: EA:AA:55:E7:C6:94
   picture: https://home-assistant.io/images/favicon-192x192.png
-  gravatar: test@example.com
   track: yes
   hide_if_away: no
 ```
@@ -72,7 +71,8 @@ devicename:
 | `name`         | Host name or "Unnamed Device" | The friendly name of the device                                                                         |
 | `mac`          | None                          | The MAC address of the device. Add this if you are using a network device tracker like Nmap or SNMP     |
 | `picture`      | None                          | A picture that you can use to easily identify the person or device. You can also save the image file in a folder "www" in the same location (can be obtained from developer tools) where you have your configuration.yaml file and just use `picture: /local/favicon-192x192.png`.                                      |
+| `icon`         | mdi:account                   | An icon for this device (use as an alternative to `picture`).                           |
 | `gravatar`     | None                          | An email address for the device's owner. If provided, it will override `picture`                        |
-| `track`        | False                         | If  `yes`/`on`/`true` then the device will be tracked. Otherwise its location and state will not update |
+| `track`        | [uses platform setting]       | If  `yes`/`on`/`true` then the device will be tracked. Otherwise its location and state will not update |
 | `hide_if_away` | False                         | If `yes`/`on`/`true` then the device will be hidden if it is not at home                                |
 | `consider_home` | [uses platform setting]      | Allows you to override the global `consider_home` setting from the platform configuration on a per device level                                |


### PR DESCRIPTION
- Add `icon` to `device_tracker` config documentation (see https://github.com/home-assistant/home-assistant/issues/1237).
- Remove gravatar from example because it makes no sense to configure gravatar *and* picture.
- Fix default value for `track`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7759