### PR TITLE
Update insteon local documentation

### DIFF
--- a/source/_components/fan.insteon_local.markdown
+++ b/source/_components/fan.insteon_local.markdown
@@ -14,16 +14,4 @@ ha_version: 0.48
 
 The `insteon_local` fan component lets you control your fan connected to an [Insteon Hub](http://www.insteon.com/insteon-hub/) with Home Assistant.
 
-To integrate add a fan, configure your hub Insteon(local) with Home Assistant, add the following section to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml platform entry
-insteon_local:
-  host: YOUR HUB IP
-  username: YOUR HUB USERNAME
-  password: YOUR HUB PASSWORD
-  timeout: 10
-  port: 25105
-```
-
-The devices will be discovered by the hub and added to Homeassistant. The name of the devices will be the Insteon address. 
+To get your insteon fans working with Home Assistant, follow the instructions for the general [Insteon local component](/components/insteon_local/). The fans will be automatically disovered and added to Home Assistant. The device names will be the Insteon address of the fans.

--- a/source/_components/fan.insteon_local.markdown
+++ b/source/_components/fan.insteon_local.markdown
@@ -26,9 +26,4 @@ insteon_local:
   port: 25105
 ```
 
-To add fans to your set-up, add the platform to your light configuration:
-```yaml
-fan:
-  - platform: insteon_local
-```
-
+The devices will be discovered by the hub and added to Homeassistant. The name of the devices will be the Insteon address. 

--- a/source/_components/insteon_local.markdown
+++ b/source/_components/insteon_local.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: insteon.png
 ha_category: Hub
 ha_iot_class: "Local Polling"
-ha_version: 0.59.2
+ha_version: 0.36
 ---
 
 The `insteon_local` component let you use your [Insteon Hub](http://www.insteon.com/insteon-hub/) with Home Assistant.
@@ -35,7 +35,7 @@ Configuration variables:
 
 ### {% linkable_title Full configuration %} 
 
-The `insteon_local` component currently supports both lights (dimmers) and switches, fans are now supported as well. With the recent update there is no longer any need to add the light, switch, or fans under the configuration. 
+The `insteon_local` component currently supports both lights (dimmers), switches, and fans. 
 
 ```yaml
 insteon_local:
@@ -46,5 +46,4 @@ insteon_local:
   port: 25105
 ```
 
-In the most recent update we changed the naming of devices to match the insteon address. This means that the automations and scenes will have to be updated. You can also set friendly names for the devices using the customization option.  https://home-assistant.io/docs/configuration/customizing-devices/
 

--- a/source/_components/insteon_local.markdown
+++ b/source/_components/insteon_local.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Insteon (local)"
 description: "Instructions how to setup the Insteon Hub locally within Home Assistant."
-date:  2017-12-11 08:00
+date:  2016-12-18 08:00
 sidebar: true
 comments: false
 sharing: true
@@ -33,9 +33,9 @@ Configuration variables:
 - **timeout** (*Optional*): Timeout to wait for connections. Defaults to 10 seconds.
 - **port** (*Optional*): The port your hub is configured to listen to. Defaults to `25105`.
 
-### {% linkable_title Full configuration %} 
+### {% linkable_title Full configuration %}
 
-The `insteon_local` component currently supports both lights (dimmers), switches, and fans. 
+The `insteon_local` component currently supports lights (dimmers), switches and fans.
 
 ```yaml
 insteon_local:
@@ -45,5 +45,3 @@ insteon_local:
   timeout: 10
   port: 25105
 ```
-
-

--- a/source/_components/insteon_local.markdown
+++ b/source/_components/insteon_local.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Insteon (local)"
 description: "Instructions how to setup the Insteon Hub locally within Home Assistant."
-date:  2016-12-18 08:00
+date:  2017-12-11 08:00
 sidebar: true
 comments: false
 sharing: true
@@ -10,7 +10,7 @@ footer: true
 logo: insteon.png
 ha_category: Hub
 ha_iot_class: "Local Polling"
-ha_version: 0.36
+ha_version: 0.59.2
 ---
 
 The `insteon_local` component let you use your [Insteon Hub](http://www.insteon.com/insteon-hub/) with Home Assistant.
@@ -35,7 +35,7 @@ Configuration variables:
 
 ### {% linkable_title Full configuration %} 
 
-The `insteon_local` component currently supports both lights (dimmers) and switches. A full configuration may look like so:
+The `insteon_local` component currently supports both lights (dimmers) and switches, fans are now supported as well. With the recent update there is no longer any need to add the light, switch, or fans under the configuration. 
 
 ```yaml
 insteon_local:
@@ -44,14 +44,7 @@ insteon_local:
   password: YOUR HUB PASSWORD
   timeout: 10
   port: 25105
-
-light:
-  - platform: insteon_local
-  
-switch:
-  - platform: insteon_local
-  
-fan:
-  - platform: insteon_local
 ```
+
+In the most recent update we changed the naming of devices to match the insteon address. This means that the automations and scenes will have to be updated. You can also set friendly names for the devices using the customization option.  https://home-assistant.io/docs/configuration/customizing-devices/
 

--- a/source/_components/light.insteon_local.markdown
+++ b/source/_components/light.insteon_local.markdown
@@ -27,10 +27,4 @@ insteon_local:
   port: 25105
 ```
 
-To add lights (dimmers) to your set-up, add the platform to your light configuration:
-
-```yaml
-light:
-  - platform: insteon_local
-```
-
+The lights will be auto discovered by the hub. The names of the devices will be the insteon address of the devices.

--- a/source/_components/light.insteon_local.markdown
+++ b/source/_components/light.insteon_local.markdown
@@ -15,16 +15,4 @@ ha_iot_class: "Local Push"
 
 The `insteon_local` light component lets you control your lights connected to an [Insteon Hub](http://www.insteon.com/insteon-hub/) with Home Assistant.
 
-To integrate add a light, configure your hub Insteon(local) with Home Assistant, add the following section to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml platform entry
-insteon_local:
-  host: YOUR HUB IP
-  username: YOUR HUB USERNAME
-  password: YOUR HUB PASSWORD
-  timeout: 10
-  port: 25105
-```
-
-The lights will be auto discovered by the hub. The names of the devices will be the insteon address of the devices.
+To get your insteon lights working with Home Assistant, follow the instructions for the general [Insteon local component](/components/insteon_local/). The lights will be automatically disovered and added to Home Assistant. The device names will be the Insteon address of the lights.

--- a/source/_components/switch.insteon_local.markdown
+++ b/source/_components/switch.insteon_local.markdown
@@ -14,15 +14,4 @@ ha_version: 0.36
 
 The `insteon_local` switch component lets you control your switches connected to an [Insteon Hub](http://www.insteon.com/insteon-hub/) with Home Assistant.
 
-To integrate add a switch, configure your hub Insteon(local) with Home Assistant, add the following section to your `configuration.yaml` file:
-```yaml
-# Example configuration.yaml platform entry
-insteon_local:
-  host: YOUR HUB IP
-  username: YOUR HUB USERNAME
-  password: YOUR HUB PASSWORD
-  timeout: 10
-  port: 25105
-```
-
-The switches will be discovered by the hub and added to Homeassistant. The device names will be the Insteon address of the switch.
+To get your insteon switches working with Home Assistant, follow the instructions for the general [Insteon local component](/components/insteon_local/). The switches will be automatically disovered and added to Home Assistant. The device names will be the Insteon address of the switch.

--- a/source/_components/switch.insteon_local.markdown
+++ b/source/_components/switch.insteon_local.markdown
@@ -25,9 +25,4 @@ insteon_local:
   port: 25105
 ```
 
-To add switches to your set-up, add the platform to your light configuration:
-```yaml
-switch:
-  - platform: insteon_local
-```
-
+The switches will be discovered by the hub and added to Homeassistant. The device names will be the Insteon address of the switch.


### PR DESCRIPTION
**Description:**
This is the update for the insteon local documentation for the PR 

In the most recent update we changed the naming of devices to match the Insteon address. This means that the automations and scenes will have to be updated. You can also set friendly names for the devices using the customization option.  https://home-assistant.io/docs/configuration/customizing-devices/

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11088 

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
