### PR TITLE
Update cron job command

### DIFF
--- a/source/_docs/ecosystem/certificates/lets_encrypt.markdown
+++ b/source/_docs/ecosystem/certificates/lets_encrypt.markdown
@@ -495,7 +495,7 @@ $ crontab -e
  * Scroll to the bottom of the file and paste in the following line
  
 ```text
-30 2 * * 1 /usr/bin/letsencrypt renew >> /var/log/le-renew.log
+30 2 * * 1 ~/certbot/certbot-auto renew --quiet --no-self-upgrade --standalone --preferred-challenges http-01
 ```
  * Save the file and exit
  


### PR DESCRIPTION
/usr/bin/letsencrypt does not exist anymore, the file is located in ~/certbot/

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

