### PR TITLE
Make component cards 100% width on mobile

### DIFF
--- a/sass/custom/_component_page.scss
+++ b/sass/custom/_component_page.scss
@@ -14,6 +14,16 @@
   }
 }
 
+@media only screen and (max-width: $palm-end) {
+  #components-page {
+    .hass-option-cards {
+      .option-card {
+        width: 100%;
+      }
+    }
+  }
+}
+
 @media only screen and (max-width: $lap-end) {
   #components-page {
     .filter-button-group {


### PR DESCRIPTION
**Description:**

Currently the component cards don't take up the full width in mobile while still collapsing to 1 card per row. This is a small style update to make the cards take up the full width for very small resolutions.

This:

![image](https://user-images.githubusercontent.com/4155121/27478165-62b7af92-5817-11e7-9e0f-cf6459d3eac9.png)

Becomes this:

![image](https://user-images.githubusercontent.com/4155121/27478200-81f4b0da-5817-11e7-86fe-1ce26c1484b7.png)
