### PR TITLE
Document new turn_on_action for philips TV

### DIFF
--- a/source/_components/media_player.philips_js.markdown
+++ b/source/_components/media_player.philips_js.markdown
@@ -29,3 +29,4 @@ Configuration variables:
 
 - **host** (*Required*): IP address of TV.
 - **name** (*Optional*): The name you would like to give to the Philips TV.
+- **turn_on_action** (*Optional*): A script that will be executed to turn on the TV (can be used with wol).


### PR DESCRIPTION
This got added in home-assistant/home-assistant/pull/12065

**Description:**
Document new turn_on_action for Philips TV

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12065

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
