### PR TITLE
Ping binary sensor: Ping interval can be set

### DIFF
--- a/source/_components/binary_sensor.ping.markdown
+++ b/source/_components/binary_sensor.ping.markdown
@@ -37,6 +37,17 @@ The sensor exposes the different round trip times values measured by `ping` as a
 - `round trip time min`
 - `round trip time max`
 
+The default polling interval is 5 minutes. As many components [based on the entity class](/docs/configuration/platform_options), it is possible to overwrite this scan interval by specifying a `scan_interval` configuration key (value in seconds). In the example below we setup the `ping` binary sensor to poll the devices every 30 seconds.
+
+```yaml
+# Example configuration.yaml entry to ping host 192.168.0.1 with 2 packets every 30 seconds.
+binary_sensor:
+  - platform: ping
+    host: 192.168.0.1
+    count: 2
+    scan_interval: 30
+```
+
 <p class='note'>
 When run on Windows systems, the round trip time attributes are rounded to the nearest millisecond and the mdev value is unavailable.
 </p>


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

  - [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`. 
  - [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
