### PR TITLE
Adds KU6290 to tested Samsung TV models

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -56,6 +56,7 @@ Currently known supported models:
 - U6300 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - K6500AF (port must be set to 8001)
 - KS8005 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- KU6290 (port must be set to 8001)
 - MU6170UXZG (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - KS7502 (port must be set to 8001, and `pip3 install websocket-client` must be executed, turn on doesn't work, turn off works fine)
 - K5600AK (partially supported, turn on works but state is not updated)


### PR DESCRIPTION
Tested on Samsung UN65KU6290.  Power on, power off, mute, volume up and down all work.  Also tested next and previous track buttons in Youtube App and they appear to act as fast forward and rewind functions.  Requires port 8001.