### PR TITLE
Update allow_tradfri_groups in docs

### DIFF
--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -33,7 +33,7 @@ tradfri:
 Configuration variables:
 
  - **host** (*Required*): The IP address or hostname of your Trådfri gateway.
- - **allow_tradfri_groups** (*Optional*): Enable this to stop Home Assistant from importing the groups defined on the Trådfri bridge. Defaults to `true`.
+ - **allow_tradfri_groups** (*Optional*): Set this to `false` to stop Home Assistant from importing the groups defined on the Trådfri bridge. Defaults to `true`.
 
 <p class='note'>
 Do not use the `api_key` variable. The key is only needed once at initial setup.


### PR DESCRIPTION
The previous docs were very unclear on this option

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
