### PR TITLE
Cleaning up some other things in glossary

### DIFF
--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -5,7 +5,7 @@
 - topic: Service
   description: "[Services](/docs/scripts/service-calls/) are called to perform actions."
 - topic: Event
-  description: When somethings happen.
+  description: When something happens.
 - topic: Entity
   description: An entity is the representation of a single device, unit or web service.
 - topic: Device

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -1,18 +1,18 @@
 - topic: Platform
-  description: [Platforms](/docs/configuration/platform_options/) make the connection to a specific software or hardware platform. For example, the `pushbullet` platform works with the service pushbullet.com to send notifications.
+  description: "[Platforms](/docs/configuration/platform_options/) make the connection to a specific software or hardware platform. For example, the `pushbullet` platform works with the service pushbullet.com to send notifications."
 - topic: Component
   description: "[Components](/docs/configuration/platform_options/) provide the core logic for the functionality in Home Assistant. Like `notify` provides sending notifications."
 - topic: Service
   description: "[Services](/docs/scripts/service-calls/) are called to perform actions."
 - topic: Event
-  description: An [event](/docs/configuration/events/) is when something happens.
+  description: "An [event](/docs/configuration/events/) is when something happens."
   description: When something happens.
 - topic: Entity
   description: An [entity](/docs/configuration/platform_options/) is the representation of a single device, unit or web service.
 - topic: Device
   description: "A device is usually a physical unit which can do or observe something."
 - topic: hass
-  description: "HASS is often used as an abbreviation for Home Assistant."
+  description: "HASS or hass is often used as an abbreviation for Home Assistant."
 - topic: Discovery
   description: Discovery is the automatic setup of zeroconf/mDNS and uPnP devices after they are discovered.
 - topic: Groups

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -1,42 +1,42 @@
 - topic: Platform
-  description: A platform makes the connection to a specific software or hardware platform. The `pushbullet` platform works with the service from pushbullet.com.
+  description: [Platforms](/docs/configuration/platform_options/) make the connection to a specific software or hardware platform. For example, the `pushbullet` platform works with the service pushbullet.com to send notifications.
 - topic: Component
-  description: "The components provide the core logic for the functionality in Home Assistant. Like `notify` provides sending notifications."
+  description: "[Components](/docs/configuration/platform_options/) provide the core logic for the functionality in Home Assistant. Like `notify` provides sending notifications."
 - topic: Service
   description: "[Services](/docs/scripts/service-calls/) are called to perform actions."
 - topic: Event
-  description: When something happens.
+  description: An [event](/docs/configuration/events/) is when something happens.
 - topic: Entity
-  description: An entity is the representation of a single device, unit or web service.
+  description: An [entity](/docs/configuration/platform_options/) is the representation of a single device, unit or web service.
 - topic: Device
-  description: "Usually this is a physical unit which can do or observe something."
+  description: "A device is usually a physical unit which can do or observe something."
 - topic: hass
-  description: "Often used abbreviation for Home Assistant."
+  description: "HASS is often used as an abbreviation for Home Assistant."
 - topic: Discovery
   description: The automatic setup of zeroconf/mDNS and uPnP devices after they are discovered.
 - topic: Groups
   description: "Groups are a way to organize your entities into a single unit."
 - topic: Automation
-  description: "Capability to call a service based on a simple or complex trigger. Automation allows a condition such as sunset to cause an event, such as a light turning on."
+  description: "[Automations](/docs/automation/) offer the capability to call a service based on a simple or complex trigger. Automation allows a condition such as sunset to cause an event, such as a light turning on."
 - topic: Trigger
-  description: "Values or conditions of a platform that are defined to cause an automation to run."
+  description: "A [trigger](/docs/automation/trigger/) is a set of values or conditions of a platform that are defined to cause an automation to run."
 - topic: Template
-  description: "An automation definition can include variables for the service or data from the trigger values. This allows automations to generate dynamic actions."
+  description: "A [template](/docs/automation/templating/) is an automation definition that can include variables for the service or data from the trigger values. This allows automations to generate dynamic actions."
 - topic: Script
-  description: "A component that allows users to specify a sequence of actions to be executed by Home Assistant when turned on"
+  description: "[Scripts](/docs/scripts/) are components that allow users to specify a sequence of actions to be executed by Home Assistant when turned on"
 - topic: Scene
-  description: "You can create scenes that capture the states you want certain entities to be. For example a scene can specify that light A should be turned on and light B should be bright red." 
+  description: "Scenes capture the states you want certain entities to be. For example a scene can specify that light A should be turned on and light B should be bright red." 
 - topic: hassio
-  description: "An operating system to manage Home Assistant easily using various HASS.io add-ons"
+  description: "hassio is an operating system that can be used to manage Home Assistant easily using various HASS.io add-ons"
 - topic: HADashboard
-  description: "HADashboard is a modular, skinnable dashboard for Home Assistant that is intended to be wall mounted, and is optimized for distance viewing."
+  description: "[HADashboard](/docs/ecosystem/hadashboard/) is a modular, skinnable dashboard for Home Assistant that is intended to be wall mounted, and is optimized for distance viewing."
 - topic: Hass.io
-  description: "Hass.io is an operating system that will take care of installing and updating Home Assistant, is managed from the Home Assistant UI, allows creating/restoring snapshots of your configuration and can easily be extended"
+  description: "Hass.io is an operating system that will take care of installing and updating Home Assistant, is managed from the Home Assistant UI, allows creating/restoring snapshots of your configuration, and can easily be extended"
 - topic: Cookbook
-  description: "Home Assistant configuration examples of the community"
+  description: "The [Cookbook](/cookbook/) contains a set of configuration examples of Home Assistant from the community"
 - topic: Packages
-  description: "Packages allow to bundle different component configuations together."
+  description: "Packages allow you to bundle different component configuations together."
 - topic: Customizing
-  description: "Customization allows overwriting default parameter of the devices in the configuration."
+  description: "[Customization](/docs/configuration/customizing-devices/) allows you to overwrite the default parameter of your devices in the configuration."
 - topic: Zones
-  description: "Area used for presence detection."
+  description: "Zones are areas that can be used for presence detection."

--- a/source/_data/glossary.yml
+++ b/source/_data/glossary.yml
@@ -13,7 +13,7 @@
 - topic: hass
   description: "HASS is often used as an abbreviation for Home Assistant."
 - topic: Discovery
-  description: The automatic setup of zeroconf/mDNS and uPnP devices after they are discovered.
+  description: Discovery is the automatic setup of zeroconf/mDNS and uPnP devices after they are discovered.
 - topic: Groups
   description: "Groups are a way to organize your entities into a single unit."
 - topic: Automation


### PR DESCRIPTION
As I was making the other commit (#3766) I noticed some other things in the glossary that could be changed.

One of the main things is that each example read differently so there was a lot of jumping between how examples were written, I've made them a bit more unified.

I also added a bit more explanatory text and added some links as suggested in #3764.

I made this a separate pull because I figured it might be a bit more opinionated than the typo error.