### PR TITLE
Replaced references to Yahoo Finance

### DIFF
--- a/source/_components/sensor.alpha_vantage.markdown
+++ b/source/_components/sensor.alpha_vantage.markdown
@@ -16,7 +16,7 @@ ha_release: "0.60"
 
 The `alpha_vantage` sensor platform uses [Alpha Vantage](https://www.alphavantage.co) to monitor the stock market.
 
-To enable the `yahoo_finance` platform, add the following lines to your `configuration.yaml` file:
+To enable the `alpha_vantage` platform, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -45,7 +45,7 @@ In this section you find some real life examples of how to use this sensor.
 
 ```yaml
 sensor:
-  - platform: yahoo_finance
+  - platform: alpha_vantage
     symbols:
       - RHT
       - GOOGL


### PR DESCRIPTION
Unless something weird is needed with using the `yahoo_finance`, replaced this with `alpha_vantage`

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
