### PR TITLE
Extend risks in using YAMLLint and alternative

### DIFF
--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -30,7 +30,7 @@ The basics of YAML syntax are block collections and mappings containing key-valu
 
 Note that indentation (just like in Python) is an important part of specifying relationships using YAML. Things that are indented are nested "inside" things that are one level higher. So in the above example, `platform: pushbullet` is a property of (nested inside) the `notify` component.
 Getting the right indentation can be tricky if you're not using an editor with a fixed width font. Tabs are not allowed to be used for indentation. Convention is to use 2 spaces for each level of indentation.
-You can use the online service [YAMLLint](http://www.yamllint.com/) to check if your YAML-syntax is correct before loading it into Home Assistant which will save you some time. If you do so, be aware that this is a 3rd-party service and is not maintained by the Home Assistant community. *Please pay attention on not putting in private data.*
+You can use the online service [YAMLLint](http://www.yamllint.com/) to check if your YAML-syntax is correct before loading it into Home Assistant which will save you some time. If you do so, be aware that this is a 3rd-party service and is not maintained by the Home Assistant community. *Please pay attention on not storing private data (passwords, api-keys, etc.) directly in that file.* 
 
 Text following a `#` are comments and are ignored by the system.
 

--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -31,6 +31,7 @@ The basics of YAML syntax are block collections and mappings containing key-valu
 Note that indentation (just like in Python) is an important part of specifying relationships using YAML. Things that are indented are nested "inside" things that are one level higher. So in the above example, `platform: pushbullet` is a property of (nested inside) the `notify` component.
 Getting the right indentation can be tricky if you're not using an editor with a fixed width font. Tabs are not allowed to be used for indentation. Convention is to use 2 spaces for each level of indentation.
 You can use the online service [YAMLLint](http://www.yamllint.com/) to check if your YAML-syntax is correct before loading it into Home Assistant which will save you some time. If you do so, be aware that this is a 3rd-party service and is not maintained by the Home Assistant community. *Please pay attention on not storing private data (passwords, api-keys, etc.) directly in that file.*
+Private data can be stored in environmental variables, which circumvents this problem of security.
 
 Text following a `#` are comments and are ignored by the system.
 

--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -30,8 +30,8 @@ The basics of YAML syntax are block collections and mappings containing key-valu
 
 Note that indentation (just like in Python) is an important part of specifying relationships using YAML. Things that are indented are nested "inside" things that are one level higher. So in the above example, `platform: pushbullet` is a property of (nested inside) the `notify` component.
 Getting the right indentation can be tricky if you're not using an editor with a fixed width font. Tabs are not allowed to be used for indentation. Convention is to use 2 spaces for each level of indentation.
-You can use the online service [YAMLLint](http://www.yamllint.com/) to check if your YAML-syntax is correct before loading it into Home Assistant which will save you some time. If you do so, be aware that this is a 3rd-party service and is not maintained by the Home Assistant community. *Please pay attention on not storing private data (passwords, api-keys, etc.) directly in that file.*
-Private data can be stored in environmental variables, which circumvents this problem of security.
+You can use the online service [YAMLLint](http://www.yamllint.com/) to check if your YAML syntax is correct before loading it into Home Assistant which will save you some time. If you do so, be aware that this is a third-party service and is not maintained by the Home Assistant community. *Please pay attention on not storing private data (passwords, api-keys, etc.) directly in that file.*
+Private data can be stored in a [seperate file](/docs/configuration/secrets/) or in [environmental variables](/docs/configuration/yaml/#using-environment-variables), which circumvents this problem of security.
 
 Text following a `#` are comments and are ignored by the system.
 

--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -30,8 +30,7 @@ The basics of YAML syntax are block collections and mappings containing key-valu
 
 Note that indentation (just like in Python) is an important part of specifying relationships using YAML. Things that are indented are nested "inside" things that are one level higher. So in the above example, `platform: pushbullet` is a property of (nested inside) the `notify` component.
 Getting the right indentation can be tricky if you're not using an editor with a fixed width font. Tabs are not allowed to be used for indentation. Convention is to use 2 spaces for each level of indentation.
-You can use [YAMLLint](http://www.yamllint.com/) to check if your YAML-syntax is correct before loading it into Home Assistant which will save you some time.
-*Please pay attention on not putting in private data, as it is a 3rd-party website not maintained by Home Assistant.*
+You can use the online service [YAMLLint](http://www.yamllint.com/) to check if your YAML-syntax is correct before loading it into Home Assistant which will save you some time. If you do so, be aware that this is a 3rd-party service and is not maintained by the Home Assistant community. *Please pay attention on not putting in private data.*
 
 Text following a `#` are comments and are ignored by the system.
 

--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -30,7 +30,7 @@ The basics of YAML syntax are block collections and mappings containing key-valu
 
 Note that indentation (just like in Python) is an important part of specifying relationships using YAML. Things that are indented are nested "inside" things that are one level higher. So in the above example, `platform: pushbullet` is a property of (nested inside) the `notify` component.
 Getting the right indentation can be tricky if you're not using an editor with a fixed width font. Tabs are not allowed to be used for indentation. Convention is to use 2 spaces for each level of indentation.
-You can use the online service [YAMLLint](http://www.yamllint.com/) to check if your YAML-syntax is correct before loading it into Home Assistant which will save you some time. If you do so, be aware that this is a 3rd-party service and is not maintained by the Home Assistant community. *Please pay attention on not storing private data (passwords, api-keys, etc.) directly in that file.* 
+You can use the online service [YAMLLint](http://www.yamllint.com/) to check if your YAML-syntax is correct before loading it into Home Assistant which will save you some time. If you do so, be aware that this is a 3rd-party service and is not maintained by the Home Assistant community. *Please pay attention on not storing private data (passwords, api-keys, etc.) directly in that file.*
 
 Text following a `#` are comments and are ignored by the system.
 


### PR DESCRIPTION
Elaborate on "to be careful", when using YAMLLint, with regards to private data (password, API keys, etc.). 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>
