### PR TITLE
Update Postgresql example

### DIFF
--- a/source/_components/sensor.sql.md
+++ b/source/_components/sensor.sql.md
@@ -90,6 +90,12 @@ SELECT * FROM states WHERE entity_id='binary_sensor.xyz789' GROUP BY state ORDER
 
 ### {% linkable_title Database size in Postgres %}
 
-```sql
-SELECT pg_size_pretty(pg_database_size('Database Name'));
+```yaml
+- platform: sql
+    db_url: postgresql://user:password@host/dbname
+    queries:
+    - name: db_size
+      query: "SELECT (pg_database_size('dsmrreader')/1024/1024) as db_size;"
+      column: "db_size"
+      unit_of_measurement: MB 
 ```


### PR DESCRIPTION
**Description:**

The old query with pg_size_pretty returns the value as a string, that way you can’t have a nice chart or make value comparison. Inserted new query to return value as number.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** Only doc change, no PR related

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
