### PR TITLE
Expose attributes in a custom component

### DIFF
--- a/source/developers/development_states.markdown
+++ b/source/developers/development_states.markdown
@@ -124,4 +124,15 @@ After a start or a restart of Home Assistant the component will be visible in th
 <img src='/images/screenshots/create-component01.png' />
 </p>
 
+In order to expose attributes of your component, you will need to define a method called `state_attributes` which will return a dictionary of attributes:
+
+```
+    @property
+    def state_attributes(self):
+        """Return the attributes of the entity.
+        """
+
+        return self._attributes
+```
+
 To get your component included in the Home Assistant releases, follow the steps described in the [Submitting improvements](https://home-assistant.io/developers/#submitting-improvements) section. Basically you only need to move your component in the `homeassistant/component/` directory of your fork and create a Pull Request.

--- a/source/developers/development_states.markdown
+++ b/source/developers/development_states.markdown
@@ -127,12 +127,10 @@ After a start or a restart of Home Assistant the component will be visible in th
 In order to expose attributes of your component, you will need to define a method called `state_attributes` which will return a dictionary of attributes:
 
 ```
-    @property
-    def state_attributes(self):
-        """Return the attributes of the entity.
-        """
-
-        return self._attributes
+@property
+def state_attributes(self):
+    """Return the attributes of the entity."""
+    return self._attributes
 ```
 
 To get your component included in the Home Assistant releases, follow the steps described in the [Submitting improvements](https://home-assistant.io/developers/#submitting-improvements) section. Basically you only need to move your component in the `homeassistant/component/` directory of your fork and create a Pull Request.


### PR DESCRIPTION
Added an example on how to expose attributes in a custom component.

**Description:**
Changed the documentation with an example on how to give access to attributes. Idea used here: https://community.home-assistant.io/t/solved-parsing-a-json-value-from-an-existing-entity-in-a-template-sensor/20490/12

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

