### PR TITLE
Remove target_sensor from the configuration

### DIFF
--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -70,7 +70,6 @@ A full configuration example looks like the one below.
 climate:
   - platform: mqtt
     name: Study
-    target_sensor: sensor.study_temperature
     modes:
       - off
       - cool


### PR DESCRIPTION
Seems it's there by mistake. As looking through MQTT HVAC uses current_temperature_topic instead. Which is actually a drawback

