### PR TITLE
Update remote.itach.markdown

### DIFF
--- a/source/_components/remote.itach.markdown
+++ b/source/_components/remote.itach.markdown
@@ -51,5 +51,5 @@ An example to call the component from developer tools using the remote, send_com
 Note: Global Cache devices expect data in their own format of "sendir...". This component converts hex code to Global Cache IR form.
 
 API Docs:
-https://www.globalcache.com/files/docs/API-iTach.pdf
-http://www.globalcache.com/files/docs/API-GC-100.pdf
+- [iTach](https://www.globalcache.com/files/docs/API-iTach.pdf)
+- [GC-100](http://www.globalcache.com/files/docs/API-GC-100.pdf)

--- a/source/_components/remote.itach.markdown
+++ b/source/_components/remote.itach.markdown
@@ -14,7 +14,7 @@ ha_release: 0.39
 ---
 
 
-The `itach` remote platform allows you to control IR devices with a [Global Caché iTach Device](https://www.globalcache.com/products/itach/ip2irspecs)
+The `itach` remote platform allows you to control IR devices with a [Global Caché iTach Device](https://www.globalcache.com/products/itach/ip2irspecs) and GC-100 devices. The Global Cache IR API are similar accross their product line. See API documentation links at the end of this page.
 
 To use your iTach remote in your installation, you will need to know the IR commands for your devices in Pronto hex format and add the following to your `configuration.yaml` file:
 
@@ -35,13 +35,21 @@ remote:
 ```
 
 Configuration variables:
-- **name** (*Required*): The iTach's name to display in the front end.
+- **name** (*Optional*): The iTach's name to display in the front end.
 - **host** (*Required*): The iTach's IP address.
 - **port** (*Optional*): The iTach's port. 4998 is default.
 - **devices** array (*Required*): Devices controlled by the iTach.
   - **name** (*Required*): Name of the device.
   - **modaddr** (*Optional*): iTach module address for the IR emitter. 1 is default.
-  - **connaddr** (*Required*): iTach connection address for the IR emitter.
+  - **connaddr** (*Required*): iTach connection location for the IR emitter. (Note connaddr is a misleading label. Do not put the connection address here. Technically the connection address is the combination of the module address plus the connection location).
   - **commands** array (*Required*): Commands available to send to the device.
     - **name** (*Required*): Command name.
     - **data** (*Required*): Hex command data.
+
+An example to call the component from developer tools using the remote, send_command service `{ "entity_id":"remote.tv", "device":"0", "command":"menu" }`
+
+Note: Global Cache devices expect data in their own format of "sendir...". This component converts hex code to Global Cache IR form.
+
+API Docs:
+https://www.globalcache.com/files/docs/API-iTach.pdf
+http://www.globalcache.com/files/docs/API-GC-100.pdf


### PR DESCRIPTION
add links to API. note that GC devices use same IR instructions accross other products and this componenet works on gc-100 as well as itach. service call example

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

