### PR TITLE
reference python-miio instead of python-mirobo

### DIFF
--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -155,7 +155,7 @@ To fetch the token follow these instructions depending on your mobile phone plat
 
 Follow the pairing process using your phone and Mi-Home app. You will be able to retrieve the token from a SQLite file inside your phone.
 
-Before you begin you need to install `libffi-dev` and `libssl-dev` by running the command below. This is needed for `python-mirobo` to be installed correctly.
+Before you begin you need to install `libffi-dev` and `libssl-dev` by running the command below. This is needed for `python-miio` to be installed correctly.
 
 ```bash
 $ sudo apt-get install libffi-dev libssl-dev
@@ -185,7 +185,7 @@ To fetch the token follow these instructions depending on your mobile phone plat
 
 Follow the pairing process using your phone and Mi-Home app. You will be able to retrieve the token from a SQLite file inside your phone.
 
-Before you begin you need to install `libffi-dev` and `libssl-dev` by running the command below. This is needed for `python-mirobo` to be installed correctly.
+Before you begin you need to install `libffi-dev` and `libssl-dev` by running the command below. This is needed for `python-miio` to be installed correctly.
 
 ```bash
 $ sudo apt-get install libffi-dev libssl-dev


### PR DESCRIPTION
**Description:**
The xiaomi vacuum module already lists [python-miio as dependency](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/vacuum/xiaomi_miio.py#L24) hence the documentation should too or am I missing something?

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
