### PR TITLE
Link to example implementation of a Manual MQTT Alarm control panel

### DIFF
--- a/source/_posts/2017-07-29-release-50.markdown
+++ b/source/_posts/2017-07-29-release-50.markdown
@@ -43,6 +43,10 @@ Yes, it has happened! After being in beta for a while, the Xiaomi support is now
 
 Another awesome integration is that of the Velbus home automation system which has been contributed by [@thomasdelaet]. It integrates their sensors, covers, fans, lights and switches.
 
+### {% linkable_title Manual alarm with MQTT control %}
+
+A new version of the manual alarm component is now available with full MQTT control thanks to [@colinodell]. Using this you can build your own control panel to remotely arm/disarm the alarm.  For example, here's a guide on creating one with a Raspberry Pi: <https://www.hackster.io/colinodell/diy-alarm-control-panel-for-home-assistant-ac1813>
+
 ## {% linkable_title New Platforms %}
 
 - Initial support for Google Wifi/OnHub ([@fronzbot] - [#8485]) ([sensor.google_wifi docs]) (new-platform)

--- a/source/_posts/2017-07-29-release-50.markdown
+++ b/source/_posts/2017-07-29-release-50.markdown
@@ -45,7 +45,7 @@ Another awesome integration is that of the Velbus home automation system which h
 
 ### {% linkable_title Manual alarm with MQTT control %}
 
-A new version of the manual alarm component is now available with full MQTT control thanks to [@colinodell]. Using this you can build your own control panel to remotely arm/disarm the alarm.  For example, here's a guide on creating one with a Raspberry Pi: <https://www.hackster.io/colinodell/diy-alarm-control-panel-for-home-assistant-ac1813>
+A new version of the manual alarm component is now available with full MQTT control thanks to [@colinodell]. Using this you can build your own control panel to remotely arm/disarm the alarm. For example, using a [Raspberry Pi to create an alarm](https://www.hackster.io/colinodell/diy-alarm-control-panel-for-home-assistant-ac1813).
 
 ## {% linkable_title New Platforms %}
 


### PR DESCRIPTION
**Description:**

If you're interested, I've created a [guide on building an alarm control panel which interfaces with the new Manual MQTT alarm component](https://www.hackster.io/colinodell/diy-alarm-control-panel-for-home-assistant-ac1813).  Not sure if this is appropriate or desired in your release notes, but many in the community have been asking for a write-up, so I figured I'd propose it for inclusion here.

The article is currently set to **Unlisted** - you can only find it with a direct link.  Once 0.50 is released I'll be publishing this as **Public** and announcing it to my Twitter feed.

I won't be offended if you choose to reject this PR or change the wording around :)