### PR TITLE
Update light.markdown

### DIFF
--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -36,6 +36,27 @@ Most lights do not support all attributes. You can check the platform documentat
 | `flash` | yes | Tell light to flash, can be either value `short` or `long`.
 | `effect`| yes | Applies an effect such as `colorloop` or `random`.
 
+<p class='note'>
+In order to apply atributtes to an entity you will need to add `data:` to the configuration. See example below
+</p>
+
+```yaml
+# Example configuration.yaml entry
+automation
+- id: one
+  alias: Turn on light when motion is detected
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.motion_1
+      to: 'on'
+  action:
+    - service: light.turn_on
+      data:
+        entity_id: light.living_room
+        brightness: 255
+        kelvin: 2700
+```
+
 ### {% linkable_title Service `light.turn_off` %}
 
 Turns one or multiple lights off.

--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -37,12 +37,12 @@ Most lights do not support all attributes. You can check the platform documentat
 | `effect`| yes | Applies an effect such as `colorloop` or `random`.
 
 <p class='note'>
-In order to apply atributtes to an entity you will need to add `data:` to the configuration. See example below
+In order to apply attributes to an entity you will need to add `data:` to the configuration. See example below
 </p>
 
 ```yaml
 # Example configuration.yaml entry
-automation
+automation:
 - id: one
   alias: Turn on light when motion is detected
   trigger:


### PR DESCRIPTION
I had a hard time setting up attributes to entities until I research for some other user's examples and saw they were using "data:". I feel like this should be mentioned or at least exposed with an example. I saw being used in 2 different ways:

```yaml
  action:
     service: light.turn_on
     data:
       entity_id: light.kitchen_lights
       brightness: 200
```

```yaml
  action:
    - service: light.turn_on
      entity_id: light.kitchen_lights
      data:
        brightness: 200
```

I'm not sure which one is the best/correct way but tried with both and they work

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

