### PR TITLE
Document default names for TP-Link devices

### DIFF
--- a/source/_components/light.tplink.markdown
+++ b/source/_components/light.tplink.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "TPLink Bulb"
-description: "Instructions how to integrate TPLink bulbs into Home Assistant."
+title: "TP-Link Bulb"
+description: "Instructions how to integrate TP-Link bulbs into Home Assistant."
 date: 2017-07-25 08:00
 sidebar: true
 comments: false
@@ -14,7 +14,7 @@ ha_release: "0.50"
 ---
 
 
-The `tplink` light platform allows you to control the state of your [TPLink smart bulb](http://www.tp-link.com/en/products/list-5609.html).
+The `tplink` light platform allows you to control the state of your [TP-Link smart bulb](http://www.tp-link.com/en/products/list-5609.html).
 
 Supported units:
 
@@ -23,7 +23,7 @@ Supported units:
 - LB120
 - LB130
 
-To use your TPLink light in your installation, add the following to your `configuration.yaml` file:
+To use your TP-Link light in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -32,9 +32,15 @@ light:
     host: IP_ADDRESS
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address of your TP-Link bulb, eg. `192.168.1.32`.
-- **name** (*Optional*): The name to use when displaying this bulb.
-
+{% configuration %}
+name:
+  description: The name to use when displaying this bulb.
+  required: false
+  type: string
+  default: TP-Link Light
+host:
+  description: "The IP address of your TP-Link bulb, eg. `192.168.1.32`."
+  required: true
+  type: string
+{% endconfiguration %}
 

--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "TPLink Switch"
-description: "Instructions how to integrate TPLink switches into Home Assistant."
+title: "TP-Link Switch"
+description: "Instructions how to integrate TP-Link switches into Home Assistant."
 date: 2016-07-13 08:00
 sidebar: true
 comments: false
@@ -14,7 +14,7 @@ ha_release: "0.24"
 ---
 
 
-The `tplink` switch platform allows you to control the state of your [TPLink smart switch](http://www.tp-link.com/en/products/list-5258.html).
+The `tplink` switch platform allows you to control the state of your [TP-Link smart switch](http://www.tp-link.com/en/products/list-5258.html).
 
 Supported units:
 
@@ -23,7 +23,7 @@ Supported units:
 - HS110
 - HS200
 
-To use your TPLink switch in your installation, add the following to your `configuration.yaml` file:
+To use your TP-Link switch in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -37,7 +37,7 @@ name:
   description: The name to use when displaying this switch.
   required: false
   type: string
-  default: Random Sensor
+  default: TP-Link Switch
 host:
   description: "The IP address of your TP-Link switch, eg. `192.168.1.32`."
   required: true
@@ -48,6 +48,4 @@ enable_leds:
   type: boolean
   default: true
 {% endconfiguration %}
-
-
 


### PR DESCRIPTION
**Description:**

- Document default names for smart sockets and bulbs
- Change all references to the company to "TP-Link"

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11346

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/