### PR TITLE
Update rss_feed_template.markdown

### DIFF
--- a/source/_components/rss_feed_template.markdown
+++ b/source/_components/rss_feed_template.markdown
@@ -23,7 +23,7 @@ rss_feed_template:
   # Example: https://localhost:8123/api/rss_template/garden
   garden:
     requires_api_password: False
-    title: "Garden {% raw %}{{ as_timestamp(now())|timestamp_custom('%H:%m', True) }}{% endraw %}"
+    title: "Garden {% raw %}{{ as_timestamp(now())|timestamp_custom('%H:%M', True) }}{% endraw %}"
     items:
     - title: "Outside temperature"
       description: "{% raw %}{% if is_state('sensor.temp_outside','unknown') %}---{% else %}{{states.sensor.temp_outside.state}} °C{% endif %}{% endraw %}"


### PR DESCRIPTION
**Description:**

Use a capital M in the timestamp to show current minute instead of current month