### PR TITLE
Add UV data_type

### DIFF
--- a/source/_components/sensor.rfxtrx.markdown
+++ b/source/_components/sensor.rfxtrx.markdown
@@ -66,6 +66,7 @@ Only these data_type are valid :
 - *Sound*
 - *Sensor Status*
 - *Counter value*
+- *UV*
 
 Example configuration:
 


### PR DESCRIPTION
**Description:** Add UV data_type to sensor.rfxtrx documentation page, as it was added to pyRFXtrx library some times ago.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
