### PR TITLE
Specify that RPC Shutdown is only for Windows computers

### DIFF
--- a/source/_addons/rpc_shutdown.markdown
+++ b/source/_addons/rpc_shutdown.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 ---
 
-Allow to shutdown a Windows computer with a service call from Home-Assistant.
+Allow to shutdown a Windows computer with a service call from Home Assistant.
 
 ```json
 {

--- a/source/_addons/rpc_shutdown.markdown
+++ b/source/_addons/rpc_shutdown.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 ---
 
-Allow to shutdown a computer with a service call from Home-Assistant.
+Allow to shutdown a Windows computer with a service call from Home-Assistant.
 
 ```json
 {


### PR DESCRIPTION
**Description:**
In the page is not specified that RPC calls are Windows only.

