### PR TITLE
Update hue.markdown

### DIFF
--- a/source/_components/hue.markdown
+++ b/source/_components/hue.markdown
@@ -106,7 +106,7 @@ More information can be found on the [Philips Hue API documentation](https://www
 
 The Hue platform has it's own concept of scenes for setting the colors of a group of lights at once. Hue Scenes are very cheap, get created by all kinds of apps (as it is the only way to have 2 or more lights change at the same time), and are rarely deleted. A typical Hue hub might have hundreds of scenes stored in them, many that you've never used, almost all very poorly named.
 
-To avoid user interface overload we don't expose scenes directly. Instead there is a [light.hue_activate_scene](/components/light/#service-lighthue_activate_scene) service which can be used by `automation` or `script` components.
+To avoid user interface overload we don't expose scenes directly. Instead there is a hue.hue_activate_scene service which can be used by `automation` or `script` components.
 This will have all the bulbs transitioned at once, instead of one at a time using standard scenes in Home Assistant.
 
 For instance:
@@ -115,7 +115,7 @@ For instance:
 script:
   porch_on:
     sequence:
-      - service: light.hue_activate_scene
+      - service: hue.hue_activate_scene
         data:
           group_name: "Porch"
           scene_name: "Porch Orange"


### PR DESCRIPTION
- changed service name to align with breaking changes in .60
- removed link (no longer applies)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
