### PR TITLE
Fixed a typo in code listing.

### DIFF
--- a/source/_cookbook/python_component_mqtt_basic.markdown
+++ b/source/_cookbook/python_component_mqtt_basic.markdown
@@ -46,7 +46,7 @@ def setup(hass, config):
     # Subscribe our listener to a topic.
     mqtt.subscribe(hass, topic, message_received)
 
-    # Set the intial state
+    # Set the initial state.
     hass.states.set(entity_id, 'No messages')
 
     # Service to publish a message on MQTT.


### PR DESCRIPTION
**Description:**

There was a simple typo in python comment, and a missing dot to align the style with other comments.