### PR TITLE
Added new supported TV Model

### DIFF
--- a/source/_components/media_player.aquostv.markdown
+++ b/source/_components/media_player.aquostv.markdown
@@ -53,5 +53,6 @@ Currently known supported models:
 - LC-60LE925UN
 - LC-60LE857U
 - LC-60EQ10U
+- LC-60SQ15U
 
 If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.github.io/tree/current/source/_components/media_player.aquostv.markdown).


### PR DESCRIPTION
Tested the component with Sharp Aquos TV (LC-60SQ15U), and works great! Added that model to the supported TVs list.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
