### PR TITLE
Added extra arguments to onvif config

### DIFF
--- a/source/_components/camera.onvif.markdown
+++ b/source/_components/camera.onvif.markdown
@@ -31,6 +31,6 @@ Configuration variables:
 - **username** (*Optional*): The username for the camera.
 - **password** (*Optional*): The password for the camera.
 - **port** (*Optional*): The port for the camera. This defaults to 5000
-
+- **extra_arguments** (*Optional*): Extra options to pass to `ffmpeg`, e.g. image quality or video filter options. More details in [FFmpeg component](/components/ffmpeg).
 
 If you are running into trouble with this sensor, please refer to the [Troubleshooting section](/components/ffmpeg/#troubleshooting).


### PR DESCRIPTION
**Description:**
FFMPEG platform allows to set additional parameters in the config. ONVIF platform didn't allow that until this CL. There were always arguments provided by author of onvif platform plugin '-q:v 2'. Somebody may want to use another arguments, like '-pred 1 -q:v 10'.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11680

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
