### PR TITLE
Adds docs for folder_watcher component

### DIFF
--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -31,7 +31,7 @@ folder:
 patterns:
   description: Pattern matching to apply
   required: false
-  default: `*`
+  default: *
   type: string
 {% endconfiguration %}
 

--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -1,0 +1,65 @@
+---
+layout: page
+title: "folder watcher"
+description: "Component for monitoring changes within the filesystem."
+date: 2018-03-11 14:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: home-assistant.png
+ha_category: System Monitor
+ha_iot_class: "Local Polling"
+ha_release: 0.66
+---
+
+This component adds [Watchdog](https://pythonhosted.org/watchdog/) file system monitoring, publishing events on the Home-Assistant bus on the creation/deletion/modification of files.
+
+To configure the `folder_watcher` component add to you `configuration.yaml` file:
+
+```yaml
+folder_watcher:
+  watchers:
+    - folder: /config
+```
+
+{% configuration %}
+folder:
+  description: The folder path
+  required: true
+  type: string
+patterns:
+  description: Pattern matching to apply
+  required: false
+  default: `*`
+  type: string
+{% endconfiguration %}
+
+## Patterns
+Pattern matching using [fnmatch](https://docs.python.org/3.6/library/fnmatch.html) can be used to limit filesystem monitoring to only files which match the configured patterns. The following example shows the configuration required to only monitor filetypes `.yaml` and `.txt`.
+
+```yaml
+folder_watcher:
+  watchers:
+    - folder: /config
+      patterns:
+        - '*.yaml'
+        - '*.txt'
+```
+
+## Automations
+Automations can be triggered on filesystem event data using a data_template. The following automation will send a notification with the name and folder of new files added to that folder:
+
+```yaml
+- action:
+  - data_template:
+      message: 'Created {{trigger.event.data.file}} in {{trigger.event.data.folder}}'
+    service: notify.my_notify_service
+  alias: New file alert
+  condition: []
+  id: '1234'
+  trigger:
+  - event_data: {"event_type":"created"}
+    event_type: folder_watcher
+    platform: event
+```

--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -54,10 +54,13 @@ Automations can be triggered on filesystem event data using a data_template. The
 - action:
   - data_template:
       message: 'Created {{trigger.event.data.file}} in {{trigger.event.data.folder}}'
-    service: notify.my_notify_service
+      title: New image captured!
+      data:
+        file: "{{trigger.event.data.folder}}/{{trigger.event.data.file}}"
+    service: notify.pushbullet
   alias: New file alert
   condition: []
-  id: '1234'
+  id: '1520092824697'
   trigger:
   - event_data: {"event_type":"created"}
     event_type: folder_watcher

--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -56,7 +56,7 @@ Automations can be triggered on filesystem event data using a data_template. The
       message: 'Created {{trigger.event.data.file}} in {{trigger.event.data.folder}}'
       title: New image captured!
       data:
-        file: "{{trigger.event.data.folder}}/{{trigger.event.data.file}}"
+        file: "{{trigger.event.data.path}}"
     service: notify.pushbullet
   alias: New file alert
   condition: []

--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -52,6 +52,7 @@ folder_watcher:
 
 Automations can be triggered on filesystem event data using a data_template. The following automation will send a notification with the name and folder of new files added to that folder:
 
+{% raw %}
 ```yaml
 - action:
   - data_template:
@@ -68,3 +69,4 @@ Automations can be triggered on filesystem event data using a data_template. The
     event_type: folder_watcher
     platform: event
 ```
+{% endraw %}

--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -36,6 +36,7 @@ patterns:
 {% endconfiguration %}
 
 ## Patterns
+
 Pattern matching using [fnmatch](https://docs.python.org/3.6/library/fnmatch.html) can be used to limit filesystem monitoring to only files which match the configured patterns. The following example shows the configuration required to only monitor filetypes `.yaml` and `.txt`.
 
 ```yaml
@@ -48,6 +49,7 @@ folder_watcher:
 ```
 
 ## Automations
+
 Automations can be triggered on filesystem event data using a data_template. The following automation will send a notification with the name and folder of new files added to that folder:
 
 ```yaml

--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: home-assistant.png
 ha_category: System Monitor
 ha_iot_class: "Local Polling"
-ha_release: 0.66
+ha_release: 0.67
 ---
 
 This component adds [Watchdog](https://pythonhosted.org/watchdog/) file system monitoring, publishing events on the Home-Assistant bus on the creation/deletion/modification of files.

--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -18,9 +18,11 @@ This component adds [Watchdog](https://pythonhosted.org/watchdog/) file system m
 To configure the `folder_watcher` component add to you `configuration.yaml` file:
 
 ```yaml
+{% raw %}
 folder_watcher:
   watchers:
     - folder: /config
+{% endraw %}
 ```
 
 {% configuration %}
@@ -31,7 +33,7 @@ folder:
 patterns:
   description: Pattern matching to apply
   required: false
-  default: *
+  default: "*" 
   type: string
 {% endconfiguration %}
 
@@ -40,20 +42,22 @@ patterns:
 Pattern matching using [fnmatch](https://docs.python.org/3.6/library/fnmatch.html) can be used to limit filesystem monitoring to only files which match the configured patterns. The following example shows the configuration required to only monitor filetypes `.yaml` and `.txt`.
 
 ```yaml
+{% raw %}
 folder_watcher:
   watchers:
     - folder: /config
       patterns:
         - '*.yaml'
         - '*.txt'
+{% raw %}
 ```
 
 ## Automations
 
 Automations can be triggered on filesystem event data using a data_template. The following automation will send a notification with the name and folder of new files added to that folder:
 
-{% raw %}
 ```yaml
+{% raw %}
 - action:
   - data_template:
       message: 'Created {{trigger.event.data.file}} in {{trigger.event.data.folder}}'
@@ -68,5 +72,6 @@ Automations can be triggered on filesystem event data using a data_template. The
   - event_data: {"event_type":"created"}
     event_type: folder_watcher
     platform: event
-```
 {% endraw %}
+```
+


### PR DESCRIPTION
**Description:**
Adds documentation for the new folder_watcher component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant/pull/12918) (if applicable):** home-assistant/home-assistant#12918

## Checklist:

- [ x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ x] The documentation follow the [standards][standards].
