### PR TITLE
Update switch.pilight.markdown to add variables and update links

### DIFF
--- a/source/_components/switch.pilight.markdown
+++ b/source/_components/switch.pilight.markdown
@@ -13,10 +13,9 @@ ha_release: 0.26
 ha_iot_class: "Local Polling"
 ---
 
-
 The `pilight` switch platform is issuing 433 MHz commands using [pilight](https://www.pilight.org/) to turn a 433 MHz device on or off. The Pilight Home Assistant hub has to be set up.
 
-Additionally RF commands can be defined that trigger this switch to turn on and off. This allows you to also use the remote shipped with your 433 MHz switch without mixing up the Home Assistant states. You can even define several on/off commands, thus several RF remotes to toggle this switch.
+Additionally, RF commands can be defined that trigger this switch to turn on and off. This allows you to also use the remote shipped with your 433 MHz switch without mixing up the Home Assistant states. You can even define several on/off commands, thus several RF remotes to toggle this switch.
 
 To be really sure that Home Assistant knows the actual state of your device it is recommended to use the RF remote with codes unknown to any of your 433 MHz devices. Thus you use the remote to trigger this switch to send the correct RF code to the device.
 
@@ -42,21 +41,21 @@ Configuration variables:
   - **[entry]** (*Required*): Name of the command switch. Multiple entries are possible.
     - **on_code** (*Required*): The code to turn the device on.
     - **off_code** (*Required*): The code to turn the device off.
-    - **on_code_receive** (*Optional*): If given, this command will turn the switch on if it is received by Pilight.
-    - **off_code_receive** (*Optional*): If given, this command will turn the switch off if it is received by Pilight.
+    - **on_code_receive** (*Optional*): If given, this command will turn the switch on if it is received by pilight.
+    - **off_code_receive** (*Optional*): If given, this command will turn the switch off if it is received by pilight.
 
 Variables for the different codes (`on_code` and `off_code`):
 
 - **protocol** (*Required*): Protocol to use, eg. `intertechno_old` or `daycom`.
 - **systemcode** (*Optional*): The systemcode of the device.
-- **unit** (*Optional*): The unit to use (is equivalent to pilight-send --unit).
-- **unitcode** (*Optional*): The unitcode to use (is equivalent to pilight-send --unitcode).
+- **unit** (*Optional*): The unit to use (is equivalent to `pilight-send --unit`).
+- **unitcode** (*Optional*): The unitcode to use (is equivalent to `pilight-send --unitcode`).
 - **id** (*Optional*): ID of the device
 - **state** (*Optional*): `'on'` or `'off'` has to be in apostrophes to be parsed correctly.
 - **'off'** (*Optional*): `1` or `0`
 - **'on'** (*Optional*): `1` or `0`
 
-For possible code entries look at the [pilight API](https://manual.pilight.org/development/api.html). All commands allowed by [pilight-send](https://manual.pilight.org/programs/send.html) can be used. Which means that if for a certain protocol there are different parameters used, you should be able to replace the variables above by the proper ones required by the specific protocol. When using the `elro_800_switch` or `mumbi` protocol for example, you will have to replace the variable `unit` with `unitcode` or there will be errors occurring.
+For possible code entries, look at the [pilight API](https://manual.pilight.org/development/api.html). All commands allowed by [pilight-send](https://manual.pilight.org/programs/send.html) can be used. Which means that if, for a certain protocol, there are different parameters used, you should be able to replace the variables above by the proper ones required by the specific protocol. When using the `elro_800_switch` or `mumbi` protocol, for example, you will have to replace the variable `unit` with `unitcode` or there will be errors occurring.
 
 Variables for the different receive codes (`on_code_receive` and `off_code_receive`):
 

--- a/source/_components/switch.pilight.markdown
+++ b/source/_components/switch.pilight.markdown
@@ -51,7 +51,6 @@ Variables for the different codes (`on_code` and `off_code`):
 - **systemcode** (*Optional*): The systemcode of the device.
 - **unit** (*Optional*): The unit to use (is equivalent to pilight-send --unit).
 - **unitcode** (*Optional*): The unitcode to use (is equivalent to pilight-send --unitcode).
-- **programcode** (*Optional*): The programcode to use (is equivalent to pilight-send --programcode).
 - **id** (*Optional*): ID of the device
 - **state** (*Optional*): `'on'` or `'off'` has to be in apostrophes to be parsed correctly.
 - **'off'** (*Optional*): `1` or `0`

--- a/source/_components/switch.pilight.markdown
+++ b/source/_components/switch.pilight.markdown
@@ -49,13 +49,15 @@ Variables for the different codes (`on_code` and `off_code`):
 
 - **protocol** (*Required*): Protocol to use, eg. `intertechno_old` or `daycom`.
 - **systemcode** (*Optional*): The systemcode of the device.
-- **unit** (*Optional*): The unit to use.
+- **unit** (*Optional*): The unit to use (is equivalent to pilight-send --unit).
+- **unitcode** (*Optional*): The unitcode to use (is equivalent to pilight-send --unitcode).
+- **programcode** (*Optional*): The programcode to use (is equivalent to pilight-send --programcode).
 - **id** (*Optional*): ID of the device
 - **state** (*Optional*): `'on'` or `'off'` has to be in apostrophes to be parsed correctly.
 - **'off'** (*Optional*): `1` or `0`
 - **'on'** (*Optional*): `1` or `0`
 
-For possible code entries look at the [pilight API](https://www.pilight.org/development/api/). All commands allowed by [pilight-send](https://wiki.pilight.org/doku.php/psend) can be used. Which means that if for a certain protocol there are different parameters used, you should be able to replace the variables above by the proper ones required by the specific protocol. When using the `elro_800_switch` or `mumbi` protocol for example, you will have to replace the variable `unit` with `unitcode` or there will be errors occurring.
+For possible code entries look at the [pilight API](https://manual.pilight.org/development/api.html). All commands allowed by [pilight-send](https://manual.pilight.org/programs/send.html) can be used. Which means that if for a certain protocol there are different parameters used, you should be able to replace the variables above by the proper ones required by the specific protocol. When using the `elro_800_switch` or `mumbi` protocol for example, you will have to replace the variable `unit` with `unitcode` or there will be errors occurring.
 
 Variables for the different receive codes (`on_code_receive` and `off_code_receive`):
 


### PR DESCRIPTION
**Description:**

The variables _unitcode_ and _programcode_ are missing from the variables-list, _unitcode_ is mentioned in the text below but they should be listed as optional variables if they are in fact optional variables.

furthermore the wiki-links to pilight are outdated, so i replaced the _wiki.pilight.org_ links with _manual.pilight,org_ links to their respective updated pages.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
