### PR TITLE
Add documentation for OwnTracks over HTTP

### DIFF
--- a/source/_components/device_tracker.owntracks.markdown
+++ b/source/_components/device_tracker.owntracks.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: owntracks.png
 ha_category: Presence Detection
-featured: true
+featured: false
 ha_release: 0.7.4
 ---
 

--- a/source/_components/device_tracker.owntracks_http.markdown
+++ b/source/_components/device_tracker.owntracks_http.markdown
@@ -1,0 +1,36 @@
+---
+layout: page
+title: "OwnTracks (via HTTP)"
+description: "Instructions how to use Owntracks via HTTP to track devices in Home Assistant."
+date: 2017-09-28 07:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: owntracks.png
+ha_category: Presence Detection
+featured: true
+ha_release: 0.55
+---
+
+OwnTracks is a free and open source application that allows you to track your location in Home Assistant. This is a platform that supports OwnTracks via their HTTP publishing method.
+
+To integrate Owntracks tracking via HTTP in Home Assistant, add the following section to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+device_tracker:
+  - platform: owntracks_http
+```
+
+For configuration options and usage instructions, read the documentation for the [OwnTracks platform](/components/device_tracker.owntracks/).
+
+## {% linkable_title Configuring OwnTracks to submit data via HTTP %}
+
+Open OwnTracks and go to Connection preferences:
+
+ - Mode: Private HTTP
+ - Host: <Home Assistant url>/api/owntracks/<your name>/<device name>
+ - Identification: turn authentication on, username `homeassistant` and password is your API password that you use to login to Home Assistant.
+ 
+Host example: If I host my Home Assistant at `https://example.duckdns.org`, my name is Paulus and my phone is a Pixel I would set the host to be `https://example.duckdns.org/api/owntracks/paulus/pixel`. This will result in an entity with an ID of `device_tracker.paulus_pixel`. You can pick any name for the user and the device.


### PR DESCRIPTION
**Description:**
Add documentation for the OwnTracks over HTTP device tracker platform.

Also swaps out the featured platform from OwnTracks to be OwnTracks over HTTP as it's easier to configure (doesn't require MQTT).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/9582 (already merged)

