### PR TITLE
Clarify distribution of random values

### DIFF
--- a/source/_components/sensor.random.markdown
+++ b/source/_components/sensor.random.markdown
@@ -14,7 +14,7 @@ ha_release: 0.32
 ---
 
 
-The `random` sensor platform is creating random sensor values (integers) out of a given range. This can be useful if you want to test automation rules. It generates a new value every time it is polled.
+The `random` sensor platform is creating random sensor values (integers) out of a given range. Returned values form a [discrete uniform distribution](https://en.wikipedia.org/wiki/Discrete_uniform_distribution), meaning that each integer value in the range configured is equally likely to be drawn. This can be useful if you want to test automation rules. It generates a new value every time it is polled.
 
 To enable the random sensor, add the following lines to your `configuration.yaml`:
 


### PR DESCRIPTION
Clarify that values drawn produce a discrete uniform distribution, and not for example a normal (or bell shaped) distribution. I intend to implement a random physics sensor which will return a bell distribution and this edit will avoid confusion.