### PR TITLE
eQ-3 Max docs update

### DIFF
--- a/source/_components/maxcube.markdown
+++ b/source/_components/maxcube.markdown
@@ -18,6 +18,7 @@ ha_iot_class: "Local Polling"
 Limitations:
 - Configuring weekly schedules is not possible.
 - Implementation is based on the reverse engineered [MAX! protocol](https://github.com/Bouni/max-cube-protocol).
+- Radiator valves only report the current room temperature shortly after the actuator has moved. Ordinarily, they will report 0 temperature.
 
 Supported Devices:
 - MAX! Radiator Thermostat (tested)

--- a/source/_components/maxcube.markdown
+++ b/source/_components/maxcube.markdown
@@ -22,7 +22,7 @@ Limitations:
 
 Supported Devices:
 - MAX! Radiator Thermostat (tested)
-- MAX! Radiator Thermostat+
+- MAX! Radiator Thermostat+ (tested)
 - MAX! Window Sensor (tested)
 - MAX! Wall Thermostat (tested)
 

--- a/source/_components/maxcube.markdown
+++ b/source/_components/maxcube.markdown
@@ -36,3 +36,4 @@ maxcube:
 Configuration variables:
 - **host** (*Required*): The IP address of the eQ-3 MAX! Cube to use.
 - **port** (*Optional*): The UDP port number. Defaults to `62910`.
+- **trv_on_off** (*Optional*): Reports the state of TRVs as being either on or off based on actuator position, rather than their configured state.


### PR DESCRIPTION
**Description:**

- Document limitation around TRVs only reporting temperature shortly after they have moved
- Document the fact that Thermostat+ is now tested
- Add docs for new config option trv_on_off

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8519

