### PR TITLE
Change upgrade homeassistant to upgrade home-assistant

### DIFF
--- a/source/_docs/installation/hassbian/common-tasks.markdown
+++ b/source/_docs/installation/hassbian/common-tasks.markdown
@@ -37,7 +37,7 @@ To get the current state of the `homeassistant.service` replace `stop` with `sta
 ### {% linkable_title Update Home Assistant %}
 
 <p class='note'>
-You can also use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade homeassistant`
+You can also use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade home-assistant`
 </p>
 
 Log in as the `pi` account and execute the following commands:


### PR DESCRIPTION
Correct
You can also use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade homeassistant`
to
You can also use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade home-assistant`

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
