### PR TITLE
input_select: add note about boolean equivalents

### DIFF
--- a/source/_components/input_select.markdown
+++ b/source/_components/input_select.markdown
@@ -43,6 +43,8 @@ Configuration variables:
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your input and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.
 
+**Note**: Because yaml [defines](http://yaml.org/type/bool.html) them as equivalent, any variations of 'On', 'Yes', 'Y', 'Off', 'No', or 'N'  (regardless of case) used as option names will be replaced by True and False unless they are defined in quotation marks. 
+
 ### {% linkable_title Services %}
 
 This components provide three services to modify the state of the `input_select`:

--- a/source/_components/input_select.markdown
+++ b/source/_components/input_select.markdown
@@ -43,7 +43,9 @@ Configuration variables:
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your input and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.
 
-**Note**: Because yaml [defines](http://yaml.org/type/bool.html) them as equivalent, any variations of 'On', 'Yes', 'Y', 'Off', 'No', or 'N'  (regardless of case) used as option names will be replaced by True and False unless they are defined in quotation marks. 
+<p class='note'>
+Because YAML defines [booleans](http://yaml.org/type/bool.html) as equivalent, any variations of 'On', 'Yes', 'Y', 'Off', 'No', or 'N'  (regardless of case) used as option names will be replaced by True and False unless they are defined in quotation marks.
+</p>
 
 ### {% linkable_title Services %}
 


### PR DESCRIPTION
**Description:**
Adds warning for users that any unquoted input select options defined using strings that Yaml defines as boolean identifiers will be replaced by True and False. The background is discussed [here](https://github.com/home-assistant/home-assistant/issues/8214) 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

