### PR TITLE
Add some emphasis about Breaking Changes

### DIFF
--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -14,7 +14,7 @@ redirect_from: /getting-started/updating/
 The upgrade process differs depending on the installation you have, so please review the documentation that is specific to your install [Hass.io](/hassio/), [HASSbian](/docs/hassbian/common-tasks/#update-home-assistant), [Vagrant](/docs/installation/vagrant/), or [Virtualenv](/docs/installation/virtualenv/#upgrading-home-assistant).
 </p>
 
-View what's new in the latest version and potential impacts on your system [here](https://github.com/home-assistant/home-assistant/releases). It is in good practice to review the release notes and pay close attention to the Breaking Changes that are listed there. If you have not done an update in sometime, you should also look at previous release notes as they can also have Breaking Changes that may impact your system. Breaking Changes may require configuration updates for your components, if not done before the update home assistant may not load or the component will not work.
+View what's new in the latest version and potential impacts on your system [here](https://github.com/home-assistant/home-assistant/releases). It is in good practice to review the release notes and pay close attention to the Breaking Changes that are listed there. If you have not done an update in sometime, you should also look at previous release notes as they can also have Breaking Changes that may impact your system. Breaking Changes may require configuration updates for your components, if not done before the update Home Assistant may not load or the component will not work.
 
 The default way to update Home Assistant to the latest release, when available, is:
 

--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -14,7 +14,7 @@ redirect_from: /getting-started/updating/
 The upgrade process differs depending on the installation you have, so please review the documentation that is specific to your install [Hass.io](/hassio/), [HASSbian](/docs/hassbian/common-tasks/#update-home-assistant), [Vagrant](/docs/installation/vagrant/), or [Virtualenv](/docs/installation/virtualenv/#upgrading-home-assistant).
 </p>
 
-View what's new in the latest version and potential impacts on your system [here](https://github.com/home-assistant/home-assistant/releases). It is in good practice to review the release notes and pay close attention to the Breaking Changes that are listed there. If you have not done an update in sometime, you should also look at previous release notes as they can also have Breaking Changes that may impact your system. Breaking Changes may require configuration updates for your components, if not done before the update Home Assistant may not load or the component will not work.
+View what's new in the latest version and potential impacts on your system in [release notes](https://github.com/home-assistant/home-assistant/releases). It is in good practice to review the release notes and pay close attention to the **Breaking Changes** that are listed there. If you have not done an update in sometime, you should also look at previous release notes as they can also have **Breaking Changes** that may impact your system. **Breaking Changes** may require configuration updates for your components, if not done before the update Home Assistant may not load or the component will not work.
 
 The default way to update Home Assistant to the latest release, when available, is:
 

--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -14,7 +14,7 @@ redirect_from: /getting-started/updating/
 The upgrade process differs depending on the installation you have, so please review the documentation that is specific to your install [Hass.io](/hassio/), [HASSbian](/docs/hassbian/common-tasks/#update-home-assistant), [Vagrant](/docs/installation/vagrant/), or [Virtualenv](/docs/installation/virtualenv/#upgrading-home-assistant).
 </p>
 
-View what's new in the latest version and potential impacts on your system in [release notes](https://github.com/home-assistant/home-assistant/releases). It is in good practice to review the release notes and pay close attention to the **Breaking Changes** that are listed there. If you have not done an update in sometime, you should also look at previous release notes as they can also have **Breaking Changes** that may impact your system. **Breaking Changes** may require configuration updates for your components, if not done before the update Home Assistant may not load or the component will not work.
+Check what's new in the latest version and potentially impacts your system in [Home Assistant release notes](https://github.com/home-assistant/home-assistant/releases). It is good practice to review these release notes and pay close attention to the **Breaking Changes** that are listed there. If you havn't done an update for a while, you should also check previous release notes as they can also contain relevant **Breaking Changes**. **Breaking Changes** may require configuration updates for your components. If you missed this and Home Assistant refuses to start, check `<config-dir>/home-assistant.log` for details about broken components.
 
 The default way to update Home Assistant to the latest release, when available, is:
 

--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -14,7 +14,7 @@ redirect_from: /getting-started/updating/
 The upgrade process differs depending on the installation you have, so please review the documentation that is specific to your install [Hass.io](/hassio/), [HASSbian](/docs/hassbian/common-tasks/#update-home-assistant), [Vagrant](/docs/installation/vagrant/), or [Virtualenv](/docs/installation/virtualenv/#upgrading-home-assistant).
 </p>
 
-View what's new in the latest version and potential impacts on your system [here](https://github.com/home-assistant/home-assistant/releases).
+View what's new in the latest version and potential impacts on your system [here](https://github.com/home-assistant/home-assistant/releases). It is in good practice to review the release notes and pay close attention to the Breaking Changes that are listed there. If you have not done an update in sometime, you should also look at previous release notes as they can also have Breaking Changes that may impact your system. Breaking Changes may require configuration updates for your components, if not done before the update home assistant may not load or the component will not work.
 
 The default way to update Home Assistant to the latest release, when available, is:
 


### PR DESCRIPTION
We should provide proper guidance to the user about the importance of release notes and paying attention to breaking changes.  A common error users face while updating home assistant is not paying attention to the breaking changes.  If the user has not done an update in sometime they may also forget about previous breaking changes that still stand.


## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
