### PR TITLE
Update venv link to python 3

### DIFF
--- a/source/developers/development_environment.markdown
+++ b/source/developers/development_environment.markdown
@@ -85,7 +85,7 @@ $ git remote add upstream https://github.com/home-assistant/home-assistant.git
 
 ### {% linkable_title Setting up virtual environment %} 
 
-To isolate your environment from the rest of the system, set up a [`venv`](https://docs.python.org/3.4/library/venv.html). Within the `home-assistant` directory, create and activate your virtual environment.
+To isolate your environment from the rest of the system, set up a [`venv`](https://docs.python.org/3/library/venv.html). Within the `home-assistant` directory, create and activate your virtual environment.
 
 ```bash
 $ python3 -m venv .


### PR DESCRIPTION
**Description:**
Currently the venv links to python 3.4 specifically. Since support for py 3.4 is being dropped it makes more sense to point to the python 3 page where the user can select the version they are using. This principle probably applies to many links in the docs.


