### PR TITLE
Fix Linode link

### DIFF
--- a/source/_components/linode.markdown
+++ b/source/_components/linode.markdown
@@ -13,7 +13,7 @@ ha_release: 0.57
 ha_iot_class: "Cloud Polling"
 ---
 
-The `linode` component allows you to access the information about your [Linode](https://welcome.linode.com) systems from Home Assistant.
+The `linode` component allows you to access the information about your [Linode](https://linode.com) systems from Home Assistant.
 
 Obtain your API key from Linode account.
 


### PR DESCRIPTION
Their landing page at some point must have changed.

**Description:**

Fixes link to Linode for the given component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
