### PR TITLE
New config option: referer for camera.generic

### DIFF
--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -36,7 +36,7 @@ Configuration variables:
 - **authentication** (*Optional*): Type for authenticating the requests `basic` (default) or `digest`.
 - **limit_refetch_to_url_change** (*Optional*): True/false value (default: false). Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
 - **content_type** (*Optional*): Set the content type for the IP camera if it is not a jpg file (default: `image/jpeg`). Use `image/svg+xml` to add a dynamic svg file.
-- **referer** (*Optional*): Set the `Referer` header for the requests. Unset by default.
+- **headers** (*Optional*): Set request headers. Unset by default.
 
 <p class='img'>
   <a href='/cookbook/google_maps_card/'>
@@ -57,4 +57,15 @@ camera:
     name: Weather
     still_image_url: https://www.yr.no/place/Norway/Oslo/Oslo/Oslo/meteogram.svg
     content_type: 'image/svg+xml'
+```
+
+### {% linkable_title Public webcam requiring headers %}
+
+```yaml
+camera:
+  - platform: generic
+    name: centre_pompidou_metz
+    still_image_url: "http://metz.fr/pages/webcams/images/amphitheatre.jpg?{{ as_timestamp(now()) * 1000 }}"
+    headers:
+      referer: "http://metz.fr/pages/webcams/quartier_amphitheatre.php"
 ```

--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -36,6 +36,7 @@ Configuration variables:
 - **authentication** (*Optional*): Type for authenticating the requests `basic` (default) or `digest`.
 - **limit_refetch_to_url_change** (*Optional*): True/false value (default: false). Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
 - **content_type** (*Optional*): Set the content type for the IP camera if it is not a jpg file (default: `image/jpeg`). Use `image/svg+xml` to add a dynamic svg file.
+- **referer** (*Optional*): Set the `Referer` header for the requests. Unset by default.
 
 <p class='img'>
   <a href='/cookbook/google_maps_card/'>


### PR DESCRIPTION
**Description:**
Add documentation for the new `referer` config option.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11139

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
