### PR TITLE
Provide a script for macOS to generate the secure key

### DIFF
--- a/source/_docs/z-wave/adding.markdown
+++ b/source/_docs/z-wave/adding.markdown
@@ -28,6 +28,11 @@ An easy script to generate a random key:
 cat /dev/urandom | tr -dc '0-9A-F' | fold -w 32 | head -n 1 | sed -e 's/\(..\)/0x\1, /g' -e 's/, $//'
 ```
 
+On macOS, this script will generate a random key:
+```bash
+cat /dev/urandom | LC_CTYPE=C tr -dc '0-9A-F' | fold -w 32 | head -n 1 | sed -e 's/\(..\)/0x\1, /g' -e 's/, $//'
+```
+
 <p class='note warning'>
 Ensure you keep a backup of this key. If you have to rebuild your system and don't have a backup of this key, you won't be able to reconnect to any security devices. This may mean you have to do a factory reset on those devices, and your controller, before rebuilding your Z-Wave network.
 </p>


### PR DESCRIPTION
Without including the LC_CTYPE=C environment variable on macOS, tr returns a "Illegal byte sequence" error.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

