### PR TITLE
Update git_pull doc with password support

### DIFF
--- a/source/_addons/git_pull.markdown
+++ b/source/_addons/git_pull.markdown
@@ -36,6 +36,8 @@ Load and update configuration files for Home Assistant from a GIT repository.
 - **auto_restart** (*Optional*): Make a restart of Home-Assistant if the config have change and is valid.
 - **repeat/active** (*Optional*): Pull periodic for GIT updates.
 - **repeat/interval** (*Optional*): Pull all x seconds and look for changes.
+- **deployment_user** (*Optional*): Username to use when authenticating to a repo with a username and password.
+- **deployment_password** (*Optional*): Password to use when authenticating to a repo.  Ignored if deployment_user is not set.
 - **deployment_key** (*Optional*): A private SSH key that will be used for communication during git operations. This key is mandatory for ssh-accessed repositories, which are the ones with the following pattern: `<user>@<host>:<repository path>`.
 - **deployment_key_protocol** (*Optional*): The key protocol. Default is "rsa". Valid protocols are:
 


### PR DESCRIPTION
This is a documentation update that corresponds to https://github.com/home-assistant/hassio-addons/pull/217

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
