### PR TITLE
Mark entity_id attribute of media_extractor as optional

### DIFF
--- a/source/_components/media_extractor.markdown
+++ b/source/_components/media_extractor.markdown
@@ -30,7 +30,7 @@ This will download the file from the given URL.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |       no | Name(s) of entities to seek media on, eg. `media_player.living_room_chromecast`
+| `entity_id`            |      yes | Name(s) of entities to seek media on, eg. `media_player.living_room_chromecast`. Defaults to all.
 | `media_content_id`     |       no | The ID of the content to play. Platform dependent.
 | `media_content_type`   |       no | The type of the content to play. Must be one of MUSIC, TVSHOW, VIDEO, EPISODE, CHANNEL or PLAYLIST MUSIC.
 


### PR DESCRIPTION
**Description:**
Strictly speaking 'entity_id' is optional attribute, as media_extractor.play_media is just decorates media_player.play_media service and it does not need this attribute at all. This attribute is optional for media_player.play_media https://home-assistant.io/components/media_player/#service-media_playerplay_media