### PR TITLE
Default recorder purge_interval to 1

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -36,11 +36,11 @@ recorder:
         required: false
         type: URL
       purge_keep_days:
-        description: Specify the number of history days to keep in recorder database after purge.
+        description: Specify the number of history days to keep in recorder database after a purge.
         required: false
         type: int
       purge_interval:
-        description: How often (in days) the purge task runs. If a scheduled purge is missed (e.g if Home Assistant was not running), the schedule will resume soon after Home Assistant restarts. You can use the [service](#service-purge) call `purge` when required without impacting the purge schedule.
+        description: How often (in days) the purge task runs. If a scheduled purge is missed (e.g., if Home Assistant was not running), the schedule will resume soon after Home Assistant restarts. You can use the [service](#service-purge) call `purge` when required without impacting the purge schedule.
         required: false
         default: 1
         type: int

--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -35,13 +35,15 @@ recorder:
         description: The URL which points to your database.
         required: false
         type: URL
-      purge_interval:
-        description: Enable scheduled purge of older events and states. The purge task runs every `purge_interval` days from when the `recorder component` is first enabled. If a scheduled purge is missed (e.g if Home Assistant was not running), the schedule will resume soon after Home Assistant restarts. You can use the [service](#service-purge) call `purge` when required without impacting the purge schedule. If `purge_interval` is set, `purge_keep_days` needs to be set as well.
-        required: Inclusive
-        type: int
       purge_keep_days:
-        description: Specify the number of history days to keep in recorder database after purge. If `purge_interval` is set, `purge_keep_days` needs to be set as well.
-        required: Inclusive
+        description: Specify the number of history days to keep in recorder database after purge.
+        required: false
+        type: int
+      purge_interval:
+        description:
+        How often (in days) the purge task runs. If a scheduled purge is missed (e.g if Home Assistant was not running), the schedule will resume soon after Home Assistant restarts. You can use the [service](#service-purge) call `purge` when required without impacting the purge schedule.
+        required: false
+        default: 1
         type: int
       exclude:
         description: Configure which components should be excluded
@@ -76,7 +78,6 @@ Define domains and entities to `exclude` (aka. blacklist). This is convenient wh
 ```yaml
 # Example configuration.yaml entry with exclude
 recorder:
-  purge_interval: 2
   purge_keep_days: 5
   db_url: sqlite:///home/user/.homeassistant/test
   exclude:

--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -40,8 +40,7 @@ recorder:
         required: false
         type: int
       purge_interval:
-        description:
-        How often (in days) the purge task runs. If a scheduled purge is missed (e.g if Home Assistant was not running), the schedule will resume soon after Home Assistant restarts. You can use the [service](#service-purge) call `purge` when required without impacting the purge schedule.
+        description: How often (in days) the purge task runs. If a scheduled purge is missed (e.g if Home Assistant was not running), the schedule will resume soon after Home Assistant restarts. You can use the [service](#service-purge) call `purge` when required without impacting the purge schedule.
         required: false
         default: 1
         type: int


### PR DESCRIPTION
**Description:**

Besides adding the new default I am also downplaying `purge_interval` a bit because changing it willy-nilly is probably a bad idea.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#11976

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/