### PR TITLE
Decrease size of search bar and remove outline

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -23,13 +23,14 @@ $primary-color: #049cdb;
     float: right;
 
     .algolia-autocomplete {
-      width: calc(100% - 58px);
+      width: calc(100% - 64px);
       margin: 0 10px;
     }
 
     input {
       border: 0;
       width: 100%;
+      outline: none;
     }
   }
 }


### PR DESCRIPTION
**Description:**
This ensures that the close button stays in the first line, and doesn't get pushed below the search icon.
