### PR TITLE
{"error":"Invalid key"}

### DIFF
--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -179,3 +179,4 @@ That means that Home Assistant is not getting any response from your Xiaomi gate
 - Try to disable and then enable LAN access.
 - Hard reset the gateway: Press the button of the gateway 30 seconds and start again from scratch.
 - If you are using Home Assistant in [Docker](/docs/installation/docker/), make sure to use `--net=host`.
+- If you receive an {"error":"Invalid key"} in your logs while trying to control the gateway light, you should generate the key again using an Android Phone or alternativly an emulator such as bluestacks - https://www.bluestacks.com in some instances there is an issue with keys being generated using the iOs application.

--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -179,4 +179,4 @@ That means that Home Assistant is not getting any response from your Xiaomi gate
 - Try to disable and then enable LAN access.
 - Hard reset the gateway: Press the button of the gateway 30 seconds and start again from scratch.
 - If you are using Home Assistant in [Docker](/docs/installation/docker/), make sure to use `--net=host`.
-- If you receive an {"error":"Invalid key"} in your logs while trying to control the gateway light, you should generate the key again using an Android Phone or alternativly an emulator such as bluestacks - https://www.bluestacks.com in some instances there is an issue with keys being generated using the iOs application.
+- If you receive an `{"error":"Invalid key"}` in your log while trying to control the gateway light, you should generate the key again using an Android Phone or alternativly an emulator such as [bluestacks](https://www.bluestacks.com). In some instances there is an issue with keys being generated using the iOS application.


### PR DESCRIPTION
resolution to {"error":"Invalid key"} issue when trying to control the gateway lights via Home Assistant UI.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

