### PR TITLE
Added doc for controlling two or more covers at once

### DIFF
--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -86,14 +86,6 @@ cover:
     covers:
       all_covers:
         friendly_name: 'All Covers'
-        value_template: >
-          {% if is_state('cover.bedroom', 'open') %}
-            true
-          {% elif is_state('cover.livingroom', 'open') %}
-            true
-          {% else %}
-            false
-          {% endif %}
         open_cover:
           service: script.cover_all_open
         close_cover:
@@ -104,6 +96,27 @@ cover:
           service: script.cover_all_set_position
           data_template:
           position: '{{ position }}'
+        value_template: "{{ states.sensor.all_covers.state }}"
+        icon_template: >
+          {% if is_state('sensor.all_covers', 'open') %}
+            mdi:window-open
+          {% else %}
+            mdi:window-closed
+          {% endif %}
+        entity_id:
+          - cover.bedroom
+          - cover.livingroom
+
+sensor:
+  - platform: template
+    sensors:
+      all_covers:
+        value_template: >
+          {% if is_state('cover.bedroom', 'open') %}
+            open
+          {% elif is_state('cover.livingroom', 'open') %}
+            open
+          {% endif %}
         entity_id:
           - cover.bedroom
           - cover.livingroom

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -96,7 +96,12 @@ cover:
           service: script.cover_all_set_position
           data_template:
           position: '{{ position }}'
-        value_template: "{% raw %}{{ states.sensor.all_covers.state }}{% endraw %}"
+        value_template: {% raw %}>
+          {% if is_state('sensor.all_covers', 'open') %}
+            open
+          {% else %}
+            closed
+          {% endif %}{% endraw %}
         icon_template: {% raw %}>
           {% if is_state('sensor.all_covers', 'open') %}
             mdi:window-open
@@ -116,6 +121,8 @@ sensor:
             open
           {% elif is_state('cover.livingroom', 'open') %}
             open
+          {% else %}
+            closed
           {% endif %}{% endraw %}
         entity_id:
           - cover.bedroom

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -76,11 +76,16 @@ cover:
 
 ```
 
-### Multi Covers
+### {% linkable_title Multi Covers %}
 
 This example allows you to control two or more covers at once.
 
 ```yaml
+homeassistant:
+  customize:
+    all_covers:
+      assume_state: true
+
 cover:
   - platform: template
     covers:
@@ -95,7 +100,7 @@ cover:
         set_cover_position:
           service: script.cover_all_set_position
           data_template:
-          position: '{{ position }}'
+          position: "{% raw %}{{ position }}{% endraw %}"
         value_template: {% raw %}>
           {% if is_state('sensor.all_covers', 'open') %}
             open
@@ -156,7 +161,7 @@ script:
       - service: cover.set_cover_position
         entity_id: cover.livingroom
         data_template:
-          position: '{{ position }}'
+          position: "{% raw %}{{ position }}{% endraw %}"
 
 automation:
   - alias: 'Close covers at night'

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -75,3 +75,78 @@ cover:
         icon_template: "{% raw %}{% if not is_state('sensor.garage_door', 'on') %}mdi:garage-open{% else %}mdi:garage{% endif %}{% endraw %}"
 
 ```
+
+### Multi Covers
+
+This example allows you to control two or more covers at once.
+
+```yaml
+cover:
+  - platform: template
+    covers:
+      all_covers:
+        friendly_name: 'All Covers'
+        value_template: >
+          {% if is_state('cover.bedroom', 'open') %}
+            true
+          {% elif is_state('cover.livingroom', 'open') %}
+            true
+          {% else %}
+            false
+          {% endif %}
+        open_cover:
+          service: script.cover_all_open
+        close_cover:
+          service: script.cover_all_close
+        stop_cover:
+          service: script.cover_all_stop
+        set_cover_position:
+          service: script.cover_all_set_position
+          data_template:
+          position: '{{ position }}'
+        entity_id:
+          - cover.bedroom
+          - cover.livingroom
+
+script:
+  cover_all_open:
+    sequence:
+      - service: cover.open_cover
+        entity_id: cover.bedroom
+      - service: cover.open_cover
+        entity_id: cover.livingroom
+  cover_all_stop:
+    sequence:
+      - service: cover.stop_cover
+        entity_id: cover.bedroom
+      - service: cover.stop_cover
+        entity_id: cover.livingroom
+  cover_all_close:
+    sequence:
+      - service: cover.close_cover
+        entity_id: cover.bedroom
+      - service: cover.close_cover
+        entity_id: cover.livingroom
+  cover_all_set_position:
+    sequence:
+      - service: cover.set_cover_position
+        entity_id: cover.bedroom
+        data_template:
+          position: '{{ position }}'
+      - service: cover.set_cover_position
+        entity_id: cover.livingroom
+        data_template:
+          position: '{{ position }}'
+
+automation:
+  - alias: 'Close covers at night'
+    trigger:
+      - platform: sun
+        event: sunset
+        offset: '+00:30:00'
+    action:
+      service: cover.set_cover_position
+      entity_id: cover.all_covers
+      data_template:
+        position: 25
+```

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -96,13 +96,13 @@ cover:
           service: script.cover_all_set_position
           data_template:
           position: '{{ position }}'
-        value_template: "{{ states.sensor.all_covers.state }}"
-        icon_template: >
+        value_template: "{% raw %}{{ states.sensor.all_covers.state }}{% endraw %}"
+        icon_template: {% raw %}>
           {% if is_state('sensor.all_covers', 'open') %}
             mdi:window-open
           {% else %}
             mdi:window-closed
-          {% endif %}
+          {% endif %}{% endraw %}
         entity_id:
           - cover.bedroom
           - cover.livingroom
@@ -111,12 +111,12 @@ sensor:
   - platform: template
     sensors:
       all_covers:
-        value_template: >
+        value_template: {% raw %}>
           {% if is_state('cover.bedroom', 'open') %}
             open
           {% elif is_state('cover.livingroom', 'open') %}
             open
-          {% endif %}
+          {% endif %}{% endraw %}
         entity_id:
           - cover.bedroom
           - cover.livingroom

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -24,7 +24,7 @@ cover:
     covers:
       garage_door:
         friendly_name: "Garage Door"
-        value_template: "{% raw %}{{is_state('sensor.garage_door > 0'}}{% endraw %}"
+        value_template: "{% raw %}'{{is_state('sensor.garage_door > 0'}}'{% endraw %}"
         open_cover:
           service: script.open_garage_door
         close_cover:
@@ -57,12 +57,13 @@ In this section you will find some real life examples of how to use this cover.
 This example converts a garage door with a controllable switch and position sensor into a cover.
 
 ```yaml
+{% raw %}
 cover:
   - platform: template
     covers:
       garage_door:
         friendly_name: 'Garage Door'
-        value_template: "{% raw %}{{ sensor.garage_door }}{% endraw %}"
+        value_template: "{{ sensor.garage_door }}"
         open_cover:
           service: switch.turn_on
           entity_id: switch.garage_door
@@ -72,8 +73,7 @@ cover:
         stop_cover:
           service: switch.turn_on
           entity_id: switch.garage_door
-        icon_template: "{% raw %}{% if not is_state('sensor.garage_door', 'on') %}mdi:garage-open{% else %}mdi:garage{% endif %}{% endraw %}"
-
+        icon_template: "{% if not is_state('sensor.garage_door', 'on') %}mdi:garage-open{% else %}mdi:garage{% endif %}"{% endraw %}
 ```
 
 ### {% linkable_title Multi Covers %}
@@ -81,6 +81,7 @@ cover:
 This example allows you to control two or more covers at once.
 
 ```yaml
+{% raw %}
 homeassistant:
   customize:
     all_covers:
@@ -100,19 +101,21 @@ cover:
         set_cover_position:
           service: script.cover_all_set_position
           data_template:
-          position: "{% raw %}{{ position }}{% endraw %}"
-        value_template: {% raw %}>
+          position: "{{ position }}"
+        value_template: >
           {% if is_state('sensor.all_covers', 'open') %}
             open
           {% else %}
             closed
-          {% endif %}{% endraw %}
-        icon_template: {% raw %}>
+          {% endif %}
+
+        icon_template: >
           {% if is_state('sensor.all_covers', 'open') %}
             mdi:window-open
           {% else %}
             mdi:window-closed
-          {% endif %}{% endraw %}
+          {% endif %}
+
         entity_id:
           - cover.bedroom
           - cover.livingroom
@@ -121,14 +124,15 @@ sensor:
   - platform: template
     sensors:
       all_covers:
-        value_template: {% raw %}>
+        value_template: >
           {% if is_state('cover.bedroom', 'open') %}
             open
           {% elif is_state('cover.livingroom', 'open') %}
             open
           {% else %}
             closed
-          {% endif %}{% endraw %}
+          {% endif %}
+
         entity_id:
           - cover.bedroom
           - cover.livingroom
@@ -157,11 +161,11 @@ script:
       - service: cover.set_cover_position
         entity_id: cover.bedroom
         data_template:
-          position: '{{ position }}'
+          position: "{{ position }}"
       - service: cover.set_cover_position
         entity_id: cover.livingroom
         data_template:
-          position: "{% raw %}{{ position }}{% endraw %}"
+          position: "{{ position }}"
 
 automation:
   - alias: 'Close covers at night'
@@ -173,5 +177,5 @@ automation:
       service: cover.set_cover_position
       entity_id: cover.all_covers
       data_template:
-        position: 25
+        position: 25{% endraw %}
 ```


### PR DESCRIPTION
Unresolved issues:
- open_covers only available when all covers are closed -> Possible fix: allow third state for value_template (half open)
- position value in detailed view are either 0 (closed) or 100 (open), neverthanless set_position works as intended

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

