### PR TITLE
Add include/exclude filter to mqtt_statestream docs

### DIFF
--- a/source/_components/mqtt_statestream.markdown
+++ b/source/_components/mqtt_statestream.markdown
@@ -32,6 +32,12 @@ Configuration variables:
 Default is false.
 - **publish_timestamps** (*Optional*): Publish the last_changed and last_updated timestamps for the entity.
 Default is false.
+- **exclude** (*Optional*): Configure which components should be excluded from recordings.  See *Include/Exclude* section below for details.
+  - **entities** (*Optional*): The list of entity ids to be excluded from recordings.
+  - **domains** (*Optional*): The list of domains to be excluded from recordings.
+- **include** (*Optional*): Configure which components should be included in recordings. If set, all other entities will not be recorded.
+  - **entities** (*Optional*): The list of entity ids to be included from recordings.
+  - **domains** (*Optional*): The list of domains to be included from recordings.
 
 ## Operation
 
@@ -44,6 +50,56 @@ For example, with the example configuration above, if an entity called 'light.ma
 
 If that entity also has an attribute called `brightness`, the component will also publish the value of that attribute to `homeassistant/light/master_bedroom_dimmer/brightness`.
 
-All states and attributes are passed through JSON serialization before publishing. **Please note** that this causes strings to be quoted (e.g., the string 'on' will be published as '"on"'). You can access the JSON deserialized values (as well as unquoted strings) at many places by using `value_json` instead of `value`. 
+All states and attributes are passed through JSON serialization before publishing. **Please note** that this causes strings to be quoted (e.g., the string 'on' will be published as '"on"'). You can access the JSON deserialized values (as well as unquoted strings) at many places by using `value_json` instead of `value`.
 
 The last_updated and last_changed values for the entity will be published to `homeassistant/light/master_bedroom_dimmer/last_updated` and `homeassistant/light/master_bedroom_dimmer/last_changed`, respectively.  The timestamps are in ISO 8601 format - for example, `2017-10-01T23:20:30.920969+00:00`.
+
+## Include/exclude
+
+The **exclude** and **include** configuration variables can be used to filter the items that are published to MQTT.
+
+1\. If neither **exclude** or **include** are specified, all entiies are published.
+
+2\. If only **exclude** is specified, then all entities except the ones listed are published.
+
+```yaml
+# Example of excluding entities
+mqtt_statestream:
+  base_topic: homeassistant
+  exclude:
+    domains:
+      - switch
+    entities:
+      - sensor.nopublish
+```
+In the above example, all entities except for *switch.x* and *sensor.nopublish* will be published to MQTT.
+
+3\. If only **include** is specified, then only the specified entries are published.
+
+```yaml
+# Example of excluding entities
+mqtt_statestream:
+  base_topic: homeassistant
+  include:
+    domains:
+      - sensor
+    entities:
+      - lock.important
+```
+In this example, only *sensor.x* and *lock.important* will be published.
+
+4\. If both **include** and **exclude** are specified then all entities specified by **include** are published except for the ones
+specified by **exclude**.
+
+```yaml
+# Example of excluding entities
+mqtt_statestream:
+  base_topic: homeassistant
+  include:
+    domains:
+      - sensor
+  exclude:
+    entities:
+      - sensor.noshow
+```
+In this example, all sensors except for *sensor.noshow* will be published.

--- a/source/_components/mqtt_statestream.markdown
+++ b/source/_components/mqtt_statestream.markdown
@@ -32,7 +32,7 @@ Configuration variables:
 Default is false.
 - **publish_timestamps** (*Optional*): Publish the last_changed and last_updated timestamps for the entity.
 Default is false.
-- **exclude** (*Optional*): Configure which components should be excluded from recordings.  See *Include/Exclude* section below for details.
+- **exclude** (*Optional*): Configure which components should be excluded from recordings. See *Include/Exclude* section below for details.
   - **entities** (*Optional*): The list of entity ids to be excluded from recordings.
   - **domains** (*Optional*): The list of domains to be excluded from recordings.
 - **include** (*Optional*): Configure which components should be included in recordings. If set, all other entities will not be recorded.
@@ -58,7 +58,7 @@ The last_updated and last_changed values for the entity will be published to `ho
 
 The **exclude** and **include** configuration variables can be used to filter the items that are published to MQTT.
 
-1\. If neither **exclude** or **include** are specified, all entiies are published.
+1\. If neither **exclude** or **include** are specified, all entities are published.
 
 2\. If only **exclude** is specified, then all entities except the ones listed are published.
 


### PR DESCRIPTION
**Description:**

Documentation for include/exclude configuration in mqtt_statestream.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10354

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
