### PR TITLE
Updated docs for Lutron Caseta component and platforms

### DIFF
--- a/source/_components/cover.lutron_caseta.markdown
+++ b/source/_components/cover.lutron_caseta.markdown
@@ -13,14 +13,10 @@ ha_iot_class: "Local Polling"
 ha_release: 0.45
 ---
 
-To get your Lutron Caseta covers (Serena Shades) working with Home Assistant, first follow the instructions for the general [Lutron Caseta component](/components/lutron_caseta/).
+To get Lutron Caseta roller and honeycomb shades working with Home Assistant, first follow the instructions for the general [Lutron Caseta component](/components/lutron_caseta/).
 
-You also need to configure Lutron Caseta as a cover platform in your `configuration.yaml` file:
+After setup, shades will appear in Home Assistant using an `entity_id` based on the name used in the Lutron mobile app. For example, a shade called 'Living Room Window' will appear in Home Assistant as `cover.living_room_window`.
 
-```yaml
-# Example configuration.yaml entry
-cover:
-  - platform: lutron_caseta
-```
+For more information on working with shades in Home Assistant, see the [Covers component](/components/cover/).
 
-Your Lutron Caseta shades will be pulled into Home Assistant with the names they were assigned in the Lutron Caseta app.
+Available services: `cover.open_cover`, `cover.close_cover` and `cover.set_cover_position`. Cover `position` ranges from `0` for fully closed to `100` for fully open.

--- a/source/_components/light.lutron_caseta.markdown
+++ b/source/_components/light.lutron_caseta.markdown
@@ -12,4 +12,12 @@ ha_category: Light
 ha_iot_class: "Local Polling"
 ---
 
-To get your Lutron Caseta lights working with Home Assistant, follow the instructions for the general [Lutron Caseta component](/components/lutron_caseta/).
+To get Lutron Caseta lights working with Home Assistant, follow the instructions for the general [Lutron Caseta component](/components/lutron_caseta/).
+
+After setup, dimmable lights including wall and plug-in dimmers will appear in Home Assistant using an `entity_id` based on the name used in the Lutron mobile app. For example, a light called 'Bedroom Lamp' will appear in Home Assistant as `light.bedroom_lamp`.
+
+For non-dimmable lights or switched loads, see [Lutron Caseta Switch](/components/switch.lutron_caseta/).
+
+For more information on working with lights in Home Assistant, see the [Lights component](/components/light/).
+
+Available services: `light.turn_on`, `light.turn_off` and `light.toggle`. The `light.turn_on` service supports attributes `brightness` and `brightness_pct`.

--- a/source/_components/lutron_caseta.markdown
+++ b/source/_components/lutron_caseta.markdown
@@ -14,18 +14,20 @@ ha_release: 0.41
 ha_iot_class: "Local Polling"
 ---
 
-[Lutron](http://www.lutron.com/) is an American lighting control company. They have several lines of home automation devices that manage light switches/dimmers, occupancy sensors, HVAC controls, etc. The `lutron_caseta` component in Home Assistant is responsible for communicating with the Lutron SmartBridge for these systems.  Both 'pro' and 'standard' models are supported.
+[Lutron](http://www.lutron.com/) is an American lighting control company. They have several lines of home automation devices that manage light switches, dimmers, occupancy sensors, HVAC controls, etc. The `lutron_caseta` component in Home Assistant is responsible for communicating with the Lutron Caseta Smart Bridge for the [Caseta](http://www.casetawireless.com) product line of dimmers, switches and shades.
 
-This component only supports the Caseta line of products. The current supported Caseta devices are:
+This component only supports the [Caseta](http://www.casetawireless.com) line of products. Both Smart Bridge (L-BDG2-WH) and Smart Bridge PRO (L-BDGPRO2-WH) models are supported. For the RadioRA 2 product line, see the [Lutron component](/components/lutron/).
 
-- Dimmers as Home Assistant lights
-- Wall switches as Home Assistant switches
-- Scenes as Home Assistant scenes
-- Serena shades (honeycomb and roller) as Home Assistant covers
+The currently supported Caseta devices are:
 
-When configured, the `lutron_caseta` component will automatically discover the currently support devices as setup in the Lutron SmartBridge.
+- Wall and plug-in dimmers as Home Assistant [lights](/components/light.lutron_caseta/)
+- Wall switches as Home Assistant [switches](/components/switch.lutron_caseta/)
+- Scenes as Home Assistant [scenes](/components/scene.lutron_caseta/)
+- Lutron shades as Home Assistant [covers](/components/cover.lutron_caseta/)
 
-To use Lutron Caseta devices in your installation, add the following to your `configuration.yaml` file using the IP of your lutron Smartbridge:
+When configured, the `lutron_caseta` component will automatically discover the currently supported devices as setup in the Lutron Smart Bridge. The name assigned in the Lutron mobile app will be used to form the `entity_id` used in Home Assistant. e.g. a dimmer called 'Bedroom Lamp' becomes `light.bedroom_lamp` in Home Assistant.
+
+To use Lutron Caseta devices in your installation, add the following to your `configuration.yaml` file using the IP of your Smart Bridge:
 
 ```yaml
 # Example configuration.yaml entry
@@ -35,8 +37,10 @@ lutron_caseta:
 
 Configuration variables:
 
-- **host** (*Required*): The IP address of the Lutron SmartBridge.
+- **host** (*Required*): The IP address of the Lutron Smart Bridge.
 
 <p class='note'>
-It is recommended to assign a static IP address to your Lutron SmartBridge. This ensures that it won't change IP address, so you won't have to change the `host` if it reboots and comes up with a different IP address.
+It is recommended to assign a static IP address to your Lutron Smart Bridge. This ensures that it won't change IP address, so you won't have to change the `host` if it reboots and comes up with a different IP address.
+<br>
+Use a DHCP reservation on your router to reserve the address or in the PRO model of the Smart Bridge, set the IP address under Network Settings in the Advanced / Integration menu in the mobile app.
 </p>

--- a/source/_components/scene.lutron_caseta.markdown
+++ b/source/_components/scene.lutron_caseta.markdown
@@ -13,7 +13,12 @@ ha_release: 0.49.2
 ha_iot_class: "Cloud Polling"
 ---
 
+To get Lutron Caseta Scenes working with Home Assistant, follow the instructions for the general [Lutron Caseta component](/components/lutron_caseta/).
 
-The Lutron Caseta scene platform allows you to control your [Lutron Caseta](http://www.casetawireless.com/Pages/Caseta.aspx) SmartBridge Scenes.
+The Lutron Caseta scene platform allows you to control your Smart Bridge Scenes that are created in the Lutron mobile app.
 
-The requirement is that you have setup the [Lutron Caseta](/components/lutron_caseta/) component.
+After setup, scenes will appear in Home Assistant using an `entity_id` based on the name used in the Lutron mobile app. For example, a scene called 'Entertain' will appear in Home Assistant as `scene.entertain`.
+
+For more information on working with scenes in Home Assistant, see the [Scenes component](/components/scene/).
+
+Available services: `scene.turn_on`.

--- a/source/_components/switch.lutron_caseta.markdown
+++ b/source/_components/switch.lutron_caseta.markdown
@@ -12,4 +12,12 @@ ha_category: Switch
 ha_iot_class: "Local Polling"
 ---
 
-To get your Lutron Caseta switches working with Home Assistant, follow the instructions for the general [Lutron Caseta component](/components/lutron_caseta/).
+To get Lutron Caseta switches working with Home Assistant, follow the instructions for the general [Lutron Caseta component](/components/lutron_caseta/).
+
+After setup, switches will appear in Home Assistant using an `entity_id` based on the name used in the Lutron mobile app. For example, a light switch called 'Master Bathroom Vanity' will appear in Home Assistant as `switch.master_bathroom_vanity`.
+
+For dimmable lights including wall and plug-in dimmers, see [Lutron Caseta Light](/components/light.lutron_caseta/).
+
+For more information on working with switches in Home Assistant, see the [Switches component](/components/switch/).
+
+Available services: `switch.turn_on` and `switch.turn_off`.


### PR DESCRIPTION
**Description:**
Updated and expanded documentation for the Lutron Caseta component and its platforms.

- Expanded text for each platform to help new users understand how it will work. Gives an example for how their light/switch/cover/scene will appear in Home Assistant. Points them to the Home Assistant component for light/switch/cover/scene for additional help.
- Expanded text with available services for each platform since not all services are implemented.
- Standardized the spelling of 'Smart Bridge' and 'Smart Bridge PRO', which follows how Lutron names the products in their documentation and on their website.
- On the component page, added the model numbers of the supported hubs and pointed them to the 'lutron' component if they have RadioRA 2. This can otherwise be confusing to the reader if they are uncertain why there are multiple Lutron components.
- On the component page, added a note about DHCP reservation and how to set a static IP for the hub in the Lutron app.
- On the cover platform page removed the configuation yaml text which was causing duplicate shades to appear (as per [this thread](https://community.home-assistant.io/t/support-for-lutron-serena-shades/17517/11?u=upsert)). All platforms are loaded by the component so additional configuration is not needed.
- Removed references to 'Serena' shades since the component will now support multiple Lutron shades.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9302

