### PR TITLE
device_tracker.mqtt configuration.yaml is wrong

### DIFF
--- a/source/_components/device_tracker.mqtt.markdown
+++ b/source/_components/device_tracker.mqtt.markdown
@@ -22,8 +22,8 @@ To use this device tracker in your installation, add the following to your `conf
 device_tracker:
   - platform: mqtt
     devices:
-      paulus_oneplus: /location/paulus
-      annetherese_n4: /location/annetherese
+      paulus_oneplus: 'location/paulus'
+      annetherese_n4: 'location/annetherese'
 ```
 
 Configuration variables:


### PR DESCRIPTION
The topic to be looked up must be in quotes for the example to work.

**Description:**
The current documentation's example does not wrong. By putting the topic in quotes the mqtt device tracker actually does work.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

