### PR TITLE
Update sensor.buienradar.markdown text

### DIFF
--- a/source/_components/sensor.buienradar.markdown
+++ b/source/_components/sensor.buienradar.markdown
@@ -27,7 +27,7 @@ sensor:
       - symbol
       - humidity
       - temperature
-      - windspeed
+      - wind_speed
       - pressure
 ```
 
@@ -67,11 +67,11 @@ Full configuration example where location is manually specified:
       - symbol
       - humidity
       - temperature
-      - groundtemperature
-      - windspeed
-      - windforce
-      - winddirection
-      - windazimuth
+      - ground_temperature
+      - wind_speed
+      - wind_force
+      - wind_direction
+      - wind_direction_azimuth
       - pressure
       - visibility
       - windgust


### PR DESCRIPTION
While implementing the buienradar sensor, I have noticed some sensors not showing up in my card. Some monitored_conditions were missing an '_' in their naming convention. I have already made the changes in the text above.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

