### PR TITLE
Fix typo - extra ()

### DIFF
--- a/source/_components/sensor.folder.markdown
+++ b/source/_components/sensor.folder.markdown
@@ -13,7 +13,7 @@ ha_iot_class: "Local Polling"
 ha_release: 0.64
 ---
 
-Sensor for monitoring the contents of a folder. Note that folder paths must be added to [whitelist_external_dirs](https://home-assistant.io/docs/configuration/basic/). Optionally a [wildcard filter]((https://docs.python.org/3.6/library/fnmatch.html)) can be applied to the files considered within the folder. The state of the sensor is the size in MB of files within the folder that meet the filter criteria. The number of filtered files in the folder and total size in bytes of those files are exposed as attributes.
+Sensor for monitoring the contents of a folder. Note that folder paths must be added to [whitelist_external_dirs](https://home-assistant.io/docs/configuration/basic/). Optionally a [wildcard filter](https://docs.python.org/3.6/library/fnmatch.html) can be applied to the files considered within the folder. The state of the sensor is the size in MB of files within the folder that meet the filter criteria. The number of filtered files in the folder and total size in bytes of those files are exposed as attributes.
 
 To enable the `folder` sensor in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
The extra () resulted in a 404 error

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
