### PR TITLE
Added redirect_from for /components/ios/

### DIFF
--- a/source/_docs/ecosystem/ios.markdown
+++ b/source/_docs/ecosystem/ios.markdown
@@ -8,6 +8,7 @@ comments: false
 sharing: true
 footer: true
 redirect_from: /ecosystem/ios/
+redirect_from: /components/ios/
 ---
 
 The Home Assistant for iOS app offers a companion app for iOS which is deeply integrated into both Home Assistant and iOS. Its basic features include:


### PR DESCRIPTION
The Invalid Config card showing the ios component sends you to /components/ios/ which has now been moved to /docs/ecosystem/ios/, causing a 404 to be shows to users who click the link. Added the redirect statement to this page to accommodate.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
