### PR TITLE
Update notify.webostv.markdown

### DIFF
--- a/source/_components/notify.webostv.markdown
+++ b/source/_components/notify.webostv.markdown
@@ -32,8 +32,9 @@ Configuration variables:
 
 - **host** (*Required*): The IP of the LG WebOS Smart TV, e.g. 192.168.0.10
 - **name** (*Required*): The name you would like to give to the LG WebOS Smart TV.
+- **icon** (*Required*): The path to an image file to use as the icon in notifications.
 - **filename** (*Optional*): The filename where the pairing key with the TV should be stored. This path is relative to Home Assistant's config directory. It defaults to `webostv.conf`.
-- **icon** (*Optional*): The path to an image file to use as the icon in notifications. If provided, this image will override the Home Assistant logo.
+
 
 A possible automation could be:
 


### PR DESCRIPTION
Due to the separation of polymer frontend from the base HA repo, this component does not work unless an icon file is provided. Therefore I have changed the icon to be *required* from *optional*.

See issue [here](https://github.com/home-assistant/home-assistant/issues/10538).

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
