### PR TITLE
Adding quotes for the "login attempts" command

### DIFF
--- a/source/_components/sensor.command_line.markdown
+++ b/source/_components/sensor.command_line.markdown
@@ -81,7 +81,7 @@ If you'd like to know how many failed login attempts are made to Home Assistant,
 sensor:
   - platform: command_line
     name: badlogin
-    command: grep -c 'Login attempt' /home/hass/.homeassistant/home-assistant.log
+    command: "grep -c 'Login attempt' /home/hass/.homeassistant/home-assistant.log"
 ```
 
 Make sure to configure the [logger component](/components/logger) to monitor the [http component](https://home-assistant.io/components/http/) at least the `warning` level.


### PR DESCRIPTION
In hass.io installation, the command value must be quoted.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
