### PR TITLE
Added bose soundtouch as an allowed value

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -54,6 +54,7 @@ Valid values for ignore are:
 
  * `apple_tv`: Apple TV
  * `axis`: (Axis Communications security devices)
+ * `bose_soundtouch`: Bose Soundtouch speakers
  * `denonavr`: Denon Network Receivers
  * `directv`: DirecTV
  * `flux_led`: Flux Led/MagicLight


### PR DESCRIPTION
**Description:**

Base soundtouch is already allowed as an ignored value, as per https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/discovery.py#L60 but its not documented.

Document it

