### PR TITLE
Add detail on external client/server requirement

### DIFF
--- a/source/_components/alarm_control_panel.concord232.markdown
+++ b/source/_components/alarm_control_panel.concord232.markdown
@@ -14,7 +14,7 @@ ha_release: 0.31
 
 The `concord232` platform provides integration with GE, Interlogix (and other brands) alarm panels that support the RS-232 Automation Control Panel interface module (or have it built in). Supported panels include Concord 4.
 
-To use this platform, you will need to have the external concord232 client and server installed.  The server must be running on the device which is connected to the automation module's serial port.  The client must be installed on the machine running home assistant.  These may often be the same machine, but do not have to be.  For additional details in setting up and testing the client and server, see https://github.com/JasonCarter80/concord232.
+To use this platform, you will need to have the external concord232 client and server installed. The server must be running on the device which is connected to the automation module's serial port. The client must be installed on the machine running Home Assistant. These may often be the same machine, but do not have to be. For additional details in setting up and testing the client and server, see https://github.com/JasonCarter80/concord232.
 
 To enable this platform in home assistant, add the following lines to your `configuration.yaml`:
 

--- a/source/_components/alarm_control_panel.concord232.markdown
+++ b/source/_components/alarm_control_panel.concord232.markdown
@@ -14,7 +14,9 @@ ha_release: 0.31
 
 The `concord232` platform provides integration with GE, Interlogix (and other brands) alarm panels that support the RS-232 Automation Control Panel interface module (or have it built in). Supported panels include Concord 4.
 
-To enable this, add the following lines to your `configuration.yaml`:
+To use this platform, you will need to have the external concord232 client and server installed.  The server must be running on the device which is connected to the automation module's serial port.  The client must be installed on the machine running home assistant.  These may often be the same machine, but do not have to be.  For additional details in setting up and testing the client and server, see https://github.com/JasonCarter80/concord232.
+
+To enable this platform in home assistant, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
**Description:**

The documentation for the concord232 component didn't explicitly mention the need for the external client/server package.  Added a couple sentence introduction and a link which points to the github repo containing the external package, which contains more details in the README.

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
