### PR TITLE
Added brief explanation to the HTTP binary_sensor page

### DIFF
--- a/source/_components/binary_sensor.http.markdown
+++ b/source/_components/binary_sensor.http.markdown
@@ -12,6 +12,10 @@ ha_category: Binary Sensor
 ha_release: pre 0.7
 ---
 
+The HTTP binary sensor is dynamically created with the first request that is made to its URL. You don't have to define it in the configuration first.
+
+The sensor will then exist as long as Home Assistant is running. After a restart of Home Assistant the sensor will be gone until it is triggered again.
+
 The URL for a binary sensor looks like the example below:
 
 ```bash


### PR DESCRIPTION
**Description:**

I hope this makes it a bit more clear that the HTTP binary sensor is created automatically and doesn't have to be created via the configuration like other binary sensors.
