### PR TITLE
Add websocket proxy to / for nginx subdomain setup

### DIFF
--- a/source/_docs/ecosystem/nginx_subdomain.markdown
+++ b/source/_docs/ecosystem/nginx_subdomain.markdown
@@ -36,6 +36,10 @@ server {
     location / {
         proxy_pass http://localhost:8123/;
         proxy_set_header Host $host;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 
     location /api/websocket {


### PR DESCRIPTION
Without the proxy_http_version and proxy_header upgrades an the nginx subdomain setup generates socket errors on the login page. This makes that users can't login.  Adding the websocket lines both to the "/" location as well as the "/api/websocket" location solves the issue. 

Solution copied from: KickHackerz, mar 1 answer on https://community.home-assistant.io/t/ngnix-so-confused-doing-something-wrong/12736/3.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

