### PR TITLE
Fix bmw connected drive attribute

### DIFF
--- a/source/_components/bmw_connected_drive.markdown
+++ b/source/_components/bmw_connected_drive.markdown
@@ -22,8 +22,7 @@ To enable this component in your installation, add the following to your
 ```yaml
 # Example configuration.yaml entry
 bmw_connected_drive:
-  mycar:
-    name: Car 1
+  name:
     username: USERNAME_BMW_CONNECTED_DRIVE
     password: PASSWORD_BMW_CONNECTED_DRIVE
     country: COUNTRY_BMW_CONNECTED_DRIVE


### PR DESCRIPTION
**Description:**
Removed "name:" as the component does NOT use this attribute.
Fixes https://github.com/home-assistant/home-assistant/issues/12698

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
