### PR TITLE
`automation` and `automation old` in the same time

### DIFF
--- a/source/_docs/automation/editor.markdown
+++ b/source/_docs/automation/editor.markdown
@@ -65,7 +65,9 @@ automation old:
     platform: ...
 ```
 
-You can use the `automation:` and `automation old:` sections in the same time to keep yout manual designed automations and use the editor for next ones:
+You can use the `automation:` and `automation old:` sections in the same time:
+ - `automation old:` to keep your manual designed automations
+ - `automation:` to save the automation created by the online editor
 
 ```yaml
 automation: !include automations.yaml

--- a/source/_docs/automation/editor.markdown
+++ b/source/_docs/automation/editor.markdown
@@ -65,6 +65,14 @@ automation old:
     platform: ...
 ```
 
+You can use the `automation:` and `automation old:` sections in the same time to keep yout manual designed automations and use the editor for next ones:
+
+```yaml
+automation: !include automations.yaml
+automation old: !include_dir_merge_list automations
+```
+
+
 ## {% linkable_title Migrating your automations to `automations.yaml` %}
 
 If you want to migrate your old automations to use the editor, you'll have to copy them to `automations.yaml`. Make sure that `automations.yaml` remains a list! For each automation that you copy over you'll have to add an `id`. This can be any string as long as it's unique.


### PR DESCRIPTION
Additional comment and example to explain we can use the both sections in the same time.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
