### PR TITLE
Extends Fitbit sensors to track the device battery level

### DIFF
--- a/source/_components/sensor.fitbit.markdown
+++ b/source/_components/sensor.fitbit.markdown
@@ -63,6 +63,7 @@ activities/tracker/steps
 body/bmi
 body/fat
 body/weight
+devices/battery
 sleep/awakeningsCount
 sleep/efficiency
 sleep/minutesAfterWakeup


### PR DESCRIPTION
## Description:

Extends Fitbit sensors to track the device battery level.  This PR also adds a sensor attribution to Fitbit.com

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8583


## Example entry for `configuration.yaml` (if applicable):
```yaml
#configuration.yaml
sensor:
 - platform: fitbit
   monitored_resources:
    - "activities/steps"
    - "devices/battery"
```
<img src="https://community-home-assistant-assets.s3.amazonaws.com/original/2X/b/b2594faeae67f634cbceb51512853f1947ffb3ad.png" width="255" height="103">

<img src="https://community-home-assistant-assets.s3.amazonaws.com/original/2X/1/1ac913ea6a410c07f4ce9e1017853803b6542a50.png" width="388" height="305">

<img src="https://community-home-assistant-assets.s3.amazonaws.com/original/2X/d/db41407feca47620327e438794d1d9e3ed88cb11.png" width="388" height="305">