### PR TITLE
Missing dependancy for Debian

### DIFF
--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -26,14 +26,9 @@ The basic guide is for testing Home Assistant. Also check the advanced guide for
 ```bash
 $ sudo apt-get update
 $ sudo apt-get upgrade
-$ sudo apt-get install python3-pip python3-dev
+$ sudo apt-get install python3-pip python3-dev python3-venv
 $ sudo pip3 install --upgrade virtualenv
 ```
-For Debian (8.9+?) installation, add:
-```bash
-$ sudo apt-get install python3-venv
-```
-
 
 ## {% linkable_title Step 2: Setup virtualenv %}
 

--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -29,6 +29,11 @@ $ sudo apt-get upgrade
 $ sudo apt-get install python3-pip python3-dev
 $ sudo pip3 install --upgrade virtualenv
 ```
+For Debian (8.9+?) installation, add:
+```bash
+$ sudo apt-get install python3-venv
+```
+
 
 ## {% linkable_title Step 2: Setup virtualenv %}
 


### PR DESCRIPTION
I'm not sure since what Debian version...

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
