### PR TITLE
Add esphomelib link

### DIFF
--- a/source/_components/light.mqtt_json.markdown
+++ b/source/_components/light.mqtt_json.markdown
@@ -199,4 +199,4 @@ light:
 
 - [MQTT JSON Light](https://github.com/mertenats/Open-Home-Automation/tree/master/ha_mqtt_rgbw_light_with_discovery) is another implementation for ESP8266 including [MQTT discovery](/docs/mqtt/discovery/).
 
-- [esphomelib](https://github.com/OttoWinter/esphomelib) is a library for ESP32-based boards that has many of Home Assistants MQTT features (like discovery) pre-implemented and provides high-level abstractions for components such as lights or sensors.
+- [esphomelib](https://github.com/OttoWinter/esphomelib) is a library for ESP32-based boards that has many of Home Assistant's MQTT features (like [discovery](/docs/mqtt/discovery/)) pre-implemented and provides high-level abstractions for components such as lights or sensors.


### PR DESCRIPTION
**Description:**

Add a link to [esphomelib](https://github.com/OttoWinter/esphomelib), which is a library that aims to make using Home Assistant with ESP32s really easy, in the documentation of the Light MQTT-JSON platform. 

Note: this can probably be considered somewhat of a self-promotion, but I strongly believe this library can help lots of makers save lots of time. Additionally, this library could also be used for other MQTT components such as sensors or switches, but plastering this "ad" all over those documentations is most likely annoying/too much - and implementing those components yourself, in contrast to lights, is relatively easy.

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
