### PR TITLE
Document new attributes

### DIFF
--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -34,18 +34,18 @@ Configuration variables:
 
 The following statistics will be exposed as attributes.
 
-|Attribute                    |Description                                                  |
-|:----------------------------|:------------------------------------------------------------|
-|is_linked                    |True if the FritzBox is physically linked to the provider    |
-|is_connected                 |True if the FritzBox has established an internet-connection  |
-|wan_access_type              |Connection-type, can be `DSL` or `Cable`                     |
-|external_ip                  |External ip address                                          |
-|uptime                       |Uptime in seconds                                            |
-|bytes_sent                   |Bytes sent                                                   |
-|bytes_received               |Bytes received                                               |
-|transmission_rate_upstream   |Current upstream speed in bytes/s                            |
-|transmission_rate_downstream |Current downstream speed in bytes/s                          |
-|max_byte_rate_up             |Maximum upstream-rate in bytes/s                             |
-|max_byte_rate_down           |Maximum downstream-rate in bytes/s                           |
+|Attribute              |Description                                                  |
+|:----------------------|:------------------------------------------------------------|
+|is_linked              |True if the FritzBox is physically linked to the provider    |
+|is_connected           |True if the FritzBox has established an internet-connection  |
+|wan_access_type        |Connection-type, can be `DSL` or `Cable`                     |
+|external_ip            |External ip address                                          |
+|uptime                 |Uptime in seconds                                            |
+|bytes_sent             |Bytes sent                                                   |
+|bytes_received         |Bytes received                                               |
+|transmission_rate_up   |Current upstream speed in bytes/s                            |
+|transmission_rate_down |Current downstream speed in bytes/s                          |
+|max_byte_rate_up       |Maximum upstream-rate in bytes/s                             |
+|max_byte_rate_down     |Maximum downstream-rate in bytes/s                           |
 
 The sensor's state corresponds to the `is_linked` attribute and is either `online`, `offline`, or `unavailable` (in case connection to the router is lost).

--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -34,16 +34,18 @@ Configuration variables:
 
 The following statistics will be exposed as attributes.
 
-|Attribute         |Description                                                  |
-|:-----------------|:------------------------------------------------------------|
-|is_linked         |True if the FritzBox is physically linked to the provider    |
-|is_connected      |True if the FritzBox has established an internet-connection  |
-|wan_access_type   |Connection-type, can be `DSL` or `Cable`                     |
-|external_ip       |External ip address                                          |
-|uptime            |Uptime in seconds                                            |
-|bytes_sent        |Bytes sent                                                   |
-|bytes_received    |Bytes received                                               |
-|max_byte_rate_up  |Maximum upstream-rate in bytes/s                             |
-|max_byte_rate_down|Maximum downstream-rate in bytes/s                           |
+|Attribute                    |Description                                                  |
+|:----------------------------|:------------------------------------------------------------|
+|is_linked                    |True if the FritzBox is physically linked to the provider    |
+|is_connected                 |True if the FritzBox has established an internet-connection  |
+|wan_access_type              |Connection-type, can be `DSL` or `Cable`                     |
+|external_ip                  |External ip address                                          |
+|uptime                       |Uptime in seconds                                            |
+|bytes_sent                   |Bytes sent                                                   |
+|bytes_received               |Bytes received                                               |
+|transmission_rate_upstream   |Current upstream speed in bytes/s                            |
+|transmission_rate_downstream |Current downstream speed in bytes/s                          |
+|max_byte_rate_up             |Maximum upstream-rate in bytes/s                             |
+|max_byte_rate_down           |Maximum downstream-rate in bytes/s                           |
 
 The sensor's state corresponds to the `is_linked` attribute and is either `online`, `offline`, or `unavailable` (in case connection to the router is lost).


### PR DESCRIPTION
**Description:**
Add documentation for the new attributes `transmission_rate_up` and `transmission_rate_down`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10740

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
