### PR TITLE
add Samsung D6500 to be compatible

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -38,6 +38,7 @@ Configuration variables:
 Currently known supported models:
 
 - C7700
+- D6500
 - D7000
 - D8000
 - ES5500


### PR DESCRIPTION
**Description:**
Update readme of the samsung component to state that the Samsung D6500 is compatible and worked for me.

