### PR TITLE
Harmony docs to breaking change in .64

### DIFF
--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -47,9 +47,10 @@ You can override some default configuration values on a discovered hub (e.g. the
 Configuration variables:
 
 - **name** (*Required*): The hub's name to display in the frontend. This name must match the name you have set on the Hub.
+- **activity** (*Optional*): Activity to use when `turn_on` service is called without any data. Overrides the `activity` setting for this discovered hub.
 - **host** (*Optional*): The Harmony device's IP address. Leave empty for the IP to be discovered automatically.
 - **port** (*Optional*): The Harmony device's port. Defaults to 5222.
-- **activity** (*Optional*): Activity to use when `turn_on` service is called without any data. Overrides the `activity` setting for this discovered hub.
+
 - **delay_secs** (*Optional*): Default duration in seconds between sending commands to a device.
 
 Configuration file:


### PR DESCRIPTION
Variable activity is Required since 0.64, changed the docs to clarify

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
