### PR TITLE
Add climate to the list of exposed entities to google assistant

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -56,6 +56,7 @@ google_assistant:
     - `fan`
     - `scene`
     - `script`
+    - `climate`
 
 You can also customize your devices similar to other components by adding keys to entities:
 


### PR DESCRIPTION
Add climate to the list of exposed entities to google assistant

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
