### PR TITLE
Removed reference to WPS-only setup

### DIFF
--- a/source/_components/binary_sensor.mystrom.markdown
+++ b/source/_components/binary_sensor.mystrom.markdown
@@ -38,7 +38,7 @@ binary_sensor:
 
 ### {% linkable_title Setup of the myStrom Buttons %}
 
-You need to configure every button to make it work with Home Assistant. First connect the Wifi Buttons to your wireless network. Keep in mind that they only support WPS (Wi-FI Protected Setup). Once a button is connected you have three minutes to set the actions for the push patterns. The fastest way is to use `curl`. Check the [documentation](https://mystrom.ch/wp-content/uploads/REST_API_WBP.txt) of the WiFi Button for further details about the implementation (`http://` is replaced by `get://` or `post://`). `action` is the name of the corresponding push pattern (see above).
+You need to configure every button to make it work with Home Assistant. First connect the Wifi Buttons to your wireless network. Once a button is connected you have three minutes to set the actions for the push patterns. The fastest way is to use `curl`. Check the [documentation](https://mystrom.ch/wp-content/uploads/REST_API_WBP.txt) of the WiFi Button for further details about the implementation (`http://` is replaced by `get://` or `post://`). `action` is the name of the corresponding push pattern (see above).
 
 The endpoint that is receiving the data is `[IP address Home Assistant]:8123/api/mystrom`.
 


### PR DESCRIPTION
MyStrom buttons can be set up via the app (as per the manual, confirmed by me today).

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

