### PR TITLE
Added note about display in Overview

### DIFF
--- a/source/_components/script.markdown
+++ b/source/_components/script.markdown
@@ -112,3 +112,9 @@ script:
           title: "{% raw %}{{ title }}{% endraw %}"
           message: "{% raw %}{{ message }}{% endraw %}"
 ```
+
+### {% linkable_title In the Overview %}
+
+Scripts in the Overview panel will be displayed with an **ACTIVATE** button if the device has no `delay:` or `wait:` statement, and as a toggle switch if it has either of those.
+
+This is to enable you to stop a running script.


### PR DESCRIPTION
It's come up quite a few times, with people asking why some scripts have a toggle, and some don't. This is to add a little clarity about it (I'm **assuming** that `wait` also results in a toggle - it'd be good to get that verified).