### PR TITLE
Update the Alarm Decoder docs to outline the services and attributes

### DIFF
--- a/source/_components/alarm_control_panel.alarmdecoder.markdown
+++ b/source/_components/alarm_control_panel.alarmdecoder.markdown
@@ -18,7 +18,7 @@ The `alarmdecoder` alarm control panel platform allows you to control your [Alar
 
 The requirement is that you have setup your [AlarmDecoder hub](/components/alarmdecoder/).
 
-### Services
+### {% linkable_title Services %}
 
 The Alarm Decoder component gives you access to several services for you to control your alarm with.
 
@@ -30,7 +30,7 @@ The Alarm Decoder component gives you access to several services for you to cont
 
 **Note**: `alarm_arm_custom_bypass` and `alarm_trigger`, while available in the services list in Home Assistant, are not currently implemented in the Alarm Decoder component.
 
-### Attributes
+### {% linkable_title Attributes %}
 
 There are several attributes available on the alarm panel to give you more information about your alarm.
 
@@ -44,12 +44,13 @@ There are several attributes available on the alarm panel to give you more infor
 - `ready`: Set to `true` if your system is ready to be armed. Any faults, including motions sensors, will make this value `false`.
 - `zone_bypassed`: Set to `true` if your system is currently bypassing a zone.
 
-### Examples
+### {% linkable_title Examples %}
 
 Using a combination of the available services and attributes, you can create switch templates.
 
-#### Chime Status and Control
+#### {% linkable_title Chime Status and Control %}
 
+{% raw %}
 ```yaml
 - platform: template
   switches:
@@ -71,3 +72,4 @@ Using a combination of the available services and attributes, you can create swi
             mdi:bell-off
           {% endif %}
 ```
+{% endraw %}

--- a/source/_components/alarm_control_panel.alarmdecoder.markdown
+++ b/source/_components/alarm_control_panel.alarmdecoder.markdown
@@ -18,3 +18,56 @@ The `alarmdecoder` alarm control panel platform allows you to control your [Alar
 
 The requirement is that you have setup your [AlarmDecoder hub](/components/alarmdecoder/).
 
+### Services
+
+The Alarm Decoder component gives you access to several services for you to control your alarm with.
+
+- `alarm_arm_away`: Arms the alarm in away mode; all faults will trigger the alarm.
+- `alarm_arm_home`: Arms the alarm in stay mode; faults to the doors or windows will trigger the alarm.
+- `alarm_arm_night`: Arms the alarm in instant mode; all faults will trigger the alarm. Additionally, the entry delay is turned off on the doors.
+- `alarm_disarm`: Disarms the alarm from any state. Also clears a `check_zone` flag after an alarm was triggered.
+- `alarmdecoder_alarm_toggle_chime`: Toggles the alarm's chime state.
+
+**Note**: `alarm_arm_custom_bypass` and `alarm_trigger`, while available in the services list in Home Assistant, are not currently implemented in the Alarm Decoder component.
+
+### Attributes
+
+There are several attributes available on the alarm panel to give you more information about your alarm.
+
+- `ac_power`: Set to `true` if your system has AC power supplying it.
+- `backlight_on`: Set to `true` if your keypad's backlight is on.
+- `battery_low`: Set to `true` if your system's back-up battery is low.
+- `check_zone`: Set to `true` if your system was recently triggered. When `check_zone` is `true`, it must be cleared by entering your code + 1 before attempting to rearm your alarm.
+- `chime`: Set to `true` if your system's chime is activated. When activated, your system will beep anytime a door or window is faulted while the alarm is disarmed.
+- `entry_delay_off`: Set to `true` if your system is in "Instant" mode, meaning the alarm will sound on any faults.
+- `programming_mode`: Set to `true` if your system is in programming mode.
+- `ready`: Set to `true` if your system is ready to be armed. Any faults, including motions sensors, will make this value `false`.
+- `zone_bypassed`: Set to `true` if your system is currently bypassing a zone.
+
+### Examples
+
+Using a combination of the available services and attributes, you can create switch templates.
+
+#### Chime Status and Control
+
+```yaml
+- platform: template
+  switches:
+    alarm_chime:
+      friendly_name: Chime
+      value_template: "{{ is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) }}"
+      turn_on:
+        service: alarm_control_panel.alarmdecoder_alarm_toggle_chime
+        data:
+          code: !secret alarm_code
+      turn_off:
+        service: alarm_control_panel.alarmdecoder_alarm_toggle_chime
+        data:
+          code: !secret alarm_code
+      icon_template: >-
+          {% if is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) %}
+            mdi:bell-ring
+          {% else %}
+            mdi:bell-off
+          {% endif %}
+```


### PR DESCRIPTION
**Description:**
Adds more information to the Alarm Decoder alarm panel document. Outlines the existing services, as well as a new service being added. Also outlines all attributes being added.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11271

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
