### PR TITLE
ZWave: Changed parameter name

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -82,7 +82,7 @@ new_entity_ids:
   required: false
   type: boolean
   default: True
-device_config:
+device_config / device_config_domain / device_config_glob:
   description: This attribute contains node-specific override values. (For releases prior to 0.39 this variable is called **customize**) See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format.
   required: false
   type: string, list


### PR DESCRIPTION
**Description:**
* Added device_config_domain and device_config_glob

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
