### PR TITLE
Add ‘unit_system’ configuration variable

### DIFF
--- a/source/_components/sensor.fitbit.markdown
+++ b/source/_components/sensor.fitbit.markdown
@@ -22,6 +22,7 @@ Enable the sensor by adding the following to your `configuration.yaml` file:
 sensor:
   - platform: fitbit
     clock_format: 12H
+    unit_system: metric
     monitored_resources:
       - "body/weight"
 ```
@@ -36,6 +37,7 @@ Configuration variables:
 
 - **monitored_resources** (*Optional*): Resource to monitor. Defaults to `activities/steps`.
 - **clock_format** (*Optional*): Format to use for `sleep/startTime` resource. Accepts `12H` or `24H`. Defaults to `24H`.
+- **unit_system** (*Optional*): Unit system to use for measurements. Accepts `default`, `metric`, `en_US` or `en_GB`. Defaults to `default`.
 
 Below is the list of resources that you can add to `monitored_resources`. One sensor is exposed for every resource.
 

--- a/source/_components/sensor.fitbit.markdown
+++ b/source/_components/sensor.fitbit.markdown
@@ -22,7 +22,6 @@ Enable the sensor by adding the following to your `configuration.yaml` file:
 sensor:
   - platform: fitbit
     clock_format: 12H
-    unit_system: metric
     monitored_resources:
       - "body/weight"
 ```


### PR DESCRIPTION
**Description:**
Adds an additional configuration variable to allow having a different unit system than either the one defined in Fitbit locale or in Hass config.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11817

## Checklist:

  - [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
