### PR TITLE
Update emulated_hue with info about initial device

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -29,6 +29,10 @@ A physical Hue Bridge is required for Philips Hue lights to function - this virt
 It is recommended to assign a static IP address to the computer running Home Assistant. This is because the Amazon Echo discovers devices by IP addresses, and if the IP changes, the Echo won't be able to control it. This is easiest done from your router, see your router's manual for details.
 </p>
 
+<p class='note'>
+Both Google Home and Alexa devices communicate through the device they were initially set up with, so if that device is removed from the network, emulated_hue will cease to fnction unless it is re-added. (See [this thread](https://community.home-assistant.io/t/41839))
+</p>
+
 ### {% linkable_title Configuration %}
 
 To enable the emulated Hue bridge, add one of the following configs to your `configuration.yaml` file:

--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -30,7 +30,7 @@ It is recommended to assign a static IP address to the computer running Home Ass
 </p>
 
 <p class='note'>
-Both Google Home and Alexa devices communicate through the device they were initially set up with, so if that device is removed from the network, emulated_hue will cease to fnction unless it is re-added. (See [this thread](https://community.home-assistant.io/t/41839/5))
+Both Google Home and Alexa use the device they were initially set up with for communication with emulated_hue. In other words: if you remove/replace this device you will also break emulated_hue.
 </p>
 
 ### {% linkable_title Configuration %}

--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -30,7 +30,7 @@ It is recommended to assign a static IP address to the computer running Home Ass
 </p>
 
 <p class='note'>
-Both Google Home and Alexa devices communicate through the device they were initially set up with, so if that device is removed from the network, emulated_hue will cease to fnction unless it is re-added. (See [this thread](https://community.home-assistant.io/t/41839))
+Both Google Home and Alexa devices communicate through the device they were initially set up with, so if that device is removed from the network, emulated_hue will cease to fnction unless it is re-added. (See [this thread](https://community.home-assistant.io/t/41839/5))
 </p>
 
 ### {% linkable_title Configuration %}


### PR DESCRIPTION
**Description:**
Add a note about the need to keep the device that connected to emulated_hue online

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** 

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
