### PR TITLE
Clarification on which username/password to use

### DIFF
--- a/source/_components/device_tracker.unifi_direct.markdown
+++ b/source/_components/device_tracker.unifi_direct.markdown
@@ -32,11 +32,11 @@ host:
   required: true
   type: string
 username:
-  description: The username used to connect to your Unifi AP.
+  description: The SSH device username used to connect to your Unifi AP.
   required: true
   type: string
 password:
-  description: The password used to connect to your Unifi AP.
+  description: The SSH device password used to connect to your Unifi AP.
   required: true
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
As the standard Unifi component uses an admin user/pass, clarification that you're using the device SSH user/pass instead seems useful. They are different and will cause a failure if not changed when converted over.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
