### PR TITLE
Update git_pull.markdown

### DIFF
--- a/source/_addons/git_pull.markdown
+++ b/source/_addons/git_pull.markdown
@@ -45,3 +45,8 @@ Load and update configuration files for Home Assistant from a GIT repository.
   * **rsa**
   
   The protocol is typically known by the suffix of the private key --e.g., a key file named `id_rsa` will be a private key using "rsa" protocol.
+  
+  
+  
+** Important Note **
+  You should only use this add-on if you do not have an existing config or if your existing config is already a git repository. If the script does not find the necessary git files in your config folder, it will delete anything that might be there. Please ensure that there is a `.git` folder in your config before using this. You can verify this by listing the items in the config folder including hidden files. The command is `ls -a /config`

--- a/source/_addons/git_pull.markdown
+++ b/source/_addons/git_pull.markdown
@@ -44,9 +44,8 @@ Load and update configuration files for Home Assistant from a GIT repository.
   * **ed25519**
   * **rsa**
   
-  The protocol is typically known by the suffix of the private key --e.g., a key file named `id_rsa` will be a private key using "rsa" protocol.
+The protocol is typically known by the suffix of the private key --e.g., a key file named `id_rsa` will be a private key using "rsa" protocol.
   
-  
-  
-** Important Note **
-  You should only use this add-on if you do not have an existing config or if your existing config is already a git repository. If the script does not find the necessary git files in your config folder, it will delete anything that might be there. Please ensure that there is a `.git` folder in your config before using this. You can verify this by listing the items in the config folder including hidden files. The command is `ls -a /config`
+<p class='note warning'>
+You should only use this add-on if you do not have an existing configuration or if your existing configuration is already in a git repository. If the script does not find the necessary git files in your configuration folder, it will delete anything that might be there. Please ensure that there is a `.git` folder before using this. You can verify this by listing the items in the configuration folder including hidden files. The command is `ls -a /config`.
+</p>


### PR DESCRIPTION
Some people are trying to use this add-on without having a previous git repo cloned. This is causing them to lose whatever they had on their config. It is important that they know this info. Please refer to this discussion. https://community.home-assistant.io/t/git-pull-addon/23435/17

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
