### PR TITLE
Optional variables added to sensor.cups.markdown

### DIFF
--- a/source/_components/sensor.cups.markdown
+++ b/source/_components/sensor.cups.markdown
@@ -36,8 +36,8 @@ sensor:
 Configuration variables:
 
 - **printers** array (*Required*): List of printers to add.
-- **host** (*Optional*): IP address of the CUPS Print Server
-- **port** (*Optional*): Port address of the CUPS Print Server (typically 631)
+- **host** (*Optional*): IP address of the CUPS print server.
+- **port** (*Optional*): Port address of the CUPS print server. Defaults to 631.
 
 
 <p class='note'>

--- a/source/_components/sensor.cups.markdown
+++ b/source/_components/sensor.cups.markdown
@@ -36,8 +36,8 @@ sensor:
 Configuration variables:
 
 - **printers** array (*Required*): List of printers to add.
-- host (Optional): IP address of the CUPS Print Server
-- port (Optional): Port address of the CUPS Print Server (typically 631)
+- **host** (*Optional*): IP address of the CUPS Print Server
+- **port** (*Optional*): Port address of the CUPS Print Server (typically 631)
 
 
 <p class='note'>

--- a/source/_components/sensor.cups.markdown
+++ b/source/_components/sensor.cups.markdown
@@ -36,6 +36,8 @@ sensor:
 Configuration variables:
 
 - **printers** array (*Required*): List of printers to add.
+- host (Optional): IP address of the CUPS Print Server
+- port (Optional): Port address of the CUPS Print Server (typically 631)
 
 
 <p class='note'>


### PR DESCRIPTION
Sensor configuration supports two additional variables which are not listed but would be extremely helpful to anyone running their print server on a host other than the one running Home Assistant.

Added two lines to the Configuration variables section to show host and port optional values.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

