### PR TITLE
light.yeelight: rename Developer mode with the new LAN mode

### DIFF
--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -47,7 +47,7 @@ Per default the bulb limits the amount of requests per minute to 60, a limitatio
 ### {% linkable_title Initial setup %}
 <p class='note'>
 Before trying to control your light through Home Assistant, you have to setup your bulb using Yeelight app. ( [Android](https://play.google.com/store/apps/details?id=com.yeelight.cherry&hl=fr), [IOS](https://itunes.apple.com/us/app/yeelight/id977125608?mt=8) ).
-In the bulb property, you have to enable "Developer Mode"  Developer mode may only be available with the latest firmware installed on your bulb.  Firmware can be updated in the application after connecting the bulb.
+In the bulb property, you have to enable "LAN Mode" (previously called "Developer mode"). LAN mode may only be available with the latest firmware installed on your bulb.  Firmware can be updated in the application after connecting the bulb.
 Determine your bulb IP (using router, software, ping ...)
 </p>
 


### PR DESCRIPTION
**Description:**

Developer mode has been renamed to LAN mode.  For reference http://forum.yeelight.com/t/no-developer-mode-with-rgbw-and-yeelight-app/2514

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
