### PR TITLE
Remove deprecated Tellstick script from documentation

### DIFF
--- a/source/_docs/installation/hassbian/customization.markdown
+++ b/source/_docs/installation/hassbian/customization.markdown
@@ -18,8 +18,7 @@ To allow you to customize your installation further, we have included a tool cal
  - Install Open Z-Wave-pip. Installs Python Open Z-Wave from a pip package. This is the quickest and recommended way of installing Z-Wave support but does not OZWCP pre-installed.
  - Install Open Z-Wave. Installs Python Open Z-Wave and OZWCP from git.
  - Install Samba. Allows anyone on your network to edit your configuration from any computer. This share is unsecured and it's usage is not recommended if you share your network with others.
- - Install Tellstick. Installs the Tellstick package for controlling and using a connected Tellstick.
- - Install Tradfri. Installs dependencies for using IKEA Trådfri.
+  - Install Tradfri. Installs dependencies for using IKEA Trådfri.
 
 The tool is available by running `hassbian-config`. To view the available packages run `hassbian-config show` and `sudo hassbian-config install PACKAGENAME`.
 For more information about this tool have a look at the [hassbian-scripts repository][hassbian-repo].

--- a/source/_docs/installation/hassbian/customization.markdown
+++ b/source/_docs/installation/hassbian/customization.markdown
@@ -18,7 +18,7 @@ To allow you to customize your installation further, we have included a tool cal
  - Install Open Z-Wave-pip. Installs Python Open Z-Wave from a pip package. This is the quickest and recommended way of installing Z-Wave support but does not OZWCP pre-installed.
  - Install Open Z-Wave. Installs Python Open Z-Wave and OZWCP from git.
  - Install Samba. Allows anyone on your network to edit your configuration from any computer. This share is unsecured and it's usage is not recommended if you share your network with others.
-  - Install Tradfri. Installs dependencies for using IKEA Trådfri.
+ - Install Tradfri. Installs dependencies for using IKEA Trådfri.
 
 The tool is available by running `hassbian-config`. To view the available packages run `hassbian-config show` and `sudo hassbian-config install PACKAGENAME`.
 For more information about this tool have a look at the [hassbian-scripts repository][hassbian-repo].


### PR DESCRIPTION
**Description:**
Install script for Tellstick was removed with Raspbian Stretch since dependencies are no longer available for install.

https://github.com/home-assistant/hassbian-scripts/issues/54
