### PR TITLE
Added minutes to uptime sensor

### DIFF
--- a/source/_components/sensor.uptime.markdown
+++ b/source/_components/sensor.uptime.markdown
@@ -27,4 +27,4 @@ sensor:
 Configuration variables:
 
 - **name** (*Optional*): Name of the sensor. Defaults to `Uptime`.
-- **unit_of_measurement** (*Optional*): Units for uptime measurement in either `days` or `hours`.  Defaults to `days`.
+- **unit_of_measurement** (*Optional*): Units for uptime measurement in either `days`, `hours`, or `minutes`.  Defaults to `days`.


### PR DESCRIPTION
Added `minutes` to `uptime` sensor. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10082

