### PR TITLE
Extend Ring doorbell camera documentation by adding a python_script to o download the video

### DIFF
--- a/source/_components/camera.ring.markdown
+++ b/source/_components/camera.ring.markdown
@@ -31,3 +31,41 @@ Configuration variables:
 **Note:** To be able to playback the last capture, it is required to install the `ffmpeg` component. Make sure to follow the steps mentioned at [FFMPEG](https://home-assistant.io/components/ffmpeg/) documentation.
 
 Currently it supports doorbell and stickup cameras.
+
+
+## {% linkable_title Saving locally the videos captured by your Ring Door Bell %}
+
+You can save locally the latest video captured by your Ring Door Bell by enabling the [downloader](/components/downloader) and the [python_scripts](/components/python_script) components.
+
+  - Add to the `configuration.yaml` the `downloader` and `python_scripts`. Visit the component page for further details.
+
+```json
+python_script:
+downloader:
+  download_dir: downloads
+```
+  - Create a file `ring_downloader.py` in the folder `<config>/python_scripts` and give it this content:
+
+```python
+# obtain ring doorbell camera object
+# replace the camera.front_door by your camera entity
+ring_cam = hass.states.get('camera.front_door')
+
+subdir_name = 'ring_{}'.format(ring_cam.attributes.get('friendly_name'))
+
+# get video URL
+data = {
+    'url': ring_cam.attributes.get('video_url'),
+    'subdir': subdir_name,
+}
+
+# call downloader component to save the video
+hass.services.call('downloader', 'download_file', data)
+```
+
+  - Start Home Assistant
+  - Call the server `python_script/ring_downloader`
+
+You should be able to see a video file saved under `<config>/<downloader_dir>/ring_<camera_name>/`.
+
+You can also automate the process by integrating it with the (automation)[/components/automation) component.


### PR DESCRIPTION
**Description:**

 This PR extend the Ring Door Bell camera documentation by adding an example of how to 


```python
# obtain ring doorbell camera object
# replace the camera.front_door by your camera entity
ring_cam = hass.states.get('camera.front_door')

subdir_name = 'ring_{}'.format(ring_cam.attributes.get('friendly_name'))

# get video URL
data = {
    'url': ring_cam.attributes.get('video_url'),
    'subdir': subdir_name,
}

# call downloader component to save the video
hass.services.call('downloader', 'download_file', data)
```