### PR TITLE
calendar.caldav.markdown typo fix

### DIFF
--- a/source/_components/calendar.caldav.markdown
+++ b/source/_components/calendar.caldav.markdown
@@ -22,7 +22,7 @@ You need to have a CalDav server and eventually credentials for it. This compone
 You might need some additional system packages to compile the Python caldav library. On a Debian based system, install them by:
 
 ```bash
-$ sudo apt-get install libxm2-dev libxslt1-dev zlib1g-dev
+$ sudo apt-get install libxml2-dev libxslt1-dev zlib1g-dev
 ```
 
 ### {% linkable_title Basic Setup %}


### PR DESCRIPTION
**Description:**
Additional system packages had libxm2-dev which should be libxml2-dev

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
