### PR TITLE
Add device class for low battery

### DIFF
--- a/source/_components/binary_sensor.markdown
+++ b/source/_components/binary_sensor.markdown
@@ -14,6 +14,7 @@ Binary sensors gather information about the state of devices which have a "digit
 The way these sensors are displayed in the frontend can be modified in the [customize section](/getting-started/customizing-devices/). The following device classes are supported for binary sensors:
 
 - **None**: Generic on/off. This is the default and doesn't need to be set.
+- **battery**: `On` means low, `Off` means normal
 - **cold**: `On` means cold
 - **connectivity**: `On` means connection present, `Off` means no connection
 - **gas**: `On` means gas detected


### PR DESCRIPTION
**Description:**
Adds a new battery device class for binary sensors to show normal vs. low battery states.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10829

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
