### PR TITLE
apostrophe correction

### DIFF
--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -37,7 +37,7 @@ Configuration variables:
   - **unit_of_measurement** (*Optional*): Defines the units of measurement of the sensor, if any.
   - **value_template** (*Required*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the event bus.
   - **icon_template** (*Optional*): Defines a [template](/topics/templating/) for the icon of the sensor.
-  - **entity_id** (*Optional*): Add a list of entity IDs so the sensor only reacts to state changes of these entities. This will reduce the number of times the sensor will try to update it's state.
+  - **entity_id** (*Optional*): Add a list of entity IDs so the sensor only reacts to state changes of these entities. This will reduce the number of times the sensor will try to update its state.
 
 
 ## {% linkable_title Examples %}


### PR DESCRIPTION
Never trust code that isn't described with grammatical accuracy.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

