### PR TITLE
Update Docker note

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -27,7 +27,7 @@ You need to have a [supported Z-Wave USB stick or module](https://github.com/Ope
 | ZWave.me UZB1           |   &#10003;     |                  |              |
 
 <p class='note'>
-  If you're using Hass.io, it's recommended to use a USB stick, not a module. Passing a module through Docker is more complicated than passing a USB stick through.
+  If you're using Hass.io or running HASS in a Docker container, it's recommended to use a USB stick, not a module. Passing a module through Docker is more complicated than passing a USB stick through.
 </p>
 
 ## {% linkable_title Stick Alternatives %}


### PR DESCRIPTION
**Description:**
Added extra information about running HASS in a Docker container to the module pass-through note.

**Pull request in [home-assistant docs](https://github.com/home-assistant/home-assistant.github.io) (if applicable):** home-assistant/home-assistant.github.io#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
