### PR TITLE
added documentation for monoprice_snapshot/monoprice_restore services.

### DIFF
--- a/source/_components/media_player.monoprice.markdown
+++ b/source/_components/media_player.monoprice.markdown
@@ -68,4 +68,4 @@ Restore a previously taken snapshot of one or more speakers. If no `entity_id` i
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`s of zone.
+| `entity_id` | yes | String or list of strings that point at `entity_id`s of zones.

--- a/source/_components/media_player.monoprice.markdown
+++ b/source/_components/media_player.monoprice.markdown
@@ -48,7 +48,7 @@ Configuration variables:
 - **zones** (*Required*): This is the list of zones available. Valid zones are 11,12,13,14,15,16. In case multiple Monoprice devices are stacked together the list of valid zones is extended by 21,22,23,24,25,26 for the second device and 31,32,33,34,35,36 for the third device. Each zone must have a name assigned to it.
 - **sources** (*Required*): The list of sources available. Valid source numbers are 1,2,3,4,5,6. Each source number corresponds to the input number on the Monoprice amplifier. Similar to zones, each source must have a name assigned to it.
 
-### {% linkable_title Service `monoprice_snapshot` %}
+### {% linkable_title Service `snapshot` %}
 
 Take a snapshot of one or more zones' states. This service, and the following one are useful if you want to play a doorbell or notification sound and resume playback afterward. If no `entity_id` is provided, all zones are snapshotted.
 
@@ -62,7 +62,7 @@ The following attributes are stored in a snapshot:
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`s of zones.
 
-### {% linkable_title Service `monoprice_restore` %}
+### {% linkable_title Service `restore` %}
 
 Restore a previously taken snapshot of one or more speakers. If no `entity_id` is provided, all zones are restored.
 

--- a/source/_components/media_player.monoprice.markdown
+++ b/source/_components/media_player.monoprice.markdown
@@ -50,16 +50,22 @@ Configuration variables:
 
 ### {% linkable_title Service `monoprice_snapshot` %}
 
-Take a snapshot of one or more speakers' states. This service, and the following one are useful if you want to play a doorbell or notification sound and resume playback afterward. If no `entity_id` is provided, all speakers are snapshotted.
+Take a snapshot of one or more zones' states. This service, and the following one are useful if you want to play a doorbell or notification sound and resume playback afterward. If no `entity_id` is provided, all zones are snapshotted.
+
+The following attributes are stored in a snapshot:
+- Power status (On/Off)
+- Mute status (On/Off)
+- Volume level
+- Source
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`s of coordinator speakers.
+| `entity_id` | yes | String or list of strings that point at `entity_id`s of zones.
 
 ### {% linkable_title Service `monoprice_restore` %}
 
-Restore a previously taken snapshot of one or more speakers. If no `entity_id` is provided, all speakers are restored.
+Restore a previously taken snapshot of one or more speakers. If no `entity_id` is provided, all zones are restored.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`s of coordinator speakers.
+| `entity_id` | yes | String or list of strings that point at `entity_id`s of zone.

--- a/source/_components/media_player.monoprice.markdown
+++ b/source/_components/media_player.monoprice.markdown
@@ -47,3 +47,19 @@ Configuration variables:
 - **port** (*Required*): The serial port to which Monoprice amplifier is connected
 - **zones** (*Required*): This is the list of zones available. Valid zones are 11,12,13,14,15,16. In case multiple Monoprice devices are stacked together the list of valid zones is extended by 21,22,23,24,25,26 for the second device and 31,32,33,34,35,36 for the third device. Each zone must have a name assigned to it.
 - **sources** (*Required*): The list of sources available. Valid source numbers are 1,2,3,4,5,6. Each source number corresponds to the input number on the Monoprice amplifier. Similar to zones, each source must have a name assigned to it.
+
+### {% linkable_title Service `monoprice_snapshot` %}
+
+Take a snapshot of one or more speakers' states. This service, and the following one, are useful if you want to play a doorbell or notification sound and resume playback afterwards. If no `entity_id` is provided, all speakers are snapshotted.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that point at `entity_id`s of coordinator speakers.
+
+### {% linkable_title Service `monoprice_restore` %}
+
+Restore a previously taken snapshot of one or more speakers. If no `entity_id` is provided, all speakers are restored.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that point at `entity_id`s of coordinator speakers.

--- a/source/_components/media_player.monoprice.markdown
+++ b/source/_components/media_player.monoprice.markdown
@@ -50,7 +50,7 @@ Configuration variables:
 
 ### {% linkable_title Service `monoprice_snapshot` %}
 
-Take a snapshot of one or more speakers' states. This service, and the following one, are useful if you want to play a doorbell or notification sound and resume playback afterwards. If no `entity_id` is provided, all speakers are snapshotted.
+Take a snapshot of one or more speakers' states. This service, and the following one are useful if you want to play a doorbell or notification sound and resume playback afterward. If no `entity_id` is provided, all speakers are snapshotted.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION
**Description:**

Documentation for new services for `monoprice` platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10296

