### PR TITLE
Update HASS Configurator documentation

### DIFF
--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -57,7 +57,7 @@ Screenshot of the HASS Configurator.
 - **ssl** (*Optional*): Enable or Disable SSL for the editor.
 - **allowed_networks** (*Optional*): Limit access to the configurator by adding allowed IP addresses / networks to the list.
 - **banned_ips** (*Optional*): List of statically banned IP addresses.
-- **banlimit** (*Optional*): Ban access from IPs after `banlimit` failed login attempts. The default value `0` disables this feature.
+- **banlimit** (*Optional*): Ban access from IPs after `banlimit` failed login attempts. The default value `0` disables this feature. Restart the add-on to clear the list of banned IP addresses.
 - **ignore_pattern** (*Optional*): Files and folders to ignore in the UI.
 - **dirsfirst** (*Optional*): List directories before files in the filebrowser.
 

--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -46,7 +46,9 @@ Screenshot of the HASS Configurator.
   "ssl": false,
   "allowed_networks": ["192.168.0.0/16"],
   "banned_ips": ["8.8.8.8"],
-  "ignore_pattern": ["__pycache__"]
+  "banlimit": 0,
+  "ignore_pattern": ["__pycache__"],
+  "dirsfirst": false,
 }
 ```
 
@@ -55,7 +57,9 @@ Screenshot of the HASS Configurator.
 - **ssl** (*Optional*): Enable or Disable SSL for the editor.
 - **allowed_networks** (*Optional*): Limit access to the configurator by adding allowed IP addresses / networks to the list.
 - **banned_ips** (*Optional*): List of statically banned IP addresses.
+- **banlimit** (*Optional*): Ban access from IPs after `banlimit` failed login attempts. The default value `0` disables this feature.
 - **ignore_pattern** (*Optional*): Files and folders to ignore in the UI.
+- **dirsfirst** (*Optional*): List directories before files in the filebrowser.
 
 ### {% linkable_title Embedding into Home-Assistant %}
 

--- a/source/_docs/ecosystem/hass-configurator.markdown
+++ b/source/_docs/ecosystem/hass-configurator.markdown
@@ -15,6 +15,11 @@ redirect_from: /ecosystem/hass-configurator/
 Since there currently is no nice way to edit the yaml-files Home Assistant is using through the frontend, here is a small webapp that hopefully makes the configuration easier. It is a customized and embedded [Ace editor](https://ace.c9.io/), which has syntax highlighting for yaml, the format used for Home Assistants configuration files. There is an integrated file browser to select whatever file you want to edit. When you're done with editing the file, click the save-button and it will replace the original.  
 Essentially this is a browser-based alternative to modifying your configuration through SSH, Windows + SMB, Github etc..
 
+<p class='img'>
+<img src='/images/hassio/screenshots/addon-hass-configurator.png'>
+Screenshot of the HASS Configurator.
+</p>
+
 ### {% linkable_title Feature list %}
 
 - Web-Based editor to modify your files
@@ -64,6 +69,10 @@ Limit access to the configurator by adding allowed IP addresses / networks to th
 List of statically banned IP addresses, e.g. `BANNED_IPS = ["1.1.1.1", "2.2.2.2"]`
 #### BANLIMIT (integer)
 Ban IPs after `n` failed login attempts. Restart the service to reset banning. The default of `0` disables this feature. `CREDENTIALS` has to be set for this to work.
+#### IGNORE_PATTERN (list)
+Files and folders to ignore in the UI, e.g. `IGNORE_PATTERN = [".*", "*.log", "__pycache__"]`.
+#### DIRSFIRST (bool)
+If set to `True`, directories will be displayed at the top of the filebrowser.
 #### GIT (bool)
 Set this variable to `True` to enable Git integration. This feature requires [GitPython](https://gitpython.readthedocs.io)
  to be installed on the system that is running the configurator. For technical reasons this feature can not be enabled with the static settings file.


### PR DESCRIPTION
**Description:**
Added new options that have made their way into the configurator. Also added the screenshot the hass.io documentation already has to the ecosystem documentation.

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
