### PR TITLE
Add documentation on associating an RF serial-number with the zone

### DIFF
--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -54,4 +54,4 @@ Configuration variables:
 - **baudrate** (*Optional*): The baud rate of the AlarmDecoder device, if using serial type. Default: `115200`
 - **panel_display** (*Optional*): Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
 - **zones** (*Optional*): AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.*
-- **rfid** (*Optional*): The RF serial-number associated with RF zones.  Providing this field allws HomeAssistant to associate raw sensor data to a given zone, allowing direct monitoring of the state, battery, and supervision status.
+- **rfid** (*Optional*): The RF serial-number associated with RF zones.  Providing this field allows Home Assistant to associate raw sensor data to a given zone, allowing direct monitoring of the state, battery, and supervision status.

--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -39,6 +39,7 @@ alarmdecoder:
     01:
       name: 'Smoke Detector'
       type: 'smoke'
+      rfid: '0123456'
     02:
       name: 'Front Door'
       type: 'opening'
@@ -53,3 +54,4 @@ Configuration variables:
 - **baudrate** (*Optional*): The baud rate of the AlarmDecoder device, if using serial type. Default: `115200`
 - **panel_display** (*Optional*): Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
 - **zones** (*Optional*): AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.*
+- **rfid** (*Optional*): The RF serial-number associated with RF zones.  Providing this field allws HomeAssistant to associate raw sensor data to a given zone, allowing direct monitoring of the state, battery, and supervision status.


### PR DESCRIPTION
**Description:**
Update documentation to describe linking RF serial-number to securtiy zone in alarmdecoder component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10841

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
