### PR TITLE
removed double negative

### DIFF
--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -33,7 +33,7 @@ Configuration variables:
 - **password** (*Required*): The password for your given admin account.
 - **site_id** (*Optional*): Allows you to specify a `site_id` for device tracking. Defaults to `default`. Found in the URL of the controller (i.e. https://CONTROLLER:PORT/manage/site/SITE_ID/dashboard).
 - **verify_ssl** (*Optional*): Controls if the SSL certificate running on your Unifi webserver must be trusted by a known Certificate Authority on the server running Home Assistant. Defaults to 'True' but can also be a value that points to your custom cert "path/to/custom_cert.pem".
-- **detection_time** (*Optional*): The Unifi component will not return a device that has not been seen by the controller in the last 180 seconds. You can adjust this threshold with this variable and accepts seconds or `00:00:00` time formats.
+- **detection_time** (*Optional*): The Unifi component will only return devices that have been seen by the controller in the last 180 seconds. You can adjust this threshold with this variable and accepts seconds or `00:00:00` time formats.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.
 


### PR DESCRIPTION
Reworded the detection_time explanation to make it easier to parse and understand.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
