### PR TITLE
Add documentation for the group alarm platform

### DIFF
--- a/source/_components/alarm_control_panel.group.markdown
+++ b/source/_components/alarm_control_panel.group.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Alarm Group"
-description: "Instructions how to setup the alarm group platform."
+description: "Instructions on how to set up the alarm group platform."
 date: 2017-11-22 00:12
 sidebar: true
 comments: false
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: home-assistant.png
 ha_category: Alarm
-ha_release: 0.64
+ha_release: 0.66
 ---
 
 The `group` alarm platform allows you to combine multiple `alarm` platforms into a single service.

--- a/source/_components/alarm_control_panel.group.markdown
+++ b/source/_components/alarm_control_panel.group.markdown
@@ -1,0 +1,52 @@
+---
+layout: page
+title: "Alarm Group"
+description: "Instructions how to setup the alarm group platform."
+date: 2017-11-22 00:12
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: home-assistant.png
+ha_category: Alarm
+ha_release: 0.59
+---
+
+The `group` alarm platform allows you to combine multiple `alarm` platforms into a single service.
+
+To use this notification platform in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+alarm:
+  - name: ALARM_NAME
+    platform: group
+    code_format: '\d+'
+    panels:
+    - panel: alarm_control_panel.garage
+    - panel: alarm_control_panel.living_room
+    - panel: alarm_control_panel.bedroom
+    - panel: alarm_control_panel.tampering
+```
+
+Configuration variables:
+
+{% configuration %}
+  name:
+    description: The name of the group
+    required: true
+    type: string
+  code_format:
+    description: A regular expression for the code, only required if you want to protect the alarm with a code.  `'\d+'` denotes a numeric code.
+    required: false
+    type: string
+  panels:
+    description: A list of alarm control panels to be included in the group.
+    required: false
+    type: map
+    keys:
+      panel:
+        description: The entity id of the panel.
+        required: true
+        type: string
+{% endconfiguration %}

--- a/source/_components/alarm_control_panel.group.markdown
+++ b/source/_components/alarm_control_panel.group.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: home-assistant.png
 ha_category: Alarm
-ha_release: 0.59
+ha_release: 0.64
 ---
 
 The `group` alarm platform allows you to combine multiple `alarm` platforms into a single service.
@@ -29,24 +29,17 @@ alarm:
     - panel: alarm_control_panel.tampering
 ```
 
-Configuration variables:
-
 {% configuration %}
   name:
     description: The name of the group
-    required: true
+    required: false
     type: string
   code_format:
     description: A regular expression for the code, only required if you want to protect the alarm with a code.  `'\d+'` denotes a numeric code.
     required: false
     type: string
-  panels:
-    description: A list of alarm control panels to be included in the group.
+  entities:
+    description: A list of entity ids for the alarm control panels to be included in the group.
     required: false
-    type: map
-    keys:
-      panel:
-        description: The entity id of the panel.
-        required: true
-        type: string
+    type: list
 {% endconfiguration %}

--- a/source/_components/alarm_control_panel.group.markdown
+++ b/source/_components/alarm_control_panel.group.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: home-assistant.png
 ha_category: Alarm
-ha_release: 0.66
+ha_release: 0.68
 ---
 
 The `group` alarm platform allows you to combine multiple `alarm` platforms into a single service.

--- a/source/_cookbook/automation_alarm.markdown
+++ b/source/_cookbook/automation_alarm.markdown
@@ -24,13 +24,13 @@ to GPIO pins, Zigbee sensors, or anything else.
 ```yaml
 input_boolean:
   alarm_presence_garage:
-    name: IR sensor for garage area
+    name: IR sensor for the garage area
     initial: off
   alarm_presence_livingroom:
-    name: IR sensor for living room area
+    name: IR sensor for the living room area
     initial: off
   alarm_presence_bedroom:
-    name: IR sensor for bed room area
+    name: IR sensor for the bedroom area
     initial: off
   alarm_tamper_garage:
     name: Anti-tampering signal on garage area IR sensor
@@ -39,10 +39,10 @@ input_boolean:
     name: Anti-tampering signal on living room IR sensor
     initial: off
   alarm_tamper_bedroom:
-    name: Anti-tampering signal on bed room IR sensor
+    name: Anti-tampering signal on bedroom IR sensor
     initial: off
   alarm_tamper_siren:
-    name: Anti-tampering signal on siren
+    name: Anti-tampering signal on the siren
     initial: off
 ```
 
@@ -122,7 +122,7 @@ alarm_control_panel:
 
 The next step is adding a template switch to trigger the siren.  In this
 simplified example I'm only turning the LED on/off, and therefore the
-script only has one action.  However, in a real application you would
+script only has one action.  However, in a real application, you would
 probably toggle the siren itself in these scripts!
 
 ```yaml

--- a/source/_cookbook/automation_alarm.markdown
+++ b/source/_cookbook/automation_alarm.markdown
@@ -1,0 +1,248 @@
+---
+layout: page
+title: "Manual alarm control panel setup"
+description: "How to set up an alarm control panel"
+date: 2017-11-22 15:35
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Automation Examples
+---
+
+Assume that you have a few motion sensors in various rooms and a wall
+siren.  This recipe will show how to set up the alarm control panel so
+that each motion sensor has custom rules for when to trigger the alarm,
+and the overall alarm state is visible and modifiable in the Home
+Assistant dashboard.
+
+For simplicity and to allow for easy experimentation, the recipe uses
+[**input_boolean**](/components/input_boolean) components instead of
+actual motion detectors.  These can be changed, depending on your setup,
+to GPIO pins, Zigbee sensors, or anything else.
+
+```yaml
+input_boolean:
+  alarm_presence_garage:
+    name: IR sensor for garage area
+    initial: off
+  alarm_presence_livingroom:
+    name: IR sensor for living room area
+    initial: off
+  alarm_presence_bedroom:
+    name: IR sensor for bed room area
+    initial: off
+  alarm_tamper_garage:
+    name: Anti-tampering signal on garage area IR sensor
+    initial: off
+  alarm_tamper_livingroom:
+    name: Anti-tampering signal on living room IR sensor
+    initial: off
+  alarm_tamper_bedroom:
+    name: Anti-tampering signal on bed room IR sensor
+    initial: off
+  alarm_tamper_siren:
+    name: Anti-tampering signal on siren
+    initial: off
+```
+
+We also want two LEDs that show the state of the alarm without opening
+the dashboard.  In this example, I'm using **input_boolean** for those
+as well, though in a real-world scenario you might use GPIO pins or MQTT.
+
+```yaml
+  led_siren:
+    name: Siren LED
+    initial: off
+  led_armed:
+    name: Alarm LED
+    initial: off
+```
+
+The heart of this example is the configuration of the
+[**manual**](/components/alarm_control_panel.manual)
+and [**group**](/components/alarm_control_panel.group) components.
+All the manual control panels can be hidden using the
+**[customize](/docs/configuration/customizing-devices/)** YAML entries,
+leaving only the group visible.
+
+```yaml
+alarm_control_panel:
+- platform: manual
+  name: 'Living room'
+  code: '5555'
+  # The living room fires immediately when the alarm is armed
+  pending_time: 0
+  disarmed:
+    trigger_time: 0
+
+- platform: manual
+  name: 'Garage'
+  code: '5555'
+  # The garage door fires after 30 seconds when the alarm is armed-away;
+  # this gives you some time to leave or enter the building.  Because
+  # we're using delay_time, there's no need for pending_time in the
+  # "triggered" state.
+  pending_time: 30
+  triggered:
+    pending_time: 0
+  delay_time: 30
+  armed_home:
+    delay_time: 0
+  disarmed:
+    trigger_time: 0
+
+- platform: manual
+  name: 'Bedroom'
+  code: '5555'
+  # The bedroom alarm fires immediately when the alarm is armed-away,
+  # but not at all when it is armed-home.
+  pending_time: 0
+  armed_home:
+    trigger_time: 0
+  disarmed:
+    trigger_time: 0
+
+- platform: manual
+  name: 'Tampering'
+  code: '5555'
+  # The anti-tamper can trigger even if the alarm is not armed
+  pending_time: 0
+
+- platform: group
+  name: Home Alarm
+  code_format: '\d+'
+  panels:
+    - panel: alarm_control_panel.garage
+    - panel: alarm_control_panel.living_room
+    - panel: alarm_control_panel.bedroom
+    - panel: alarm_control_panel.tampering
+```
+
+The next step is adding a template switch to trigger the siren.  In this
+simplified example I'm only turning the LED on/off, and therefore the
+script only has one action.  However, in a real application you would
+probably toggle the siren itself in these scripts!
+
+```yaml
+script:
+  siren_off:
+    alias: Turn off siren
+    sequence:
+      - service: input_boolean.turn_off
+        data:
+          entity_id: input_boolean.led_siren
+  siren_on:
+    alias: Turn on siren
+    sequence:
+      - service: input_boolean.turn_on
+        data:
+          entity_id: input_boolean.led_siren
+```
+
+Finally, here are the automation rules; first of all, each sensor needs
+to trigger one of the alarm control panels:
+
+```yaml
+automation:
+  # Rules to trigger the alarm_control_panel.manual components
+  - alias: 'Garage trigger'
+    hide_entity: True
+    trigger:
+      - platform: state
+        entity_id: input_boolean.alarm_presence_garage
+        to: 'on'
+    action:
+      service: alarm_control_panel.alarm_trigger
+      entity_id: alarm_control_panel.garage
+
+  - alias: 'Livingroom trigger'
+    hide_entity: True
+    trigger:
+      - platform: state
+        entity_id: input_boolean.alarm_presence_livingroom
+        to: 'on'
+    action:
+      service: alarm_control_panel.alarm_trigger
+      entity_id: alarm_control_panel.living_room
+
+  - alias: 'Bedroom trigger'
+    hide_entity: True
+    trigger:
+      - platform: state
+        entity_id: input_boolean.alarm_presence_bedroom
+        to: 'on'
+    action:
+      - service: alarm_control_panel.alarm_trigger
+        entity_id: alarm_control_panel.bedroom
+
+  - alias: 'Tamper trigger'
+    hide_entity: True
+    trigger:
+      - platform: state
+        entity_id: input_boolean.alarm_tamper_livingroom
+        to: 'on'
+      - platform: state
+        entity_id: input_boolean.alarm_tamper_garage
+        to: 'on'
+      - platform: state
+        entity_id: input_boolean.alarm_tamper_bedroom
+        to: 'on'
+      - platform: state
+        entity_id: input_boolean.alarm_tamper_siren
+        to: 'on'
+    action:
+      - service: alarm_control_panel.alarm_trigger
+        entity_id: alarm_control_panel.tampering
+```
+
+Then, let's expose the alarm state on the LEDs:
+
+```yaml
+  - alias: 'Alarm armed'
+    hide_entity: True
+    trigger:
+      - platform: state
+        entity_id: alarm_control_panel.home_alarm
+        from: 'disarmed'
+    action:
+      - service: input_boolean.turn_on
+        entity_id: input_boolean.led_armed
+
+  - alias: 'Alarm disarmed'
+    hide_entity: True
+    trigger:
+      - platform: state
+        entity_id: alarm_control_panel.home_alarm
+        to: 'disarmed'
+    action:
+      - service: input_boolean.turn_off
+        entity_id: input_boolean.led_armed
+```
+
+And finally, let's turn on and off the siren!
+
+```yaml
+  - alias: 'Alarm triggered'
+    hide_entity: True
+    trigger:
+      - platform: state
+        entity_id: alarm_control_panel.home_alarm
+        to: 'triggered'
+    action:
+      - service: switch.turn_on
+        entity_id: switch.alarm_siren
+
+  - alias: 'Turn off siren'
+    hide_entity: True
+    trigger:
+      - platform: state
+        entity_id: alarm_control_panel.home_alarm
+        from: 'triggered'
+    action:
+      - service: switch.turn_off
+        entity_id: switch.alarm_siren
+```
+
+As you can see, the timing is entirely described by the **manual**
+alarm control panels and transparently brought to the entire group.

--- a/source/_cookbook/automation_alarm.markdown
+++ b/source/_cookbook/automation_alarm.markdown
@@ -47,8 +47,9 @@ input_boolean:
 ```
 
 We also want two LEDs that show the state of the alarm without opening
-the dashboard.  In this example, I'm using **input_boolean** for those
-as well, though in a real-world scenario you might use GPIO pins or MQTT.
+the dashboard.  In this example, I'm using
+[**input_boolean**](/components/input_boolean) for those as well,
+though in a real-world scenario you might use GPIO pins or MQTT.
 
 ```yaml
   led_siren:
@@ -61,10 +62,10 @@ as well, though in a real-world scenario you might use GPIO pins or MQTT.
 
 The heart of this example is the configuration of the
 [**manual**](/components/alarm_control_panel.manual)
-and [**group**](/components/alarm_control_panel.group) components.
-All the manual control panels can be hidden using the
-**[customize](/docs/configuration/customizing-devices/)** YAML entries,
-leaving only the group visible.
+and [**group**](/components/alarm_control_panel.group) alarm
+control panel components.  If desired, the manual control panels can be
+hidden using the **[customize](/docs/configuration/customizing-devices/)**
+YAML entries, so that only the group remains visible.
 
 ```yaml
 alarm_control_panel:
@@ -244,5 +245,6 @@ And finally, let's turn on and off the siren!
         entity_id: switch.alarm_siren
 ```
 
-As you can see, the timing is entirely described by the **manual**
-alarm control panels and transparently brought to the entire group.
+As you can see, the timing is entirely described by the
+[**manual**](/components/alarm_control_panel.manual) alarm
+control panels and transparently brought to the entire group.


### PR DESCRIPTION
**Description:**

This pull request introduces a "group" alarm control panel platform. The platform distributes the commands to multiple sub-panels, and reports a unified state from all the sub-panels. The main use case is to apply different delay times to different rooms, and to disable some rooms in the "armed_home" or "armed_night" states.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11323

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
