### PR TITLE
Updated Safari in browsers.markdown (map CSS is corrupted)

### DIFF
--- a/source/_docs/frontend/browsers.markdown
+++ b/source/_docs/frontend/browsers.markdown
@@ -29,7 +29,7 @@ We would appreciate if you help to keep this page up-to-date and add feedback.
 
 | Browser               | Release        | State      | Comments                 |
 | :-------------------- |:---------------|:-----------|:-------------------------|
-| [Safari]              |                | works      | Map has corrupted CSS.   |
+| [Safari]              |                | works      | Some problems with the Map.   |
 
 ## {% linkable_title Linux %}
 
@@ -60,7 +60,7 @@ We would appreciate if you help to keep this page up-to-date and add feedback.
 
 | Browser               | Release        | State      | Comments                 |
 | :-------------------- |:---------------|:-----------|:-------------------------|
-| [Safari]              |                | works      | Can also be added to desktop. Map has corrupted CSS. |
+| [Safari]              |                | works      | Can also be added to desktop. Some problems with the Map. |
 | [Chrome]              |                | works      |                          |
 
 

--- a/source/_docs/frontend/browsers.markdown
+++ b/source/_docs/frontend/browsers.markdown
@@ -29,7 +29,7 @@ We would appreciate if you help to keep this page up-to-date and add feedback.
 
 | Browser               | Release        | State      | Comments                 |
 | :-------------------- |:---------------|:-----------|:-------------------------|
-| [Safari]              |                | works      |                          |
+| [Safari]              |                | works      | Map has corrupted CSS.   |
 
 ## {% linkable_title Linux %}
 
@@ -60,7 +60,7 @@ We would appreciate if you help to keep this page up-to-date and add feedback.
 
 | Browser               | Release        | State      | Comments                 |
 | :-------------------- |:---------------|:-----------|:-------------------------|
-| [Safari]              |                | works      | Can also be added to desktop |
+| [Safari]              |                | works      | Can also be added to desktop. Map has corrupted CSS. |
 | [Chrome]              |                | works      |                          |
 
 


### PR DESCRIPTION
Map has corrupted CSS on Mac and iOS

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

