### PR TITLE
Changed note about base url

### DIFF
--- a/source/_components/tts.markdown
+++ b/source/_components/tts.markdown
@@ -22,6 +22,10 @@ tts:
   - platform: google
 ```
 
+<p class='note'>
+If you are running Home Assistant over SSL or from within a container, you will have to setup a base URL (`base_url`) inside the [http component](/components/http/).
+</p>
+
 The following optional parameters can be used with any platform. However the TTS component will only look for global settings under the configuration of the first configured platform:
 
 | Parameter           | Default | Description                                                                                                                                                                                                                                                                                                                                                                               |
@@ -40,10 +44,6 @@ tts:
     cache_dir: /tmp/tts
     time_memory: 300
 ```
-
-<p class='note'>
-If you are running Home Assistant over SSL or from within a container, you will have to setup a base URL (`base_url`) inside the [http component](/components/http/).
-</p>
 
 ## {% linkable_title Service say %}
 

--- a/source/_components/tts.markdown
+++ b/source/_components/tts.markdown
@@ -23,16 +23,16 @@ tts:
 ```
 
 <p class='note'>
-If you are running Home Assistant over SSL or from within a container, you will have to setup a base URL (`base_url`) inside the [http component](/components/http/).
+Depending on your setup, you might need to set a base URL (`base_url`) inside the [http component](/components/http/).
 </p>
 
-The following optional parameters can be used with any platform. However the TTS component will only look for global settings under the configuration of the first configured platform:
+The following optional parameters can be used with any platform. However, the TTS component will only look for global settings under the configuration of the first configured platform:
 
 | Parameter           | Default | Description                                                                                                                                                                                                                                                                                                                                                                               |
 |---------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `cache` | True    | Allow TTS to cache voice file to local storage. |
-| `cache_dir`  | tts      | Folder name or path to folder for caching files. |
-| `time_memory`     | 300     | Time to hold the voice data inside memory for fast play on media player. Minimum is 60 s and the maximum 57600 s (16 hours). |
+| `cache_dir`  | tts      | Folder name or path to a folder for caching files. |
+| `time_memory`     | 300     | Time to hold the voice data inside memory for fast play on a media player. Minimum is 60 s and the maximum 57600 s (16 hours). |
 
 The extended example from above would look like the following sample:
 
@@ -47,7 +47,7 @@ tts:
 
 ## {% linkable_title Service say %}
 
-The `say` service support `language` and on some platforms also `options` for set i.e. *voice, motion, speed, etc*. The text for speech is set with `message`.
+The `say` service support `language` and on some platforms also `options` for set, i.e., *voice, motion, speed, etc*. The text for speech is set with `message`.
 
 Say to all `media_player` device entities:
 


### PR DESCRIPTION
Changed the location to be above the fold

**Description:**

I have noticed a few threads in the home assistant community where people have made this mistake of not configuring their base url when trying to get TTS to work, I think its quite easy to miss since you can just add the two line config at the top and it will appear to give you something.

Not a major change but thought it might help others :+1: 

home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
