### PR TITLE
add doc for zha fans

### DIFF
--- a/source/_components/fan.zha.markdown
+++ b/source/_components/fan.zha.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: zigbee.png
 ha_category: Fan
 ha_iot_class: "Local Polling"
+ha_release: 0.66
 ---
 
 To get your ZigBee fans working with Home Assistant, follow the instructions for the general [ZigBee Home Automation component](/components/zha/).

--- a/source/_components/fan.zha.markdown
+++ b/source/_components/fan.zha.markdown
@@ -1,0 +1,15 @@
+---
+layout: page
+title: "ZigBee Home Automation Fan"
+description: "Instructions how to setup ZigBee Home Automation fans within Home Assistant."
+date: 2018-02-10 00:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: zigbee.png
+ha_category: Fan
+ha_iot_class: "Local Polling"
+---
+
+To get your ZigBee fans working with Home Assistant, follow the instructions for the general [ZigBee Home Automation component](/components/zha/).

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -22,6 +22,7 @@ There is currently support for the following device types within Home Assistant:
 - [Sensor](../sensor.zha) (e.g. temperature sensors)
 - [Light](../light.zha)
 - [Switch](../switch.zha)
+- [Fan](../fan.zha)
 
 Known working ZigBee radios:
 


### PR DESCRIPTION
**Description:**
Adds docs for the new zha fan platform. The platform doesn't have any configuration of its own, so the doc is pretty sparse (basically copied from zha lights and replaces lights/fans)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/12289

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
