### PR TITLE
Apllication can *not* be installed

### DIFF
--- a/source/hassio/run_local.markdown
+++ b/source/hassio/run_local.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 ---
 
-Hass.io is a managed environment, which means that you can install applications that can be embedded into Home Assistant using the `command_line` sensor/switch.
+Hass.io is a managed environment, which means that you can't install applications that can be embedded into Home Assistant using the `command_line` sensor/switch.
 
 There are two options if you need to run a script to read data from a sensor or send commands to other devices on Hass.io.
 


### PR DESCRIPTION
If I'm not mistaken application can not be installed to be used with the command_line sensor. Documentation stated otherwise

