### PR TITLE
Language clarification

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -127,7 +127,7 @@ homeassistant:
 	2. Under the gear icon, click `Permissions`
 	3. Click `Add`, type the new user's e-mail address and choose `Project -> Editor` role
 	4. Have the new user go to [developer console](https://console.actions.google.com/) and repeat steps starting from point 7.
-11. If you want to use the request_sync service in Home Assistant, then Enable Homegraph API for your project:
+11. If you want to use the `google_assistant.request_sync` service in Home Assistant, then enable Homegraph API for your project:
 	1. Go to https://console.cloud.google.com/apis/api/homegraph.googleapis.com/overview
 	2. Select your project and click Enable Homegraph API
 	3. Go to Credentials and select API Key from Create Credentials

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -115,7 +115,7 @@ homeassistant:
 5. You'll need to fill out most of the information on that page, but none of it really matters since you won't be addressing the App directly, only through the Smart Home functionality built into Google Assistant.
 6. The final item on that page `Account linking` is required for your app to interact with Home Assistant.
 	1. Grant type: `Implicit`
-	2. Client ID: Should be the same as `client_id` from your hass config above
+	2. Client ID: The `client_id` from your Home Assistant configuration above
 	3. Authorization URL (replace with your actual URL): `https://[YOUR HOME ASSISTANT URL]/api/google_assistant/auth`
 	4. Configure your client. Add scopes for `email` and `name`
 	5. Testing instructions: doesn't matter since you won't submit this app


### PR DESCRIPTION
Made it clearer that in 4.2 the client_id is the same as used before. Existing language is unclear and suggests that making them the same is optional.
