### PR TITLE
TP-Link switch LEDs are unchanged by default

### DIFF
--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -46,6 +46,5 @@ enable_leds:
   description: If the LEDs on the switch (WiFi and power) should be lit.
   required: false
   type: boolean
-  default: true
 {% endconfiguration %}
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11416

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
