### PR TITLE
Clarified requirements for allowed_chat_ids parameter

### DIFF
--- a/source/_components/telegram_bot.webhooks.markdown
+++ b/source/_components/telegram_bot.webhooks.markdown
@@ -34,13 +34,15 @@ telegram_bot:
 
 Configuration variables:
 
-- **allowed_chat_ids** (*Required*): A list of user in the `user_id` Telegram format enabled to interact to webhook
+- **allowed_chat_ids** (*Required*): A list of ids representing the users and group chats that are authorised to interact with the webhook.
 - **api_key** (*Required*): The API token of your bot.
 - **trusted_networks** (*Optional*): Telegram server access ACL as list. Defaults to `149.154.167.197-233`.
 - **parse_mode** (*Optional*): Default parser for messages if not explicit in message data: 'html' or 'markdown'. Default is 'markdown'.
 - **url** (*Optional*): Allow to overwrite the `base_url` from http component for diferent configs.
 
-To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram) .
+To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram). 
+
+*Note: If you have added your bot to a group. In the allowed_chat_ids list you will need to include the id for the chat as well as the user. Both of these ids are visible using the getUpdates methods described in the link above.*
 
 Full configuration sample:
 

--- a/source/_components/telegram_bot.webhooks.markdown
+++ b/source/_components/telegram_bot.webhooks.markdown
@@ -40,9 +40,7 @@ Configuration variables:
 - **parse_mode** (*Optional*): Default parser for messages if not explicit in message data: 'html' or 'markdown'. Default is 'markdown'.
 - **url** (*Optional*): Allow to overwrite the `base_url` from http component for diferent configs.
 
-To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram). 
-
-*Note: If you have added your bot to a group. In the allowed_chat_ids list you will need to include the id for the chat as well as the user. Both of these ids are visible using the getUpdates methods described in the link above.*
+To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram). As well as authorising the chat, if you have added your bot to a group you will also need to authorise any user that will be interacting with the webhook. When an unauthorised user tries to interact with the webhook Home Assistant will raise an error ("Incoming message is not allowed"), you can easily obtain the the users id by looking in the "from" section of this error message.
 
 Full configuration sample:
 


### PR DESCRIPTION
I'm not 100% sure on this but my tests seem to back it up. Unless I list both the chat id and my user id in the allowed_chat_ids parameter then I receive a "Incoming message is not allowed" message in the HA log.

**Description:** Clarified requirements for allowed_chat_ids parameter
