### PR TITLE
light.template: Fix typo in device list key

### DIFF
--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -42,7 +42,7 @@ light:
 {% endraw %}
 
 {% configuration %}
-  switches:
+  lights:
     description: List of your lights.
     required: true
     type: map


### PR DESCRIPTION
**Description:**
"switches" should be "lights" for light.template

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
