### PR TITLE
Added documentation for password mode in input_text

### DIFF
--- a/source/_components/input_text.markdown
+++ b/source/_components/input_text.markdown
@@ -29,7 +29,7 @@ input_text:
     pattern: '[a-fA-F0-9]*'
   text4:
     name: Text 4
-    mode: password'
+    mode: 'password'
 ```
 
 {% configuration %}

--- a/source/_components/input_text.markdown
+++ b/source/_components/input_text.markdown
@@ -29,7 +29,7 @@ input_text:
     pattern: '[a-fA-F0-9]*'
   text4:
     name: Text 4
-    mode: 'password'
+    mode: password
 ```
 
 {% configuration %}

--- a/source/_components/input_text.markdown
+++ b/source/_components/input_text.markdown
@@ -12,7 +12,7 @@ ha_category: Automation
 ha_release: 0.53
 ---
 
-The `input_text` component allows the user to define values that can be controlled via the frontend and can be used within conditions of automation. Changes to the value stored in the text box generate state events. These state events can be utilized as `automation` triggers as well. 
+The `input_text` component allows the user to define values that can be controlled via the frontend and can be used within conditions of automation. Changes to the value stored in the text box generate state events. These state events can be utilized as `automation` triggers as well. It can also be configured in password mode (obscured text).
 
 ```yaml
 # Example configuration.yaml entries
@@ -27,6 +27,9 @@ input_text:
   text3:
     name: Text 3
     pattern: '[a-fA-F0-9]*'
+  text4:
+    name: Text 4
+    mode: password'
 ```
 
 {% configuration %}
@@ -59,6 +62,11 @@ input_text:
         required: false
         type: String
         default: empty
+      mode:
+        description: Can specify `text` or `password`. Elements of type "password" provide a way for the user to securely enter a value.
+        required: false
+        type: String
+        default: text
 {% endconfiguration %}
 
 ### {% linkable_title Restore State %}


### PR DESCRIPTION
**Description:**
Added `mode: password` to `input_text` documentation.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** 
https://github.com/home-assistant/home-assistant/pull/11849
https://github.com/home-assistant/home-assistant-polymer/pull/824
## Checklist:

  - [ x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [ x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
