### PR TITLE
Enable Daikin autodiscovery

### DIFF
--- a/source/_components/climate.daikin.markdown
+++ b/source/_components/climate.daikin.markdown
@@ -29,8 +29,7 @@ Current temperature is displayed.
 
 ### Configuration ###
 
-The component has been integrated with discovery so all your Daikin AC's climate devices can be automatically discovered.
-Manual configuration and customization is also possible by using the sample configuration from below:
+Manual configuration and customization is possible by using the sample configuration from below:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/climate.daikin.markdown
+++ b/source/_components/climate.daikin.markdown
@@ -29,8 +29,8 @@ Current temperature is displayed.
 
 ### Configuration ###
 
-The component has been integrated with discovery so all your Daikin AC's can be autodiscovered.
-Manual configuration and customization is also possible by using the sample configuration from below
+The component has been integrated with discovery so all your Daikin AC's climate devices can be automatically discovered.
+Manual configuration and customization is also possible by using the sample configuration from below:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/climate.daikin.markdown
+++ b/source/_components/climate.daikin.markdown
@@ -29,7 +29,8 @@ Current temperature is displayed.
 
 ### Configuration ###
 
-Manual configuration and customization is possible by using the sample configuration from below:
+The component has been integrated with discovery so all your Daikin AC's climate devices can be automatically discovered.
+Manual configuration and customization is also possible by using the sample configuration from below:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/climate.daikin.markdown
+++ b/source/_components/climate.daikin.markdown
@@ -29,7 +29,8 @@ Current temperature is displayed.
 
 ### Configuration ###
 
-Manual configuration and customization is possible by using the sample configuration from below:
+The component has been integrated with discovery so all your Daikin AC's can be autodiscovered.
+Manual configuration and customization is also possible by using the sample configuration from below
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/daikin.markdown
+++ b/source/_components/daikin.markdown
@@ -38,7 +38,8 @@ daikin:
 {% configuration %}
 hosts:
   description: List of IP addresses or hostnames.
-  required: true
+  required: false
+  detault: All discovered hosts
   type: array
 monitored_conditions:
   description: List of items you want to monitor for each device.

--- a/source/_components/daikin.markdown
+++ b/source/_components/daikin.markdown
@@ -38,8 +38,7 @@ daikin:
 {% configuration %}
 hosts:
   description: List of IP addresses or hostnames.
-  required: false
-  detault: All discovered hosts
+  required: true
   type: array
 monitored_conditions:
   description: List of items you want to monitor for each device.

--- a/source/_components/daikin.markdown
+++ b/source/_components/daikin.markdown
@@ -18,13 +18,19 @@ ha_iot_class: "Local Polling"
 The component integrates Daikin air conditioning systems into Home Assistant.
 
 To automatically add all your Daikin devices (ACs and associated sensors) into your Home Assistant installation, add the following to your 'configuration.yaml' file:
+```yaml
+# Example configuration.yaml entry
+daikin:
+```
 
 <p class='note warning'>
     Please note, the Daikin platform integrates **ONLY the european versions of Daikin ACs (models BRP069A41, 42, 43, 45)** into Home Assistant
 </p>
 
+A full manual configuration example is give below:
+
 ```yaml
-# Example configuration.yaml entry
+# Full manual example configuration.yaml entry
 daikin:
   hosts:
     - 192.168.4.161
@@ -38,7 +44,8 @@ daikin:
 {% configuration %}
 hosts:
   description: List of IP addresses or hostnames.
-  required: true
+  required: false
+  default: All discovered hosts
   type: array
 monitored_conditions:
   description: List of items you want to monitor for each device.

--- a/source/_components/sensor.daikin.markdown
+++ b/source/_components/sensor.daikin.markdown
@@ -25,7 +25,8 @@ The sensor component integrates Daikin air conditioning systems into Home Assist
 
 ### Configuration ###
 
-Manual configuration and customization is possible by using the sample configuration from below:
+The component has been integrated with discovery so all your Daikin AC's climate devices can be automatically discovered.
+Manual configuration and customization is also possible by using the sample configuration from below:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/sensor.daikin.markdown
+++ b/source/_components/sensor.daikin.markdown
@@ -25,8 +25,7 @@ The sensor component integrates Daikin air conditioning systems into Home Assist
 
 ### Configuration ###
 
-The component has been integrated with discovery so all your Daikin AC's climate devices can be automatically discovered.
-Manual configuration and customization is also possible by using the sample configuration from below:
+Manual configuration and customization is possible by using the sample configuration from below:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
**Description:**
Daikin was build from the beginning with autodiscovery in mind but since at the moment of the release, the netdisco fix was not released yet I had to disable it.

This PR simply re-enables it.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11842

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
