### PR TITLE
Add missing 'tap and hold off' details

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -155,3 +155,4 @@ Double tap off|2|3
 Triple tap on|1|4
 Triple tap off|2|4
 Tap and hold on|1|2
+Tap and hold off|2|2


### PR DESCRIPTION
**Description:**

Adding the details of holding off button to the homeseer switch example

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

