### PR TITLE
Updated sensor.template example

### DIFF
--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -27,7 +27,6 @@ sensor:
     sensors:
       solar_angle:
         friendly_name: "Sun angle"
-        entity_id: sun.sun
         unit_of_measurement: 'degrees'
         value_template: "{{ states.sun.sun.attributes.elevation }}"
 


### PR DESCRIPTION
Removed entity_id from sensor.template example, entity_id was deprecated for template platforms with release 0.61 (issue #11123).

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
