### PR TITLE
lirc configration has changed in strech

### DIFF
--- a/source/_components/lirc.markdown
+++ b/source/_components/lirc.markdown
@@ -26,28 +26,15 @@ To allow Home Assistant to talk to your IR receiver, you need to first make sure
 $ sudo apt-get install lirc liblircclient-dev
 ```
 
-
 <p class='note'>
-If you are configuring on a Raspberry Pi, there are excellent instructions with GPIO schematics and driver configurations [here](http://alexba.in/blog/2013/01/06/setting-up-lirc-on-the-raspberrypi/). Take notice, the instructions in this blog are valid for Raspian Jesse where lirc 0.9.0 was included in the debian package. In raspian Stretch lirc 0.9.4 is included in the debian package.
+If you are configuring on a Raspberry Pi, there are excellent instructions with GPIO schematics and driver configurations [here](http://alexba.in/blog/2013/01/06/setting-up-lirc-on-the-raspberrypi/). Take notice, the instructions in this blog are valid for Raspian Jesse where lirc 0.9.0 was included in the debian package. In Raspian Stretch lirc 0.9.4 is included in the Debian package.
 The configuration is slightly different :
 
-The changes
-
-  - The hardware.conf file is not supported, obsoleted by a new
-    lirc_options.conf file and systemd unit definitions.
-
-  - The former single lirc service is replaced with the three systemd
-    services lircd.service, lircmd.service and irexec.service. There is
-    no counterpart to the 0.9.0 'lirc' service which covered all of these.
-    Using a separate transmitter device requires yet another service.
-
-  - 0.9.4 defaults to using systemd for controlling the services. This
-    is not just start/stop functionality, systemd is used to implement
-    new features and to address shortcomings in 0.9.0. However, traditional
-    systemV scripts are also installed and could be used although this
-    is less tested and not really documented.  
+- The `hardware.conf` file is not supported, obsoleted by a new `lirc_options.conf` file and systemd unit definitions.
+ - The former single `lirc` service is replaced with the three systemd services `lircd.service`, `lircmd.service` and `irexec.service`. There is no counterpart to the 0.9.0 `lirc` service which covered all of these. Using a separate transmitter device requires yet another service.
+ - 0.9.4 defaults to using systemd for controlling the services. This is not just start/stop functionality, systemd is used to implement new features and to address shortcomings in 0.9.0. However, traditional systemV scripts are also installed and could be used although this is less tested and not really documented.  
     
-For more infomation have a look at : /usr/share/doc/lirc/README.Debian.gz where the update process is explained when you have updated from jessie to stretch    
+For more infomation have a look at `/usr/share/doc/lirc/README.Debian.gz` where the update process is explained when you have updated from jessie to stretch.
 </p>
 
 ### {% linkable_title Configuring LIRC %}

--- a/source/_components/lirc.markdown
+++ b/source/_components/lirc.markdown
@@ -30,7 +30,7 @@ $ sudo apt-get install lirc liblircclient-dev
 If you are configuring on a Raspberry Pi, there are excellent instructions with GPIO schematics and driver configurations [here](http://alexba.in/blog/2013/01/06/setting-up-lirc-on-the-raspberrypi/). Take notice, the instructions in this blog are valid for Raspian Jesse where lirc 0.9.0 was included in the debian package. In Raspian Stretch lirc 0.9.4 is included in the Debian package.
 The configuration is slightly different :
 
-- The `hardware.conf` file is not supported, obsoleted by a new `lirc_options.conf` file and systemd unit definitions.
+ - The `hardware.conf` file is not supported, obsoleted by a new `lirc_options.conf` file and systemd unit definitions.
  - The former single `lirc` service is replaced with the three systemd services `lircd.service`, `lircmd.service` and `irexec.service`. There is no counterpart to the 0.9.0 `lirc` service which covered all of these. Using a separate transmitter device requires yet another service.
  - 0.9.4 defaults to using systemd for controlling the services. This is not just start/stop functionality, systemd is used to implement new features and to address shortcomings in 0.9.0. However, traditional systemV scripts are also installed and could be used although this is less tested and not really documented.  
     

--- a/source/_components/lirc.markdown
+++ b/source/_components/lirc.markdown
@@ -28,7 +28,26 @@ $ sudo apt-get install lirc liblircclient-dev
 
 
 <p class='note'>
-If you are configuring on a Raspberry Pi, there are excellent instructions with GPIO schematics and driver configurations [here](http://alexba.in/blog/2013/01/06/setting-up-lirc-on-the-raspberrypi/). Consider following these.
+If you are configuring on a Raspberry Pi, there are excellent instructions with GPIO schematics and driver configurations [here](http://alexba.in/blog/2013/01/06/setting-up-lirc-on-the-raspberrypi/). Take notice, the instructions in this blog are valid for Raspian Jesse where lirc 0.9.0 was included in the debian package. In raspian Stretch lirc 0.9.4 is included in the debian package.
+The configuration is slightly different :
+
+The changes
+
+  - The hardware.conf file is not supported, obsoleted by a new
+    lirc_options.conf file and systemd unit definitions.
+
+  - The former single lirc service is replaced with the three systemd
+    services lircd.service, lircmd.service and irexec.service. There is
+    no counterpart to the 0.9.0 'lirc' service which covered all of these.
+    Using a separate transmitter device requires yet another service.
+
+  - 0.9.4 defaults to using systemd for controlling the services. This
+    is not just start/stop functionality, systemd is used to implement
+    new features and to address shortcomings in 0.9.0. However, traditional
+    systemV scripts are also installed and could be used although this
+    is less tested and not really documented.  
+    
+For more infomation have a look at : /usr/share/doc/lirc/README.Debian.gz where the update process is explained when you have updated from jessie to stretch    
 </p>
 
 ### {% linkable_title Configuring LIRC %}


### PR DESCRIPTION
The instructions here are only valid for rasberry pi with raspbian jessie. With raspbian stretch the he hardware.conf file is not supported, obsoleted by a new lirc_options.conf file and systemd unit definitions

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
