### PR TITLE
Update ubus documentation for optional DHCP name resolution

### DIFF
--- a/source/_components/device_tracker.ubus.markdown
+++ b/source/_components/device_tracker.ubus.markdown
@@ -68,7 +68,7 @@ Configuration variables:
 - **host** (*Required*): The IP address of your router, eg. 192.168.1.1.
 - **username** (*Required*): The username of an user with administrative privileges, usually *root*.
 - **password** (*Required*): The password for your given account.
-- **dhcp_software** (*Optional*): The DHCP software used in your router: `dnsmasq` or `dhcpd`. Defaults to `dnsmasq`.
+- **dhcp_software** (*Optional*): The DHCP software used in your router: `dnsmasq`, `dhcpd`, or `none`. Defaults to `dnsmasq`.
 
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12658

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
