### PR TITLE
typo / grammar fixes for zwave

### DIFF
--- a/source/hassio/zwave.markdown
+++ b/source/hassio/zwave.markdown
@@ -16,17 +16,16 @@ zwave:
   usb_path: /dev/ttyACM0
 ```
 
-If you need GPIO on raspberry-pi3 for you Z-Wave module add follow line into `config.txt`:
+If you need GPIO on raspberry-pi3 for your Z-Wave module, add the following line into `config.txt`:
 ```
 dtoverlay=pi3-miniuart-bt
 ```
 
-For some exceptional devices, the `/dev/ttyAMA0` will not be detected by udev and are therefor not mapped with docker.
-So you need explicit set this device for mapping to Home-Assistant. Execute this command on ssh add-on:
+For some devices the `/dev/ttyAMA0` device is not detected by udev and is therefore not mapped by Docker. To explicitly set this device for mapping to Home-Assistant, execute the following command using the ssh add-on:
 ```bash
 $ curl -d '{"devices": ["ttyAMA0"]}' http://hassio/homeassistant/options
 ```
-After that, you need change `usb_path` to `/dev/ttyAMA0`.
+After that, you need to change `usb_path` to `/dev/ttyAMA0`.
 
 ### HUSBZB-1:
 ```yaml


### PR DESCRIPTION
**Description:**
typo fixes for hass.io zwave setup page


