### PR TITLE
Fix URL in Mercedes me binary sensor documentation

### DIFF
--- a/source/_components/binary_sensor.mercedesme.markdown
+++ b/source/_components/binary_sensor.mercedesme.markdown
@@ -17,4 +17,4 @@ The `Mercedes me` platform allows you to get data from your [Mercedes me connect
 
 They will be automatically discovered if the Mercedes me component is loaded.
 
-For more configuration information see the [Mercedes me component](/components/mercedes me/) documentation.
+For more configuration information see the [Mercedes me component](/components/mercedesme/) documentation.


### PR DESCRIPTION
**Description:**
Fix a broken link in the Mercedes Me binary sensor documentation.
Link should redirect to the main Mercedes Me component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
