### PR TITLE
Add documentation for availability topic and payloads

### DIFF
--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -38,7 +38,7 @@ Configuration variables:
 - **availability_topic** (*Optional*): The MQTT topic subscribed to receive birth and LWT messages from the MQTT device. If `availability_topic` is not defined, the binary sensor availability state will always be `available`. If `availability_topic` is defined, the binary sensor availability state will be `unavailable` by default.
 - **payload_available** (*Optional*): The payload that represents the online state. Default is `online`.
 - **payload_not_available** (*Optional*): The payload that represents the offline state. Default is `offline`.
-- **qos** (*Optional*): The maximum QoS level to be used when receiving and publishing messages. Default is `0`.
+- **qos** (*Optional*): The maximum QoS level to be used when receiving messages. Default is `0`.
 - **device_class** (*Optional*): The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
 - **value_template** (*Optional*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
 

--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -14,9 +14,13 @@ ha_iot_class: "depends"
 ---
 
 
-The `mqtt` binary sensor platform uses the MQTT message payload as the sensor value. If messages in this `state_topic` are published with *RETAIN* flag, the sensor will receive an instant update with the last known value. Otherwise, the initial state will be off.
+The `mqtt` binary sensor platform uses an MQTT message payload to set the binary sensor to one of two states: `on` or `off`.
 
-To use your MQTT binary sensor in your installation, add the following to your `configuration.yaml` file:
+The binary sensor state will be updated only after a new message is published on `state_topic` matching `payload_on` or `payload_off`. If these messages are published with the `retain` flag set, the binary sensor will receive an instant state update after subscription and Home Assistant will display the correct state on startup. Otherwise, the initial state displayed in Home Assistant will be `unknown`.
+
+The `mqtt` binary sensor platform optionally supports an `availability_topic` to receive online and offline messages (birth and LWT messages) from the MQTT device. During normal operation, if the MQTT cover device goes offline (i.e. publishes `payload_not_available` to `availability_topic`), Home Assistant will display the binary sensor as `unavailable`. If these messages are published with the `retain` flag set, the binary sensor will receive an instant update after subscription and Home Assistant will display the correct availability state of the binary sensor when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the binary sensor as `unavailable` when Home Assistant starts up. If no `availability_topic` is defined, Home Assistant will consider the MQTT device to be available.
+
+To use an MQTT binary sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -27,32 +31,37 @@ binary_sensor:
 
 Configuration variables:
 
+- **name** (*Optional*): The name of the binary sensor. Default is `MQTT Binary Sensor`.
 - **state_topic** (*Required*): The MQTT topic subscribed to receive sensor values.
-- **name** (*Optional*): The name of the sensor. Default is 'MQTT Sensor'. 
-- **qos** (*Optional*): The maximum QoS level of the state topic. Default is 0.
-- **payload_on** (*Optional*): The payload that represents on state. Default is "ON".
-- **payload_off** (*Optional*): The payload that represents  state. Default is "OFF".
+- **payload_on** (*Optional*): The payload that represents the on state. Default is `ON`.
+- **payload_off** (*Optional*): The payload that represents the off state. Default is `OFF`.
+- **availability_topic** (*Optional*): The MQTT topic subscribed to receive birth and LWT messages from the MQTT device. If `availability_topic` is not defined, the binary sensor availability state will always be `available`. If `availability_topic` is defined, the binary sensor availability state will be `unavailable` by default.
+- **payload_available** (*Optional*): The payload that represents the online state. Default is `online`.
+- **payload_not_available** (*Optional*): The payload that represents the offline state. Default is `offline`.
+- **qos** (*Optional*): The maximum QoS level to be used when receiving and publishing messages. Default is `0`.
 - **device_class** (*Optional*): The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
 - **value_template** (*Optional*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
 
-For a quick check you can use the commandline tools shipped with `mosquitto` to send MQTT messages. Set the state of a sensor manually:
+To test, you can use the command line tool `mosquitto_pub` shipped with `mosquitto` or the `mosquitto-clients` package to send MQTT messages. To set the state of the binary sensor manually:
 
 ```bash
 $  mosquitto_pub -h 127.0.0.1 -t home-assistant/window/contact -m "OFF"
 ```
 
-An extended configuration for the same sensor could look like this if you want/need to be more specific.
+The example below shows a full configuration for a binary sensor:
 
 ```yaml
 # Example configuration.yaml entry
 binary_sensor:
   - platform: mqtt
+    name: "Window Contact Sensor"
     state_topic: "home-assistant/window/contact"
-    name: "Windows contact"
+    payload_on: "ON"
+    payload_off: "OFF"
+    availability_topic: "home-assistant/window/availability"
+    payload_available: "online"
+    payload_not_available: "offline"
     qos: 0
-    payload_on: "1"
-    payload_off: "0"
     device_class: opening
     value_template: '{% raw %}{{ value.x }}{% endraw %}'
 ```
-

--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -49,7 +49,7 @@ Configuration variables:
 - **payload_available** (*Optional*): The payload that represents the online state. Default is `online`.
 - **payload_not_available** (*Optional*): The payload that represents the offline state. Default is `offline`.
 - **optimistic** (*Optional*): Flag that defines if switch works in optimistic mode. Default is `true` if no state topic defined, else `false`.
-- **qos** (*Optional*): The maximum QoS level to be used when receiving and publishing messages.
+- **qos** (*Optional*): The maximum QoS level to be used when receiving and publishing messages. Default is `0`.
 - **retain** (*Optional*): Defines if published messages should have the retain flag set. Default is `false`.
 - **value_template** (*Optional*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
 - **set_position_topic** (*Optional*): The MQTT topic to publish position commands to.

--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -13,39 +13,44 @@ ha_iot_class: "depends"
 ha_release: 0.18
 ---
 
-The `mqtt` cover platform enables the possibility to control an MQTT cover. The device state will be updated only after receiving the a new
-state from `state_topic`. If these messages are published with `RETAIN` flag, the MQTT device will receive an instant state update after subscription and will start with correct state. Otherwise, the initial state will be `unknown`.
+The `mqtt` cover platform allows you to control an MQTT cover (such as blinds, a rollershutter, or a garage door).
 
-There is a state attribute that stores the relative position of the device, where 0 means the device is `closed` and all other intermediate positions means the device is `open`.
+The device state (`open` or `closed`) will be updated only after a new message is published on `state_topic` matching `state_open` or `state_closed`. If these messages are published with the `retain` flag set, the cover will receive an instant state update after subscription and Home Assistant will display the correct state on startup. Otherwise, the initial state displayed in Home Assistant will be `unknown`.
 
-When a state topic is not available, the cover will work in optimistic mode. In this mode, the cover will immediately change state after every command. Otherwise, the cover will wait for state confirmation from device (message from `state_topic`).
+There is an attribute that stores the relative position of the device, where 0 means the device is `closed` and all other intermediate positions means the device is `open`.
 
-Optimistic mode can be forced, even if `state_topic` is available. Try to enable it, if experiencing incorrect cover operation.
+If a state topic is not defined, the cover will work in optimistic mode. In this mode, the cover will immediately change state (`open` or `closed`) after every command sent by Home Assistant. If a state topic is defined, the cover will wait for a message on `state_topic` matching `state_open` or `state_closed` before changing state in Home Assistant.
+
+Optimistic mode can be forced, even if a `state_topic` is defined. Try to enable it if experiencing incorrect cover operation.
+
+The `mqtt` cover platform optionally supports an `availability_topic` to receive online and offline messages (birth and LWT messages) from the MQTT cover device. During normal operation, if the MQTT cover device goes offline (i.e. publishes `payload_not_available` to `availability_topic`), Home Assistant will display the cover as "unavailable". If these messages are published with the `retain` flag set, the cover will receive an instant update after subscription and Home Assistant will display correct availability state of the cover when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the cover as "unavailable" when Home Assistant starts up.
 
 To use your MQTT cover in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 cover:
   - platform: mqtt
     name: "MQTT Cover"
-    state_topic: "home-assistant/cover"
     command_topic: "home-assistant/cover/set"
 ```
 
 Configuration variables:
 
 - **name** (*Optional*): The name of the sensor. Default is `MQTT Cover`.
-- **state_topic** (*Optional*): The MQTT topic subscribed to receive sensor values.
-- **command_topic** (*Optional*): The MQTT topic to publish commands to control the rollershutter.
+- **command_topic** (*Optional*): The MQTT topic to publish commands to control the cover.
 - **payload_open** (*Optional*): The payload that opens the cover. Default is `OPEN`.
 - **payload_close** (*Optional*): The payload that closes the cover. Default is `CLOSE`.
-- **payload_stop** (*Optional*):  The payload that stops the rollershutter. default is `STOP`.
-- **state_open** (*Optional*): The payload that represents open state. Default is `open`.
-- **state_closed** (*Optional*): The payload that represents closed state. Default is `closed`.
+- **payload_stop** (*Optional*):  The payload that stops the cover. default is `STOP`.
+- **state_topic** (*Optional*): The MQTT topic subscribed to receive cover state messages.
+- **state_open** (*Optional*): The payload that represents the open state. Default is `open`.
+- **state_closed** (*Optional*): The payload that represents the closed state. Default is `closed`.
+- **availability_topic** (*Optional*): The MQTT topic subscribed to to receive birth and LWT messages from the MQTT cover device. If `availability_topic` is not defined, the cover availability state will always be "available". If `availability_topic` is defined, the cover availability state will be "unavailable" by default.
+- **payload_available** (*Optional*): The payload that represents the online state. Default is `online`.
+- **payload_not_available** (*Optional*): The payload that represents the offline state. Default is `offline`.
 - **optimistic** (*Optional*): Flag that defines if switch works in optimistic mode. Default is `true` if no state topic defined, else `false`.
-- **qos** (*Optional*): The maximum QoS level of the state topic. Default is `0`. Will also be used when publishing messages.
-- **retain** (*Optional*): If the published message should have the retain flag on or not. Default is `false`.
+- **qos** (*Optional*): The maximum QoS level to be used when receiving and publishing messages.
+- **retain** (*Optional*): Defines if published messages should have the retain flag set. Default is `false`.
 - **value_template** (*Optional*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
 - **set_position_topic** (*Optional*): The MQTT topic to publish position commands to.
 - **set_position_template** (*Optional*): Defines a [template](/topics/templating/) to define the position to be sent to the `set_position_topic` topic. Incoming position value is available for use in the template `{{position}}`. If no template is defined, the numeric position (0-100) will be written directly to the topic.
@@ -60,7 +65,7 @@ Configuration variables:
 
 ## {% linkable_title Examples %}
 
-In this section you find some real life examples of how to use this sensor.
+In this section you find some real life examples of how to use this platform.
 
 ### {% linkable_title Full configuration without tilt %}
 
@@ -70,16 +75,19 @@ The example below shows a full configuration for a cover without tilt.
 # Example configuration.yml entry
 cover:
   - platform: mqtt
-    state_topic: "home-assistant/cover"
-    command_topic: "home-assistant/cover/set"
     name: "MQTT Cover"
+    command_topic: "home-assistant/cover/set"
+    state_topic: "home-assistant/cover/state"
+    availability_topic: "home-assistant/cover/availability"    
     qos: 0
     retain: true
     payload_open: "OPEN"
     payload_close: "CLOSE"
     payload_stop: "STOP"
-    state_open: "OPEN"
-    state_closed: "STATE"
+    state_open: "open"
+    state_closed: "closed"
+    payload_available: "online"
+    payload_not_available: "offline"
     optimistic: false
     value_template: '{% raw %}{{ value.x }}{% endraw %}'
 ```
@@ -92,27 +100,30 @@ The example below shows a full configuration for a cover.
 # Example configuration.yml entry
 cover:
   - platform: mqtt
-    state_topic: "home-assistant/cover"
-    command_topic: "home-assistant/cover/set"
     name: "MQTT Cover"
+    command_topic: "home-assistant/cover/set"
+    state_topic: "home-assistant/cover/state"
+    availability_topic: "home-assistant/cover/availability"
     qos: 0
     retain: true
     payload_open: "OPEN"
     payload_close: "CLOSE"
     payload_stop: "STOP"
-    state_open: "OPEN"
-    state_closed: "STATE"
+    state_open: "open"
+    state_closed: "closed"
+    payload_available: "online"
+    payload_not_available: "offline"
     optimistic: false
     value_template: '{% raw %}{{ value.x }}{% endraw %}'
     tilt_command_topic: 'home-assistant/cover/tilt'
-    tilt_status_topic: 'home-assistant/cover/tilt-status'
+    tilt_status_topic: 'home-assistant/cover/tilt-state'
     tilt_min: 0
     tilt_max: 180
     tilt_closed_value: 70
     tilt_opened_value: 180
 ```
 
-For a check you can use the command line tools `mosquitto_pub` shipped with `mosquitto` to send MQTT messages. This allows you to operate your cover manually:
+To test, you can use the command line tool `mosquitto_pub` shipped with `mosquitto` or the `mosquitto-clients` package to send MQTT messages. This allows you to operate your cover manually:
 
 ```bash
 $  mosquitto_pub -h 127.0.0.1 -t home-assistant/cover/set -m "CLOSE"


### PR DESCRIPTION
**Description:**

Added documentation for availability topic and payloads added in pull requests. Also cleaned up documentation for the MQTT cover generally to make clear the differences between state topic and messages and availability topic and messages, and the MQTT binary sensor generally.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9445, home-assistant/home-assistant#9507