### PR TITLE
change homeassistant.appapi to appdaemon.appapi

### DIFF
--- a/source/_docs/ecosystem/appdaemon.markdown
+++ b/source/_docs/ecosystem/appdaemon.markdown
@@ -58,7 +58,7 @@ This is also fairly easy to achieve with Home Assistant automations, but we are 
 Our next example is to turn on a light when motion is detected and it is dark, and turn it off after a period of time. This time, the `initialize()` function registers a callback on a state change (of the motion sensor) rather than a specific time. We tell AppDaemon that we are only interested in state changes where the motion detector comes on by adding an additional parameter to the callback registration - `new = "on"`. When the motion is detected, the callback function `motion()` is called, and we check whether or not the sun has set using a built-in convenience function: `sun_down()`. Next, we turn the light on with `turn_on()`, then set a timer using `run_in()` to turn the light off after 60 seconds, which is another call to the scheduler to execute in a set time from now, which results in `AppDaemon` calling `light_off()` 60 seconds later using the `turn_off()` call to actually turn the light off. This is still pretty simple in code terms:
 
 ```python
-import homeassistant.appapi as appapi
+import appdaemon.appapi as appapi
 
 class FlashyMotionLights(appapi.AppDaemon):
 
@@ -79,7 +79,7 @@ This is starting to get a little more complex in Home Assistant automations, req
 Now let's extend this with a somewhat artificial example to show something that is simple in AppDaemon but very difficult if not impossible using automations. Let's warn someone inside the house that there has been motion outside by flashing a lamp on and off ten times. We are reacting to the motion as before by turning on the light and setting a timer to turn it off again, but in addition, we set a 1-second timer to run `flash_warning()`, which, when called, toggles the inside light and sets another timer to call itself a second later. To avoid re-triggering forever, it keeps a count of how many times it has been activated and bales out after ten iterations.
 
 ```python
-import homeassistant.appapi as appapi
+import appdaemon.appapi as appapi
 
 class MotionLights(appapi.AppDaemon):
 


### PR DESCRIPTION
As far as I understand it (I'm a noob), there is no such thing as homeassistant.appapi , but rather should be appdaemon.appapi. I encountered this issue as described in this thread: https://community.home-assistant.io/t/appdaemon-first-steps/24820/6?u=dolores

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
