### PR TITLE
Add OpenWRT device tracker overview

### DIFF
--- a/source/_components/device_tracker.luci.markdown
+++ b/source/_components/device_tracker.luci.markdown
@@ -12,7 +12,7 @@ ha_category: Presence Detection
 ha_release: pre 0.7
 ---
 
-_This is one of the two ways we support OpenWRT. If you encounter problems, try [ubus](/components/device_tracker.ubus/)._
+_This is one of multiple ways we support OpenWRT. For an overview, see [openwrt](/components/device_tracker.openwrt/)._
 
 This is a presence detection scanner for OpenWRT using [luci](http://wiki.openwrt.org/doc/techref/luci).
 

--- a/source/_components/device_tracker.openwrt.markdown
+++ b/source/_components/device_tracker.openwrt.markdown
@@ -35,7 +35,7 @@ There are _multiple_ ways of integrating an OpenWRT router for presence detction
     * [openwrt_hass_devicetracker](https://github.com/mueslo/openwrt_hass_devicetracker)
     * your own custom script
 
-### Event-based device tracker
+### {% linkable_title Event-based device tracker %}
 
 This can be achieved by running a simple shell script on the OpenWRT router which calls the appropriate Home Assistant service. An OpenWRT package which does this is listed above. As this method directly calls the [service API](/developers/rest_api.markdown#post-apiservicesltdomainltservice), no special configuration is necessary on the Home Assistant side, except for ensuring the device_tracker API is running, which is achieved by adding the following to your `configuration.yaml` file:
 

--- a/source/_components/device_tracker.openwrt.markdown
+++ b/source/_components/device_tracker.openwrt.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "OpenWRT"
-description: "Instructions how to integrate OpenWRT routers into Home Assistant."
+description: "Instructions on how to integrate OpenWRT routers into Home Assistant."
 date: 2018-03-09 12:00
 sidebar: true
 comments: false
@@ -12,7 +12,7 @@ ha_category: Presence Detection
 ha_release: pre 0.7
 ---
 
-There are _multiple_ ways of integrating an OpenWRT router for presence detction. A broad distinction can be made between presence detection methods which actively scan for devices (by default every 12 seconds) and those that are notified by some external service on changes. It is essentially a problem of synchronizing states between two remote machines.
+There are _multiple_ ways of integrating an OpenWRT router for presence detection. A broad distinction can be made between presence detection methods which actively scan for devices (by default every 12 seconds) and those that are notified by some external service on changes. It is essentially a problem of synchronizing states between two remote machines.
 
 * __active scanning__  
   Scan for devices regularly.
@@ -25,7 +25,7 @@ There are _multiple_ ways of integrating an OpenWRT router for presence detction
     * [ubus](/components/device_tracker.ubus/)
     * [luci](/components/device_tracker.luci/)
 * __passive/event-based__  
-  External services which notify Home Assistant of devices vie the [REST API endpoint](/developers/rest_api.markdown). 
+  External services which notify Home Assistant of devices via the [REST API endpoint](/developers/rest_api.markdown). 
   * Advantages: 
     * devices typically registered in under one second when they connect
     * very few network requests

--- a/source/_components/device_tracker.openwrt.markdown
+++ b/source/_components/device_tracker.openwrt.markdown
@@ -1,0 +1,48 @@
+---
+layout: page
+title: "OpenWRT"
+description: "Instructions how to integrate OpenWRT routers into Home Assistant."
+date: 2018-03-09 12:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: openwrt.png
+ha_category: Presence Detection
+ha_release: pre 0.7
+---
+
+There are _multiple_ ways of integrating an OpenWRT router for presence detction. A broad distinction can be made between presence detection methods which actively scan for devices (by default every 12 seconds) and those that are notified by some external service on changes. It is essentially a problem of synchronizing states between two remote machines.
+
+* __active scanning__  
+  Scan for devices regularly.
+  * Advantages:
+    * robust on an unreliable set-up where the the router may not be reachable occasionally
+  * Disadvantages:
+    * average six-second delay between connecting and being registered as `home`
+    * lots of unnecessary network requests
+  * Examples: 
+    * [ubus](/components/device_tracker.ubus/)
+    * [luci](/components/device_tracker.luci/)
+* __passive/event-based__  
+  External services which notify Home Assistant of devices vie the [REST API endpoint](/developers/rest_api.markdown). 
+  * Advantages: 
+    * devices typically registered in under one second when they connect
+    * very few network requests
+  * Disadvantages:
+    * prone to missed events when connectivity between Home Assistant and the router is not guaranteed
+  * Examples:
+    * [openwrt_hass_devicetracker](https://github.com/mueslo/openwrt_hass_devicetracker)
+    * your own custom script
+
+### Event-based device tracker
+
+This can be achieved by running a simple shell script on the OpenWRT router which calls the appropriate Home Assistant service. An OpenWRT package which does this is listed above. As this method directly calls the [service API](/developers/rest_api.markdown#post-apiservicesltdomainltservice), no special configuration is necessary on the Home Assistant side, except for ensuring the device_tracker API is running, which is achieved by adding the following to your `configuration.yaml` file:
+
+```yaml
+device_tracker:
+```
+
+To get the best of both worlds, you can combine the two approaches, running both a periodic device scanner and an event-based device tracker.
+
+See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.ubus.markdown
+++ b/source/_components/device_tracker.ubus.markdown
@@ -12,20 +12,6 @@ ha_category: Presence Detection
 ha_release: 0.7.6
 ---
 
-_This is one of the multiple ways we support OpenWRT. If you encounter problems, see [openwrt](---
-layout: page
-title: "OpenWRT (luci)"
-description: "Instructions how to integrate OpenWRT routers into Home Assistant."
-date: 2015-03-23 19:59
-sidebar: true
-comments: false
-sharing: true
-footer: true
-logo: openwrt.png
-ha_category: Presence Detection
-ha_release: pre 0.7
----
-
 _This is one of multiple ways we support OpenWRT. For an overview, see [openwrt](/components/device_tracker.openwrt/)._
 
 This is a presence detection scanner for OpenWRT using [luci](http://wiki.openwrt.org/doc/techref/luci).

--- a/source/_components/device_tracker.ubus.markdown
+++ b/source/_components/device_tracker.ubus.markdown
@@ -12,7 +12,58 @@ ha_category: Presence Detection
 ha_release: 0.7.6
 ---
 
-_This is one of the two ways we support OpenWRT. If you encounter problems, try [luci](/components/device_tracker.luci/)._
+_This is one of the multiple ways we support OpenWRT. If you encounter problems, see [openwrt](---
+layout: page
+title: "OpenWRT (luci)"
+description: "Instructions how to integrate OpenWRT routers into Home Assistant."
+date: 2015-03-23 19:59
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: openwrt.png
+ha_category: Presence Detection
+ha_release: pre 0.7
+---
+
+_This is one of multiple ways we support OpenWRT. For an overview, see [openwrt](/components/device_tracker.openwrt/)._
+
+This is a presence detection scanner for OpenWRT using [luci](http://wiki.openwrt.org/doc/techref/luci).
+
+<p class='note'>
+This component requires a [workaround](https://github.com/home-assistant/home-assistant/issues/1258#issuecomment-252469880) when using luci with HTTPS and a self-signed certificate.
+</p>
+
+Before this scanner can be used you have to install the luci RPC package on OpenWRT:
+
+```bash
+# opkg install luci-mod-rpc
+```
+
+To use this device tracker in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+device_tracker:
+  - platform: luci
+    host: ROUTER_IP_ADDRESS
+    username: YOUR_ADMIN_USERNAME
+    password: YOUR_ADMIN_PASSWORD
+```
+
+Configuration variables:
+
+- **host** (*Required*): The IP address of your router, e.g. `192.168.1.1`.
+- **username** (*Required*): The username of an user with administrative privileges, usually `admin`.
+- **password** (*Required*): The password for your given admin account.
+
+See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.
+
+<p class='note warning'>
+Some installations have [a small bug](https://github.com/openwrt/luci/issues/576). The timeout for luci RPC calls is not set and this makes the call fail. 
+</p>
+
+)._
 
 This is a presence detection scanner for [OpenWRT](https://openwrt.org/) using [ubus](http://wiki.openwrt.org/doc/techref/ubus). It scans for changes in `hostapd.*`, which will detect and report changes in devices connected to the access point on the router.
 


### PR DESCRIPTION
**Description:** Adds an overview page for the different device tracker possibilities for OpenWRT.

Related to pull request  [#12849](https://github.com/home-assistant/home-assistant/pull/12849)
