### PR TITLE
Add Hass.io log location

### DIFF
--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -68,8 +68,16 @@ data:
   homeassistant.components.media_player.yamaha: debug
 ```
 
-The log information are stored in the [configuration directory](/docs/configuration/) as `home-assistant.log` and you can read it with the command-line tool `cat` or follow it dynamically with `tail -f`. If you are a Hassbian user you can use the example below:
+The log information are stored in the [configuration directory](/docs/configuration/) as `home-assistant.log` and you can read it with the command-line tool `cat` or follow it dynamically with `tail -f`. 
+
+If you are a Hassbian user you can use the example below:
 
 ```bash
 $ tail -f /home/homeassistant/.homeassistant/home-assistant.log
+```
+
+If you are a Hass.io user you can use the example below, whenlogged in through the ssh addon:
+
+```bash
+$ tail -f /config/home-assistant.log
 ```


### PR DESCRIPTION
**Description:**

To aid debugging Hass.io logs
