### PR TITLE
Revert "Update sensor.buienradar.markdown text"

### DIFF
--- a/source/_components/sensor.buienradar.markdown
+++ b/source/_components/sensor.buienradar.markdown
@@ -27,7 +27,7 @@ sensor:
       - symbol
       - humidity
       - temperature
-      - wind_speed
+      - windspeed
       - pressure
 ```
 
@@ -67,11 +67,11 @@ Full configuration example where location is manually specified:
       - symbol
       - humidity
       - temperature
-      - ground_temperature
-      - wind_speed
-      - wind_force
-      - wind_direction
-      - wind_direction_azimuth
+      - groundtemperature
+      - windspeed
+      - windforce
+      - winddirection
+      - windazimuth
       - pressure
       - visibility
       - windgust


### PR DESCRIPTION
Reverts home-assistant/home-assistant.github.io#3036

My apologies for this request, there is some strange behavior between the documented 'monitored conditions' and created sensors. I must have misinterpreted it somehow.
As I was missing some sensors showing up on the card, and renaming them to my suggested changes, it started working for me.

There are more users having these issues, see thread:
https://community.home-assistant.io/t/dutch-precipitation-forecast-based-on-buienradar-nl/4697/85?u=iotmessenger

I will let things be sorted by mjj4791 and stop 'helping'.
;-)
