### PR TITLE
Update how to save proper authorized_keys

### DIFF
--- a/source/developers/hassio/debugging.markdown
+++ b/source/developers/hassio/debugging.markdown
@@ -28,7 +28,7 @@ Alternative instructions, for Mac, Windows and Linux can be found [here](https:/
 
 Follow steps 1-4 under 'Generating a new SSH key' (The other sections are not applicable to Hass.io and can be ignored.)
 
-Step 3 in the link above, shows the path to the private key file `id_rsa` for your chosen operating system. Your public key, `id_rsa.pub`, is saved in the same folder. Next, select all text from text box "Public key for pasting into OpenSSH authorized_keys file" and save it to to the root of your SD card as `authorized_keys`.
+Step 3 in the link above, shows the path to the private key file `id_rsa` for your chosen operating system. Your public key, `id_rsa.pub`, is saved in the same folder. Next, select all text from text box "Public key for pasting into OpenSSH authorized_keys file" and save it to the root of your SD card as `authorized_keys`.
 
 <p class='note'>
 Make sure when you are copying the public key to the root of the /resin-boot partition of the SD card that you rename the file correctly to `authorized_keys` with no `.pub` file extension.

--- a/source/developers/hassio/debugging.markdown
+++ b/source/developers/hassio/debugging.markdown
@@ -28,7 +28,7 @@ Alternative instructions, for Mac, Windows and Linux can be found [here](https:/
 
 Follow steps 1-4 under 'Generating a new SSH key' (The other sections are not applicable to Hass.io and can be ignored.)
 
-Step 3 in the link above, shows the path to the private key file `id_rsa` for your chosen operating system. Your public key, `id_rsa.pub`, is saved in the same folder. Next, copy your public key file to the root of your SD card as `authorized_keys`.
+Step 3 in the link above, shows the path to the private key file `id_rsa` for your chosen operating system. Your public key, `id_rsa.pub`, is saved in the same folder. Next, select all text from text box "Public key for pasting into OpenSSH authorized_keys file" and save it to to the root of your SD card as `authorized_keys`.
 
 <p class='note'>
 Make sure when you are copying the public key to the root of the /resin-boot partition of the SD card that you rename the file correctly to `authorized_keys` with no `.pub` file extension.


### PR DESCRIPTION
Saving private key straight from puttygen didn't work. Text from text-box must be saved to SD.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
