### PR TITLE
Update automatic docs with example vehicle ID

### DIFF
--- a/source/_components/device_tracker.automatic.markdown
+++ b/source/_components/device_tracker.automatic.markdown
@@ -51,6 +51,8 @@ automation:
         event_type: automatic_update
         event_data:
           type: "ignition:on"
+          vehicle:
+            id: "C_1234567890abcdefc"
     action:
       - service: light.turn_off
 ```


### PR DESCRIPTION
**Description:**
Update the automatic docs with an example of vehicle ID filtering.

I feels like overkill to me to call this out specifically on the Automation Trigger page, as it's something I'd expect to Just Work. I can add it there though if we'd like.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9732

