### PR TITLE
RFC: Suggestions for climate component refactoring

### DIFF
--- a/source/_components/climate.markdown
+++ b/source/_components/climate.markdown
@@ -22,37 +22,40 @@ climate:
 
 ## {% linkable_title Properties %}
 
-Every climate device has a set of properties that control the operation of the climate device. These properties can be set via the frontend or by calling services and are reported in the attributes of the device's state. Note that not all platforms implement all the properties.
+Every climate device has a set of properties that control the operation of the climate device. These properties can be set via the frontend or by calling services and are reported in the attributes of the device's state. Note that not all platforms implement all the properties. Also, for properties that have a certain set of possible choices, not all platforms implement all choices.
 
 We explain each of the properties and the possible choices for them shortly:
 
-* The **action** property specifies the overall operational mode that the device is currently in. Choices are:
- * Cooling
- * Heating
- * Auto (Cool or heat, depending on what's necessary to achieve the target temperature)
- * Off
+* The `on / off` property completely disables the device if set of `off`.
+* The **temperature_action** property specifies how the device currently controls the room's temperature. It can be any of:
+  * Cooling
+  * Heating
+  * Auto (Cool or heat, depending on what's necessary to achieve the target temperature)
+  * Off
+* The **humidity_action** property specifies how the device currently controls the room's humidity. It can be any of:
+  * Humidifying
+  * Dehumidifying
+  * Auto (Humidify or dehumidify, depending on what's necessary to achieve the target humidity)
+  * Off
 * The **target_temperature** property selects the desired temperature for the device to achieve. The device will take measures to do so depending on what `action` is chosen. While most devices allow only to specify a `target_temperature` and will start heating / cooling when the temperature differs too far from that temperature, some devices allow finer control by specifying an  acceptable temperature corridor:
-  * The **target_temp_high** property selects an upper limit on the acceptable temperature. The device will start cooling (if `cooling` or `auto` are selected as `action`) if that temperature is exceeded.
-  * The **target_temp_low** property selects a lower limit on the acceptable temperature. The device will start heating (if `heating` or `auto` are selected as `action`) if that temperature is exceeded.
-* The **target_humidity** property selects the target humidity. If this is set and the device is able to dry / humidify the air, it will do so if the actual humidity differs from this value.
-* The **control** property specifies how the device is currently being controlled. Many devices allow to chose between an automated control (following a given preset, see below) or a manual control. *Note*: This does *not* influence whether the device is controlled by Home Assistant. The device is always controlled by Home Assistant, even if in `manual` mode. This property controls only the setting on the actual device. Choices are:
- * Preset (device follows the device-specific preset, see below)
- * Manual (the device itself is only controlled manually / via Home Assistant)
-* The **source** property specifies (for devices which support this), what source to use for achieving the goal given in the `action`. Choices are:
+  * The **target_temperature_high** property selects an upper limit on the acceptable temperature. The device will start cooling (if `cooling` or `auto` are selected as `temperature_action`) if that temperature is exceeded.
+  * The **target_temperature_low** property selects a lower limit on the acceptable temperature. The device will start heating (if `heating` or `auto` are selected as `temperature_action`) if that temperature is undershot.
+* The **target_humidity** property selects the target humidity. If this is set and the device is able to humidify / dehumidify the air, it will do so if the actual humidity differs from this value. Some devices allow for a finer control of the target humidity:
+  * The **target_humidity_high** property selects an upper limit on the acceptable humidity. The device will start dehumidifying (if `dehumidifying` or `auto` are selected as `humidity_action`) if that humidity is exceeded.
+  * The **target_humidity_low** property selects an lower limit on the acceptable humidity. The device will start humidifying (if `humidifying` or `auto` are selected as `humidity_action`) if that humidity is undershot.
+* The **control** property specifies how the device is currently being controlled. Many devices allow to chose between an automated control (following a given preset) or a manual control. Thus, while the choices for this property are not strictly standardized, common possibilities are:
+  * Manual
+  * Auto
+  * Eco
+* The **source** property specifies (for devices which support this), what source to use for achieving the goal given in the `action`. Each of the possible choices can be individually turned on or off. Choices are:
  * Electric
  * Gas
- * Fan_only
-* The **preset** property controls which preset to follow, if `preset` is selected for the `control` property. If the devices is in `manual` mode, this setting has no effect. The choices for this property are not standardized but differ from device to device. Note that the presets must be provided by the device, either statically or by direct configuration of the device. Home Assistant does not yet allow you to create / edit presets. If you want to emulate a preset, an automation and a timer component might be what you want.
-* The **away** property can only be on or off and sets devices into a away-mode in which they usually conserve energy by heating / cooling less.
+ * Auxiliary
+ * Heat Pump
+* The **away** property can only be on or off and sets devices into a away-mode in which they usually conserve energy by heating / cooling less. After disabling the away mode, the device should return to the exact settings it had set before the away mode was enabled.
 * The **fan_mode** property selects between the different modes of the device's fan, if it has any. Choices differ from device to device.
 * The **swing_mode** property selects whether and how the device should swing, if it supports this. Choices differ from device to device.
-
-Additionally, there are a couple of deprecated properties that are still implemented by older platforms, but will gradually be replaced by the properties mentioned above:
-
-* The **operation_mode** property (**deprecated**) is a mix of `action` and `control` above.
-* The **aux_heat** property (**deprecated**) turns auxiliary heating on or off and is controlled via `action` in newer devices.
-* The **hold_mode** property (**deprecated**) handles different choices for possible `target_temperature`s and is handled via the `preset` property for newer devices.
-
+P
 ## {% linkable_title Services %}
 
 ### {% linkable_title Climate control services %}

--- a/source/_components/climate.markdown
+++ b/source/_components/climate.markdown
@@ -11,7 +11,7 @@ footer: true
 
 
 The `climate` component is built for the controlling and monitoring of HVAC (heating, ventilating, and air conditioning) and thermostat devices.
- 
+
 To enable this component, pick one of the platforms, and add it to your `configuration.yaml`:
 
 ```yaml
@@ -19,6 +19,39 @@ To enable this component, pick one of the platforms, and add it to your `configu
 climate:
   platform: demo
 ```
+
+## {% linkable_title Properties %}
+
+Every climate device has a set of properties that control the operation of the climate device. These properties can be set via the frontend or by calling services and are reported in the attributes of the device's state. Note that not all platforms implement all the properties.
+
+We explain each of the properties and the possible choices for them shortly:
+
+* The **action** property specifies the overall operational mode that the device is currently in. Choices are:
+ * Cooling
+ * Heating
+ * Auto (Cool or heat, depending on what's necessary to achieve the target temperature)
+ * Off
+* The **target_temperature** property selects the desired temperature for the device to achieve. The device will take measures to do so depending on what `action` is chosen. While most devices allow only to specify a `target_temperature` and will start heating / cooling when the temperature differs too far from that temperature, some devices allow finer control by specifying an  acceptable temperature corridor:
+  * The **target_temp_high** property selects an upper limit on the acceptable temperature. The device will start cooling (if `cooling` or `auto` are selected as `action`) if that temperature is exceeded.
+  * The **target_temp_low** property selects a lower limit on the acceptable temperature. The device will start heating (if `heating` or `auto` are selected as `action`) if that temperature is exceeded.
+* The **target_humidity** property selects the target humidity. If this is set and the device is able to dry / humidify the air, it will do so if the actual humidity differs from this value.
+* The **control** property specifies how the device is currently being controlled. Many devices allow to chose between an automated control (following a given preset, see below) or a manual control. *Note*: This does *not* influence whether the device is controlled by Home Assistant. The device is always controlled by Home Assistant, even if in `manual` mode. This property controls only the setting on the actual device. Choices are:
+ * Preset (device follows the device-specific preset, see below)
+ * Manual (the device itself is only controlled manually / via Home Assistant)
+* The **source** property specifies (for devices which support this), what source to use for achieving the goal given in the `action`. Choices are:
+ * Electric
+ * Gas
+ * Fan_only
+* The **preset** property controls which preset to follow, if `preset` is selected for the `control` property. If the devices is in `manual` mode, this setting has no effect. The choices for this property are not standardized but differ from device to device. Note that the presets must be provided by the device, either statically or by direct configuration of the device. Home Assistant does not yet allow you to create / edit presets. If you want to emulate a preset, an automation and a timer component might be what you want.
+* The **away** property can only be on or off and sets devices into a away-mode in which they usually conserve energy by heating / cooling less.
+* The **fan_mode** property selects between the different modes of the device's fan, if it has any. Choices differ from device to device.
+* The **swing_mode** property selects whether and how the device should swing, if it supports this. Choices differ from device to device.
+
+Additionally, there are a couple of deprecated properties that are still implemented by older platforms, but will gradually be replaced by the properties mentioned above:
+
+* The **operation_mode** property (**deprecated**) is a mix of `action` and `control` above.
+* The **aux_heat** property (**deprecated**) turns auxiliary heating on or off and is controlled via `action` in newer devices.
+* The **hold_mode** property (**deprecated**) handles different choices for possible `target_temperature`s and is handled via the `preset` property for newer devices.
 
 ## {% linkable_title Services %}
 
@@ -54,7 +87,7 @@ automation:
 
 ### {% linkable_title Service `climate.set_away_mode` %}
 
-Set away mode for climate device. The away mode changes the target temperature permanently to a temperature 
+Set away mode for climate device. The away mode changes the target temperature permanently to a temperature
 reflecting a situation where the climate device is set to save energy. This may be used to emulate a
 "vacation mode", for example.
 


### PR DESCRIPTION
# **Do not merge this! The changes are not yet implemented! This is a Request for Comments!**

This is a suggestion for a refactoring of the climate component. I thought I'd outline this in form of documentation before starting the actual coding, to have a place for discussion how the new climate component looks like.

Most of this is taken from https://github.com/home-assistant/home-assistant/pull/10151#discussion_r147630587 . Some comments on the changed properties:

* I tried to avoid name clashes between the "old" properties (that have been deprecated) and the new ones. My plan for implementation is this: 
 1. Implement the new properties, increasing the size of the climate component. Additional, every climate object will have a "legacy" flag that determines whether the old (deprecated) or the new properties are in use. This requires no changes in the platforms aside from setting the legacy flag everywhere.
 2. Build a new-to-old translation where possible. E.g., setting `heating` as `action` will select `heating` as (deprectated) `operation_mode`. This should allow us to use some (many?) legacy platforms with the new interface.
 3. Wait for all platforms  to implement the new interface, remove all deprecated properties and code.
* The `fan_mode` and `swing_mode` properties still feel too platform-specific, but I'm not sure how to generalize this.