### PR TITLE
arlo: Documentation for alarm control panel

### DIFF
--- a/source/_components/alarm_control_panel.arlo.markdown
+++ b/source/_components/alarm_control_panel.arlo.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: arlo.png
 ha_category: Alarm
-ha_release: 0.55
+ha_release: 0.56
 ha_iot_class: "Cloud Polling"
 ---
 

--- a/source/_components/alarm_control_panel.arlo.markdown
+++ b/source/_components/alarm_control_panel.arlo.markdown
@@ -1,0 +1,31 @@
+---
+layout: page
+title: "Arlo Control Panel"
+description: "Instructions how to setup the Netgear Arlo Base Stations as a control panel within Home Assistant."
+date: 2017-10-05 17:45
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: arlo.png
+ha_category: Alarm
+ha_release: 0.55
+ha_iot_class: "Cloud Polling"
+---
+
+
+The `arlo` control panel platform allows you to control your [Arlo](https://arlo.netgear.com/) base stations.
+
+To get your [Arlo](https://arlo.netgear.com/) base stations working within Home Assistant, please follow the instructions for the general [Arlo component](/components/arlo).
+
+Once you have enabled the [Arlo component](/components/arlo), add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+alarm_control_panel:
+  - platform: arlo
+```
+
+Configuration variables:
+
+- **home_mode_name**: (*Optional*): Arlo base station does not have a built-in home mode. You can map one of your custom modes to home assistant's home mode by setting the name of the custom mode in this configuration variable. The name of the custom mode should match exactly as you set it up in the Arlo app.

--- a/source/_components/arlo.markdown
+++ b/source/_components/arlo.markdown
@@ -31,7 +31,7 @@ Configuration variables:
 
 It is recommended to create a dedicated user on Arlo website to be used within Home Assistant and then share your Arlo cameras.
 
-Finish its configuration by visiting the [Arlo sensor page](/components/sensor.arlo/) or [Arlo camera page](/components/camera.arlo/).
+Finish its configuration by visiting the [Arlo sensor page](/components/sensor.arlo/) or [Arlo camera page](/components/camera.arlo/) or [Arlo control panel page](/components/alarm_control_panel.arlo/).
 
 The Arlo component also provides a service to enable/disable the motion detection sensor. The example below enables the motion detection every time the Home Assistant service starts.
 


### PR DESCRIPTION
**Description:**

Arlo base station exposed as an alarm control panel component in
HA.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):**

https://github.com/home-assistant/home-assistant/pull/9711