### PR TITLE
Fix symbolic links, permissions and ownership

### DIFF
--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -61,6 +61,8 @@ Create homeassistant config directory & switch to it
 
 ```bash
 # mkdir /volume1/homeassistant
+# chown /volume1/homeassistant homeassistant
+# chmod 755 /volume1/homeassistant
 # cd /volume1/homeassistant
 ```
 Hint: alternatively you can also create a "Shared Folder" via Synology WebUI (e.g. via "File Station") - this has the advantage that the folder is visible via "File Station".
@@ -175,8 +177,8 @@ esac
 Create links to python folders to make things easier in the future:
 
 ```bash
-# ln -s /volume1/@appstore/py3k/usr/local/bin python3
-# ln -s /volume1/@appstore/py3k/usr/local/lib/python3.5/site-packages/homeassistant
+# ln -s /volume1/@appstore/py3k/usr/local/bin/python3 python3
+# ln -s /volume1/@appstore/py3k/usr/local/lib/python3.5/site-packages/homeassistant homeassistant
 ```
 
 Set the owner and permissions on your config folder


### PR DESCRIPTION
Fix symbolic links to python3 and homeassistant executable. Fix permissions and ownership to homeassistant directory to allow writing to home-assistant.log.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
