### PR TITLE
Fix value_template not visible

### DIFF
--- a/source/_components/sensor.hp_ilo.markdown
+++ b/source/_components/sensor.hp_ilo.markdown
@@ -77,11 +77,11 @@ sensor:
       - name: CPU fanspeed
         sensor_type: server_health
         unit_of_measurement: '%'
-        value_template: '{{ ilo_data.fans["Fan 1"].speed[0] }}'
+        value_template: '{% raw %}{{ ilo_data.fans["Fan 1"].speed[0] }}{% endraw %}'
       - name: Inlet temperature
         sensor_type: server_health
         unit_of_measurement: '°C'
-        value_template: '{{ ilo_data.temperature["01-Inlet Ambient"].currentreading[0] }}'
+        value_template: '{% raw %}{{ ilo_data.temperature["01-Inlet Ambient"].currentreading[0] }}{% endraw %}'
       - name: Server Health
         sensor_type: server_health
 


### PR DESCRIPTION
**Description:**
The `value_template` for the HP ILO component were not being generated in the site. Fixed this by enclosing the example values in `{% raw %}` `{% endraw %}` tags.

**Fixes:** #2791 