### PR TITLE
Updated Pandora component install instructions

### DIFF
--- a/source/_components/media_player.pandora.markdown
+++ b/source/_components/media_player.pandora.markdown
@@ -19,12 +19,18 @@ If you have a Pandora account, you can control it from Home Assistant with this 
 
 ### {% linkable_title Installation of Pianobar %}
 
-This media player uses the [Pianobar command-line Pandora client](https://github.com/PromyLOPh/pianobar), which you have to install separately. This can be done on a Raspberry Pi 2 with Raspbian Jesse as follows . _(Note: Other platforms may have different installation processes)_
+This media player uses the [Pianobar command-line Pandora client](https://github.com/PromyLOPh/pianobar), which you have to install separately. This can be done on a Raspberry Pi 2/3 with Raspbian Jessie as follows . _(Note: Other platforms may have different installation processes)_
 
-Install the following dependencies:
+The version of pianobar that comes with Jessie has a bug, so you have to build a more recent version. The latest version depends on a recent version of libraries associated with ffmpeg, so you should make sure you go through the backport process documented in [The FFmpeg component](https://home-assistant.io/components/ffmpeg/) before doing this. Install the following basic dependencies:
 
 ```bash
-$ sudo apt-get install git libao-dev libgcrypt11-dev libfaad-dev libmad0-dev libjson0-dev make pkg-config libav-tools libavcodec-extra libavcodec-dev libcurl4-openssl-dev  libavfilter-dev libavformat-dev
+$ sudo apt-get install git libao-dev libgcrypt11-dev libfaad-dev libmad0-dev libjson0-dev make pkg-config  libcurl4-openssl-dev  
+```
+
+And now install the backported ffmpeg-related libraries (note that if you're using an older version of ffmpeg for other things on this machine, you may encounter issues after doings this):
+
+```bash
+$ sudo apt-get -t jessie-backports install libav-tools libavcodec-extra libavcodec-dev libavfilter-dev libavformat-dev
 ```
 
 Now clone the Pianobar repo and build pianobar:


### PR DESCRIPTION
The dependency Pianobar now depends on a more recent version of ffmpeg and the jessie-backports mode of installation is required.


