### PR TITLE
Shell command naming convention change

### DIFF
--- a/source/_components/shell_command.markdown
+++ b/source/_components/shell_command.markdown
@@ -12,6 +12,7 @@ logo: home-assistant.png
 ---
 
 This component can expose regular shell commands as services. Services can be called from a [script] or in [automation].
+Shell commands aren't allowed for a camel-case naming, please use lowercase naming only and separate the names with underscores 
 
 [script]: /components/script/
 [automation]: /getting-started/automation/

--- a/source/_components/shell_command.markdown
+++ b/source/_components/shell_command.markdown
@@ -12,7 +12,7 @@ logo: home-assistant.png
 ---
 
 This component can expose regular shell commands as services. Services can be called from a [script] or in [automation].
-Shell commands aren't allowed for a camel-case naming, please use lowercase naming only and separate the names with underscores 
+Shell commands aren't allowed for a camel-case naming, please use lowercase naming only and separate the names with underscores.
 
 [script]: /components/script/
 [automation]: /getting-started/automation/


### PR DESCRIPTION
camel case naming isn't allowed (shell command configuration validation fails

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

