### PR TITLE
Update the YAML example to a more "generic" example

### DIFF
--- a/source/_components/switch.command_line.markdown
+++ b/source/_components/switch.command_line.markdown
@@ -21,11 +21,11 @@ To enable it, add the following lines to your `configuration.yaml`:
 ```yaml
 # Example configuration.yaml entry
 switch:
-  platform: command_line
-  switches:
-    kitchen_light:
-      command_on: switch_command on kitchen
-      command_off: switch_command off kitchen
+  - platform: command_line
+    switches:
+      kitchen_light:
+        command_on: switch_command on kitchen
+        command_off: switch_command off kitchen
 ```
 
 Configuration variables:


### PR DESCRIPTION
The original YAML platform example was written to only support one platform within a switch component.

**Description:**

Fixes YAML example to work for case with both single and multiple platforms.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [y] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [y] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
