### PR TITLE
Remote control updates

### DIFF
--- a/source/_components/remote.apple_tv.markdown
+++ b/source/_components/remote.apple_tv.markdown
@@ -37,7 +37,4 @@ data:
     - left
     - menu
     - select
-  device: ''
 ```
-
-Please note that `device` must be specified (because of validation) but is not used by this platform. So you may specify any value.

--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -70,7 +70,7 @@ Turn off all devices that were switched on from the start of the current activit
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on specific remote. Else targets all.
+| `entity_id`            |      yes | Only act on a specific remote, else target all.
 
 ### {% linkable_title Service `remote.turn_on` %}
 
@@ -78,7 +78,7 @@ Start an activity. Will start the default `activity` from configuration.yaml if 
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on specific remote. Else targets all.
+| `entity_id`            |      yes | Only act on a specific remote, else target all.
 | `activity`             |      yes | Activity ID or Activity Name to start.
 
 ### {% linkable_title Service `remote.send_command` %}
@@ -87,8 +87,8 @@ Send a single command or a set of commands to one device, device ID and availabl
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on specific remote. Else targets all.
-| `device`               |       no | Device ID to send command to.
+| `entity_id`            |      yes | Only act on a specific remote, else target all.
+| `device`               |       no | Device ID to send the command to.
 | `command`              |       no | A single command or a list of commands to send.
 | `num_repeats`          |      yes | The number of times to repeat the command(s).
 | `delay_secs`           |      yes | The number of seconds between sending each command.
@@ -112,7 +112,7 @@ Synchronize the Harmony device with the Harmony web service if any changes are m
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on specific remote. Else targets all.
+| `entity_id`            |      yes | Only act on a specific remote, else target all.
 
 ### {% linkable_title Examples %}
 

--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -53,7 +53,7 @@ Configuration variables:
 - **name** (*Required*): The hub's name to display in the frontend.
 - **host** (*Optional*): The Harmony device's IP address. Leave empty for the IP to be discovered automatically.
 - **port** (*Optional*): The Harmony device's port. Defaults to 5222.
-- **activity** (*Optional*): Activity to use when turnon service is called without any data.
+- **activity** (*Optional*): Activity to use when `turn_on` service is called without any data.
 - **delay_secs** (*Optional*): Default duration in seconds between sending commands to a device.
 
 Configuration file:
@@ -64,31 +64,57 @@ Upon startup one file will be written to your Home Assistant configuration direc
 - List of all programmed device names and ID numbers
 - List of all available commands per programmed device
 
-Supported services:
+### {% linkable_title Service `remote.turn_off` %}
 
-- **Turn Off**: Turn off all devices that were switched on from the start of the current activity.s
-- **Turn On**: Start an activity, will start the default activity from configuration.yaml if no activity is specified.  The specified activity can either be the activity name or the activity ID from the configuration file written to your [Home Assistant configuration directory](/docs/configuration/).
-- **Send Command**: Send a single command or a set of commands to one device, device ID and available commands are written to the configuration file at startup. You can optionally specify the number of times you wish to repeat the command(s) and delay you want between repeated command(s).
-- **Sync**: Synchronizes the Harmony device with the Harmony web service if any changes are made from the web portal or app.
+Turn off all devices that were switched on from the start of the current activity.
 
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |      yes | Only act on specific remote. Else targets all.
 
-### {% linkable_title Examples %}
+### {% linkable_title Service `remote.turn_on` %}
 
-A template switch can be used to display and control the state of an activity in the frontend.
+Start an activity. Will start the default `activity` from configuration.yaml if no activity is specified.  The specified activity can either be the activity name or the activity ID from the configuration file written to your [Home Assistant configuration directory](/docs/configuration/).
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |      yes | Only act on specific remote. Else targets all.
+| `activity`             |      yes | Activity ID or Activity Name to start.
+
+### {% linkable_title Service `remote.send_command` %}
+
+Send a single command or a set of commands to one device, device ID and available commands are written to the configuration file at startup. You can optionally specify the number of times you wish to repeat the command(s) and delay you want between repeated command(s).
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |      yes | Only act on specific remote. Else targets all.
+| `device`               |       no | Device ID to send command to.
+| `command`              |       no | A single command or a list of commands to send.
+| `num_repeats`          |      yes | The number of times to repeat the command(s).
+| `delay_secs`           |      yes | The number of seconds between sending each command.
+
+A typical service call for sending several button presses looks like this:
 
 ```yaml
-switch:
-  - platform: template
-    switches:
-      tv:
-        value_template: "{% raw %}{% if is_state('remote.family_room', 'on') %}on{% else %}off{% endif %}{% endraw %}"
-        turn_on:
-          service: remote.turn_on
-          entity_id: remote.family_room
-        turn_off:
-          service: remote.turn_off
-          entity_id: remote.family_room
+service: remote.send_command
+data:
+  entity_id: remote.tv_room
+  command:
+    - home
+    - 1
+    - 2
+  delay_secs: 0.6
 ```
+
+### {% linkable_title Service `remote.harmony_sync` %}
+
+Synchronize the Harmony device with the Harmony web service if any changes are made from the web portal or app.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |      yes | Only act on specific remote. Else targets all.
+
+### {% linkable_title Examples %}
 
 Template sensors can be utilized to display current activity in the frontend.
 
@@ -103,7 +129,6 @@ sensor:
         value_template: {% raw %}'{{ states.remote.bedroom.attributes.current_activity }}'{% endraw %}
         friendly_name: 'bedroom'
 ```
-
 
 The example below shows how to control an `input_boolean` switch using the Harmony remote's current activity. The switch will turn on when the remote's state changes and the Kodi activity is started and off when the remote's state changes and the current activity is PowerOff.
 
@@ -129,40 +154,4 @@ automation:
     action:
       service: input_boolean.turn_off
       entity_id: input_boolean.notify
-````
-
-The automation example below shows how to send a command via the harmony remote using the `send_command` service to send the 'Pause' command to the hub, which is already defined as an IR code for each device to be used via the Harmony app. It is checking for the activity name as exposed through the sensor in the harmony remote component using Jinja if statements to set the device_id, sending the correct Pause command for the given activity. This requires checking your activity list and device_id from the `harmony_REMOTENAME.conf` file created when you start the component. In this example, the harmony hub is named bedroom.
-
-```yaml
-automation:
-  - alias: Harmony Pause contextual for activity
-    trigger:
-    # trigger happens to be from a flic button - could be any valid event
-      platform: event
-      event_type: flic_click
-      event_data:
-        button_name: flic_80e4da70bbb1
-        click_type: double
-    action:
-      service: remote.send_command
-      data_template:
-      # using a data template to have if brances for relevant device
-        # Always the same entity_id - the harmony hub
-        entity_id: remote.bedroom
-        # Always the same command - the Pause key
-        command: Pause
-        # select device based upon the activity being undertaken.
-        device: >
-          # when in WATCH TV activity, the pause key relates to a TiVo, which is device 22987101
-          {% raw %}{% if is_state("sensor.bedroom", "WATCH TV") %}{% raw %}
-            22987101
-          # when in WATCH APPLE TV activity, the pause key relates to an Apple TV, which is device 23002316
-          {% raw %}{% elif is_state("sensor.bedroom", "WATCH APPLE TV") %}{% endraw %}
-            23002316
-          {% raw %}{% elif is_state("sensor.bedroom", "PLEX") %}{% endraw %}
-            23048786
-          {% raw %}{% elif is_state("sensor.bedroom", "WATCH BLU RAY") %}{% endraw %}
-            23043122
-          {% raw %}{% endif %}{% endraw %}
-
 ````

--- a/source/_components/remote.itach.markdown
+++ b/source/_components/remote.itach.markdown
@@ -48,7 +48,7 @@ Configuration variables:
     - **name** (*Required*): Command name.
     - **data** (*Required*): Hex command data.
 
-An example to call the component from developer tools using the remote, send_command service `{ "entity_id":"remote.tv", "device":"0", "command":"menu" }`
+An example to call the component from developer tools using the `remote.send_command` service: `{ "entity_id":"remote.tv", "command":"menu" }`
 
 Note: Global Cache devices expect data in their own format of "sendir...". This component converts hex code to Global Cache IR form.
 

--- a/source/_components/remote.markdown
+++ b/source/_components/remote.markdown
@@ -25,6 +25,6 @@ Go to the **Developer Tools**, then to **Call Service** in the frontend, and cho
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on specific remote. Else targets all.
+| `entity_id`            |      yes | Only act on a specific remote, else target all.
 
 See the platform documentation for each type of remote for more detailed examples.

--- a/source/_components/remote.markdown
+++ b/source/_components/remote.markdown
@@ -13,7 +13,7 @@ ha_release: "0.34"
 Keeps track which remotes are in your environment, their state and allows you to control them.
 
  * Maintains a state per remote and a combined state `all_remotes`.
- * Registers services `remote/turn_on`, `remote/turn_off`, `remote/toggle`, `remote/sync`, and `remote/send_command` to control remotes.
+ * Registers services `remote/turn_on`, `remote/turn_off`, `remote/toggle`, and `remote/send_command` to control remotes.
 
 ### {% linkable_title Use the services %}
 
@@ -27,3 +27,4 @@ Go to the **Developer Tools**, then to **Call Service** in the frontend, and cho
 | ---------------------- | -------- | ----------- |
 | `entity_id`            |      yes | Only act on specific remote. Else targets all.
 
+See the platform documentation for each type of remote for more detailed examples.


### PR DESCRIPTION
**Description:**

* Remove obsolete mentions of `sync` (moved to Harmony) and `device` (is now optional) from remote, remote.apple_tv and remote.itach.
* Document all service data attributes for Harmony remote.
* Cut down on complex Harmony examples that confuse rather than help.

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
