### PR TITLE
Update light.mqtt

### DIFF
--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -143,7 +143,7 @@ white_value_state_topic:
   description: The MQTT topic subscribed to receive white value updates.
   required: false
   type: string
-white_value_value_template:
+white_value_template:
   description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the white value."
   required: false
   type: string


### PR DESCRIPTION
Bad name of a parameter (double 'value')

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
