### PR TITLE
Return of entity_id in template platforms

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -48,6 +48,10 @@ binary_sensor:
             description: Name to use in the frontend.
             required: false
             type: string
+          entity_id:
+            description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
+            required: false
+            type: string, list
           device_class:
             description: The type/class of the sensor to set the icon in the frontend.
             required: false

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -48,6 +48,10 @@ cover:
         description: Name to use in the frontend.
         required: false
         type: string
+      entity_id:
+        description: A list of entity IDs so the cover only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
+        required: false
+        type: [string, list]
       value_template:
         description: Defines a template to get the state of the cover. Valid values are `open`/`true` or `closed`/`false`. [`value_template`](#value_template) and [`position_template`](#position_template) cannot be specified concurrently.
         required: exclusive
@@ -197,6 +201,9 @@ cover:
           {% else %}
             mdi:window-closed
           {% endif %}
+        entity_id:
+          - cover.bedroom
+          - cover.livingroom
 
 sensor:
   - platform: template

--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -51,6 +51,10 @@ light:
         description: Name to use in the frontend.
         required: false
         type: string
+      entity_id:
+        description: A list of entity IDs so the light only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
+        required: false
+        type: [string, list]
       value_template:
         description: Defines a template to get the state of the light.
         required: false

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -45,6 +45,10 @@ sensor:
         description: Name to use in the frontend.
         required: false
         type: string
+      entity_id:
+        description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
+        required: false
+        type: string, list
       unit_of_measurement:
         description: Defines the units of measurement of the sensor, if any.
         required: false

--- a/source/_components/switch.template.markdown
+++ b/source/_components/switch.template.markdown
@@ -55,6 +55,10 @@ switch:
         description: Name to use in the frontend.
         required: false
         type: string
+      entity_id:
+        description: A list of entity IDs so the switch only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
+        required: false
+        type: [string, list]
       value_template:
         description: Defines a template to set the state of the switch.
         required: true


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12234

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
