### PR TITLE
Update flux stop_time default.

### DIFF
--- a/source/_components/switch.flux.markdown
+++ b/source/_components/switch.flux.markdown
@@ -36,7 +36,7 @@ Configuration variables:
 - **lights** (*Required*) array: List of light entities.
 - **name** (*Optional*): The name to use when displaying this switch.
 - **start_time** (*Optional*): The start time. Default to sunrise.
-- **stop_time** (*Optional*): The stop time. Defaults to 22:00.
+- **stop_time** (*Optional*): The stop time. Defaults to dusk.
 - **start_colortemp** (*Optional*): The color temperature at the start. Defaults to `4000`.
 - **sunset_colortemp** (*Optional*): The sun set color temperature. Defaults to `3000`.
 - **stop_colortemp** (*Optional*): The color temperature at the end. Defaults to `1900`.


### PR DESCRIPTION
**Description:**

Updated docs for stop_time being set to dusk by default (needs below PR before merge!).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12062>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

