### PR TITLE
add content_type option to generic camera

### DIFF
--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -35,6 +35,7 @@ Configuration variables:
 - **password** (*Optional*): The password for accessing your camera.
 - **authentication** (*Optional*): Type for authenticating the requests `basic` (default) or `digest`.
 - **limit_refetch_to_url_change** (*Optional*): True/false value (default: false). Limits refetching of the remote image to when the url changes. Only relevant if using a template to fetch the remote image.
+- **content_type** (*Optional*): Set the content type for the IP camera if it is not a jpg file (default: `image/jpeg`). Use `image/svg+xml` to add a dynamic svg file.
 
 <p class='img'>
   <a href='/cookbook/google_maps_card/'>


### PR DESCRIPTION
**Description:**

Doc about the `content_type` config parameter for `camera.generic`, to be able to add cameras for time-changing SVGs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8188

