### PR TITLE
Mentioned the naming of the disk_use sensor

### DIFF
--- a/source/_components/sensor.systemmonitor.markdown
+++ b/source/_components/sensor.systemmonitor.markdown
@@ -67,7 +67,7 @@ The table contains types and their argument to use in your `configuration.yaml` 
 | memory_free         | sensor.ram_available     |
 | memory_use_percent  | sensor.ram_used          |
 | processor_use       | sensor.cpu_used          |
-| disk_use            | sensor.disk_use**d**     |
+| disk_use            | sensor.disk_used         |
 
 ## {% linkable_title Linux specific %}
 

--- a/source/_components/sensor.systemmonitor.markdown
+++ b/source/_components/sensor.systemmonitor.markdown
@@ -67,6 +67,7 @@ The table contains types and their argument to use in your `configuration.yaml` 
 | memory_free         | sensor.ram_available     |
 | memory_use_percent  | sensor.ram_used          |
 | processor_use       | sensor.cpu_used          |
+| disk_use            | sensor.disk_use**d**     |
 
 ## {% linkable_title Linux specific %}
 


### PR DESCRIPTION
**Description:**

The disk_use parameter creates sensors named disk_used. This should be mentioned along the other differing entity names. This not being mentioned on release made me lose one month of data.

~Cheers

## Checklist:

  - [ x ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ x ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
