### PR TITLE
Specify how to handle region key inheritance

### DIFF
--- a/source/developers/frontend_translation.markdown
+++ b/source/developers/frontend_translation.markdown
@@ -23,6 +23,7 @@ The translation of the Home Assistant frontend is still a work in progress. More
 1. Only native speakers should submit translations.
 2. Stick to [Material Design guidelines](https://material.io/guidelines/style/writing.html).
 3. Don't translate or change proper nouns like `Home Assistant`, `Hass.io` or `Hue`.
+4. For a region specific translation, keys that will be the same as the base translation should be filled with `[VOID]`. These will be replaced during our translation build process.
 
 ## {% linkable_title Adding a new language %}
 If your language is not listed you can request it at [GitHub](https://github.com/home-assistant/home-assistant-polymer/issues/new). Please provide both the English name and the native name for your language. For example:


### PR DESCRIPTION
**Description:**

https://docs.lokalise.co/article/D5IbR00fwq-universal-placeholders

The `[VOID]` placehoder is replaced with an empty string on export. Our translation rollup will strip this key and it will be replaced with the base translation.

This gives us a good way to acknowledge that this key was checked and should be the same as the base translation. It also counts the key as translated for percentages.

CC @c727 