### PR TITLE
Dim (and brighten) lights via a remote

### DIFF
--- a/source/_cookbook/dim_and_brighten_lights.markdown
+++ b/source/_cookbook/dim_and_brighten_lights.markdown
@@ -10,9 +10,9 @@ footer: true
 ha_category: Automation Examples
 ---
 
-This requires both a light on a dimmer, and a z-wave remote control that sends one scene when a button is held, and another when released. This ensures that the scripts (which follow) are stopped, avoiding the risks of a script that never ends.
+This requires both a a dimmable light, and a Z-Wave remote control that sends one scene when a button is held, and another when released. This ensures that the scripts (which follow) are stopped, avoiding the risks of a script that never ends.
 
-In the following automation, replace `zwave.YOURCONTROLLER` with the actual entity ID of your controller. For the controller this was written for scene ID 13 was sent when the up button was held, and 15 when released. Similarly scene 14 when the down button was held, and 16 when released. You'll need to use the scene IDs that are sent by your remote if different.
+In the following automation, replace `zwave.YOUR_REMOTE` with the actual entity ID of your controller. For the controller this was written for scene ID 13 was sent when the up button was held, and 15 when released. Similarly scene 14 when the down button was held, and 16 when released. You'll need to use the scene IDs that are sent by your remote if different.
 
 ```yaml
 automation: 
@@ -24,7 +24,7 @@ automation:
         event_type: zwave.scene_activated
         event_data:
           scene_id: 13
-          entity_id: zwave.YOURCONTROLLER
+          entity_id: zwave.YOUR_REMOTE
     action:
       - service: script.turn_on
         data:
@@ -37,7 +37,7 @@ automation:
         event_type: zwave.scene_activated
         event_data:
           scene_id: 15
-          entity_id: zwave.YOURCONTROLLER
+          entity_id: zwave.YOUR_REMOTE
     action:
       - service: script.turn_off
         data_template:
@@ -53,7 +53,7 @@ automation:
         event_type: zwave.scene_activated
         event_data:
           scene_id: 14
-          entity_id: zwave.YOURCONTROLLER
+          entity_id: zwave.YOUR_REMOTE
     action:
       - service: script.turn_on
         data:
@@ -66,7 +66,7 @@ automation:
         event_type: zwave.scene_activated
         event_data:
           scene_id: 16
-          entity_id: zwave.YOURCONTROLLER
+          entity_id: zwave.YOUR_REMOTE
     action:
       - service: script.turn_off
         data_template:
@@ -78,7 +78,7 @@ automation:
 
 There are 2 variables that control the speed of the change for the scripts below. The first is the `step` - small steps create a smooth transition. The second is the delay, larger delays will create a slower transition.
 
-To allow flexibility, we'll use an input_slider for the step (at the time of writing this, it's not possible to template the delay when the delay uses milliseconds). We're also using a slider to set the minimum and maximum brightness, so that it's easy to tune that (or manage it through an automation).
+To allow flexibility, an [Input Slider](/components/input_slider/) is used for the step (at the time of writing this, it's not possible to template the delay when the delay uses milliseconds). Two additional [Input Sliders](/components/input_slider/) are used to set the minimum and maximum brightness, so that it's easy to tune that (or manage it through an automation).
 
 ```yaml
 input_slider:
@@ -113,13 +113,13 @@ script:
       sequence:
         - service: light.turn_on
           data_template:
-            entity_id: light.YOURLIGHT
+            entity_id: light.YOUR_LIGHT
             brightness: >-
-              {% raw %}{% set current = (states.light.YOURLIGHT.attributes|default).brightness|default(0)|int %}
-              {% set step = states.input_slider.light_step.states|int %}
+              {% raw %}{% set current = states.light.YOUR_LIGHT.attributes.brightness|default(0)|int %}
+              {% set step = states('input_slider.light_step')|int %}
               {% set next = current + step %}
-              {% if next > states.input_slider.light_maximum.states|int %}
-                {% set next = states.input_slider.light_maximum.states|int %}
+              {% if next > states('input_slider.light_maximum)|int %}
+                {% set next = states('input_slider.light_maximum)|int %}
               {% endif %}
               {{ next }}{% endraw %}
 
@@ -139,13 +139,13 @@ script:
       sequence:
         - service: light.turn_on
           data_template:
-            entity_id: light.YOURLIGHT
+            entity_id: light.YOUR_LIGHT
             brightness: >-
-              {% raw %}{% set current = (states.light.YOURLIGHT.attributes|default).brightness|default(0)|int %}
-              {% set step = states.input_slider.light_step.states|int %}
+              {% raw %}{% set current = states.light.YOUR_LIGHT.attributes.brightness|default(0)|int %}
+              {% set step = states('input_slider.light_step')|int %}
               {% set next = current - step %}
-              {% if next < states.input_slider.light_minimum.states|int %}
-                {% set next = states.input_slider.light_minimum.states|int %}
+              {% if next < states('input_slider.light_minimum')|int %}
+                {% set next = states('input_slider.light_minimum')|int %}
               {% endif %}
               {{ next }}{% endraw %}
 

--- a/source/_cookbook/dim_and_brighten_lights.markdown
+++ b/source/_cookbook/dim_and_brighten_lights.markdown
@@ -1,0 +1,164 @@
+---
+layout: page
+title: "Dim (and brighten) lights via a remote"
+description: "The scripts and automations to allow you to use a remote to dim and brighten a light"
+date: 2017-09-06 18:30
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Automation Examples
+---
+
+This requires both a light on a dimmer, and a z-wave remote control that sends one scene when a button is held, and another when released. This ensures that the scripts (which follow) are stopped, avoiding the risks of a script that never ends.
+
+In the following automation, replace `zwave.YOURCONTROLLER` with the actual entity ID of your controller. For the controller this was written for scene ID 13 was sent when the up button was held, and 15 when released. Similarly scene 14 when the down button was held, and 16 when released. You'll need to use the scene IDs that are sent by your remote if different.
+
+```yaml
+automation: 
+
+  - alias: 'Make the lights go bright'
+    initial_state: 'on'
+    trigger:
+      - platform: event
+        event_type: zwave.scene_activated
+        event_data:
+          scene_id: 13
+          entity_id: zwave.YOURCONTROLLER
+    action:
+      - service: script.turn_on
+        data:
+          entity_id: script.light_bright
+
+  - alias: 'Stop the bright just there'
+    initial_state: 'on'
+    trigger:
+      - platform: event
+        event_type: zwave.scene_activated
+        event_data:
+          scene_id: 15
+          entity_id: zwave.YOURCONTROLLER
+    action:
+      - service: script.turn_off
+        data_template:
+          entity_id: script.light_bright
+      - service: script.turn_off
+        data:
+          entity_id: script.light_bright_pause
+
+  - alias: 'Make the lights go dim'
+    initial_state: 'on'
+    trigger:
+      - platform: event
+        event_type: zwave.scene_activated
+        event_data:
+          scene_id: 14
+          entity_id: zwave.YOURCONTROLLER
+    action:
+      - service: script.turn_on
+        data:
+          entity_id: script.light_dim
+
+  - alias: 'Stop the dim just there'
+    initial_state: 'on'
+    trigger:
+      - platform: event
+        event_type: zwave.scene_activated
+        event_data:
+          scene_id: 16
+          entity_id: zwave.YOURCONTROLLER
+    action:
+      - service: script.turn_off
+        data_template:
+          entity_id: script.light_dim
+      - service: script.turn_off
+        data:
+          entity_id: script.light_dim_pause
+```
+
+There are 2 variables that control the speed of the change for the scripts below. The first is the `step` - small steps create a smooth transition. The second is the delay, larger delays will create a slower transition.
+
+To allow flexibility, we'll use an input_slider for the step (at the time of writing this, it's not possible to template the delay when the delay uses milliseconds). We're also using a slider to set the minimum and maximum brightness, so that it's easy to tune that (or manage it through an automation).
+
+```yaml
+input_slider:
+  light_step:
+    name: 'Step the lights this much'
+    initial: 20
+    min: 1
+    max: 64
+    step: 1
+
+  light_minimum:
+    name: 'No dimmer than this'
+    initial: 5
+    min: 1
+    max: 255
+    step: 1
+    
+  light_maximum:
+    name: 'No brighter than this'
+    initial: 255
+    min: 50
+    max: 255
+    step: 1
+```
+
+Now the scripts. There are 2 pairs of scripts. The first steps the light brighter to the maximum, and the second provides the delay. These call each other until both are stopped. The second pair do the same for dimming.
+
+```yaml
+# Replace YOURLIGHT with the actual light entity
+script:
+    light_bright:
+      sequence:
+        - service: light.turn_on
+          data_template:
+            entity_id: light.YOURLIGHT
+            brightness: >-
+              {% raw %}{% set current = (states.light.YOURLIGHT.attributes|default).brightness|default(0)|int %}
+              {% set step = states.input_slider.light_step.states|int %}
+              {% set next = current + step %}
+              {% if next > states.input_slider.light_maximum.states|int %}
+                {% set next = states.input_slider.light_maximum.states|int %}
+              {% endif %}
+              {{ next }}{% endraw %}
+
+        - service: script.turn_on
+          data:
+            entity_id: script.light_bright_pause
+        
+    light_bright_pause:
+      sequence:
+        - delay:
+            milliseconds: 1
+        - service: script.turn_on
+          data:
+            entity_id: script.light_bright
+
+    light_dim:
+      sequence:
+        - service: light.turn_on
+          data_template:
+            entity_id: light.YOURLIGHT
+            brightness: >-
+              {% raw %}{% set current = (states.light.YOURLIGHT.attributes|default).brightness|default(0)|int %}
+              {% set step = states.input_slider.light_step.states|int %}
+              {% set next = current - step %}
+              {% if next < states.input_slider.light_minimum.states|int %}
+                {% set next = states.input_slider.light_minimum.states|int %}
+              {% endif %}
+              {{ next }}{% endraw %}
+
+        - service: script.turn_on
+          data:
+            entity_id: script.light_dim_pause
+        
+    light_dim_pause:
+      sequence:
+        - delay:
+            milliseconds: 1
+        - service: script.turn_on
+          data:
+            entity_id: script.light_dim
+```
+

--- a/source/_cookbook/dim_and_brighten_lights.markdown
+++ b/source/_cookbook/dim_and_brighten_lights.markdown
@@ -118,8 +118,8 @@ script:
               {% raw %}{% set current = states.light.YOUR_LIGHT.attributes.brightness|default(0)|int %}
               {% set step = states('input_slider.light_step')|int %}
               {% set next = current + step %}
-              {% if next > states('input_slider.light_maximum)|int %}
-                {% set next = states('input_slider.light_maximum)|int %}
+              {% if next > states('input_slider.light_maximum')|int %}
+                {% set next = states('input_slider.light_maximum')|int %}
               {% endif %}
               {{ next }}{% endraw %}
 
@@ -161,4 +161,3 @@ script:
           data:
             entity_id: script.light_dim
 ```
-

--- a/source/_cookbook/dim_and_brighten_lights.markdown
+++ b/source/_cookbook/dim_and_brighten_lights.markdown
@@ -10,9 +10,9 @@ footer: true
 ha_category: Automation Examples
 ---
 
-This requires both a a dimmable light, and a Z-Wave remote control that sends one scene when a button is held, and another when released. This ensures that the scripts (which follow) are stopped, avoiding the risks of a script that never ends.
+This requires both a dimmable light, and a Z-Wave remote control that sends one scene when a button is held, and another when released. This ensures that the scripts (which follow) are stopped, avoiding the risks of a script that never ends.
 
-In the following automation, replace `zwave.YOUR_REMOTE` with the actual entity ID of your controller. For the controller this was written for scene ID 13 was sent when the up button was held, and 15 when released. Similarly scene 14 when the down button was held, and 16 when released. You'll need to use the scene IDs that are sent by your remote if different.
+In the following automation, replace `zwave.YOUR_REMOTE` with the actual entity ID of your controller. For the controller this was written for scene ID 13 was sent when the up button was held, and 15 when released. Similarly, scene 14 when the down button was held, and 16 when released. You'll need to use the scene IDs that are sent by your remote if different.
 
 ```yaml
 automation: 
@@ -76,7 +76,7 @@ automation:
           entity_id: script.light_dim_pause
 ```
 
-There are 2 variables that control the speed of the change for the scripts below. The first is the `step` - small steps create a smooth transition. The second is the delay, larger delays will create a slower transition.
+There are 2 variables that control the speed of the change for the scripts below. The first is the `step`, small steps create a smooth transition. The second is the delay, larger delays will create a slower transition.
 
 To allow flexibility, an [Input Slider](/components/input_slider/) is used for the step (at the time of writing this, it's not possible to template the delay when the delay uses milliseconds). Two additional [Input Sliders](/components/input_slider/) are used to set the minimum and maximum brightness, so that it's easy to tune that (or manage it through an automation).
 

--- a/source/_cookbook/dim_and_brighten_lights.markdown
+++ b/source/_cookbook/dim_and_brighten_lights.markdown
@@ -104,7 +104,7 @@ input_slider:
     step: 1
 ```
 
-Now the scripts. There are 2 pairs of scripts. The first steps the light brighter to the maximum, and the second provides the delay. These call each other until both are stopped. The second pair do the same for dimming.
+Now the scripts. There are 2 pairs of scripts. The first steps the light brighter to the maximum and the second provides the delay. These call each other until both are stopped. The second pair does the same for dimming.
 
 ```yaml
 # Replace YOURLIGHT with the actual light entity


### PR DESCRIPTION
Hopefully this one won't break everything ;)

As per chat in the Discord, these are the scripts, automations, and input_sliders to allow a light to be dimmed and brightened by holding down the down or up button on an appropriate remote.

This has been extended to use input_sliders for the dim/brighten step, and for the minimum and maximum brightness levels. The defaults have been set based upon DariBer's experience, so they should be close to "right" for others.

