### PR TITLE
Reverse proxy details for Caddy Server

### DIFF
--- a/source/_docs/ecosystem/caddy.markdown
+++ b/source/_docs/ecosystem/caddy.markdown
@@ -16,5 +16,6 @@ hass.example.org {
     proxy / localhost:8123 {
         websocket
         transparent
+    }
 }
 ```

--- a/source/_docs/ecosystem/caddy.markdown
+++ b/source/_docs/ecosystem/caddy.markdown
@@ -1,0 +1,20 @@
+---
+layout: page
+title: "Caddy Server reverse proxy"
+description: "Configure Caddy Server as a reverse proxy to Home Assistant."
+date: 2017-08-22 22:20
+sidebar: true
+comments: false
+sharing: true
+footer: true
+---
+
+Configure [Caddy Server](https://caddyserver.com/) for use as a reverse proxy to Home Assistant.
+
+```
+hass.example.org {
+    proxy / localhost:8123 {
+        websocket
+        transparent
+}
+```

--- a/source/_includes/asides/docs_navigation.html
+++ b/source/_includes/asides/docs_navigation.html
@@ -163,6 +163,7 @@
             Remote access
             <ul>
               <li>{% active_link /docs/ecosystem/apache/ Apache %}</li>
+              <li>{% active_link /docs/ecosystem/caddy/ Caddy Server %}</li>
               <li>{% active_link /docs/ecosystem/nginx/ NGINX %}</li>
               <li>{% active_link /docs/ecosystem/nginx_subdomain/ NGINX with subdomain%}</li>
               <li>{% active_link /docs/ecosystem/tor/ Tor Onion Service %}</li>


### PR DESCRIPTION
**Description:**

Add documentation showing a working example of using Caddy as a reverse proxy to Home Assistant.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** no new code, only documentation

