### PR TITLE
Support to hide accessories in HomeKit

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -51,6 +51,16 @@ After Home Assistant has started, all supported entities (see the [list](#suppor
 
 After the setup is completed you should be able to control your Home Assistant components through `Home` and `Siri`.
 
+## {% linkable_title Hide accessories %}
+
+To not include specific accessories in HomeKit, you can set the `homekit_hidden` attribute in `customize.yaml`:
+
+```yaml
+# Example to hide accessory in homekit
+domain.name:
+  homekit_hidden: True
+```
+
 ## {% linkable_title Supported Components %}
 
 The following components are currently supported:

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -58,7 +58,7 @@ To not include specific accessories in HomeKit, you can set the `homekit_hidden`
 ```yaml
 # Example to hide accessory in homekit
 domain.name:
-  homekit_hidden: True
+  homekit_hidden: true
 ```
 
 ## {% linkable_title Supported Components %}


### PR DESCRIPTION
**Description:**

Support to hide accessories in HomeKit

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#12974

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/