### PR TITLE
Script - wait_template 'trigger.entity_id' support

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -90,6 +90,30 @@ wait_template: {% raw %}"{{ states.climate.kitchen.attributes.valve < 10 }}"{% e
 timeout: 00:01:00
 ```
 
+When using `wait_template` within an automation `trigger.entity_id` is supported for `state`, `numeric_state` and `template` triggers, see also [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data).
+
+{% raw %}
+```yaml
+# Important: Note the whitespace before and after `trigger.entity_id`.
+wait_template: "{{ is_state( trigger.entity_id , 'on') }}"
+```
+{% endraw %}
+
+It is also possible to use dummy variables, e.g. in scripts, when using `wait_template`.
+
+{% raw %}
+```yaml
+# Service call, e.g. from an automation.
+service: script.do_something
+data_template:
+  dummy: "{{ input_boolean.switch }}"
+
+# Inside the script
+# Important: Note the whitespace before and after `dummy`.
+wait_template: "{{ is_state( dummy , 'off') }}"
+```
+{% endraw %}
+
 ### {% linkable_title Fire an Event %}
 
 This action allows you to fire an event. Events can be used for many things. It could trigger an automation or indicate to another component that something is happening. For instance, in the below example it is used to create an entry in the logbook.

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -94,8 +94,7 @@ When using `wait_template` within an automation `trigger.entity_id` is supported
 
 {% raw %}
 ```yaml
-# Important: Note the whitespace before and after `trigger.entity_id`.
-wait_template: "{{ is_state( trigger.entity_id , 'on') }}"
+wait_template: "{{ is_state(trigger.entity_id, 'on') }}"
 ```
 {% endraw %}
 
@@ -109,8 +108,7 @@ data_template:
   dummy: "{{ input_boolean.switch }}"
 
 # Inside the script
-# Important: Note the whitespace before and after `dummy`.
-wait_template: "{{ is_state( dummy , 'off') }}"
+wait_template: "{{ is_state(dummy, 'off') }}"
 ```
 {% endraw %}
 

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -98,7 +98,7 @@ wait_template: "{{ is_state(trigger.entity_id, 'on') }}"
 ```
 {% endraw %}
 
-It is also possible to use dummy variables, e.g. in scripts, when using `wait_template`.
+It is also possible to use dummy variables, e.g., in scripts, when using `wait_template`.
 
 {% raw %}
 ```yaml


### PR DESCRIPTION
**Description:**
Added `trigger.entity_id` and `variables` support for wait_template

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#9807

