### PR TITLE
Fixed command for installing all test requirements

### DIFF
--- a/source/developers/development_testing.markdown
+++ b/source/developers/development_testing.markdown
@@ -42,7 +42,7 @@ $ tox -e py36 -- tests/test_core.py --duration=10
 Running tox will invoke the full test suite. Even if you specify which tox target to run, you still run all tests inside that target. That's not very convenient to quickly iterate on your code! To be able to run the specific test suites without Tox, you'll need to install the test dependencies into your Python environment:
 
 ```bash
-$ bash pip3 install -r requirements_test_all.txt
+$ pip3 install -r requirements_test_all.txt
 ```
 
 Now that you have all test dependencies installed, you can run tests on individual files:


### PR DESCRIPTION
previous command was giving me:

```bash
(venv) dgrant@16elford:~/home-assistant$ bash pip3 install -r requirements_test_all.txt
import: unable to open X server `' @ error/import.c/ImportImageCommand/364.
import: unable to open X server `' @ error/import.c/ImportImageCommand/364.
from: can't read /var/mail/pip
/home/dgrant/home-assistant/venv/bin/pip3: pip3: line 10: syntax error near unexpected token `('
/home/dgrant/home-assistant/venv/bin/pip3: pip3: line 10: `    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])'
```

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

