### PR TITLE
fix typo in link to rainbird component

### DIFF
--- a/source/_components/sensor.rainbird.markdown
+++ b/source/_components/sensor.rainbird.markdown
@@ -15,7 +15,7 @@ ha_iot_class: "Local Polling"
 
 This `rainbird` sensor allows interacting with [LNK WiFi](http://www.rainbird.com/landscape/products/controllers/LNK-WiFi.htm) module of the Rain Bird Irrigation system in Home Assistant.
 
-Once you have enabled the [Rain Bird component](/components/rainburd), add the following to your `configuration.yaml` file to enable the rain sensor:
+Once you have enabled the [Rain Bird component](/components/rainbird), add the following to your `configuration.yaml` file to enable the rain sensor:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
