### PR TITLE
Typo Fix: Alexa Documentation

### DIFF
--- a/source/_components/alexa.markdown
+++ b/source/_components/alexa.markdown
@@ -101,7 +101,7 @@ This means that we can now ask Alexa things like:
 
 When activated, the Alexa component will have Home Assistant's native intent support handle the incoming intents. If you want to run actions based on intents, use the [`intent_script`](/components/intent_script) component.
 
-To enable Alex add the following entry to your `configuration.yaml` file:
+To enable Alexa add the following entry to your `configuration.yaml` file:
 
 ```yaml
 alexa:


### PR DESCRIPTION
**Description:**
Just a simple typo fix in the documentation for Alexa integration.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

