### PR TITLE
Fix platform incorrect CaSe

### DIFF
--- a/source/_components/sensor.bh1750.markdown
+++ b/source/_components/sensor.bh1750.markdown
@@ -26,7 +26,7 @@ To use your BH1750 sensor in your installation, add the following to your `confi
 ```yaml
 # Example configuration.yaml entry
 sensor:
-  - platform: BH1750
+  - platform: bh1750
 ```
 
 Configuration variables:


### PR DESCRIPTION
Was saying platform not found with incorrect case when I used check config
Lower down in the doc it shows a correct example with lower case that did work

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
