### PR TITLE
Add libssl dependency to recorder.markdown

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -109,14 +109,14 @@ Not all Python bindings for the chosen database engine can be installed directly
 For MariaDB you may have to install a few dependencies. On the Python side we use the `mysqlclient`:
 
 ```bash
-$ sudo apt-get install libmariadbclient-dev
+$ sudo apt-get install libmariadbclient-dev libssl-dev
 $ pip3 install mysqlclient
 ```
 
 For MySQL you may have to install a few dependencies. You can choose between `pymysql` and `mysqlclient`:
 
 ```bash
-$ sudo apt-get install default-libmysqlclient-dev
+$ sudo apt-get install default-libmysqlclient-dev libssl-dev
 $ pip3 install mysqlclient
 ```
 


### PR DESCRIPTION
**Description:**
The libssl-dev is a hard dependency for mysqlclient package, otherwise `pip3 install mysqlclient` fails with 
```
    /usr/bin/ld: cannot find -lssl
    /usr/bin/ld: cannot find -lcrypto
    collect2: error: ld returned 1 exit status
    error: command 'arm-linux-gnueabihf-gcc' failed with exit status 1
```

It should be documented as less experienced users won't be able to install mysqlclient on their machines

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

