### PR TITLE
media_content_type should be lowercase

### DIFF
--- a/source/_components/media_player.markdown
+++ b/source/_components/media_player.markdown
@@ -47,7 +47,7 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | -----------------------| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            |      yes | Target a specific media player. Defaults to all.                                                                                                                       |
 | `media_content_id`     |       no | A media identifier. The format of this is component dependent. For example, you can provide URLs to Sonos and Cast but only a playlist ID to iTunes.                   |
-| `media_content_type`   |       no | A media type. Must be one of `MUSIC`, `TVSHOW`, `VIDEO`, `EPISODE`, `CHANNEL` or `PLAYLIST`. For example, to play music you would set `media_content_type` to `MUSIC`. |
+| `media_content_type`   |       no | A media type. Must be one of `music`, `tvshow`, `video`, `episode`, `channel` or `playlist`. For example, to play music you would set `media_content_type` to `music`. |
 
 #### {% linkable_title Service `media_player/select_source` %}
 


### PR DESCRIPTION
**Description:**
Homeassistant gives an error when `media_content_type` is uppercase.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

