### PR TITLE
updated documentation: show on map

### DIFF
--- a/source/_components/sensor.luftdaten.markdown
+++ b/source/_components/sensor.luftdaten.markdown
@@ -64,13 +64,12 @@ sensor:
     description: Option to show the position of the ISS on the map.
     required: optional
     default: false
-    type: string
+    type: boolean
 {% endconfiguration %}
 
 <p class='note warning'>
-If you set `show_on_map` `True` then the location attributes are named `latitude` and `longitude`. The default name of the location attributes is `lat` and `long` to avoid showing them on the map.
+If you set `show_on_map` to `True` then the location attributes are named `latitude` and `longitude`. The default name of the location attributes is `lat` and `long` to avoid showing them on the map.
 </p>
-
 
 Not all sensors provide all conditions. Also, it's possible that the sensor values are not available all the time. To check what a sensor is publishing use `curl`:
 

--- a/source/_components/sensor.luftdaten.markdown
+++ b/source/_components/sensor.luftdaten.markdown
@@ -60,7 +60,17 @@ sensor:
         description: Display the humidity from the sensor.
       pressure:
         description: Display the pressure from the sensor.
+  show_on_map:
+    description: Option to show the position of the ISS on the map.
+    required: optional
+    default: false
+    type: string
 {% endconfiguration %}
+
+<p class='note warning'>
+If you set `show_on_map` `True` then the location attributes are named `latitude` and `longitude`. The default name of the location attributes is `lat` and `long` to avoid showing them on the map.
+</p>
+
 
 Not all sensors provide all conditions. Also, it's possible that the sensor values are not available all the time. To check what a sensor is publishing use `curl`:
 

--- a/source/_components/sensor.luftdaten.markdown
+++ b/source/_components/sensor.luftdaten.markdown
@@ -61,7 +61,7 @@ sensor:
       pressure:
         description: Display the pressure from the sensor.
   show_on_map:
-    description: Option to show the position of the ISS on the map.
+    description: Option to show the position of the sensor on the map.
     required: optional
     default: false
     type: boolean


### PR DESCRIPTION
**Description:**

added optional parameter for the luftdaten.info sensor component:
the show_on_map flag (optional)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>
https://github.com/home-assistant/home-assistant/pull/12375
## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/