### PR TITLE
Added filename attribute to override filename via downloader

### DIFF
--- a/source/_components/downloader.markdown
+++ b/source/_components/downloader.markdown
@@ -40,4 +40,5 @@ This will download the file from the given URL.
 | ---------------------- | -------- | ---------------------------------------------- |
 | `url`                  |       no | The url of the file to download.               |
 | `subdir`               |      yes | Download into subdirectory of **download_dir** |
+| `filename`             |      yes | Determine the filename.                        |
 


### PR DESCRIPTION
**Description:**

Added filename attribute to override filename via downloader. 


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10059

* `python_script` example used on this test
```python
# obtain ring doorbell camera object
# replace the camera.front_door by your camera entity
ring_cam = hass.states.get('camera.front_door')

subdir_name = 'ring_{}'.format(ring_cam.attributes.get('friendly_name'))
filename = 'test.mp4'

# get video URL
data = {
    'url': ring_cam.attributes.get('video_url'),
    'subdir': subdir_name,
    'filename': filename,
}

# call downloader component to save the video
hass.services.call('downloader', 'download_file', data)
```

* Result
```bash
(python:ha-py36) ↪ tree ~/.homeassistant_tests/downloads/
/home/mdemello/.homeassistant_tests/downloads/
└── ring_FrontDoor
    └── test.mp4
```
