### PR TITLE
Update component_loading.markdown

### DIFF
--- a/source/developers/component_loading.markdown
+++ b/source/developers/component_loading.markdown
@@ -14,8 +14,8 @@ A component will be loaded on start if a section (ie. `light:`) for it exists in
  * `<config directory>/custom_components/<component name>`
  * `homeassistant/components/<component name>` (built-in components)
     
-    If Home Assistant is installed in an **venv**:
-    * `homeassistant/lib/python3.5/site-packages/homeassistant/components/<component name>`
+    If Home Assistant is installed in an **venv** you find the components folder under the following subfolder:
+    * `lib/python3.5/site-packages/homeassistant/components/<component name>`
 
 Once loaded, a component will only be setup if all dependencies can be loaded and are able to setup. Keep an eye on the logs to see if your component could be loaded and initialized.
 

--- a/source/developers/component_loading.markdown
+++ b/source/developers/component_loading.markdown
@@ -11,17 +11,13 @@ footer: true
 
 A component will be loaded on start if a section (ie. `light:`) for it exists in the `configuration.yaml` file. A component can also be loaded if another component is loaded that depends on it. When loading a component Home Assistant will check the following paths:
 
- * `<config directory>/custom_components/<component name>`
+ * `.homeassistant/custom_components/<component name>`
  * `homeassistant/components/<component name>` (built-in components)
     
 If Home Assistant is installed in an [`venv`](/docs/installation/virtualenv/) you find the components folder under the following subfolder: `lib/python3.5/site-packages/homeassistant/components/<component name>`
 
 Once loaded, a component will only be setup if all dependencies can be loaded and are able to setup. Keep an eye on the logs to see if your component could be loaded and initialized.
 
-<p class='note warning'>
-You can override a built-in component by having a component with the same name in your `config/custom_components` folder. If the built-in component is inside a subfolder, take care to place your customization in a folder with the same name in `config/custom_components/*folder*`. Note that overriding built-in components is not recommended and will probably break things!
-</p>
+You can override a built-in component by having a component with the same name in a `custom_components` folder inside your [`.homeassistant`](/docs/configuration/) directory. If the built-in component is inside a subfolder, take care to place your customization in a folder with the same name in `.homeassistant/custom_components/[platform]`. Note that overriding built-in components is not recommended and will probably break things!
 
-<p class='note'>
-Home Assistant will use the directory that contains your config file as the directory that holds your customizations. By default this is the `config` folder in your current work directory. You can use a different folder by running Home Assistant with the `--config` argument: `$ python3 homeassistant --config /YOUR/CONFIG/PATH/`.
-</p>
+Home Assistant will use the directory that contains your configuration file as the directory that holds your customizations. By default this is the [.homeassistant] folder. You can use a different folder by running Home Assistant with the `--config` argument: `$ python3 homeassistant --config /YOUR/CONFIG/PATH/`.

--- a/source/developers/component_loading.markdown
+++ b/source/developers/component_loading.markdown
@@ -14,7 +14,7 @@ A component will be loaded on start if a section (ie. `light:`) for it exists in
  * `<config directory>/custom_components/<component name>`
  * `homeassistant/components/<component name>` (built-in components)
     
-If Home Assistant is installed in an [`venv`](/docs/installation/virtualenv/) you find the components folder under the following subfolder:`lib/python3.5/site-packages/homeassistant/components/<component name>`
+If Home Assistant is installed in an [`venv`](/docs/installation/virtualenv/) you find the components folder under the following subfolder: `lib/python3.5/site-packages/homeassistant/components/<component name>`
 
 Once loaded, a component will only be setup if all dependencies can be loaded and are able to setup. Keep an eye on the logs to see if your component could be loaded and initialized.
 

--- a/source/developers/component_loading.markdown
+++ b/source/developers/component_loading.markdown
@@ -13,6 +13,9 @@ A component will be loaded on start if a section (ie. `light:`) for it exists in
 
  * `<config directory>/custom_components/<component name>`
  * `homeassistant/components/<component name>` (built-in components)
+    
+    If Home Assistant is installed in an **venv**:
+    * `homeassistant/lib/python3.5/site-packages/homeassistant/components/<component name>`
 
 Once loaded, a component will only be setup if all dependencies can be loaded and are able to setup. Keep an eye on the logs to see if your component could be loaded and initialized.
 

--- a/source/developers/component_loading.markdown
+++ b/source/developers/component_loading.markdown
@@ -20,4 +20,4 @@ Once loaded, a component will only be setup if all dependencies can be loaded an
 
 You can override a built-in component by having a component with the same name in a `custom_components` folder inside your [`.homeassistant`](/docs/configuration/) directory. If the built-in component is inside a subfolder, take care to place your customization in a folder with the same name in `.homeassistant/custom_components/[platform]`. Note that overriding built-in components is not recommended and will probably break things!
 
-Home Assistant will use the directory that contains your configuration file as the directory that holds your customizations. By default this is the [.homeassistant] folder. You can use a different folder by running Home Assistant with the `--config` argument: `$ python3 homeassistant --config /YOUR/CONFIG/PATH/`.
+Home Assistant will use the directory that contains your configuration file as the directory that holds your customizations. By default this is the `.homeassistant` folder. You can use a different folder by running Home Assistant with the `--config` argument: `$ python3 homeassistant --config /YOUR/CONFIG/PATH/`.

--- a/source/developers/component_loading.markdown
+++ b/source/developers/component_loading.markdown
@@ -9,20 +9,19 @@ sharing: true
 footer: true
 ---
 
-A component will be loaded on start if a section (ie. `light:`) for it exists in the config file. A component can also be loaded if another component is loaded that depends on it. When loading a component Home Assistant will check the following paths:
+A component will be loaded on start if a section (ie. `light:`) for it exists in the `configuration.yaml` file. A component can also be loaded if another component is loaded that depends on it. When loading a component Home Assistant will check the following paths:
 
  * `<config directory>/custom_components/<component name>`
  * `homeassistant/components/<component name>` (built-in components)
     
-    If Home Assistant is installed in an **venv** you find the components folder under the following subfolder:
-    * `lib/python3.5/site-packages/homeassistant/components/<component name>`
+If Home Assistant is installed in an [`venv`](/docs/installation/virtualenv/) you find the components folder under the following subfolder:`lib/python3.5/site-packages/homeassistant/components/<component name>`
 
 Once loaded, a component will only be setup if all dependencies can be loaded and are able to setup. Keep an eye on the logs to see if your component could be loaded and initialized.
 
 <p class='note warning'>
-You can override a built-in component by having a component with the same name in your <code>config/custom_components</code> folder. If the built-in component is inside a subfolder, take care to place your customization in a folder with the same name in <code>config/custom_components/*folder*</code>. Note that overriding built-in components is not recommended and will probably break things!
+You can override a built-in component by having a component with the same name in your `config/custom_components` folder. If the built-in component is inside a subfolder, take care to place your customization in a folder with the same name in `config/custom_components/*folder*`. Note that overriding built-in components is not recommended and will probably break things!
 </p>
 
 <p class='note'>
-Home Assistant will use the directory that contains your config file as the directory that holds your customizations. By default this is the <code>config</code> folder in your current work directory. You can use a different folder by running Home Assistant with the --config argument: <code>python3 homeassistant --config /YOUR/CONFIG/PATH/</code>.
+Home Assistant will use the directory that contains your config file as the directory that holds your customizations. By default this is the `config` folder in your current work directory. You can use a different folder by running Home Assistant with the `--config` argument: `$ python3 homeassistant --config /YOUR/CONFIG/PATH/`.
 </p>

--- a/source/developers/component_loading.markdown
+++ b/source/developers/component_loading.markdown
@@ -11,10 +11,10 @@ footer: true
 
 A component will be loaded on start if a section (ie. `light:`) for it exists in the `configuration.yaml` file. A component can also be loaded if another component is loaded that depends on it. When loading a component Home Assistant will check the following paths:
 
- * `.homeassistant/custom_components/<component name>`
+ * `<config directory>/custom_components/<component name>`
  * `homeassistant/components/<component name>` (built-in components)
     
-If Home Assistant is installed in an [`venv`](/docs/installation/virtualenv/) you find the components folder under the following subfolder: `lib/python3.5/site-packages/homeassistant/components/<component name>`
+If Home Assistant is installed in an [`venv`](/docs/installation/virtualenv/) your `<config directory>` is located at: `lib/python3.x/site-packages/homeassistant/`. You need to replace 3.x with your Python version.
 
 Once loaded, a component will only be setup if all dependencies can be loaded and are able to setup. Keep an eye on the logs to see if your component could be loaded and initialized.
 


### PR DESCRIPTION
Maybe there should be an info where the components can be found if Home Assistant is installed in an venv.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
