### PR TITLE
fixed URL for github access token

### DIFF
--- a/source/_components/sensor.travisci.markdown
+++ b/source/_components/sensor.travisci.markdown
@@ -26,7 +26,7 @@ sensor:
 
 Configuration variables:
 
-- **api_key** (*Required*): GitHub [access token](https://github.com/settings/applications) with the following scopes: *read:org*, *user:email*, *repo_deployment*, *repo:status*, *write:repo_hook*.
+- **api_key** (*Required*): GitHub [access token](https://github.com/settings/tokens) with the following scopes: *read:org*, *user:email*, *repo_deployment*, *repo:status*, *write:repo_hook*.
 - **branch** (*Optional*): Determine which default branch should be used by the **state** condition. Defaults to *master*.
 - **scan_interval** (*Optional*): How frequently to query for new data. Defaults to 30 seconds.
 - **monitored_conditions** array (*Optional*): Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.


### PR DESCRIPTION
**Description:**

fixed URL for github access token

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
