### PR TITLE
added invert_state optional parameter

### DIFF
--- a/source/_components/cover.rpi_gpio.markdown
+++ b/source/_components/cover.rpi_gpio.markdown
@@ -37,6 +37,7 @@ Configuration variables:
 
 - **relay_time** (*Optional*): The time that the relay will be on for in seconds. Default is 0.2 seconds.
 - **state_pull_mode** (*Optional*): The direction the State pin is pulling. It can be UP or DOWN. Default is UP.
+- **state_invert** (*Optional*): Invert the value of the State pin so that 0 means closed. Default is False.
 - **covers** array (*Required*): List of your doors.
   - **relay_pin** (*Required*): The pin of your Raspberry Pi where the relay is connected.
   - **state_pin** (*Required*): The pin of your Raspberry Pi to retrieve the state.
@@ -50,6 +51,7 @@ cover:
   - platform: rpi_gpio
     relay_time: 0.2
     state_pull_mode: 'UP'
+    state_invert: True
     covers:
       - relay_pin: 10
         state_pin: 11

--- a/source/_components/cover.rpi_gpio.markdown
+++ b/source/_components/cover.rpi_gpio.markdown
@@ -36,6 +36,7 @@ cover:
 Configuration variables:
 
 - **relay_time** (*Optional*): The time that the relay will be on for in seconds. Default is 0.2 seconds.
+- **relay_invert** (*Optional*): Invert the relay pin output so that it is active-high.  Default is False (active-low).
 - **state_pull_mode** (*Optional*): The direction the State pin is pulling. It can be UP or DOWN. Default is UP.
 - **state_invert** (*Optional*): Invert the value of the State pin so that 0 means closed. Default is False.
 - **covers** array (*Required*): List of your doors.
@@ -50,6 +51,7 @@ Full example:
 cover:
   - platform: rpi_gpio
     relay_time: 0.2
+    relay_invert: False
     state_pull_mode: 'UP'
     state_invert: True
     covers:

--- a/source/_components/cover.rpi_gpio.markdown
+++ b/source/_components/cover.rpi_gpio.markdown
@@ -36,9 +36,9 @@ cover:
 Configuration variables:
 
 - **relay_time** (*Optional*): The time that the relay will be on for in seconds. Default is 0.2 seconds.
-- **relay_invert** (*Optional*): Invert the relay pin output so that it is active-high.  Default is False (active-low).
+- **invert_relay** (*Optional*): Invert the relay pin output so that it is active-high.  Default is False (active-low).
 - **state_pull_mode** (*Optional*): The direction the State pin is pulling. It can be UP or DOWN. Default is UP.
-- **state_invert** (*Optional*): Invert the value of the State pin so that 0 means closed. Default is False.
+- **invert_state** (*Optional*): Invert the value of the State pin so that 0 means closed. Default is False.
 - **covers** array (*Required*): List of your doors.
   - **relay_pin** (*Required*): The pin of your Raspberry Pi where the relay is connected.
   - **state_pin** (*Required*): The pin of your Raspberry Pi to retrieve the state.
@@ -51,9 +51,9 @@ Full example:
 cover:
   - platform: rpi_gpio
     relay_time: 0.2
-    relay_invert: False
+    invert_relay: False
     state_pull_mode: 'UP'
-    state_invert: True
+    invert_state: True
     covers:
       - relay_pin: 10
         state_pin: 11


### PR DESCRIPTION
**Description:**
Added a new configuration variable to the Raspberry Pi Cover component that allows the state pin to be interpreted as 0 = closed.

This is in response to a feature request:
https://community.home-assistant.io/t/invert-logic-cover-rpi-gpio/4147


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8695

