### PR TITLE
Added quote marks around target phone number in documentation for notify.facebook component

### DIFF
--- a/source/_components/notify.facebook.markdown
+++ b/source/_components/notify.facebook.markdown
@@ -46,8 +46,8 @@ automation:
       data:
         message: 'Good Evening'
         target:
-          - +919413017584
-          - +919784516314
+          - '+919413017584'
+          - '+919784516314'
 ```
 
 You can also send messages to users that do not have stored their phone number with Facebook, but this requires a bit more work. The Messenger platform uses page specific user IDs instead of a global user ID. You will need to enable a webhook for the "messages" event in Facebook's developer console. Once a user writes a message to a page, that webhook will then receive the user's page specifc ID as part of the webhook's payload. Below is a simple PHP script that reacts to the message "get my id" and sends a reply containing the user's ID: 


### PR DESCRIPTION
The notification will not work if the target phone number is not quoted.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

