### PR TITLE
Update binary threshold sensor configuration

### DIFF
--- a/source/_components/binary_sensor.threshold.markdown
+++ b/source/_components/binary_sensor.threshold.markdown
@@ -41,12 +41,11 @@ entity_id:
   description: "The entity to monitor. Only [sensors](/components/sensor/) are supported."
   required: true
   type: entity_id
-lower:
-  description: The lower threshold which the observed value is compared against.
+type:
+  description: The type of threshold, `upper` or `lower`.
   required: false
-  type: float
-upper:
-  description: The upper threshold which the observed value is compared against.
+threshold:
+  description: The value of the threshold.
   required: false
   type: float
 hysteresis:


### PR DESCRIPTION
The existing documentation is incorrect and results in config errors. Per this thread (https://community.home-assistant.io/t/threshold-binary-sensor/7316/5) and my experience, my file change is in line with what the configuration actually needs to be.

My proposed changes are probably incomplete due to the fact that I'm not a programmer, but I hope it's more useful than the erroneous info in the existing version!

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
