### PR TITLE
Add note for Hass.io users

### DIFF
--- a/source/_components/device_tracker.nmap_tracker.markdown
+++ b/source/_components/device_tracker.nmap_tracker.markdown
@@ -17,6 +17,10 @@ As an alternative to the router-based device tracking, it is possible to directl
 
 If you're on Debian or Ubuntu, you might have to install the packages for `arp` and `nmap`. Do so by running `$ sudo apt-get install net-tools nmap`. On a Fedora host run `$ sudo dnf -y install nmap`. 
 
+<p class='note'>
+If you are using [Hass.io](/hassio/) then just move forward to the configuration as all requirements are already fullfilled.
+</p>
+
 Host detection is done via Nmap's "fast scan" (`-F`) of the most frequently used 100 ports, with a host timeout of 5 seconds.
 
 To use this device tracker in your installation, add the following to your `configuration.yaml` file:

--- a/source/_components/ffmpeg.markdown
+++ b/source/_components/ffmpeg.markdown
@@ -11,10 +11,14 @@ logo: ffmpeg.png
 ha_category: Hub
 ---
 
-The FFmpeg component allows other Home Assistant components to process video and audio streams. This component supports all FFmpeg versions since 3.0.0; if you have a older version, please update.
+The `ffmpeg` component allows other Home Assistant components to process video and audio streams. This component supports all FFmpeg versions since 3.0.0; if you have a older version, please update.
 
 <p class='note'>
 You need the `ffmpeg` binary in your system path. On Debian 8 or Raspbian (Jessie) you can install it from [debian-backports](https://backports.debian.org/Instructions/). If you want [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) support on a Raspberry Pi, you will need to build from source by yourself. Windows binaries are available on the [FFmpeg](http://www.ffmpeg.org/) website.
+</p>
+
+<p class='note'>
+If you are using [Hass.io](/hassio/) then just move forward to the configuration as all requirements are already fullfilled.
 </p>
 
 To set it up, add the following information to your `configuration.yaml` file:

--- a/source/_components/hdmi_cec.markdown
+++ b/source/_components/hdmi_cec.markdown
@@ -13,7 +13,7 @@ ha_release: 0.23
 ha_iot_class: "Local Push"
 ---
 
-The HDMI CEC component provides services that allow selecting the active device, powering on all devices, setting all devices to standby and creates switch entites for HDMI devices. Devices are defined in the configuration file by associating HDMI port number and a device name. Connected devices that provide further HDMI ports, such as Soundbars and AVRs are also supported. Devices are listed from the perspective of the CEC-enabled Home Assistant device. Any connected device can be listed, regardless of whether it supports CEC. Ideally the HDMI port number on your device will map correctly the CEC physical address. If it does not, use `cec-client` (part of the `libcec` package) to listen to traffic on the CEC bus and discover the correct numbers.
+The `hdmi_cec` component provides services that allow selecting the active device, powering on all devices, setting all devices to standby and creates switch entites for HDMI devices. Devices are defined in the configuration file by associating HDMI port number and a device name. Connected devices that provide further HDMI ports, such as Soundbars and AVRs are also supported. Devices are listed from the perspective of the CEC-enabled Home Assistant device. Any connected device can be listed, regardless of whether it supports CEC. Ideally the HDMI port number on your device will map correctly the CEC physical address. If it does not, use `cec-client` (part of the `libcec` package) to listen to traffic on the CEC bus and discover the correct numbers.
 
 ## {% linkable_title CEC Setup %}
 
@@ -24,6 +24,10 @@ The computer running Home Assistant must support CEC, and of course be connected
 ### {% linkable_title libcec %}
 
 [libcec](https://github.com/Pulse-Eight/libcec) must be installed for this component to work. Follow the installation instructions for your environment, provided at the link. `libcec` installs Python 3 bindings by default as a system Python module. If you are running Home Assistant in a [Python virtual environment](/getting-started/installation-virtualenv/), make sure it can access the system module, by either symlinking it or using the `--system-site-packages` flag.
+
+<p class='note'>
+If you are using [Hass.io](/hassio/) then just move forward to the configuration as all requirements are already fullfilled.
+</p>
 
 #### {% linkable_title Symlinking into virtual environment %}
 

--- a/source/_components/image_processing.openalpr_cloud.markdown
+++ b/source/_components/image_processing.openalpr_cloud.markdown
@@ -28,6 +28,7 @@ image_processing:
    source:
     - entity_id: camera.garage
 ```
+
 Configuration variables:
 
 - **region** (*Required*): Country or region. List of supported [values](https://github.com/openalpr/openalpr/tree/master/runtime_data/config).

--- a/source/_components/image_processing.opencv.markdown
+++ b/source/_components/image_processing.opencv.markdown
@@ -17,8 +17,6 @@ ha_release: 0.47
 
 Some pre-defined classifiers can be found here: https://github.com/opencv/opencv/tree/master/data
 
-### {% linkable_title Configuration %}
-
 To setup OpenCV with Home Assistant, add the following section to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_components/image_processing.seven_segments.markdown
+++ b/source/_components/image_processing.seven_segments.markdown
@@ -17,6 +17,10 @@ ha_iot_class: "Local Polling"
 
 The `seven_segments` image processing platform allows you to read physical seven segments displays through Home Assistant. [`ssocr`](https://www.unix-ag.uni-kl.de/~auerswal/ssocr/) is used to extract the value shown on the display which is observed by a [camera](/components/camera/). `ssocr` need to be available on your system. Check the installation instruction for Fedora below or use `$ sudo apt-get install ssocr` on a Debian-based system:
 
+<p class='note'>
+If you are using [Hass.io](/hassio/) then just move forward to the configuration as all requirements are already fullfilled.
+</p>
+
 ```bash
 $ sudo dnf -y install imlib2-devel
 $ git clone https://github.com/auerswal/ssocr.git

--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -18,6 +18,10 @@ The `tradfri` component supports for the IKEA Trådfri (Tradfri) gateway. The ga
 
 For this to work, you need to install a modified lib-coap library.
 
+<p class='note'>
+If you are using [Hass.io](/hassio/) then just move forward to the configuration as all requirements are already fullfilled.
+</p>
+
 Linux:
 
 ```bash


### PR DESCRIPTION
**Description:**
Hass.io is shipped with already installed binaries for some components/platforms. To avoid confusion is a note added that Hass.io users not need to go through the manual installation process.

If you know more components/platforms please add a comment or open a PR. Thanks.



