### PR TITLE
Update python_script.markdown

### DIFF
--- a/source/_components/python_script.markdown
+++ b/source/_components/python_script.markdown
@@ -25,7 +25,9 @@ This component allows you to write Python scripts that are exposed as services i
 
 ## {% linkable_title Writing your first script %}
 
- - Add to `configuration.yaml`: `python_script:`
+ - Add to `configuration.yaml`: 
+   `python_script:`
+   `  python_scripts:`
  - Create folder `<config>/python_scripts`
  - Create a file `hello_world.py` in the folder and give it this content:
 


### PR DESCRIPTION
Using Homeassistant 0.56.2, the latest at this time, the component python_script.py defines the DOMAIN as 'python_script' and the FOLDER 'python_scripts'.  As is you will encounter the error: 'Unable to find component python_script'.  It took awhile to figure out that figure out that the DOMAIN and FOLDER should be linked and a quick change to the documentation was all that was needed.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

