### PR TITLE
Updated Google calendar documentation

### DIFF
--- a/source/_components/calendar.google.markdown
+++ b/source/_components/calendar.google.markdown
@@ -28,6 +28,7 @@ Generate a Client ID and Client Secret on [Google Developers Console](https://co
 1. Click 'Create credentials' -> OAuth client ID.
 1. Set the Application type to 'Other' and give this credential set a name then click Create.
 1. Save the client ID and secret as you will need to put these in your configuration.yaml file.
+1. Click on "Library", search for "Google Calendar API" and enable it.
 
 ### {% linkable_title Basic Setup %}
 


### PR DESCRIPTION
**Description:**


The documentation was missing the step to enable the calendar API. It this step is not completed, the following error appears in the log:  Encountered 403 Forbidden with reason "accessNotConfigured"

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
