### PR TITLE
Device tracker: disabled Tiles and automatic session renewal

### DIFF
--- a/source/_components/device_tracker.tile.markdown
+++ b/source/_components/device_tracker.tile.markdown
@@ -28,6 +28,7 @@ device_tracker:
     monitored_variables:
       - TILE
       - PHONE
+    show_inactive: false
 ```
 
 {% configuration %}
@@ -43,4 +44,8 @@ device_tracker:
     description: the Tile types to monitor; valid values are `TILE` and `PHONE` (default is for all types to be included)
     required: false
     type: list
+  show_inactive:
+    description: whether to show expired/disabled Tiles
+    required: false
+    type: boolean
 {% endconfiguration %}

--- a/source/_components/device_tracker.tile.markdown
+++ b/source/_components/device_tracker.tile.markdown
@@ -25,10 +25,6 @@ device_tracker:
   - platform: tile
     username: email@address.com
     password: MY_PASSWORD_123
-    monitored_variables:
-      - TILE
-      - PHONE
-    show_inactive: false
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:**
Adds info about the new Tile configuration parameter: `show_inactive`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11172

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
