### PR TITLE
Update Plex docs for SSL connections

### DIFF
--- a/source/_components/media_player.plex.markdown
+++ b/source/_components/media_player.plex.markdown
@@ -29,7 +29,7 @@ If your Plex server has local authentication enabled or multiple users defined, 
 
 If you don't know your token, see [Finding your account token / X-Plex-Token](https://support.plex.tv/hc/en-us/articles/204059436).
 
-If your server enforces SSL connections, write anything in the "Use SSL" field. If it does not have a valid SSL certificate available but you still want to use it, write anything in the "Do not verify SSL" field.
+If your server enforces SSL connections, write "`on`" or "`true`" in the _"Use SSL"_ field. If it does not have a valid SSL certificate available but you still want to use it, write "`on`" or "`true`" in the _"Do not verify SSL"_ field as well.
 
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/plex-token.png' />

--- a/source/_components/media_player.plex.markdown
+++ b/source/_components/media_player.plex.markdown
@@ -29,6 +29,8 @@ If your Plex server has local authentication enabled or multiple users defined, 
 
 If you don't know your token, see [Finding your account token / X-Plex-Token](https://support.plex.tv/hc/en-us/articles/204059436).
 
+If your server enforces SSL connections, write anything in the "Use SSL" field. If it does not have a valid SSL certificate available but you still want to use it, write anything in the "Do not verify SSL" field.
+
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/plex-token.png' />
 </p>
@@ -44,12 +46,14 @@ media_player:
 In case [discovery](/components/discovery/) does not work (GDM disabled or non-local plex server), you can create `~/.homeassistant/plex.conf` manually.
 
 ```json
-{"IP_ADDRESS:PORT": {"token": "TOKEN"}}
+{"IP_ADDRESS:PORT": {"token": "TOKEN", "ssl": false, "verify": true}}
 ```
 
-- **IP_ADDRESS** (*Required*): IP address of the Plex Media Server
-- **PORT** (*Required*): Port where Plex is listening. Default is 32400
+- **IP_ADDRESS** (*Required*): IP address of the Plex Media Server.
+- **PORT** (*Required*): Port where Plex is listening. Default is 32400.
 - **TOKEN** (*Optional*): Only if authentication is required. Set to `null` (without quotes) otherwise.
+- **ssl** (*Optional*): Whether to use SSL or not. _(Boolean)_
+- **verify** (*Optional*): Whether to allow invalid or self-signed SSL certificates or not. _(Boolean)_
 
 ## Customization
 You can customize the Plex component by adding any of the variables below to your configuration:
@@ -129,4 +133,4 @@ Plays a song, playlist, TV episode, or video on a connected client.
   INFO:homeassistant.components.media_player.plex:No server found at: http://192.168.1.10:32400
   ```
 
-  If this occurs, try changing the setting `Secure connections` in your Plex Media Server to `Preferred` (instead of `Required`). The Plex component does not currently support HTTPS.
+  If this occurs, check the setting `Server`>`Network`>`Secure connections` in your Plex Media Server: if it is set to `Preferred` or `Required`, you may need to manually set the `ssl` and `verify` booleans in the `plex.conf` file to, respectively, `true` and `false`. See the **"Setup"** section above for details.


### PR DESCRIPTION
**Description:**
Companion PR to home-assistant/home-assistant#8341, syncs docs to new configuration options and support for SSL connections (both with valid and invalid certificates).


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#8341

