### PR TITLE
Added missing certfile/keyfile entries to code

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -23,7 +23,9 @@ Set up [Mosquitto](https://mosquitto.org/) as MQTT broker.
   "customize": {
     "active": false,
     "folder": "mosquitto"
-  }
+  },
+  "certfile": "fullchain.pem",
+  "keyfile": "privkey.pem"
 }
 ```
 


### PR DESCRIPTION
If user accidentally removes those by copy/pasting what was listed, it throws a "missing" error.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
