### PR TITLE
Update media_player.apple_tv.markdown

### DIFF
--- a/source/_components/media_player.apple_tv.markdown
+++ b/source/_components/media_player.apple_tv.markdown
@@ -83,7 +83,7 @@ then device authentication is required. Press the icon in the upper left corner 
 
 <img src='/images/screenshots/developer-tools.png' />
 
-Select `apple_tv` as domain, `apple_tv_authenticate` as service and enter `{'entity_id': 'XXX'}` into "Service Data", but replace XXX with the entity id of your device (e.g. `media_player.apple_tv`). Press the button and hopefully you are presented with an input dialog asking for a pin code:
+Select `apple_tv` as domain, `apple_tv_authenticate` as service and enter `{"entity_id": "XXX"}` into "Service Data", but replace XXX with the entity id of your device (e.g. `media_player.apple_tv`). Press the button and hopefully you are presented with an input dialog asking for a pin code:
 
 <img src='/images/components/apple_tv/authenticate.png' />
 


### PR DESCRIPTION
Line 86: replaced single quotes with double quotes in {"entity_id": "XXX"} because of improper JSON and resulting failed command.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

