### PR TITLE
Fix typo: MariDB to MariaDB

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -119,7 +119,7 @@ action:
 
 Not all Python bindings for the chosen database engine can be installed directly. This section contains additional details which should help you to get it working.
 
-### {% linkable_title MariDB and MySQL %}
+### {% linkable_title MariaDB and MySQL %}
 
 For MariaDB you may have to install a few dependencies. On the Python side we use the `mysqlclient`:
 


### PR DESCRIPTION
**Description:** A simple typo fix
Changes the linkable title for MariaDB from _MariDB_ to _Mari**a**DB_.


**Pull request in [home-assistant documentation](https://github.com/home-assistant/home-assistant.github.io):** home-assistant/home-assistant.github.io#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
