### PR TITLE
Fix incorrect closing paragraph tag

### DIFF
--- a/source/_docs/installation.markdown
+++ b/source/_docs/installation.markdown
@@ -12,7 +12,7 @@ redirect_from: /getting-started/installation/
 
 <p class='note'>
 Beginners should check our [Getting started guide](/getting-started/) first. This is for users that require advanced installations.
-<p class='note'>
+</p>
 
 Home Assistant provides multiple ways to be installed. A requirement is that you have [Python](https://www.python.org/downloads/) installed. For Windows, we require at least **Python 3.5** and for other operating systems at least **Python 3.4.2**.
 


### PR DESCRIPTION
**Description:** There was a paragraph tag which wasn't closed correctly, which was
causing issues on the installation instructions pages.

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
