### PR TITLE
LIFX: make broadcast address configurable

### DIFF
--- a/source/_components/light.lifx.markdown
+++ b/source/_components/light.lifx.markdown
@@ -21,11 +21,11 @@ _Please note, the `lifx` platform does not support Windows. The `lifx_legacy` pl
 # Example configuration.yaml entry
 light:
   - platform: lifx
-    server: 192.168.1.10
 ```
 Configuration variables:
 
-- **server** (*Optional*): Your server address. Only needed if using more than one network interface. Omit if you are unsure.
+- **broadcast** (*Optional*): The broadcast address for discovering lights. Only needed if using more than one network interface. Omit if you are unsure.
+- **server** (*Optional*): Your server address. Will listen on all interfaces if omitted. Omit if you are unsure.
 
 ## {% linkable_title Set state %}
 


### PR DESCRIPTION
**Description:**

The LIFX broadcast address can now be set.

While at it, remove `server` from the configuration example because listing it implies that it is needed while in reality it rarely is. If you have more than one network interface you probably know what you are doing and can figure out how to set it.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8453
