### PR TITLE
Update 2017-10-06-deprecating-python-3.4-support.markdown

### DIFF
--- a/source/_posts/2017-10-06-deprecating-python-3.4-support.markdown
+++ b/source/_posts/2017-10-06-deprecating-python-3.4-support.markdown
@@ -26,6 +26,6 @@ If you're running Hassbian it's recommended that you make a backup of your confi
 If you're on Windows, you're fine as our minimum version for Windows has been 3.5 for a while now.
 
 #### Other Debian based systems
-If you're running a Debian based system , follow [these instructions][dist-upgrade] to upgrade.
+If you're running a Debian based system, follow [these instructions][dist-upgrade] to upgrade.
 
 [dist-upgrade]: https://linuxconfig.org/raspbian-gnu-linux-upgrade-from-jessie-to-raspbian-stretch-9


### PR DESCRIPTION
Really persnickety update to remove an erroneous space

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

