### PR TITLE
adding device_tracker.tomato https params

### DIFF
--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -34,23 +34,24 @@ device_tracker:
 
 {% configuration %}
 host:
-  description: "The IP address or hostname of your router, e.g. `192.168.1.1` "or `rt-ac68u`.
+  description: "The IP address or hostname of your router, e.g. `192.168.1.1` or `rt-ac68u`."
   required: false
   type: string
 port:
-  description: "The port number of your router, e.g. `443`.""
+  description: "The port number of your router, e.g. `443`."
   required: false
   type: int
   default: 80
 ssl:
-  description: "Whether to connect via `https`.""
+  description: "Whether to connect via `https`."
   required: false
   type: bool
   default: false
 verify_ssl:
   description: "If SSL verification for https resources needs to be turned off (for self-signed certs, etc.) this can take on boolean values `False` or `True` or you can pass a location on the device where a certificate can be used for verification e.g. `/mnt/NAS/router_cert.pem`."
-  required: true
+  required: false
   type: [string, bool]
+  default: true
 username:
   description: "The username of an user with administrative privileges, usually *admin*."
   required: true

--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -38,7 +38,7 @@ port:
   description: "The port number of your router, e.g. `443`."
   required: false
   type: int
-  default: 80/443 (ssl disabled/ssl enabled)
+  default: 80/443 (automatically detected)
 ssl:
   description: "Whether to connect via `https`."
   required: false

--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -38,7 +38,7 @@ port:
   description: "The port number of your router, e.g. `443`."
   required: false
   type: int
-  default: 80
+  default: 80/443 (ssl disabled/ssl enabled)
 ssl:
   description: "Whether to connect via `https`."
   required: false

--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -48,8 +48,8 @@ ssl:
   type: bool
   default: false
 verify_ssl:
-  description: "If SSL Verification needs to be turned off (for self-signed certs, etc.) this can take on boolean values `False` or `True` or you can pass a location on the device where a certificate can be used for verification e.g. `/mnt/NAS/router_cert.pem`."
-  required: false
+  description: "If SSL verification for https resources needs to be turned off (for self-signed certs, etc.) this can take on boolean values `False` or `True` or you can pass a location on the device where a certificate can be used for verification e.g. `/mnt/NAS/router_cert.pem`."
+  required: true
   type: [string, bool]
 username:
   description: "The username of an user with administrative privileges, usually *admin*."

--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -23,7 +23,10 @@ To use this device tracker in your installation, add the following to your `conf
 # Example configuration.yaml entry
 device_tracker:
   - platform: tomato
-    host: YOUR_ROUTER_IP_ADDRESS
+    host: YOUR_ROUTER_IP_ADDRESS_OR_HOSTNAME
+    port: YOUR_ROUTER_PORT
+    ssl: True
+    ssl_verify: /mnt/NAS/router_cert.pem
     username: YOUR_ADMIN_USERNAME
     password:  YOUR_ADMIN_PASSWORD
     http_id: YOUR_HTTP_ID
@@ -31,7 +34,10 @@ device_tracker:
 
 Configuration variables:
 
-- **host** (*Required*): The IP address of your router, e.g. 192.168.1.1.
+- **host** (*Required*): The IP address or hostname of your router, e.g. `192.168.1.1` or `rt-ac68u`.
+- **port** (*Optional*): The port number of your router, e.g. `999`. If no port is provided, the default port (80) will be used.
+- **ssl** (*Optional*): Whether to connect via `https`. Defaults to `false`.
+- **verify_ssl** (*Optional*): Whether SSL certificates should be validated. Defaults to `False` but can (and **should**) point to a certificate accessible by the device, e.g. `/mnt/NAS/router_cert.pem`.
 - **username** (*Required*: The username of an user with administrative privileges, usually *admin*.
 - **password** (*Required*): The password for your given admin account.
 - **http_id** (*Required*): The value can be obtained by logging in to the Tomato admin interface and search for `http_id` in the page source code.
@@ -39,4 +45,11 @@ Configuration variables:
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.
 
 A description of the API s available in this [Tomato API](http://paulusschoutsen.nl/blog/2013/10/tomato-api-documentation/) blog post.
-    
+
+
+SSL Certificate:
+
+Gathering the SSL Certificate of your router can be accomplished with this (or a similar) command:
+```bash
+openssl s_client -showcerts -connect 172.10.10.1:443 </dev/null 2>/dev/null | openssl x509 -outform PEM > router_cert.pem
+```

--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -69,7 +69,6 @@ See the [device tracker component page](/components/device_tracker/) for instruc
 
 A description of the API s available in this [Tomato API](http://paulusschoutsen.nl/blog/2013/10/tomato-api-documentation/) blog post.
 
-
 SSL Certificate:
 
 Gathering the SSL Certificate of your router can be accomplished with this (or a similar) command:

--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -32,15 +32,38 @@ device_tracker:
     http_id: YOUR_HTTP_ID
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address or hostname of your router, e.g. `192.168.1.1` or `rt-ac68u`.
-- **port** (*Optional*): The port number of your router, e.g. `999`. If no port is provided, the default port (80) will be used.
-- **ssl** (*Optional*): Whether to connect via `https`. Defaults to `false`.
-- **verify_ssl** (*Optional*): Whether SSL certificates should be validated. Defaults to `False` but can (and **should**) point to a certificate accessible by the device, e.g. `/mnt/NAS/router_cert.pem`.
-- **username** (*Required*: The username of an user with administrative privileges, usually *admin*.
-- **password** (*Required*): The password for your given admin account.
-- **http_id** (*Required*): The value can be obtained by logging in to the Tomato admin interface and search for `http_id` in the page source code.
+{% configuration %}
+host:
+  description: "The IP address or hostname of your router, e.g. `192.168.1.1` "or `rt-ac68u`.
+  required: false
+  type: string
+port:
+  description: "The port number of your router, e.g. `443`.""
+  required: false
+  type: int
+  default: 80
+ssl:
+  description: "Whether to connect via `https`.""
+  required: false
+  type: bool
+  default: false
+verify_ssl:
+  description: "If SSL Verification needs to be turned off (for self-signed certs, etc.) this can take on boolean values `False` or `True` or you can pass a location on the device where a certificate can be used for verification e.g. `/mnt/NAS/router_cert.pem`."
+  required: false
+  type: [string, bool]
+username:
+  description: "The username of an user with administrative privileges, usually *admin*."
+  required: true
+  type: string
+password:
+  description: "The password for your given admin account."
+  required: true
+  type: string
+http_id:
+  description: "The value can be obtained by logging in to the Tomato admin interface and search for `http_id` in the page source code."
+  required: true
+  type: string
+{% endconfiguration %}
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.
 

--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -23,10 +23,7 @@ To use this device tracker in your installation, add the following to your `conf
 # Example configuration.yaml entry
 device_tracker:
   - platform: tomato
-    host: YOUR_ROUTER_IP_ADDRESS_OR_HOSTNAME
-    port: YOUR_ROUTER_PORT
-    ssl: True
-    ssl_verify: /mnt/NAS/router_cert.pem
+    host: YOUR_ROUTER_IP_ADDRESS
     username: YOUR_ADMIN_USERNAME
     password:  YOUR_ADMIN_PASSWORD
     http_id: YOUR_HTTP_ID


### PR DESCRIPTION
**Description:**
Added new configuration parameters for https support in the device_tracker.tomato component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11566

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
