### PR TITLE
Added information about Hass.io update process.

### DIFF
--- a/source/hassio/index.markdown
+++ b/source/hassio/index.markdown
@@ -30,7 +30,7 @@ The advantages of using Hass.io:
 
 ### {% linkable_title Upgrading %}
 
-Hass.io users can update Home Assistant via the ‘Hass.io' page in the UI.  However please note that Home Assistant updates take time to roll into the Hass.io builds.  Therefore there is often a slight delay between the availability of a Home Assistant update and an update being available in Hass.io, be patient.  When a Hass.io update is available it will be shown as available on the ‘Hass.io' page in your UI.
+Hass.io users can update Home Assistant via the 'Hass.io' page in the UI. However please note that Home Assistant updates take time to roll into the Hass.io builds. Therefore there is often a slight delay between the availability of a Home Assistant update and an update being available in Hass.io, be patient. When a Hass.io update is available it will be shown as available on the ‘Hass.io' page in your UI.
 
 <p class='img'>
 <img src='/images/hassio/screenshots/dashboard.png'>

--- a/source/hassio/index.markdown
+++ b/source/hassio/index.markdown
@@ -13,6 +13,10 @@ Hass.io turns your Raspberry Pi (or another device) into the ultimate home autom
 
 [Go to the installation instructions &raquo;][install]
 
+ <p class='note'>
+Home Assistant updates take time to roll into the Hass.io builds.  Therefore there is often a slight delay between the availability of a Home Assistant update and an update being available in Hass.io, be patient. See: [Upgrading](#upgrading)
+ </p>
+
 The advantages of using Hass.io:
 
  - Free and open source
@@ -28,10 +32,16 @@ The advantages of using Hass.io:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/XWPluWcYRMI" frameborder="0" allowfullscreen></iframe>
 </div>
 
+### {% linkable_title Upgrading %}
+
+Hass.io users can update Home Assistant via the ‘Hass.io' page in the UI.  However please note that Home Assistant updates take time to roll into the Hass.io builds.  Therefore there is often a slight delay between the availability of a Home Assistant update and an update being available in Hass.io, be patient.  When a Hass.io update is available it will be shown as available on the ‘Hass.io' page in your UI.
+
 <p class='img'>
 <img src='/images/hassio/screenshots/dashboard.png'>
 Hass.io dashboard
 </p>
+
+If you would prefer not to be notified of the general updates in the UI you can disable the [updater](components/updater/) component in your configuration.
 
 [Google Assistant]: /addons/google_assistant/
 [Snips.ai]: /addons/snips/

--- a/source/hassio/index.markdown
+++ b/source/hassio/index.markdown
@@ -13,10 +13,6 @@ Hass.io turns your Raspberry Pi (or another device) into the ultimate home autom
 
 [Go to the installation instructions &raquo;][install]
 
- <p class='note'>
-Home Assistant updates take time to roll into the Hass.io builds.  Therefore there is often a slight delay between the availability of a Home Assistant update and an update being available in Hass.io, be patient. See: [Upgrading](#upgrading)
- </p>
-
 The advantages of using Hass.io:
 
  - Free and open source


### PR DESCRIPTION
**Description:**  Hass.io users end up on this page when an update is available, but then can't see what they have to do.  This is because of the the updater component and the inevitable delay in updates getting into the hass.io build.

This update informs users about an updates transition from HA into Hass.io, how to install it, and suggests disabling the updater component to alleviate 'notification stress'.