### PR TITLE
Update sensor.template to show entity_id example

### DIFF
--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -27,6 +27,7 @@ sensor:
     sensors:
       solar_angle:
         friendly_name: "Sun angle"
+        entity_id: sun.sun
         unit_of_measurement: 'degrees'
         value_template: "{{ states.sun.sun.attributes.elevation }}"
 


### PR DESCRIPTION
Right now this page has no examples using the optional entity_id field. I think we should include it in the top example because otherwise the template sensor will react to all state changes rather than just the one or two the user will care about. May also be nice to show an example of a list for the template sensor, but we do include one on the Binary Sensor Template page so maybe that's sufficient?

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
