### PR TITLE
Remove "Change the icon" in Template Binary Sensor Documentation

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -96,19 +96,6 @@ binary_sensor:
           - sensor.kitchen_co_status
           - sensor.wardrobe_co_status
 ```
-### {% linkable_title Change the icon %}
-
-This example shows how to change the icon based on the day/night cycle.
-
-```yaml
-sensor:
-  - platform: template
-    sensors:
-      day_night:
-        friendly_name: 'Day/Night'
-        value_template: {% raw %}'{% if is_state("sun.sun", "above_horizon") %}Day{% else %}Night{% endif %}'{% endraw %}
-        icon_template: {% raw %}'{% if is_state("sun.sun", "above_horizon") %}mdi:weather-sunny{% else %}mdi:weather-night{% endif %}'{% endraw %}
-```
 
 ### {% linkable_title Is anyone home? %}
 


### PR DESCRIPTION
**Description:**
This page contains copy that has been taken verbatim from the Template Sensor page.  As it stands, the Template Binary Sensor does not contain the `icon_template` configuration variable.