### PR TITLE
Add note to iOS actionable notifications for clarity

### DIFF
--- a/source/_docs/ecosystem/ios/notifications/actions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/actions.markdown
@@ -141,4 +141,4 @@ Notes:
 
 * `textInput` will only exist if `behavior` was set to `textInput`.
 * `actionData` is a dictionary with parameters passed in the `action_data` dictionary of the `push` dictionary in the original notification.
-* When adding or updating push categories be sure to update push settings within the Home Assistant iOS app.  This can be found within the app at Setting (gear icon) > Notification Settings.
+* When adding or updating push categories be sure to update push settings within the Home Assistant iOS app.  This can be found within the app at Settings (gear icon) > Notification Settings.

--- a/source/_docs/ecosystem/ios/notifications/actions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/actions.markdown
@@ -141,4 +141,4 @@ Notes:
 
 * `textInput` will only exist if `behavior` was set to `textInput`.
 * `actionData` is a dictionary with parameters passed in the `action_data` dictionary of the `push` dictionary in the original notification.
-* When adding or updating push categories be sure to update push settings within the Home Assistant iOS app.  This can be found within the app at Settings (gear icon) > Notification Settings.
+* When adding or updating push categories be sure to update push settings within the Home Assistant iOS app. This can be found within the app at **Settings** (gear icon) > **Notification Settings**.

--- a/source/_docs/ecosystem/ios/notifications/actions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/actions.markdown
@@ -141,3 +141,4 @@ Notes:
 
 * `textInput` will only exist if `behavior` was set to `textInput`.
 * `actionData` is a dictionary with parameters passed in the `action_data` dictionary of the `push` dictionary in the original notification.
+* When adding or updating push categories be sure to update push settings within the Home Assistant iOS app.  This can be found within the app at Setting (gear icon) > Notification Settings.


### PR DESCRIPTION
**Description:**

Added note to remind users to update push settings within the app.  There are multiple community questions around this and performing this update will take care of many issues when implementing actionable notifications.

