### PR TITLE
light.hyperion: Add priority attribute

### DIFF
--- a/source/_components/light.hyperion.markdown
+++ b/source/_components/light.hyperion.markdown
@@ -29,4 +29,5 @@ Configuration variables:
 - **host** (*Required*): The IP address of the device the Hyperion service is running on.
 - **port** (*Optional*): The port used to communicate with the Hyperion service. Defaults to `19444`.
 - **name** (*Optional*): The name of the device used in the frontend.
+- **priority** (*Optional*): The priority of the hyperion instance. Defaults to `128`.
 - **default_color** (*Optional*): The color of the light. Defaults to `[255, 255, 255]`.


### PR DESCRIPTION
**Description:**
Add 'priority' attribute to set the priority of the hyperion remote instance.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10102

