### PR TITLE
Added scan_interval defaults

### DIFF
--- a/source/_components/binary_sensor.command_line.markdown
+++ b/source/_components/binary_sensor.command_line.markdown
@@ -33,6 +33,7 @@ Configuration variables:
 - **payload_on** (*Optional*): The payload that represents enabled state. Default is "ON".
 - **payload_off** (*Optional*): The payload that represents disabled state. Default is "OFF".
 - **value_template** (*Optional*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
+- **scan_interval** (*Optional*): Defines number of seconds for polling interval (defaults to 60 seconds). 
 
 ## {% linkable_title Examples %}
 

--- a/source/_components/sensor.command_line.markdown
+++ b/source/_components/sensor.command_line.markdown
@@ -31,7 +31,7 @@ Configuration variables:
 - **name** (*Optional*): Name of the command sensor.
 - **unit_of_measurement** (*Optional*): Defines the unit of measurement of the sensor, if any.
 - **value_template** (*Optional*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
-- **scan_interval** (*Optional*): Defines number of seconds for polling interval.
+- **scan_interval** (*Optional*): Defines number of seconds for polling interval (defaults to 60 seconds). 
 
 ## {% linkable_title Examples %}
 
@@ -104,7 +104,7 @@ sensor:
 
 ### {% linkable_title Read value out of a remote text file %}
 
-If you own a devices which are storing values in text files which are accessible over HTTP then you can use the same approach as shown in the previous section. Instead of looking at the JSON response we directly grab the sensor's value. 
+If you own a devices which are storing values in text files which are accessible over HTTP then you can use the same approach as shown in the previous section. Instead of looking at the JSON response we directly grab the sensor's value.
 
 ```yaml
 sensor:


### PR DESCRIPTION
Added `scan_interval` defaults to Command Line and Command Line Binary sensors. 