### PR TITLE
clarify that the pin numbers are from BCM mode

### DIFF
--- a/source/_components/binary_sensor.rpi_gpio.markdown
+++ b/source/_components/binary_sensor.rpi_gpio.markdown
@@ -29,7 +29,7 @@ binary_sensor:
 Configuration variables:
 
 - **ports** array (*Required*): Array of used ports.
-  - **port: name** (*Required*): Port numbers and corresponding names.
+  - **port: name** (*Required*): Port numbers (BCM mode pin numbers) and corresponding names.
 - **pull_mode** (*Optional*): The internal pull to use (UP or DOWN). Default is UP.
 - **bouncetime** (*Optional*): The time in milliseconds for port debouncing. Default is 50ms.
 - **invert_logic** (*Optional*): If true, inverts the output logic to ACTIVE LOW. Default is false (ACTIVE HIGH).


### PR DESCRIPTION
This took me a long time to figure out why it did not work.

**Description:**
Clarify that pin numbering scheme is from BCM mode, not BOARD mode

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

