### PR TITLE
Rename time trigger 'after' to 'at'

### DIFF
--- a/source/_components/binary_sensor.workday.markdown
+++ b/source/_components/binary_sensor.workday.markdown
@@ -44,7 +44,7 @@ automation:
   alias: Turn on heater on workdays
   trigger:
     platform: time
-    after: '08:00:00'
+    at: '08:00:00'
   condition:
     condition: state
     entity_id: 'binary_sensor.workday_sensor'

--- a/source/_components/climate.markdown
+++ b/source/_components/climate.markdown
@@ -44,7 +44,7 @@ Turn auxiliary heater on/off for climate device
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: climate.set_aux_heat
       data:
@@ -69,7 +69,7 @@ reflecting a situation where the climate device is set to save energy. This may 
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: climate.set_away_mode
       data:
@@ -96,7 +96,7 @@ temporary target temperature. The particular modes available depend on the clima
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: climate.set_hold_mode
       data:
@@ -122,7 +122,7 @@ Set target temperature of climate device
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: climate.set_temperature
       data:
@@ -146,7 +146,7 @@ Set target humidity of climate device
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: climate.set_humidity
       data:
@@ -169,7 +169,7 @@ Set fan operation for climate device
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: climate.set_fan_mode
       data:
@@ -192,7 +192,7 @@ Set operation mode for climate device
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: climate.set_operation_mode
       data:
@@ -215,7 +215,7 @@ Set operation mode for climate device
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: climate.set_swing_mode
       data:

--- a/source/_components/climate.zwave.markdown
+++ b/source/_components/climate.zwave.markdown
@@ -42,7 +42,7 @@ automation:
   - alias: Turn on Heater at 8pm
     trigger:
       - platform: time
-        after: "20:00:00"
+        at: "20:00:00"
     action:
       - service: climate.set_operation_mode
         entity_id: climate.remotec_zxt120_heating_1_id
@@ -61,7 +61,7 @@ automation:
   - alias: Turn off Heater at 9pm
     trigger:
       - platform: time
-        after: "21:00:00"
+        at: "21:00:00"
     action:
       - service: climate.set_operation_mode
         entity_id: climate.remotec_zxt120_heating_1_id

--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -41,7 +41,7 @@ Set cover position of one or multiple covers.
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: cover.set_cover_position
       data:
@@ -64,7 +64,7 @@ Set cover tilt position of one or multiple covers.
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     - service: cover.set_cover_tilt_position
       data:

--- a/source/_components/switch.mysensors.markdown
+++ b/source/_components/switch.mysensors.markdown
@@ -66,7 +66,7 @@ automation:
   - alias: turn hvac on
     trigger:
       platform: time
-      after: '5:30:00'
+      at: '5:30:00'
     action:
       service: switch.mysensors_send_ir_code
       entity_id: switch.hvac_1_1
@@ -76,7 +76,7 @@ automation:
   - alias: turn hvac off
     trigger:
       platform: time
-      after: '0:30:00'
+      at: '0:30:00'
     action:
       service: switch.mysensors_send_ir_code
       entity_id: switch.hvac_1_1

--- a/source/_cookbook/automation_first_light.markdown
+++ b/source/_cookbook/automation_first_light.markdown
@@ -30,7 +30,7 @@ automation:
   - alias: Enable First Morning Trigger
     trigger:
       - platform: time
-        after: '5:00'
+        at: '5:00'
     action: 
       service: homeassistant.turn_on
       entity_id: input_boolean.trigger_first_morning

--- a/source/_cookbook/automation_sun.markdown
+++ b/source/_cookbook/automation_sun.markdown
@@ -35,7 +35,7 @@ _Note, Philips Hue is currently the only light platform that support transitions
 automation:
   trigger:
     platform: time
-    after: "07:15:00"
+    at: "07:15:00"
   action:
     service: light.turn_on
     entity_id: light.bedroom

--- a/source/_cookbook/configuration_yaml_from_bassclarinetl2.markdown
+++ b/source/_cookbook/configuration_yaml_from_bassclarinetl2.markdown
@@ -148,7 +148,7 @@ automation:
 #      zone: zone.barracuda_sj
 #      event: enter
 #    - platform: time
-#      after: '07:15'
+#      at: '07:15'
 #      before: '09:00'
 #  action:
 #    service: ifttt.trigger

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -127,7 +127,7 @@ automation:
 
 ### {% linkable_title Time trigger %}
 
-Time can be triggered in many ways. The most common is to specify `after` and trigger at a specific point in time each day. Alternatively, you can also match if the hour, minute or second of the current time has a specific value. You can prefix the value with a `/` to match whenever the value is divisible by that number. You cannot use `after` together with hour, minute or second.
+Time can be triggered in many ways. The most common is to specify `at` and trigger at a specific point in time each day. Alternatively, you can also match if the hour, minute or second of the current time has a specific value. You can prefix the value with a `/` to match whenever the value is divisible by that number. You cannot use `at` together with hour, minute or second.
 
 ```yaml
 automation:
@@ -140,9 +140,9 @@ automation:
 automation 2:
   trigger:
     platform: time
-    # When 'after' is used, you cannot also match on hour, minute, seconds.
+    # When 'at' is used, you cannot also match on hour, minute, seconds.
     # Military time format.
-    after: '15:32:00'
+    at: '15:32:00'
 
 automation 3:
   trigger:

--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -217,14 +217,14 @@ automation:
   - alias: soft reset at 2:30am
     trigger:
       platform: time
-      after: '2:30:00'
+      at: '2:30:00'
     action:
       service: zwave.soft_reset
 
   - alias: heal at 2:31am
     trigger:
       platform: time
-      after: '2:31:00'
+      at: '2:31:00'
     action:
       service: zwave.heal_network
 ```


### PR DESCRIPTION
**Description:**

This PR renames the time trigger 'after' option to 'at'.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7846

