### PR TITLE
Correct 'with' to 'without'

### DIFF
--- a/source/developers/component_generic_discovery.markdown
+++ b/source/developers/component_generic_discovery.markdown
@@ -67,7 +67,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 ```
 
 
-The `load_platform` method allows the platforms to be loaded with the need for any additional platform entries in your `configuration.yaml` file, which normally would have been:
+The `load_platform` method allows the platforms to be loaded without the need for any additional platform entries in your `configuration.yaml` file, which normally would have been:
 
 ```yaml
 #light:


### PR DESCRIPTION
The final statement reads states that 'The `load_platform` method allows the platforms to be loaded with the need for any additional platform entries in your `configuration.yaml` file' but it appears the 'with' should be 'without'..

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

