### PR TITLE
Fix setup documentation link leading to 404

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ This is the source for the [Home-Assistant.io website](https://home-assistant.io
 
 ## Setup
 
-Setting up to contribute to documentation and the process for submitting pull requests is [explained here](https://home-assistant.io/developers/website/).
+Setting up to contribute to documentation and the process for submitting pull requests is [explained here](https://home-assistant.io/developers/documentation/).
 
 ## Site preview
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

