### PR TITLE
Update the list of Danish region on CLA signature page

### DIFF
--- a/source/developers/cla_sign.html
+++ b/source/developers/cla_sign.html
@@ -155,7 +155,7 @@ footer: true
   s_a[56] = "Camaguey|Ciego de Avila|Cienfuegos|Ciudad de La Habana|Granma|Guantanamo|Holguin|Isla de la Juventud|La Habana|Las Tunas|Matanzas|Pinar del Rio|Sancti Spiritus|Santiago de Cuba|Villa Clara";
   s_a[57] = "Famagusta|Kyrenia|Larnaca|Limassol|Nicosia|Paphos";
   s_a[58] = "Brnensky|Budejovicky|Jihlavsky|Karlovarsky|Kralovehradecky|Liberecky|Olomoucky|Ostravsky|Pardubicky|Plzensky|Praha|Stredocesky|Ustecky|Zlinsky";
-  s_a[59] = "Arhus|Bornholm|Fredericksberg|Frederiksborg|Fyn|Kobenhavn|Kobenhavns|Nordjylland|Ribe|Ringkobing|Roskilde|Sonderjylland|Storstrom|Vejle|Vestsjalland|Viborg";
+  s_a[59] = "Nordjylland|Midtjylland|Syddanmark|Hovedstaden|Sjaelland";
   s_a[60] = "'Ali Sabih|Dikhil|Djibouti|Obock|Tadjoura";
   s_a[61] = "Saint Andrew|Saint David|Saint George|Saint John|Saint Joseph|Saint Luke|Saint Mark|Saint Patrick|Saint Paul|Saint Peter";
   s_a[62] = "Azua|Baoruco|Barahona|Dajabon|Distrito Nacional|Duarte|El Seibo|Elias Pina|Espaillat|Hato Mayor|Independencia|La Altagracia|La Romana|La Vega|Maria Trinidad Sanchez|Monsenor Nouel|Monte Cristi|Monte Plata|Pedernales|Peravia|Puerto Plata|Salcedo|Samana|San Cristobal|San Juan|San Pedro de Macoris|Sanchez Ramirez|Santiago|Santiago Rodriguez|Valverde";
@@ -424,7 +424,7 @@ footer: true
     var match = location.search.match(new RegExp("[?&]"+key+"=([^&]+)(&|$)"));
     return match && decodeURIComponent(match[1].replace(/\+/g, " "));
   }
-  
+
   $(document).ready(function(){
     populateCountries("country", "region");
     var spinner = new Spinner().spin(document.getElementById('spinner'));


### PR DESCRIPTION
**Description:**
Updated the list of Danish regions, as it is outdated. The old danish "amter" (counties) were reshuffled into [5 regions](https://en.wikipedia.org/wiki/Regions_of_Denmark) in 2007.
