### PR TITLE
New parameter to query Samsung TV Status via REST

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -34,7 +34,7 @@ Configuration variables:
 - **name** (*Optional*): The name you would like to give to the Samsung Smart TV.
 - **timeout** (*Optional*): The time-out in seconds for the communication with the TV. Defaults to 0 (no timeout).
 - **mac** (*Optional*): The MAC address of the Samsung Smart TV, eg. `00:11:22:33:44:55:66`. Required for power on support via wake on lan.
-- **get_status_via_rest** (*Optional*): Use samsung REST end point to determine the status of the TV (host:8001/api/v2/), eg. `True` or `False`. Required for latest 2017 model that are turned ON randomly (sending a key to check status turned the TV ON)
+- **get_status_via_rest** (*Optional*): Use Samsung REST endpoint to determine the status of the TV (host:8001/api/v2/), e.g. `True` or `False`. Required for latest 2017 model that are turned ON randomly (sending a key to check status turned the TV ON)
 
 Currently known supported models:
 
@@ -60,7 +60,7 @@ Currently known supported models:
 - KS7502 (port must be set to 8001, and `pip3 install websocket-client` must be executed, turn on doesn't work, turn off works fine)
 - K5600AK (partially supported, turn on works but state is not updated)
 - UE65KS8005 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
-- MU6300 (port must be set to 8001, `pip3 install websocket-client` must be executed and `get_status_via_rest` must be set to True or the TV will randomly be turned ON)
+- MU6300 (port must be set to 8001, `pip3 install websocket-client` must be executed and `get_status_via_rest` must be set to True, or the TV will randomly be turned ON)
 
 Currently tested but not working models:
 

--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -34,6 +34,7 @@ Configuration variables:
 - **name** (*Optional*): The name you would like to give to the Samsung Smart TV.
 - **timeout** (*Optional*): The time-out in seconds for the communication with the TV. Defaults to 0 (no timeout).
 - **mac** (*Optional*): The MAC address of the Samsung Smart TV, eg. `00:11:22:33:44:55:66`. Required for power on support via wake on lan.
+- **get_status_via_rest** (*Optional*): Use samsung REST end point to determine the status of the TV (host:8001/api/v2/), eg. `True` or `False`. Required for latest 2017 model that are turned ON randomly (sending a key to check status turned the TV ON)
 
 Currently known supported models:
 
@@ -59,6 +60,7 @@ Currently known supported models:
 - KS7502 (port must be set to 8001, and `pip3 install websocket-client` must be executed, turn on doesn't work, turn off works fine)
 - K5600AK (partially supported, turn on works but state is not updated)
 - UE65KS8005 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
+- MU6300 (port must be set to 8001, `pip3 install websocket-client` must be executed and `get_status_via_rest` must be set to True or the TV will randomly be turned ON)
 
 Currently tested but not working models:
 
@@ -67,7 +69,6 @@ Currently tested but not working models:
 - JU7500 - Unable to see state and unable to control
 - JS9000 - State is always "on" and unable to control (but port 8001 *is* open)
 - JS9500 - State is always "on" and unable to control (but port 8001 *is* open)
-- MU6300 - Port set to 8001, `pip3 install websocket-client` must be executed, turning on works, status not working reliably, turning off is not permanent (it comes back on)
  
 If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.github.io/tree/current/source/_components/media_player.samsungtv.markdown).
 The first letter (U, P, L, H & K) represent the screen type, e.g. LED or Plasma. The second letter represents the region, E is Europe, N is North America and A is Asia & Australia. The two numbers following that represent the screen size.


### PR DESCRIPTION
New parameter get_status_via_rest to allow querying the TV status via its REST end point instead of sending a dummy key (which turned ON some TV).


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11179

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
