### PR TITLE
Fix unintended typo in Bayesian Documentation

### DIFF
--- a/source/_components/binary_sensor.bayesian.markdown
+++ b/source/_components/binary_sensor.bayesian.markdown
@@ -40,7 +40,7 @@ Configuration variables:
   - **entity_id** (*Required*): Name of the entity to monitor.
   - **prob_given_true** (*Required*): The probability of the observation occurring, given the event is `true`.
   - **prob_given_false** (*Optional*): The probability of the observation occurring, given the event is `false` can be set as well.  If `prob_given_false` is not set, it will default to `1 - prob_given_true`.
-  - **platform** (*Required*): The only supported observation platforms are `state` and `numeric_state`, which are modeled after their corresponding triggers for automations, requiring `before` and/or `after` instead of `to_state`.
+  - **platform** (*Required*): The only supported observation platforms are `state` and `numeric_state`, which are modeled after their corresponding triggers for automations, requiring `below` and/or `above` instead of `to_state`.
   - **to_state** (*Required*): The target state.
 - **probability_threshold** (*Optional*): The probability at which the sensor should trigger to `on`.
 - **name** (*Optional*): Name of the sensor to use in the frontend. Defaults to `Bayesian Binary`.


### PR DESCRIPTION
Got distracted and typed before/after instead of below/above

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

