### PR TITLE
Update media_player.universal.markdown

### DIFF
--- a/source/_components/media_player.universal.markdown
+++ b/source/_components/media_player.universal.markdown
@@ -153,7 +153,7 @@ media_player:
 - platform: universal
   name: Kodi TV
   state_template: >
-    {% raw %}{% if is_state('media_player.kodi', 'idle') and (is_state('input_boolean.kodi_tv_state', 'off') %}
+    {% raw %}{% if is_state('media_player.kodi', 'idle') and is_state('input_boolean.kodi_tv_state', 'off') %}
     off
     {% else %}
     {{ states('media_player.kodi') }}

--- a/source/_components/media_player.universal.markdown
+++ b/source/_components/media_player.universal.markdown
@@ -153,7 +153,7 @@ media_player:
 - platform: universal
   name: Kodi TV
   state_template: >
-    {% raw %}{% if (is_state('media_player.kodi', 'idle') and (is_state('input_boolean.kodi_tv_state', 'off') %}
+    {% raw %}{% if is_state('media_player.kodi', 'idle') and (is_state('input_boolean.kodi_tv_state', 'off') %}
     off
     {% else %}
     {{ states('media_player.kodi') }}


### PR DESCRIPTION
This state template is invalid...
    `{% if (is_state('media_player.kodi', 'idle') `
causing the following error...
 `   Error rendering template: TemplateSyntaxError: unexpected '}', expected ')'`
It seems there is a rogue bracket. when deleted the template reads...
   ` {% if is_state('media_player.kodi', 'idle') `
the template now works

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
