### PR TITLE
Static IP allocation note

### DIFF
--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -47,3 +47,5 @@ If you use a port other than `8123` or an SSL proxy, change the port number acco
 ## {% linkable_title Router configuration %}
 
 You'll need to forward the port you listed in your configuration (8123 in the example above) on your router to your Home Assistant system. You can find guides on how to do this on [Port Forward](https://portforward.com/) - noting that you'll only need to forward the TCP port.
+
+Ensure that you allocate the Home Assistant system a fixed IP on your network before you configure port forwarding. You can do this either on the computer itself (see the [install guide](/hassio/installation/) or via a static lease on your router.


### PR DESCRIPTION
The guide forgets to call out that the IP for the system must be fixed, which has tripped up more than a few
