### PR TITLE
Update camera.rpi_camera.markdown

### DIFF
--- a/source/_components/camera.rpi_camera.markdown
+++ b/source/_components/camera.rpi_camera.markdown
@@ -21,7 +21,7 @@ To enable this camera in your installation, add the following to your `configura
 ```yaml
 # Example configuration.yaml entry
 camera:
-  - platform: rpi_camera
+  platform: rpi_camera
 ```
 
 Configuration variables:


### PR DESCRIPTION
fix typo - removed the leading dash before the keyword platform at line 24.
   platform: rpi_camera

**Description:**
removed the leading dash before the keyword platform at line 24.
   platform: rpi_camera
