### PR TITLE
minor typo correction

### DIFF
--- a/source/_components/notify.ciscospark.markdown
+++ b/source/_components/notify.ciscospark.markdown
@@ -14,9 +14,9 @@ ha_release: "0.40"
 
 The `ciscospark` notification platform allows you to deliver notifications from Home Assistant to [Cisco Spark](https://ciscospark.com/).
 
-To use this notification platform you need to get a developer token. To obtain a token visit [Spark for Devleopers](https://developer.ciscospark.com/index.html)
+To use this notification platform you need to get a developer token. To obtain a token visit [Spark for Developers](https://developer.ciscospark.com/index.html)
 
-At this time you also need to specify the `Cisco Spark` `roomid`. The `roomid` can also be found at [Spark for Devleopers](https://developer.ciscospark.com/index.html). Just look in the Doumentation under Rooms. 
+At this time you also need to specify the `Cisco Spark` `roomid`. The `roomid` can also be found at [Spark for Developers](https://developer.ciscospark.com/index.html). Just look in the Doumentation under Rooms. 
 
 To enable the Cisco Spark notification in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
'Developers' was misspelled.

**Description:**
This is a request to fix a simple typo found while viewing docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

