### PR TITLE
switch.flux: Corrected update service name in docs

### DIFF
--- a/source/_components/switch.flux.markdown
+++ b/source/_components/switch.flux.markdown
@@ -18,7 +18,7 @@ The component will update your lights based on the the time of day. It will only
 
 During the day (in between `start time` and `sunset time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`.  After sunset (between `sunset_time` and `stop_time`), the lights will fade from the the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights every 30 seconds with a 30 second transition time.
 
-If you don't wish to have flux update on 30 second intervals, you can leave the switch turned off and use automation rules that call the service `switch.flux_update` whenever you want the lights updated.
+If you don't wish to have flux update on 30 second intervals, you can leave the switch turned off and use automation rules that call the service `switch.<name>_update` whenever you want the lights updated, where `<name>` equals the `name:` property in the switch configuration.
 
 To use the Flux switch in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**

The docs previously suggested a "generalized" service name for updating flux manually, when the name is actually determined by the name of the switch in the config. I corrected that.
