### PR TITLE
Update freenas.markdown

### DIFF
--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -33,7 +33,7 @@ Create an `/etc/rc.local` file to enable Home Assistant to start when the jail s
 
 
 ```bash
-# cd / && mkdir /home && mkdir /home/.homeassistant/
+# cd / && mkdir -p /home/.homeassistant
 ```
 
 ```bash

--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -33,7 +33,7 @@ Create an `/etc/rc.local` file to enable Home Assistant to start when the jail s
 
 
 ```bash
-# cd / && mkdir /home && /home/.homeassistant/
+# cd / && mkdir /home && mkdir /home/.homeassistant/
 ```
 
 ```bash


### PR DESCRIPTION
The example provided for a chained command to mkdir /home and /home/.homeassistant was missing the second mkdir command.  A copy and paste of this example would fail.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
