### PR TITLE
Fixing Typo that was mentioned in #3764

### DIFF
--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -5,7 +5,7 @@
 - topic: Service
   description: "[Services](/docs/scripts/service-calls/) are called to perform actions."
 - topic: Event
-  description: When somethings happen.
+  description: When something happens.
 - topic: Entity
   description: An entity is the representation of a single device, unit or web service.
 - topic: Device


### PR DESCRIPTION
@itchaboy mentioned a typo with the event section of the Glossary page for Home Assistant in #3764, this should fix it.

