### PR TITLE
Update systemd.markdown with After=network-online.target for robust start up

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -28,7 +28,7 @@ A service file is needed to control Home Assistant with `systemd`. The template 
 ```
 [Unit]
 Description=Home Assistant
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple
@@ -46,7 +46,7 @@ If you've setup Home Assistant in `virtualenv` following our [Python installatio
 ```
 [Unit]
 Description=Home Assistant
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
I found that After=network.target was not robust enough for Auto-discovery to work correctly and find devices on the network. I changed this to After=network-online.target to wait until the network was completely "up" before starting.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
