### PR TITLE
Add initial support fo HomematicIP components

### DIFF
--- a/source/_components/homematicip.markdown
+++ b/source/_components/homematicip.markdown
@@ -10,16 +10,16 @@ footer: true
 logo: homematicip.png
 ha_category: Hub
 ha_iot_class: "Cloud Polling"
+ha_release: 0.66
 featured: false
 ---
 
 The [HomematicIP](http://www.homematicip.com/) component platform is used as an interface to the cloud server. 
 For for communication [homematicip-rest-api](https://github.com/coreGreenberet/homematicip-rest-api) is used.
 
+To set up the component:
 
-To set up the component: 
-
-- **generate the authenication token**:
+- **generate the authentication token**:
 ```yaml
 generate_auth_token.py
 ```
@@ -35,9 +35,9 @@ homematicip:
 
 Configuration variables (global):
 
-- **name** (*Required*): Name to identify your accesspoint, this will be
+- **name** (*Required*): Name to identify your access point, this will be
   used to prefix your device names.
-- **accesspoint** (*Required*): This is the accesspoint id (SGTIN)
+- **accesspoint** (*Required*): This is the access point id (SGTIN)
 - **authtoken** (*Required*): Authentification token generated with
 `generate_auth_token.py`.
 

--- a/source/_components/homematicip.markdown
+++ b/source/_components/homematicip.markdown
@@ -1,0 +1,43 @@
+---
+layout: page
+title: "HomematicIP"
+description: "Instructions for integrating HomematicIP into Home Assistant."
+date: 2018-03-06 20:40
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: homematicip.png
+ha_category: Hub
+ha_iot_class: "Cloud Polling"
+featured: false
+---
+
+The [HomematicIP](http://www.homematicip.com/) component platform is used as an interface to the cloud server. 
+For for communication [homematicip-rest-api](https://github.com/coreGreenberet/homematicip-rest-api) is used.
+
+
+To set up the component: 
+
+- **generate the authenication token**:
+```yaml
+generate_auth_token.py
+```
+
+- ** add the information to your `configuration.yaml` file:
+
+```yaml
+homematicip:
+  - name: NAME
+    accesspoint: IDENTIFIER
+    authtoken: AUTHTOKEN
+```
+
+Configuration variables (global):
+
+- **name** (*Required*): Name to identify your accesspoint, this will be
+  used to prefix your device names.
+- **accesspoint** (*Required*): This is the accesspoint id (SGTIN)
+- **authtoken** (*Required*): Authentification token generated with
+`generate_auth_token.py`.
+


### PR DESCRIPTION
**Description:**
Initial support fo HomematicIP components

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12761

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
