### PR TITLE
Fix binary_sensor.template example

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -56,36 +56,40 @@ sensor:
 Some movement sensors and door/window sensors will appear as a switch. By using a template binary sensor, the switch can be displayed as a binary sensors. The original switch can then be hidden by [customizing.](/getting-started/customizing-devices/)
 
 ```yaml
-binary_sensor: 
-  - platform: template 
+binary_sensor:
+  - platform: template
     sensors:
       movement:
         value_template: {% raw %}"{{ states.switch.movement.state == 'on' }}"{% endraw %}
         device_class: motion
       door:
-        value_template: {% raw %}"{{ states.switch.door.state == 'on' }}"{% endraw %} 
+        value_template: {% raw %}"{{ states.switch.door.state == 'on' }}"{% endraw %}
         device_class: opening
 ```
 
 
 ### {% linkable_title Combining multiple sensors, and using entity_id: %}
 
-This example combines multiple CO sensors into a single overall status. It also shows how to use `entity_id`
+This example combines multiple CO sensors into a single overall
+status. When using templates with binary sensors, you need to return
+`True` or `False` explicitly. `entity_id` is used to limit which
+sensors are being monitored to update the state, making computing this
+sensor far more efficient.
 
 ```yaml
-binary_sensor: 
-  - platform: template 
+binary_sensor:
+  - platform: template
     sensors:
       co:
         friendly_name: 'CO'
         device_class: 'gas'
         value_template: {% raw %}>-
-          {%- if is_state("sensor.bedroom_co_status", "Ok") 
+          {%- if is_state("sensor.bedroom_co_status", "Ok")
               and is_state("sensor.kitchen_co_status", "Ok")
               and is_state("sensor.wardrobe_co_status", "Ok") -%}
-          Off
+          False
           {%- else -%}
-          On
+          True
           {%- endif %}{% endraw %}
         entity_id:
           - sensor.bedroom_co_status
@@ -104,5 +108,41 @@ sensor:
         friendly_name: 'Day/Night'
         value_template: {% raw %}'{% if is_state("sun.sun", "above_horizon") %}Day{% else %}Night{% endif %}'{% endraw %}
         icon_template: {% raw %}'{% if is_state("sun.sun", "above_horizon") %}mdi:weather-sunny{% else %}mdi:weather-night{% endif %}'{% endraw %}
-        
+```
+
+### {% linkable_title Is anyone home? %}
+
+This example is determining if anyone is home based on the combination
+of device tracking and motion sensors. It's extremely useful if you
+have kids / baby sitter / grand parrents who might still be in your
+house that aren't represented by a trackable device in home
+assistant. This is providing a composite of wifi based device tracking
+and z-wave multisensor presence sensors.
+
+```yaml
+binary_sensor:
+  - platform: template
+    sensors:
+      people_home:
+        value_template: >-
+          {%- if is_state("device_tracker.sean", "home")
+          or is_state("device_tracker.susan", "home")
+          or is_state("binary_sensor.office_124", "on")
+          or is_state("binary_sensor.hallway_134", "on")
+          or is_state("binary_sensor.living_room_139", "on")
+          or is_state("binary_sensor.porch_ms6_1_129", "on")
+          or is_state("binary_sensor.family_room_144", "on")
+              -%}
+          True
+          {%- else -%}
+          False
+          {%- endif %}
+        entity_id:
+          - device_tracker.sean
+          - device_tracker.susan
+          - binary_sensor.office_124
+          - binary_sensor.hallway_134
+          - binary_sensor.living_room_139
+          - binary_sensor.porch_ms6_1_129
+          - binary_sensor.family_room_144
 ```


### PR DESCRIPTION
The binary_sensor.template was return states of "On" and "Off",
however that doesn't seem to work in 0.47. You need True / False,
which makes sense, given that's what the single line evals are going
to return. Update the existing example, and add another one about
computing composite occupancy from device tracker and motion sensors.

