### PR TITLE
Documentation tweaks for Google Home support

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -28,6 +28,8 @@ To enable the emulated Hue bridge, add one of the following configs to your `con
 ```yaml
 # Google Home example configuration.yaml entry
 emulated_hue:
+  type: google_home
+  listen_port: 80
   # Google Home does not work on different ports.
 ```
 
@@ -110,6 +112,8 @@ You can verify that the `emulated_hue` component has been loaded and is respondi
 
  - `http://<HA IP Address>:8300/description.xml` - This URL should return a descriptor file in the form of an XML file.
  - `http://<HA IP Address>:8300/api/pi/lights` - This will return a list of devices, lights, scenes, groups, etc.. that `emulated_hue` is exposing to Alexa.
+
+For Google Home, verify that the URLs above are using  port 80, rather than port 8300 (i.e. http://<HA IP Address>:80/description.xml). 
 
 An additional step is required to run Home Assistant as non-root user and use port 80 when using the AiO script.  Execute the following command to allow `emulated_hue` to use port 80 as non-root user.
 


### PR DESCRIPTION
**Description:**

I had to explicitly set `listen_port: 80` for Google Home to work properly. It was defaulting to port 8300 without that declaration.

Also the docs should be more explicit in the Troubleshooting section because the URLs you need to confirm for Google Home are actually
- http://<HA IP Address>:80/description.xml
- http://<HA IP Address>:80/api/pi/lights

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>