### PR TITLE
extra_html_url is split into extra_html_url and extra_html_url_es5

### DIFF
--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -23,7 +23,7 @@ frontend:
     description: "Version of the JavaScript to serve to clients. Options: `es5` - transpiled so old browsers understand it.  `latest` - not transpiled, so will work on recent browsers only. `auto` - select a version according to the browser user-agent. The value in the config can be overiden by putting `es5` or `latest` in the URL. For example `http://localhost:8123/states?es5` "
     required: false
     type: string
-    default: es5
+    default: auto
   themes:
     description: Allow to define different themes. See below for further details.
     required: false

--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -39,7 +39,11 @@ frontend:
             required: true
             type: [list, string]
   extra_html_url:
-    description: "List of addtional [resources](/developers/frontend_creating_custom_ui/) to load."
+    description: "List of addtional [resources](/developers/frontend_creating_custom_ui/) to load in `latest` javascript mode."
+    required: false
+    type: list
+  extra_html_url_es5:
+    description: "List of addtional [resources](/developers/frontend_creating_custom_ui/) to load in `es5` javascript mode."
     required: false
     type: list
   development_repo:

--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -23,7 +23,7 @@ frontend:
     description: "Version of the JavaScript to serve to clients. Options: `es5` - transpiled so old browsers understand it.  `latest` - not transpiled, so will work on recent browsers only. `auto` - select a version according to the browser user-agent. The value in the config can be overiden by putting `es5` or `latest` in the URL. For example `http://localhost:8123/states?es5` "
     required: false
     type: string
-    default: auto
+    default: es5
   themes:
     description: Allow to define different themes. See below for further details.
     required: false


### PR DESCRIPTION
**Description:**

`extra_html_url` is split into `extra_html_url` and `extra_html_url_es5`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10776

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
