### PR TITLE
Comment Line Fix

### DIFF
--- a/source/_components/script.markdown
+++ b/source/_components/script.markdown
@@ -33,7 +33,8 @@ The preferred way to separate words for better readability is to use underscore 
 </p>
 
 ```yaml
-  # Turns on the bedroom lights and then the living room lights 1 minute later
+  
+  # Turns on the bedroom lights and then the living room lights 1 minute later
   wakeup:
     alias: Wake Up
     sequence:

--- a/source/_components/script.markdown
+++ b/source/_components/script.markdown
@@ -11,11 +11,9 @@ logo: home-assistant.png
 ha_category: Automation
 ---
 
-The script component allows users to specify a sequence of actions to be executed by Home Assistant when turned on. The script component will create an entity for each script and allow them to be controlled via services.
+The `script` component allows users to specify a sequence of actions to be executed by Home Assistant when turned on. The script component will create an entity for each script and allow them to be controlled via services.
 
-The sequence of actions is specified using the [Home Assistant Script Syntax].
-
-[Home Assistant Script Syntax]: /getting-started/scripts/
+The sequence of actions is specified using the [Home Assistant Script Syntax](/getting-started/scripts/).
 
 ```yaml
 # Example configuration.yaml entry
@@ -33,7 +31,7 @@ The preferred way to separate words for better readability is to use underscore 
 </p>
 
 ```yaml
-  
+script: 
   # Turns on the bedroom lights and then the living room lights 1 minute later
   wakeup:
     alias: Wake Up
@@ -100,6 +98,7 @@ automation:
 ```
 
 Using the variables in the script requires the use of `data_template`:
+
 ```yaml
 # Example configuration.yaml entry
 script:


### PR DESCRIPTION
The commented line wasn't being displayed as a greyed out line, rather, it's red, and since the line truncates in the display, it looks like the word "later" is the first line in the script.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

