### PR TITLE
Added documentation for the env_var tag in configuration files

### DIFF
--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -61,3 +61,20 @@ sensor:
     state_topic: sensor2/topic
 ```
 
+### {% linkable_title Using Environment Variables %}
+
+You can include values from your system's environment variables with `!env_var`.
+
+```yaml
+http:
+  api_password: !env_var PASSWORD
+```
+
+#### Default Value
+
+If an environment variable is not set, you can fallback to a default value.
+
+```yaml
+http:
+  api_password: !env_var PASSWORD default_password
+```


### PR DESCRIPTION
Added documentation for the !env_var tag in configuration files, including a default value parameter as described in the pull request below.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#8484

