### PR TITLE
fixed dead link to retrieving access token for xiaomi vacuum and switch

### DIFF
--- a/source/_components/switch.xiaomi_miio.markdown
+++ b/source/_components/switch.xiaomi_miio.markdown
@@ -17,7 +17,7 @@ The `xiaomi_miio` switch platform allows you to control the state of your Xiaomi
 
 Currently, the supported features are `on`, `off`. If the device provides the current load, it will be reported.
 
-Please follow the instructions on [Retrieving the Access Token](/components/vacuum.xiaomi/#retrieving-the-access-token) to get the API token to use in the `configuration.yaml` file.
+Please follow the instructions on [Retrieving the Access Token](/components/vacuum.xiaomi_miio/#retrieving-the-access-token) to get the API token to use in the `configuration.yaml` file.
 
 To add a plug to your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -28,7 +28,7 @@ Currently supported features are:
 - `set_fanspeed`
 - remote control of your robot.
 
-Please follow [Retrieving the Access Token](/components/vacuum.xiaomi/#retrieving-the-access-token) to retrieve the API token used in
+Please follow [Retrieving the Access Token](/components/vacuum.xiaomi_miio/#retrieving-the-access-token) to retrieve the API token used in
 `configuration.yaml`.
 
 ## {% linkable_title Configuring the Platform %}


### PR DESCRIPTION
the link to the description of how to retrieve the access token for xiaomi vacuum and switch was dead. It still linked to the docs of the components without the protokol suffix