### PR TITLE
Added note calling out Hass.io only

### DIFF
--- a/source/addons/index.html
+++ b/source/addons/index.html
@@ -17,8 +17,7 @@ regenerate: false
 </p>
 
 <p class='note'>
-Add-ons are only available if you've use the Hass.io installer. If you installed Home Assistant using any other method then you cannot use add-ons 
-  (but you can achieve the same result manually).
+Add-ons are only available if you've used the Hass.io installer. If you installed Home Assistant using any other method then you cannot use add-ons (but you can achieve the same result manually).
 </p>
 
 {% assign addons = site.addons | sort: 'title' %}

--- a/source/addons/index.html
+++ b/source/addons/index.html
@@ -16,6 +16,11 @@ regenerate: false
   Check the Hass.io forums for <a href='https://community.home-assistant.io/tags/hassio-repository'>add-on repositories managed by the community</a>.
 </p>
 
+<p class='note'>
+Add-ons are only available if you've use the Hass.io installer. If you installed Home Assistant using any other method then you cannot use add-ons 
+  (but you can achieve the same result manually).
+</p>
+
 {% assign addons = site.addons | sort: 'title' %}
 
 <h3>{% linkable_title Featured add-ons %}</h3>


### PR DESCRIPTION
Given the ongoing confusion that add-ons cause, adding a note box to call out that add-ons are Hass.io only.