### PR TITLE
Update light.yeelight.markdown

### DIFF
--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -48,7 +48,8 @@ Per default the bulb limits the amount of requests per minute to 60, a limitatio
 <p class='note'>
 Before trying to control your light through Home Assistant, you have to setup your bulb using Yeelight app. ( [Android](https://play.google.com/store/apps/details?id=com.yeelight.cherry&hl=fr), [IOS](https://itunes.apple.com/us/app/yeelight/id977125608?mt=8) ).
 In the bulb property, you have to enable "LAN Mode" (previously called "Developer mode"). LAN mode may only be available with the latest firmware installed on your bulb.  Firmware can be updated in the application after connecting the bulb.
-Determine your bulb IP (using router, software, ping ...)
+Determine your bulb IP (using router, software, ping ...).
+Information on how to enable "LAN Mode" can be found [here](https://getyeti.co/posts/how-to-control-yeelight-and-your-smarthome-with-yeti).
 </p>
 
 <p class='note warning'>
@@ -58,6 +59,7 @@ This component is tested to work with the following models. If you have a differ
 - **YLDP01YL**: LED Bulb (White)
 - **YLDP02YL**: LED Bulb (Color)
 - **YLDP03YL**: LED Bulb (Color) - E26
+- **YLDD01YL**: Lightstrip (Color)
 - **YLDD02YL**: Lightstrip (Color)
 
 


### PR DESCRIPTION
Updated the page as this also works for YLDD01YL lightstrip and added a link with information on how to enable the LAN mode

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
