### PR TITLE
Add text about serial option for z stick operation

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -25,11 +25,11 @@ $ sudo /Applications/Python\ x.x/Install\ Certificates.command
 ```
 
 <p class='note'>
-The installation of python-openzwave happens when you first enable the Z-Wave component, and can take half an hour or more on a Raspbery Pi.
+The installation of python-openzwave happens when you first enable the Z-Wave component, and can take half an hour or more on a Raspberry Pi.
 </p>
 
 <p class='note'>
-On raspberry pi you will need to enable the serial interface in the raspbi-config tool before you can add zwave to home assistant.
+On Raspberry Pi you will need to enable the serial interface in the raspbi-config tool before you can add Z-Wave to home assistant.
 </p>
 
 ## {% linkable_title Configuration %}

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -29,7 +29,7 @@ The installation of python-openzwave happens when you first enable the Z-Wave co
 </p>
 
 <p class='note'>
-On Raspberry Pi you will need to enable the serial interface in the raspbi-config tool before you can add Z-Wave to home assistant.
+On Raspberry Pi you will need to enable the serial interface in the raspbi-config tool before you can add Z-Wave to Home Assistant.
 </p>
 
 ## {% linkable_title Configuration %}

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -28,6 +28,10 @@ $ sudo /Applications/Python\ x.x/Install\ Certificates.command
 The installation of python-openzwave happens when you first enable the Z-Wave component, and can take half an hour or more on a Raspbery Pi.
 </p>
 
+<p class='note'>
+On raspberry pi you will need to enable the serial interface in the raspbi-config tool before you can add zwave to home assistant.
+</p>
+
 ## {% linkable_title Configuration %}
 
 ```yaml


### PR DESCRIPTION
**Description:**
This adds a note to the Z-Stick installation page about enabling the serial interface in the Raspberry Pi


## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
