### PR TITLE
Updated Yeelight Markdown

### DIFF
--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -61,8 +61,7 @@ This component is tested to work with the following models. If you have a differ
 - **YLDP03YL**: LED Bulb (Color) - E26
 - **YLDD01YL**: Lightstrip (Color)
 - **YLDD02YL**: Lightstrip (Color)
-
-
+- **MJCTD01YL**: Xiaomi Mijia Bedside Lamp - WIFI Version!
 
 
 


### PR DESCRIPTION
**Description:**
Updated Yeelight markdown with new supported device.

The module works perfectly with the latest Xiaomi Mijia bedside lamp, it's WIFI based and appears to share the same API as the yeelight LED bulbs.