### PR TITLE
Add market restriction note

### DIFF
--- a/source/_components/mercedesme.markdown
+++ b/source/_components/mercedesme.markdown
@@ -21,6 +21,10 @@ This component provides the following platforms:
  - Sensors - such as fuel status, service interval, remaining km...
  - Device tracker - to track location of your car
 
+<p class='note warning'>
+  The component can integrate cars out of the European and Africa markets only.  
+</p>
+
 To use Mercedes me in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -29,7 +33,6 @@ mercedesme:
   username: email
   password: password
 ```
-
 
 {% configuration %}
 username:


### PR DESCRIPTION
**Description:**
Add a note that the component can integrate cars in Europe and Africa only currently.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
