### PR TITLE
Clarity edit for timelapse and file path

### DIFF
--- a/source/_components/camera.rpi_camera.markdown
+++ b/source/_components/camera.rpi_camera.markdown
@@ -72,5 +72,5 @@ file_path:
   type: string
 {% endconfiguration %}
  
-The given **file_path** must be an existing file because the camera platform setup performs a writeable check on it. Also, keep in mind that the path should be [whitelisted](https://home-assistant.io/docs/configuration/basic/).
+The given **file_path** must be an existing file because the camera platform setup performs a writeable check on it. Also, keep in mind that the path should be [whitelisted](/docs/configuration/basic/).
 


### PR DESCRIPTION
Existing wording for timelapse implies that a value of 1000 results in pictures being taken every millisecond, so the value is in microseconds.

Added link for the whitelist to make it easier to find the relevant config section.
