### PR TITLE
Revamp getting started

### DIFF
--- a/source/_docs/installation.markdown
+++ b/source/_docs/installation.markdown
@@ -14,9 +14,21 @@ redirect_from: /getting-started/installation/
 Beginners should check our [Getting started guide](/getting-started/) first. This is for users that require advanced installations.
 </p>
 
-Home Assistant provides multiple ways to be installed. A requirement is that you have [Python](https://www.python.org/downloads/) installed. For Windows, we require at least **Python 3.5** and for other operating systems at least **Python 3.4.2**.
+Home Assistant provides multiple ways to be installed. A requirement is that you have [Python 3.5+](https://www.python.org/downloads/) installed.
 
 <div class="text-center hass-option-cards" markdown="0">
+  <a class='option-card' href='/getting-started/'>
+    <div class='img-container'>
+      <img src='/images/supported_brands/home-assistant.png' />
+    </div>
+    <div class='title'>Hass.io<br>(Beginner friendly)</div>
+  </a>
+  <a class='option-card' href='/docs/installation/virtualenv/'>
+    <div class='img-container'>
+      <img src='/images/supported_brands/python.svg' />
+    </div>
+    <div class='title'>On top of an existing Python 3.5+ installation</div>
+  </a>
   <a class='option-card' href='/docs/hassbian/installation/'>
     <div class='img-container'>
       <img src='/images/supported_brands/home-assistant.png' />

--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -9,19 +9,55 @@ sharing: true
 footer: true
 ---
 
-When launched for the first time, Home Assistant will write a default configuration file, called `configuration.yaml`, enabling the web interface and [device discovery](/components/discovery/). It can take up to a minute for your devices to be discovered and appear in the user interface.
+If you made it here, awesome! That means that you got Home Assistant up and running. It might have already found some of your networked devices. This is going to be fun!
 
-The `configuration.yaml` is written in [YAML](/docs/configuration/yaml/), stored in [`.homeassistant`](/docs/configuration/), and can be modified with a text editor.
+Home Assistant stores its configuration in a file called `configuration.yaml`. A default one is created when Home Assistant is started for the first time. Some of the things in the configuration file can be editted via the user interface, other parts require you to edit the configuration file directly.
 
-See the [components overview page](/components/) to find sample entries for your devices and services. For a sensor that is showing [random values](/components/sensor.random/), the entry would look like the sample below:
+There are two common approaches to edit your configuration: via Samba/Windows Networking and via the HASS Configurator. Both of these are [official add-ons for Hass.io](/addons/).
+
+## {% linkable_title Installing Hass.io add-ons %}
+
+Hass.io add-ons are installed from the add-on store embedded in the Hass.io panel:
+
+ - Open Home Assistant by navigating to [http://hassio.local:8123][local].
+ - Click on the menu icon in the top left and select Hass.io in the sidebar.
+ - The Hass.io panel opens, now open the add-on store by clicking the shopping bag.
+
+[local]: http://hassio.local:8123
+
+<p class='img'>
+<img src='/images/hassio/screenshots/main_panel_store_icon.png' />
+From the Hass.io main panel open the add-on store.
+</p>
+
+### {% linkable_title Editing config via HASS Configurator %}
+
+The first add-on we should install is the HASS Configurator. With the HASS Configurator you'll be able to edit your Home Assistant configuration from the web interface.
+
+Go to the add-on store (see previous step), click on Configurator and click on INSTALL. When installation is complete you will be able to click the "WEB UI" link to open the Web UI.
+
+Time for the first practice with the configurator. Add the following to your `configuration.yaml` file to add a link to the Configurator in the sidebar:
 
 ```yaml
-sensor:
-  - platform: random
+panel_iframe:
+  configurator:
+    title: Configurator
+    icon: mdi:wrench
+    url: http://hassio.local:3218
 ```
 
-The [Setting up devices part](/docs/configuration/devices/) contains the additional documentation details about adding devices and services and [customization](/docs/configuration/customizing-devices/).
+Now restart Home Assistant for the changes to the configuration to take effect. You can do this by going to the config panel (Configuration in the sidebar) -> General -> Restart Home Assistant.
 
-For further details about configuration, please take a look at the [configuration documentation](/docs/configuration/).
+### {% linkable_title Editing config via Samba/Windows Networking %}
+
+Maybe you are not a big fan of our web editor and want to use a text editor on your computer instead. This is possible by sharing the configuration over the network using the Samba add-on, which can be installed from the Hass.io add-on store.
+
+After you have installed it, click on START. Hass.io should now be available in the networking tab on your computer.
+
+## {% linkable_title Configuring integrations %}
+
+Now that you are able to edit the configuration, it's time to set up some of your devices and services. Each service and device will have its own instructions on how to be integrated. Find  your devices and services on the [components overview page](/components/).
+
+<p class='note'>YAML can be a little daunting at first. A lot is possible! [Here is some more info.](/docs/configuration/devices/)</p>
 
 ### [Next step: Automate Home Assistant &raquo;](/getting-started/automation/)

--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -11,7 +11,7 @@ footer: true
 
 If you made it here, awesome! That means that you got Home Assistant up and running. It might have already found some of your networked devices. This is going to be fun!
 
-Home Assistant stores its configuration in a file called `configuration.yaml`. A default one is created when Home Assistant is started for the first time. Some of the things in the configuration file can be editted via the user interface, other parts require you to edit the configuration file directly.
+Home Assistant stores its configuration in a file called `configuration.yaml`. A default one is created when Home Assistant is started for the first time. Some of the things in the configuration file can be edited via the user interface, other parts require you to edit the configuration file directly.
 
 There are two common approaches to edit your configuration: via Samba/Windows Networking and via the HASS Configurator. Both of these are [official add-ons for Hass.io](/addons/).
 

--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -34,9 +34,13 @@ From the Hass.io main panel open the add-on store.
 
 The first add-on we should install is the HASS Configurator. With the HASS Configurator you'll be able to edit your Home Assistant configuration from the web interface.
 
-Go to the add-on store (see previous step), click on Configurator and click on INSTALL. When installation is complete you will be able to click the "WEB UI" link to open the Web UI.
+Go to the add-on store (see previous step), click on Configurator and click on INSTALL. When installation is complete the UI will go to the add-on details page for the configurator. Here you will be able to change settings, start and stop the add-on.
 
-Time for the first practice with the configurator. Add the following to your `configuration.yaml` file to add a link to the Configurator in the sidebar:
+ - Change the settings to set a password and click on save
+ - Start the add-on
+ - You will be able to click the "WEB UI" link to open the Web UI
+
+Time for the first practice with the configurator. Add the following to `configuration.yaml` file to add a link to the Configurator in the sidebar:
 
 ```yaml
 panel_iframe:
@@ -52,7 +56,7 @@ Now restart Home Assistant for the changes to the configuration to take effect. 
 
 Maybe you are not a big fan of our web editor and want to use a text editor on your computer instead. This is possible by sharing the configuration over the network using the Samba add-on, which can be installed from the Hass.io add-on store.
 
-After you have installed it, click on START. Hass.io should now be available in the networking tab on your computer.
+After you have installed it, click on START. Hass.io should now be available in the networking tab on your computer. Use a text editor like the free [Visual Studio Code](https://code.visualstudio.com/) to edit `configuration.yaml`.
 
 ## {% linkable_title Configuring integrations %}
 

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -26,6 +26,7 @@ We will need a few things to get started with installing Home Assistant. Links b
 
  - Download [Hass.io image for Raspberry Pi 3][pi3]
  - Download [Etcher] to write the image to an SD card
+ - Text Editor like [Visual Studio Code](https://code.visualstudio.com/)
 
 [Etcher]: https://etcher.io/
 [pi3]: https://github.com/home-assistant/hassio-build/releases/download/1.1/resinos-hassio-1.1-raspberrypi3.img.bz2

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -9,30 +9,38 @@ sharing: true
 footer: true
 ---
 
-First you will need to install Home Assistant before we can get started:
+The goal of this getting started guide is to install Hass.io on a Raspberry Pi 3. Hass.io is our own all in one solution that turns your Raspberry PI into the utlimate home automation hub.
 
-We have developed **Hass.io** to turn your device into a dedicated Home Assistant hub controlled by a nice webinterface.
-For Raspberry Pi and Intel NUC we offer configured images. Flash the image, setup WiFi (if required) and everything else can be done inside the Hass.io webinterface. Great, isn't it?
+Follow this guide if you want to easily get started with Home Assistant or if you have none or little Linux experience. For advanced users, check our [alternative installation methods](/docs/installation/).
 
-Also Home Assistant runs on any other device that supports **Python 3**.
-<div class="text-center hass-option-cards" markdown="0">
-  <a class='option-card' href='/hassio/installation/'>
-    <div class='img-container'>
-      <img src='/images/supported_brands/home-assistant.png' />
-    </div>
-    <div class='title'>Install Home Assistant using Hass.io</div>
-  </a>
-  <a class='option-card' href='/docs/installation/virtualenv/'>
-    <div class='img-container'>
-      <img src='/images/supported_brands/python.svg' />
-    </div>
-    <div class='title'>Install Home Assistant on your computer</div>
-  </a>
-</div>
-<br>
+### {% linkable_title Hardware requirements %}
 
-For alternative installation methods, please take a look at the [installation documentation](/docs/installation/).
+We will need a few things to get started with installing Home Assistant. Links below are linking to Amazon US. If you're not in the US, you should be able to find these items in web stores in your country.
 
-If you run into any issues, please see [the troubleshooting page](/docs/installation/troubleshooting/) or [communication channels](/help/). It contains solutions to many commonly encountered issues.
+ - [Raspberry Pi 3 model B](http://a.co/gEfMqL4) + [Power Supply](http://a.co/cgKUgkt) (atleast 2.5A)
+ - [Micro SD Card](http://a.co/gslOydD). Get one that is Class 10 as they are more reliable. Size 32GB or bigger recommended.
+ - SD Card reader. Part of most laptops. Also available as [standalone USB sticks](http://a.co/5FCyb0N) (brand doesn't matter, just pick cheapest)
+ - Ethernet cable (optional, Hass.io can work with wifi too)
+
+### {% linkable_title Software requirements %}
+
+ - Download [Hass.io image for Raspberry Pi 3][pi3]
+ - Download [Etcher] to write the image to an SD card
+
+[Etcher]: https://etcher.io/
+[pi3]: https://github.com/home-assistant/hassio-build/releases/download/1.1/resinos-hassio-1.1-raspberrypi3.img.bz2
+
+### Installing Hass.io
+
+ 1. Put the SD card in your SD card reader,
+ 2. Open Etcher, select the Hass.io image and flash it to the SD card.
+ 3. Wifi setup only: open the file `system-connections/resin-sample` with a text editor. Change `ssid` to be your network name and `psk` to be your password.
+ 4. Unmount the SD card and remove it from your SD card reader.
+ 5. Insert the SD card into your Raspberry Pi 3. If you are going to use an ethernet cable to supply internet, connect that too into the Pi.
+ 6. Connect your Raspberry Pi to the power supply so it turns on.
+ 7. The Raspberry Pi will now boot up, connect to the internet and download the latest version of Home Assistant. This will take about 20 minutes.
+ 8. Home Assistant will be available at [http://hassio.local:8123][local].
+
+[local]: http://hassio.local:8123
 
 ### [Next step: Configuring Home Assistant &raquo;](/getting-started/configuration/)

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -20,7 +20,7 @@ We will need a few things to get started with installing Home Assistant. Links b
  - [Raspberry Pi 3 model B](http://a.co/gEfMqL4) + [Power Supply](http://a.co/cgKUgkt) (atleast 2.5A)
  - [Micro SD Card](http://a.co/gslOydD). Get one that is Class 10 as they are more reliable. Size 32GB or bigger recommended.
  - SD Card reader. Part of most laptops. Also available as [standalone USB sticks](http://a.co/5FCyb0N) (brand doesn't matter, just pick cheapest)
- - Ethernet cable (optional, Hass.io can work with wifi too)
+ - Ethernet cable (optional, Hass.io can work with WiFi too)
 
 ### {% linkable_title Software requirements %}
 
@@ -34,11 +34,11 @@ We will need a few things to get started with installing Home Assistant. Links b
 
  1. Put the SD card in your SD card reader,
  2. Open Etcher, select the Hass.io image and flash it to the SD card.
- 3. Wifi setup only: open the file `system-connections/resin-sample` with a text editor. Change `ssid` to be your network name and `psk` to be your password.
+ 3. WiFi setup only: open the file `system-connections/resin-sample` with a text editor. Change `ssid` to be your network name and `psk` to be your password.
  4. Unmount the SD card and remove it from your SD card reader.
- 5. Insert the SD card into your Raspberry Pi 3. If you are going to use an ethernet cable to supply internet, connect that too into the Pi.
+ 5. Insert the SD card into your Raspberry Pi 3. If you are going to use an Ethernet cable to supply Internet, connect that too.
  6. Connect your Raspberry Pi to the power supply so it turns on.
- 7. The Raspberry Pi will now boot up, connect to the internet and download the latest version of Home Assistant. This will take about 20 minutes.
+ 7. The Raspberry Pi will now boot up, connect to the Internet and download the latest version of Home Assistant. This will take about 20 minutes.
  8. Home Assistant will be available at [http://hassio.local:8123][local].
 
 [local]: http://hassio.local:8123


### PR DESCRIPTION
This revamps the installation and configuration pages of getting started. Instead of offering the virtual env and the Hass.io option it's now all about Hass.io as it is the most beginner friendly. We still link out to the alternative installation page on the top.

(The virtualenv installation was too complicated, I've simplified it in #4191 but it was not a good fit with a getting started)

I've expanded the Hass.io installation instructions to list required hardware, software and each step to get to a successful installation.

The configuration page will now talk about how to install the HASS Configurator and Samba add-on.

#For future PRs:
 - Rewrite automation getting started guide to use the automation and script editor
 - Add a step for DuckDNS + Let's Encrypt
 - Presence detection should just focus on OwnTracks over HTTP (using DuckDNS url from previous step)