### PR TITLE
Added path-setting and Intertechno information

### DIFF
--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -14,9 +14,10 @@ featured: false
 ---
 
 
-The [Homematic](http://www.homematic.com/) component provides bi-directional communication with your CCU/Homegear. It uses a XML-RPC connection to set values on devices and subscribes to receive events the devices and the CCU emit.
+The [Homematic](http://www.homematic.com/) component provides bi-directional communication with your CCU/Homegear. It uses a XML-RPC connection to set values on devices and subscribes to receive events the devices and the CCU emit.  
+If you are using Homegear with paired [Intertechno](http://intertechno.at/) devices, uni-directional communication is possible as well.
 
-Device support is available for most of the wired and wireless devices, as well as a few IP devices. If you have a setup with mixed protocols, you have to configure additional hosts with the appropriate ports. The default is using port 2001, which are wireless devices. Wired devices usually are available through port 2000 and IP devices through port 2010.
+Device support is available for most of the wired and wireless devices, as well as a few IP devices. If you have a setup with mixed protocols, you have to configure additional hosts with the appropriate ports. The default is using port 2001, which are wireless devices. Wired devices usually are available through port 2000 and IP devices through port 2010. The virtual thermostatgroups the CCU provides use port 9292 __and__ require you to set the path-setting to `/groups`.
 
 If you want to see if a specific device you have is supported, head over to the [pyhomematic](https://github.com/danielperna84/pyhomematic/tree/master/pyhomematic/devicetypes) repository and browse through the source code. A dictionary with the device identifiers (e.g. HM-Sec-SC-2) can be found within the relevant modules near the bottom. If your device is not supported, feel free to contribute.
 
@@ -41,7 +42,7 @@ Configuration variables (global):
 Configuration variables (host):
 
 - **ip** (*Required*): IP address of CCU/Homegear device.
-- **port** (*Optional*): Port of CCU/Homegear XML-RPC Server. Default is 2001, use 2000 for wired and 2010 for IP.
+- **port** (*Optional*): Port of CCU/Homegear XML-RPC Server. Wireless: 2001, wired: 2000, IP: 2010, thermostatgroups: 9292.
 - **callback_ip** (*Optional*): Set this, if Home Assistant is reachable under a different IP from the CCU (NAT, Docker etc.).
 - **callback_port** (*Optional*): Set this, if Home Assistant is reachable under a different port from the CCU (NAT, Docker etc.).
 - **resolvenames** (*Optional*): [`metadata`, `json`, `xml`] Try to fetch device names. Defaults to `false` if not specified.
@@ -49,6 +50,7 @@ Configuration variables (host):
 - **password** (*Optional*): When fetching names via JSON-RPC, you need to specify the password of the user you have configured above.
 - **primary** (*Optional*): Set to `true` when using multiple hosts and this host should provide the services and variables.
 - **variables** (*Optional*): Set to `true` if you want to use CCU2/Homegear variables. Should only be enabled for the primary host. When using a CCU credentials are required.
+- **path** (*Optional*): Set to `/groups` when using port 9292.
 
 #### Example configuration with multiple protocols and some other options set:
 
@@ -71,6 +73,13 @@ homematic:
     ip:
       ip: 127.0.0.1
       port: 2010
+    groups:
+      ip: 127.0.0.1
+      port: 9292
+      resolvenames: json
+      username: Admin
+      password: secret
+      path: /groups
 ```
 
 ### {% linkable_title The `resolvenames` option %}

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -17,7 +17,7 @@ featured: false
 The [Homematic](http://www.homematic.com/) component provides bi-directional communication with your CCU/Homegear. It uses a XML-RPC connection to set values on devices and subscribes to receive events the devices and the CCU emit.  
 If you are using Homegear with paired [Intertechno](http://intertechno.at/) devices, uni-directional communication is possible as well.
 
-Device support is available for most of the wired and wireless devices, as well as a few IP devices. If you have a setup with mixed protocols, you have to configure additional hosts with the appropriate ports. The default is using port 2001, which are wireless devices. Wired devices usually are available through port 2000 and IP devices through port 2010. The virtual thermostatgroups the CCU provides use port 9292 __and__ require you to set the path-setting to `/groups`.
+Device support is available for most of the wired and wireless devices, as well as a few IP devices. If you have a setup with mixed protocols, you have to configure additional hosts with the appropriate ports. The default is using port 2001, which are wireless devices. Wired devices usually are available through port 2000 and IP devices through port 2010. The virtual thermostatgroups the CCU provides use port 9292 **and** require you to set the `path` setting to `/groups`.
 
 If you want to see if a specific device you have is supported, head over to the [pyhomematic](https://github.com/danielperna84/pyhomematic/tree/master/pyhomematic/devicetypes) repository and browse through the source code. A dictionary with the device identifiers (e.g. HM-Sec-SC-2) can be found within the relevant modules near the bottom. If your device is not supported, feel free to contribute.
 


### PR DESCRIPTION
**Description:**
https://github.com/home-assistant/home-assistant/pull/9707 adds support for the optional path-setting, which is required to use thermostatgroups. Also simple Intertechnoe switches are now supported when using Homegear as the XML-RPC backend.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9707

