### PR TITLE
Update counter.markdown

### DIFF
--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -70,7 +70,7 @@ Select <img src='/images/screenshots/developer-tool-services-icon.png' alt='serv
 
 ```json
 {
-  "entitiy": "counter.count0"
+  "entity": "counter.count0"
 }
 ```
 


### PR DESCRIPTION
**Description:**

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

Under "Use the service"

entity is misspelled to entitiy.

```
{
  "entitiy": "counter.count0"
}
```

should be:

```
{
  "entity": "counter.count0"
}
```