### PR TITLE
sync usb_path to other docs

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -162,14 +162,6 @@ zwave:
   usb_path: /dev/ttyACM0
 ```
 
-For some devices the `/dev/ttyACM0` device is not detected by udev and is therefore not mapped by Docker. To explicitly set this device for mapping to Home-Assistant, execute the following command using the ssh add-on:
-
-```bash
-$ curl -d '{"devices": ["ttyACM0"]}' http://hassio/homeassistant/options
-```
-
-After that, you need to change `usb_path` to `/dev/ttyACM0`.
-
 ### {% linkable_title RancherOS %}
 
 If you're using RancherOS for containers, you'll need to ensure you enable the kernel-extras service so that the `USB_ACM` module (also known as `cdc_acm`) is loaded:

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -159,16 +159,16 @@ To enable Z-Wave, plug your Z-Wave USB stick into your Raspberry Pi 3 and add th
 
 ```yaml
 zwave:
-  usb_path: /dev/ttyAMA0
+  usb_path: /dev/ttyACM0
 ```
 
-For some devices the `/dev/ttyAMA0` device is not detected by udev and is therefore not mapped by Docker. To explicitly set this device for mapping to Home-Assistant, execute the following command using the ssh add-on:
+For some devices the `/dev/ttyACM0` device is not detected by udev and is therefore not mapped by Docker. To explicitly set this device for mapping to Home-Assistant, execute the following command using the ssh add-on:
 
 ```bash
-$ curl -d '{"devices": ["ttyAMA0"]}' http://hassio/homeassistant/options
+$ curl -d '{"devices": ["ttyACM0"]}' http://hassio/homeassistant/options
 ```
 
-After that, you need to change `usb_path` to `/dev/ttyAMA0`.
+After that, you need to change `usb_path` to `/dev/ttyACM0`.
 
 ### {% linkable_title RancherOS %}
 


### PR DESCRIPTION
The hassio zwave documents reference usb_path: /dev/ttyACM0, so this document should be in sync. After some discussion it appears that this could be variable, in which case there should be a good way to figure out the CORRECT answer rather than using a guess as example code without stating it as such. Possibly linking back to the linux "how to find" section?

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
