### PR TITLE
Fixed the sunrise / sunset example code in the documentation

### DIFF
--- a/source/_docs/ecosystem/appdaemon.markdown
+++ b/source/_docs/ecosystem/appdaemon.markdown
@@ -40,8 +40,8 @@ import appdaemon.appapi as appapi
 class OutsideLights(appapi.AppDaemon):
 
   def initialize(self):
-    self.run_at_sunrise(self.sunrise_cb, 0)
-    self.run_at_sunset(self.sunset_cb, 0)
+    self.run_at_sunrise(self.sunrise_cb)
+    self.run_at_sunset(self.sunset_cb)
     
   def sunrise_cb(self, kwargs):
     self.turn_on(self.args["off_scene"])


### PR DESCRIPTION
I removed the offset so the callback is simply: 

`self.run_at_sunrise(self.sunrise_cb)`

The example code is now running fine.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

