### PR TITLE
Remove note about differing entity_ids for System Monitor component

### DIFF
--- a/source/_components/sensor.systemmonitor.markdown
+++ b/source/_components/sensor.systemmonitor.markdown
@@ -65,7 +65,7 @@ The table contains types and their argument to use in your `configuration.yaml` 
 | Sensor type         | Entity ID                |
 | :------------------ |:-------------------------|
 | memory_free         | sensor.ram_available     |
-| memory_use_percent  | sensor.ram_used          |
+| memory_use_percent  | sensor.ram_used_percent  |
 | processor_use       | sensor.cpu_used          |
 | disk_use            | sensor.disk_used         |
 

--- a/source/_components/sensor.systemmonitor.markdown
+++ b/source/_components/sensor.systemmonitor.markdown
@@ -65,7 +65,7 @@ The table contains types and their argument to use in your `configuration.yaml` 
 | Sensor type         | Entity ID                |
 | :------------------ |:-------------------------|
 | memory_free         | sensor.ram_available     |
-| memory_use_percent  | sensor.ram_used_percent  |
+| memory_use_percent  | sensor.memory_use_percent  |
 | processor_use       | sensor.cpu_used          |
 | disk_use            | sensor.disk_used         |
 

--- a/source/_components/sensor.systemmonitor.markdown
+++ b/source/_components/sensor.systemmonitor.markdown
@@ -60,15 +60,6 @@ The table contains types and their argument to use in your `configuration.yaml` 
 | last_boot           |                           |
 | since_last_boot     |                           |
 
-**Note**: Some `type:` names used in the `configuration.yaml` file differ from the entity names.
-
-| Sensor type         | Entity ID                |
-| :------------------ |:-------------------------|
-| memory_free         | sensor.ram_available     |
-| memory_use_percent  | sensor.memory_use_percent  |
-| processor_use       | sensor.cpu_used          |
-| disk_use            | sensor.disk_used         |
-
 ## {% linkable_title Linux specific %}
 
 To retrieve all available network interfaces on a Linux System, execute the `ifconfig` command.


### PR DESCRIPTION
**Description:**
Required small update since home-assistant/home-assistant#12124 got merged.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12124

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
