### PR TITLE
added quotes around the host

### DIFF
--- a/source/_components/namecheapdns.markdown
+++ b/source/_components/namecheapdns.markdown
@@ -24,7 +24,7 @@ To use the component in your installation, add the following to your `configurat
 ```yaml
 # Example configuration.yaml entry
 namecheapdns:
-  host: @
+  host: '@'
   domain: example.com
   access_token: 0123_Dynamic_DNS_Password
 ```


### PR DESCRIPTION
Throws "while scanning for the next token found character '@' that cannot start any token" an error without quotes around it.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

