### PR TITLE
Googleified the Google Assistant docs (Alexa -> Google Assistant)

### DIFF
--- a/source/_components/cloud.google_assistant.markdown
+++ b/source/_components/cloud.google_assistant.markdown
@@ -38,7 +38,7 @@ cloud:
         - switch.outside
     entity_config:
       switch.kitchen:
-        name: Custom Name for Alexa
+        name: Custom Name for Google Assistant
         aliases:
          - bright lights
          - entry lights
@@ -52,7 +52,7 @@ google_actions:
   type: map
   keys:
     filter:
-      description: Filters for entities to include/exclude from Alexa.
+      description: Filters for entities to include/exclude from Google Assistant.
       required: false
       type: map
       keys:

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -37,7 +37,7 @@ google_assistant:
     - group
   entity_config:
     switch.kitchen:
-      name: Custom Name for Alexa
+      name: Custom Name for Google Assistant
       aliases:
         - bright lights
         - entry lights


### PR DESCRIPTION
**Description:**
Changed Alexa to Google Assistant for Google Assistant docs

@balloob Maybe we should get these into 0.61, before merge? (Sorry to ping you)

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
