### PR TITLE
Xiaomi light description updated

### DIFF
--- a/source/_components/light.xiaomi.markdown
+++ b/source/_components/light.xiaomi.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Push"
 ---
 
 
-The `xiaomi` light platform allows you to get data from your [Xiaomi](http://www.mi.com/en/) lights.
+The `xiaomi` light platform allows you to control the internal light of the xiaomi gatway. The component will be loaded automatically and provides a device called `light.gateway_light_28ffffffffff`.
 
 The requirement is that you have setup [Xiaomi](/components/xiaomi/).
 

--- a/source/_components/light.xiaomi.markdown
+++ b/source/_components/light.xiaomi.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Push"
 ---
 
 
-The `xiaomi` light platform allows you to control the internal light of the xiaomi gatway. The component will be loaded automatically and provides a device called `light.gateway_light_28ffffffffff`.
+The `xiaomi` light platform allows you to control the internal light of the xiaomi gateway. The component will be loaded automatically and provides a device called `light.gateway_light_28ffffffffff`.
 
 The requirement is that you have setup [Xiaomi](/components/xiaomi/).
 

--- a/source/_components/xiaomi.markdown
+++ b/source/_components/xiaomi.markdown
@@ -46,6 +46,8 @@ What's not available?
 
 Follow the setup process using your phone and Mi-Home app. From here you will be able to retrieve the key from within the app following [this tutorial](https://community.home-assistant.io/t/beta-xiaomi-gateway-integration/8213/1832)
 
+Please check the instructions in this [section](/xiaomi/#retrieving-the-access-token) to get the API token to use with your platforms.
+
 To enable Xiaomi gateway in your installation, add the following to your `configuration.yaml` file:
 
 ### {% linkable_title One Gateway %}

--- a/source/_components/xiaomi.markdown
+++ b/source/_components/xiaomi.markdown
@@ -46,8 +46,6 @@ What's not available?
 
 Follow the setup process using your phone and Mi-Home app. From here you will be able to retrieve the key from within the app following [this tutorial](https://community.home-assistant.io/t/beta-xiaomi-gateway-integration/8213/1832)
 
-Please check the instructions in this [section](/xiaomi/#retrieving-the-access-token) to get the API token to use with your platforms.
-
 To enable Xiaomi gateway in your installation, add the following to your `configuration.yaml` file:
 
 ### {% linkable_title One Gateway %}


### PR DESCRIPTION

The current explanation doesn't fit. It looks like there are zigbee sub-devices called "xiaomi lights" which can be controlled via the xiaomi gateway. In reality there is just the internal night light of the gateway which can be controlled. No additional lights are supported. 