### PR TITLE
Added replace from , to . for float handling

### DIFF
--- a/source/_components/sensor.scrape.markdown
+++ b/source/_components/sensor.scrape.markdown
@@ -126,7 +126,7 @@ sensor:
     resource: https://elen.nu/timpriser-pa-el-for-elomrade-se3-stockholm/
     name: Electricity price
     select: ".elspot-content"
-    value_template: '{{ value.split(" ")[0] }}'
+    value_template: '{{ ((value.split(" ")[0]) | replace (",", ".")) }}'
     unit_of_measurement: "öre/kWh"
 ```
 {% endraw %}


### PR DESCRIPTION
Since the website saves numbers with , the sensor ends up with "," when trying to use it in automations float does not work.
So i thought i added this if somone ells uses the example

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
