### PR TITLE
Add information to install libffi-dev, needed for python-mirobo

### DIFF
--- a/source/_components/vacuum.xiaomi.markdown
+++ b/source/_components/vacuum.xiaomi.markdown
@@ -20,6 +20,11 @@ Current supported features are `turn_on`, `pause`, `stop`, `return_to_home`, `tu
 
 Follow the pairing process using your phone and Mi-Home app. From here you will be able to retrieve the token from a SQLite file inside your phone.
 
+Before you begin you need to install libffi-dev by running the command below. This is needed for python-mirobi to be installed correctly. 
+```bash
+$ apt-get install libffi-dev
+```
+
 <p class='note warning'>
 If your Home Assistant installation is running in a [Virtualenv](/docs/installation/virtualenv/#upgrading-home-assistant), make sure you activate it by running the commands below.</p>
 

--- a/source/_components/vacuum.xiaomi.markdown
+++ b/source/_components/vacuum.xiaomi.markdown
@@ -20,9 +20,10 @@ Current supported features are `turn_on`, `pause`, `stop`, `return_to_home`, `tu
 
 Follow the pairing process using your phone and Mi-Home app. From here you will be able to retrieve the token from a SQLite file inside your phone.
 
-Before you begin you need to install libffi-dev by running the command below. This is needed for python-mirobi to be installed correctly. 
+Before you begin you need to install `libffi-dev` by running the command below. This is needed for `python-mirobi` to be installed correctly. 
+
 ```bash
-$ apt-get install libffi-dev
+apt-get install libffi-dev
 ```
 
 <p class='note warning'>


### PR DESCRIPTION
**Description:**
libffi-dev is needed for home assistant to install python-mirobo.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8938
