### PR TITLE
IFTTT Maker service has been renamed to Webhooks

### DIFF
--- a/source/_components/ifttt.markdown
+++ b/source/_components/ifttt.markdown
@@ -52,7 +52,7 @@ When your screen looks like this, click the 'call service' button.
 
 ### {% linkable_title Setting up a recipe %}
 
-Press the *New applet* button and search for *Maker* .
+Press the *New applet* button and search for *Webhooks*.
 
 <p class='img'>
 <img src='/images/components/ifttt/setup_service.png' />


### PR DESCRIPTION

![setup_service](https://user-images.githubusercontent.com/31635854/30528759-f73e4566-9c70-11e7-86dc-b4e2200eb9ad.png)
**Description:**
IFTTT Maker service has been renamed to Webhooks.  Created new screenshot, and modified relevant paragraph.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

