### PR TITLE
Added Nest Developer Outbound Port Info

### DIFF
--- a/source/_components/nest.markdown
+++ b/source/_components/nest.markdown
@@ -34,6 +34,8 @@ The Nest component is the main component to integrate all [Nest](https://nest.co
 9. Once the new product page opens the "Product ID" and "Product Secret" are located on the right side. These will be used as `client_id` and `client_secret` below.
 10. Once Home Assistant is started, a configurator will pop up asking you to log into your Nest account and copy a PIN code into Home Assistant.
 
+Connecting to the Nest Developer API requires outbound port 8553 on your firewall. The configuration will fail if this is not accessible.
+
 ### {% linkable_title Configuration %}
 
 ```yaml


### PR DESCRIPTION
Configuration fails if outbound port is unavailable.

Added info about required port from Known Issues section in: https://github.com/openhab/openhab1-addons/wiki/Nest-Binding

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

