### PR TITLE
Update variable names for away mode

### DIFF
--- a/source/_components/climate.honeywell.markdown
+++ b/source/_components/climate.honeywell.markdown
@@ -36,5 +36,5 @@ Configuration variables:
 - **region** (*Optional*): Region identifier (either 'eu' or 'us'). Defaults to 'eu' if not provided.
 - **scan_interval**(*Optional*): Scan interval is expressed in seconds. Recommended value of 600 seconds. Default value is 120 seconds. Omitting scan_interval may result in too-frequent polling and cause you to rate-limited by Honeywell.
 - **away_temperature** (*Optional*) (*only for eu region*): Heating setpoint when away mode is on. If omitted it defaults to 16.0 deg C.
-- **cool_away_temperature** (*Optional*) (*only for us region*): Cooling setpoint when away mode is on. If omitted it defaults to 30.0 deg C.
-- **heat_away_temperature** (*Optional*) (*only for us region*): Heating setpoint when away mode is on. If omitted it defaults to 16.0 deg C.
+- **away_cool_temperature** (*Optional*) (*only for us region*): Cooling setpoint when away mode is on. If omitted it defaults to 30.0 deg C.
+- **away_heat_temperature** (*Optional*) (*only for us region*): Heating setpoint when away mode is on. If omitted it defaults to 16.0 deg C.


### PR DESCRIPTION
The actual variables in the honeywell.py script are looking for 'away_cool_temperature' and 'away_heat_temperature'.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
