### PR TITLE
fix YAML spacing

### DIFF
--- a/source/_components/switch.hook.markdown
+++ b/source/_components/switch.hook.markdown
@@ -25,16 +25,16 @@ Configure with either your username/password or your API token for the official 
 ```yaml
 # Example configuration.yaml entry
 switch: 
--  platform: hook
-   username: <email address>
-   password: !secret hook
+  -  platform: hook
+     username: <email address>
+     password: !secret hook
 ```
 Or
 ```yaml
 # Example configuration.yaml entry
 switch:
--  platform: hook
-   token: <your API token>
+  -  platform: hook
+     token: <your API token>
 ```
 
 Extra debug logging is available, if you need it.


### PR DESCRIPTION
Whoops, needed to fix YAML spacing after ````switch:````

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
