### PR TITLE
Added alternate path for virtualenv and cleaned up hassio docs

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -52,11 +52,11 @@ Configuration variables:
 - **upnp_bind_multicast** (*Optional*): Whether or not to bind the UPNP (SSDP) listener to the multicast address (239.255.255.250) or instead to the (unicast) host_ip address specified above (or automatically determined). The default is true, which will work for most situations.  In special circumstances, like running in a FreeBSD or FreeNAS jail, you may need to disable this.
 
 - **off_maps_to_on_domains** (*Optional*): The domains that maps an "off" command to an "on" command.
-  
+
   For example, if `script` is included in the list, and you ask Alexa to "turn off the *water plants* script," the command will be handled as if you asked her to turn on the script.
-  
+
   If not specified, this defaults to the following list:
-  
+
   - `script`
   - `scene`
 
@@ -87,7 +87,7 @@ emulated_hue:
     - light
 ```
 
-With additional customization you will be able to specify the behaviour of the existing entities. 
+With additional customization you will be able to specify the behavior of the existing entities.
 
 ```yaml
 # Example customization
@@ -113,13 +113,14 @@ You can verify that the `emulated_hue` component has been loaded and is respondi
  - `http://<HA IP Address>:8300/description.xml` - This URL should return a descriptor file in the form of an XML file.
  - `http://<HA IP Address>:8300/api/pi/lights` - This will return a list of devices, lights, scenes, groups, etc.. that `emulated_hue` is exposing to Alexa.
 
-For Google Home, verify that the URLs above are using  port 80, rather than port 8300 (i.e. `http://<HA IP Address>:80/description.xml`). 
+For Google Home, verify that the URLs above are using  port 80, rather than port 8300 (i.e. `http://<HA IP Address>:80/description.xml`).
 
 An additional step is required to run Home Assistant as non-root user and use port 80 when using the AiO script.  Execute the following command to allow `emulated_hue` to use port 80 as non-root user.
 
 ```bash
 sudo setcap 'cap_net_bind_service=+ep' /srv/homeassistant/homeassistant_venv/bin/python3
 ```
+Please note that your path may be different depending on your installation method. For example, if you followed the [Virtualenv instructions](https://home-assistant.io/docs/installation/virtualenv/), your path will be `/srv/homeassistant/bin/python3`.
 
 ### {% linkable_title License %}
 

--- a/source/hassio/external_storage.markdown
+++ b/source/hassio/external_storage.markdown
@@ -12,12 +12,11 @@ footer: true
 
 ### {% linkable_title ResinOS / Generic %}
 
-Map the usb drive into add-on with `devices` options. If you need it on multiple add-ons you can use the `/share` folder which is accessable from multiple add-ons.
-It is also possible to create a add-on that only mount stuff to `share`.
+Map the USB drive into add-on with `devices` options. If you need it on multiple add-ons you can use the `/share` folder which is accessible from multiple add-ons.
+It is also possible to create an add-on that only mounts stuff to `share`.
 
-You can format the usb device with multiple volumes and map it to the specific add-on.
+You can format the USB device with multiple volumes and map it to a specific add-on.
 
 ### {% linkable_title Generic %}
 
 The `share` is default on `/usr/share/hassio/share` so you can mount your volumes into this folder.
-

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -11,13 +11,13 @@ footer: true
 
 Hass.io images are available for all available Raspberry Pi and Intel NUC platforms.
 
-- Download the appropriate image for your Raspberry Pi / intel nuc:
+- Download the appropriate image for your Raspberry Pi / Intel NUC:
   - [Raspberry Pi / Zero][pi1]
   - [Raspberry Pi 2][pi2]
   - [Raspberry Pi 3][pi3]
   - [Intel NUC][nuc]
 - Flash the downloaded image to an SD card using [Etcher].
-- Optional - Setup the WiFi or static ip: On the SD-card, edit the `system-connections/resin-sample` file and follow the [ResinOS howto][resinos-network].
+- Optional - Setup the WiFi or static IP: On the SD-card, edit the `system-connections/resin-sample` file and follow the [ResinOS howto][resinos-network].
 - Insert SD card to Raspberry Pi and turn it on. On first boot, it downloads the latest version of Home Assistant which takes ~20 minutes (slower/faster depending on the platform).
 - You will be able to reach your installation at [http://hassio.local:8123][local].
 - Enable either the [Samba add-on][samba] or the [SSH add-on][ssh] to manage your configuration.

--- a/source/hassio/run_local.markdown
+++ b/source/hassio/run_local.markdown
@@ -9,11 +9,11 @@ sharing: true
 footer: true
 ---
 
-Hass.io is a managed environment. This means that you're unable to install applications that you can embed into Home Assistant using the `command_line` sensor/switch.
+Hass.io is a managed environment. This means that you can install applications that can be embedded into Home Assistant using the `command_line` sensor/switch.
 
 There are two options if you need to run a script to read data from a sensor or send commands to other devices on Hass.IO.
 
-First option is to write a custom component for Home Assistant. Using Python you can communicate with your device. For custom component, look at the [devoloper site][custom-component].
+First option is to write a custom component for Home Assistant. Using Python you can communicate with your device. For custom component, look at the [developer site][custom-component].
 
 The second option is to make a local add-on for Hass.io that sends the data to Home Assistant via MQTT. Before we dive into this, read up on [Hass.io add-on development][addons-tutorial].
 


### PR DESCRIPTION
The path in `sudo setcap` command was not correct for alternate installation methods. Added the alternate path that should work for most users. 

Also, cleaned up Hassio docs

