### PR TITLE
Adds folder sensor

### DIFF
--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "folder sensor"
+title: "Folder sensor"
 description: "Sensor for monitoring the contents of a folder."
 date: 2018-02-21 14:00
 sidebar: true
@@ -14,6 +14,8 @@ ha_release: 0.64
 ---
 
 Sensor for monitoring the contents of a folder. Note that folder paths must be added to [whitelist_external_dirs](https://home-assistant.io/docs/configuration/basic/). Optionally a [wildcard filter]((http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm)) can be applied to the files considered within the folder. The state of the sensor is the size in MB of files within the folder that meet the filter criteria. The number of filtered files in the folder and total size in bytes of those files are exposed as attributes.
+
+To enable the `folder` sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 sensor:

--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -22,8 +22,6 @@ sensor:
     folder: /config
 ```
 
-Configuration variables:
-
 {% configuration %}
 folder:
   description: The folder path

--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -1,8 +1,8 @@
 ---
 layout: page
 title: "folder sensor"
-description: "Component for monitoring the contents of a folder."
-date: 2018-02-06 14:00
+description: "Sensor for monitoring the contents of a folder."
+date: 2018-02-21 14:00
 sidebar: true
 comments: false
 sharing: true
@@ -10,16 +10,18 @@ footer: true
 logo: file.png
 ha_category: Sensor
 ha_iot_class: "Local Polling"
-ha_release: 0.63
+ha_release: 0.64
 ---
 
-Component for monitoring the contents of a folder. Note that folder paths must be added to [whitelist_external_dirs](https://home-assistant.io/docs/configuration/basic/). The state of the sensor is the time that the most recently modified file in a folder was modified. The use case is detecting when a file in a folder is created or updated. The number of files in the folder and the names of those files are exposed as attributes. Optionally a [wildcard filter]((http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm) ) can be applied to the files considered.
+Sensor for monitoring the contents of a folder. Optionally a [wildcard filter]((http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm)) can be applied to the files considered. The state of the sensor is the size in MB of files within the folder that meet the filter criteria. The number of files in the folder and total size in bytes of those files are exposed as attributes.
 
 ```yaml
 sensor:
   - platform: folder
     folder: /config
 ```
+
+Configuration variables:
 
 {% configuration %}
 folder:

--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -21,8 +21,6 @@ sensor:
     folder: /config
 ```
 
-Configuration variables:
-
 {% configuration %}
 folder:
   description: The folder path

--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -13,19 +13,25 @@ ha_iot_class: "Local Polling"
 ha_release: 0.63
 ---
 
-Home-assistant component for monitoring the contents of a folder.
-The state of the sensor is the time that the most recently modified file in a folder was modified. The use case is detecting when a file in a folder is created or updated. The number of files in the folder and the names of those files are exposed as attributes. Optionally a filter can be applied to the files considered.
+Component for monitoring the contents of a folder.
+The state of the sensor is the time that the most recently modified file in a folder was modified. The use case is detecting when a file in a folder is created or updated. The number of files in the folder and the names of those files are exposed as attributes. Optionally a [wildcard filter]((http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm) ) can be applied to the files considered.
 
 ```yaml
 sensor:
-  - platform: folder
-    folder: /share/motion
-    filter: '*capture.jpg'
   - platform: folder
     folder: /config
 ```
 
 Configuration variables:
 
-- **folder** (*Required*): The folder path
-- **filter** (*Optional*): Optional filter
+{% configuration %}
+folder:
+  description: The folder path
+  required: true
+  type: string
+filter:
+  description: Filter to apply
+  required: false
+  default: `*`
+  type: string
+{% endconfiguration %}

--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -13,7 +13,7 @@ ha_iot_class: "Local Polling"
 ha_release: 0.64
 ---
 
-Sensor for monitoring the contents of a folder. Optionally a [wildcard filter]((http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm)) can be applied to the files considered. The state of the sensor is the size in MB of files within the folder that meet the filter criteria. The number of files in the folder and total size in bytes of those files are exposed as attributes.
+Sensor for monitoring the contents of a folder. Note that folder paths must be added to [whitelist_external_dirs](https://home-assistant.io/docs/configuration/basic/). Optionally a [wildcard filter]((http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm)) can be applied to the files considered within the folder. The state of the sensor is the size in MB of files within the folder that meet the filter criteria. The number of filtered files in the folder and total size in bytes of those files are exposed as attributes.
 
 ```yaml
 sensor:

--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -31,6 +31,6 @@ folder:
 filter:
   description: Filter to apply
   required: false
-  default: `*`
+  default: "`*`"
   type: string
 {% endconfiguration %}

--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -13,8 +13,7 @@ ha_iot_class: "Local Polling"
 ha_release: 0.63
 ---
 
-Component for monitoring the contents of a folder.
-The state of the sensor is the time that the most recently modified file in a folder was modified. The use case is detecting when a file in a folder is created or updated. The number of files in the folder and the names of those files are exposed as attributes. Optionally a [wildcard filter]((http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm) ) can be applied to the files considered.
+Component for monitoring the contents of a folder. Note that folder paths must be added to [whitelist_external_dirs](https://home-assistant.io/docs/configuration/basic/). The state of the sensor is the time that the most recently modified file in a folder was modified. The use case is detecting when a file in a folder is created or updated. The number of files in the folder and the names of those files are exposed as attributes. Optionally a [wildcard filter]((http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm) ) can be applied to the files considered.
 
 ```yaml
 sensor:

--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -1,0 +1,31 @@
+---
+layout: page
+title: "folder sensor"
+description: "Component for monitoring the contents of a folder."
+date: 2018-02-06 14:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: file.png
+ha_category: Sensor
+ha_iot_class: "Local Polling"
+ha_release: 0.63
+---
+
+Home-assistant component for monitoring the contents of a folder.
+The state of the sensor is the time that the most recently modified file in a folder was modified. The use case is detecting when a file in a folder is created or updated. The number of files in the folder and the names of those files are exposed as attributes. Optionally a filter can be applied to the files considered.
+
+```yaml
+sensor:
+  - platform: folder
+    folder: /share/motion
+    filter: '*capture.jpg'
+  - platform: folder
+    folder: /config
+```
+
+Configuration variables:
+
+- **folder** (*Required*): The folder path
+- **filter** (*Optional*): Optional filter


### PR DESCRIPTION
**Description:**
Home-assistant component for monitoring the contents of a folder.
The state of the sensor is the time that the most recently modified file in a folder was modified. The use case is detecting when a file in a folder is created or updated. The number of files in the folder and the names of those files are exposed as attributes. Optionally a filter can be applied to the files considered.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant/pull/12208) (if applicable):** home-assistant/home-assistant#12208

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
