### PR TITLE
Update template_sensor with friendly_name_template attribute and example

### DIFF
--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -46,7 +46,7 @@ sensor:
         required: false
         type: string
       friendly_name_template:
-        description: Defines a template for the name to be used in the frontend. (this overrides friendly_name)
+        description: Defines a template for the name to be used in the frontend (this overrides friendly_name).
         required: false
         type: template
       entity_id:

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -262,12 +262,31 @@ sensor:
       forecast_1_day_ahead:
         friendly_name_template: >-
           {%- set date = as_timestamp(now()) + (1 * 86400 ) -%}
-          {{ date | timestamp_custom("Tomorrow (%-m/%-d)") }}
+          {{ date|timestamp_custom("Tomorrow (%-m/%-d)") }}
         value_template: "{{ sensor.darksky_weather_forecast_1 }}"
       forecast_2_days_ahead:
         friendly_name_template: >-
           {%- set date = as_timestamp(now()) + (2 * 86400 ) -%}
-          {{ date | timestamp_custom("%A (%-m/%-d)") }}
+          {{ date|timestamp_custom("%A (%-m/%-d)") }}
         value_template: "{{ sensor.darksky_weather_forecast_2 }}"
+```
+{% endraw %}
+
+This example shows how to change the name that gets used in the frontend based on a state
+
+{% raw %}
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      net_power:
+        friendly_name_template: >-
+          {% if states('sensor.power_consumption')|float < 0 %}
+            Power Consumption
+          {% else %}
+            Power Production
+          {% end %}
+        value_template: "{{ sensor.power_consumption }}"
+        unit_of_measurement: 'kW'
 ```
 {% endraw %}

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -45,6 +45,10 @@ sensor:
         description: Name to use in the frontend.
         required: false
         type: string
+      friendly_name_template:
+        description: Defines a template for the name to be used in the frontend. (this overrides friendly_name)
+        required: false
+        type: template
       entity_id:
         description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
         required: false
@@ -242,5 +246,28 @@ sensor:
           {% else %}
             /local/nighttime.png
           {% endif %}
+```
+{% endraw %}
+
+### {% linkable_title Change The Name Used in the Frontend %}
+
+This example shows how to change the name that gets used in the frontend based on a date.
+Explanation: we add a multiple of 86400 seconds (= 1 day) to the current unix timestamp to get a future date.
+
+{% raw %}
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      forecast_1_day_ahead:
+        friendly_name_template: >-
+          {%- set date = as_timestamp(now()) + (1 * 86400 ) -%}
+          {{ date | timestamp_custom("Tomorrow (%-m/%-d)") }}
+        value_template: {{sensor.darksky_weather_forecast_1}}
+      forecast_2_days_ahead:
+        friendly_name_template: >-
+          {%- set date = as_timestamp(now()) + (2 * 86400 ) -%}
+          {{ date | timestamp_custom("%A (%-m/%-d)") }}
+        value_template: {{sensor.darksky_weather_forecast_2}}
 ```
 {% endraw %}

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -249,9 +249,9 @@ sensor:
 ```
 {% endraw %}
 
-### {% linkable_title Change The Name Used in the Frontend %}
+### {% linkable_title Change the Friendly Name Used in the Frontend %}
 
-This example shows how to change the name that gets used in the frontend based on a date.
+This example shows how to change the `friendly_name` based on a date.
 Explanation: we add a multiple of 86400 seconds (= 1 day) to the current unix timestamp to get a future date.
 
 {% raw %}
@@ -272,7 +272,7 @@ sensor:
 ```
 {% endraw %}
 
-This example shows how to change the name that gets used in the frontend based on a state
+This example shows how to change the `friendly_name` based on a state.
 
 {% raw %}
 ```yaml

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -286,7 +286,7 @@ sensor:
           {% else %}
             Power Production
           {% end %}
-        value_template: "{{ sensor.power_consumption }}"
+        value_template: "{{ states('sensor.power_consumption') }}"
         unit_of_measurement: 'kW'
 ```
 {% endraw %}

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -263,11 +263,11 @@ sensor:
         friendly_name_template: >-
           {%- set date = as_timestamp(now()) + (1 * 86400 ) -%}
           {{ date | timestamp_custom("Tomorrow (%-m/%-d)") }}
-        value_template: {{sensor.darksky_weather_forecast_1}}
+        value_template: "{{ sensor.darksky_weather_forecast_1 }}"
       forecast_2_days_ahead:
         friendly_name_template: >-
           {%- set date = as_timestamp(now()) + (2 * 86400 ) -%}
           {{ date | timestamp_custom("%A (%-m/%-d)") }}
-        value_template: {{sensor.darksky_weather_forecast_2}}
+        value_template: "{{ sensor.darksky_weather_forecast_2 }}"
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**

Adds documentation and example for friendly_name_template attribute of template_sensor

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#12268

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/