### PR TITLE
Fix Typo in mercedesme.markdown

### DIFF
--- a/source/_components/mercedesme.markdown
+++ b/source/_components/mercedesme.markdown
@@ -22,7 +22,7 @@ This component provides the following platforms:
  - Device tracker - to track location of your car
 
 <p class='note warning'>
-  The component can integrate cars out of the European and Africa markets only.  
+  The component can integrate cars out of the European and African markets only.  
 </p>
 
 To use Mercedes me in your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**
Fix Typo. Based on after merge comment from @Landrash (#4571)

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
