### PR TITLE
Add Groups definition to glossary

### DIFF
--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -14,4 +14,5 @@
   description: "Often used abbreviation for Home Assistant."
 - topic: Discovery
   description: The automatic setup of zeroconf/mDNS and uPnP devices after they are discovered.
-
+- topic: Groups
+  description: "Groups are a way to organize your entities into a group."


### PR DESCRIPTION
A [Hacktoberfest](https://hacktoberfest.digitalocean.com/) contribution to the glossary as referenced in issue #3612.

Based on my reading this should be merged to the `current` branch, but if it should go to another branch please let me know.