### PR TITLE
Fix link to "other installation guides"

### DIFF
--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -64,5 +64,5 @@ _(If you're on a Debian based system, you will need to install Python virtual en
 - It's recommanded to run Home Assistant as a dedicated user.
 
 <p class='info'>
-Looking for more advanced guides? Check our [Rasbian guide](/docs/installation/raspberry-pi/) or the [other installation guides](/docs/installation/].
+Looking for more advanced guides? Check our [Rasbian guide](/docs/installation/raspberry-pi/) or the [other installation guides](/docs/installation/).
 </p>


### PR DESCRIPTION
**Description:**
Trivial typo fix to make the link to "other installation guides" clickable.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
