### PR TITLE
erorrs with degree symbol

### DIFF
--- a/source/_components/sensor.command_line.markdown
+++ b/source/_components/sensor.command_line.markdown
@@ -53,6 +53,7 @@ sensor:
   - platform: command_line
     name: HD Temperature
     command: "hddtemp -n /dev/sda"
+    # If errors occur, remove degree symbol below
     unit_of_measurement: "°C"
 ```
 
@@ -65,6 +66,7 @@ Thanks to the [`proc`](https://en.wikipedia.org/wiki/Procfs) file system, variou
   - platform: command_line
     name: CPU Temperature
     command: "cat /sys/class/thermal/thermal_zone0/temp"
+    # If errors occur, remove degree symbol below
     unit_of_measurement: "°C"
     value_template: '{% raw %}{{ value | multiply(0.001) }}{% endraw %}'
 ```


### PR DESCRIPTION
I was unable to get the examples above working when using that degree symbol in the unit of measurement, removing that symbol fixed the problem. I did try pasting in a fresh degree symbol, and even tried using one from the HASS front end, but that didn't work. However, this example has been here for a long time and I can't find any other cases of complaints, so I figured i'd add a warning in the comments in case anyone else has the same problem.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

