### PR TITLE
Fix notation (fixes #3947)

### DIFF
--- a/source/_components/device_tracker.nmap_tracker.markdown
+++ b/source/_components/device_tracker.nmap_tracker.markdown
@@ -29,7 +29,7 @@ To use this device tracker in your installation, add the following to your `conf
 # Example configuration.yaml entry
 device_tracker:
   - platform: nmap_tracker
-    hosts: 192.168.1.1/24
+    hosts: 192.168.1.0/24
 ```
 
 Configuration variables:
@@ -47,7 +47,7 @@ A full example for the `nmap` tracker could look like the following sample:
 # One whole subnet, and skipping two specific IPs.
 device_tracker:
   - platform: nmap_tracker
-    hosts: 192.168.1.1/24
+    hosts: 192.168.1.0/24
     home_interval: 10
     exclude:
      - 192.168.1.12
@@ -60,7 +60,7 @@ device_tracker:
 device_tracker:
   - platform: nmap_tracker
     hosts:
-      - 192.168.1.1/24
+      - 192.168.1.0/24
       - 10.0.0.2
       - 10.0.0.15
 ```


### PR DESCRIPTION
**Description:**
Fix for CIDR notation.

**Fixes:** #3947

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
