### PR TITLE
fix documentation for input_datetime

### DIFF
--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -39,7 +39,7 @@ Configuration variables:
   - **name** (*Optional*): Friendly name of the datetime input.
   - **has_time** (*Optional*): Set to `true` if this input should have time. Defaults to `false`.
   - **has_date** (*Optional*): Set to `true` if this input should have a date. Defaults to `false`.
-  - **initial** (*Optional*): Set the initial value of this input. Defaults to '1970-01-01 00:00'.
+  - **initial** (*Optional*): Set the initial value of this input. Defaults to '1970-01-01 00:00'. If has_time is `false` this must be just a date (e.g.: '1970-01-01'). If has_date is `false` this must be just a time (e.g.: '15:16').
 
 A datetime input entity's state exports several attributes that can be useful in automations and templates:
 


### PR DESCRIPTION
**Description:**
changes from home-assistant/home-assistant#10417 breaks old configs

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10417

