### PR TITLE
Xiaomi vacuum documentation

### DIFF
--- a/source/_components/vacuum.markdown
+++ b/source/_components/vacuum.markdown
@@ -1,0 +1,96 @@
+---
+layout: page
+title: "Vacuum cleaner robots"
+description: "Instructions how to setup a botvac in Home Assistant."
+date: 2017-07-28 15:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+---
+
+The `vacuum` component enables the ability to control home cleaning robots within Home Assistant.
+
+To use this component in your installation, add a `vacuum` platform to your `configuration.yaml` file, like the [Xiaomi](/components/vacuum.xiaomi/).
+
+```yaml
+# Example configuration.yaml entry
+vacuum:
+- platform: xiaomi
+  name: 'name of the robot'
+  host: 192.168.1.2
+  token: your-token-here
+```
+
+### {% linkable_title Component services %}
+
+Available services: `turn_on`, `turn_off`, `start_pause`, `stop`, `return_to_home`, `locate`, `set_fanspeed` and `send_command`.
+
+Before calling one of these services, make sure your botvac platform supports it.
+
+#### {% linkable_title Service `vacuum/turn_on` %}
+
+Start a new cleaning task.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+
+#### {% linkable_title Service `vacuum/turn_off` %}
+
+Stop the current cleaning task and return to the dock.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+
+#### {% linkable_title Service `vacuum/start_pause` %}
+
+Start, pause or resume a cleaning task.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+
+#### {% linkable_title Service `vacuum/stop` %}
+
+Stop the current activity of the botvac.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+
+#### {% linkable_title Service `vacuum/return_to_home` %}
+
+Tell the botvac to return home.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+
+#### {% linkable_title Service `vacuum/locate` %}
+
+Start a new cleaning task.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+
+#### {% linkable_title Service `vacuum/set_fanspeed` %}
+
+Set the fan speed of the botvac. The `fanspeed` can be a label, as `balanced` or `turbo`, or be a number, it depends of the `vacuum` platform.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `fanspeed`                |       no | Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium', or by percentage, between 0 and 100. |
+
+#### {% linkable_title Service `vacuum/send_command` %}
+
+Send a platform-specific command to the vacuum cleaner.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `command`                 |       no | Command to execute.                                   |
+| `params`                  |      yes | Parameters for the command.                           |

--- a/source/_components/vacuum.xiaomi.markdown
+++ b/source/_components/vacuum.xiaomi.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: xiaomi.png
-ha_category: Vacuum
+ha_category: Hub
 ha_release: 0.50
 ---
 
@@ -16,7 +16,7 @@ The `xiaomi` vacuum platform allows you to control the state of your [Xiaomi Mi 
 
 Current supported features are `turn_on`, `pause`, `stop`, `return_to_home`, `turn_off` (stops goes to dock), `locate`, `set_fanspeed` and even remote control your robot.
 
-{% linkable_title Getting started %}
+## {% linkable_title Getting started %}
 
 Follow the pairing process using your phone and Mi-Home app. From here you will be able to retrieve the token from a SQLite file inside your phone.
 
@@ -64,7 +64,7 @@ java.exe -jar ../android-backup-extractor/abe.jar unpack backup.ab backup.tar ""
 4. Extract this file /raw data/com.xiami.mihome/_mihome.sqlite to your computer
 5. Open the file extracted using notepad. You will then see the list of all the device in your account with their token.
 
-{% linkable_title Configuration %}
+## {% linkable_title Configuration %}
 
 ```yaml
 # Example configuration.yaml entry
@@ -79,3 +79,48 @@ Configuration variables:
 - **name** (*Optional*): The name of your robot
 - **host** (*Required*): The IP of your robot
 - **token** (*Required*): The token of your robot. Go to Getting started section to read more about how to get it
+
+### {% linkable_title Platform services %}
+
+In addition to all [`vacuum` component services](/components/vacuum#component-services) (`turn_on`, `turn_off`, `start_pause`, `stop`, `return_to_home`, `locate`, `set_fanspeed` and `send_command`), the `xiaomi` platform introduces specific services to access the remote control mode of the botvac.
+
+These are: `xiaomi_remote_control_start`, `xiaomi_remote_control_stop`, `xiaomi_remote_control_move` and `xiaomi_remote_control_move_step`.
+
+#### {% linkable_title Service `vacuum/xiaomi_remote_control_start` %}
+
+Start the remote control mode of the vacuum cleaner. You can then move it with `remote_control_move`, when done call `remote_control_stop`.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+
+#### {% linkable_title Service `vacuum/xiaomi_remote_control_stop` %}
+
+Exit the remote control mode of the vacuum cleaner.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+
+#### {% linkable_title Service `vacuum/xiaomi_remote_control_move` %}
+
+Remote control the vacuum cleaner, make sure you first set it in remote control mode with `remote_control_start`.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `velocity`                |       no | Speed, between -0.29 and 0.29.                        |
+| `rotation`                |       no | Rotation, between -179 degrees and 179 degrees.       |
+| `duration`                |       no | Parameter affecting the duration of the movement.     |
+
+
+#### {% linkable_title Service `vacuum/xiaomi_remote_control_move_step` %}
+
+Use this call to enter the remote control mode, make one movement, and stop and exit the remote control mode.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `velocity`                |       no | Speed, between -0.29 and 0.29.                        |
+| `rotation`                |       no | Rotation, between -179 degrees and 179 degrees.       |
+| `duration`                |       no | Parameter affecting the duration of the movement.     |

--- a/source/_components/vacuum.xiaomi.markdown
+++ b/source/_components/vacuum.xiaomi.markdown
@@ -8,12 +8,13 @@ comments: false
 sharing: true
 footer: true
 logo: xiaomi.png
-ha_category: Switch
-ha_release: 0.48
+ha_category: Vacuum
+ha_release: 0.50
 ---
 
-The `xiaomi_vacuum`switch platform allows you to control the state of your [Xiaomi Mi Robot Vacuum](http://www.mi.com/roomrobot/). 
-Current supported features are `start` and `stop` (goes to dock).
+The `xiaomi` vacuum platform allows you to control the state of your [Xiaomi Mi Robot Vacuum](http://www.mi.com/roomrobot/).
+
+Current supported features are `turn_on`, `pause`, `stop`, `return_to_home`, `turn_off` (stops goes to dock), `locate`, `set_fanspeed` and even remote control your robot.
 
 {% linkable_title Getting started %}
 
@@ -67,7 +68,8 @@ java.exe -jar ../android-backup-extractor/abe.jar unpack backup.ab backup.tar ""
 
 ```yaml
 # Example configuration.yaml entry
-- platform: xiaomi_vacuum
+vacuum:
+- platform: xiaomi
   name: 'name of the robot'
   host: 192.168.1.2
   token: your-token-here


### PR DESCRIPTION
**Description:**

Documentation for the new component `vacuum` and its first platform `xiaomi`. 
The `switch.xiaomi_vacuum` is now `vacuum.xiaomi`, and has new services.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#8623

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer):** home-assistant/home-assistant-polymer#359