### PR TITLE
Mqtt publish service topic_template

### DIFF
--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -11,7 +11,7 @@ logo: mqtt.png
 redirect_from: /components/mqtt/#publish-service
 ---
 
-The MQTT component will register the service `publish` which allows publishing messages to MQTT topics. There are two ways of specifying your payload. You can either use `payload` to hard-code a payload or use `payload_template` to specify a [template](/topics/templating/) that will be rendered to generate the payload.
+The MQTT component will register the service `publish` which allows publishing messages to MQTT topics. There are two ways of specifying topics or payloads. You can either use `topic` and `payload` to hard-code them, or use ``topic_template`` and ``payload_template`` to specify a [template](/topics/templating/) that will be rendered to generate the topic and/or payload.
 
 ```yaml
 - service: mqtt.publish
@@ -25,5 +25,12 @@ The MQTT component will register the service `publish` which allows publishing m
   data:
      topic: "home-assistant/light/1/state",
      payload_template: "{% raw %}{{ states('device_tracker.paulus') }}{% endraw %}"
+```
+
+```yaml
+- service: mqtt.publish
+  data:
+     topic_template: "home-assistant/light/{% raw %}{{ states('input_select.light_source.state') }}{% endraw }/state",
+     payload: "on"
 ```
 

--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -34,4 +34,4 @@ The MQTT component will register the service `publish` which allows publishing m
      payload: "on"
 ```
 
-Note that in automations, you may want to use ``data_template`` instead of ``data``.
+Note that in automations, you may want to use `data_template` instead of `data`.

--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -11,7 +11,7 @@ logo: mqtt.png
 redirect_from: /components/mqtt/#publish-service
 ---
 
-The MQTT component will register the service `publish` which allows publishing messages to MQTT topics. There are two ways of specifying topics or payloads. You can either use `topic` and `payload` to hard-code them, or use ``topic_template`` and ``payload_template`` to specify a [template](/topics/templating/) that will be rendered to generate the topic and/or payload.
+The MQTT component will register the service `publish` which allows publishing messages to MQTT topics. There are two ways of specifying topics or payloads. You can either use `topic` and `payload` to hard-code them, or use `topic_template` and `payload_template` to specify a [template](/topics/templating/) that will be rendered to generate the topic and/or payload.
 
 ```yaml
 - service: mqtt.publish

--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -34,3 +34,4 @@ The MQTT component will register the service `publish` which allows publishing m
      payload: "on"
 ```
 
+Note that in automations, you may want to use ``data_template`` instead of ``data``.

--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -13,17 +13,17 @@ redirect_from: /components/mqtt/#publish-service
 
 The MQTT component will register the service `publish` which allows publishing messages to MQTT topics. There are two ways of specifying your payload. You can either use `payload` to hard-code a payload or use `payload_template` to specify a [template](/topics/templating/) that will be rendered to generate the payload.
 
-```json
-{
-  "topic": "home-assistant/light/1/command",
-  "payload": "on"
-}
+```yaml
+- service: mqtt.publish
+  data:
+     topic: "home-assistant/light/1/command"
+     payload: "on"
 ```
 
-```json
-{
-  "topic": "home-assistant/light/1/state",
-  "payload_template": "{% raw %}{{ states('device_tracker.paulus') }}{% endraw %}"
-}
+```yaml
+- service: mqtt.publish
+  data:
+     topic: "home-assistant/light/1/state",
+     payload_template: "{% raw %}{{ states('device_tracker.paulus') }}{% endraw %}"
 ```
 


### PR DESCRIPTION
**Description:**

The MQTT Publish Service (``mqtt.publish``) currently supports a ``payload_template``attribute as a templated alternative to ``payload``. However, it does not yet support ``topic_template`` as an alternative to ``topic``. This PR documents support for such a ``topic_template`` and clears up the examples (they were JSON instead of YAML)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8722

