### PR TITLE
removed cython dependency, removed api_key conf

### DIFF
--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -16,29 +16,27 @@ ha_release: 0.43
 
 The `tradfri` component supports for the IKEA Trådfri (Tradfri) gateway. The gateway can control lights connected to it and Home Assistant will automatically discover its presence on your network.
 
-This component requires cython, please ensure it's installed by running the following in your Home Assistant environment (virtualenv, etc);
-
-```
-$ pip3 install cython
-```
-
-You will be prompted to configure the gateway through the Home Assistant interface, Enter the security key when prompted and click configure
+You will be prompted to configure the gateway through the Home Assistant interface, Enter the security key when prompted and click configure.
 
 <p class='note'>
 If you see an "Unable to connect" message, restart the gateway and try again. Don't forget to assign a permanent IP to your Trådfri gateway.
 </p>
 
-The gateway can also be manually configured by adding the following lines to your `configuration.yaml` file:
+You can add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 tradfri:
   host: IP_ADDRESS
-  api_key: API_KEY
 ```
+
+alternatively you can use the `discover:` flag in `configuration.yaml`.
 
 Configuration variables:
 
  - **host** (*Required*): The IP address or hostname of your Trådfri gateway.
- - **api_key** (*Required*): Can be found listed as Security Key on the back of the Trådfri gateway.
  - **allow_tradfri_groups** (*Optional*): (true/false) Enable this to stop Home Assistant from importing the groups defined on the Trådfri bridge.
+
+<p class='note'>
+Do not use the `api_key` variable. The key is only needed once at initial setup.
+</p>

--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -14,15 +14,15 @@ ha_iot_class: "Local Polling"
 ha_release: 0.43
 ---
 
-The `tradfri` component supports for the IKEA Trådfri (Tradfri) gateway. The gateway can control lights connected to it and Home Assistant will automatically discover its presence on your network.
+The `tradfri` component supports for the IKEA Trådfri (Tradfri) gateway. The gateway can control lights connected to it and Home Assistant will automatically discover its presence on your network, if `discovery:` is present in your `configuration.yaml` file.
 
-You will be prompted to configure the gateway through the Home Assistant interface, Enter the security key when prompted and click configure.
+You will be prompted to configure the gateway through the Home Assistant interface. Enter the security key when prompted and click configure.
 
 <p class='note'>
 If you see an "Unable to connect" message, restart the gateway and try again. Don't forget to assign a permanent IP to your Trådfri gateway.
 </p>
 
-You can add the following to your `configuration.yaml` file:
+You can add the following to your `configuration.yaml` file if you are not using the [`discovery:`](/components/discovery/) component:
 
 ```yaml
 # Example configuration.yaml entry
@@ -30,12 +30,10 @@ tradfri:
   host: IP_ADDRESS
 ```
 
-alternatively you can use the `discover:` flag in `configuration.yaml`.
-
 Configuration variables:
 
  - **host** (*Required*): The IP address or hostname of your Trådfri gateway.
- - **allow_tradfri_groups** (*Optional*): (true/false) Enable this to stop Home Assistant from importing the groups defined on the Trådfri bridge.
+ - **allow_tradfri_groups** (*Optional*): Enable this to stop Home Assistant from importing the groups defined on the Trådfri bridge. Defaults to `true`.
 
 <p class='note'>
 Do not use the `api_key` variable. The key is only needed once at initial setup.


### PR DESCRIPTION
Cython is pulled in by DTLSSocket since 1.0.4 no need for manual install
fixed with home-assistant/home-assistant#10123

removed the api_key parameter
relates to home-assistant/home-assistant#10282
