### PR TITLE
typo in code example.

### DIFF
--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -158,7 +158,7 @@ group:
 ```yaml
 sensor:
   - platform: wunderground
-  - api_key: your_api_key
+    api_key: your_api_key
     monitored_conditions:
       - temp_high_record_c
       - temp_high_1d_c


### PR DESCRIPTION
**Description:**

Need to remove the dash in front of api_key in the second example.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

