### PR TITLE
Specify the minimum required ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby "> 2.3.0"
+
 group :development do
   gem 'rake', '~> 10.0'
   gem 'jekyll', '~> 3.0'

--- a/source/developers/documentation/index.markdown
+++ b/source/developers/documentation/index.markdown
@@ -20,7 +20,7 @@ For larger changes, we suggest that you clone the website repository. This way, 
 
 To test your changes locally, you need to install **Ruby** and its dependencies (gems):
 
-- [Install Ruby](https://www.ruby-lang.org/en/documentation/installation/) if you don't have it already.
+- [Install Ruby](https://www.ruby-lang.org/en/documentation/installation/) if you don't have it already. Ruby version 2.3.0 or higher is required.
 - Install `bundler`, a dependency manager for Ruby: `$ gem install bundler`
 - In your home-assistant.github.io root directory, run `$ bundle` to install the gems you need.
 


### PR DESCRIPTION
**Description:**
We currently use the [squiggly heredoc](https://infinum.co/the-capsized-eight/multiline-strings-ruby-2-3-0-the-squiggly-heredoc) operator here: https://github.com/home-assistant/home-assistant.github.io/blob/0c26ea618dab3881c664c803964ab87fbc932ceb/plugins/configuration.rb#L104 This operator is only supported on version 2.3 or higher of Ruby. (Maybe we have other incompatibilities, but that's the first one I hit on my 2.2 system.)