### PR TITLE
telegram_bot platform to only send messages (#8186)

### DIFF
--- a/source/_components/telegram_bot.broadcast.markdown
+++ b/source/_components/telegram_bot.broadcast.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Telegram onlysend"
+title: "Telegram broadcast"
 description: "Telegram support to send messages only"
 date: 2017-06-24 11:20
 sidebar: true
@@ -12,7 +12,7 @@ ha_category: Telegram chatbot
 ha_release: 0.48
 ---
 
-Telegram implementation to support **sending messages only**. Your Home Assistant does not have to be exposed to the Internet and there is no polling to receive messages sent to Bot.
+Telegram implementation to support **sending messages only**. Your Home Assistant instance does not have to be exposed to the Internet and there is no polling to receive messages sent to the bot.
 
 To integrate this into Home Assistant, add the following section to your `configuration.yaml` file:
 
@@ -20,7 +20,7 @@ To integrate this into Home Assistant, add the following section to your `config
 # Example configuration.yaml entry
 
 telegram_bot:
-  - platform: onlysend
+  - platform: broadcast
     api_key: <telegram api key>
     allowed_chat_ids:
       - 12345

--- a/source/_components/telegram_bot.markdown
+++ b/source/_components/telegram_bot.markdown
@@ -17,6 +17,7 @@ Use Telegram on your mobile or desktop device to send and receive messages or co
 
 This component creates notification services to send, or edit previously sent, messages from a [Telegram Bot account](https://core.telegram.org/bots) configured either with the [polling](/components/telegram_bot.polling/) method or with the [webhooks](/components/telegram_bot.webhooks/) one, and trigger events when receiving messages.
 
+If you don't need to receive messages, you can use the [onlysend](/components/telegram_bot.onlysend/) platform instead.
 
 ### {% linkable_title Notification services %}
 Available services: `send_message`, `send_photo`, `send_document`, `send_location`, `edit_message`, `edit_replymarkup`, `edit_caption`, `answer_callback_query`.

--- a/source/_components/telegram_bot.markdown
+++ b/source/_components/telegram_bot.markdown
@@ -17,7 +17,7 @@ Use Telegram on your mobile or desktop device to send and receive messages or co
 
 This component creates notification services to send, or edit previously sent, messages from a [Telegram Bot account](https://core.telegram.org/bots) configured either with the [polling](/components/telegram_bot.polling/) method or with the [webhooks](/components/telegram_bot.webhooks/) one, and trigger events when receiving messages.
 
-If you don't need to receive messages, you can use the [onlysend](/components/telegram_bot.onlysend/) platform instead.
+If you don't need to receive messages, you can use the [broadcast](/components/telegram_bot.broadcast/) platform instead.
 
 ### {% linkable_title Notification services %}
 Available services: `send_message`, `send_photo`, `send_document`, `send_location`, `edit_message`, `edit_replymarkup`, `edit_caption`, `answer_callback_query`.

--- a/source/_components/telegram_bot.onlysend.markdown
+++ b/source/_components/telegram_bot.onlysend.markdown
@@ -1,0 +1,37 @@
+---
+layout: page
+title: "Telegram onlysend"
+description: "Telegram support to send messages only"
+date: 2017-06-24 11:20
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: telegram.png
+ha_category: Telegram chatbot
+ha_release: 0.48
+---
+
+Telegram implementation to support **sending messages only**. Your Home Assistant does not have to be exposed to the Internet and there is no polling to receive messages sent to Bot.
+
+To integrate this into Home Assistant, add the following section to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+
+telegram_bot:
+  - platform: onlysend
+    api_key: <telegram api key>
+    allowed_chat_ids:
+      - 12345
+      - 67890
+```
+
+Configuration variables:
+
+- **allowed_chat_ids** (*Required*): A list of user in the `user_id` Telegram format enabled to interact to webhook
+- **api_key** (*Required*): The API token of your bot.
+- **parse_mode** (*Optional*): Default parser for messages if not explicit in message data: 'html' or 'markdown'. Default is 'markdown'.
+
+To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram/).
+


### PR DESCRIPTION
**Description:**

Doc for new `telegram_bot/onlysend` platform for send messages only.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8186
