### PR TITLE
docs: clarify location of counter alias

### DIFF
--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -19,7 +19,7 @@ To add a counter to your installation, add the following to your `configuration.
 ```yaml
 # Example configuration.yaml entry
 counter:
-  counter:
+  my_custom_counter:
     initial: 30
     step: 1
 ```


### PR DESCRIPTION

**Description:**

We clarify the location of the counter alias by renaming it `counter` --> `my_custom_counter` and remove potential for confusion with the similarly named `counter` field above.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** 

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
