### PR TITLE
Closes #4368  Fix image file extensions

### DIFF
--- a/source/_components/device_tracker.huawei_router.markdown
+++ b/source/_components/device_tracker.huawei_router.markdown
@@ -7,7 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: huawei.png
+logo: huawei.svg
 ha_category: Presence Detection
 ha_release: 0.51
 ---

--- a/source/_components/sensor.dublin_bus_transport.markdown
+++ b/source/_components/sensor.dublin_bus_transport.markdown
@@ -7,7 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: dublin_bus.jpg
+logo: dublin_bus.png
 ha_category: Transport
 ha_iot_class: "Cloud Polling"
 ha_release: 0.36


### PR DESCRIPTION
**Description:**

Rename file extensions for `huawei_router` and `dublin_bus_transport` to correctly reference the corresponding image files.