### PR TITLE
Added supported model to Panasonic Viera component page

### DIFF
--- a/source/_components/media_player.panasonic_viera.markdown
+++ b/source/_components/media_player.panasonic_viera.markdown
@@ -26,6 +26,7 @@ Currently known supported models:
 - TX-L42ET50
 - TX-P50GT60E
 - TX-65EXW784
+- TX-32AS520E
 
 If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.io).
 


### PR DESCRIPTION
**Description:**
Added compatible Panasonic Viera model to documentation

What works:

- Skipping forwards and backwards (Cannot stop due to missing pause button)
- Turning TV off
- Volume control

What does not:

- Cannot track media 
- Pausing content 
- Turning on TV using MAC

