### PR TITLE
Update device_tracker.bluetooth_le_tracker.markdown

### DIFF
--- a/source/_components/device_tracker.bluetooth_le_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_le_tracker.markdown
@@ -30,7 +30,7 @@ $ sudo apt install bluetooth libbluetooth-dev pkg-config libboost-python-dev lib
 Before you get started with this platform, please note that:
 
  - This platform is incompatible with Windows
- - This platform requires root privileges
+ - This platform requires access to the bluetooth stack, See <a href = "#rootless-setup" >here for infomation</a>
 
 To use the Bluetooth tracker in your installation, add the following to your `configuration.yaml` file:
 
@@ -50,7 +50,9 @@ Configuration variables:
 As some BT LE devices change their MAC address regularly, a new device is only discovered when it has been seen 5 times.
 Some BTLE devices (e.g. fitness trackers) are only visible to the devices that they are paired with. In this case, the BTLE tracker won't see this device.
 
-For running Home Assistant as non root user we can give python3 the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](http://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
+## {% linkable_title Rootless Setup %}
+
+Normaly accessing the bluetooth stack is reserved for root, but running programs that are networked as root is a bad security wise. To allow non root accsess to the bluetooth stack we can give python3 the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](http://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
 
 ```bash
 $ sudo apt-get install libcap2-bin

--- a/source/_components/device_tracker.bluetooth_le_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_le_tracker.markdown
@@ -30,7 +30,7 @@ $ sudo apt install bluetooth libbluetooth-dev pkg-config libboost-python-dev lib
 Before you get started with this platform, please note that:
 
  - This platform is incompatible with Windows
- - This platform requires access to the bluetooth stack, See <a href = "#rootless-setup" >here for infomation</a>
+ - This platform requires access to the bluetooth stack, see [Rootless Setup section](#rootless-setup) for further infomation
 
 To use the Bluetooth tracker in your installation, add the following to your `configuration.yaml` file:
 
@@ -52,7 +52,7 @@ Some BTLE devices (e.g. fitness trackers) are only visible to the devices that t
 
 ## {% linkable_title Rootless Setup %}
 
-Normaly accessing the bluetooth stack is reserved for root, but running programs that are networked as root is a bad security wise. To allow non root accsess to the bluetooth stack we can give python3 the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](http://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
+Normaly accessing the Bluetooth stack is reserved for root, but running programs that are networked as root is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](http://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
 
 ```bash
 $ sudo apt-get install libcap2-bin


### PR DESCRIPTION
**Description:**
Removed suggestion of running as root and instead mentioned that it needs access to the bluetooth stack and linked to the instructions lower down in the doc

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards]. I think it does, leaving up to a maintainer to decide

[standards]: https://home-assistant.io/developers/documentation/standards/
