### PR TITLE
Add note for systemd

### DIFF
--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -110,6 +110,15 @@ If you get this error `AttributeError: module 'ssl' has no attribute 'PROTOCOL_T
 </p>
 
 <p class='note'>
+If you are running a Mosquitto instance on the same server as Home Assistant then you must ensure that the Mosquitto service starts before Home Assistant. For a Linux instance running Systemd (Raspberry Pi, Debian, Ubuntu and others) then you should edit the file /etc/systemd/system/home-assistant@homeassistant.service as root (e.g. sudo nano /etc/systemd/system/home-assistant@homeassistant.service) and add the mosquitto service:
+```
+[Unit]
+Description=Home Assistant
+After=network.target mosquitto.service
+```
+</p>
+
+<p class='note'>
 If you are running a Mosquitto instance on a different server with proper SSL encryption using a service like Let's Encrypt you may have to set the certificate to the operating systems own `.crt` certificates file. In the instance of Ubuntu this would be `certificate: /etc/ssl/certs/ca-certificates.crt`
 </p>
 


### PR DESCRIPTION
Add note for systemd to start Mosquitto before Home Assistant

**Description:**
Ensure Mosquitto service starte before Home Assistant

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
