### PR TITLE
Added KU6020 to the tested Samsung TV models.

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -57,6 +57,7 @@ Currently known supported models:
 - K5579 (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 - K6500AF (port must be set to 8001)
 - KS8005 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- KU6020 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - KU6290 (port must be set to 8001)
 - KU7000 (port must be set to 8001)
 - MU6170UXZG (port must be set to 8001, and `pip3 install websocket-client` must be executed)


### PR DESCRIPTION
**Description:**

This adds the Samsung TV model: KU6020 to the tested models and shows what is needed to get it to work with Home Assistant.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
