### PR TITLE
Added J5500 to tested Models

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -65,6 +65,7 @@ Currently known supported models:
 Currently tested but not working models:
 
 - J5200 - Unable to see state and unable to control
+- J5500 - State is always "on" and unable to control (but port 8001 *is* open)
 - JU7000 - Unable to see state and unable to control (but port 8001 *is* open)
 - JU7500 - Unable to see state and unable to control
 - JS9000 - State is always "on" and unable to control (but port 8001 *is* open)


### PR DESCRIPTION
I have tested a Samsung UE50J5550. After changing to Port 8001 the TV  is discovered but the state is always on and it does not react to any actions like power off or mute.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
