### PR TITLE
Change default JS version to 'auto'

### DIFF
--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -23,7 +23,7 @@ frontend:
     description: "Version of the JavaScript to serve to clients. Options: `es5` - transpiled so old browsers understand it.  `latest` - not transpiled, so will work on recent browsers only. `auto` - select a version according to the browser user-agent. The value in the config can be overiden by putting `es5` or `latest` in the URL. For example `http://localhost:8123/states?es5` "
     required: false
     type: string
-    default: es5
+    default: auto
   themes:
     description: Allow to define different themes. See below for further details.
     required: false


### PR DESCRIPTION
**Description:**

Change default JS version to 'auto'

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#10999

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
