### PR TITLE
Consistent documentation for user_id / chat_id

### DIFF
--- a/source/_components/telegram_bot.markdown
+++ b/source/_components/telegram_bot.markdown
@@ -29,7 +29,7 @@ Send a notification.
 |---------------------------|----------|--------------------------------------------------|
 | `message`                 |       no | Message body of the notification. |
 | `title`                   |      yes | Optional title for your notification. Will be composed as '%title\n%message'. |
-| `target`                  |      yes | An array of pre-authorized chat_ids to send the notification to. Defaults to the first allowed chat_id. |
+| `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `parse_mode`              |      yes | Parser for the message text: `html` or `markdown`. |
 | `disable_notification`    |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |
 | `disable_web_page_preview`|      yes | True/false for disable link previews for links in the message. |
@@ -47,7 +47,7 @@ Send a photo.
 | `username`                |      yes | Username for a URL which require HTTP basic authentication. |
 | `password`                |      yes | Password for a URL which require HTTP basic authentication. |
 | `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
-| `target`                  |      yes | An array of pre-authorized chat_ids to send the notification to. Defaults to the first allowed chat_id. |
+| `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `disable_notification`    |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |
 | `keyboard`                |      yes | List of rows of commands, comma-separated, to make a custom keyboard. Example: `["/command1, /command2", "/command3"]` |
 | `inline_keyboard`         |      yes | List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data. Example: `["/button1, /button2", "/button3"]` or `[[["Text btn1", "/button1"], ["Text btn2", "/button2"]], [["Text btn3", "/button3"]]]` |
@@ -64,7 +64,7 @@ Send a video.
 | `username`                |      yes | Username for a URL which requires HTTP basic authentication. |
 | `password`                |      yes | Password for a URL which requires HTTP basic authentication. |
 | `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
-| `target`                  |      yes | An array of pre-authorized chat_ids to send the notification to. Defaults to the first allowed chat_id. |
+| `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `disable_notification`    |      yes | True/false to send the message silently. iOS users and web users will not receive a notification. Android users will receive a notification with no sound. Defaults to False. |
 | `keyboard`                |      yes | List of rows of commands, comma-separated, to make a custom keyboard. Example: `["/command1, /command2", "/command3"]` |
 | `inline_keyboard`         |      yes | List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data. Example: `["/button1, /button2", "/button3"]` or `[[["Text btn1", "/button1"], ["Text btn2", "/button2"]], [["Text btn3", "/button3"]]]` |
@@ -80,7 +80,7 @@ Send a document.
 | `username`                |      yes | Username for a URL which require HTTP basic authentication. |
 | `password`                |      yes | Password for a URL which require HTTP basic authentication. |
 | `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
-| `target`                  |      yes | An array of pre-authorized chat_ids to send the notification to. Defaults to the first allowed chat_id. |
+| `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `disable_notification`    |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |
 | `keyboard`                |      yes | List of rows of commands, comma-separated, to make a custom keyboard. Example: `["/command1, /command2", "/command3"]` |
 | `inline_keyboard`         |      yes | List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data. Example: `["/button1, /button2", "/button3"]` or `[[["Text btn1", "/button1"], ["Text btn2", "/button2"]], [["Text btn3", "/button3"]]]` |
@@ -92,7 +92,7 @@ Send a location.
 |---------------------------|----------|--------------------------------------------------|
 | `latitude`                |       no | The latitude to send. |
 | `longitude`               |       no | The longitude to send.  |
-| `target`                  |      yes | An array of pre-authorized chat_ids to send the notification to. Defaults to the first allowed chat_id. |
+| `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `disable_notification`    |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |
 | `keyboard`                |      yes | List of rows of commands, comma-separated, to make a custom keyboard. Example: `["/command1, /command2", "/command3"]` |
 | `inline_keyboard`         |      yes | List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data. Example: `["/button1, /button2", "/button3"]` or `[[["Text btn1", "/button1"], ["Text btn2", "/button2"]], [["Text btn3", "/button3"]]]` |
@@ -316,7 +316,7 @@ Message editor:
     - service: telegram_bot.edit_message
       data_template:
         message_id: {% raw %}'{{ trigger.event.data.message.message_id }}'{% endraw %}
-        chat_id: {% raw %}'{{ trigger.event.data.user_id }}'{% endraw %}
+        chat_id: {% raw %}'{{ trigger.event.data.chat_id }}'{% endraw %}
         title: '*Message edit*'
         inline_keyboard:
           - "Edit message:/edit_msg, Don't:/do_nothing"
@@ -344,7 +344,7 @@ Keyboard editor:
     - service: telegram_bot.edit_replymarkup
       data_template:
         message_id: 'last'
-        chat_id: {% raw %}'{{ trigger.event.data.user_id }}'{% endraw %}
+        chat_id: {% raw %}'{{ trigger.event.data.chat_id }}'{% endraw %}
         inline_keyboard:
           - "Edit message:/edit_msg, Don't:/do_nothing"
 ```
@@ -400,7 +400,7 @@ class TelegramBotEventListener(appapi.AppDaemon):
         assert event_id == 'telegram_callback'
         data_callback = payload_event['data']
         callback_id = payload_event['id']
-        user_id = payload_event['user_id']
+        chat_id = payload_event['chat_id']
         # keyboard = ["Edit message:/edit_msg, Don't:/do_nothing",
         #             "Remove this button:/remove button"]
         keyboard = [[("Edit message", "/edit_msg"),
@@ -420,7 +420,7 @@ class TelegramBotEventListener(appapi.AppDaemon):
             title = '*Message edit*'
             msg = 'Callback received from %s. Message id: %s. Data: ``` %s ```'
             self.call_service('telegram_bot/edit_message',
-                              chat_id=user_id,
+                              chat_id=chat_id,
                               message_id=msg_id,
                               title=title,
                               message=msg % (user, msg_id, data_callback),
@@ -436,7 +436,7 @@ class TelegramBotEventListener(appapi.AppDaemon):
             # Edit the keyboard
             new_keyboard = keyboard[:1]
             self.call_service('telegram_bot/edit_replymarkup',
-                              chat_id=user_id,
+                              chat_id=chat_id,
                               message_id='last',
                               inline_keyboard=new_keyboard)
 


### PR DESCRIPTION
Using a more consistent usage regarding the interaction between `target`, `user_id` and `chat_id`.

The `target` can be both a `user_id` or a `target_id`, leaving the `user_id` (which was the original one). But the `chat_id` parameters should be a `chat_id` identificator, for consistency.

Also updated the description for `target` parameter on Telegram calls.
