### PR TITLE
add documentation for "shared_gpio" flag to component switch.rpi_gpio

### DIFF
--- a/source/_components/switch.rpi_gpio.markdown
+++ b/source/_components/switch.rpi_gpio.markdown
@@ -32,6 +32,7 @@ Configuration variables:
 - **ports** array (*Required*): Array of used ports.
   - **port: name** (*Required*): Port numbers and corresponding names (GPIO #).
 - **invert_logic** (*Optional*): If true, inverts the output logic to ACTIVE LOW. Default is false (ACTIVE HIGH).
+- **shared_gpio** (*Optional*): If true, forces a GPIO.setup() before each write. Default is false.
 
 For more details about the GPIO layout, visit the Wikipedia [article](https://en.wikipedia.org/wiki/Raspberry_Pi#GPIO_connector) about the Raspberry Pi.
 
@@ -46,4 +47,14 @@ switch:
       17: Speaker Relay
 ```
 
+In case you have any other python scripts running that use RPi.GPIO no values will be written after the initial HASS-start.
+Setting **shared_gpio** to true will reinit the pin before each write, working around this issue.
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: rpi_gpio
+    shared_gpio: true
+    ports:
+      19: LED-Red
+```
 


### PR DESCRIPTION
**Description:**
Adds documentation for the "shared_gpio" flag in component.switch.rpi_gpio

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#12255

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
