### PR TITLE
Add instructions around authorized_keys

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -18,8 +18,10 @@ Hass.io images are available for all available Raspberry Pi and intel nuc platfo
   - [Intel Nuc][nuc]
 - Flash the downloaded image to an SD card using [Etcher].
 - Optional - Setup the WiFi or static ip: On the SD-card, edit the `system-connections/resin-sample` file and follow the [ResinOS howto][resinos-network].
+- Optional - Install ssh key for connecting to your hass.io during setup: `cat ~/.ssh/id_rsa.pub >> /[path_to_mounted_sdcard_boot]/authorized_keys`
 - Insert SD card to Raspberry Pi and turn it on. On first boot, it downloads the latest version of Home Assistant which can take some time.
 - You will be able to reach your installation at [http://hassio.local:8123][local].
+- To ssh inside your hass.io you can use `ssh root@<IP Address> -p 22222` from the user that supplied the ssh key
 
 <p class='note'>
 If you copy over your existing Home Assistant configuration, make sure to enable the Hass.io panel by adding either `discovery:` or `hassio:` to your configuration.


### PR DESCRIPTION
As you don't have display output and as you can't ssh using username&password I recommend you add this in the installation steps.

I know there is the option to use the ssh server in the addons, but that is only available after you blindly wait up to 10 minutes with no clue if it's going to work.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

