### PR TITLE
Update Trådfri documentation to mention the Python version dependency

### DIFF
--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -22,6 +22,10 @@ You will be prompted to configure the gateway through the Home Assistant interfa
 If you see an "Unable to connect" message, restart the gateway and try again. Don't forget to assign a permanent IP to your Trådfri gateway.
 </p>
 
+<p class='note'>
+  The Python version 3.4.4 or greater is required for this component.. The component will not initialize without this, amd will report a `Could not install all requirements` error in the logs.
+</p>
+
 You can add the following to your `configuration.yaml` file if you are not using the [`discovery:`](/components/discovery/) component:
 
 ```yaml

--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -23,7 +23,7 @@ If you see an "Unable to connect" message, restart the gateway and try again. Do
 </p>
 
 <p class='note'>
-  The Python version 3.4.4 or greater is required for this component. The component will not initialize without this, amd will report a `Could not install all requirements` error in the logs.
+  The Python version 3.4.4 or greater is required for this component. The component will not initialize without this and will report a `Could not install all requirements` error in the logs.
 </p>
 
 You can add the following to your `configuration.yaml` file if you are not using the [`discovery:`](/components/discovery/) component:

--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -23,7 +23,7 @@ If you see an "Unable to connect" message, restart the gateway and try again. Do
 </p>
 
 <p class='note'>
-  The Python version 3.4.4 or greater is required for this component.. The component will not initialize without this, amd will report a `Could not install all requirements` error in the logs.
+  The Python version 3.4.4 or greater is required for this component. The component will not initialize without this, amd will report a `Could not install all requirements` error in the logs.
 </p>
 
 You can add the following to your `configuration.yaml` file if you are not using the [`discovery:`](/components/discovery/) component:


### PR DESCRIPTION
Dependency is caused by aiocoap==0.3

**Description:**
Update Trådfri documentation to mention the Python version dependency, as this is not mentioned.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
