### PR TITLE
Remove "away_mode_name"

### DIFF
--- a/source/_components/alarm_control_panel.arlo.markdown
+++ b/source/_components/alarm_control_panel.arlo.markdown
@@ -29,4 +29,3 @@ alarm_control_panel:
 Configuration variables:
 
 - **home_mode_name**: (*Optional*): Arlo base station does not have a built-in home mode. You can map one of your custom modes to home assistant's home mode by setting the name of the custom mode in this configuration variable. The name of the custom mode should match exactly as you set it up in the Arlo app.
-- **away_mode_name**: (*Optional*): Like the home mode, the Arlo base station does not have a built-in away mode, however, you can map a custom mode from the Arlo app to Home Assistant with this variable, just make sure the name matches exactly what you have set up in the Arlo app.


### PR DESCRIPTION
**Description:**
Remove "away_mode_name" as an option as it is not implemented in the code.

**Related issue:**
https://github.com/home-assistant/home-assistant/issues/10794

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
