### PR TITLE
Fixed terminology for consistency

### DIFF
--- a/source/_components/linode.markdown
+++ b/source/_components/linode.markdown
@@ -13,16 +13,21 @@ ha_release: 0.57
 ha_iot_class: "Cloud Polling"
 ---
 
-The `linode` component allows you to access the information about your [Linode](https://welcome.linode.com) systems from Home Assistant.
+The `linode` component allows you to access the information about your [Linode](https://www.linode.com) systems from Home Assistant.
 
-Obtain your API key from Linode account.
+Obtain your oAuth2 Access Token from Linode account.
+*   <http://cloud.linode.com>
+*   Log in
+*   Select API Tokens
+*   Create a Personal Access Token,
+*   Assigned scope (Please choose the least possible access required.)
 
 To integrate Linode with Home Assistant, add the following section to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 linode:
-  access_token: YOUR_API_KEY
+  access_token: YOUR_ACCESS_TOKEN
 ```
 
 {% configuration %}
@@ -31,4 +36,3 @@ linode:
     required: true
     type: string
 {% endconfiguration %}
-


### PR DESCRIPTION
Updated to add location to get Access Token from as non-obvious.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
