### PR TITLE
Added request_rssi configuration variable to docs

### DIFF
--- a/source/_components/device_tracker.bluetooth_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_tracker.markdown
@@ -29,7 +29,13 @@ device_tracker:
 
 Configuration variables:
 
-- **request_rssi** (*Optional*): Performs a request for the "Received signal strength indication" (RSSI) of each tracked device. Defaults to `False`.
+{% configuration %}
+request_rssi:
+  description: Performs a request for the "Received signal strength indication" (RSSI) of each tracked device
+  required: false
+  type: boolean
+  default: False
+{% endconfiguration %}
 
 In some cases it can be that your device is not discovered. In that case let your phone scan for Bluetooth devices while you restart Home Assistant. Just hit `Scan` on your phone all the time until Home Assistant is fully restarted and the device should appear in `known_devices.yaml`.
 

--- a/source/_components/device_tracker.bluetooth_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_tracker.markdown
@@ -27,6 +27,10 @@ device_tracker:
   - platform: bluetooth_tracker
 ```
 
+Configuration variables:
+
+- **request_rssi** (*Optional*): Performs a request for the "Received signal strength indication" (RSSI) of each tracked device. Defaults to `False`.
+
 In some cases it can be that your device is not discovered. In that case let your phone scan for Bluetooth devices while you restart Home Assistant. Just hit `Scan` on your phone all the time until Home Assistant is fully restarted and the device should appear in `known_devices.yaml`.
 
 For additional configuration variables check the [Device tracker page](/components/device_tracker/).

--- a/source/_components/device_tracker.bluetooth_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_tracker.markdown
@@ -27,8 +27,6 @@ device_tracker:
   - platform: bluetooth_tracker
 ```
 
-Configuration variables:
-
 {% configuration %}
 request_rssi:
   description: Performs a request for the "Received signal strength indication" (RSSI) of each tracked device


### PR DESCRIPTION
**Description:**
Adds documentation for the configuration variable added in my pull request.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12458

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
