### PR TITLE
Updated temperature max/min to high/low

### DIFF
--- a/source/_components/sensor.darksky.markdown
+++ b/source/_components/sensor.darksky.markdown
@@ -102,10 +102,10 @@ Configuration variables:
   - **minutely_summary**: A human-readable text summary for the next hour.
   - **hourly_summary**: A human-readable text summary for the next 24 hours.
   - **daily_summary**: A human-readable text summary for the next 7 days.
-  - **temperature_max**: Today's expected high temperature.
-  - **temperature_min**: Today's expected low temperature.
-  - **apparent_temperature_max**: Today's expected apparent high temperature.
-  - **apparent_temperature_min**: Today's expected apparent low temperature.
+  - **temperature_high**: Today's daytime expected high temperature.
+  - **temperature_low**: Today's overnight expected low temperature.
+  - **apparent_temperature_high**: Today's daytime expected apparent high temperature.
+  - **apparent_temperature_low**: Today's overnight expected apparent low temperature.
   - **precip_intensity_max**: Today's expected maximum intensity of precipitation.
   - **uv_index**: The current UV index.
 - **units** (*Optional*): Specify the unit system. Default to `si` or `us` based on the temperature preference in Home Assistant. Other options are `auto`, `us`, `si`, `ca`, `uk` and `uk2`.


### PR DESCRIPTION
**Description:**
removed the old max/min for temperature because they are deprecated on the dark sky api documentation. Replaced with high/low.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12233

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
