### PR TITLE
Make init script raspi-proof

### DIFF
--- a/source/_docs/autostart/init.d.markdown
+++ b/source/_docs/autostart/init.d.markdown
@@ -93,11 +93,7 @@ FLAGS="-v --config $CONFIG_DIR --pid-file $PID_FILE --log-file $LOG_FILE --daemo
 
 
 start() {
-  if [ ! -d "$PID_DIR" ]; then
-    echo "It seems you did not run"
-    echo -e "\tservice hass-daemon install"
-    return 1
-  fi
+  create_piddir
   if [ -f $PID_FILE ] && kill -0 $(cat $PID_FILE) 2> /dev/null; then
     echo 'Service already running' >&2
     return 1
@@ -217,11 +213,7 @@ LOG_FILE="$LOG_DIR/home-assistant.log"
 FLAGS="-v --config $CONFIG_DIR --pid-file $PID_FILE --log-file $LOG_FILE --daemon"
 
 start() {
-  if [ ! -d "$PID_DIR" ]; then
-    echo "It seems you did not run"
-    echo -e "\tservice hass-daemon install"
-    return 1
-  fi
+  create_piddir
   if [ -f $PID_FILE ] && kill -0 $(cat $PID_FILE) 2> /dev/null; then
     echo 'Service already running' >&2
     return 1


### PR DESCRIPTION
Raspbian does not keep files in /run. Therefor the pid directory needs to be created every time after boot. The easies is to put this into the start function.

Sorry, I did not test the patch with all my legacy systems.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
