### PR TITLE
State that dependencies are from pypi

### DIFF
--- a/source/developers/development_checklist.markdown
+++ b/source/developers/development_checklist.markdown
@@ -12,7 +12,7 @@ footer: true
 
 Before you commit any changes, check your work against these requirements:
 
-- All dependencies are included via the `REQUIREMENTS` variable in your platform or component and only imported inside functions that use them
+- All dependencies from [pypi](https://pypi.python.org/pypi) are included via the `REQUIREMENTS` variable in your platform or component and only imported inside functions that use them
 - New dependencies are added to `requirements_all.txt` (if applicable), using `script/gen_requirements_all.py`
 - The `.coveragerc` file is updated to exclude your platform if there are no tests available or your new code uses a third-party library for communication with the device, service, or sensor
 - Documentation is developed for [home-assistant.io](https://home-assistant.io/)


### PR DESCRIPTION
Clarify that dependencies are loaded from and must be available on pypi

**Description:**
Currently not clear where dependencies are loaded from (although obvious with hindsight)

