### PR TITLE
Fix the ha release value for component

### DIFF
--- a/source/_components/climate.ephember.markdown
+++ b/source/_components/climate.ephember.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: ephcontrolsember.png
 ha_category: Climate
-ha_release: "0.55"
+ha_release: 0.57
 ha_iot_class: "Local Polling"
 ---
 


### PR DESCRIPTION
Fix the ha release value for component


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
