### PR TITLE
Enable broadcast of Facebook bot messages

### DIFF
--- a/source/_components/notify.facebook.markdown
+++ b/source/_components/notify.facebook.markdown
@@ -128,76 +128,10 @@ To enable broadcast just use the keyword "BROADCAST" as your target. Only put ON
     platform: sun
     event: sunset
   action:
-    service: notify.<FACEBOOK_NOTIFY_COMPONENT_NAME_YOU_CREATED>
+    service: notify.facebook
     data:
-      message: <TEXT_YOU_ARE_SENDING>
+      message: Some text you want to send
       target:
         - BROADCAST
 ```
 
-Here is an advanced sample for broadcasting wind alerts from a wunderground weather station:
-
-configuration.yaml:
-
-```yaml
-notify:
-  - platform: facebook
-    name: facebook_wind_alerts
-    page_access_token: !secret facebook_page_access_token  
-
- platform: wunderground
- api_key: !secret wunder_api_key
- pws_id: !secret  wunder_station_id
- monitored_conditions:
-    - wind_kph
-    - wind_dir
-    - wind_gust_kph
-    - pressure_trend
-    - wind_string
-    - weather_1h
- 
- 
- platform: template
- sensors:
-    windy:
-      friendly_name: 'Wind'
-      icon_template: mdi:weather-windy
-      value_template: >-
-        "{% if (states.sensor.pws_wind_kph.state | float + states.sensor.pws_wind_gust_kph.state | float)/2.0 > 18.0 -%}"
-            Windy
-        "{%- else -%}"
-            Beer
-        "{%- endif -%}"
-
-```
-
-automations.yaml:
-```yaml
-
-- alias: Facebook Wind Alert
-  trigger:
-    platform: state
-    entity_id: sensor.windy
-    to: 'Windy'
-  condition:
-    condition: and
-    conditions:
-      - condition: state
-        entity_id: sun.sun
-        state: 'above_horizon'
-      - condition: state
-        entity_id: input_boolean.wind_alert
-        state: 'on'
-      - condition: time
-        before: '19:00:00'
-        after: '07:00:00'
-  action:
-    service: notify.facebook_wind_alerts
-    data_template:
-      message: >
-        {{ states.sensor.pws_wind_string.state }}
-        Pressure Trend : {{ states.sensor.pws_pressure_trend.state }}
-        Next Hour: {{ states.sensor.pws_weather_1h.state }}
-     target:
-       - BROADCAST
-```

--- a/source/_components/notify.facebook.markdown
+++ b/source/_components/notify.facebook.markdown
@@ -118,20 +118,21 @@ script:
                 payload: DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_BLUE
 ```
 
-You can now also use FB public beta broadcast API to push messages to ALL users who interacted with your chatbot on your page, without having to collect their number. This will scale to thousands of users. FB requires that this only be used for non-commercial purposes and they validate every message you send. Also note, your FB bot needs to be authorized for "page_subscritions" if you want to make it to all, but can be used right away to a selected group of testers of your choice. 
+You can now also use Facebook public beta broadcast API to push messages to ALL users who interacted with your chatbot on your page, without having to collect their number. This will scale to thousands of users. FB requires that this only be used for non-commercial purposes and they validate every message you send. Also note, your Facebook bot needs to be authorized for "page_subscritions" if you want to make it to all, but can be used right away to a selected group of testers of your choice. 
 
 To enable broadcast just use the keyword "BROADCAST" as your target. Only put ONE target BROADCAST as below:
 
 ```yaml
 - alias: Facebook Broadcast
   trigger:
-    <YOUR_TRIGGER_HERE>
+    platform: sun
+    event: sunset
   action:
     service: notify.<FACEBOOK_NOTIFY_COMPONENT_NAME_YOU_CREATED>
     data:
-     message: <TEXT_YOU_ARE_SENDING>
-     target:
-       - BROADCAST
+      message: <TEXT_YOU_ARE_SENDING>
+      target:
+        - BROADCAST
 ```
 
 Here is an advanced sample for broadcasting wind alerts from a wunderground weather station:
@@ -159,14 +160,14 @@ notify:
  platform: template
  sensors:
     windy:
-        friendly_name: 'Wind'
-        icon_template: mdi:weather-windy
-        value_template: >-
-         {% if (states.sensor.pws_wind_kph.state | float + states.sensor.pws_wind_gust_kph.state | float)/2.0 > 18.0 -%}
+      friendly_name: 'Wind'
+      icon_template: mdi:weather-windy
+      value_template: >-
+        {% if (states.sensor.pws_wind_kph.state | float + states.sensor.pws_wind_gust_kph.state | float)/2.0 > 18.0 -%}
             Windy
-          {%- else -%}
+        {%- else -%}
             Beer
-          {%- endif -%}
+        {%- endif -%}
 
 ```
 
@@ -193,16 +194,10 @@ automations.yaml:
   action:
     service: notify.facebook_wind_alerts
     data_template:
-     message: >
-     
-            {{ states.sensor.pws_wind_string.state }}
-  
-            
-            Pressure Trend : {{ states.sensor.pws_pressure_trend.state }}
-  
-            
-            Next Hour: {{ states.sensor.pws_weather_1h.state }}
+      message: >
+        {{ states.sensor.pws_wind_string.state }}
+        Pressure Trend : {{ states.sensor.pws_pressure_trend.state }}
+        Next Hour: {{ states.sensor.pws_weather_1h.state }}
      target:
        - BROADCAST
-
 ```

--- a/source/_components/notify.facebook.markdown
+++ b/source/_components/notify.facebook.markdown
@@ -163,11 +163,11 @@ notify:
       friendly_name: 'Wind'
       icon_template: mdi:weather-windy
       value_template: >-
-        {% if (states.sensor.pws_wind_kph.state | float + states.sensor.pws_wind_gust_kph.state | float)/2.0 > 18.0 -%}
+        "{% if (states.sensor.pws_wind_kph.state | float + states.sensor.pws_wind_gust_kph.state | float)/2.0 > 18.0 -%}"
             Windy
-        {%- else -%}
+        "{%- else -%}"
             Beer
-        {%- endif -%}
+        "{%- endif -%}"
 
 ```
 

--- a/source/_components/notify.facebook.markdown
+++ b/source/_components/notify.facebook.markdown
@@ -118,7 +118,7 @@ script:
                 payload: DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_BLUE
 ```
 
-You can now also use Facebook public beta broadcast API to push messages to ALL users who interacted with your chatbot on your page, without having to collect their number. This will scale to thousands of users. FB requires that this only be used for non-commercial purposes and they validate every message you send. Also note, your Facebook bot needs to be authorized for "page_subscritions" if you want to make it to all, but can be used right away to a selected group of testers of your choice. 
+You can now also use Facebook public beta broadcast API to push messages to ALL users who interacted with your chatbot on your page, without having to collect their number. This will scale to thousands of users. Facebook requires that this only be used for non-commercial purposes and they validate every message you send. Also note, your Facebook bot needs to be authorized for "page_subscritions" if you want to make it to all, but can be used right away to a selected group of testers of your choice. 
 
 To enable broadcast just use the keyword "BROADCAST" as your target. Only put ONE target BROADCAST as below:
 

--- a/source/_components/notify.facebook.markdown
+++ b/source/_components/notify.facebook.markdown
@@ -50,7 +50,7 @@ automation:
           - '+919784516314'
 ```
 
-You can also send messages to users that do not have stored their phone number with Facebook, but this requires a bit more work. The Messenger platform uses page specific user IDs instead of a global user ID. You will need to enable a webhook for the "messages" event in Facebook's developer console. Once a user writes a message to a page, that webhook will then receive the user's page specific ID as part of the webhook's payload. Below is a simple PHP script that reacts to the message "get my id" and sends a reply containing the user's ID: 
+You can also send messages to users that do not have stored their phone number on Facebook, but this requires a bit more work. The Messenger platform uses page-specific user IDs instead of a global user ID. You will need to enable a webhook for the "messages" event in Facebook's developer console. Once a user writes a message to a page, that webhook will then receive the user's page specific ID as part of the webhook's payload. Below is a simple PHP script that reacts to the message "get my id" and sends a reply containing the user's ID: 
 
 ```php
 <?php
@@ -96,10 +96,10 @@ if (preg_match('/get my id/', strtolower($message))) {
 ```
 
 ### {% linkable_title Rich messages %}
-You could also send rich messing (cards, buttons, images, videos, etc). [Info](https://developers.facebook.com/docs/messenger-platform/send-api-reference) to which types or messages and how to build them.
+You could also send rich messing (cards, buttons, images, videos, etc). [Info](https://developers.facebook.com/docs/messenger-platform/send-api-reference) to which types of messages and how to build them.
 
 ```yaml
-# Example script with a notification entry with rich message
+# Example script with a notification entry with a rich message
 
 script:
   test_fb_notification:
@@ -118,7 +118,7 @@ script:
                 payload: DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_BLUE
 ```
 
-You can now also use Facebook public beta broadcast API to push messages to ALL users who interacted with your chatbot on your page, without having to collect their number. This will scale to thousands of users. Facebook requires that this only be used for non-commercial purposes and they validate every message you send. Also note, your Facebook bot needs to be authorized for "page_subscritions" if you want to make it to all, but can be used right away to a selected group of testers of your choice. 
+You can now also use Facebook public beta broadcast API to push messages to ALL users who interacted with your chatbot on your page, without having to collect their number. This will scale to thousands of users. Facebook requires that this only be used for non-commercial purposes and they validate every message you send. Also note, your Facebook bot needs to be authorized for "page_subscritions" if you want to make it to all but can be used right away to a selected group of testers of your choice. 
 
 To enable broadcast just use the keyword "BROADCAST" as your target. Only put ONE target BROADCAST as below:
 


### PR DESCRIPTION
**Description:**
it enables FB messenger broadcast ability to send messages to all people who interacted with the bot previously and have the chat open.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12459 

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
