### PR TITLE
Incorrect case in stateObj

### DIFF
--- a/source/developers/frontend_creating_custom_ui.markdown
+++ b/source/developers/frontend_creating_custom_ui.markdown
@@ -48,7 +48,7 @@ frontend:
     <style>
 
     </style>
-    <textarea>[[_toStr(StateObj)]]</textarea>
+    <textarea>[[_toStr(stateObj)]]</textarea>
   </template>
 </dom-module>
 


### PR DESCRIPTION
The stateObj was spelled StateObj, which resulted in an empty string, causing a noob like me great confusion. Hope this helps someone. :)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
