### PR TITLE
Correct sentence

### DIFF
--- a/source/_components/notify.slack.markdown
+++ b/source/_components/notify.slack.markdown
@@ -42,7 +42,7 @@ Configuration variables:
 
 ### {% linkable_title Slack service data %}
 
-The following attributes can be placed `data` for extended functionality.
+The following attributes can be placed inside `data` for extended functionality.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION
**Description:** The explanation for Slack service data was missing a word.
The sentence was missing the word _inside_.

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
