### PR TITLE
Update switch.rpi_gpio.markdown

### DIFF
--- a/source/_components/switch.rpi_gpio.markdown
+++ b/source/_components/switch.rpi_gpio.markdown
@@ -30,8 +30,20 @@ switch:
 Configuration variables:
 
 - **ports** array (*Required*): Array of used ports.
-  - **port: name** (*Required*): Port numbers and corresponding names.
+  - **port: name** (*Required*): Port numbers and corresponding names (GPIO #).
 - **invert_logic** (*Optional*): If true, inverts the output logic to ACTIVE LOW. Default is false (ACTIVE HIGH).
 
 For more details about the GPIO layout, visit the Wikipedia [article](https://en.wikipedia.org/wiki/Raspberry_Pi#GPIO_connector) about the Raspberry Pi.
+
+A common question is what does Port refer to, this number is the actual GPIO # not the pin #.
+For example, if you have a relay connected to pin 11 its GPIO # is 17.
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: rpi_gpio
+    ports:
+      17: Speaker Relay
+```
+
 


### PR DESCRIPTION
I found the current documentation confusing as it did not clearly state whether the code is look at the pin # or GPIO #. Looking on the forums others were having the same issue. My goal is to make it clear that GPIO # is what users should be entering into their configs.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

