### PR TITLE
Update switch.broadlink.markdown

### DIFF
--- a/source/_components/switch.broadlink.markdown
+++ b/source/_components/switch.broadlink.markdown
@@ -31,7 +31,7 @@ Configuration variables:
 - **mac** (*Required*):  Device MAC address.
 - **timeout** (*Optional*): Timeout in seconds for the connection to the device.
 - **friendly_name** (*Optional*): The name used to display the switch in the frontend.
-- **type** (*Optional*): Switch type. Choose one from: `rm`, `rm2`, `rm_mini`, `rm_pro_phicomm`, `rm2_home_plus`, `rm2_home_plus_gdt`, `rm2_pro_plus`, `rm2_pro_plus2`, `rm2_pro_plus_bl`, `rm_mini_shate`, `sp1`, `sp2`, `honeywell_sp2`, `sp3`, `spmini2` or `spminiplus`.
+- **type** (*Required for some models*): Switch type. Choose one from: `rm`, `rm2`, `rm_mini`, `rm_pro_phicomm`, `rm2_home_plus`, `rm2_home_plus_gdt`, `rm2_pro_plus`, `rm2_pro_plus2`, `rm2_pro_plus_bl`, `rm_mini_shate`, `sp1`, `sp2`, `honeywell_sp2`, `sp3`, `spmini2` or `spminiplus`.
 - **switches** (*Optional*): The array that contains all switches.
   - **identifier** (*Required*): Name of the command switch as slug. Multiple entries are possible.
     - **friendly_name** (*Optional*): The name used to display the switch in the frontend.


### PR DESCRIPTION
**Description:**

Have changed "type" from Optional, to "Required for some models". I don't know if this is non-standard for documentation...

Regardless, my SP3 would not work without this field configured.  I spent a lot of time reading various threads on what to troubleshoot.

This post: https://community.home-assistant.io/t/broadlink-rm-pro-and-a1-sensor/3678/305 also implied the friendly_name is required but I found this not to be the case, and instead "Broadlink Switch" was simply displayed.

After much googling and trying various things, I believe the following two pip packages were required for broadlink.py to work:

sudo pip3 install pycrypto voluptuous

Should I also add this to the documentation?

Thanks,

Matt

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

