### PR TITLE
Input_number: Added display_state option

### DIFF
--- a/source/_components/input_number.markdown
+++ b/source/_components/input_number.markdown
@@ -80,6 +80,11 @@ input_number:
         description: Icon to display in front of the box/slider in the frontend. Refer to the [Customizing devices](/docs/configuration/customizing-devices/#possible-values) page for possible values.
         required: false
         type: icon
+      display_state:
+        description: For `slider` - Display the current state with unit. For `box` - Display the unit next to the state.
+        required: false
+        type: boolean
+        default: true
 {% endconfiguration %}
 
 ### {% linkable_title Restore State %}


### PR DESCRIPTION
**Description:**
Added parameter to make changes made by home-assistant/home-assistant-polymer/pull/808 optional.
The default for `display_state` is `true`, so it doesn't change anything until it's set to `false`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12351
**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** home-assistant/home-assistant-polymer#886

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
