### PR TITLE
Document sending Slack attachments

### DIFF
--- a/source/_components/notify.slack.markdown
+++ b/source/_components/notify.slack.markdown
@@ -52,8 +52,10 @@ The following attributes can be placed `data` for extended functionality.
 | `username`             |      yes | Username if the url requires authentication. Is placed inside `file`.
 | `password`             |      yes | Password if the url requires authentication. Is placed inside `file`.
 | `auth`                 |      yes | If set to `digest` HTTP-Digest-Authentication is used. If missing HTTP-BASIC-Authentication is used. Is placed inside `file`.
+| `attachments`          |      yes | Array of [Slack attachments](https://api.slack.com/docs/message-attachments). See [the attachment documentation](https://api.slack.com/docs/message-attachments) for how to format. *NOTE*: if using `attachments`, they are shown **in addition** to `message`
 
-Example for posting file from URL
+Example for posting file from URL:
+
 ```json
 {
   "message":"Message that will be added as a comment to the file.",
@@ -68,7 +70,9 @@ Example for posting file from URL
   }
 }
 ```
-Example for posting file from local path
+
+Example for posting file from local path:
+
 ```json
 {
   "message":"Message that will be added as a comment to the file.",
@@ -81,6 +85,24 @@ Example for posting file from local path
 }
 ```
 Please note that `path` is validated against the `whitelist_external_dirs` in the `configuration.yaml`.
+
+Example for posting formatted attachment:
+
+```json
+{
+  "message": "",
+  "data": {
+    "attachments": [
+      {
+        "title": "WHAT A HORRIBLE NIGHT TO HAVE A CURSE.",
+        "image_url": "http://i.imgur.com/JEExnsI.gif"
+      }
+    ]
+  }
+}
+```
+
+Please note that both `message` is a required key, but is always shown, so use an empty (`""`) string for `message` if you don't want the extra text.
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
 


### PR DESCRIPTION

**Description:**

Document using Slack notifications to send [rich attachments](https://api.slack.com/docs/message-attachments). Took me a minute to get to this :sweat_smile:


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/2914