### PR TITLE
Add missing configuration for polly

### DIFF
--- a/source/_components/tts.amazon_polly.markdown
+++ b/source/_components/tts.amazon_polly.markdown
@@ -25,6 +25,7 @@ tts:
     aws_secret_access_key: AWS_SECRET_ACCESS_KEY
     profile_name: AWS_PROFILE
     region_name: 'us-east-1'
+    voice: Joanna
 ```
 
 Configuration variables:
@@ -33,12 +34,14 @@ Configuration variables:
 |---------------------|----------|-------------|
 | `aws_access_key_id` | Required |  Your AWS Access Key ID. For more information, please read the [AWS General Reference regarding Security Credentials](http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html). If provided, you must also provide an `aws_secret_access_key` and must **not** provide a `profile_name` |
 | `aws_secret_access_key` | Required | Your AWS Secret Access Key. For more information, please read the [AWS General Reference regarding Security Credentials](http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html). If provided, you must also provide an `aws_access_key_id` and must **not** provide a `profile_name`. |
-| `profile_name` | Optional | A credentials profile name. For more information, please see the [boto3  |
+| `profile_name` | Optional | A credentials profile name. For more information, please see the [boto3 Documentation](http://boto3.readthedocs.io/en/latest/guide/configuration.html#shared-credentials-file) for more information. |
 | `region_name` | Optional | The region identifier to connect to. The default is `us-east-1`. |
-| `name` | Optional | Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
- |
-| `text_type` | text/ssml    | text or ssml: Specify wherever to use text (default) or ssml markup |
-
+| `name` | Optional | Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`. |
+| `text_type` | text/ssml    | text or ssml: Specify wherever to use text (default) or ssml markup by default. |
+| `voice` | Optional | Voice name to be used. See the [Amazon Documentation](http://docs.aws.amazon.com/polly/latest/dg/voicelist.html) for available voices. |
+| `output_format` | mp3/ogg_vorbis/pcm | Override the default output format, defaults to MP3. |
+| `sample_rate` | 8000/16000/22050 | Override the default sample rate, defaults to 22050 for MP3 and Ogg Vorbis, 16000 for pcm. |
+ 
 ## Usage
 Say to all `media_player` device entities:
 ```yaml


### PR DESCRIPTION
**Description:**
Add documentation for missing configuration options for Amazon Polly TTS.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** 
N/A