### PR TITLE
The above/below conditions no longer match equal values

### DIFF
--- a/source/_cookbook/automation_first_light.markdown
+++ b/source/_cookbook/automation_first_light.markdown
@@ -75,15 +75,15 @@ automation:
             # if light is off, force a 0, otherwise use the brightness value
             value_template: {% raw %}'{% if states.light.livingroom_ec.state == "on"  %}{{ states.light.livingroom_ec.attributes.brightness }}{% else %}0{% endif %}'{% endraw %}
             # brightness below 50% (255 = 100%)
-            below: 127
+            below: 128
           - condition: numeric_state
             entity_id: light.kitchen_bar
             value_template: {% raw %}'{% if states.light.kitchen_bar.state == "on"  %}{{ states.light.kitchen_bar.attributes.brightness }}{% else %}0{% endif %}'{% endraw %}
-            below: 127
+            below: 128
           - condition: numeric_state
             entity_id: light.kitchen_ceiling
             value_template: {% raw %}'{% if states.light.kitchen_ceiling.state == "on"  %}{{ states.light.kitchen_ceiling.attributes.brightness }}{% else %}0{% endif %}'{% endraw %}
-            below: 127
+            below: 128
                 
       # Trigger a scene
       # You could add as many services or scenes as you'd like

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -68,9 +68,9 @@ condition:
 
 ### {% linkable_title Numeric state condition %}
 
-This type of condition attempts to parse the state of specified entity as a number and triggers if the value matches all of the above or below thresholds.
+This type of condition attempts to parse the state of specified entity as a number and triggers if the value matches the thresholds.
 
-For above, the condition passes if `value >= above`. For below, the condition passes if `value <= below`. If both `below` and `above` are specified, both tests have to pass.
+If both `below` and `above` are specified, both tests have to pass.
 
 You can optionally use a `value_template` to process the value of the state before testing it.
 


### PR DESCRIPTION
**Description:**

The `above`/`below` conditions now work more intuitively so we can just remove the explicit description of the matching rules.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7857

