### PR TITLE
Adds a link directly to the cheatsheet

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -63,7 +63,7 @@ homeassistant:
 | `homebridge_hidden` | Set to `true` to hide the entity from `HomeBridge`.
 | `emulated_hue_hidden` | Set to `true` to hide the entity from `emulated_hue`.
 | `entity_picture` | Url to use as picture for entity.
-| `icon` | Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com). Prefix name with `mdi:`, ie `mdi:home`.
+| `icon` | Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://materialdesignicons.com/cheatsheet)). Prefix name with `mdi:`, ie `mdi:home`.
 | `assumed_state` | For switches with an assumed state two buttons are shown (turn off, turn on) instead of a switch. By setting `assumed_state` to `false` you will get the default switch icon.
 | `device_class` | Sets the class of the device, changing the device state and icon that is displayed on the UI (see below).
 | `initial_state` | Sets the initial state for automations. `on` or `off`.


### PR DESCRIPTION
The cheatsheet shows icons and their name in text on the same page, makes it easier to search for them.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
