### PR TITLE
Add network_key configuration

### DIFF
--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -91,18 +91,6 @@ To add a Z-Wave device to your system, go to the Services menu and select the `z
 
 Security Z-Wave devices require a network key before being added to the network using the `zwave.add_node_secure` service. You must set the *network_key* configuration variable to use a network key before adding these devices.
 
-Edit your `options.xml` file:
-
-```bash
-  <!-- <Option name="NetworkKey" value="0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F 0x10" /> -->
-```
-Uncomment the line:
-```bash
-   <Option name="NetworkKey" value="0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10" />
-```
-
-You can replace these values with your own 16 byte network key. For more information on this process see the [OpenZwave](https://github.com/OpenZWave/open-zwave) wiki article [Adding Security Devices to OZW](https://github.com/OpenZWave/open-zwave/wiki/Adding-Security-Devices-to-OZW)
-
 An easy script to generate a random key:
 ```bash
 cat /dev/urandom | tr -dc '0-9A-F' | fold -w 32 | head -n 1 | sed -e 's/\(..\)/0x\1, /g'

--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -35,6 +35,7 @@ zwave:
 Configuration variables:
 
 - **usb_path** (*Optional*): The port where your device is connected to your Home Assistant host.
+- **network_key** (*Optional*): The 16 byte network key in the form `"0x01,0x02..."` used in order to connect securely to compatible devices.
 - **config_path** (*Optional*): The path to the Python OpenZWave configuration files. Defaults to the 'config' that is installed by python-openzwave
 - **autoheal** (*Optional*): Allows disabling auto Z-Wave heal at midnight. Defaults to True.
 - **polling_interval** (*Optional*): The time period in milliseconds between polls of a nodes value. Be careful about using polling values below 30000 (30 seconds) as polling can flood the zwave network and cause problems.
@@ -88,7 +89,7 @@ To add a Z-Wave device to your system, go to the Services menu and select the `z
 
 ### {% linkable_title Adding Security Devices %}
 
-Security Z-Wave devices require a network key before being added to the network using the `zwave.add_node_secure` service. You must edit the `options.xml` file, located in your `python-openzwave config_path` to use a network key before adding these devices.
+Security Z-Wave devices require a network key before being added to the network using the `zwave.add_node_secure` service. You must set the *network_key* configuration variable to use a network key before adding these devices.
 
 Edit your `options.xml` file:
 


### PR DESCRIPTION
Network key can be set here rather than in the (difficult to find) configuration `options.xml`. It takes the same comma separated "0xNN" string syntax as previous.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

