### PR TITLE
Clarification about SMTP with Google accounts

### DIFF
--- a/source/_components/notify.smtp.markdown
+++ b/source/_components/notify.smtp.markdown
@@ -60,7 +60,7 @@ notify:
     sender_name: My Home Assistant
 ```
 
-Keep in mind that Google has some extra layers of protection which need special attention (Hint: 'Less secure apps').
+Keep in mind that Google has some extra layers of protection which need special attention (Hint: 'Less secure apps'). If you have 2-step verification enabled on your Google account, you'll need to use [an application-specific password](https://support.google.com/mail/answer/185833?hl=en).
 
 To use the SMTP notification, refer to it in an automation or script like in this example:
 


### PR DESCRIPTION
The hint about enabling "Less secure apps" access to your Gmail account is a bit outdated; most people with the technical know-how to set up Home Assistant and edit the configuration files will likely have two-step verification enabled on their Gmail accounts. I added a small clarification about using application-specific passwords in that instance to hopefully save people an internet search.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#3193

