### PR TITLE
Add example for local image on HASS.IO

### DIFF
--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -57,3 +57,15 @@ camera:
     still_image_url: https://www.yr.no/place/Norway/Oslo/Oslo/Oslo/meteogram.svg
     content_type: 'image/svg+xml'
 ```
+
+### Local image with HASS.IO
+
+You can show an static image with this component.
+Just place the image here: /config/www/your_image.png
+
+```yaml
+camera:
+  - platform: generic
+    name: Some Image
+    still_image_url: https://127.0.0.1:8123/local/your_image.png
+```

--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -58,10 +58,9 @@ camera:
     content_type: 'image/svg+xml'
 ```
 
-### Local image with HASS.IO
+### {% linkable_title Local image with Hass.io %}
 
-You can show an static image with this component.
-Just place the image here: /config/www/your_image.png
+You can show an static image with this platform. Just place the image here: `/config/www/your_image.png`
 
 ```yaml
 camera:


### PR DESCRIPTION
**Description:**

Add an example for showing a static local image on HASS.IO with the Generic IP Camera component