### PR TITLE
Add documentation for Dyson 360 Eye robot vacuum

### DIFF
--- a/source/_components/dyson.markdown
+++ b/source/_components/dyson.markdown
@@ -13,9 +13,7 @@ ha_iot_class: "Cloud Polling"
 ha_release: 0.47
 ---
 
-The `dyson` component is the main component to integrate all [Dyson](https://dyson.com) related platforms.
-
-Currently limited to Cool Link Purifier.
+The `dyson` component is the main component to integrate all [Dyson](https://dyson.com) related platforms: [Fans](/components/fan/dyson/) and [Robot vacuum](/components/vacuum/dyson/).
 
 To enable this component, add the following lines to your `configuration.yaml`:
 
@@ -25,9 +23,9 @@ dyson:
   password: <dyson_acount_password>
   language: <dyson_account_language>
   devices:
-    - device_id: <device_id_1>
+    - device_id: <device_id_1> # eg: Pure Cool Link device
       device_ip: <device_ip_1>
-    - device_id: <device_id_2>
+    - device_id: <device_id_2> # eg: Eye 360 robot vacuum
       device_ip: <device_ip_2>
     ...
 ```
@@ -42,6 +40,8 @@ Configuration variables:
   - **device_ip** (*Required*): Device IP address
 
 `devices` list is optional but you'll have to provide them if discovery is not working (warnings in the logs and the devices are not available in Home Assistant web interface).
+*If your are using a robot vacuum (Dyson 360 Eye), discovery is not yet supported so you have to provide `devices` list.*
+
 To find devices IP address, you can use your router or `nmap`:
 
 ```bash

--- a/source/_components/vacuum.dyson.markdown
+++ b/source/_components/vacuum.dyson.markdown
@@ -1,0 +1,30 @@
+---
+layout: page
+title: "Dyson 360 Eye"
+description: "Instructions how to integrate your Dyson Eye 360 vacuum robot within Home Assistant."
+date: 2017-08-06 10:30
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: dyson.png
+ha_category: Vacuum
+ha_iot_class: "Cloud Polling"
+ha_release: 0.51
+---
+
+The `dyson` vacuum platform allows you to control your Dyson 360 Eye robot vacuum.
+
+You have first to setup the [Dyson component](/components/dyson/)
+
+### {% linkable_title Component services %}
+
+This component support the following services (see [Vacuum Cleaner Robots](/components/vacuum/)):
+* [`turn_on`](/components/vacuum/#service-vacuumturn_on)
+* [`turn_off`](/components/vacuum/#service-vacuumturn_off)
+* [`start_pause`](/components/vacuum/#service-vacuumstart_pause)
+* [`stop`](/components/vacuum/#service-vacuumstop)
+* [`return_to_home`](/components/vacuum/#service-vacuumreturn_to_home)
+* [`set_fan_speed`](/components/vacuum/#service-vacuumset_fanspeed). Fan speed values:
+  * `Quiet`
+  * `Max`


### PR DESCRIPTION
**Description:**

Add documentation for Dyson 360 robot vacuum.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8852

One thing to note: The 2 others vacuums (iRobot and Xiaomi ) are in the `ha_category` *Hub* and not *Vacuum*. I don't know if it is a copy/paste error or if I'm misunderstanding this parameter.
