### PR TITLE
Update media_player.braviatv.markdown

### DIFF
--- a/source/_components/media_player.braviatv.markdown
+++ b/source/_components/media_player.braviatv.markdown
@@ -15,7 +15,7 @@ ha_iot_class: "Local Polling"
 
 The `braviatv` platform allows you to control a [Sony Bravia TV](http://www.sony.com).
 
-Almost all [Sony Bravia TV 2013 and newer](http://info.tvsideview.sony.net/en_ww/home_device.html#bravia) are supported.
+Almost all [Sony Bravia TV 2013 and newer](http://info.tvsideview.sony.net/en_ww/home_device.html#bravia) are supported. A more generic method for older TVs connected to a Raspberry Pi with HDMI-CEC is explained further below. 
 
 You will need to configure your TV to allow the Home Assistant for remote usage. To do that, ensure that your TV is turned on. Open the configuration popup on Home Assistant and enter a random PIN (for example 0000). After that, the TV will show you a PIN and Home Assistant will allow you to re-enter that PIN. Enter the PIN shown on your TV and Home Assistant will be able to control your Sony Bravia TV.
 
@@ -37,4 +37,40 @@ You are also able to configure the TV manually by placing a `bravia.conf` file i
 
 ```json
 {"192.168.0.10": {"pin": "7745", "mac": "ac:1e:0a:e1:0c:01"}}
+```
+
+## For TVs older than 2013.
+
+Users of TVs older than 2013 still have several options for controlling their TV via Home Assistant.
+
+Unfortunately depending on desired goal, the outcome may have some undesired trade off.
+
+#### Using HDMI-CEC ####
+
+If you have a Raspberry Pi connected to your TV:
+
+```json
+- platform: command_line
+  switches:
+    tv_rpi:
+      command_on: ssh root@[IP] "echo 'on 0' | cec-client -s"
+      command_off: ssh root@[IP] "echo 'standby 0' | cec-client -s"
+      command_state: ssh root@[IP] "echo 'pow 0' | cec-client -s |grep 'power status:'"
+      value_template: '{{ value == "power status: on" }}'
+```
+
+Using cec-client seems like a great method to turn your TV off/on, however the trade off is if you're using Kodi, it will no longer be able to control your TV using the TV Remote. 
+
+This is because only one process can control the CEC functionality within the Raspberry Pi at a time, and running the above commands terminates the functionality inside libCEC within Kodi. Kodi must be restarted for TV remove functionality to work again.
+
+**Workaround:**
+
+If your desire is only to turn on your TV, the following "workaround" may be desirable:
+
+Change the 'on' command to a restart for Kodi - this doesn't reboot the Kodi device.
+
+Restarting Kodi will trigger a HDMI-CEC event to bring the TV out of standby. The following can replace your TV 'on' command.
+
+```json
+command_on: ssh root@[IP] "systemctl restart kodi"
 ```


### PR DESCRIPTION
Updated instructions for those using Sony Bravia TVs older than 2013.

This text is actually quite generic, however only applies to users with a Raspberry Pi or similar device which has HDMI-CEC functionality built in.

Source of rewritten content:
- from https://community.home-assistant.io/t/turning-a-tv-on-off-via-kodi-cec-libreelec-no-hass-device-attached/5944/2
- https://community.home-assistant.io/t/turning-a-tv-on-off-via-kodi-cec-libreelec-no-hass-device-attached/5944/3

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

