### PR TITLE
Docs for 12598 (Room hinting for Google Assistant)

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -44,6 +44,7 @@ google_assistant:
       type: light
     light.living_room:
       expose: false
+      room: living room
 ```
 
 Configuration variables:
@@ -103,6 +104,10 @@ entity_config:
           type: list
         type:
           description: Override how Google Assistant interprets the domain of the entity. For example, set to `light` for a switch entity to have it be handled as a light.
+          required: false
+          type: string
+        room:
+          description: Allows for associating this device to a Room in Google Assistant.  This is currently non-functional, but will be enabled in the near future.
           required: false
           type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12598

## Checklist:

- [x ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
