### PR TITLE
Update counter.markdown

### DIFF
--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -70,7 +70,7 @@ Select <img src='/images/screenshots/developer-tool-services-icon.png' alt='serv
 
 ```json
 {
-  "entity": "counter.count0"
+  "entity_id": "counter.count0"
 }
 ```
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

```json
{
  "entity": "counter.count0"
}
```

needs to be:

```json
{
  "entity_id": "counter.count0"
}
```

Note: I just recently sent in a pull request for a typo but I just noticed this issue also while I was trying to troubleshoot another user's issues with with the service trigger not working properly with JSON. I didn't intend on sending multiple requests on somewhat the same issue. I wasn't sure if I should've commented on the previous one or not so I went ahead and put in another one.

Here is the post I'm referring to:

https://community.home-assistant.io/t/counter-component-help/28735