### PR TITLE
Fixing some typos in docs for Microsoft TTS component.

### DIFF
--- a/source/_components/tts.microsoft.markdown
+++ b/source/_components/tts.microsoft.markdown
@@ -28,12 +28,12 @@ Configuration variables:
 
 - **api_key** (*Required*): Your API key.
 - **language** (*Optional*): The language to use. Defaults to `en-us`. Accepted values are listed in the documentation mentioned below. Note that if you set the language to anything other than the default of `en-us`, you will need to specify a matching voice type as well.
-- **gender** (*Optional*): The gender you would like to use for the voice. Accepted values are `Female` and `Male`. Defaults to `Female`
-- **type** (*Optional*): The voice type you want to use. Accepted values are listed in the service name mapping [in the documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/Speech/api-reference-rest/bingvoiceoutput). Defaults to `ZiraRUS`
-- **rate** (*Optional*): Change the rate of speaking. Example values: `-25%`, `+50%`. Defaults to `+0%` (no change)
-- **volume** (*Optional*): Change the volume of the output. Example values: `-20%`, `+70%`. Defaults to `+0%` (no change)
-- **pitch** (*Optional*): Change the pitch of the output. Example values: `high`. Defaults to `default` (no change)
-- **contour** (*Optional*): Change the contour of the output. This overrides the pitch setting. See the [W3 SSML specification](http://www.w3.org/TR/speech-synthesis/#pitch_contour) for what it does. Example value: `(0%,+0%) (100%,+100%)`
+- **gender** (*Optional*): The gender you would like to use for the voice. Accepted values are `Female` and `Male`. Defaults to `Female`.
+- **type** (*Optional*): The voice type you want to use. Accepted values are listed as the service name mapping [in the documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/Speech/api-reference-rest/bingvoiceoutput). Defaults to `ZiraRUS`.
+- **rate** (*Optional*): Change the rate of speaking in percentage. Example values: `25`, `50`. Defaults to `0` (no change).
+- **volume** (*Optional*): Change the volume of the output in percentage. Example values: `-20`, `70`. Defaults to `0` (no change).
+- **pitch** (*Optional*): Change the pitch of the output. Example values: `high`. Defaults to `default` (no change).
+- **contour** (*Optional*): Change the contour of the output in percentages. This overrides the pitch setting. See the [W3 SSML specification](http://www.w3.org/TR/speech-synthesis/#pitch_contour) for what it does. Example value: `(0,0) (100,100)`.
 
 A full configuration sample including optional configuration variables:
 
@@ -45,8 +45,8 @@ tts:
     language: en-gb
     gender: Male
     type: George, Apollo
-    rate: +20%
-    volume: -50%
+    rate: 20
+    volume: -50
     pitch: high
-    contour: (0%, +0%) (100%, +100%)
+    contour: (0, 0) (100, 100)
 ```


### PR DESCRIPTION
**Description:**
Fixing some typos in docs for Microsoft TTS component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
