### PR TITLE
Create systemd.markdown

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -22,7 +22,7 @@ If you want Home Assistant to be launched automatically, an extra step is needed
 
 - `ExecStart` contains the path to `hass` and this may vary. Check with `whereis hass` for the location.
 - If running Home Assistant in a Python virtual environment or a Docker container, please skip to section below.
-- For most systems, the file is `/etc/systemd/system/home-assistant@[your user].service` with [your user] replaced by the user account that Home Assistant will run as - normally `homeassistant`.  For Ubuntu 16.04, the file is `/lib/systemd/system/home-assistant.service` and requires running this command `sudo ln -s /lib/systemd/system/home-assistant.service /etc/systemd/system/home-assistant.service` after file is created.
+- For most systems, the file is `/etc/systemd/system/home-assistant@[your user].service` with [your user] replaced by the user account that Home Assistant will run as - normally `homeassistant`.  In particular, this is the case for Ubuntu 16.04. 
 - If unfamiliar with command-line text editors, `sudo nano -w [filename]` can be used with `[filename]` replaced with the full path to the file.  Ex. `sudo nano -w /etc/systemd/system/home-assistant@[your user].service`.  After text entered, press CTRL-X then press Y to save and exit.
 
 ```


### PR DESCRIPTION
**Description:**
The wiki instructions for how to create a systemctl daemon on Ubuntu 16.04 are apparently wrong. I am running Ubuntu MATE 16.04 on a Raspberry Pi 3. The home-assistant@homeassistant.service file should initially be created in the /etc/systemd/system directory. When using the directions as previously stated, one gets an error that there are symbolic links that go too deep. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

