### PR TITLE
Update nest.markdown

### DIFF
--- a/source/_components/nest.markdown
+++ b/source/_components/nest.markdown
@@ -34,7 +34,7 @@ The Nest component is the main component to integrate all [Nest](https://nest.co
 9. Once the new product page opens the "Product ID" and "Product Secret" are located on the right side. These will be used as `client_id` and `client_secret` below.
 10. Once Home Assistant is started, a configurator will pop up asking you to log into your Nest account and copy a PIN code into Home Assistant.
 
-Connecting to the Nest Developer API requires outbound port 8553 on your firewall. The configuration will fail if this is not accessible.
+Connecting to the Nest Developer API requires outbound port 9553 on your firewall. The configuration will fail if this is not accessible.
 
 ### {% linkable_title Configuration %}
 


### PR DESCRIPTION
Firebase requests to the Nest API uses outgoing port 9553 instead of 8553.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
