### PR TITLE
Adds www folder doc

### DIFF
--- a/source/_docs/configuration/www_folder.markdown
+++ b/source/_docs/configuration/www_folder.markdown
@@ -1,0 +1,13 @@
+---
+layout: page
+title: "Sharing files"
+description: "Share files via the www folder."
+date: 2018-03-02 12:50
+sidebar: true
+comments: false
+sharing: true
+footer: true
+redirect_from: /getting-started/basic/#www-folder
+---
+
+If you wish to share or view files via the Home-Assistant front end this can be done by creating a folder ```www``` in the configuration directory. Files added to this folder can then be viewed in a browser by navigating to the appropriate url. For example, if you added the file image.jpg this would be viewable at ```http://localhost:8123/local/image.jpg```. Note that ```www``` or one of its parent directories must be added to the whitelist_external_dirs.


### PR DESCRIPTION
**Description:**
The use of the www folder is not documented anywhere from what I can tell. 

As a separate issue it is a bit confusing that you create a ```www``` folder but then access the ```local``` path.

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
