### PR TITLE
Update documentation for SNMP switch component to reflect changes.

### DIFF
--- a/source/_components/switch.snmp.markdown
+++ b/source/_components/switch.snmp.markdown
@@ -29,13 +29,16 @@ switch:
 
 Configuration variables:
 
-- **baseoid** (*Required*): The SNMP BaseOID which to poll for the state of the switch and which to set in order to turn the switch on and off.
+- **baseoid** (*Required*): The SNMP BaseOID which to poll for the state of the switch.
+- **command_oid** (*Optional*): The SNMP OID which to set in order to turn the switch on and off, if different from `baseoid`.
 - **host** (*Optional*): The IP/host which to control. Defaults to `localhost`.
 - **port** (*Optional*): The port on which to communicate. Defaults to `161`.
 - **community** (*Optional*): community string to use for authentication. Defaults to `private`.
 - **version** (*Optional*): SNMP version to use - either `1` or `2c`. Defaults to `1`.
-- **payload_on** (*Optional*): What return value represents an `On` state for the switch. The same value is used in writes to turn on the switch. Defaults to `1`.
-- **payload_off** (*Optional*): What return value represents an `Off` state for the switch. The same value is used in writes to turn off the switch. Defaults to `0`.
+- **payload_on** (*Optional*): What return value represents an `On` state for the switch. The same value is used in writes to turn on the switch if `command_payload_on` is not set. Defaults to `1`.
+- **payload_off** (*Optional*): What return value represents an `Off` state for the switch. The same value is used in writes to turn off the switch if `command_payload_off` is not set. Defaults to `0`.
+- **command_payload_on** (*Optional*): The value to write to turn on the switch, if different from `payload_on`.
+- **command_payload_off** (*Optional*): The value to write to turn off the switch, if different from `payload_off`.
 
 You should check with your device's vendor to find out the correct BaseOID and what values turn the switch on and off.
 


### PR DESCRIPTION
**Description:**
It is evident that some switch devices, such as the PDU/CDU units made by Server Technology, use different OIDs and payloads for reading vs. writing the on/off state of power outlets. Therefore, I have expanded the SNMP switch component **in a fully backwards-compatible manner** to allow for these devices which use separate command and state OIDs and variable mappings to be used with HA.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11075

## Checklist:

  - [ X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
