### PR TITLE
Update the UPC Connect component documentation

### DIFF
--- a/source/_components/device_tracker.upc_connect.markdown
+++ b/source/_components/device_tracker.upc_connect.markdown
@@ -21,12 +21,10 @@ To use a Connect Box in your installation, add the following to your `configurat
 # Example configuration.yaml entry
 device_tracker:
   - platform: upc_connect
-    password: YOUR_PASSWORD
 ```
 
 Configuration variables:
 
-- **password** (*Required*): The password for your Connect Box.
 - **host** (*Optional*): The IP address of your router. Set it if you are not using `192.168.0.1`.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
**Description:**

Remove the ``password`` parameter on the UPC Connect component which is not needed.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#8335

