### PR TITLE
Added new configuration variable visibility_distance

### DIFF
--- a/source/_components/sensor.metoffice.markdown
+++ b/source/_components/sensor.metoffice.markdown
@@ -33,6 +33,7 @@ sensor:
       - wind_direction
       - wind_gust
       - visibility
+      - visibility_distance
       - uv
       - precipitation
       - humidity


### PR DESCRIPTION
**Description:**
The values for visibility provided by the Met Office are not in km but are codes (VG=Very Good, etc). These then map to estimated distance ranges of visibility.
Add new value to doc.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8454

