### PR TITLE
SMTP notify defaults to starttls

### DIFF
--- a/source/_components/notify.smtp.markdown
+++ b/source/_components/notify.smtp.markdown
@@ -32,11 +32,11 @@ Configuration variables:
 - **sender** (*Required*): E-mail address of the sender.
 - **recipient** (*Required*): E-mail address of the recipient of the notification. This can be a recipient address or a list of addresses for multiple recipients.
 - **server** (*Optional*): SMTP server which is used to end the notifications. Defaults to `localhost`.
-- **port** (*Optional*): The port that the SMTP server is using. Defaults to 465.
+- **port** (*Optional*): The port that the SMTP server is using. Defaults to 587.
 - **timeout** (*Optional*): The timeout in seconds that the SMTP server is using. Defaults to 5.
 - **username** (*Optional*): Username for the SMTP account.
 - **password** (*Optional*): Password for the SMTP server that belongs to the given username. If the password contains a colon it need to be wrapped in apostrophes.
-- **encryption** (*Optional*): Set mode for encryption, `tls`, `starttls` or `none`. Defaults to `tls`.
+- **encryption** (*Optional*): Set mode for encryption, `starttls`, `tls` or `none`. Defaults to `starttls`.
 - **sender_name** (*Optional*): Sets a custom 'sender name' in the emails headers (*From*: Custom name <example@mail.com>).
 - **debug** (*Optional*): Enables Debug, eg. True or False. Defaults to False.
 


### PR DESCRIPTION
**Description:**

The defaults were changed during the 0.48 release process: home-assistant/home-assistant@b1f3492fd03a36b107d28006070b17e23a2aad0c
