### PR TITLE
Added Hint to Unpack the file

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -16,6 +16,8 @@ Hass.io images are available for all available Raspberry Pi and Intel NUC platfo
   - [Raspberry Pi 2][pi2]
   - [Raspberry Pi 3][pi3]
   - [Intel NUC][nuc]
+
+- Unpack the .bz2 File
 - Flash the downloaded image to an SD card using [Etcher].
 - Optional - Setup the WiFi or static IP: On the SD-card, edit the `system-connections/resin-sample` file and follow the [ResinOS howto][resinos-network].
 - Insert SD card to Raspberry Pi and turn it on. On first boot, it downloads the latest version of Home Assistant which takes ~20 minutes (slower/faster depending on the platform).


### PR DESCRIPTION
Flashing will stop if you try to flash the .img.bz2 file directly on MacOS

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
