### PR TITLE
entity_id is optional for the light.turn_off service

### DIFF
--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -63,7 +63,7 @@ Turns one or multiple lights off.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`s of lights. Else targets all.
 | `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds.
 
 ### {% linkable_title Service `light.toggle` %}


### PR DESCRIPTION
**Description:**
This is to correct the documentation saying that the `entity_id` is optional for the `light.turn_off` service.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>
Here's the PR that tests that this is the case: https://github.com/home-assistant/home-assistant/pull/7981
