### PR TITLE
Allow to set long/lat and make mon conditions optional

### DIFF
--- a/source/_components/sensor.zamg.markdown
+++ b/source/_components/sensor.zamg.markdown
@@ -23,17 +23,15 @@ To add ZAMG to your installation, add the following to your `configuration.yaml`
 # Example configuration.yaml entry
 sensor:
   - platform: zamg
-    station_id: 11035
-    monitored_conditions:
-      - temperature
-      - humidity
 ```
 
 Configuration variables:
 
 - **station_id** (*Optional*): The ID number for a supported ZAMG station.
 - **name** (*Optional*): Additional name for the sensors. Defaults to platform name.
-- **monitored_conditions** array (*Required*): Conditions to display in the frontend.
+- **latitude** (*Optional*): Latitude coordinate to monitor weather of (required if **longitude** is specificed). Defaults to coordinates defined in your `configuration.yaml` file.
+- **longitude** (*Optional*): Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file.
+- **monitored_conditions** array (*Optional*): Conditions to display in the frontend.
   - **pressure**: Pressure at station level
   - **pressure_sealevel**: Pressure at sea Level
   - **humidity**: Humidity
@@ -46,7 +44,19 @@ Configuration variables:
   - **precipitation**: Precipitation
   - **dewpoint**: Dew point
 
+A full configuration example:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: zamg
+    station_id: 11035
+    name: Wien
+    monitored_conditions:
+      - temperature
+      - humidity
+```
+
 <p class='note'>
-This sensor is an alternative to the [`zamg`](/components/weather.zamg/) weather platform.
-The weather platform is easier to configure but less customisable.
+This sensor is an alternative to the [`zamg`](/components/weather.zamg/) weather platform. The `zamg` weather platform is easier to configure but less customisable.
 </p>

--- a/source/_components/weather.zamg.markdown
+++ b/source/_components/weather.zamg.markdown
@@ -29,8 +29,9 @@ Configuration variables:
 
 - **station_id** (*Optional*): The ID number for a supported ZAMG station.
 - **name** (*Optional*): A name for the weather platform.
+- **latitude** (*Optional*): Latitude coordinate to monitor weather of (required if **longitude** is specificed). Defaults to coordinates defined in your `configuration.yaml` file.
+- **longitude** (*Optional*): Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file.
 
 <p class='note'>
-This platform is an alternative to the [`zamg`](/components/sensor.zamg/) sensor.
-The weather platform is easier to configure but less customisable.
+This platform is an alternative to the [`zamg`](/components/sensor.zamg/) sensor. The weather platform is easier to configure but less customisable.
 </p>


### PR DESCRIPTION
**Description:**
- Allow to set longitude and latitude
- Make `monitored_conditions` optional

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8858

