### PR TITLE
Update automation examples to proper formatting

### DIFF
--- a/source/_components/climate.zwave.markdown
+++ b/source/_components/climate.zwave.markdown
@@ -46,12 +46,12 @@ automation:
         at: "20:00:00"
     action:
       - service: climate.set_operation_mode
-        entity_id: climate.remotec_zxt120_heating_1_id
         data:
+          entity_id: climate.remotec_zxt120_heating_1_id
           operation_mode: Heat
       - service: climate.set_temperature
-        entity_id: climate.remotec_zxt120_heating_1_39
         data:
+          entity_id: climate.remotec_zxt120_heating_1_39
           temperature: 24
 ```
 
@@ -65,8 +65,8 @@ automation:
         at: "21:00:00"
     action:
       - service: climate.set_operation_mode
-        entity_id: climate.remotec_zxt120_heating_1_id
         data:
+          entity_id: climate.remotec_zxt120_heating_1_id
           operation_mode: 'Off'
 ```
 


### PR DESCRIPTION
Updated the automation examples to reflect the proper climate format and listing the entity_id inside the `data:` section.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
