### PR TITLE
Mochad light fixes

### DIFF
--- a/source/_components/light.mochad.markdown
+++ b/source/_components/light.mochad.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Mochad Light"
-description: "Instructions how to integrate X10 Mochad switches into Home Assistant."
+description: "Instructions how to integrate X10 Mochad lights into Home Assistant."
 date: 2017-07-14 11:29
 sidebar: true
 comments: false
@@ -11,7 +11,7 @@ ha_category: Light
 ha_release: 0.51
 ---
 
-The `mochad` switch platform lets you control an X10 enabled dimmer/light
+The `mochad` light platform lets you control an X10 enabled dimmer/light
 device.
 
 To enable this sensor, you first have to set up the [mochad component](/components/mochad/) and then add the following to your `configuration.yaml` file:
@@ -28,7 +28,7 @@ light:
 Configuration variables:
 
 - **address** (*Required*): The X10 address of the light.
-- **name** (*Optional*): The name of the switch. Default is: x10_light_dev_*address*.
+- **name** (*Optional*): The name of the light. Default is: x10_light_dev_*address*.
 - **comm_type** (*Optional*): pl (powerline) or rf (radio frequency). Default is pl.
 - **brightness_levels** (*Optional*): The number of brightness levels the X10 light device supports. This can either be 32, 64, or 256 (note that the max
 value sent to the device will be n-1 because it starts at 0)

--- a/source/_components/light.mochad.markdown
+++ b/source/_components/light.mochad.markdown
@@ -30,3 +30,5 @@ Configuration variables:
 - **address** (*Required*): The X10 address of the light.
 - **name** (*Optional*): The name of the switch. Default is: x10_light_dev_*address*.
 - **comm_type** (*Optional*): pl (powerline) or rf (radio frequency). Default is pl.
+- **brightness_levels** (*Optional*): The number of brightness levels the X10 light device supports. This can either be 32, 64, or 256 (note that the max
+value sent to the device will be n-1 because it starts at 0)


### PR DESCRIPTION
**Description:**
Add brightness levels option to mochad
 
In home-assistant/home-assistant#11146 a new configuration option, brighness_levels, is added to the mochad light component. This is used to tell home-assistant how many brightness levels the X10 light device supports because there is no way to actually discover this. This commit adds documentation for the new option.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11146

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/