### PR TITLE
Clarifying numeric state trigger description

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -56,7 +56,7 @@ automation:
 ```
 
 ### {% linkable_title Numeric state trigger %}
-On state change of a specified entity, attempts to parse the state as a number and triggers if value is above and/or below a threshold.
+On state change of a specified entity, attempts to parse the state as a number and triggers once if value is changing from above to below a threshold, or from below to above the given threshold.
 
 ```yaml
 automation:


### PR DESCRIPTION
As discussed in the #zwave channel at the Discord Chat Server, the current description isn't clear about you need to have a higher, then a lower temperature, to trigger this event. This is important when trying if it works or not.

And it only triggers once, not on each value change.