### PR TITLE
Add http_rgb platform

### DIFF
--- a/source/_components/light.http_rgb.markdown
+++ b/source/_components/light.http_rgb.markdown
@@ -9,10 +9,10 @@ sharing: true
 footer: true
 ha_category: Light
 ha_iot_class: "Local Polling"
-ha_release: 0.55
+ha_release: 0.56
 ---
 
-The `http_rgb` light platform lets you control lights that use a simple [HTTP API protocol](git@github.com:robhowlett/http-rgb).
+The `http_rgb` light platform lets you control lights that use a simple [HTTP API protocol](https://github.com/robhowlett/http_rgb/README.md).
 
 To enable `http_rgb` in your installation, add the following to your `configuration.yaml` file:
 
@@ -23,7 +23,13 @@ light:
     host: IP_ADDRESS
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address of the device the Hyperion service is running on.
-- **name** (*Optional*): The name of the device used in the frontend.
+{% configuration %}
+  host:
+    description: The IP address of the device you're controlling.
+    required: true
+    type: string
+  name:
+    description: Name to use in the frontend.
+    required: false
+    type: string
+{% endconfiguration %}

--- a/source/_components/light.http_rgb.markdown
+++ b/source/_components/light.http_rgb.markdown
@@ -12,7 +12,7 @@ ha_iot_class: "Local Polling"
 ha_release: 0.56
 ---
 
-The `http_rgb` light platform lets you control lights that use a simple [HTTP API protocol](https://github.com/robhowlett/http_rgb/README.md).
+The `http_rgb` light platform lets you control lights that use a simple [HTTP API protocol](https://github.com/robhowlett/http_rgb/blob/master/README.md#protocol).
 
 To enable `http_rgb` in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/light.http_rgb.markdown
+++ b/source/_components/light.http_rgb.markdown
@@ -1,0 +1,29 @@
+---
+layout: page
+title: "http_rgb"
+description: "Instructions how to setup http_rgb lights within Home Assistant."
+date: 2017-10-13 14:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Light
+ha_iot_class: "Local Polling"
+ha_release: 0.55
+---
+
+The `http_rgb` light platform lets you control lights that use a simple [HTTP API protocol](git@github.com:robhowlett/http-rgb).
+
+To enable `http_rgb` in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+light:
+  - platform: http_rgb
+    host: IP_ADDRESS
+```
+
+Configuration variables:
+
+- **host** (*Required*): The IP address of the device the Hyperion service is running on.
+- **name** (*Optional*): The name of the device used in the frontend.


### PR DESCRIPTION
**Description:**

Add support for hobby lights using simple HTTP API

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9849

