### PR TITLE
Update history_stats doc about the 'from' and 'to' attributes

### DIFF
--- a/source/_components/sensor.history_stats.markdown
+++ b/source/_components/sensor.history_stats.markdown
@@ -143,5 +143,5 @@ Here, last Monday is _today_ as a timestamp, minus 86400 times the current weekd
 ```
 
 <p class='note'>
-    If you want to check if your period is right, just click on your component, the `from` and `to` attributes will show the start and end of the period, nicely formatted.
+    The `/dev-template` page of your home-assistant UI can help you check if the values for `start`, `end` or `duration` are correct.
 </p>


### PR DESCRIPTION
**Description:**

The 'from' and 'to' attributes have been removed from the `history_stats` component.
This is an update for the related documentation.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7858

