### PR TITLE
Add missing influxdb_migrator

### DIFF
--- a/source/_docs/tools/influxdb_migrator.markdown
+++ b/source/_docs/tools/influxdb_migrator.markdown
@@ -7,7 +7,6 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-redirect_from: /components/influxdb/#data-import-script
 ---
 
 Script to convert an old-structure Influx database to a new one.

--- a/source/_docs/tools/influxdb_migrator.markdown
+++ b/source/_docs/tools/influxdb_migrator.markdown
@@ -1,0 +1,40 @@
+---
+layout: page
+title: "influxdb_migrator"
+description: "Script to convert an old-structure Influx database to a new one."
+release_date: 2017-02-23 11:00:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+redirect_from: /components/influxdb/#data-import-script
+---
+
+Script to convert an old-structure Influx database to a new one.
+
+Example to run the script:
+
+```bash
+$ hass --script influxdb_migrator -H IP_INFLUXDB_HOST \
+    -u INFLUXDB_USERNAME -p INFLUXDB_PASSWORD \
+    --dbname INFLUXDB_DB_NAME
+```
+Script arguments:
+
+```
+optional arguments:
+  -h, --help            show this help message and exit
+  -d dbname, --dbname dbname
+                        InfluxDB database name
+  -H host, --host host  InfluxDB host address
+  -P port, --port port  InfluxDB host port
+  -u username, --username username
+                        InfluxDB username
+  -p password, --password password
+                        InfluxDB password
+  -s step, --step step  How many points to migrate at the same time
+  -o override_measurement, --override-measurement override_measurement
+                        Store all your points in the same measurement
+  -D, --delete          Delete old database
+```
+

--- a/source/_includes/asides/docs_navigation.html
+++ b/source/_includes/asides/docs_navigation.html
@@ -93,6 +93,7 @@
           <li>{% active_link /docs/tools/db_migrator/ db_migrator %}</li>
           <li>{% active_link /docs/tools/ensure_config/ ensure_config %}</li>
           <li>{% active_link /docs/tools/influxdb_import/ influxdb_import %}</li>
+          <li>{% active_link /docs/tools/influxdb_migrator/ influxdb_migrator %}</li>
           <li>{% active_link /docs/tools/keyring/ keyring %}</li>
         </ul>
       </li>


### PR DESCRIPTION
**Description:**
Add missing influxdb_migrator script

I missed that script in #4554.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
