### PR TITLE
Update USPS docs to include required driver declaration

### DIFF
--- a/source/_components/usps.markdown
+++ b/source/_components/usps.markdown
@@ -32,6 +32,8 @@ Install the latest version of [PhantomJS]( http://phantomjs.org/download.html). 
   Don't use apt-get to install PhantomJS. This version is not compatible.
 </p>
 
+If you use the PhantomJS option, specify `driver: phantomjs` in your `usps` configuration.
+
 
 ### Chrome
 
@@ -60,6 +62,7 @@ Configuration options for the USPS component:
 
 - **username** (*Required*): The username to access the MyUSPS service.
 - **password** (*Required*): The password for the given username.
+- **driver** (*Required*): Specify if you're using `phantomjs` or `chrome`.
 - **name** (*Optional*): Prefix for sensor names (defaults to "USPS")
 
 <p class='note warning'>


### PR DESCRIPTION


**Description:**

With the changes to the USPS component in #12465 we're now required to specify the `driver` regardless if using `phantomjs` or `chrome`. Updating docs to reflect the required `driver: phantomjs` if using it. 

Re: 
* https://github.com/happyleavesaoc/python-myusps/issues/11
* https://github.com/home-assistant/home-assistant/pull/12465

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12465

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
