### PR TITLE
Adding remark pertaining to secure devices

### DIFF
--- a/source/_docs/z-wave/adding.markdown
+++ b/source/_docs/z-wave/adding.markdown
@@ -28,7 +28,7 @@ When you add a device, it may initially appear without a specific entity ID (eg 
 
 ## {% linkable_title Adding Secure Devices %}
 
-Security Z-Wave devices require a network key - you must set the *network_key* configuration variable to use a network key before adding these devices. Some devices only expose their full capabilities when included this way, you should always read the manual for your device to find out the recommended inclusion method. To add (include) a secure Z-Wave device:
+Security Z-Wave devices require a network key - you must set the *network_key* configuration variable to use a network key before adding these devices. Some devices only expose their full capabilities when included this way, you should always read the manual for your device to find out the recommended inclusion method. Note, secure devices that had been connected to another hub/network in the past may have a "theft protection" feature whih requires to first exclude the device successfully from the previous hub before it can be enrolled in a new hub/network. To add (include) a secure Z-Wave device:
 
 1. Go to the [Z-Wave control panel](/docs/z-wave/control-panel/) in the Home Assistant frontend
 2. Click the **Add Node Secure** button in the *Z-Wave Network Management* card - this will place the controller in inclusion mode

--- a/source/_docs/z-wave/adding.markdown
+++ b/source/_docs/z-wave/adding.markdown
@@ -28,7 +28,7 @@ When you add a device, it may initially appear without a specific entity ID (eg 
 
 ## {% linkable_title Adding Secure Devices %}
 
-Security Z-Wave devices require a network key - you must set the *network_key* configuration variable to use a network key before adding these devices. Some devices only expose their full capabilities when included this way, you should always read the manual for your device to find out the recommended inclusion method. Note, secure devices that had been connected to another hub/network in the past may have a "theft protection" feature whih requires to first exclude the device successfully from the previous hub before it can be enrolled in a new hub/network. To add (include) a secure Z-Wave device:
+Security Z-Wave devices require a network key - you must set the *network_key* configuration variable to use a network key before adding these devices. Some devices only expose their full capabilities when included this way, you should always read the manual for your device to find out the recommended inclusion method. Note, secure devices that had been connected to another hub/network in the past may have a "theft protection" feature whih requires to first exclude the device successfully from the previous hub using the previous hub/SW setup before it can be enrolled in a new hub/network. To add (include) a secure Z-Wave device:
 
 1. Go to the [Z-Wave control panel](/docs/z-wave/control-panel/) in the Home Assistant frontend
 2. Click the **Add Node Secure** button in the *Z-Wave Network Management* card - this will place the controller in inclusion mode

--- a/source/_docs/z-wave/adding.markdown
+++ b/source/_docs/z-wave/adding.markdown
@@ -28,7 +28,7 @@ When you add a device, it may initially appear without a specific entity ID (eg 
 
 ## {% linkable_title Adding Secure Devices %}
 
-Security Z-Wave devices require a network key - you must set the *network_key* configuration variable to use a network key before adding these devices. Some devices only expose their full capabilities when included this way, you should always read the manual for your device to find out the recommended inclusion method. Note, secure devices that had been connected to another hub/network in the past may have a "theft protection" feature whih requires to first exclude the device successfully from the previous hub using the previous hub/SW setup before it can be enrolled in a new hub/network. To add (include) a secure Z-Wave device:
+Security Z-Wave devices require a network key. You must set the *network_key* configuration variable to use a network key before adding these devices. Some devices only expose their full capabilities when included this way, you should always read the manual for your device to find out the recommended inclusion method. Note, secure devices that had been connected to another hub/network in the past may have a "theft protection" feature which requires to first exclude the device successfully from the previous hub using the previous hub/Software setup before it can be enrolled in a new hub/network. To add (include) a secure Z-Wave device:
 
 1. Go to the [Z-Wave control panel](/docs/z-wave/control-panel/) in the Home Assistant frontend
 2. Click the **Add Node Secure** button in the *Z-Wave Network Management* card - this will place the controller in inclusion mode


### PR DESCRIPTION
Per experience with Schlage locks, you need to 1st exclude them from the previous network/hub before you can enroll them in a new network. This seems to be true for secure zwave devices with anti-theft protection

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
