### PR TITLE
Modbus binary sensor scan_interval clarify.

### DIFF
--- a/source/_components/binary_sensor.modbus.markdown
+++ b/source/_components/binary_sensor.modbus.markdown
@@ -36,3 +36,22 @@ Configuration variables:
   - **name** (*Required*): Name of the sensor.
   - **slave** (*Required*): The number of the slave (Optional for TCP and UDP Modbus).
   - **coil** (*Required*): Coil number.
+  
+It's possible to change the default 30 seconds scan interval for the sensor updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.
+
+### {% linkable_title Full example %}
+
+Example a sensor with a 10 seconds scan interval:
+
+```yaml
+binary_sensor:
+  - platform: modbus
+    scan_interval: 10
+    coils:
+      - name: Sensor1
+        slave: 1
+        coil: 100
+      - name: Sensor2
+        slave: 1
+        coil: 110
+```


### PR DESCRIPTION
**Description:**

Alignment documentation along the same lines as modbus sensor.