### PR TITLE
add alternative command

### DIFF
--- a/source/hassio/zwave.markdown
+++ b/source/hassio/zwave.markdown
@@ -26,6 +26,13 @@ So you need explicit set this device for mapping to Home-Assistant. Execute this
 ```bash
 $ curl -d '{"devices": ["ttyAMA0"]}' http://hassio/homeassistant/options
 ```
+<p class='note'>
+  if you have set dns localname "hassio.example.local" or "hassio" is resolving to a local address use the below command instead :
+ ```bash
+$ curl -d ‘{“devices”: [“ttyAMA0”]}’ http://172.17.0.2/homeassistant/options
+```
+</p>
+
 After that, you need change `usb_path` to `/dev/ttyAMA0`.
 
 ### HUSBZB-1:


### PR DESCRIPTION

**Description:**
if you have set dns local-name "hassio.example.local" or "hassio" is resolving to a local address like 192.x.x.x or 172.x.x.x or 10.x.x.x.x the command give strange results. alternatively the 172.17.0.2 command has fix the problem.



**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

