### PR TITLE
Update Xiaomi Air Filter support

### DIFF
--- a/source/_components/fan.xiaomi_miio.markdown
+++ b/source/_components/fan.xiaomi_miio.markdown
@@ -13,7 +13,7 @@ ha_version: 0.57
 ha_iot_class: "Local Polling"
 ---
 
-The `xiaomi_miio` fan platform allows you to control the Xiaomi Air Purifier 2. The Air Purifier Pro isn't supported right now.
+The `xiaomi_miio` fan platform allows you to control the Xiaomi Air Purifier 2, Air Purifier 2S andd Air Purifier Pro.
 
 Currently, the supported features are
 


### PR DESCRIPTION
**Description:**

I have tested and verified that the Xiaomi Air Purifier plugin (fan.miio, as of 0.58.1) works on the Air Purifier Pro and the Air Purifier 2S. This PR corrects the documentation.

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
