### PR TITLE
influxdb: Give Information on privileges, update link

### DIFF
--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -23,13 +23,13 @@ The default InfluxDB configuration doesn't enforce authentication. If you have i
 influxdb:
 ```
 
-You will still need to create a database named `home_assistant` via InfluxDB's web interface or command line. For instructions how to create a database check the [InfluxDB documentation](https://docs.influxdata.com/influxdb/v1.0/introduction/getting_started/#creating-a-database) relevant to the version you have installed.
+You will still need to create a database named `home_assistant` via InfluxDB's web interface or command line. For instructions how to create a database check the [InfluxDB documentation](https://docs.influxdata.com/influxdb/latest/introduction/getting_started/#creating-a-database) relevant to the version you have installed.
 
 Configuration variables:
 
 - **host** (*Optional*): IP address of your database host, e.g. 192.168.1.10. Defaults to `localhost`.
 - **port** (*Optional*): Port to use. Defaults to 8086.
-- **username** (*Optional*): The username of the database user.
+- **username** (*Optional*): The username of the database user. The user needs read/write privileges on the database.
 - **password** (*Optional*): The password for the database user account.
 - **database** (*Optional*): Name of the database to use. Defaults to `home_assistant`. The database must already exist.
 - **ssl** (*Optional*): Use https instead of http to connect. Defaults to false.


### PR DESCRIPTION
**Description:**
* If the used influxdb is configured to use authentication the user needs read/write permissions on the database. Mention this in the doc.
* The influxdb documentation has a `/latest` link. Use this instead of a fixed version number.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7947

