### PR TITLE
Adds correction to Zooz switch manual

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -215,3 +215,7 @@ Button one single tap|1|TBC
 Button two single tap|2|TBC
 Button three single tap|3|TBC
 Button four single tap|4|TBC
+
+### {% linkable_title Zooz Toggle Switches %}
+
+Some models of the Zooz Toggle switches ship with an instruction manual with incorrect instruction for Z wave inclusion/exclusion. The instructions say that the switch should be quickly switched on-off-on for inclusion and off-on-off for exclusion. However, the correct method is on-on-on for inclusion and off-off-off for exclusion.

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -218,4 +218,4 @@ Button four single tap|4|TBC
 
 ### {% linkable_title Zooz Toggle Switches %}
 
-Some models of the Zooz Toggle switches ship with an instruction manual with incorrect instruction for Z wave inclusion/exclusion. The instructions say that the switch should be quickly switched on-off-on for inclusion and off-on-off for exclusion. However, the correct method is on-on-on for inclusion and off-off-off for exclusion.
+Some models of the Zooz Toggle switches ship with an instruction manual with incorrect instruction for Z-Wave inclusion/exclusion. The instructions say that the switch should be quickly switched on-off-on for inclusion and off-on-off for exclusion. However, the correct method is on-on-on for inclusion and off-off-off for exclusion.


### PR DESCRIPTION
Adds correction to Zooz switch manual, which supplied incorrect instruction on how to include/exclude the switch from a Z-wave network.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
