### PR TITLE
Changed name of the theme in automation example

### DIFF
--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -48,5 +48,5 @@ automation:
     action:
       service: frontend.set_theme
       data:
-        name: pink
+        name: happy
 ```


### PR DESCRIPTION
**Description:**
It was a little confusing, when pink is used in automation example, and the theme_name is happy.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

