### PR TITLE
Update index.html

### DIFF
--- a/docs/installation/virtualenv/index.html
+++ b/docs/installation/virtualenv/index.html
@@ -85,7 +85,7 @@ Beginners should check our <a href="/getting-started/">getting started guide</a>
 <h2><a class="title-link" name="step-1-install-dependencies" href="#step-1-install-dependencies"></a> Step 1: Install dependencies</h2>
 <div class="language-bash highlighter-rouge"><pre class="highlight"><code><span class="gp">$ </span>sudo apt-get update
 <span class="gp">$ </span>sudo apt-get upgrade
-<span class="gp">$ </span>sudo apt-get install python3-pip python3-dev
+<span class="gp">$ </span>sudo apt-get install python3-pip python3-dev python3-venv
 <span class="gp">$ </span>sudo pip3 install --upgrade virtualenv
 </code></pre>
 </div>
@@ -118,7 +118,7 @@ Beginners should check our <a href="/getting-started/">getting started guide</a>
 <p>This can be anywhere you want.  We chose to put it in <code class="highlighter-rouge">/srv</code>. You also need to change the ownership of the directory to the user you created above.</p>
 <div class="language-bash highlighter-rouge"><pre class="highlight"><code><span class="gp">$ </span>sudo mkdir /srv/homeassistant
 <span class="gp">$ </span>sudo chown homeassistant:homeassistant /srv/homeassistant
-<span class="gp">$ </span>python3 -m venv /srv/homeassistant
+<span class="gp">$ </span>sudo -u homeassistant python3 -m venv /srv/homeassistant
 </code></pre>
 </div>
 <h2><a class="title-link" name="install-or-update-home-assistant" href="#install-or-update-home-assistant"></a> Install or update Home Assistant</h2>


### PR DESCRIPTION
After helping someone with issues installing in Ubuntu Server 16.04 (fully updated), I would like to propose a couple of fixes.
python3-venv package might be required in some installs. And the documentation by default initialises the venv as logged in user, not homeassistant-user.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
