### PR TITLE
Update project.json example

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -78,7 +78,7 @@ homeassistant:
     "automation" :
     {
       "name": "automation",
-      "url": "https://[YOUR HOME ASSISTANT URL]/api/google_assistant"
+      "url": "https://[YOUR HOME ASSISTANT URL]/api/google_assistant/auth"
     }
   }
 }


### PR DESCRIPTION
'url" was missing the trailing "/auth"

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

