### PR TITLE
Added documentation for new Emby options

### DIFF
--- a/source/_components/media_player.emby.markdown
+++ b/source/_components/media_player.emby.markdown
@@ -33,3 +33,4 @@ Configuration variables:
 - **ssl** (*Optional*): True if you want to connect with https/wss. Your SSL certificate must be valid. Default is False.
 - **port** (*Optional*): The port number. Defaults to 8096 with SSL set to False and 8920 with SSL set to True.
 - **auto_hide** (*Optional*): True if you want to automatically hide devices that are unavailable from the Home Assistant Interface. Defaults to False.
+- **auto_group** (*Optional*): True if you want available Emby application instances to automatically be added to a group called "emby". This group can then be referenced elsewhere in home-assistant. Defaults to False.


### PR DESCRIPTION
**Description:**
Added documentation for proposed auto_group option for the Emby component


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10655

## Checklist:

  - [Y] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [Y] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
