### PR TITLE
Typo in example for RFXTRX RFY configuration

### DIFF
--- a/source/_components/cover.rfxtrx.markdown
+++ b/source/_components/cover.rfxtrx.markdown
@@ -57,7 +57,7 @@ cover:
     devices:
       0b1100ce3213c7f210010f70: # Siemens/LightwaveRF
         name: Bedroom Shutter
-      070a00000a000101: # RFY
+      071a00000a000101: # RFY
         name: Bathroom Shutter
 ```
 


### PR DESCRIPTION
In details it is properly stated to use `071a0000` prefix but in sample it was `070a0000`, this caused me a few hesitations during my initial setup, fixing it for others ;)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

