### PR TITLE
Update joaoapps_join.markdown

### DIFF
--- a/source/_components/joaoapps_join.markdown
+++ b/source/_components/joaoapps_join.markdown
@@ -13,22 +13,21 @@ ha_release: "0.24"
 ---
 
 
-The Join platform exposes services from [Join](http://joaoapps.com/join). In Home Assistant, the Join features are divided up in two locations, the Join component, and the Join notify platform. The notify platform allows us to send messages to Join devices, the component allows us to access the other special features that Join offers.
+The `joaoapps_join` component exposes services from [Join](http://joaoapps.com/join). In Home Assistant, the Join features are divided up in two locations, the Join component, and the Join notify platform. The notify platform allows us to send messages to Join devices, the component allows us to access the other special features that Join offers.
 
 In the `configuration.yaml` file you need to provide the api key and device id or name of the target device.  You can find your device id and api key [here](https://joinjoaomgcd.appspot.com/).
 
 To set it up, add the following information to your `configuration.yaml` file:
 
 ```yaml
+# Example configuration.yaml entry
 notify:
   - platform: joaoapps_join
     api_key: asd97823jb628a34fwsdfwefd5384345tf2d
-    device_id: d5asdfasdf54645h45h368761dfe5gt8a   *optional
-    device_ids: d5asdfasdf54645h45h368761dfe5gt8a, a4asdfasdf54645h45h368761dfe5gt3b  *optional
-    device_names: Pixel, iPhone       *optional
-    name: Phones                      *optional
-
-
+    device_id: d5asdfasdf54645h45h368761dfe5gt8a
+    device_ids: d5asdfasdf54645h45h368761dfe5gt8a, a4asdfasdf54645h45h368761dfe5gt3b
+    device_names: Pixel, iPhone
+    name: Phones
 joaoapps_join:
   - name: android
     device_id: group.android
@@ -42,20 +41,20 @@ Configuration variables:
 - **device_ids** (*Optional*): Comma separated list of device ids.
 - **device_names** (*Optional*): Comma separated list of device names.
 
-The notify service has two optional parameters: `icon` and `vibration`.  You can use them like so:
+The notify service has two optional parameters: `icon` and `vibration`. You can use them like so:
 
 ```json
 {"message":"Hello from Home Assistant!","title":"Home Assistant","data":{"icon":"https://goo.gl/xeetdy", "vibration":"0,65,706,86,657,95,668,100"}}
 ```
 
-The services exposed in the joaoapps_join component can be used with the service data described below:
+The services exposed in the `joaoapps_join` component can be used with the service data described below:
 
 | Service                       | Data                                                              |
 |------------------------------ |------------------------------------------------------------------ |
 | joaoapps_join/ring            |                                                                   |
-| joaoapps_join/send_sms        | ``` {"number":"5553334444", "message":"Hello!"}```                       |
-| joaoapps_join/send_tasker     | ```{"command":"test"}```                                                |
-| joaoapps_join/send_url        | ```{"url":"http://google.com"}```                                       |
-| joaoapps_join/send_wallpaper  | ```{"url":"http://www.planwallpaper.com/static/images/ZhGEqAP.jpg"}```  |
-| joaoapps_join/send_file       | ```{"url":"http://download.thinkbroadband.com/5MB.zip"}```              |
+| joaoapps_join/send_sms        | `{"number":"5553334444", "message":"Hello!"}`                       |
+| joaoapps_join/send_tasker     | `{"command":"test"}`                                                |
+| joaoapps_join/send_url        | `{"url":"http://google.com"}`                                       |
+| joaoapps_join/send_wallpaper  | `{"url":"http://www.planwallpaper.com/static/images/ZhGEqAP.jpg"}`  |
+| joaoapps_join/send_file       | `{"url":"http://download.thinkbroadband.com/5MB.zip"}`              |
 

--- a/source/_components/joaoapps_join.markdown
+++ b/source/_components/joaoapps_join.markdown
@@ -53,9 +53,9 @@ The services exposed in the joaoapps_join component can be used with the service
 | Service                       | Data                                                              |
 |------------------------------ |------------------------------------------------------------------ |
 | joaoapps_join/ring            |                                                                   |
-| joaoapps_join/send_sms        | {"number":"5553334444", "message":"Hello!"}                       |
-| joaoapps_join/send_tasker     | {"command":"test"}                                                |
-| joaoapps_join/send_url        | {"url":"http://google.com"}                                       |
-| joaoapps_join/send_wallpaper  | {"url":"http://www.planwallpaper.com/static/images/ZhGEqAP.jpg"}  |
-| joaoapps_join/send_file       | {"url":"http://download.thinkbroadband.com/5MB.zip"}              |
+| joaoapps_join/send_sms        | ``` {"number":"5553334444", "message":"Hello!"}```                       |
+| joaoapps_join/send_tasker     | ```{"command":"test"}```                                                |
+| joaoapps_join/send_url        | ```{"url":"http://google.com"}```                                       |
+| joaoapps_join/send_wallpaper  | ```{"url":"http://www.planwallpaper.com/static/images/ZhGEqAP.jpg"}```  |
+| joaoapps_join/send_file       | ```{"url":"http://download.thinkbroadband.com/5MB.zip"}```              |
 


### PR DESCRIPTION
After publishing, the website displays this quotes as curly/smart quotation marks which breaks copy and paste
See where someone ran into this issue on a reddit post here: https://www.reddit.com/r/homeassistant/comments/7dvqka/anybody_using_joaoapps_join_error_parsing_json/

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
