### PR TITLE
Added Python version notes

### DIFF
--- a/source/_docs/installation/windows.markdown
+++ b/source/_docs/installation/windows.markdown
@@ -9,7 +9,11 @@ sharing: true
 footer: true
 ---
 
-To run Home Assistant on Microsoft Windows installation you need to install Python first. Download Python for [https://www.python.org/downloads/windows/](https://www.python.org/downloads/windows/) and follow the instructions of the installer.
+To run Home Assistant on Microsoft Windows installation you need to install Python first. Download Python (the latest version of Python 3.6 is recommended) for [https://www.python.org/downloads/windows/](https://www.python.org/downloads/windows/) and follow the instructions of the installer.
+
+<p class='note'>
+There may be alpha or beta releases of Python listed on that download page (marked by the letters `a` or `b` in the version number. Do not use these versions.
+</p>
 
 Start 
 


### PR DESCRIPTION
Given that people using Windows keep grabbing the alpha releases of 3.7, I've added a recommendation of Python 3.6, and a note about not downloading alpha or beta versions, and how to identify them.
