### PR TITLE
changed image

### DIFF
--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -7,7 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: heat-control.png
+logo: mqtt.png
 ha_category: Climate
 ha_release: 0.55
 ha_iot_class: "Local Polling"


### PR DESCRIPTION
**Description:**
I feel like the MQTT HVAC should be using the MQTT logo rather than the ```heat-control.png``` picture to keep it similar to the other mqtt components

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].
