### PR TITLE
Update recorder.markdown

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -105,15 +105,15 @@ action:
 | Database engine | `db_url`                                                 | 
 | :---------------|:---------------------------------------------------------|
 | SQLite          | `sqlite:///PATH/TO/DB_NAME`                              |
-| MariaDB         | `mysql://SERVER_IP/DB_NAME`                              |
-| MariaDB         | `mysql://user:password@SERVER_IP/DB_NAME`                |
-| MySQL           | `mysql://SERVER_IP/DB_NAME`                              |
-| MySQL           | `mysql://user:password@SERVER_IP/DB_NAME`                |
-| MySQL (pymysql) | `mysql+pymysql://SERVER_IP/DB_NAME`                      |
-| MySQL (pymysql) | `mysql+pymysql://user:password@SERVER_IP/DB_NAME`        |
+| MariaDB         | `mysql://SERVER_IP/DB_NAME?charset=utf8`                 |
+| MariaDB         | `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8`   |
+| MySQL           | `mysql://SERVER_IP/DB_NAME?charset=utf8`                 |
+| MySQL           | `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8`   |
+| MySQL (pymysql) | `mysql+pymysql://SERVER_IP/DB_NAME?charset=utf8`         |
+| MySQL (pymysql) | `mysql+pymysql://user:password@SERVER_IP/DB_NAME?charset=utf8` |
 | PostgreSQL      | `postgresql://SERVER_IP/DB_NAME`                         |
 | PostgreSQL      | `postgresql://scott:tiger@SERVER_IP/DB_NAME`             |
-| MS SQL Server   | `mssql+pymssql://user:pass@SERVER_IP/DB_NAME?charset=utf8`      |
+| MS SQL Server   | `mssql+pymssql://user:pass@SERVER_IP/DB_NAME?charset=utf8` |
 
 ## {% linkable_title Installation notes %}
 


### PR DESCRIPTION
https://community.home-assistant.io/t/error-during-query-latin-1-codec-cant-encode-character/13630 - Better safe than sorry. Might as well always put this parameter in.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
