### PR TITLE
developers/frontend - replaced relative with absolute path

### DIFF
--- a/source/developers/frontend.markdown
+++ b/source/developers/frontend.markdown
@@ -27,7 +27,7 @@ First step is to configure Home Assistant to use the development mode for the fr
 
 ```yaml
 frontend:
-  development_repo: ../home-assistant-polymer
+  development_repo: <absolute path to home-assistant-polymer>
 ```
 
 Next step is to git clone the [home-assistant-polymer repository][hass-polymer]. You can place the repository anywhere on your system but to keep these instructions simple we're cloning the home-assistant-polymer repository as a sibling to the Home Assistant repo.


### PR DESCRIPTION
**Description:**
Fixed instructions so frontend developers are using absolute paths in the configuration.yaml
This confused me quite a bit: https://github.com/home-assistant/home-assistant/issues/10546


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
