### PR TITLE
Change links to tutorial to get the xiaomi gateway key

### DIFF
--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: xiaomi.png
 ha_category: Hub
-ha_release: "0.50"
+ha_release: "0.57"
 ha_iot_class: "Local Push"
 redirect_from: /components/xiaomi/
 ---
@@ -49,7 +49,7 @@ The `xiaomi_aqara` component allows you to integrate [Xiaomi](http://www.mi.com/
 
 ## {% linkable_title Setup %}
 
-Follow the setup process using your phone and Mi-Home app. From here you will be able to retrieve the key from within the app following [this tutorial](https://community.home-assistant.io/t/beta-xiaomi-gateway-integration/8213/1832).
+Follow the setup process using your phone and Mi-Home app. From here you will be able to retrieve the key (password) from within the app following [this tutorial](https://www.domoticz.com/wiki/Xiaomi_Gateway_(Aqara)#Adding_the_Xiaomi_Gateway_to_Domoticz).
 
 To enable {{ page.title }} in your installation, add the following to your `configuration.yaml` file:
 
@@ -236,7 +236,7 @@ If you run into trouble initializing the gateway with your app, try another smar
 ```
 
 That means that Home Assistant is not getting any response from your Xiaomi gateway. Might be a local network problem or your firewall.
-- Make sure you have [enabled LAN access](https://community.home-assistant.io/t/beta-xiaomi-gateway-integration/8213/1832).
+- Make sure you have [enabled LAN access](https://www.domoticz.com/wiki/Xiaomi_Gateway_(Aqara)#Adding_the_Xiaomi_Gateway_to_Domoticz).
 - Turn off the firewall on the system where Home Assistant is running.
 - Ensure your router supports multicast as this is a requirement of the Xiaomi GW
 - Try to leave the MAC address `mac:` blank.


### PR DESCRIPTION
The old links were referring to a forum post in which it only was explained how to enable the advanced settings, followed by a link to the remaining part of the tutorial (on the Domoticz site). I changed the link to the domoticz forum directly, as it gives the full instructions, including enabling the advanced settings in the app. Added the word “password” in brackets as it is called “password” in the Mii app, and not “key” in the app.

**Description:**
See above

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
