### PR TITLE
Update Linksys AP device tracker documentation

### DIFF
--- a/source/_components/device_tracker.linksys_ap.markdown
+++ b/source/_components/device_tracker.linksys_ap.markdown
@@ -32,6 +32,7 @@ Configuration variables:
 - **username** (*Required*: The username of an user with administrative privileges (read-only is sufficient).
 - **password** (*Required*): The password for your given admin account.
 - **verify_ssl** (*Optional*): Verify SSL certificate for https request. Defaults to true.
+- **enable_cookies** (*Optional*): Enable session support for newer firmware releases. Defaults to false.
 
 Example for all configuration options:
 ```yaml
@@ -44,6 +45,7 @@ device_tracker:
     verify_ssl: true
     scan_interval: 6
     consider_home: 12
+    enable_cookies: false
 ```
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
https://github.com/mateuszdrab/home-assistant/commit/874d581bad182a071bb5378572047ba4af54b9ee

**Description:**
New AP firmware requires a session_id cookie obtained by sending post form request to login.cgi. I've implemented support for session cookies and the new behaviour is activated using a new enable_cookies parameter. This is set to false by default to maintain compability with existing setups.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12899

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
