### PR TITLE
update to synology docker install page

### DIFF
--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -72,6 +72,10 @@ Remark: to restart your Home Assistant within Synology NAS, you just have to do 
 * Go to the Docker-app and move to "Container"-section
 * Right-click on it and select "Action"->"Restart".
 
+NOTE: If you want to use a USB Bluetooth adapter or Z-Wave USB Stick with Home Assistant on Synology docker these instructions do not correctly configure the container to access the USB devices. 
+* To configure these devices on your Synology docker Home Assistant you can follow the instructions provided [here](https://philhawthorne.com/installing-home-assistant-io-on-a-synology-diskstation-nas/) by Phil Hawthorne. 
+
+
 ### {% linkable_title Restart %}
 
 This will launch Home Assistant and serve the web interface from port 8123 on your Docker host.

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -72,9 +72,9 @@ Remark: to restart your Home Assistant within Synology NAS, you just have to do 
 * Go to the Docker-app and move to "Container"-section
 * Right-click on it and select "Action"->"Restart".
 
-NOTE: If you want to use a USB Bluetooth adapter or Z-Wave USB Stick with Home Assistant on Synology docker these instructions do not correctly configure the container to access the USB devices. 
-* To configure these devices on your Synology docker Home Assistant you can follow the instructions provided [here](https://philhawthorne.com/installing-home-assistant-io-on-a-synology-diskstation-nas/) by Phil Hawthorne. 
-
+<p class='note'>
+If you want to use a USB Bluetooth adapter or Z-Wave USB Stick with Home Assistant on Synology Docker these instructions do not correctly configure the container to access the USB devices. To configure these devices on your Synology Docker Home Assistant you can follow the instructions provided [here](https://philhawthorne.com/installing-home-assistant-io-on-a-synology-diskstation-nas/) by Phil Hawthorne. 
+</p>
 
 ### {% linkable_title Restart %}
 


### PR DESCRIPTION
Unfortunately the Synology GUI way of installing Home Assistant through docker does not allow access to the USB devices to use a Bluetooth or Z-Wave radio (has to be done via ssh) - User Phil Hawthorne has provided great instructions on his blog to access these devices - so wondered if it was acceptable to provide a link (otherwise it would require adding quite a lot of info to the page). (Phil gave his permission to add this link)
Regards,
James

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
