### PR TITLE
Fix broken link

### DIFF
--- a/source/_components/alarm_control_panel.manual_mqtt.markdown
+++ b/source/_components/alarm_control_panel.manual_mqtt.markdown
@@ -58,7 +58,7 @@ The following configuration variables from the base manual alarm platform are av
   - **pending_time** (*Optional*): State specific setting for **pending_time** (all states except **disarmed**)
   - **trigger_time** (*Optional*): State specific setting for **trigger_time** (all states except **triggered**)
 
-See the documentation for the [manual alarm platform](/component/alarm_control_panel.manual/) for a description.
+See the documentation for the [manual alarm platform](/components/alarm_control_panel.manual/) for a description.
 
 Additionally, the following MQTT configuration variables are also available:
 


### PR DESCRIPTION
**Description:**
Fixed broken link to Manual Alarm Control Panel

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
