### PR TITLE
Not used default notification Icon

### DIFF
--- a/source/_components/notify.webostv.markdown
+++ b/source/_components/notify.webostv.markdown
@@ -33,7 +33,7 @@ Configuration variables:
 - **host** (*Required*): The IP of the LG WebOS Smart TV, e.g. 192.168.0.10
 - **name** (*Required*): The name you would like to give to the LG WebOS Smart TV.
 - **filename** (*Optional*): The filename where the pairing key with the TV should be stored. This path is relative to Home Assistant's config directory. It defaults to `webostv.conf`.
-- **icon** (*Optional*): The path to an image file to use as the icon in notifications. If provided, this image will override the Home Assistant logo.
+- **icon** (*Optional*): The path to an image file to use as the icon in notifications.
 
 A possible automation could be:
 


### PR DESCRIPTION
**Description:**
Image is removed from the repository, so we don't send HA icon as default

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11027

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
