### PR TITLE
Support for multiple min-max sensors

### DIFF
--- a/source/_components/sensor.min_max.markdown
+++ b/source/_components/sensor.min_max.markdown
@@ -14,16 +14,18 @@ ha_release: "0.31"
 ---
 
 
-The `min_max` sensor platform consumes the state from other sensors to determine the minimum, maximum, latest (last) and the mean of the collected states. The sensor will always show you the lowest/highest/latest value which was received from all monitored sensors. If you have spikes in your values, it's recommended to filter/equalize your values with a [statistics sensor](/components/sensor.statistics/) first.
+The `min_max` sensor platform consumes the state from other sensors to determine the `minimum`, `maximum`, `latest (last)` and the `mean` of the collected states. The sensor will always show you the lowest/highest/latest value which was received from all monitored sensors. If you have spikes in your values, it's recommended to filter/equalize your values with a [statistics sensor](/components/sensor.statistics/) first.
 
 This sensor is an alternative to the [template sensor](/components/sensor.template/)'s `value_template:` to get the average of multiple sensors.
 
+{% raw %}
 ```yaml
-{% raw %}{{ ((float(states.sensor.kitchen_temperature.state) + 
+{{ ((float(states.sensor.kitchen_temperature.state) + 
      float(states.sensor.living_room_temperature.state) +
      float(states.sensor.office_temperature.state)) / 3) | round(2)
-}}{% endraw %}
+}}
 ```
+{% endraw %}
 
 Sensors with an unknown state will be ignored in the calculation. If the unit of measurement of the sensors differs, the `min_max` sensor will go to an error state where the value is `UNKNOWN` and unit of measurement is `ERR`.
 
@@ -33,16 +35,36 @@ To enable the `min_max` sensor, add the following lines to your `configuration.y
 # Example configuration.yaml entry
 sensor:
   - platform: min_max
-    entity_ids:
-      - sensor.kitchen_temperature
-      - sensor.living_room_temperature
-      - sensor.office_temperature
+    sensors:
+      my_max_sensor:
+        entity_ids:
+          - sensor.kitchen_temperature
+          - sensor.living_room_temperature
+          - sensor.office_temperature
 ```
 
-Configuration variables:
-
-- **entity_ids** (*Required*): At least two entities to monitor. The unit of measurement of the first entry will be the one that's used. All entities must use the same unit of measurement.
-- **type** (*Optional*): The type of sensor: `min`, `max`, `last` or `mean`. Defaults to `max`.
-- **name** (*Optional*): Name of the sensor to use in the frontend.
-- **round_digits** (*Optional*): Round mean value to specified number of digits. Defaults to 2.
-
+{% configuration %}
+  sensors:
+    description: List of your sensors.
+    required: true
+    type: map
+    keys:
+      friendly_name:
+        description: Name to use in the frontend.
+        required: false
+        type: string
+      type:
+        description: The type of the sensor.
+        required: false
+        type: [min | max | last | mean]
+        default: max
+      round_digits:
+        description: Round mean value to specified number of digits.
+        required: false
+        type: int
+        default: 2
+      entity_ids:
+        description: At least two entities to monitor. All entities must use the same unit of measurement.
+        required: true
+        type: list
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
* Updated config example
* Updated configuration

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12500

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
