### PR TITLE
Removed last_boot and replaced with since_last_boot

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -53,7 +53,7 @@ recorder:
       - updater
     entities:
       - sun.sun   # Don't record sun data
-      - sensor.last_boot
+      - sensor.since_last_boot
       - sensor.date
 ```
 
@@ -81,11 +81,11 @@ recorder:
       - media_player
   exclude:
     entities:
-     - sensor.last_boot
+     - sensor.since_last_boot
      - sensor.date
 ```
 
-If you only want to hide events from e.g. your history, take a look at the [`history` component](/components/history/). Same goes for logbook. But if you have privacy concerns about certain events or neither want them in history or logbook, you should use the `exclude`/`include` options of the `recorder` component, that they aren't even in your database. That way you can save storage and keep the database small by excluding certain often-logged events (like `sensor.last_boot`).
+If you only want to hide events from e.g. your history, take a look at the [`history` component](/components/history/). Same goes for logbook. But if you have privacy concerns about certain events or neither want them in history or logbook, you should use the `exclude`/`include` options of the `recorder` component, that they aren't even in your database. That way you can save storage and keep the database small by excluding certain often-logged events (like `sensor.since_last_boot`).
 
 ### {% linkable_title Service `purge` %}
 

--- a/source/_components/sensor.systemmonitor.markdown
+++ b/source/_components/sensor.systemmonitor.markdown
@@ -57,6 +57,7 @@ The table contains types and their argument to use in your `configuration.yaml` 
 | ipv6_address        | Interface, eg. `eth0`    |
 | processor_use       |                          |
 | process             | Binary, eg. `octave-cli` |
+| last_boot           |                          |
 | since_last_boot     |                          |
 
 ## {% linkable_title Linux specific %}

--- a/source/_components/sensor.systemmonitor.markdown
+++ b/source/_components/sensor.systemmonitor.markdown
@@ -57,7 +57,6 @@ The table contains types and their argument to use in your `configuration.yaml` 
 | ipv6_address        | Interface, eg. `eth0`    |
 | processor_use       |                          |
 | process             | Binary, eg. `octave-cli` |
-| last_boot           |                          |
 | since_last_boot     |                          |
 
 ## {% linkable_title Linux specific %}


### PR DESCRIPTION
Checked the source code of system monitor, cannot find last_boot anymore, hence removed it in favor of the one still in used 'since_last_boot'. Noticed it since the example recorder didn't remove it for me.