### PR TITLE
Document separate command and state OIDs and payloads in SNMP switch

### DIFF
--- a/source/_components/nest.markdown
+++ b/source/_components/nest.markdown
@@ -34,7 +34,7 @@ The Nest component is the main component to integrate all [Nest](https://nest.co
 9. Once the new product page opens the "Product ID" and "Product Secret" are located on the right side. These will be used as `client_id` and `client_secret` below.
 10. Once Home Assistant is started, a configurator will pop up asking you to log into your Nest account and copy a PIN code into Home Assistant.
 
-Connecting to the Nest Developer API requires outbound port 8553 on your firewall. The configuration will fail if this is not accessible.
+Connecting to the Nest Developer API requires outbound port 9553 on your firewall. The configuration will fail if this is not accessible.
 
 ### {% linkable_title Configuration %}
 

--- a/source/_components/sensor.coinmarketcap.markdown
+++ b/source/_components/sensor.coinmarketcap.markdown
@@ -28,12 +28,12 @@ sensor:
 currency:
   description: The cryptocurrency to use.
   required: false
-  type: string, list
+  type: string
   default: Bitcoin
 display_currency:
   description: The currency to display.
   required: false
-  type: string, list
+  type: string
   default: USD
 {% endconfiguration %}
 

--- a/source/_components/switch.snmp.markdown
+++ b/source/_components/switch.snmp.markdown
@@ -29,13 +29,16 @@ switch:
 
 Configuration variables:
 
-- **baseoid** (*Required*): The SNMP BaseOID which to poll for the state of the switch and which to set in order to turn the switch on and off.
+- **baseoid** (*Required*): The SNMP BaseOID which to poll for the state of the switch.
+- **command_oid** (*Optional*): The SNMP OID which to set in order to turn the switch on and off, if different from `baseoid`.
 - **host** (*Optional*): The IP/host which to control. Defaults to `localhost`.
 - **port** (*Optional*): The port on which to communicate. Defaults to `161`.
 - **community** (*Optional*): community string to use for authentication. Defaults to `private`.
 - **version** (*Optional*): SNMP version to use - either `1` or `2c`. Defaults to `1`.
-- **payload_on** (*Optional*): What return value represents an `On` state for the switch. The same value is used in writes to turn on the switch. Defaults to `1`.
-- **payload_off** (*Optional*): What return value represents an `Off` state for the switch. The same value is used in writes to turn off the switch. Defaults to `0`.
+- **payload_on** (*Optional*): What return value represents an `On` state for the switch. The same value is used in writes to turn on the switch if `command_payload_on` is not set. Defaults to `1`.
+- **payload_off** (*Optional*): What return value represents an `Off` state for the switch. The same value is used in writes to turn off the switch if `command_payload_off` is not set. Defaults to `0`.
+- **command_payload_on** (*Optional*): The value to write to turn on the switch, if different from `payload_on`.
+- **command_payload_off** (*Optional*): The value to write to turn off the switch, if different from `payload_off`.
 
 You should check with your device's vendor to find out the correct BaseOID and what values turn the switch on and off.
 

--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -20,7 +20,7 @@ Before configuring the Z-Wave setup, please take a moment and read [this article
 
 Z-Wave is a wireless communication protocol designed for home automation. It uses a low power, and low bandwidth, mesh network that allows devices that aren't within direct range of each other to communicate indirectly, via other nodes. Any device that's permanently powered (not battery powered) will help build the mesh, if you don't have enough powered devices, or you locate these poorly, your mesh will be unreliable.
 
-There is a limit of 232 devices in a single Z-Wave network. If you need more devices then you could set up a second Home Assistant system with its own Z-Wave network and connect these with the [MQTT Eventstream](/components/mqtt_eventstream/) or [MQTT Statestream](/components/mqtt_statestream) components.
+There is a limit of 232 devices in a single Z-Wave network. If you need more devices then you could set up a second Home Assistant system with its own Z-Wave network and connect these with the [MQTT Eventstream](/components/mqtt_eventstream/) or [MQTT Statestream](/components/mqtt_statestream) components. There is also a limit of 4 hops for Z-Wave, so placing the controller as centrally as you can is important.
 
 The Z-Wave standard was improved with Z-Wave Plus, and if you only use Z-Wave plus devices then you will gain the full benefits.
 


### PR DESCRIPTION
**Description:**
It is evident that some switch devices, such as the PDU/CDU units made by Server Technology, use different OIDs and payloads for reading vs. writing the on/off state of power outlets. Therefore, I have expanded the SNMP switch component **in a fully backwards-compatible manner** to allow for these devices which use separate command and state OIDs and variable mappings to be used with HA.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11075

## Checklist:

  - [ X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
