### PR TITLE
Document Dark Sky weather platform

### DIFF
--- a/source/_components/sensor.darksky.markdown
+++ b/source/_components/sensor.darksky.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Dark Sky"
+title: "Dark Sky Sensor"
 description: "How to integrate Dark Sky within Home Assistant."
 date: 2016-09-26 08:00
 sidebar: true
@@ -20,7 +20,7 @@ The `darksky` platform uses the [Dark Sky](https://darksky.net/) web service as 
 You need an API key which is free but requires [registration](https://darksky.net/dev/register). You can make up to 1000 calls per day for free which means that you could make one approximately every 86 seconds.
 
 <p class='note warning'>
-[Dark Sky](https://darksky.net/) will charge you $0.0001 per API call if you enter your credit card details and create more than 1000 calls per day.
+[Dark Sky](https://darksky.net/dev/) will charge you $0.0001 per API call if you enter your credit card details and create more than 1000 calls per day.
 </p>
 
 To add Dark Sky to your installation, add the following to your `configuration.yaml` file:
@@ -67,7 +67,7 @@ Configuration variables:
   - **apparent_temperature_min**: Today's expected apparent low temperature.
   - **precip_intensity_max**: Today's expected maximum intensity of precipitation.
   - **uv_index**: The current UV index.
-- **units** (*Optional*): Specify the unit system. Default to `si` or `us` based on the temperature preference in Home Assistant. Other options are `auto`, `us`, `si`, `ca`, and `uk2`.
+- **units** (*Optional*): Specify the unit system. Default to `si` or `us` based on the temperature preference in Home Assistant. Other options are `auto`, `us`, `si`, `ca`, `uk` and `uk2`.
 `auto` will let Dark Sky decide the unit system based on location.
 - **update_interval** (*Optional*): Minimum time interval between updates. Default is 2 minutes. Supported formats:
   - `update_interval: 'HH:MM:SS'`

--- a/source/_components/weather.darksky.markdown
+++ b/source/_components/weather.darksky.markdown
@@ -1,0 +1,70 @@
+---
+layout: page
+title: "Dark Sky"
+description: "Instructions how to integrate Dark Sky within Home Assistant."
+date: 2016-09-29 09:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: dark_sky.png
+ha_category: Weather
+ha_release: 0.61
+ha_iot_class: "Cloud Polling"
+---
+
+The `darksky` platform uses the [Dark Sky](https://darksky.net/) web service as
+a source for meteorological data for your location.
+
+You need an API key which is free but requires
+[registration](https://darksky.net/dev/register). The free tier allows up to
+1000 calls per day, this platform updates at most every 3 minutes, using up to
+480 of those calls.
+
+<p class='note warning'>
+[Dark Sky](https://darksky.net/dev/) will charge you $0.0001 per API call if you
+enter your credit card details and create more than 1000 calls per day.
+</p>
+
+To add Dark Sky to your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+weather:
+  - platform: darksky
+    api_key: YOUR_API_KEY
+```
+
+{% configuration %}
+api_key:
+  description: "Your API key for [Dark Sky](https://darksky.net/dev/)."
+  required: true
+  type: string
+latitude:
+  description: Manually specify latitude. By default the value will be taken from the Home Assistant configuration.
+  required: false
+  type: number
+  default: Provided by Home Assistant configuration
+longitude:
+  description: Manually specify longitude. By default the value will be taken from the Home Assistant configuration.
+  required: false
+  type: number
+  default: Provided by Home Assistant configuration
+units:
+  description: "Manually specify unit system. Valid values are: `auto`, `us`, `si`, `ca`, `uk` and `uk2`."
+  required: false
+  type: string
+  default: "`si` if Home Assistant unit system is metric, `us` if imperial."
+name:
+  description: Name to use in the frontend.
+  required: false
+  type: string
+  default: Open Sky
+{% endconfiguration %}
+
+<p class='note'>
+This platform is an alternative to the [`darksky`](/components/sensor.darksky/)
+sensor.
+</p>
+
+Details about the API are available in the [Dark Sky documentation](https://darksky.net/dev/docs).


### PR DESCRIPTION
**Description:**

Documents the Dark Sky weather platform introduced in https://github.com/home-assistant/home-assistant/pull/11435.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11435

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
