### PR TITLE
Mqtt_Room: Update to reflect change in away state tag

### DIFF
--- a/source/_components/sensor.mqtt_room.markdown
+++ b/source/_components/sensor.mqtt_room.markdown
@@ -35,7 +35,7 @@ Configuration variables:
 - **name** (*Optional*): The name of the sensor.
 - **state_topic** (*Optional*): The topic that contains all subtopics for the rooms.
 - **timeout** (*Optional*): The time in seconds after which a room presence state is considered old. An example: device1 is reported at scanner1 with a distance of 1. No further updates are sent from scanner1. After 5 seconds scanner2 reports device1 with a distance of 2. The old location info is discarded in favor of the new scanner2 information as the timeout has passed.
-- **away_timeout** (*Optional*): The time in seconds after which the state should be set to `away` if there were no updates. `0` disables the check and is the default.
+- **away_timeout** (*Optional*): The time in seconds after which the state should be set to `not_home` if there were no updates. `0` disables the check and is the default.
 
 Example JSON that should be published to the room topics:
 


### PR DESCRIPTION
**Description:**
Minor update to docs to reflect changing the away state of mqtt_room from "away" to "not_home".

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#9884
