### PR TITLE
Information about compatible ETHM module

### DIFF
--- a/source/_components/satel_integra.markdown
+++ b/source/_components/satel_integra.markdown
@@ -13,7 +13,7 @@ ha_release: 0.54
 ha_iot_class: "Local Push"
 ---
 
-The `satel_integra` component will allow Home Assistant users who own a Satel Integra alarm panel to leverage their alarm system and its sensors to provide Home Assistant with information about their homes. Connectivity between Home Assistant and the alarm  is accomplished through a ETHM extension module that must be installed in the alarm.
+The `satel_integra` component will allow Home Assistant users who own a Satel Integra alarm panel to leverage their alarm system and its sensors to provide Home Assistant with information about their homes. Connectivity between Home Assistant and the alarm  is accomplished through a ETHM extension module that must be installed in the alarm. Compatible with ETHM-1 Plus module with firmware ver. >2.00 (ver. 2.04 confirmed).
 
 There is currently support for the following device types within Home Assistant:
 

--- a/source/_components/satel_integra.markdown
+++ b/source/_components/satel_integra.markdown
@@ -13,7 +13,7 @@ ha_release: 0.54
 ha_iot_class: "Local Push"
 ---
 
-The `satel_integra` component will allow Home Assistant users who own a Satel Integra alarm panel to leverage their alarm system and its sensors to provide Home Assistant with information about their homes. Connectivity between Home Assistant and the alarm  is accomplished through a ETHM extension module that must be installed in the alarm. Compatible with ETHM-1 Plus module with firmware ver. >2.00 (ver. 2.04 confirmed).
+The `satel_integra` component will allow Home Assistant users who own a Satel Integra alarm panel to leverage their alarm system and its sensors to provide Home Assistant with information about their homes. Connectivity between Home Assistant and the alarm  is accomplished through a ETHM extension module that must be installed in the alarm. Compatible with ETHM-1 Plus module with firmware version > 2.00 (version 2.04 confirmed).
 
 There is currently support for the following device types within Home Assistant:
 


### PR DESCRIPTION
Component works only with ETHM-1 Plus module and firmware version > 2.00. It doesn't work with ETHM-1 module or ETHM-1 Plus module with firmware 2.00, confirmed compatibility with version 2.04.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
