### PR TITLE
Display problem with script section...

### DIFF
--- a/source/_components/ifttt.markdown
+++ b/source/_components/ifttt.markdown
@@ -98,7 +98,7 @@ automation:
 ifttt_notify:
   sequence:
     - service: ifttt.trigger
-      data_template: {"event":"TestHA_Trigger", "value1":"{{ value1 }}", "value2":"{{ value2 }}", "value3":"{{ value3 }}"}
+      data_template: {"event":"TestHA_Trigger", "value1":"{% raw %}{{ value1 }}{% endraw %}", "value2":"{% raw %}{{ value2 }}{% endraw %}", "value3":"{% raw %}{{ value3 }}{% endraw %}"}
 ```
 
 ### {% linkable_title Sending events from IFTTT to Home Assistant %}


### PR DESCRIPTION
I banged my head against the table for hours trying to make the script work on this page and then I figured out something.  When viewing the page on the HA site, the variable tags {{value1}}, etc...do not display.  I only see two quotes.

This is what I was seeing.  ```{"event":"TestHA_Trigger", "value1":"", "value2":"", "value3":""}```

And I should be seeing this:  ```{"event":"TestHA_Trigger", "value1":"{{value1}}", "value2":"{{value2}}", "value3":"{{value3}}"}

Above this section in the automation, there's a tag called { % raw % } which I'm unfamiliar with, but I made a guess that this needs to be inserted.  I may have been wrong.  If so, I hope I've identified a valid problem.  Thanks!

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
