### PR TITLE
Correct the ha_iot_class

### DIFF
--- a/source/_components/light.decora_wifi.markdown
+++ b/source/_components/light.decora_wifi.markdown
@@ -8,12 +8,12 @@ comments: false
 sharing: true
 footer: true
 ha_category: Light
-ha_iot_class: "Local Polling"
+ha_iot_class: "Cloud Polling"
 logo: leviton.png
 ha_release: 0.51
 ---
 
-Support for [Leviton Decora Wi-Fi](http://www.leviton.com/en/products/lighting-controls/decora-smart-with-wifi) dimmers/switches.
+Support for [Leviton Decora Wi-Fi](http://www.leviton.com/en/products/lighting-controls/decora-smart-with-wifi) dimmers/switches via the MyLeviton API.
 
 Supported devices (tested):
 


### PR DESCRIPTION
**Description:**
Update the ha_iot_class of leviton_decora.wifi switches.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
