### PR TITLE
Switch to new zwave entity ids by default

### DIFF
--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -46,7 +46,7 @@ Configuration variables:
   - **delay** (*Optional*): Specify the delay for refreshing of node value. Only the light component uses this. Defaults to 2 seconds.
   - **invert_openclose_buttons** (*Optional*): Inverts function of the open and close buttons for the cover domain. Defaults to `False`.
 - **debug** (*Optional*): Print verbose z-wave info to log. Defaults to `False`.
-- **new_entity_ids** (*Optional*): Switch to new entity_id generation. Defaults to `False`.
+- **new_entity_ids** (*Optional*): Switch to new entity_id generation. Defaults to `True`.
 
 To find the path of your Z-Wave USB stick or module, run:
 


### PR DESCRIPTION
**Description:**
Update Z-Wave docs to reflect new default configurations.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8192

