### PR TITLE
Clarifying hdmi_cec instructions to include _cec.so

### DIFF
--- a/source/_components/hdmi_cec.markdown
+++ b/source/_components/hdmi_cec.markdown
@@ -31,29 +31,37 @@ If you are using [Hass.io](/hassio/) then just move forward to the configuration
 
 #### {% linkable_title Symlinking into virtual environment %}
 
-Create a symlink to the `cec` installation. Keep in mind different installation methods will result in different locations of cec.
+Create a symlink to the `cec` installation including the _cec.so file. Keep in mind different installation methods will result in different locations of cec.
  
 ```bash
 $ ln -s /path/to/your/installation/of/cec /path/to/your/venv/lib/python3.4/site-packages
+$ ln -s /path/to/your/installation/of/_cec.so /path/to/your/venv/lib/python3.4/site-packages
+
 ```
+
 ##### {% linkable_title Symlinking examples: %}
 
 For the default virtual environment of a [HASSbian Image for Raspberry Pi](/getting-started/installation-raspberry-pi-image/) the command would be as follows.
 
 ```bash
 $ ln -s /usr/local/lib/python3.4/dist-packages/cec /srv/homeassistant/lib/python3.4/site-packages
+$ ln -s /usr/local/lib/python3.4/dist-packages/_cec.so /srv/homeassistant/lib/python3.4/site-packages
+
 ```
 
 For the default virtual environment of a [Raspberry Pi All-In-One installation](/getting-started/installation-raspberry-pi-all-in-one/) the command would be as follows.
 
 ```bash
 $ ln -s /usr/local/lib/python3.4/site-packages/cec /srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages
+$ ln -s /usr/local/lib/python3.4/site-packages/_cec.so /srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages
+
 ```
 
 For the default virtual environment of a [Manual installation](/getting-started/installation-raspberry-pi/) the command would be as follows.
 
 ```bash
 $ ln -s /usr/local/lib/python3.4/site-packages/cec /srv/hass/hass_venv/lib/python3.4/site-packages
+$ ln -s /usr/local/lib/python3.4/site-packages/_cec.so /srv/hass/hass_venv/lib/python3.4/site-packages
 ```
 
 

--- a/source/_components/hdmi_cec.markdown
+++ b/source/_components/hdmi_cec.markdown
@@ -34,8 +34,8 @@ If you are using [Hass.io](/hassio/) then just move forward to the configuration
 Create a symlink to the `cec` installation including the _cec.so file. Keep in mind different installation methods will result in different locations of cec.
  
 ```bash
-$ ln -s /path/to/your/installation/of/cec /path/to/your/venv/lib/python3.4/site-packages
-$ ln -s /path/to/your/installation/of/_cec.so /path/to/your/venv/lib/python3.4/site-packages
+$ ln -s /path/to/your/installation/of/cec /path/to/your/venv/lib/python*/site-packages
+$ ln -s /path/to/your/installation/of/_cec.so /path/to/your/venv/lib/python*/site-packages
 
 ```
 
@@ -44,26 +44,10 @@ $ ln -s /path/to/your/installation/of/_cec.so /path/to/your/venv/lib/python3.4/s
 For the default virtual environment of a [HASSbian Image for Raspberry Pi](/getting-started/installation-raspberry-pi-image/) the command would be as follows.
 
 ```bash
-$ ln -s /usr/local/lib/python3.4/dist-packages/cec /srv/homeassistant/lib/python3.4/site-packages
-$ ln -s /usr/local/lib/python3.4/dist-packages/_cec.so /srv/homeassistant/lib/python3.4/site-packages
+$ ln -s /usr/local/lib/python*/dist-packages/cec /srv/homeassistant/lib/python*/site-packages
+$ ln -s /usr/local/lib/python*/dist-packages/_cec.so /srv/homeassistant/lib/python*/site-packages
 
 ```
-
-For the default virtual environment of a [Raspberry Pi All-In-One installation](/getting-started/installation-raspberry-pi-all-in-one/) the command would be as follows.
-
-```bash
-$ ln -s /usr/local/lib/python3.4/site-packages/cec /srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages
-$ ln -s /usr/local/lib/python3.4/site-packages/_cec.so /srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages
-
-```
-
-For the default virtual environment of a [Manual installation](/getting-started/installation-raspberry-pi/) the command would be as follows.
-
-```bash
-$ ln -s /usr/local/lib/python3.4/site-packages/cec /srv/hass/hass_venv/lib/python3.4/site-packages
-$ ln -s /usr/local/lib/python3.4/site-packages/_cec.so /srv/hass/hass_venv/lib/python3.4/site-packages
-```
-
 
 <p class='note'>If after symlinking and adding `hdmi_cec:` to your configuration you are getting the following error in your logs, 
 `* failed to open vchiq instance` you will also need to add the user account Home Assistant runs under, to the `video` group. To add the Home Assistant user account to the `video` group, run the following command. `$ usermod -a -G video <hass_user_account>`


### PR DESCRIPTION
**Description:**
Current instructions may result in a [configuration error](https://community.home-assistant.io/t/fresh-install-and-no-module-named-cec/27291).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
