### PR TITLE
Update ecobee.markdown

### DIFF
--- a/source/_components/ecobee.markdown
+++ b/source/_components/ecobee.markdown
@@ -55,7 +55,6 @@ ecobee:
 Configuration variables:
 
 - **api_key** (*Required*): Your ecobee API key. This is only needed for the initial setup of the component. Once registered it can be removed. If you revoke the key in the ecobee portal you will need to update this again and remove the ecobee.conf file in the `.homeassistant` configuration path.
-- **hold_temp** (*Optional*): True/False whether or not to hold changes indefinitely (True) or until the next scheduled event. Defaults to `False`.
 
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/ecobee-sensor-badges.png' />


### PR DESCRIPTION
**Description:**
removed hold_temp configuration variable. It is not used in the code since revision b732174def5894708e90c7d8708e971410a43afd
