### PR TITLE
Update list of media_players supporting shuffle

### DIFF
--- a/source/_components/media_player.markdown
+++ b/source/_components/media_player.markdown
@@ -58,7 +58,7 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 
 #### {% linkable_title Service `media_player/shuffle_set` %}
 
-Currently only supported on Spotify, MPD, Kodi, and Universal.
+Currently only supported on [Spotify](/components/media_player.spotify/), [MPD](/components/media_player.mpd/), [Kodi](/components/media_player.kodi/), and [Universal](/components/media_player.universal/).
 
 | Service data attribute | Optional | Description                                          |
 | ---------------------- | -------- | ---------------------------------------------------- |

--- a/source/_components/media_player.markdown
+++ b/source/_components/media_player.markdown
@@ -57,7 +57,8 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | `source`               |       no | Name of the source to switch to. Platform dependent. |
 
 #### {% linkable_title Service `media_player/shuffle_set` %}
-Currently only supports Spotify.
+
+Currently only supported on Spotify, MPD, Kodi, and Universal.
 
 | Service data attribute | Optional | Description                                          |
 | ---------------------- | -------- | ---------------------------------------------------- |


### PR DESCRIPTION
**Description:**

The documentation says that shuffle is only supported on Spotify. Based on  doing a [search for SUPPORT_SHUFFLE_SET](https://github.com/home-assistant/home-assistant/search?utf8=%E2%9C%93&q=SUPPORT_SHUFFLE_SET&type=), it seems more support it now.