### PR TITLE
Added option to set installation giid

### DIFF
--- a/source/_components/verisure.markdown
+++ b/source/_components/verisure.markdown
@@ -45,4 +45,4 @@ Configuration variables:
 - **mouse** (*Optional*): Set to 1 to show mouse detectors, 0 to disable. Default 1.
 - **door_window** (*Optional*): Set to 1 to show door and window sensors, 0 to disable. Default 1.
 - **code_digits** (*Optional*): Number of digits in PIN code. Default 4.
-
+- **giid** (*Optional*): The GIID of your installation (If you have more then one alarm system).


### PR DESCRIPTION
**Description:**
Added new feature to Verisure component that makes it possible to choose alarm installation if you have more then one connected to your Verisure account (like multiple houses).
An optional configuration variable "giid" is added. 

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
