### PR TITLE
Fix for Neato D3 and D5

### DIFF
--- a/source/_components/neato.markdown
+++ b/source/_components/neato.markdown
@@ -28,15 +28,6 @@ Configuration variables:
 - **username** (*Required*): Username for the Neato account.
 - **password** (*Required*): Password for the Neato account.
 
-The Home Assistant Neato platform has not been tested with all models of Botvac.
-
-  | BotVac Model | Tested |
-  | --- | --- |
-  | Botvac Connected | SUCCESS |
-  | Botvac D3 Connected (firmware 4.0+) | PARTIALLY WORKING |
-  | Botvac D5 Connected (firmware 4.0+) | PARTIALLY WORKING |
-  | Botvac D7 Connected | SUCCESS |
-
 <p class='note'>
 After the update to firmware 4.0 (which adds cleaning maps) there is also support for displaying the maps of the Botvac D3 Connected and Botvac D5 Connected robots. The start/stop functionality does not work. More information on how to update here: https://support.neatorobotics.com/hc/en-us/articles/115004320694-Software-Update-4-0-for-Neato-Botvac-Connected-D3-D5-
 </p>


### PR DESCRIPTION
**Description:**
Neato D3 and D5 vacuums currently doesn't support start/pause/resume actions.
In a matter of fact they could support it, we're just using it in a wrong version. Changes made to pybotvac by @kvermilion allowed him to control his Botvac D5. Changes were made with my review, as a user of D3. @jabesq who is an owner of pybotvac repository has Botvac. So all 3 robots are covered and they work fine. Let's update!

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11775

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
