### PR TITLE
Add page on whitelist_external_dirs

### DIFF
--- a/source/_docs/configuration/whitelist.markdown
+++ b/source/_docs/configuration/whitelist.markdown
@@ -10,7 +10,7 @@ footer: true
 redirect_from: /getting-started/basic/#accessing-directories
 ---
 
-Home-assistant keeps a list of external directories that are writeable or accessible by components. If a component needs to access an external directory that is not added to the ```whitelist_external_dirs```, an error with be thrown. To add directories to the whitelist add to your configuration:
+Home-assistant keeps a list of external directories that are writeable or accessible by components. If a component needs to access an external directory that is not added to the `whitelist_external_dirs`, an error with be thrown. To add directories to the whitelist add to your configuration:
 
 ```yaml
 homeassistant:

--- a/source/_docs/configuration/whitelist.markdown
+++ b/source/_docs/configuration/whitelist.markdown
@@ -15,5 +15,5 @@ Home-assistant keeps a list of external directories that are writeable or access
 ```yaml
 homeassistant:
   whitelist_external_dirs:
-    - /www
+    - /data
 ```

--- a/source/_docs/configuration/whitelist.markdown
+++ b/source/_docs/configuration/whitelist.markdown
@@ -1,0 +1,19 @@
+---
+layout: page
+title: "Accessing directories"
+description: "Configuring access to directories via the whitelist."
+date: 2018-03-02 12:50
+sidebar: true
+comments: false
+sharing: true
+footer: true
+redirect_from: /getting-started/basic/#accessing-directories
+---
+
+Home-assistant keeps a list of external directories that are writeable or accessible by components. If a component needs to access an external directory that is not added to the ```whitelist_external_dirs```, an error with be thrown. To add directories to the whitelist add to your configuration:
+
+```yaml
+homeassistant:
+  whitelist_external_dirs:
+    - /www
+```


### PR DESCRIPTION
**Description:**
I feel whitelist_external_dirs badly needs its own page as this comes up on the forums so often. Is it worth commenting on permissions, since I know there are sometimes issues that directories need the permissions modified? (I've not direct experience of that however)

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
