### PR TITLE
Fixed service names

### DIFF
--- a/source/_components/media_player.markdown
+++ b/source/_components/media_player.markdown
@@ -20,7 +20,7 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | ---------------------- | -------- | ------------------------------------------------ |
 | `entity_id`            |      yes | Target a specific media player. Defaults to all. |
 
-#### {% linkable_title Service `media_player/volume_mute` %}
+#### {% linkable_title Service `media_player.volume_mute` %}
 
 | Service data attribute | Optional | Description                                      |
 |------------------------|----------|--------------------------------------------------|
@@ -34,14 +34,14 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | `entity_id`            |      yes | Target a specific media player. Defaults to all. |
 | `volume_level`         |       no | Float for volume level                           |
 
-#### {% linkable_title Service `media_player/media_seek` %}
+#### {% linkable_title Service `media_player.media_seek` %}
 
 | Service data attribute | Optional | Description                                            |
 |------------------------|----------|--------------------------------------------------------|
 | `entity_id`            |      yes | Target a specific media player. Defaults to all.       |
 | `seek_position`        |       no | Position to seek to. The format is platform dependent. |
 
-#### {% linkable_title Service `media_player/play_media` %}
+#### {% linkable_title Service `media_player.play_media` %}
 
 | Service data attribute | Optional | Description                                                                                                                                                            |
 | -----------------------| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -49,14 +49,14 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | `media_content_id`     |       no | A media identifier. The format of this is component dependent. For example, you can provide URLs to Sonos and Cast but only a playlist ID to iTunes.                   |
 | `media_content_type`   |       no | A media type. Must be one of `music`, `tvshow`, `video`, `episode`, `channel` or `playlist`. For example, to play music you would set `media_content_type` to `music`. |
 
-#### {% linkable_title Service `media_player/select_source` %}
+#### {% linkable_title Service `media_player.select_source` %}
 
 | Service data attribute | Optional | Description                                          |
 | ---------------------- | -------- | ---------------------------------------------------- |
 | `entity_id`            |      yes | Target a specific media player. Defaults to all.     |
 | `source`               |       no | Name of the source to switch to. Platform dependent. |
 
-#### {% linkable_title Service `media_player/shuffle_set` %}
+#### {% linkable_title Service `media_player.shuffle_set` %}
 
 Currently only supported on [Spotify](/components/media_player.spotify/), [MPD](/components/media_player.mpd/), [Kodi](/components/media_player.kodi/), [Squeezebox](/components/media_player.squeezebox/) and [Universal](/components/media_player.universal/).
 


### PR DESCRIPTION
For some reason this uses the services UI name for the services, confusing folks. Fixing that here.
