### PR TITLE
Removed relative_time

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -75,7 +75,6 @@ Home Assistant adds extensions to allow templates to access all of the current s
 - `as_timestamp()` will convert datetime object or string to UNIX timestamp
 - `distance()` will measure the distance in meters between home, entity, coordinates.
 - `closest()` will find the closest entity.
-- `relative_time(timestamp)` will format the date time as relative time vs now (ie 7 seconds)
 - `float` will format the output as float.
 - `strptime(string, format)` will parse a string to a datetime based on a [format][strp-format].
 - `log(value, base)` will take the logarithm of the input. When the base is omitted, it defaults to `e` - the natural logarithm. Can also be used as a filter.


### PR DESCRIPTION
Apparently it was removed some time ago (bug from 0.30.1 saying it didn't work then), but the docs weren't updated.
