### PR TITLE
Downgrade to rb-inotify version 0.9.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ group :development do
   gem 'sass-globbing', '~> 1.0'
   gem 'stringex', '~> 1.4'
   gem 'pry'
+
+  # See https://github.com/home-assistant/home-assistant.github.io/pull/3904
+  gem 'rb-inotify', '< 0.9.9'
 end
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,8 +73,8 @@ GEM
       rack
     rake (10.5.0)
     rb-fsevent (0.10.2)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.9.8)
+      ffi (>= 0.5.0)
     redcarpet (3.4.0)
     rouge (1.11.1)
     safe_yaml (1.0.4)
@@ -104,6 +104,7 @@ DEPENDENCIES
   octopress-include-tag
   pry
   rake (~> 10.0)
+  rb-inotify (< 0.9.9)
   sass-globbing (~> 1.0)
   sinatra (~> 1.4.2)
   stringex (~> 1.4)


### PR DESCRIPTION
**Description:**
With version 0.9.10 of rb-inotify, the following error is thrown when trying to generate a preview:
```bash
ArgumentError on line ["58"] of /home/adam/.gem/ruby/2.3.0/gems/fssm-0.2.10/lib/fssm/support.rb: comparison of String with 0 failed
Run with --trace to see the full backtrace
```

fssm is trying to compare version number components from rb-inotify:
https://github.com/ttilley/fssm/blob/cd018e4e343a8d0cf2c3ea847076dfc322bb167f/lib/fssm/support.rb#L56-L59

And when rb-inotify changed to version 0.9.9, the version number format changed as well:
https://github.com/guard/rb-inotify/commit/528f86a44d7198a44ed2245b59de324e8a819855#diff-d9e3e7592434aad4316552e64b6ada7eL17
https://github.com/guard/rb-inotify/commit/528f86a44d7198a44ed2245b59de324e8a819855#diff-0b88808273f0e0364e42dd1445b8f1e5R23

Unfortunately it looks like fssm has been abandoned, so I don't expect an update there. This at least pins us to a working state.