### PR TITLE
Correct off_delay to delay_off

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -158,7 +158,7 @@ binary_sensor:
 This example creates a washing machine "load running" sensor by monitoring an
 energy meter connected to the washer. During the washer's operation, the energy
 meter will fluctuate wildly, hitting zero frequently even before the load is
-finished. By utilizing `off_delay`, we can have this sensor only turn off if
+finished. By utilizing `delay_off`, we can have this sensor only turn off if
 there has been no washer activity for 5 minutes.
 
 {% raw %}


### PR DESCRIPTION
**Description:**

Corrected instance of `off_delay` to `delay_off` in doc.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
