### PR TITLE
Added hint to default virtual environment location

### DIFF
--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -52,7 +52,7 @@ _(If you're on a Debian based system, you will need to install Python virtual en
     ```
     $ cd homeassistant
     ```
- 3. Activate the virtual environment:
+ 3. Activate the virtual environment (typically /srv/homeassistant/):
     ```
     $ source bin/activate
     ```


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
