### PR TITLE
Add Harmony Hub to Discovery documentation

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -33,6 +33,7 @@ Home Assistant can discover and automatically configure zeroconf/mDNS and uPnP d
  * Bose Soundtouch speakers
  * Axis Communications security devices
  * IKEA Trådfri (Tradfri)
+ * Harmony Hub
 
 It will be able to add Google Chromecasts and Belkin WeMo switches automatically, for Philips Hue it will require some configuration from the user.
 


### PR DESCRIPTION
**Description:**
Add [Harmony Hub](https://home-assistant.io/components/remote.harmony/) to [Discovery](https://home-assistant.io/components/discovery/) documentation
Addresses https://github.com/home-assistant/home-assistant.github.io/issues/2952 .