### PR TITLE
add DD-wrt

### DIFF
--- a/source/_components/device_tracker.snmp.markdown
+++ b/source/_components/device_tracker.snmp.markdown
@@ -33,6 +33,7 @@ The following OID examples pull the current MAC Address table from a router. Thi
 | TP-Link | Archer VR600 | `1.3.6.1.2.1.3.1.1.2` |
 | EdgeRouter | Lite v1.9.0 | `1.3.6.1.2.1.4.22.1.2` |
 | Ruckus | ZoneDirector 9.13.3 | `1.3.6.1.4.1.25053.1.2.2.1.1.3.1.1.1.6` |
+| DD-WRT | unknown RouterOS version/model |  `1.3.6.1.2.1.4.22.1.2` |
 
 To use the SNMP version 1 platform in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
Add DD-WRT to the SNMP list.

**Description:**
Adding DD-WRT to the supported list.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
