### PR TITLE
Updated lets_encrypt doc for new automation syntax

### DIFF
--- a/source/_docs/ecosystem/certificates/lets_encrypt.markdown
+++ b/source/_docs/ecosystem/certificates/lets_encrypt.markdown
@@ -539,6 +539,24 @@ automation:
     data:
       message: 'Warning - SSL certificate expires in 21 days and has not been automatically renewed'
 ```
+
+or if you are using automation.yaml and the new automation format (introduced in Home Assistant 0.45)
+
+```yaml
+- action:
+  - alias: ''
+    data:
+      message: Warning - SSL certificate expires in 21 days and has not been automatically
+        renewed
+    service: persistent_notification.[your_notification_preference]
+  alias: SSL expiry notification
+  condition: []
+  id: '1515093929987'
+  trigger:
+  - below: '21'
+    entity_id: sensor.ssl_cert_expiry
+    platform: numeric_state
+```
 	  
 If you receive this warning notification, follow the steps for a manual update from step 8. Any error messages received at that point can be googled and resolved. If the manual update goes without a hitch there may be something wrong with your chosen method for automatic updates, and you can start troubleshooting from there.
 


### PR DESCRIPTION
The automation example for notification if the certificate didn't renew did not work when using configuration.yaml. I added an example that do work with the new format. Not sure if the old example should still be kept.

Followed the rest of the guide and it works like a charm (still have to wait 60 days to test the renewal though)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
