### PR TITLE
Added note regarding script.json-cec plugin on kodi page

### DIFF
--- a/source/_components/media_player.kodi.markdown
+++ b/source/_components/media_player.kodi.markdown
@@ -193,6 +193,7 @@ media_player:
           command: standby
 ```
 
+Note: This example and the following requires to have the [script.json-cec](https://github.com/joshjowen/script.json-cec) plugin installed on your kodi player. It'll also expose th endpoints standy, toggle and activate without authentication on your kodi player. Use this with caution.
 
 ### {% linkable_title Kodi services samples %}
 

--- a/source/_components/media_player.kodi.markdown
+++ b/source/_components/media_player.kodi.markdown
@@ -193,7 +193,9 @@ media_player:
           command: standby
 ```
 
-Note: This example and the following requires to have the [script.json-cec](https://github.com/joshjowen/script.json-cec) plugin installed on your kodi player. It'll also expose th endpoints standy, toggle and activate without authentication on your kodi player. Use this with caution.
+<p class='note'>
+This example and the following requires to have the [script.json-cec](https://github.com/joshjowen/script.json-cec) plugin installed on your kodi player. It'll also expose th endpoints standy, toggle and activate without authentication on your kodi player. Use this with caution.
+</p>
 
 ### {% linkable_title Kodi services samples %}
 


### PR DESCRIPTION
**Description:**
When setting up kodi I recognized that the page nowhere mentioned a) that an external plugin is needed and where to find it b) that the plugin basically exposes the added endpoints without authentication. 
I thought adding a note might be helpful

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

