### PR TITLE
Explain history order config flag

### DIFF
--- a/source/_components/history.markdown
+++ b/source/_components/history.markdown
@@ -87,6 +87,21 @@ history:
      - sensor.date
 ```
 
+If you'd like the order of display of the sensors to follow the way
+they are listed in the included entity list, you can set the flag
+`use_include_order` to True.
+
+```yaml
+# Example configuration.yaml entry using specified entity display order
+history:
+  use_include_order: True
+  include:
+    entities:
+      - sensor.last_boot
+      - sensor.date
+```
+
+
 #### {% linkable_title Implementation details %}
 
 The history is stored in a SQLite database `home-assistant_v2.db` within your configuration directory if the `recorder` component is not set up differently.

--- a/source/_components/history.markdown
+++ b/source/_components/history.markdown
@@ -97,8 +97,8 @@ history:
   use_include_order: True
   include:
     entities:
-      - sensor.last_boot
-      - sensor.date
+      - sun.sun
+      - light.front_porch
 ```
 
 


### PR DESCRIPTION
**Description:**

There is a new flag which controls the feature of displaying history items in the order they were included in the configuration.  Explain with an example.

This accompanies a bugfix PR in home assistant, so it's against current.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11686

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
