### PR TITLE
Command line flag to control logging output file

### DIFF
--- a/source/_docs/tools/hass.markdown
+++ b/source/_docs/tools/hass.markdown
@@ -37,9 +37,9 @@ optional arguments:
   --log-rotate-days LOG_ROTATE_DAYS
                         Enables daily log rotation and keeps up to the
                         specified days
+  --log-file LOG_FILE   Log file to write to. If not set, CONFIG/home-
+                        assistant.log is used
   --runner              On restart exit with code 100
   --script ...          Run one of the embedded scripts
   --daemon              Run Home Assistant as daemon
 ```
-
-


### PR DESCRIPTION
**Description:**
Add a hass command line flag to control where the log file is written to. If not set, the current system (CONFIG/home-assistant.log) is used. This allows users to control where the log file is written to. Many/most Linux app logs are written to /var/log. On the Pi, it's useful to have logs written to a ram disk to avoid wearing the SD card. Original feature request [thread is here](https://community.home-assistant.io/t/custom-log-file-location/12360).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9422

