### PR TITLE
Explanation for translation placeholders

### DIFF
--- a/source/developers/frontend_translation.markdown
+++ b/source/developers/frontend_translation.markdown
@@ -15,6 +15,8 @@ ha_release: 0.57
 
 First time users may find it helpful to switch between multilanguage and single language view using the <img src='/images/frontend/lokalise-multilanguage-view-button.png' alt="Multilanguage view" style="width: 17px; border: none;"/> button. For more information about the translation workflow, please see the [Lokalise translation workflow documents](https://docs.lokalise.co/category/iOzEuQPS53-for-team-leads-and-translators).
 
+Some translation strings will contain special placeholders that will be replaced later. Placeholders shown in square brackets `[]` are [Lokalise key references](https://docs.lokalise.co/article/KO5SZWLLsy-key-referencing). These are primarily used to link translation strings that will be duplicated. Different languages may not have the same duplicates as English, and are welcome to link duplicate translations that are not linked in English. Placeholders shown in curly brackets `{}` are [translation arguments](https://formatjs.io/guides/message-syntax/) that will be replaced with a live value when Home Assistant is running. Any translation argument placeholders present in the original string must be included in the translated string. These may include special syntax for defining plurals or other replacement rules. The linked format.js guide explains the syntax for adding plural definitions and other rules.
+
 <p class='note'>
 The translation of the Home Assistant frontend is still a work in progress. More phrases will be available for translation soon.
 </p>


### PR DESCRIPTION
**Description:**
This PR adds a paragraph to the translation docs explaining what the different placeholders mean.
