### PR TITLE
Reverted browsers.markdown (as maps are now fixed)

### DIFF
--- a/source/_docs/frontend/browsers.markdown
+++ b/source/_docs/frontend/browsers.markdown
@@ -29,7 +29,7 @@ We would appreciate if you help to keep this page up-to-date and add feedback.
 
 | Browser               | Release        | State      | Comments                 |
 | :-------------------- |:---------------|:-----------|:-------------------------|
-| [Safari]              |                | works      | Some problems with the Map.   |
+| [Safari]              |                | works      | Map is fixed since 0.51. |
 
 ## {% linkable_title Linux %}
 
@@ -60,7 +60,7 @@ We would appreciate if you help to keep this page up-to-date and add feedback.
 
 | Browser               | Release        | State      | Comments                 |
 | :-------------------- |:---------------|:-----------|:-------------------------|
-| [Safari]              |                | works      | Can also be added to desktop. Some problems with the Map. |
+| [Safari]              |                | works      | Can also be added to desktop. Map is fixed since 0.51. |
 | [Chrome]              |                | works      |                          |
 
 


### PR DESCRIPTION
Map in Safari is fixed in 0.51, but I'm not sure about text about it: is it needed? I wrote that it is fixed now.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

