### PR TITLE
Xiaomi MiIO Light: Flag the device as unavailable if not reachable

### DIFF
--- a/source/_components/light.xiaomi_miio.markdown
+++ b/source/_components/light.xiaomi_miio.markdown
@@ -35,7 +35,7 @@ Configuration variables:
 - **host** (*Required*): The IP of your light.
 - **token** (*Required*): The API token of your light.
 - **name** (*Optional*): The name of your light.
-- **model** (*Optional*): The model of your light. Valid values are `philips.light.bulb`, `philips.light.sread1` and `philips.light.ceiling`. This setting can be used to bypass the device model detection and is recommended if your device isn't always available.
+- **model** (*Optional*): The model of your light. Valid values are `philips.light.bulb`, `philips.light.sread1`, `philips.light.ceiling` and `philips.light.zyceiling`. This setting can be used to bypass the device model detection and is recommended if your device isn't always available.
 
 ## {% linkable_title Platform Services %}
 

--- a/source/_components/light.xiaomi_miio.markdown
+++ b/source/_components/light.xiaomi_miio.markdown
@@ -55,4 +55,4 @@ Delayed turn off.
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
-| `seconds`                 |       no | Turn off delay in seconds.                            |
+| `time_period`             |       no | Time period for the delayed turn off.                 |

--- a/source/_components/light.xiaomi_miio.markdown
+++ b/source/_components/light.xiaomi_miio.markdown
@@ -13,7 +13,7 @@ ha_version: 0.53
 ha_iot_class: "Local Polling"
 ---
 
-The `xiaomi_miio` platform allows you to control the state of your Xiaomi Philips LED Ball Lamp and Xiaomi Philips LED Ceiling Lamp.
+The `xiaomi_miio` platform allows you to control the state of your Xiaomi Philips LED Ball Lamp, Xiaomi Philips LED Ceiling Lamp and Xiaomi Philips Eyecare Lamp 2.
 
 Currently, the supported features are `on`, `off`, `set_cct` (colortemp) , `set_bright` (brightness).
 

--- a/source/_components/light.xiaomi_miio.markdown
+++ b/source/_components/light.xiaomi_miio.markdown
@@ -28,20 +28,31 @@ light:
     name: Xiaomi Philips Smart LED Ball
     host: 192.168.130.67
     token: YOUR_TOKEN
+    model: philips.light.bulb
 ```
 
 Configuration variables:
 - **host** (*Required*): The IP of your light.
 - **token** (*Required*): The API token of your light.
 - **name** (*Optional*): The name of your light.
+- **model** (*Optional*): The model of your light. Valid values are `philips.light.bulb`, `philips.light.sread1` and `philips.light.ceiling`. This setting can be used to bypass the device model detection and is recommended if your device isn't always available.
 
 ## {% linkable_title Platform Services %}
 
-### Service fan/xiaomi_miio_set_scene
+### Service light/xiaomi_miio_set_scene
 
 Set one of the 4 available fixed scenes.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific light. Else targets all.         |
+| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
 | `scene`                   |       no | Scene, between 1 and 4.                               |
+
+### Service light/xiaomi_miio_set_delayed_turn_off
+
+Delayed turn off.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
+| `delayed_turn_off`        |       no | Turn off delay in seconds.                            |

--- a/source/_components/light.xiaomi_miio.markdown
+++ b/source/_components/light.xiaomi_miio.markdown
@@ -55,4 +55,4 @@ Delayed turn off.
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
-| `delayed_turn_off`        |       no | Turn off delay in seconds.                            |
+| `seconds`                 |       no | Turn off delay in seconds.                            |

--- a/source/_components/light.xiaomi_miio.markdown
+++ b/source/_components/light.xiaomi_miio.markdown
@@ -37,9 +37,29 @@ Configuration variables:
 - **name** (*Optional*): The name of your light.
 - **model** (*Optional*): The model of your light. Valid values are `philips.light.bulb`, `philips.light.sread1`, `philips.light.ceiling` and `philips.light.zyceiling`. This setting can be used to bypass the device model detection and is recommended if your device isn't always available.
 
+{% configuration %}
+host:
+  description: The IP address of your device.
+  required: true
+  type: string
+token:
+  description: The API token of your device.
+  required: true
+  type: string
+name:
+  description: The name of your device.
+  required: false
+  type: string
+  default: Xiaomi Philips Light
+model:
+  description: The model of your device.
+  required: false
+  type: string
+{% endconfiguration %}
+
 ## {% linkable_title Platform Services %}
 
-### Service light/xiaomi_miio_set_scene
+### {% linkable_title Service `light.xiaomi_miio_set_scene` %}
 
 Set one of the 4 available fixed scenes.
 
@@ -48,7 +68,7 @@ Set one of the 4 available fixed scenes.
 | `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
 | `scene`                   |       no | Scene, between 1 and 4.                               |
 
-### Service light/xiaomi_miio_set_delayed_turn_off
+### {% linkable_title Service `light.xiaomi_miio_set_delayed_turn_off` %}
 
 Delayed turn off.
 


### PR DESCRIPTION
**Description:**

Configuration key "model" and "xiaomi_miio_set_delayed_turn_off" service added.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#12449