### PR TITLE
Add support for Eltako FSR61 switches (Enocean)

### DIFF
--- a/source/_components/enocean.markdown
+++ b/source/_components/enocean.markdown
@@ -27,6 +27,7 @@ There is currently support for the following device types within Home Assistant:
 However, only a few devices have been confirmed to work. These are:
 
 - Eltako FUD61 dimmer
+- Eltako FSR61 switch
 - Eltako FT55 battery-less wall switch
 - Jung ENOA590WW battery-less wall switch
 - Permundo PSC234 (switch and power monitor)

--- a/source/_components/switch.enocean.markdown
+++ b/source/_components/switch.enocean.markdown
@@ -13,20 +13,15 @@ ha_release: 0.21
 ha_iot_class: "Local Push"
 ---
 
-An EnOcean switch can take many forms. Currently only two types have been tested and confirmed to work well: Eltako FSR61 and Permundo PSC234
-
+An EnOcean switch can take many forms. Currently, only two types have been tested and confirmed to work well: Eltako FSR61 and Permundo PSC234
 
 To use your EnOcean device, you first have to set up your [EnOcean hub](/components/enocean/) and then add the following to your `configuration.yaml` file:
-
 
 ```yaml
 # Example configuration.yaml entry
 switch:
   - platform: enocean
-    name: my_switch_name
     id: [0x01,0x90,0x84,0x3C]
-    sender_id: [0xff,0xc6,0xea,0x14]
-    subtype: fsr61
 ```
 
 Configuration variables:
@@ -35,3 +30,13 @@ Configuration variables:
 - **name** (*Optional*): An identifier for the switch. Default to `EnOcean Switch`.
 - **subtype** (*Optional*): Only `permundo` and `fsr61` supported. Default to `permundo`.
 - **sender_id** (*Optional*): Only needed when using `fsr61` as subtype.
+
+```yaml
+# Extensive example configuration.yaml entry
+switch:
+  - platform: enocean
+    name: my_switch_name
+    id: [0x01,0x90,0x84,0x3C]
+    sender_id: [0xff,0xc6,0xea,0x14]
+    subtype: fsr61
+```

--- a/source/_components/switch.enocean.markdown
+++ b/source/_components/switch.enocean.markdown
@@ -13,19 +13,25 @@ ha_release: 0.21
 ha_iot_class: "Local Push"
 ---
 
-An EnOcean switch can take many forms. Currently only one type has been tested: Permundo PSC234
+An EnOcean switch can take many forms. Currently only two types have been tested and confirmed to work well: Eltako FSR61 and Permundo PSC234
 
 
 To use your EnOcean device, you first have to set up your [EnOcean hub](/components/enocean/) and then add the following to your `configuration.yaml` file:
+
 
 ```yaml
 # Example configuration.yaml entry
 switch:
   - platform: enocean
+    name: my_switch_name
     id: [0x01,0x90,0x84,0x3C]
+    sender_id: [0xff,0xc6,0xea,0x14]
+    subtype: fsr61
 ```
 
 Configuration variables:
 
 - **id** (*Required*): The ID of the device. This is a 4 bytes long number.
 - **name** (*Optional*): An identifier for the switch. Default to `EnOcean Switch`.
+- **subtype** (*Optional*): Only `permundo` and `fsr61` supported. Default to `permundo`.
+- **sender_id** (*Optional*): Only needed when using `fsr61` as subtype.


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
