### PR TITLE
Added `switch:` to configuration.yaml example

### DIFF
--- a/source/_components/switch.hook.markdown
+++ b/source/_components/switch.hook.markdown
@@ -24,6 +24,7 @@ Configure with either your username/password or your API token for the official 
 
 ```yaml
 # Example configuration.yaml entry
+switch: 
 -  platform: hook
    username: <email address>
    password: !secret hook
@@ -31,6 +32,7 @@ Configure with either your username/password or your API token for the official 
 Or
 ```yaml
 # Example configuration.yaml entry
+switch:
 -  platform: hook
    token: <your API token>
 ```


### PR DESCRIPTION
Added `switch:` to configuration.yaml example to help clarify what actually needs to be added to a configuration.yaml file in order for this platform to work- assuming this is the only switch in the configuration, or if you are adding it as a list item to other switches. It cannot be copied/pasted directly as it was.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
