### PR TITLE
Add doc for new changed_by attribute

### DIFF
--- a/source/_components/alarm_control_panel.spc.markdown
+++ b/source/_components/alarm_control_panel.spc.markdown
@@ -18,3 +18,19 @@ The `spc` alarm control panel platform allows you to control your [Vanderbilt SP
 
 The requirement is that you have setup your [SPC hub](/components/spc/).
 
+The `changed_by` attribute enables one to be able to take different actions depending on who armed/disarmed the alarm in [automation](/getting-started/automation/).
+
+```yaml
+automation:
+  - alias: Alarm status changed
+    trigger:
+      - platform: state
+        entity_id: alarm_control_panel.alarm_1
+    action:
+      - service: notify.notify
+        data_template:
+          message: >
+            {% raw %}Alarm changed from {{ trigger.from_state.state }}
+            to {{ trigger.to_state.state }}
+            by {{ trigger.to_state.attributes.changed_by }}{% endraw %}
+```


### PR DESCRIPTION
**Description:**
New attribute added that shows who last armed/unarmed the alarm. C.f. Verisure alarm component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

