### PR TITLE
Remove platform specific information from light component

### DIFF
--- a/source/_components/light.hue.markdown
+++ b/source/_components/light.hue.markdown
@@ -75,8 +75,9 @@ More information can be found on the [Philips Hue API documentation](https://www
 
 The Hue platform has it's own concept of Scenes for setting the colors of a group of lights at once. Hue Scenes are very cheap, get created by all kinds of apps (as it is the only way to have 2 or more lights change at the same time), and are rarely deleted. A typical Hue hub might have hundreds of scenes stored in them, many that you've never used, almost all very poorly named.
 
-To avoid user interface overload we don't expose Scenes directly. Instead there is a [light.hue_activate_scene](/components/light/#service-lighthue_activate_scene) service which can be used by `automation` or `script` components. For
-instance:
+To avoid user interface overload we don't expose Scenes directly. Instead there is a [light.hue_activate_scene](/components/light/#service-lighthue_activate_scene) service which can be used by `automation` or `script` components.
+This will have all the bulbs transitioned at once, instead of one at a time using standard scenes in Home Assistant.
+For instance:
 
 ```yaml
 script:
@@ -87,6 +88,13 @@ script:
           group_name: "Porch"
           scene_name: "Porch Orange"
 ```
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `group_name` | no | The group/room name of the lights. Find this in the Hue official app.
+| `scene_name` | no | The name of the Scene. Find this in the Hue official app.
+
+*Note*: `group_name` is not linked to Home Assistant group name.
 
 *** Finding Group and Scene Names ***
 

--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -9,18 +9,7 @@ sharing: true
 footer: true
 ---
 
-This component allows you to track and control various light bulbs.
-
-It has [4 built-in light profiles](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/light/light_profiles.csv) which you're able to extend by putting a `light_profiles.csv` file in your config dir.
-
-Preferred way to setup the Philips Hue platform is through the [the discovery component]({{site_root}}/components/discovery/). For the Wink light platform enable [the wink component]({{site_root}}/components/wink/).
-
-If you want to enable the light component directly, add the following lines to your `configuration.yaml`:
-
-```yaml
-light:
-  platform: hue
-```
+This component allows you to track and control various light bulbs. Read the platform documentation for your particular light hardware to learn how to enable it.
 
 <p class='note'>
 The light component supports multiple entries in <code>configuration.yaml</code> by appending a sequential number to the section: <code>light 2:</code>, <code>light 3:</code> etc.
@@ -30,11 +19,13 @@ The light component supports multiple entries in <code>configuration.yaml</code>
 
 Turns one light on or multiple lights on using [groups]({{site_root}}/components/group/).
 
+Most lights do not support all attributes. You can check the platform documentation of your particular light for hints but in general you will have to try things out and see what works.
+
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Else targets all.
-| `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds. *Not supported by all lights.
-| `profile` | yes | String with the name of one of the built-in profiles (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory.  Light profiles define a xy color and a brightness. If a profile is given and a brightness or xy color then the profile values will be overwritten.
+| `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds.
+| `profile` | yes | String with the name of one of the [built-in profiles](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/light/light_profiles.csv) (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory.  Light profiles define a xy color and a brightness. If a profile is given and a brightness or xy color then the profile values will be overwritten.
 | `xy_color` | yes | A list containing two floats representing the xy color you want the light to be. Two comma separated floats that represent the color in XY.
 | `rgb_color` | yes | A list containing three integers representing the rgb color you want the light to be. Three comma separated integers that represent the color in RGB.  You can find a great chart here: [Hue Color Chart](http://www.developers.meethue.com/documentation/hue-xy-values)
 | `color_temp` | yes | An INT in mireds representing the color temperature you want the light to be.
@@ -42,7 +33,7 @@ Turns one light on or multiple lights on using [groups]({{site_root}}/components
 | `color_name` | yes | A human readable string of a color name, such as `blue` or `goldenrod`. All [CSS3 color names](https://www.w3.org/TR/2010/PR-css3-color-20101028/#svg-color) are supported.
 | `brightness` | yes | Integer between 0 and 255 for how bright the color should be.
 | `brightness_pct`| yes | Alternatively, you can specify brightness in percent (a number between 0 and 100).
-| `flash` | yes | Tell light to flash, can be either value `short` or `long`. *Not supported by all lights.
+| `flash` | yes | Tell light to flash, can be either value `short` or `long`.
 | `effect`| yes | Applies an effect such as `colorloop` or `random`.
 
 ### {% linkable_title Service `light.turn_off` %}
@@ -64,17 +55,3 @@ Toggles the state of one or multiple lights using [groups]({{site_root}}/compone
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Else targets all.
 | `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds.
-
-### {% linkable_title Service `light.hue_activate_scene` %}
-
-If you have hue lights, there is a service call to directly activate
-scenes that are stored in your hue hub. This will have all the bulbs
-transitioned at once, instead of one at a time using standard scenes
-in Home Assistant.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `group_name` | no | The group/room name of the lights. Find this in the Hue official app.
-| `scene_name` | no | The name of the Scene. Find this in the Hue official app.
-
-*Note*: `group_name` is not linked to Home Assistant group name.


### PR DESCRIPTION
**Description:**

The text is rewritten to not favor any particular platform and the
`light.hue_activate_scene` service call is moved to the Hue documentation.
