### PR TITLE
where to enable add-ons (aid first installs)

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -25,7 +25,7 @@ Hass.io images are available for all available Raspberry Pi and Intel NUC platfo
   <img src='/images/hassio/screenshots/first-start.png' />
 </p>
 
-- Enable either the [Samba add-on][samba] or the [SSH add-on][ssh] to manage your configuration (via "Hass.io" in the web GUI menu).
+- Enable either the [Samba add-on][samba] or the [SSH add-on][ssh] to manage your configuration (From the UI choose **Hass.io** which is located in the sidebar).
 
 <p class='note'>
 If you copy over your existing Home Assistant configuration, make sure to enable the Hass.io panel by adding either `discovery:` or `hassio:` to your configuration.

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -25,7 +25,7 @@ Hass.io images are available for all available Raspberry Pi and Intel NUC platfo
   <img src='/images/hassio/screenshots/first-start.png' />
 </p>
 
-- Enable either the [Samba add-on][samba] or the [SSH add-on][ssh] to manage your configuration.
+- Enable either the [Samba add-on][samba] or the [SSH add-on][ssh] to manage your configuration (via "Hass.io" in the web GUI menu).
 
 <p class='note'>
 If you copy over your existing Home Assistant configuration, make sure to enable the Hass.io panel by adding either `discovery:` or `hassio:` to your configuration.


### PR DESCRIPTION
**Description:**
Excited to use Home Assistant! However, it was maddening trying to figure out how to edit the config file, then where to go to enable the ssh add-on. The goal here is to give a hint to newcomers on how to follow that instruction.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** n/a

