### PR TITLE
Document enable_leds option on TP-Link sockets

### DIFF
--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -32,10 +32,22 @@ switch:
     host: IP_ADDRESS
 ```
 
-Configuration variables:
+{% configuration %}
+name:
+  description: The name to use when displaying this switch.
+  required: false
+  type: string
+  default: Random Sensor
+host:
+  description: "The IP address of your TP-Link switch, eg. `192.168.1.32`."
+  required: true
+  type: string
+enable_leds:
+  description: If the LEDs on the switch (WiFi and power) should be lit.
+  required: false
+  type: boolean
+  default: true
+{% endconfiguration %}
 
-- **host** (*Required*): The IP address of your TP-Link switch, eg. `192.168.1.32`.
-- **name** (*Optional*): The name to use when displaying this switch.
-- **enable_leds** (*Optional*): If the LEDs on the switch (WiFi and power) should be lit (defaults `True`).
 
 

--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -36,5 +36,6 @@ Configuration variables:
 
 - **host** (*Required*): The IP address of your TP-Link switch, eg. `192.168.1.32`.
 - **name** (*Optional*): The name to use when displaying this switch.
+- **enable_leds** (*Optional*): If the LEDs on the switch (WiFi and power) should be lit (defaults `True`).
 
 


### PR DESCRIPTION
**Description:**

Documents the new `enable_leds` option for TP-Link smart plugs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10980

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
