### PR TITLE
Router changed to Modbus device

### DIFF
--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -31,7 +31,7 @@ modbus:
 Configuration variables:
 
 - **type** (*Required*): Type of the connection to Modbus.
-- **host** (*Required*): The IP address of your router, eg. 192.168.1.1.
+- **host** (*Required*): The IP address of your Modbus device, eg. 192.168.1.1.
 - **port** (*Required*): The port for the communication.
 
 For a serial connection:


### PR DESCRIPTION
Changed wording of host description to better indicate the IP to be used is the Modbus device IP and not an internet router.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

