### PR TITLE
Note about rename node being broken

### DIFF
--- a/source/_docs/z-wave/control-panel.markdown
+++ b/source/_docs/z-wave/control-panel.markdown
@@ -43,6 +43,10 @@ Here is where you [include and exclude](/docs/z-wave/adding/) Z-Wave devices fro
 
 * **Test Node** sends no_op test messages to the node. This could in theory bring back a dead node.
 
+<p class='note warning'>
+Since 0.63 and the new entity registry **Rename Node** no longer renames the entities. See [this blog post](https://home-assistant.io/blog/2018/02/10/release-63/#entity-registry) for information on the registry and [this issue](https://github.com/home-assistant/home-assistant/issues/12430).
+</p>
+
 <p class='note'>
 Battery powered devices need to be awake before you can use the Z-Wave control panel to update their settings. How to wake your device is device specific, and some devices will stay awake for only a couple of seconds. Please refer to the manual of your device for more details.
 </p>

--- a/source/_docs/z-wave/control-panel.markdown
+++ b/source/_docs/z-wave/control-panel.markdown
@@ -44,7 +44,7 @@ Here is where you [include and exclude](/docs/z-wave/adding/) Z-Wave devices fro
 * **Test Node** sends no_op test messages to the node. This could in theory bring back a dead node.
 
 <p class='note warning'>
-Since 0.63 and the new entity registry **Rename Node** no longer changes the entity id (just the default *friendly_name* and *old_entity_id* and *new_entity_id attributes). See [this blog post](https://home-assistant.io/blog/2018/02/10/release-63/#entity-registry) for information on the registry and [this issue](https://github.com/home-assistant/home-assistant/issues/12430).
+Since 0.63 and the new entity registry **Rename Node** no longer changes the entity id for anything other than the `zwave.` entity for the node (it does change, the default *friendly_name* and *old_entity_id* and *new_entity_id* attributes for all the entities). See [this blog post](https://home-assistant.io/blog/2018/02/10/release-63/#entity-registry) for information on the registry and [this issue](https://github.com/home-assistant/home-assistant/issues/12430).
 </p>
 
 <p class='note'>

--- a/source/_docs/z-wave/control-panel.markdown
+++ b/source/_docs/z-wave/control-panel.markdown
@@ -44,7 +44,7 @@ Here is where you [include and exclude](/docs/z-wave/adding/) Z-Wave devices fro
 * **Test Node** sends no_op test messages to the node. This could in theory bring back a dead node.
 
 <p class='note warning'>
-Since 0.63 and the new entity registry **Rename Node** no longer renames the entities. See [this blog post](https://home-assistant.io/blog/2018/02/10/release-63/#entity-registry) for information on the registry and [this issue](https://github.com/home-assistant/home-assistant/issues/12430).
+Since 0.63 and the new entity registry **Rename Node** no longer changes the entity id (just the default *friendly_name* and *old_entity_id* and *new_entity_id attributes). See [this blog post](https://home-assistant.io/blog/2018/02/10/release-63/#entity-registry) for information on the registry and [this issue](https://github.com/home-assistant/home-assistant/issues/12430).
 </p>
 
 <p class='note'>

--- a/source/_docs/z-wave/control-panel.markdown
+++ b/source/_docs/z-wave/control-panel.markdown
@@ -44,7 +44,7 @@ Here is where you [include and exclude](/docs/z-wave/adding/) Z-Wave devices fro
 * **Test Node** sends no_op test messages to the node. This could in theory bring back a dead node.
 
 <p class='note warning'>
-Since 0.63 and the new entity registry **Rename Node** no longer changes the entity id for anything other than the `zwave.` entity for the node (it does change, the default *friendly_name* and *old_entity_id* and *new_entity_id* attributes for all the entities). See [this blog post](https://home-assistant.io/blog/2018/02/10/release-63/#entity-registry) for information on the registry and [this issue](https://github.com/home-assistant/home-assistant/issues/12430).
+Since 0.63 and the new experimental [entity registry](https://home-assistant.io/docs/configuration/entity-registry/) **Rename Node** no longer changes the entity id for anything other than the `zwave.` entity for the node (it does change, the default *friendly_name* and *old_entity_id* and *new_entity_id* attributes for all the entities). See [this issue](https://github.com/home-assistant/home-assistant/issues/12430).
 </p>
 
 <p class='note'>


### PR DESCRIPTION
Given https://github.com/home-assistant/home-assistant/issues/12430, adding a note that Rename Node is now broken, and pointing to the blog post on how to rename nodes.

Yes, I'm frustrated ;)