### PR TITLE
Small change to recommend adding a network key to the configuration

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -53,7 +53,7 @@ usb_path:
   type: string
   default: /zwaveusbstick
 network_key:
-  description: The 16-byte network key in the form `"0x01, 0x02..."` used in order to connect securely to compatible devices. It is recommended that a network key is configured as security enabled devices will not function correctly if they are not added securely.
+  description: The 16-byte network key in the form `"0x01, 0x02..."` used in order to connect securely to compatible devices. It is recommended that a network key is configured as security enabled devices may not function correctly if they are not added securely.
   required: false
   type: string
   default: None

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -53,7 +53,7 @@ usb_path:
   type: string
   default: /zwaveusbstick
 network_key:
-  description: The 16-byte network key in the form `"0x01, 0x02..."` used in order to connect securely to compatible devices.
+  description: The 16-byte network key in the form `"0x01, 0x02..."` used in order to connect securely to compatible devices. It is recommended that a network key is configured as security enabled devices will not function correctly if they are not added securely.
   required: false
   type: string
   default: None


### PR DESCRIPTION
**Description:**

We should consider recommending a network key for all z-wave installations. As users begin to add more and more devices they may not think about adding this later on as the network grows. Many users come to Discord or elsewhere and get confused as to why their Z-Wave device is not functioning correctly and come to find out they needed a network key and to add the device securely. As more and more Z-Wave Plus devices come out there are more security enabled devices as well.  All locks and sensors are pretty much security devices.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
