### PR TITLE
Update tradfri.markdown

### DIFF
--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -18,6 +18,9 @@ The `tradfri` component supports for the IKEA Trådfri (Tradfri) gateway. The ga
 
 For this to work, you need to install a modified lib-coap library.
 
+<p class='note warning'>
+This component does **not** work on Windows, as the modified lib-coap doesn't exists for Windows.
+</p>
 <p class='note'>
 If you are using [Hass.io](/hassio/) then just move forward to the configuration as all requirements are already fullfilled.
 </p>


### PR DESCRIPTION
Added a warning for windows users that the Tradfri component doesn't work.

Source:
https://github.com/home-assistant/home-assistant/issues/7735#issuecomment-304460322

If anyone has a more technical source it would be neat.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

