### PR TITLE
Gpslogger auth

### DIFF
--- a/source/_components/device_tracker.gpslogger.markdown
+++ b/source/_components/device_tracker.gpslogger.markdown
@@ -19,7 +19,14 @@ To integrate GPSLogger in Home Assistant, add the following section to your `con
 # Example configuration.yaml entry
 device_tracker:
   - platform: gpslogger
+    password: !secret gpslogger_password
 ```
+{% configuration %}
+password:
+  description: Separate password for GPS Logger endpoint. If provided using regular API password to contact endpoint will result in 401 response.
+  required: false
+  type: string
+{% endconfiguration %}
 
 ## {% linkable_title Setup on your smartphone %}
 


### PR DESCRIPTION
**Description:**
Adds separate authentication possible for GPS logger entry point. The goal here is to minimize the impact if GPS logger password is disclosed.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11245
