### PR TITLE
add telegram_bot/delete_message doc for #8153

### DIFF
--- a/source/_components/telegram_bot.markdown
+++ b/source/_components/telegram_bot.markdown
@@ -84,7 +84,7 @@ Edit a previusly sent message in a conversation.
 
 | Service data attribute    | Optional | Description                                      |
 |---------------------------|----------|--------------------------------------------------|
-| `message_id`              |       no | Id of the message to edit. When answering a callback from a pressed button, the id of the origin message is in: `{{ trigger.event.data.message.message_id }}`. |
+| `message_id`              |       no | Id of the message to edit. When answering a callback from a pressed button, the id of the origin message is in: `{{ trigger.event.data.message.message_id }}`. You can use `"last"` to refer to the last message sent to `chat_id`. |
 | `chat_id`                 |       no | The chat_id where to edit the message.  |
 | `message`                 |       no | Message body of the notification. |
 | `title`                   |      yes | Optional title for your notification. Will be composed as '%title\n%message'. |
@@ -97,7 +97,7 @@ Edit the caption of a previusly sent message.
 
 | Service data attribute    | Optional | Description                                      |
 |---------------------------|----------|--------------------------------------------------|
-| `message_id`              |       no | Id of the message to edit. When answering a callback from a pressed button, the id of the origin message is in: `{{ trigger.event.data.message.message_id }}`. |
+| `message_id`              |       no | Id of the message to edit. When answering a callback from a pressed button, the id of the origin message is in: `{{ trigger.event.data.message.message_id }}`. You can use `"last"` to refer to the last message sent to `chat_id`. |
 | `chat_id`                 |       no | The chat_id where to edit the caption.  |
 | `caption`                 |       no | Message body of the notification. |
 | `disable_web_page_preview`|      yes | True/false for disable link previews for links in the message. |
@@ -108,7 +108,7 @@ Edit the inline keyboard of a previusly sent message.
 
 | Service data attribute    | Optional | Description                                      |
 |---------------------------|----------|--------------------------------------------------|
-| `message_id`              |       no | Id of the message to edit. When answering a callback from a pressed button, the id of the origin message is in: `{{ trigger.event.data.message.message_id }}`. |
+| `message_id`              |       no | Id of the message to edit. When answering a callback from a pressed button, the id of the origin message is in: `{{ trigger.event.data.message.message_id }}`. You can use `"last"` to refer to the last message sent to `chat_id`. |
 | `chat_id`                 |       no | The chat_id where to edit the reply_markup.  |
 | `disable_web_page_preview`|      yes | True/false for disable link previews for links in the message. |
 | `inline_keyboard`         |      yes | List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data. Example: `["/button1, /button2", "/button3"]` or `[[["Text btn1", "/button1"], ["Text btn2", "/button2"]], [["Text btn3", "/button3"]]]` |
@@ -121,6 +121,14 @@ Respond to a callback query originated by clicking on an online keyboard button.
 | `message`                 |       no | Unformatted text message body of the notification. |
 | `callback_query_id`       |       no | Unique id of the callback response. In the `telegram_callback` event data: `{{ trigger.event.data.id }}` |
 | `show_alert`              |      yes | True/false for show a permanent notification. Defaults to False. |
+
+#### {% linkable_title Service `telegram_bot/delete_message` %}
+Delete a previusly sent message in a conversation.
+
+| Service data attribute    | Optional | Description                                      |
+|---------------------------|----------|--------------------------------------------------|
+| `message_id`              |       no | Id of the message to delete. When answering a callback from a pressed button, the id of the origin message is in: `{{ trigger.event.data.message.message_id }}`. You can use `"last"` to refer to the last message sent to `chat_id`. |
+| `chat_id`                 |       no | The chat_id where to delete the message.  |
 
 ### {% linkable_title `Telegram` notification platform %}
 


### PR DESCRIPTION
**Description:**

- Add doc for new service `telegram_bot/delete_message`.
- Include explicitly the `"message_id": "last"` option in the services for editing messages.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8153
