### PR TITLE
add doc for new wake_on_lan component with service send_magic_packet

### DIFF
--- a/source/_components/wake_on_lan.markdown
+++ b/source/_components/wake_on_lan.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: ethernet.png
-ha_category: ...
+ha_category: Hub
 ha_release: "0.49"
 ha_iot_class: "Local Push"
 ---

--- a/source/_components/wake_on_lan.markdown
+++ b/source/_components/wake_on_lan.markdown
@@ -1,0 +1,36 @@
+---
+layout: page
+title: "Wake on LAN"
+description: "Instructions how to setup the Wake on LAN component in Home Assistant."
+date: 2017-07-8 15:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: ethernet.png
+ha_category: ...
+ha_release: "0.49"
+ha_iot_class: "Local Push"
+---
+
+The `wake_on_lan` component enables the ability to send _magic packets_ to [Wake on LAN](https://en.wikipedia.org/wiki/Wake-on-LAN) capable devices, in order to turn them on.
+
+To use this component in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+wake_on_lan:
+```
+
+### {% linkable_title Component services %}
+
+Available services: `send_magic_packet`.
+
+#### {% linkable_title Service `wake_on_lan/send_magic_packet` %}
+
+Send a _magic packet_ to wake up a device with 'Wake-On-LAN' capabilities.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `mac`                     |       no | MAC address of the device to wake up.                 |
+| `broadcast_address`       |      yes | Optional broadcast IP where to send the magic packet. |


### PR DESCRIPTION
**Description:**

Add documentation for new `wake_on_lan` component with service `send_magic_packet`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8397

I don't know what `ha_category` this component is, where can I find a list?