### PR TITLE
Documentation tweak

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -36,6 +36,7 @@ Home Assistant can discover and automatically configure [zeroconf](https://en.wi
  * [Samsung TVs](https://home-assistant.io/components/media_player.samsungtv/)
  * [Sonos speakers](https://home-assistant.io/components/media_player.sonos/)
  * [Telldus Live](https://home-assistant.io/components/tellduslive/)
+ * [Wink](https://home-assistant.io/components/wink/)
  * [Yamaha media player](https://home-assistant.io/components/media_player.yamaha/)
  * [Yeelight Sunflower bulb](https://home-assistant.io/components/light.yeelightsunflower/)
 
@@ -79,9 +80,10 @@ Valid values for ignore are:
  * `samsung_tv`: Samsung TVs
  * `sonos`: Sonos speakers
  * `tellduslive`: Telldus Live
+ * `wink`: Wink Hub
  * `yamaha`: Yamaha media player
  * `yeelight`: Yeelight Sunflower bulb
- 
+
 <p class='note'>
 Home Assistant must be on the same network as the devices for uPnP discovery to work.
 If running Home Assistant in a [Docker container](/docs/installation/docker/) use switch `--net=host` to put it on the host's network.

--- a/source/_components/group.markdown
+++ b/source/_components/group.markdown
@@ -22,7 +22,7 @@ By default, every group appears in the HOME tab. If you create a group `default_
 group:
   default_view:
     view: yes
-    icon: mdi:home 
+    icon: mdi:home
     entities:
       - group.kitchen
       - group.awesome_people
@@ -56,7 +56,7 @@ group:
 
 Configuration variables:
 
-- **view** (*Optional*): If yes then the entry will be shown as a view (tab) at the top.
+- **view** (*Optional*): If yes then the entry will be shown as a view (tab) at the top. Groups that are set to `view: yes` cannot be used as entities in other views.
 - **name** (*Optional*): Name of the group.
 - **icon** (*Optional*): If the group is a view, this icon will show at the top in the frontend instead of the name. If the group is a view and both name and icon have been specified, the icon will appear at the top of the frontend and the name will be displayed as the mouse-over text.  If it's not a view, then the icon shows when this group is used in another group.
 - **control** (*Optional*): Set value to `hidden`. If hidden then the group switch will be hidden.
@@ -69,7 +69,7 @@ Example of groups shown as views in the frontend.
 
 If all entities in a group are switches or lights then Home Assistant adds a switch at the top of the card that turns them all on/off at once. If you want to hide this switch, set `control` to `hidden`.
 
-You can create views (tabs) that contain other groups.
+You can create views (tabs) that contain other groups (but not other groups which are marked as `view: yes`).
 Notice in the example below that in order to refer to the group "Living Room", you use `group.living_room` (lowercase and spaces replaced with underscores).
 
 ```yaml
@@ -86,7 +86,7 @@ Notice in the example below that in order to refer to the group "Living Room", y
     entities:
       - group.living_room
       - group.bedroom
-``` 
+```
 
 ## {% linkable_title Default groups %}
 


### PR DESCRIPTION
## Description:

1. Add Wink to "discovery" component docs (this was [added to home-assistant in July 2017](https://github.com/home-assistant/home-assistant/pull/8739) )
2. Clarify that views (i.e. groups with `view: yes`) cannot be nested in other views. Some examples of forum posts with questions around this behavior can be seen in the [commit message](https://github.com/home-assistant/home-assistant.github.io/commit/d6e3afe25e541ec1e7b31f7c259467bc477e1f28)

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards](https://home-assistant.io/developers/documentation/standards/)
