### PR TITLE
Update systemd.markdown

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -128,7 +128,7 @@ Because the log can scroll quite quickly, you can select to view only the error 
 $ sudo journalctl -f -u home-assistant@[your user] | grep -i 'error'
 ```
 
-When working on Home Assitant, you can easily restart the system and then watch the log output by combining the above commands using `&&`
+When working on Home Assistant, you can easily restart the system and then watch the log output by combining the above commands using `&&`
 
 ```bash
 $ sudo systemctl restart home-assistant@[your user] && sudo journalctl -f -u home-assistant@[your user]


### PR DESCRIPTION
Correct spelling of Home Assistant on line 131.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
