### PR TITLE
authorized_key file needs to be on the boot partition

### DIFF
--- a/source/developers/hassio/debugging.markdown
+++ b/source/developers/hassio/debugging.markdown
@@ -20,7 +20,7 @@ The following debug tips and tricks are for people who are running the Hass.io i
 
 ## {% linkable_title SSH access to the host %}
 
-Create an `authorized_keys` file in the root of your SD card with your public key. Once the device is booted, you can access your device as root over SSH on port 22222.
+Create an `authorized_keys` file containing your public key, and place it in the root of the boot partition of your SD card. Once the device is booted, you can access your device as root over SSH on port 22222.
 
 Windows instructions how to generate and use private/public keys with Putty are [here][windows-keys]. Instead of the droplet instructions, add the public key as per above instructions.
 


### PR DESCRIPTION
Mentioning that it's the root of the boot partition the key file needs to be places in (when I first attempted it I presumed it was the root of the partition called "root").

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

