### PR TITLE
The identifier for the Minimote event generating entity seems to be w…

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -56,7 +56,7 @@ Here's a handy configuration for the Aeon Labs Minimote that defines all possibl
      platform: event
      event_type: zwave.scene_activated
      event_data:
-       object_id: aeon_labs_minimote_1
+       entity_id: aeon_labs_minimote_1
        scene_id: 1
 
  - alias: Minimote Button 1 Held
@@ -64,7 +64,7 @@ Here's a handy configuration for the Aeon Labs Minimote that defines all possibl
      platform: event
      event_type: zwave.scene_activated
      event_data:
-       object_id: aeon_labs_minimote_1
+       entity_id: aeon_labs_minimote_1
        scene_id: 2
 
  - alias: Minimote Button 2 Pressed
@@ -72,7 +72,7 @@ Here's a handy configuration for the Aeon Labs Minimote that defines all possibl
      platform: event
      event_type: zwave.scene_activated
      event_data:
-       object_id: aeon_labs_minimote_1
+       entity_id: aeon_labs_minimote_1
        scene_id: 3
 
  - alias: Minimote Button 2 Held
@@ -80,7 +80,7 @@ Here's a handy configuration for the Aeon Labs Minimote that defines all possibl
      platform: event
      event_type: zwave.scene_activated
      event_data:
-       object_id: aeon_labs_minimote_1
+       entity_id: aeon_labs_minimote_1
        scene_id: 4
 
  - alias: Minimote Button 3 Pressed
@@ -88,7 +88,7 @@ Here's a handy configuration for the Aeon Labs Minimote that defines all possibl
      platform: event
      event_type: zwave.scene_activated
      event_data:
-       object_id: aeon_labs_minimote_1
+       entity_id: aeon_labs_minimote_1
        scene_id: 5
 
  - alias: Minimote Button 3 Held
@@ -96,7 +96,7 @@ Here's a handy configuration for the Aeon Labs Minimote that defines all possibl
      platform: event
      event_type: zwave.scene_activated
      event_data:
-       object_id: aeon_labs_minimote_1
+       entity_id: aeon_labs_minimote_1
        scene_id: 6
 
  - alias: Minimote Button 4 Pressed
@@ -104,7 +104,7 @@ Here's a handy configuration for the Aeon Labs Minimote that defines all possibl
      platform: event
      event_type: zwave.scene_activated
      event_data:
-       object_id: aeon_labs_minimote_1
+       entity_id: aeon_labs_minimote_1
        scene_id: 7
 
  - alias: Minimote Button 4 Held
@@ -112,6 +112,6 @@ Here's a handy configuration for the Aeon Labs Minimote that defines all possibl
      platform: event
      event_type: zwave.scene_activated
      event_data:
-       object_id: aeon_labs_minimote_1
+       entity_id: aeon_labs_minimote_1
        scene_id: 8
 ```


### PR DESCRIPTION
…rong

In the suggested code for events generated by the minimote, I have suggested changing every instance of "object_id" to "entity_id".
This works in my configurations which is Hassbian running HA 0.49.
Maybe "object_id" is used in other configs, so just add a note to this effect.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

