### PR TITLE
Change default IMAP Email Content sensor value from body to subject

### DIFF
--- a/source/_components/sensor.imap_email_content.markdown
+++ b/source/_components/sensor.imap_email_content.markdown
@@ -38,7 +38,7 @@ Configuration variables:
 - **username** (*Required*): Username for the IMAP server.
 - **password** (*Required*): Password for the IMAP server.
 - **senders** (*Required*): A list of sender email addresses that are allowed to report state via email. Only emails received from these addresses will be processed.
-- **value_template** (*Optional*): If specified this template will be used to render the state of sensor. If a template is not supplied the raw message body will be used for the sensor value. The following attributes will be supplied to the template:
+- **value_template** (*Optional*): If specified this template will be used to render the state of sensor. If a template is not supplied the message subject will be used for the sensor value. The following attributes will be supplied to the template:
 
    * **from**: The from address of the email
    * **body**: The body of the email

--- a/source/_components/sensor.imap_email_content.markdown
+++ b/source/_components/sensor.imap_email_content.markdown
@@ -38,7 +38,7 @@ Configuration variables:
 - **username** (*Required*): Username for the IMAP server.
 - **password** (*Required*): Password for the IMAP server.
 - **senders** (*Required*): A list of sender email addresses that are allowed to report state via email. Only emails received from these addresses will be processed.
-- **value_template** (*Optional*): If specified this template will be used to render the state of sensor. If a template is not supplied the message subject will be used for the sensor value. The following attributes will be supplied to the template:
+- **value_template** (*Optional*): If specified this template will be used to render the state of the sensor. If a template is not supplied the message subject will be used for the sensor value. The following attributes will be supplied to the template:
 
    * **from**: The from address of the email
    * **body**: The body of the email


### PR DESCRIPTION
**Description:**
This change to IMAP Email Content sensor makes the state the email subject and moves the body to an attribute. This is to work around the new 255 character limit for states.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11096

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
