### PR TITLE
More tested components

### DIFF
--- a/source/_components/light.decora_wifi.markdown
+++ b/source/_components/light.decora_wifi.markdown
@@ -17,7 +17,8 @@ Support for [Leviton Decora Wi-Fi](http://www.leviton.com/en/products/lighting-c
 
 Supported devices (tested):
 
-- [DW6HD1-BZ](https://www.leviton.com/en/products/dw6hd) (Decora Smart Wi-Fi 600W Dimmer)
+- [DW6HD1-BZ](https://www.leviton.com/en/products/dw6hd-1bz) (Decora Smart Wi-Fi 600W Dimmer)
+- [DW15S-1BZ](https://www.leviton.com/en/products/dw15s-1bz) (Decora Smart Wi-Fi 15A Switch)
 
 To enable these lights, add the following lines to your `configuration.yaml` file:
 


### PR DESCRIPTION
Fixed bad link.
Added new tested device (I have successfully tested this component with the 15A switch)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
