### PR TITLE
minor change to make instructions clear

### DIFF
--- a/source/_components/media_player.vizio.markdown
+++ b/source/_components/media_player.vizio.markdown
@@ -20,15 +20,18 @@ The `vizio` component will allow you to control [SmartCast](https://www.vizio.co
 
 Before adding your TV to Home Assistant you'll need to pair it manually. To do so follow these steps:
 
-Install the command-line tool using pip (or you can choose to download it manually):
+Install the command-line tool using `pip` (or you can choose to download it manually):
 
 ```bash
 $ pip3 install git+https://github.com/vkorn/pyvizio.git@master
 ```
+
 or
+
 ```bash
 $ pip3 install -I .
 ```
+
 Make sure that your TV is on before continuing.
 
 If you don't know IP address of your TV run following command:

--- a/source/_components/media_player.vizio.markdown
+++ b/source/_components/media_player.vizio.markdown
@@ -24,9 +24,11 @@ Install the command-line tool using pip (or you can choose to download it manual
 
 ```bash
 $ pip3 install git+https://github.com/vkorn/pyvizio.git@master
+```
+or
+```bash
 $ pip3 install -I .
 ```
-
 Make sure that your TV is on before continuing.
 
 If you don't know IP address of your TV run following command:


### PR DESCRIPTION
change to make it clear there are two ways to install pyvizio rather than two steps.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

