### PR TITLE
sensor.alpha_vantage: removed Google as default stock

### DIFF
--- a/source/_components/sensor.alpha_vantage.markdown
+++ b/source/_components/sensor.alpha_vantage.markdown
@@ -14,7 +14,7 @@ featured: false
 ha_release: "0.60"
 ---
 
-The `alpha_vantage` sensor platform uses [Alpha Vantage](https://www.alphavantage.co) to monitor the stock market.
+The `alpha_vantage` sensor platform uses [Alpha Vantage](https://www.alphavantage.co) to monitor the stock market. This platform also provides detail about exchange rates.
 
 To enable the `alpha_vantage` platform, add the following lines to your `configuration.yaml` file:
 
@@ -25,7 +25,7 @@ sensor:
     api_key: YOUR_API_KEY
     symbols:
     - symbol: GOOGL
-      name: Google_stock
+      name: Google
     foreign_exchange:
     - name: USD_EUR
       from: USD

--- a/source/_components/sensor.alpha_vantage.markdown
+++ b/source/_components/sensor.alpha_vantage.markdown
@@ -33,7 +33,6 @@ api_key:
 symbols:
   description: List of stock market symbols for given companies.
   required: false
-  default: GOOGL
   type: map
   keys:
     name:

--- a/source/_components/sensor.alpha_vantage.markdown
+++ b/source/_components/sensor.alpha_vantage.markdown
@@ -23,7 +23,16 @@ To enable the `alpha_vantage` platform, add the following lines to your `configu
 sensor:
   - platform: alpha_vantage
     api_key: YOUR_API_KEY
+    symbols:
+    - symbol: GOOGL
+      name: Google_stock
+    foreign_exchange:
+    - name: USD_EUR
+      from: USD
+      to: EUR
 ```
+
+Either a symbol or a foreign exchange must be configured, otherwise you will not get any data.
 
 {% configuration %}
 api_key:


### PR DESCRIPTION
**Description:**
after the change to the code, we also need to remove the default stock Google from the documentation

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12252

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
