### PR TITLE
Update .travis.yml example

### DIFF
--- a/source/_docs/ecosystem/backup/backup_github.markdown
+++ b/source/_docs/ecosystem/backup/backup_github.markdown
@@ -141,7 +141,7 @@ Example .travis.yml
 ```yaml
 language: python
 python:
-  - "3.4"
+  - "3.5"
 before_install:
   - mv travis_secrets.yaml secrets.yaml
 install:


### PR DESCRIPTION
I have updated the `.travis.yml` example to test against Python 3.5 now that Python 3.4 support is deprecated. 