### PR TITLE
Add note regarding ports

### DIFF
--- a/source/_components/media_player.frontier_silicon.markdown
+++ b/source/_components/media_player.frontier_silicon.markdown
@@ -43,6 +43,8 @@ Configuration variables:
 - **port** (*Optional*): The port number. Defaults to 80.
 - **password** (*Optional*): PIN code of the Internet Radio. Defaults to 1234.
 
+Some models use a seperate port (2244) for API access, this can be verified by visiting http://[host]:[port]/device.
+
 In case your device (friendly name) is called *badezimmer*, an example automation can look something like this:
 
 ```yaml


### PR DESCRIPTION
Add note regarding alternate ports used for API access on some models (Revo heritage for example)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

