### PR TITLE
Make TekSavvy Sensor API a Link

### DIFF
--- a/source/_components/sensor.teksavvy.markdown
+++ b/source/_components/sensor.teksavvy.markdown
@@ -15,8 +15,8 @@ ha_iot_class: "Cloud Polling"
 
 Integrate your [TekSavvy](https://myaccount.teksavvy.com/) account information into Home Assistant.
 
-You can get your API key from 
-https://myaccount.teksavvy.com/ApiKey/ApiKeyManagement
+You can get your API key from:
+[TekSavvy My Account](https://myaccount.teksavvy.com/ApiKey/ApiKeyManagement)
 
 To use your TekSavvy sensor in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/sensor.teksavvy.markdown
+++ b/source/_components/sensor.teksavvy.markdown
@@ -15,8 +15,7 @@ ha_iot_class: "Cloud Polling"
 
 Integrate your [TekSavvy](https://myaccount.teksavvy.com/) account information into Home Assistant.
 
-You can get your API key from:
-[TekSavvy My Account](https://myaccount.teksavvy.com/ApiKey/ApiKeyManagement)
+You can get your API key from [TekSavvy My Account](https://myaccount.teksavvy.com/ApiKey/ApiKeyManagement).
 
 To use your TekSavvy sensor in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**

Make the URL to retrieving the TekSavvy API key an acutal link.


## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
