### PR TITLE
update docs

### DIFF
--- a/source/_components/sensor.fail2ban.markdown
+++ b/source/_components/sensor.fail2ban.markdown
@@ -37,7 +37,7 @@ Configuration variables:
 - **jails** (*Required*): List of configured jails you want to display (each jail is its own sensor).
 - **name** (*Optional*): Name of the sensor. Defaults to `fail2ban`.
 - **file_path** (*Optional*): Path to the fail2ban log.  Defaults to `/var/log/fail2ban.log`.
-- **scan_interval** (*Optional*): Used to limit how often log file is read and must be a positive integer (representing number of seconds to wait).  Defaults to 120.
+- **scan_interval** (*Required*): Used to limit how often log file is read and must be a positive integer (representing number of seconds to wait).  Recommended setting 120
 
 ### {% linkable_title Set up Fail2Ban %}
 


### PR DESCRIPTION
The scan_interval is *not* defaulted as the docs originally said and the sensor spews errors in the log and doens't work.

https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/sensor/fail2ban.py#L48

**Description:**
issue #10497 created

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
