### PR TITLE
Added single quotes around format value

### DIFF
--- a/source/_components/tts.voicerss.markdown
+++ b/source/_components/tts.voicerss.markdown
@@ -41,7 +41,7 @@ tts:
     api_key: 'XXXXX'
     language: 'de-de'
     codec: mp3
-    format: 8khz_8bit_mono
+    format: '8khz_8bit_mono'
 ```
 
 Please note, some media_players require a certain format. For example the Sonos requires a format of '44khz_16bit_stereo'


### PR DESCRIPTION
The service wont work without these

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
