### PR TITLE
Added PTV (AU) GTFS dataset link

### DIFF
--- a/source/_components/sensor.gtfs.markdown
+++ b/source/_components/sensor.gtfs.markdown
@@ -24,6 +24,7 @@ Here are some examples:
 - [Metropolitan Transit Authority of New York City (MTA)](http://www.bart.gov/schedules/developers/gtfs) - Provides separate data feeds for subway, bus, LIRR and Metro-North of the greater New York City metropolitan region.
 - [GBRail.info](http://www.gbrail.info/) - Provides data feeds for most if not all rail companies in Britain.
 - [Official Timetable Switzerland](http://www.fahrplanfelder.ch/en/timetable-data.html) - The official timetable data for Switzerland.
+- [Public Transport Victoria (Australia)](https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs) - Official PTV GTFS dataset.
 
 You need to download a GTFS ZIP file and put it into a folder named `gtfs` in your configuration directory. For ease of use, it is suggested that you rename the file to just the agency/data source name (i.e. `bart.zip` instead of `google_transit_20160328_v1.zip`). You can also unzip and place a folder in the `gtfs` folder.
 


### PR DESCRIPTION
**Description:**
Added a link to PTV Australia GTFS dataset. Dataset is outdated; however, it is the official version;

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
