### PR TITLE
Add sharing images between HASS instances

### DIFF
--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -69,9 +69,9 @@ camera:
     still_image_url: https://127.0.0.1:8123/local/your_image.png
 ```
 
-### {% linkable_title Sharing a camera feed from one home-assistant instance to another%}
+### {% linkable_title Sharing a camera feed from one Home Assistant instance to another %}
 
-If you are running more than one home-assistant instance (lets call them the 'host' and 'receiver' instances) you may wish to display the camera feed from the host instance on the receiver instance. You can use the [REST API](https://home-assistant.io/developers/rest_api/#get-apicamera_proxycameraltentity_id) to access the camera feed on the host (IP address 127.0.0.5) and display it on the receiver instance by configuring the receiver with the the following:
+If you are running more than one Home Assistant instance (let's call them the 'host' and 'receiver' instances) you may wish to display the camera feed from the host instance on the receiver instance. You can use the [REST API](/developers/rest_api/#get-apicamera_proxycameraltentity_id) to access the camera feed on the host (IP address 127.0.0.5) and display it on the receiver instance by configuring the receiver with the the following:
 
 ```yaml
 camera:

--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -68,3 +68,14 @@ camera:
     name: Some Image
     still_image_url: https://127.0.0.1:8123/local/your_image.png
 ```
+
+### {% linkable_title Sharing a camera feed from one home-assistant instance to another%}
+
+If you are running more than one home-assistant instance (lets call them the 'host' and 'receiver' instances) you may wish to display the camera feed from the host instance on the receiver instance. You can use the [REST API](https://home-assistant.io/developers/rest_api/#get-apicamera_proxycameraltentity_id) to access the camera feed on the host (IP address 127.0.0.5) and display it on the receiver instance by configuring the receiver with the the following:
+
+```yaml
+camera:
+  - platform: generic
+    name: Host instance camera feed
+    still_image_url: https://127.0.0.5:8123/api/camera_proxy/camera.live_view
+```


### PR DESCRIPTION
Adds description of how to share camera feeds between multiple home-assistant instances using the REST API.
