### PR TITLE
More SSL warning info in media_player.vizio.markdown

### DIFF
--- a/source/_components/media_player.vizio.markdown
+++ b/source/_components/media_player.vizio.markdown
@@ -97,4 +97,7 @@ Vizio SmartCast service is accessible through HTTPS with self-signed certificate
 `InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised.`
 
 You can adjust the log level for `media_player` components with the [logger](https://home-assistant.io/components/logger/) component, or if you need to keep a low log level for `media_player` you could proxy calls to your TV through an NGINX reverse proxy.
+
+If you want to only ignore only this specific [python urllib3 SSL warning](https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings), you will need to run Home Assistant with the python flag `-W` or the environment variable `PYTHONWARNINGS` set to:
+`ignore:Unverified HTTPS request is being made`
 </p>


### PR DESCRIPTION
**Description:**

Adding more specifics on how to *only* block the specific SSL verification warning line that shows up for Vizio SmartCast TVs. This is a more elegant (if advanced) way since it doesn't involve reducing overall log level or affecting all media_player components.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** not applicable

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
