### PR TITLE
Add auto start code and information for Z-wave stick

### DIFF
--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Installation on FreeNAS 9.10"
 description: "Installation of Home Assistant on your FreeNAS."
-date: 2017-04-06 17:00
+date: 2017-06-20 11:00
 sidebar: true
 comments: false
 sharing: true
@@ -29,10 +29,20 @@ Install Home Assistant itself.
 # pip3 install homeassistant
 ```
 
-Finally start Home Assistant.
+Create an /etc/rc.local file to enable Home Assistant to start when the jail starts. The command in /etc/rc.local can also be run in a terminal session but Home Assistant will exit when that session is closed.  
 
 ```bash
-# hass --open-ui
+# /usr/local/bin/hass --open-ui --config /home/.homeassistant/ &
 ```
 
-Some suggestions on using a tmux to keep it running can be found in the FreeNAS forums [HERE](https://forums.freenas.org/index.php?threads/how-to-home-assistant-in-a-jail-tested-on-9-10.50371/)
+Make /etc/rc.local executable so it runs on startup
+
+```bash
+# chmod 755 /etc/rc.local
+```
+
+Finally restart the jail from the Freenas GUI.
+
+<p class='note'>
+USB Z-wave sticks may give dmesg warnings similar to "data interface 1, has no CM over data, has no break".  This doesn't impact the function of the Z-wave stick in Hass.  Just make sure the proper /dev/cu* is used in the Home Assistant configuration.yaml file.  
+</p>

--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -29,13 +29,13 @@ Install Home Assistant itself.
 # pip3 install homeassistant
 ```
 
-Create an /etc/rc.local file to enable Home Assistant to start when the jail starts. The command in /etc/rc.local can also be run in a terminal session but Home Assistant will exit when that session is closed.  
+Create an `/etc/rc.local` file to enable Home Assistant to start when the jail starts. The command in `/etc/rc.local` can also be run in a terminal session but Home Assistant will exit when that session is closed.  
 
 ```bash
 # /usr/local/bin/hass --open-ui --config /home/.homeassistant/ &
 ```
 
-Make /etc/rc.local executable so it runs on startup
+Make `/etc/rc.local` executable so it runs on startup
 
 ```bash
 # chmod 755 /etc/rc.local
@@ -44,5 +44,5 @@ Make /etc/rc.local executable so it runs on startup
 Finally restart the jail from the Freenas GUI.
 
 <p class='note'>
-USB Z-wave sticks may give dmesg warnings similar to "data interface 1, has no CM over data, has no break".  This doesn't impact the function of the Z-wave stick in Hass.  Just make sure the proper /dev/cu* is used in the Home Assistant configuration.yaml file.  
+USB Z-wave sticks may give `dmesg` warnings similar to "data interface 1, has no CM over data, has no break".  This doesn't impact the function of the Z-wave stick in Hass. Just make sure the proper `/dev/cu*` is used in the Home Assistant `configuration.yaml` file.  
 </p>


### PR DESCRIPTION
**Description:**

Updated the installation docs to include how to make Home Assistant start on the jail start.  

Also added note for USB Z-Wave sticks that may throw error.  [This](https://forums.freebsd.org/threads/55490/) is the only place mentioning errors that may pop up in dmesg and it may cause confusion.  

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

