### PR TITLE
Update sensor.travisci.markdown

### DIFF
--- a/source/_components/sensor.travisci.markdown
+++ b/source/_components/sensor.travisci.markdown
@@ -21,7 +21,7 @@ To enable this platform, please add the following to your `configuration.yaml` f
 # Example configuration.yaml entry
 sensor:
   - platform: travisci
-    github_token: 123456789
+    api_key: 123456789
 ```
 
 Configuration variables:


### PR DESCRIPTION
Changed the code example from github_token to api_key that is what is required. It is mostly confusing to have GitHub_token instead of api_key in the example code.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

