### PR TITLE
Update splunk.markdown

### DIFF
--- a/source/_components/splunk.markdown
+++ b/source/_components/splunk.markdown
@@ -25,6 +25,6 @@ splunk:
 Configuration variables:
 
 - **token** (*Required*): The HTTP Event Collector Token already created in your Splunk instance.
-- **host** (*Optional*): IP address or host name of your Splunk host, eg. http://192.168.1.10. Will default to `localhost` if not supplied.
+- **host** (*Optional*): IP address or host name of your Splunk host, eg. 192.168.1.10. Will default to `localhost` if not supplied.
 - **port** (*Optional*): Port to use. Defaults to 8088.
 - **ssl** (*Optional*): Use https instead of http to connect. Defaults to False.


### PR DESCRIPTION
Adding the http:// directive forces the python module to try port 80 instead of the specified port

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

