### PR TITLE
Fixes wrong syntax in the newest version of hassbian-config

### DIFF
--- a/source/_docs/installation/hassbian/common-tasks.markdown
+++ b/source/_docs/installation/hassbian/common-tasks.markdown
@@ -37,7 +37,7 @@ To get the current state of the `homeassistant.service` replace `stop` with `sta
 ### {% linkable_title Update Home Assistant %}
 
 <p class='note'>
-You can also use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade home-assistant`
+You can also use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade homeassistant`
 </p>
 
 Log in as the `pi` account and execute the following commands:


### PR DESCRIPTION
**Description:**
There was a breaking change included with version 0.7.0 of hassbian-config.
https://github.com/home-assistant/hassbian-scripts/pull/90

`sudo hassbian-config upgrade home-assistant` does not work longer but `sudo hassbian-config upgrade homeassistant` does.
**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards]. _"typo"_

[standards]: https://home-assistant.io/developers/documentation/standards/
