### PR TITLE
Specify color temperature ranges and type

### DIFF
--- a/source/_components/switch.flux.markdown
+++ b/source/_components/switch.flux.markdown
@@ -16,7 +16,9 @@ The `flux` switch platform will change the temperature of your lights similar to
 
 The component will update your lights based on the time of day. It will only affect lights that are turned on and listed in the flux configuration.
 
-During the day (in between `start time` and `sunset time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`.  After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights every periodically.
+During the day (in between `start time` and `sunset time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`.  After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights periodically.
+
+The color temperature is specified kelvin, and accepted values are between 1000 and 40000 kelvin.
 
 If you want to update at variable intervals, you can leave the switch turned off and use automation rules that call the service `switch.<name>_update` whenever you want the lights updated, where `<name>` equals the `name:` property in the switch configuration.
 

--- a/source/_components/switch.flux.markdown
+++ b/source/_components/switch.flux.markdown
@@ -18,7 +18,7 @@ The component will update your lights based on the time of day. It will only aff
 
 During the day (in between `start time` and `sunset time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`.  After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights periodically.
 
-The color temperature is specified kelvin, and accepted values are between 1000 and 40000 kelvin.
+The color temperature is specified kelvin, and accepted values are between 1000 and 40000 kelvin. Lower values will seem more red, while higher will look more white.
 
 If you want to update at variable intervals, you can leave the switch turned off and use automation rules that call the service `switch.<name>_update` whenever you want the lights updated, where `<name>` equals the `name:` property in the switch configuration.
 


### PR DESCRIPTION
**Description:**
I had a bit of trouble figuring out the valid range for color temperature and did not find any mention in any documentation, so I figured it would make sense to add it here. I eventually found it in the code, but 
it would be helpful for newer users to find it in the documentation as well.
