### PR TITLE
Added component page for map

### DIFF
--- a/source/_components/map.markdown
+++ b/source/_components/map.markdown
@@ -1,0 +1,19 @@
+---
+layout: page
+title: "Map"
+description: "Offers a map to show tracked devices."
+date: 2017-10-11 10:01
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: home-assistant.png
+ha_category: "Other"
+---
+
+This offers a map on the frontend to display the location of tracked devices. To set up tracked devices, look at the [device tracker](/components/device_tracker/) documentation.
+
+```yaml
+# Example configuration.yaml entry
+map:
+```


### PR DESCRIPTION
**Description:**
Adds a page to the docs for the `map` component, since it has been extracted out.

I was not able to get this page to show up on my local dev copy when running `rake generate` or `rake preview` so I'm not sure if there is something else that needs to be done or another file that needs updated? Based on other PRs that have added new pages it looks like I should just need to create this page.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9814

