### PR TITLE
Update MercedesMe - Add lxml requirement note related to #12320

### DIFF
--- a/source/_components/mercedesme.markdown
+++ b/source/_components/mercedesme.markdown
@@ -49,3 +49,7 @@ scan_interval:
   default: 30
   type: int
 {% endconfiguration %}
+
+<p class='note'>
+The requirement `lxml` has to be [installed](http://lxml.de/installation.html) manually `pip install lxml` on some devices.
+</p>


### PR DESCRIPTION
**Description:**
Adds a note that on some devices the requirement lxml has to be installed manually.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
