### PR TITLE
Update lock.nuki.markdown

### DIFF
--- a/source/_components/lock.nuki.markdown
+++ b/source/_components/lock.nuki.markdown
@@ -31,7 +31,7 @@ Configuration variables:
 
 - **host** (*Required*): The IP or hostname of the Nuki bridge.
 - **port** (*Optional*): The port on which the Nuki bridge is listening on. Defaults to `8080`.
-- **token** (*Optional*): The token that was defined when setting up the bridge.
+- **token** (*Required*): The token that was defined when setting up the bridge.
 
 ## {% linkable_title Full configuration %}
 


### PR DESCRIPTION
Token is required, not optional

**Description:**
If no token is provided this is what HA shows in the logs
```
2017-05-30 17:21:56 ERROR (MainThread) [homeassistant.config] Invalid config for [lock.nuki]: required key not provided @ data['token']. Got None. (See ?, line ?). Please check the docs at https://home-assistant.io/components/lock.nuki/
```
**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>
