### PR TITLE
Update climate.daikin.markdown

### DIFF
--- a/source/_components/climate.daikin.markdown
+++ b/source/_components/climate.daikin.markdown
@@ -17,14 +17,15 @@ ha_iot_class: "Local Polling"
 
 The climate component integrates Daikin air conditioning systems into Home Assistant, enabling control of setting the following parameters:
 - **mode** (cool, heat, dry, fan only or auto)
-- **fan speed**
+- **fan speed** (on supported models)
 - **target temperature**
 - **swing mode** (on supported models)
 
 Current temperature is displayed.
 
 <p class='note warning'>
-    Please note, the `daikin` platform integrates **ONLY the european versions of Daikin ACs (models BRP069A41, 42, 43, 45)** into Home Assistant
+    Please note, the `daikin` platform integrates **ONLY the european versions of Daikin ACs (models BRP069A41, 42, 43, 45)** into Home Assistant.
+    BRP069A42 does not support setting of fan speed or fan swing mode.
 </p>
 
 ### Configuration ###


### PR DESCRIPTION
**Description:**
According to https://community.home-assistant.io/t/daikin-component-no-climate-entities-created-task-exception/39608/26 BRP069A42 does not support setting of fan speed or fan swing mode.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11840

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
