### PR TITLE
Fix example for the Hue component.

### DIFF
--- a/source/_components/hue.markdown
+++ b/source/_components/hue.markdown
@@ -64,8 +64,7 @@ hue:
   bridges:
     - host: BRIDGE1_IP_ADDRESS
       filename: phue.conf
-    - platform: hue
-      host: BRIDGE2_IP_ADDRESS
+    - host: BRIDGE2_IP_ADDRESS
       filename: phue2.conf
 ```
 


### PR DESCRIPTION
The current text seems to suggest `platform: hue` is still needed or supported. Not so.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
