### PR TITLE
Clarify docs of season sensor

### DIFF
--- a/source/_components/sensor.season.markdown
+++ b/source/_components/sensor.season.markdown
@@ -25,5 +25,9 @@ All information about how the seasons work was taken from Wikipedia:
 # Example configuration.yaml entry
 sensor:
   - platform: season
-    type: astronomical (optional, will default to astronomical)
+    type: astronomical
 ```
+
+Configuration variables:
+
+- **type** (*Optional*): Type of season definition. Options are `meteorological` or `astronomical`. Default is `astronomical`.


### PR DESCRIPTION
**Description:**
Just adding clearer documentation around the configuration variables for the season sensor. I had to peek at the code to know for sure what all the types were, so wanted to better document this. This brings this more inline with other component documentation as well.