### PR TITLE
Remove reference to web interface

### DIFF
--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -23,7 +23,7 @@ The default InfluxDB configuration doesn't enforce authentication. If you have i
 influxdb:
 ```
 
-You will still need to create a database named `home_assistant` via InfluxDB's web interface or command line. For instructions how to create a database check the [InfluxDB documentation](https://docs.influxdata.com/influxdb/latest/introduction/getting_started/#creating-a-database) relevant to the version you have installed.
+You will still need to create a database named `home_assistant` via InfluxDB's command line interface. For instructions on how to create a database check the [InfluxDB documentation](https://docs.influxdata.com/influxdb/latest/introduction/getting_started/#creating-a-database) relevant to the version you have installed.
 
 Configuration variables:
 


### PR DESCRIPTION
The web interface was deprecated in version 1.1: https://docs.influxdata.com/influxdb/v1.1/tools/web_admin/

An older blog post linked (https://home-assistant.io/blog/2015/12/07/influxdb-and-grafana/) detailing how to use InfluxDB and Grafana mentions this web interface as part of the setup and it may be confusing for users attempting to follow it, unless they realize the latest version doesn't have it.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
