### PR TITLE
Add a Python program to print the correct code sequence for compliant devices

### DIFF
--- a/source/_docs/z-wave/control-panel.markdown
+++ b/source/_docs/z-wave/control-panel.markdown
@@ -130,6 +130,23 @@ If your node has user codes, you can set and delete them. The format is raw hex 
 Some non compliant device like tag readers, have implemented to use raw hex code.
 Please refer to a hex ascii table to set your code. Example: http://www.asciitable.com/
 
+Here is a small Python program than will take numbers on the command line and print the correct sequence for compliant devices:
+```python
+#! /usr/bin/python3
+
+import sys
+
+translations = {}
+
+for x in range(0, 10):
+    translations["%s" % x] = "\\x3%s" % x
+
+for c in sys.argv[1]:
+    print(translations[c], end='')
+
+print()
+```
+
 
 ## {% linkable_title OZW Log %}
 

--- a/source/_docs/z-wave/control-panel.markdown
+++ b/source/_docs/z-wave/control-panel.markdown
@@ -131,9 +131,9 @@ Some non compliant device like tag readers, have implemented to use raw hex code
 Please refer to a hex ascii table to set your code. Example: http://www.asciitable.com/
 
 Here is a small Python program than will take numbers on the command line and print the correct sequence for compliant devices:
+
 ```python
 #! /usr/bin/python3
-
 import sys
 
 translations = {}
@@ -143,10 +143,7 @@ for x in range(0, 10):
 
 for c in sys.argv[1]:
     print(translations[c], end='')
-
-print()
 ```
-
 
 ## {% linkable_title OZW Log %}
 


### PR DESCRIPTION
**Description:**

Add a Python program to print the correct code sequence for compliant devices.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
