### PR TITLE
Update alarmdecoder.markdown

### DIFF
--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -50,6 +50,6 @@ Configuration variables:
 - **host** (*Optional*): The IP address of the AlarmDecoder device on your home network, if using socket type. Default: `localhost`
 - **port** (*Optional*): The port of the AlarmDecoder device on your home network, if using socket type. Default: `10000`
 - **path** (*Optional*): The path of the AlarmDecoder device, if using socket type. Default: `/dev/ttyUSB0`
-- **baud** (*Optional*): The baud rate of the AlarmDecoder device, if using serial type. Default: `115200`
+- **baudrate** (*Optional*): The baud rate of the AlarmDecoder device, if using serial type. Default: `115200`
 - **panel_display** (*Optional*): Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
 - **zones** (*Optional*): AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.*


### PR DESCRIPTION
Corrected configuration variable baud, as the schema expects 'baudrate' instead of 'baud'

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

