### PR TITLE
adding supported domains for Google Assistant component

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -107,6 +107,19 @@ entity_config:
           type: string
 {% endconfiguration %}
 
+### {% linkable_title Available domains %}
+Currently, the following domains are available to be used with Google Assistant, listed with their default types:
+
+- group = switch (on/off)
+- scene = scene (on)
+- script = scene (on)
+- switch = switch (on/off)
+- fan = switch (on/off)
+- light = light (on/off/brightness/rgb color/color temp)
+- cover = switch (on/off/set position (brightness) )
+- media_player = switch (on/off/set volume (brightness) )
+- climate = thermostat (temperature setting)
+
 It's very important that you use very long strings for `client_id` and `access_token`. Those are essentially the credentials to your Home Assistant instance. You can generate them with the following command:
 
 ```bash


### PR DESCRIPTION
ref: https://github.com/home-assistant/home-assistant.github.io/issues/4036

Adds supported domains and default mappings.

**Description:**
Not sure if this is the best position for the info, or if mappings should be included. Does anyone have an opinion?

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
