### PR TITLE
Additional attributes and services of the Xiaomi Air Purifier introduced

### DIFF
--- a/source/_components/fan.xiaomi_miio.markdown
+++ b/source/_components/fan.xiaomi_miio.markdown
@@ -8,36 +8,38 @@ comments: false
 sharing: true
 footer: true
 logo: xiaomi.png
-ha_category: Switch
+ha_category: Fan
 ha_version: 0.57
 ha_iot_class: "Local Polling"
 ---
 
-The `xiaomi_miio` fan platform allows you to control the Xiaomi Air Purifier 2, Air Purifier 2S andd Air Purifier Pro.
+The `xiaomi_miio` fan platform allows you to control the Xiaomi Air Purifier 2, Air Purifier 2S and Air Purifier Pro.
 
 Currently, the supported features are
 
 * On, Off
 * Operation modes (auto, silent, favorite, idle)
 * Buzzer (on, off)
+* Child lock (on, off)
 * LED (on, off), LED brightness (bright, dim, off)
-* Favorite Level
-* States
+* Favorite Level (0...16)
+* Attributes
   - power
   - aqi
+  - average_aqi
   - humidity
   - temperature
   - mode
+  - favorite_level
   - led
   - led_brightness
   - buzzer
   - child_lock
-  - brightness
-  - favorite_level
-  - filter1_life
-  - f1_hour_used
-  - use_time
-  - motor1_speed
+  - purify_volume
+  - filter_life_remaining
+  - filter_hours_used
+  - motor_speed
+
 
 ## {% linkable_title Setup %}
 
@@ -87,6 +89,22 @@ Turn the led on.
 ### Service fan/xiaomi_miio_set_led_off
 
 Turn the led off.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+
+### Service fan/xiaomi_miio_set_child_lock_on
+
+Turn the child lock on.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+
+### Service fan/xiaomi_miio_set_child_lock_off
+
+Turn the child lock off.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|

--- a/source/_components/fan.xiaomi_miio.markdown
+++ b/source/_components/fan.xiaomi_miio.markdown
@@ -68,7 +68,7 @@ Turn the buzzer on.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+| `entity_id`               |      yes | Only act on a specfici air purifier. Else targets all.  |
 
 ### Service fan/xiaomi_miio_set_buzzer_off
 
@@ -76,7 +76,7 @@ Turn the buzzer off.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+| `entity_id`               |      yes | Only act on a specfici air purifier. Else targets all.  |
 
 ### Service fan/xiaomi_miio_set_led_on
 
@@ -84,7 +84,7 @@ Turn the led on.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+| `entity_id`               |      yes | Only act on a specfici air purifier. Else targets all.  |
 
 ### Service fan/xiaomi_miio_set_led_off
 
@@ -92,7 +92,7 @@ Turn the led off.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+| `entity_id`               |      yes | Only act on a specfici air purifier. Else targets all.  |
 
 ### Service fan/xiaomi_miio_set_child_lock_on
 
@@ -100,7 +100,7 @@ Turn the child lock on.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+| `entity_id`               |      yes | Only act on a specfici air purifier. Else targets all.  |
 
 ### Service fan/xiaomi_miio_set_child_lock_off
 
@@ -108,7 +108,7 @@ Turn the child lock off.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+| `entity_id`               |      yes | Only act on a specfici air purifier. Else targets all.  |
 
 ### Service fan/xiaomi_miio_set_led_brightness
 
@@ -116,7 +116,7 @@ Set the led brightness. Supported values are 0 (Bright), 1 (Dim), 2 (Off).
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+| `entity_id`               |      yes | Only act on a specfici air purifier. Else targets all.  |
 | `brightness`              |       no | Brightness, between 0 and 2.                          |
 
 ### Service fan/xiaomi_miio_set_favorite_level
@@ -125,5 +125,5 @@ Set the favorite level of the operation mode "favorite".
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific air purifier. Else targets all.  |
+| `entity_id`               |      yes | Only act on a specfici air purifier. Else targets all.  |
 | `level`                   |       no |  Level, between 0 and 16.                             |


### PR DESCRIPTION
**Description:**

New attributes average_aqi and purify_volume introduced and service light.xiaomi_miio_set_child_lock_{on,off} added.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11249
