### PR TITLE
Update to remove Python 3.4 reference

### DIFF
--- a/source/_faq/pip3.markdown
+++ b/source/_faq/pip3.markdown
@@ -10,7 +10,7 @@ ha_category: Installation
 ---
 
 
-This utility should have been installed as part of the Python 3.4 installation. Check if Python 3.4 is installed by running `python3 --version`. If it is not installed, [download it here](https://www.python.org/getit/).
+This utility should have been installed as part of the Python 3 installation. Check if Python 3 is installed by running `python3 --version`. If it is not installed, [download it here](https://www.python.org/getit/).
 
 If you are able to successfully run `python3 --version` but not `pip3`, install Home Assistant by running the following command instead:
 


### PR DESCRIPTION
Making FAQ more relevant by referencing just Python 3
