### PR TITLE
Added glances CPU temperature doc.

### DIFF
--- a/source/_components/sensor.glances.markdown
+++ b/source/_components/sensor.glances.markdown
@@ -82,6 +82,4 @@ Configuration variables:
   - **process_sleeping**: Number of sleeping processes
   - **cpu_temp**: CPU Temperature (may not available on all platforms)
 
-Not all platforms are able to provide all metrics. For instance `cpu_temp` is
-requires installing `lmsensors` in Ubuntu, and may not be available at
-all in other platforms.
+Not all platforms are able to provide all metrics. For instance `cpu_temp` is requires installing and configuring `lmsensors` in Ubuntu, and may not be available at all in other platforms.

--- a/source/_components/sensor.glances.markdown
+++ b/source/_components/sensor.glances.markdown
@@ -16,7 +16,7 @@ ha_release: 0.7.3
 
 The `glances` sensor platform is consuming the system information provided by the [Glances](https://github.com/nicolargo/glances) API. This enables one to track remote host and display their stats in Home Assistant.
 
-This sensors needs a running instance of `glances` on the host. The minimal supported version of `glances` is 2.3. 
+This sensors needs a running instance of `glances` on the host. The minimal supported version of `glances` is 2.3.
 To start a Glances RESTful API server on its default port 61208, the a test the following command can be used:
 
 ```bash
@@ -57,6 +57,7 @@ sensor:
       - 'process_total'
       - 'process_thread'
       - 'process_sleeping'
+      - 'cpu_temp'
 ```
 
 Configuration variables:
@@ -79,4 +80,8 @@ Configuration variables:
   - **process_total**: Total number of processes
   - **process_thread**: Number of threads
   - **process_sleeping**: Number of sleeping processes
+  - **cpu_temp**: CPU Temperature (may not available on all platforms)
 
+Not all platforms are able to provide all metrics. For instance `cpu_temp` is
+requires installing `lmsensors` in Ubuntu, and may not be available at
+all in other platforms.


### PR DESCRIPTION
**Description:**

Added documentation about the new CPU temperature metric available in glances sensor.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):**

https://github.com/home-assistant/home-assistant/pull/8093