### PR TITLE
Its the light's state which is changed.

### DIFF
--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -29,7 +29,7 @@ light:
 
 Configuration variables:
 
-- **command_topic** (*Required*): The MQTT topic to publish commands to change the switch state.
+- **command_topic** (*Required*): The MQTT topic to publish commands to change the light's state.
 - **brightness_command_topic** (*Optional*): The MQTT topic to publish commands to change the light's brightness.
 - **brightness_scale** (*Optional*): Defines the maximum brightness value (i.e. 100%) of the MQTT device (defaults to 255).
 - **brightness_state_topic** (*Optional*): The MQTT topic subscribed to receive brightness state updates.


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
