### PR TITLE
Update manual and manual_mqtt alarm platform for upcoming changes

### DIFF
--- a/source/_components/alarm_control_panel.manual.markdown
+++ b/source/_components/alarm_control_panel.manual.markdown
@@ -25,13 +25,62 @@ Configuration variables:
 
 - **name** (*Optional*): The name of the alarm. Default is "HA Alarm".
 - **code** (*Optional*): If defined, specifies a code to enable or disable the alarm in the frontend.
-- **pending_time** (*Optional*): The time in seconds of the pending time before arming the alarm. Default is 60 seconds.
+- **code_template** (*Optional*): If defined, returns a code to enable or disable the alarm in the frontend; an empty string disables checking the code.  Inside the template, the variables **from_state** and **to_state** identify the current and desired state.  Only one of **code** and **code_template** can be specified.
+- **delay_time** (*Optional*): The time in seconds of the pending time before triggering the alarm. Default is 0 seconds.
+- **pending_time** (*Optional*): The time in seconds of the pending time before effecting a state change. Default is 60 seconds.
 - **trigger_time** (*Optional*): The time in seconds of the trigger time in which the alarm is firing. Default is 120 seconds.
 - **disarm_after_trigger** (*Optional*): If true, the alarm will automatically disarm after it has been triggered instead of returning to the previous state.
-- **armed_home/armed_away/armed_night/triggered** (*Optional*): State specific settings
-  - **pending_time**: State specific pending time override.
+- **armed_custom_bypass/armed_home/armed_away/armed_night/disarmed/triggered** (*Optional*): State specific settings
+  - **delay_time** (*Optional*): State specific setting for **delay_time** (all states except **triggered**)
+  - **pending_time** (*Optional*): State specific setting for **pending_time** (all states except **disarmed**)
+  - **trigger_time** (*Optional*): State specific setting for **trigger_time** (all states except **triggered**)
 
-In the config example below, armed_home state will have no pending time and triggered state will have pending time of 20 second whereas armed_away state will have a default pending time of 30 seconds.
+## {% linkable_title State machine %}
+
+The state machine of the manual alarm component is complex but powerful.  The
+transitions are timed according to three values, **delay_time**, **pending_time**
+and **trigger_time**.  The values in turn can come from the default configuration
+variable or from a state-specific override.
+
+When the alarm is armed, its state first goes to **pending** for a number
+of seconds equal to the destination state's **pending_time**, and then
+transitions to one of the "armed" states.  Note that **code_template**
+never receives "pending" in the **to_state** variable; instead,
+**to_state** contains the state which the user has requested.  However,
+**from_state** *can* contain "pending".
+
+When the alarm is triggered, its state goes to **pending** for a number of
+seconds equal to the previous state's **delay_time** plus the triggered
+state's **pending_time**.  Then the alarm transitions to the "triggered"
+states.  The code is never checked when triggering the alarm, so the
+**to_state** variable of **code_template** cannot ever contain "triggered"
+either; again, **from_state** *can* contain "triggered".
+
+The alarm remains in the "triggered" state for a number of seconds equal to the
+previous state's **trigger_time**.  Then, depending on **disarm_after_trigger**,
+it goes back to either the previous state or **disarmed**.  If the previous
+state's **trigger_time** is zero, the transition to "triggered" is entirely
+blocked and the alarm remains in the armed state.
+
+Each of the settings is useful in different scenarios.  **pending_time** gives
+you some time to leave the building (for "armed" states) or to disarm the alarm
+(for the "triggered" state).
+
+**delay_time** can also be used to allow some time to disarm the alarm, but with
+more flexibility.  For example, you could specify a delay time for the
+"armed away" state, in order to avoid triggering the alarm while the
+garage door opens, but not for the "armed home" state.
+
+**trigger_time** is useful to disable the alarm when disarmed, but it can also
+be used for example to sound the siren for a shorter time during the night.
+
+In the config example below:
+
+- the disarmed state never triggers the alarm;
+
+- the armed_home state will leave no time to leave the building or disarm the alarm;
+
+- while other states state will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back.
 
 ```yaml
 # Example configuration.yaml entry
@@ -40,11 +89,13 @@ alarm_control_panel:
     name: Home Alarm
     code: 1234
     pending_time: 30
+    delay_time: 20
+    trigger_time: 4
+    disarmed:
+      trigger_time: 0
     armed_home:
       pending_time: 0
-    triggered:
-      pending_time: 20
-    trigger_time: 4 
+      delay_time: 0
 ```
 
 ## {% linkable_title Examples %}

--- a/source/_components/alarm_control_panel.manual_mqtt.markdown
+++ b/source/_components/alarm_control_panel.manual_mqtt.markdown
@@ -42,15 +42,21 @@ alarm_control_panel:
 
 Configuration variables:
 
-All configuration variables from the base manual alarm platform are available:
+The following configuration variables from the base manual alarm platform are available:
 
 - **name** (*Optional*): The name of the alarm. Default is "HA Alarm".
 - **code** (*Optional*): If defined, specifies a code to enable or disable the alarm in the frontend. This code is not required for MQTT interactions.
-- **pending_time** (*Optional*): The time in seconds of the pending time before arming the alarm. Default is 60 seconds.
+- **code_template** (*Optional*): If defined, returns a code to enable or disable the alarm in the frontend; an empty string disables checking the code.  Inside the template, the variables **from_state** and **to_state** identify the current and desired state.  Only one of **code** and **code_template** can be specified.
+- **delay_time** (*Optional*): The time in seconds of the pending time before triggering the alarm. Default is 0 seconds.
+- **pending_time** (*Optional*): The time in seconds of the pending time before effecting a state change. Default is 60 seconds.
 - **trigger_time** (*Optional*): The time in seconds of the trigger time in which the alarm is firing. Default is 120 seconds.
 - **disarm_after_trigger** (*Optional*): If true, the alarm will automatically disarm after it has been triggered instead of returning to the previous state.
-- **armed_home|armed_away|armed_night|triggered** (*Optional*): State specific settings
-  - **pending_time**: State specific pending time override.
+- **armed_home/armed_away/armed_night/disarmed/triggered** (*Optional*): State specific settings
+  - **delay_time** (*Optional*): State specific setting for **delay_time** (all states except **triggered**)
+  - **pending_time** (*Optional*): State specific setting for **pending_time** (all states except **disarmed**)
+  - **trigger_time** (*Optional*): State specific setting for **trigger_time** (all states except **triggered**)
+
+See the documentation for the [manual alarm platform](../alarm_control_panel.manual/) for a description.
 
 Additionally, the following MQTT configuration variables are also available:
 
@@ -62,7 +68,13 @@ Additionally, the following MQTT configuration variables are also available:
 - **payload_arm_away** (*Optional*): The payload to set armed-away mode on this Alarm Panel. Default is "ARM_AWAY".
 - **payload_arm_night** (*Optional*): The payload to set armed-night mode on this Alarm Panel. Default is "ARM_NIGHT".
 
-In the config example below, armed_home state will have no pending time and triggered state will have a pending time of 20 seconds whereas armed_away state will have a default pending time of 30 seconds.
+In the config example below:
+
+- the disarmed state never triggers the alarm;
+
+- the armed_home state will leave no time to leave the building or disarm the alarm;
+
+- while other states state will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back.
 
 ```yaml
 # Example configuration.yaml entry
@@ -71,11 +83,13 @@ alarm_control_panel:
     state_topic: home/alarm
     command_topic: home/alarm/set
     pending_time: 30
+    delay_time: 20
+    trigger_time: 4
+    disarmed:
+      trigger_time: 0
     armed_home:
       pending_time: 0
-    triggered:
-      pending_time: 20
-    trigger_time: 4 
+      delay_time: 0
 ```
 
 ## {% linkable_title Examples %}


### PR DESCRIPTION
**Description:**

Documentation changes for new features of the manual alarm component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10738

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].
    - __Not__ using the configuration tag because the files I modified aren't using it already.

[standards]: https://home-assistant.io/developers/documentation/standards/
