### PR TITLE
clementine component does not support play_media

### DIFF
--- a/source/_components/media_player.clementine.markdown
+++ b/source/_components/media_player.clementine.markdown
@@ -40,3 +40,4 @@ You can configure this through Clementine  `Tools > Preferences > Network remote
 configuration menu. Enable `Use network remote control` and configure the other options
 for your use case.
 
+This component does not implement the play_media service so you cannot add tracks to the playlist.

--- a/source/_components/media_player.clementine.markdown
+++ b/source/_components/media_player.clementine.markdown
@@ -16,8 +16,7 @@ ha_iot_class: "Local Polling"
 
 The `clementine` platform allows you to control a [Clementine Music Player](https://www.clementine-player.org).
 
-To add a Clementine Player to your Home Assistant installation, add the following to
-your `configuration.yaml` file:
+To add a Clementine Player to your Home Assistant installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -33,11 +32,8 @@ Configuration variables:
 - **access_token** (*Optional*): The authorization code needed to connect.
 - **name** (*Optional*): The name you would like to give to the Clementine player. The default is "Clementine Remote".
 
-Remember that Clementine must be configured to accept connections through its
-network remote control protocol.
+Remember that Clementine must be configured to accept connections through its network remote control protocol.
 
-You can configure this through Clementine  `Tools > Preferences > Network remote control`
-configuration menu. Enable `Use network remote control` and configure the other options
-for your use case.
+You can configure this through Clementine  `Tools > Preferences > Network remote control` configuration menu. Enable `Use network remote control` and configure the other options for your use case.
 
-This component does not implement the play_media service so you cannot add tracks to the playlist.
+This component does not implement the `play_media` service so you cannot add tracks to the playlist.


### PR DESCRIPTION
If you use media_player.play_media with this component you get an exception so it seems best to note that it does not work before people get confused by the exception.

**Description:**
Clarify that media_player.play_media is not implemented.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

