### PR TITLE
Typo in JSON Call

### DIFF
--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -70,7 +70,7 @@ Select <img src='/images/screenshots/developer-tool-services-icon.png' alt='serv
 
 ```json
 {
-  "entitiy": "counter.count0"
+“entity_id”: “counter.coun0”
 }
 ```
 


### PR DESCRIPTION
Have replaced 
{
  "entitiy": "counter.count0"
}
with 

{
“entity_id”: “counter.count0”
}

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

