### PR TITLE
Changed example to ACM from USB

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -43,7 +43,7 @@ On Raspberry Pi you will need to enable the serial interface in the `raspi-confi
 ```yaml
 # Example configuration.yaml entry
 zwave:
-  usb_path: /dev/ttyUSB0
+  usb_path: /dev/ttyACM0
 ```
 
 {% configuration zwave %}


### PR DESCRIPTION
Most Z-Wave sticks identify as ttyACM rather than ttyUSB - changing the example in the docs to fit what'll work for most people
