### PR TITLE
Remove password configuration from automatic

### DIFF
--- a/source/_components/device_tracker.automatic.markdown
+++ b/source/_components/device_tracker.automatic.markdown
@@ -16,7 +16,7 @@ ha_iot_class: "Cloud Push"
 
 The `automatic` platform offers presence detection by retrieving your car's information from the [Automatic](http://automatic.com/) cloud service.
 
-To use Automatic with Home Assistant, first you must [create a free development account](https://developer.automatic.com/). Automatic will generate a Client ID and Secret for you to use in your Home Assistant configuration. You will also need to update your Event Delivery preferences to ensure Home Assistant can receive updates. On the developer page, under App Settings / Event Delivery, select "Websocket" for Event Delivery Preference. In order to make use of OAuth2 authentication you must specify the OAuth Redirect URL in the developer page. This should be configured to `<home-assistant-url>/api/automatic/callback`. (Example: `http://hassio.local:8123/api/automatic/callback`) Note that this URL only needs to be accessible from the browser you use to perform the authentication.
+To use Automatic with Home Assistant, first you must [create a free development account](https://developer.automatic.com/). Automatic will generate a Client ID and Secret for you to use in your Home Assistant configuration. You will need to update your Event Delivery preferences to ensure Home Assistant can receive updates. On the developer page, under App Settings / Event Delivery, select "Websocket" for Event Delivery Preference. Next, specify the OAuth Redirect URL in the developer page. This should be configured to `<home-assistant-url>/api/automatic/callback`. (Example: `http://hassio.local:8123/api/automatic/callback`) Note that this URL only needs to be accessible from the browser you use to perform the authentication.
 
 Home Assistant can also take advantage of `scope:current_location` if available. This will allow Home Assistant to receive periodic location updates during a trip. In order to use this functionality, you must request the scope for your application from Automatic. Once `scope:current_location` is available, change `current_location` to `true` in your configuration.yaml.
 
@@ -37,8 +37,6 @@ Configuration variables:
 
 - **client_id** (*Required*): The OAuth client id (get from https://developer.automatic.com/).
 - **secret** (*Required*): The OAuth client secret (get from https://developer.automatic.com/).
-- **username** (*Optional*): The username associated with your ODB reader. If username/password is not configured, the `configurator` component will be used to authenticate your account.
-- **password** (*Optional*): The password for your given ODB reader account.
 - **current_location** (*Optional*): Set to `true` if you have requested `scope:current_location` for your account. Home Assistant will then be able to receive periodic location updates during trips.
 - **devices** (*Optional*): The list of vehicle display names you wish to track. If not provided, all vehicles will be tracked.
 


### PR DESCRIPTION
**Description:**
This PR removes password configuration from automatic. The password authentication has been dropped by automatic so we now must use OAuth2.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9002