### PR TITLE
switched username and host to Optional as per schema in netgear

### DIFF
--- a/source/_components/device_tracker.netgear.markdown
+++ b/source/_components/device_tracker.netgear.markdown
@@ -29,10 +29,10 @@ device_tracker:
 
 Configuration variables:
 
-- **host** (*Required*): The IP address of your router, e.g. `192.168.1.1`.
-- **username** (*Required*): The username of an user with administrative privileges, usually `admin`.
+- **host** (*Optional*): The IP address of your router, e.g. `192.168.1.1`. If not provided `routerlogin.net` will be used.
+- **username** (*Optional*): The username of an user with administrative privileges. If not provided `admin` will be used.
+- **port** (*Optional*): The port your router communicates with (defaults to `5000`, but `80` is also known to be used on some models).
 - **password** (*Required*): The password for your given admin account.
-- **port** (*Optional*): The port your router communicates with (defaults to 5000, but 80 is also known to be used on some models)
 
 List of models that are known to use port 80:
 - Nighthawk X4S - AC2600 (R7800)


### PR DESCRIPTION
**Description:**

I noticed that the schema provided in `device_tracker/netgear.py` platform specifies that `host`, `username` and `port` are optional:
```python
DEFAULT_HOST = 'routerlogin.net'
DEFAULT_USER = 'admin'
DEFAULT_PORT = 5000

PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
    vol.Optional(CONF_USERNAME, default=DEFAULT_USER): cv.string,
    vol.Required(CONF_PASSWORD): cv.string,
    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port
})
```
This PR updates documentation page so it matches the schema.

