### PR TITLE
Adding colors to light templates

### DIFF
--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -278,7 +278,7 @@ light:
 ```
 {% endraw %}
 
-And you can use the following script that finds the closest color from a list of named colors :
+Moreover, you can use the following script that finds the closest color from a list of named colors:
 
 {% raw %}
 ```python


### PR DESCRIPTION
These modifications go along [this pull request](https://github.com/home-assistant/home-assistant/pull/12439/).
I added an example for a common classes of IR remote lights.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
