### PR TITLE
Add UV Index documentation

### DIFF
--- a/source/_components/sensor.darksky.markdown
+++ b/source/_components/sensor.darksky.markdown
@@ -66,6 +66,7 @@ Configuration variables:
   - **apparent_temperature_max**: Today's expected apparent high temperature.
   - **apparent_temperature_min**: Today's expected apparent low temperature.
   - **precip_intensity_max**: Today's expected maximum intensity of precipitation.
+  - **uv_index**: The current UV index.
 - **units** (*Optional*): Specify the unit system. Default to `si` or `us` based on the temperature preference in Home Assistant. Other options are `auto`, `us`, `si`, `ca`, and `uk2`.
 `auto` will let Dark Sky decide the unit system based on location.
 - **update_interval** (*Optional*): Minimum time interval between updates. Default is 2 minutes. Supported formats:


### PR DESCRIPTION
Added support for UV Index condition.

**Description:**
Added UV Index monitored condition as part of work done to add that functionality to HASS.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9851

