### PR TITLE
Proposed workaround for Docker for Mac error

### DIFF
--- a/source/developers/hassio/addon_publishing.markdown
+++ b/source/developers/hassio/addon_publishing.markdown
@@ -58,4 +58,8 @@ For a local repository:
 $ docker run --rm --privileged -v ~/.docker:/root/.docker -v /my_addon:/data homeassistant/amd64-builder --all -t /data
 ```
 
+<p class='note'>
+If you are developing on macOS and using Docker for Mac, you may encounter an error message similar to the following: <code>error creating aufs mount to /var/lib/docker/aufs/mnt/<SOME_ID>-init: invalid argument</code>. A proposed workaround is to add the following to the Advanced Daemon JSON configuration via Docker > Preferences > Daemon > Advanced: <code>"storage-driver" : "aufs"</code>.
+</p>
+
 [builder]: https://github.com/home-assistant/hassio-build/tree/master/builder


### PR DESCRIPTION
**Description:**

When attempting to publish a docker add on using the [automated build docker engine](https://github.com/home-assistant/hassio-build/tree/master/builder) (which is awesome), I ran into the following error: `error creating aufs mount to /var/lib/docker/aufs/mnt/cd4add6b9f4c679e3b1468123707cc071f51f2882f6bb8fcff9a3500810d816a-init: invalid argument`

After some searching, it looks like this is a [known issue](https://github.com/docker/for-mac/issues/1594) in Docker for Mac with a functioning workaround (for now).

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
