### PR TITLE
Example JSON has invalid synstax

### DIFF
--- a/source/_components/notify.nfandroidtv.markdown
+++ b/source/_components/notify.nfandroidtv.markdown
@@ -52,7 +52,7 @@ This is a fully customized JSON you can use to test how the final notification w
     "duration":2,
     "transparency":"0%",
     "color": "red",
-    "interrupt": 1,
+    "interrupt": 1
     }
 }
 ```


### PR DESCRIPTION
**Description:**
The included JSON sample has an invalid syntax, this will correct it.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
