### PR TITLE
Document min_max 'last' attribute

### DIFF
--- a/source/_components/sensor.min_max.markdown
+++ b/source/_components/sensor.min_max.markdown
@@ -14,7 +14,7 @@ ha_release: "0.31"
 ---
 
 
-The `min_max` sensor platform consumes the state from other sensors to determine the minimum, maximum, and the mean of the collected states. The sensor will always show you the lowest/highest value which was received from all monitored sensors. If you have spikes in your values, it's recommended to filter/equalize your values with a [statistics sensor](/components/sensor.statistics/) first.
+The `min_max` sensor platform consumes the state from other sensors to determine the minimum, maximum, latest (last) and the mean of the collected states. The sensor will always show you the lowest/highest/latest value which was received from all monitored sensors. If you have spikes in your values, it's recommended to filter/equalize your values with a [statistics sensor](/components/sensor.statistics/) first.
 
 This sensor is an alternative to the [template sensor](/components/sensor.template/)'s `value_template:` to get the average of multiple sensors.
 
@@ -42,7 +42,7 @@ sensor:
 Configuration variables:
 
 - **entity_ids** (*Required*): At least two entities to monitor. The unit of measurement of the first entry will be the one that's used. All entities must use the same unit of measurement.
-- **type** (*Optional*): The type of sensor: `min`, `max` or `mean`. Defaults to `max`.
+- **type** (*Optional*): The type of sensor: `min`, `max`, `last` or `mean`. Defaults to `max`.
 - **name** (*Optional*): Name of the sensor to use in the frontend.
 - **round_digits** (*Optional*): Round mean value to specified number of digits. Defaults to 2.
 


### PR DESCRIPTION
**Description:** Document addition of 'last' mode to min_max sensor, patch to follow.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11037

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
