### PR TITLE
Added quotes to target numbers

### DIFF
--- a/source/_components/notify.twilio_sms.markdown
+++ b/source/_components/notify.twilio_sms.markdown
@@ -47,6 +47,6 @@ automation:
       data:
         message: 'The sun has set'
         target:
-          - +14151234567
-          - +15105555555
+          - '+14151234567'
+          - '+15105555555'
 ```


### PR DESCRIPTION
This preserves the E164 formatting if the automation is edited in the configuration editor.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
