### PR TITLE
Update docker compose examples

### DIFF
--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -90,7 +90,8 @@ As the docker command becomes more complex, switching to `docker-compose` can be
 ```yaml
   version: '3'
   services:
-    web:
+    homeassistant:
+      container_name: home-assistant
       image: homeassistant/home-assistant
       volumes:
         - /path/to/your/config:/config
@@ -118,7 +119,8 @@ or in a `docker-compose.yml` file:
 ```yaml
   version: '3'
   services:
-    web:
+    homeassistant:
+      container_name: home-assistant
       image: homeassistant/home-assistant
       volumes:
         - /path/to/your/config:/config


### PR DESCRIPTION
The docker compose examples have you create a service called 'web', which will create web_1 docker container.  Other references within the documents say to run `docker restart home-assistant`, yet this docker container does not exist when using the docker compose examples.  Updated compose so they will have a standard name for the container that is created.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
