### PR TITLE
Removed the entity_id option from template sensors

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -48,10 +48,6 @@ binary_sensor:
             description: Name to use in the frontend.
             required: false
             type: string
-          entity_id:
-            description: Add a list of entity IDs so the sensor only reacts to state changes of these entities. This will reduce the number of times the sensor will try to update its state.
-            required: false
-            type: string, list
           device_class:
             description: The type/class of the sensor to set the icon in the frontend.
             required: false
@@ -126,13 +122,11 @@ binary_sensor:
 ```
 {% endraw %}
 
-### {% linkable_title Combining Multiple Sensors, and Using `entity_id` %}
+### {% linkable_title Combining Multiple Sensors %}
 
 This example combines multiple CO sensors into a single overall
 status. When using templates with binary sensors, you need to return
-`true` or `false` explicitly. `entity_id` is used to limit which
-sensors are being monitored to update the state, making computing this
-sensor far more efficient.
+`true` or `false` explicitly.
 
 {% raw %}
 ```yaml
@@ -142,10 +136,6 @@ binary_sensor:
       co:
         friendly_name: "CO"
         device_class: gas
-        entity_id:
-          - sensor.bedroom_co_status
-          - sensor.kitchen_co_status
-          - sensor.wardrobe_co_status
         value_template: >-
           {{ is_state('sensor.bedroom_co_status', 'Ok')
              and is_state('sensor.kitchen_co_status', 'Ok')
@@ -190,14 +180,6 @@ binary_sensor:
   - platform: template
     sensors:
       people_home:
-        entity_id:
-          - device_tracker.sean
-          - device_tracker.susan
-          - binary_sensor.office_124
-          - binary_sensor.hallway_134
-          - binary_sensor.living_room_139
-          - binary_sensor.porch_ms6_1_129
-          - binary_sensor.family_room_144
         value_template: >-
           {{ is_state('device_tracker.sean', 'home')
              or is_state('device_tracker.susan', 'home')

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -48,10 +48,6 @@ cover:
         description: Name to use in the frontend.
         required: false
         type: string
-      entity_id:
-        description: Add a list of entity IDs so the switch only reacts to state changes of these entities. This will reduce the number of times the cover will try to update its state.
-        required: false
-        type: [string, list]
       value_template:
         description: Defines a template to get the state of the cover. Valid values are `open`/`true` or `closed`/`false`. [`value_template`](#value_template) and [`position_template`](#position_template) cannot be specified concurrently.
         required: exclusive
@@ -201,9 +197,6 @@ cover:
           {% else %}
             mdi:window-closed
           {% endif %}
-        entity_id:
-          - cover.bedroom
-          - cover.livingroom
 
 sensor:
   - platform: template
@@ -217,9 +210,6 @@ sensor:
           {% else %}
             closed
           {% endif %}
-        entity_id:
-          - cover.bedroom
-          - cover.livingroom
 
 script:
   cover_group:

--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -51,10 +51,6 @@ light:
         description: Name to use in the frontend.
         required: false
         type: string
-      entity_id:
-        description: Add a list of entity IDs so the switch only reacts to state changes of these entities. This will reduce the number of times the light will try to update its state.
-        required: false
-        type: [string, list]
       value_template:
         description: Defines a template to get the state of the light.
         required: false

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -46,10 +46,6 @@ sensor:
         description: Name to use in the frontend.
         required: false
         type: string
-      entity_id:
-        description: Add a list of entity IDs so the sensor only reacts to state changes of these entities. This will reduce the number of times the sensor will try to update its state.
-        required: false
-        type: string, list
       unit_of_measurement:
         description: Defines the units of measurement of the sensor, if any.
         required: false
@@ -71,12 +67,11 @@ sensor:
 ## {% linkable_title Considerations %}
 
 If you are using the state of a platform that takes extra time to load, the
-Template Sensor may get an `unknown` state during startup. This results
-in error messages in your log file until that platform has completed loading.
-If you use `is_state()` function in your template, you can avoid this situation.
+Template Sensor may get an `unknown` state during startup. To avoid this (and the resulting
+error messages in your log file), you can use `is_state()` function in your template.
 For example, you would replace
 {% raw %}`{{ states.switch.source.state == 'on' }}`{% endraw %}
-with this equivalent that returns `true`/`false` and never gives an unknown
+with this equivalent that returns `true`/`false` and never gives an `unknown`
 result:
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
 

--- a/source/_components/switch.template.markdown
+++ b/source/_components/switch.template.markdown
@@ -55,10 +55,6 @@ switch:
         description: Name to use in the frontend.
         required: false
         type: string
-      entity_id:
-        description: Add a list of entity IDs so the switch only reacts to state changes of these entities. This will reduce the number of times the switch will try to update its state.
-        required: false
-        type: [string, list]
       value_template:
         description: Defines a template to set the state of the switch.
         required: true


### PR DESCRIPTION
**Description:** Removing the `entity_id` option from template sensors that is not required anymore now that we do automatic analysis for used entity ids. It is causing more confusion in readers mind. 

Pull request in home-assistant (if applicable): home-assistant/home-assistant#11123