### PR TITLE
Correct container name for restart command

### DIFF
--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -83,4 +83,4 @@ This will launch Home Assistant and serve the web interface from port 8123 on yo
 If you change the configuration you have to restart the server. To do that you have 2 options.
 
  1. You can go to the <img src='/images/screenshots/developer-tool-services-icon.png' alt='service developer tool icon' class="no-shadow" height="38" /> service developer tools, select the service `homeassistant/restart` and click "Call Service".
- 2. Or you can restart it from a terminal by running `docker restart homeassistant`
+ 2. Or you can restart it from a terminal by running `docker restart home-assistant`


### PR DESCRIPTION
**Description:**
Using above instructions container name includes the dash.

```
shiny % docker ps
CONTAINER ID        IMAGE                          COMMAND                  CREATED             STATUS              PORTS                    NAMES
a9be19e6c76a        homeassistant/home-assistant   "python -m homeass..."   5 minutes ago       Up About a minute   0.0.0.0:8123->8123/tcp   home-assistant
shiny % docker restart homeassistant
Error response from daemon: No such container: homeassistant
[1]    67676 exit 1     docker restart homeassistant
shiny !1! % docker restart home-assistant
home-assistant
```

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
