### PR TITLE
Installation of python_openzwave on OSX

### DIFF
--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -25,7 +25,7 @@ There is one dependency you will need to have installed ahead of time (included 
 ```bash
 $ sudo apt-get install libudev-dev
 ```
-When installing on OS X you may have to also run the command below ahead of time, replace "x.x" with the version of Python you have installed. 
+When installing on macOS you may have to also run the command below ahead of time, replace "x.x" with the version of Python you have installed. 
 
 ```bash
 sudo /Applications/Python\ x.x/Install\ Certificates.command

--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -25,6 +25,11 @@ There is one dependency you will need to have installed ahead of time (included 
 ```bash
 $ sudo apt-get install libudev-dev
 ```
+When installing on OS X you may have to also run the command below ahead of time, replace "x.x" with the version of Python you have installed. 
+
+```bash
+sudo /Applications/Python\ x.x/Install\ Certificates.command
+```
 
 ### {% linkable_title Configuration %}
 


### PR DESCRIPTION
Add command needed for installation of python_openzwave on OSX to work. 
See https://github.com/home-assistant/home-assistant.github.io/issues/3653

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

