### PR TITLE
xiaomi gateway setup tip

### DIFF
--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -154,6 +154,10 @@ and stops the sound when the button is pressed once.
 
 ## {% linkable_title Troubleshooting %}
 
+### {% linkable_title Initial setup problem %}
+
+If you run into trouble initializing the gateway with your app, try another smartphone. I had trouble with the OnePlus 3, but it worked with a Nexus 5.
+
 ### {% linkable_title Connection problem %}
 
 ```bash


### PR DESCRIPTION
Initializing the Xiaomi Home app with the OnePlus 3 failed. Trying the Nexus 5 helped.
