### PR TITLE
Documentation for es5 / untranspiled JS 

### DIFF
--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -20,7 +20,7 @@ frontend:
 
 {% configuration %}
   javascript_version:
-    description: Version of the JavaScript to serve to clients. Options: `es5` - transpiled so old browsers understand it.  `latest` - not transpiled, so will work on recent browsers only. `auto` - select a version according the the browser useragent. The value in the config can be overriden by putting `es5` or `latest` in the URL. For example `http://localhost:8123/states?es5` 
+    description: "Version of the JavaScript to serve to clients. Options: `es5` - transpiled so old browsers understand it.  `latest` - not transpiled, so will work on recent browsers only. `auto` - select a version according the the browser useragent. The value in the config can be overriden by putting `es5` or `latest` in the URL. For example `http://localhost:8123/states?es5` "
     required: false
     type: string
     default: es5

--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -20,7 +20,7 @@ frontend:
 
 {% configuration %}
   javascript_version:
-    description: "Version of the JavaScript to serve to clients. Options: `es5` - transpiled so old browsers understand it.  `latest` - not transpiled, so will work on recent browsers only. `auto` - select a version according the the browser useragent. The value in the config can be overriden by putting `es5` or `latest` in the URL. For example `http://localhost:8123/states?es5` "
+    description: "Version of the JavaScript to serve to clients. Options: `es5` - transpiled so old browsers understand it.  `latest` - not transpiled, so will work on recent browsers only. `auto` - select a version according to the browser user-agent. The value in the config can be overiden by putting `es5` or `latest` in the URL. For example `http://localhost:8123/states?es5` "
     required: false
     type: string
     default: es5

--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -19,6 +19,11 @@ frontend:
 ```
 
 {% configuration %}
+  javascript_version:
+    description: Version of the JavaScript to serve to clients. Options: `es5` - transpiled so old browsers understand it.  `latest` - not transpiled, so will work on recent browsers only. `auto` - select a version according the the browser useragent. The value in the config can be overriden by putting `es5` or `latest` in the URL. For example `http://localhost:8123/states?es5` 
+    required: false
+    type: string
+    default: es5
   themes:
     description: Allow to define different themes. See below for further details.
     required: false


### PR DESCRIPTION
**Description:**

Documentation for serving transpiled es5 / un-transpiled JS to clients.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10474
## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
