### PR TITLE
toonopafstand.eneco.nl is no longer available

### DIFF
--- a/source/_components/toon.markdown
+++ b/source/_components/toon.markdown
@@ -15,7 +15,7 @@ ha_iot_class: "Cloud Polling"
 
 The `toon` component platform can be used to control your Toon thermostat. This component adds a climate device for your Toon thermostat and sensors for power and gas consumption. The component also auto-detects any smart plugs, solar panels and smoke detectors connected to Toon and adds sensors and switches for them.
 
-For the `toon` component to work, you'll need an active Toon subscription with Eneco. The component uses your Mijn Eneco credentials to control your thermostat through the [toonopafstand](https://toonopafstand.eneco.nl) website.
+For the `toon` component to work, you'll need an active Toon subscription with Eneco. The component uses your Mijn Eneco credentials to control your thermostat through the [toonopafstand](https://toonopafstand.eneco.nl) Domain.
 
 To use your Toon thermostat in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/toon.markdown
+++ b/source/_components/toon.markdown
@@ -15,7 +15,7 @@ ha_iot_class: "Cloud Polling"
 
 The `toon` component platform can be used to control your Toon thermostat. This component adds a climate device for your Toon thermostat and sensors for power and gas consumption. The component also auto-detects any smart plugs, solar panels and smoke detectors connected to Toon and adds sensors and switches for them.
 
-For the `toon` component to work, you'll need an active Toon subscription with Eneco. The component uses your Mijn Eneco credentials to control your thermostat through the [toonopafstand](https://toonopafstand.eneco.nl) Domain.
+For the `toon` component to work, you'll need an active Toon subscription with Eneco. The component uses your Mijn Eneco credentials to control your thermostat through the [toonopafstand](https://toonopafstand.eneco.nl) domain.
 
 To use your Toon thermostat in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION


**Description:**
the toonopafstand.eneco.nl give the above message but the library look like is  keep using the domain with no problems reported.
i change the word "website" to domain so users are not confuse  when the click it .

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

