### PR TITLE
Update Onkyo and Pioneer media players documentation

### DIFF
--- a/source/_components/media_player.onkyo.markdown
+++ b/source/_components/media_player.onkyo.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Onkyo"
-description: "Instructions how to integrate Onkyo receivers into Home Assistant."
+description: "Instructions how to integrate Onkyo and some Pioneer receivers into Home Assistant."
 date: 2016-03-30 08:00
 sidebar: true
 comments: false
@@ -14,9 +14,9 @@ ha_iot_class: "Local Polling"
 ---
 
 
-The `onkyo` platform allows you to control a [Onkyo receiver](http://www.onkyo.com/) from Home Assistant. Please be aware that you need to enable "Network Standby" for this component to work in your Hardware.
+The `onkyo` platform allows you to control a [Onkyo](http://www.onkyo.com/) and some recent [Pioneer](http://www.pioneerelectronics.com) receivers from Home Assistant. Please be aware that you need to enable "Network Standby" for this component to work in your Hardware.
 
-To add an Onkyo receiver to your installation, add the following to your `configuration.yaml` file:
+To add an Onkyo or Pioneer receiver to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/media_player.pioneer.markdown
+++ b/source/_components/media_player.pioneer.markdown
@@ -14,7 +14,7 @@ ha_release: 0.19
 ha_iot_class: "Local Polling"
 ---
 
-The `pioneer` platform allows you to control Pioneer Network Receivers.
+The `pioneer` platform allows you to control Pioneer Network Receivers. Please note, however, that the more recent Pioneer models work with [Onkyo](/components/media_player.onkyo/) platform instead.
 
 To add a Pioneer receiver to your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**
Adds information to both Onkyo and Pioneer media players documentation about most recent Pioneer receivers which have in fact Onkyo-compatible firmware.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

