### PR TITLE
Remove all_day configuration key from caldav

### DIFF
--- a/source/_components/calendar.caldav.markdown
+++ b/source/_components/calendar.caldav.markdown
@@ -70,11 +70,6 @@ custom_calendars:
       required: true
       pending_charges: Regular expression for filtering the events
       type: string
-    all_day:
-      required: false
-      description: Include events that last the whole day.
-      type: boolean
-      default: true
 {% endconfiguration %}
 
 


### PR DESCRIPTION
**Description:**
Remove the `all_day` switch from the documentation as it has no effect

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11272

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
