### PR TITLE
Update downloader documentation with `subdir` data attribute

### DIFF
--- a/source/_components/downloader.markdown
+++ b/source/_components/downloader.markdown
@@ -36,7 +36,8 @@ Go the the "Developer Tools", then to "Call Service", and choose `downloader/dow
 
 This will download the file from the given URL.
 
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `url`                  |       no | The url of the file to download.
+| Service data attribute | Optional | Description                                    |
+| ---------------------- | -------- | ---------------------------------------------- |
+| `url`                  |       no | The url of the file to download.               |
+| `subdir`               |      yes | Download into subdirectory of **download_dir** |
 


### PR DESCRIPTION
**Description:**
According to [the code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/downloader.py#L31) it is also possible to download a file into a subdirectory of **download_dir**

