### PR TITLE
small grammar fix

### DIFF
--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -42,7 +42,7 @@ http:
   ssl_key: /ssl/privkey.pem
 ```
 
-If you use a other port as `8123` or a SSL proxy, change the port number.
+If you use a port other than `8123` or an SSL proxy, change the port number accordingly.
 
 ## {% linkable_title Router configuration %}
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
