### PR TITLE
Add Samsung TV UEMU6199UXZG on media_player page

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -59,6 +59,7 @@ Currently known supported models:
 - KS7502 (port must be set to 8001, and `pip3 install websocket-client` must be executed, turn on doesn't work, turn off works fine)
 - K5600AK (partially supported, turn on works but state is not updated)
 - UE65KS8005 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
+- UE6199UXZG (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 
 Currently tested but not working models:
 


### PR DESCRIPTION
**Description:**

The Samsung TV UEMU6199UXZG is recognized by Home Assistant but it needs to use port 8001 to enable the On/Off, Forward/Backward and the Volume control. The Play button is not working (it doesn't appear on the screen).

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
