### PR TITLE
Add documentation for yamaha_enable_output

### DIFF
--- a/source/_components/media_player.yamaha.markdown
+++ b/source/_components/media_player.yamaha.markdown
@@ -107,3 +107,13 @@ script:
           media_content_id: "Bookmarks>Internet>Radio Paradise"
 
 ```
+
+### {% linkable_title Service `yamaha_enable_output` %}
+
+Enable or disable an output port (HDMI) on the receiver.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of strings that point at `entity_id`s of Yamaha receivers.
+| `port` | no | Port to enable or disable, e.g. `hdmi1`.
+| `enabled` | no | To enable set true, otherwise set to false.

--- a/source/_components/media_player.yamaha.markdown
+++ b/source/_components/media_player.yamaha.markdown
@@ -114,6 +114,6 @@ Enable or disable an output port (HDMI) on the receiver.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`s of Yamaha receivers.
+| `entity_id` | yes | String or list of strings that point at `entity_id`s of Yamaha receivers.
 | `port` | no | Port to enable or disable, e.g. `hdmi1`.
 | `enabled` | no | To enable set true, otherwise set to false.


### PR DESCRIPTION
**Description:**
Add documentation for the new service.

Old PR from previous attempt to merge this: https://github.com/home-assistant/home-assistant.github.io/pull/2602

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11103

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
