### PR TITLE
Broken internal link for [autostart](docs/autostart/)

### DIFF
--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -34,7 +34,7 @@ _(If you're on a Debian based system, you will need to install Python virtual en
     ```
     $ python3 -m pip install homeassistant
     ```
- 5. Configure it to [autostart](docs/autostart/)
+ 5. Configure it to [autostart](/docs/autostart/)
  6. Or run Home Assistant manually:
     ```
     $ hass --open-ui


### PR DESCRIPTION
Current link giving 404 error

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
