### PR TITLE
Fix Tahoma documentation

### DIFF
--- a/source/_components/cover.tahoma.markdown
+++ b/source/_components/cover.tahoma.markdown
@@ -12,10 +12,6 @@ ha_category: Cover
 ha_release: 0.59
 ---
 
-To use your tahoma covers in your installation, add the following to your `configuration.yaml` file:
+The `tahoma` cover platform lets you control covers added to your Tahoma Box in Home Assistant.
 
-```yaml
-# Example configuration.yml entry
-cover:
-  platform: tahoma
-```
+Covers will be added automatically. Please refer to the [component](/components/tahoma/) configuration on how to setup Tahoma.

--- a/source/_components/sensor.tahoma.markdown
+++ b/source/_components/sensor.tahoma.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: tahoma.png
-ha_category: Cover
+ha_category: Sensor
 ha_release: 0.59
 ---
 

--- a/source/_components/sensor.tahoma.markdown
+++ b/source/_components/sensor.tahoma.markdown
@@ -12,10 +12,6 @@ ha_category: Cover
 ha_release: 0.59
 ---
 
-To use your tahoma sensors in your installation, add the following to your `configuration.yaml` file:
+The `tahoma` sensor platform lets you see sensors added to your Tahoma Box in Home Assistant.
 
-```yaml
-# Example configuration.yml entry
-sensor:
-  platform: tahoma
-```
+Sensors will be added automatically. Please refer to the [component](/components/tahoma/) configuration on how to setup Tahoma.


### PR DESCRIPTION
**Description:**

The Tahoma platform doesn't need individual configurations, all the covers and sensors get added automatically.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
