### PR TITLE
Add notes regarding data usage and network load to speedtest component. 

### DIFF
--- a/source/_components/sensor.speedtest.markdown
+++ b/source/_components/sensor.speedtest.markdown
@@ -113,3 +113,5 @@ automation:
 
 - When running on Raspberry Pi, just note that the maximum speed is limited by its 100 Mbit/s LAN adapter.
 - Entries under `monitored_conditions` only control what entities are available under home-assistant, it does not disable the condition from running.
+- If ran frequently, this component has the capability of using a very large amount of data. Frequent updates should be avoided on bandwidth capped connections. 
+- While running, network usage is fully utilized. This may have a negative affect on other devices in use the network such as gaming consoles or streaming boxes. 


### PR DESCRIPTION
**Description: Added notes regarding high data usage for bandwidth capped connections and network load negatively affecting other devices on the network.**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here> N/A

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
