### PR TITLE
Sample in url configuration variable

### DIFF
--- a/source/_components/telegram_bot.webhooks.markdown
+++ b/source/_components/telegram_bot.webhooks.markdown
@@ -42,7 +42,7 @@ Configuration variables:
 - **parse_mode** (*Optional*): Default parser for messages if not explicit in message data: 'html' or 'markdown'. Default is 'markdown'.
 - **proxy_url** (*Optional*): Proxy url if working behind one (`socks5://proxy_ip:proxy_port`)
 - **proxy_params** (*Optional*): Proxy configuration parameters, as dict, if working behind a proxy (`username`, `password`, etc.)
-- **url** (*Optional*): Allow to overwrite the `base_url` from http component for diferent configs (`https://<public_url>:<port>`).
+- **url** (*Optional*): Allow to overwrite the `base_url` from the [`http`](/components/http/) component for different configurations (`https://<public_url>:<port>`).
 
 To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram). As well as authorising the chat, if you have added your bot to a group you will also need to authorise any user that will be interacting with the webhook. When an unauthorised user tries to interact with the webhook Home Assistant will raise an error ("Incoming message is not allowed"), you can easily obtain the the users id by looking in the "from" section of this error message.
 

--- a/source/_components/telegram_bot.webhooks.markdown
+++ b/source/_components/telegram_bot.webhooks.markdown
@@ -42,7 +42,7 @@ Configuration variables:
 - **parse_mode** (*Optional*): Default parser for messages if not explicit in message data: 'html' or 'markdown'. Default is 'markdown'.
 - **proxy_url** (*Optional*): Proxy url if working behind one (`socks5://proxy_ip:proxy_port`)
 - **proxy_params** (*Optional*): Proxy configuration parameters, as dict, if working behind a proxy (`username`, `password`, etc.)
-- **url** (*Optional*): Allow to overwrite the `base_url` from http component for diferent configs.
+- **url** (*Optional*): Allow to overwrite the `base_url` from http component for diferent configs (`https://<public_url>:<port>`).
 
 To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram). As well as authorising the chat, if you have added your bot to a group you will also need to authorise any user that will be interacting with the webhook. When an unauthorised user tries to interact with the webhook Home Assistant will raise an error ("Incoming message is not allowed"), you can easily obtain the the users id by looking in the "from" section of this error message.
 


### PR DESCRIPTION


**Description:**
An example structure for the url property has been added. To prevent the full url from being written base_url + /api/telegram_webhooks

https://github.com/home-assistant/home-assistant/issues/9459

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

