### PR TITLE
Remove legacy mentions of gi folder

### DIFF
--- a/source/_components/axis.markdown
+++ b/source/_components/axis.markdown
@@ -69,10 +69,6 @@ axis:
 ```
 
 <p class='note'>
-If you are using Python 3.6, you might need to replace the 34m with 36m in the _gi.*.so filename in the gi folder.
-</p>
-
-<p class='note'>
 Any specific levels for triggers needs to be configured on the device.
 </p>
 


### PR DESCRIPTION
Since installation is handled through the `axis` package, we can remove references to the gi folder

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
