### PR TITLE
Updating Google Assistant Docs for spelling and formatting

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -102,7 +102,7 @@ entity_config:
           required: false
           type: list
         type:
-          description: Override the domain how Google Assistant has to interpretet the entity. For example, set to `light` for a switch entity to have it be handeld as a light.
+          description: Override how Google Assistant will interpretet the domain of the entity. For example, set to `light` for a switch entity to have it be handled as a light.
           required: false
           type: string
 {% endconfiguration %}
@@ -117,7 +117,7 @@ If you're not using Linux, you can use sites such as [this one](https://www.brow
 
 ### {% linkable_title Setup %}
 
-1. Download the [gactions CLI](https://developers.google.com/actions/tools/gactions-cli) (you'll use this later) - you can download and run this anywhere and on any machine, just remember where you put it for later (and don't forget to run `chmod +x gactions`to make it executable on mac or linux)
+1. Download the [gactions CLI](https://developers.google.com/actions/tools/gactions-cli) to be used later. You can download and run this anywhere and on any machine. Just remember where you put it for later and don't forget to run `chmod +x gactions` to make it executable on Mac or Linux.
 2. Create a new file named `project.json` (in the same directory you downloaded `gactions` to) and replace the `[YOUR HOME ASSISTANT URL]` below with the URL you use to access Home Assistant.
    Note: This must be an HTTPS URL to work.
 
@@ -132,7 +132,7 @@ If you're not using Linux, you can use sites such as [this one](https://www.brow
     }
   }],
   "conversations": {
-    "automation" :
+    "automation":
     {
       "name": "automation",
       "url": "https://[YOUR HOME ASSISTANT URL]/api/google_assistant"
@@ -142,10 +142,11 @@ If you're not using Linux, you can use sites such as [this one](https://www.brow
 ```
 
 3. Create a new project in the [developer console](https://console.actions.google.com/).
-	1. Add/Import project
-	2. Go to Build under the Actions SDK box
-	3. Copy the command that looks like:
-	`gactions update --action_package PACKAGE_NAME --project doctest-2d0b8`
+  a. Add/Import project
+  b. Go to Build under the Actions SDK box
+  c. Copy the command that looks like: 
+  
+  `gactions update --action_package PACKAGE_NAME --project doctest-2d0b8`
 4. Replace `PACKAGE_NAME` with `project.json` and run that command in a console from the same directory you saved `project.json` in (you'll need to put `./` before `gactions` so that it reads `./gactions` if you're running it on Linux or Windows). It should output a URL like `https://console.actions.google.com/project/doctest-2d0b8/overview` - go there.
 5. You'll need to fill out most of the information on that page, but none of it really matters since you won't be addressing the App directly, only through the Smart Home functionality built into Google Assistant.
 6. The final item on that page `Account linking` is required for your app to interact with Home Assistant.
@@ -179,4 +180,4 @@ The request_sync service may fail with a 404 if the project_id of the Homegraph 
   2. Add a new project to the [cloud console](https://console.cloud.google.com). Here you get a new project_id.
   3. Enable Homegraph API to the new project.
   4. Generate a new API key.
-  5. Again create a new project in the [developer console](https://console.actions.google.com/). Described above. But at the step 'Build under the Actions SDK box' choose your newly created project. By this, they share the same project_id.
+  5. Again, create a new project in the [developer console](https://console.actions.google.com/). Described above. But at the step 'Build under the Actions SDK box' choose your newly created project. By this, they share the same project_id.

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -18,7 +18,7 @@ The `google_assistant` component allows you to control things via Google Assista
 The Google Assistant component requires a bit more setup than most due to the way Google requires Assistant Apps to be set up.
 
 <p class='note'>
-To use Google Assistant, your Home Assistant configuration has to be externally accessible, with a hostname and SSL certificate. If you haven't already configured that you should do so before continuing.
+To use Google Assistant, your Home Assistant configuration has to be externally accessible with a hostname and SSL certificate. If you haven't already configured that, you should do so before continuing.
 </p>
 
 To enable this, add the following lines to your `configuration.yaml` file:
@@ -63,7 +63,7 @@ access_token:
   required: true
   type: string
 agent_user_id:
-  description: A string to identify the user, e.g., email address. If not provided, the component will generate one.
+  description: A string to identify the user, e.g. email address. If not provided, the component will generate one.
   required: false
   type: string
 api_key:
@@ -102,7 +102,7 @@ entity_config:
           required: false
           type: list
         type:
-          description: Override how Google Assistant will interpretet the domain of the entity. For example, set to `light` for a switch entity to have it be handled as a light.
+          description: Override how Google Assistant interprets the domain of the entity. For example, set to `light` for a switch entity to have it be handled as a light.
           required: false
           type: string
 {% endconfiguration %}


### PR DESCRIPTION
No content updates. Just changes to the spelling and formatting

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
