### PR TITLE
prevent 502 errors caused by apache port-reuse

### DIFF
--- a/source/_docs/ecosystem/apache.markdown
+++ b/source/_docs/ecosystem/apache.markdown
@@ -54,7 +54,7 @@ If you don't want HTTPS, you can change `<VirtualHost *:443>` to `<VirtualHost *
 
 
 <p class='note'>
-In case you are getting occasional HTTP 504 error messages ("Gateway Timeout") when accessing the Web UI through your proxy, try adding disablereuse=on to both ProxyPass directives:
+In case you are getting occasional HTTP 504 error messages ("Gateway Timeout") or HTTP 502 messages ("Bad Gateway") when accessing the Web UI through your proxy, try adding disablereuse=on to both ProxyPass directives:
 </p>
 ```text
 <VirtualHost *:443>


### PR DESCRIPTION
Without the 'disableeuse=On' configured, Apache will try to reuse tcp ports even when these ports were closed by home assistant (tcp FIN was sent). When Apache tries to use such a port, no answer will come from home assistant, causing Apache to respond with a HTTP 502 error.

With this option turned on, the situation will not occur (since ports will not be reused).

