### PR TITLE
Typo in link.

### DIFF
--- a/source/_components/cover.zwave.markdown
+++ b/source/_components/cover.zwave.markdown
@@ -17,7 +17,7 @@ Z-Wave garage doors, blinds, and roller shutters are supported as cover in Home 
 
 To get your Z-Wave covers working with Home Assistant, follow the instructions for the general [Z-Wave component](/components/zwave/).
 
-If you discover that you need to [invert the operation]](/docs/z-wave/installation/#invert_openclose_buttons) of open/close for a particular device, you may change this behavior in your Z-Wave section of your `configuration.yaml` file as follows:
+If you discover that you need to [invert the operation](/docs/z-wave/installation/#invert_openclose_buttons) of open/close for a particular device, you may change this behavior in your Z-Wave section of your `configuration.yaml` file as follows:
 
 ```yaml
 zwave:


### PR DESCRIPTION
**Description:**
Bonus ] in cover.zwave docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
