### PR TITLE
Add absolute url config information

### DIFF
--- a/source/_components/weblink.markdown
+++ b/source/_components/weblink.markdown
@@ -2,14 +2,14 @@
 layout: page
 title: "Weblink"
 description: "Instructions how to setup Links within Home Assistant."
-date: 2016-02-02 20:00
+date: 2018-01-19 20:00
 sidebar: true
 comments: false
 sharing: true
 footer: true
 logo: home-assistant.png
 ha_category: Front end
-ha_release: 0.13
+ha_release: 0.62
 ---
 
 The `weblink` component allows you to display links in the Home Assistant frontend.
@@ -24,11 +24,23 @@ weblink:
       url: http://192.168.1.1/
     - name: Home Assistant
       url: https://home-assistant.io
+    - name: Grafana
+      url: /grafana
 ```
-Configuration variables:
 
-- **name** (*Required*): Text for the link.
-- **url** (*Required*): The URL for the link.
-- **icon** (*Optional*): Icon for entry.
+{% configuration %}
+name:
+  description: Text for the link.
+  required: true
+  type: string
+url:
+  description: The URL (full url or absolute adress) for the link.
+  required: true
+  type: string
+icon:
+  description: Icon for entry.
+  required: false
+  type: string
+{% endconfiguration %}
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your input and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.

--- a/source/_components/weblink.markdown
+++ b/source/_components/weblink.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: home-assistant.png
 ha_category: Front end
-ha_release: 0.62
+ha_release: 0.13
 ---
 
 The `weblink` component allows you to display links in the Home Assistant frontend.
@@ -34,7 +34,7 @@ name:
   required: true
   type: string
 url:
-  description: The URL (full url or absolute adress) for the link.
+  description: The URL (absolute URL or absolute path) for the link.
   required: true
   type: string
 icon:

--- a/source/_components/weblink.markdown
+++ b/source/_components/weblink.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Weblink"
 description: "Instructions how to setup Links within Home Assistant."
-date: 2018-01-19 20:00
+date: 2016-02-02 20:00
 sidebar: true
 comments: false
 sharing: true


### PR DESCRIPTION
**Description:**
Add config information for absolute urls  

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11808

## Checklist:

  - [x] New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
