### PR TITLE
Fix MQTT discovery object_id docs

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -44,7 +44,7 @@ The discovery topic need to follow a specific format:
 
 - `<component>`: One of the supported components, eg. `binary_sensor`.
 - `<node_id>`: (*Optional*) id of the node providing the topic.
-- `<object_id>`: The ID of the device. Note: This is only to allow for separate topics for each device and is not used for the entity_id.
+- `<object_id>`: "The ID of the device. This is only to allow for separate topics for each device and is not used for the `entity_id`."
 - `<>`: The topic `config` or `state` which defines the current action.
 
 The payload will be checked like an entry in your `configuration.yaml` file if a new device is added. This means that missing variables will be filled with the platform's default values. All configuration variables which are *required* must be present in the initial payload send to `/config`.

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -44,7 +44,7 @@ The discovery topic need to follow a specific format:
 
 - `<component>`: One of the supported components, eg. `binary_sensor`.
 - `<node_id>`: (*Optional*) id of the node providing the topic.
-- `<object_id>`: The ID of the device. This will become the `entity_id` in Home Assistant.
+- `<object_id>`: The ID of the device. Note: This is only to allow for separate topics for each device and is not used for the entity_id.
 - `<>`: The topic `config` or `state` which defines the current action.
 
 The payload will be checked like an entry in your `configuration.yaml` file if a new device is added. This means that missing variables will be filled with the platform's default values. All configuration variables which are *required* must be present in the initial payload send to `/config`.


### PR DESCRIPTION
**Description:**

Fixes https://github.com/home-assistant/home-assistant/issues/10220; Basically, the `object_id` for MQTT discovey is **not** used for entity_id as expressed in the docs.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
