### PR TITLE
Remove broken redirect from

### DIFF
--- a/source/_docs/configuration/remote.markdown
+++ b/source/_docs/configuration/remote.markdown
@@ -7,7 +7,6 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-redirect_from: /getting-started/basic/#remote-access
 ---
 
 If you're interested in logging in to Home Assistant while away, you'll have to make your instance remotely accessible. Remember to follow the [securing checklist](/docs/configuration/securing/) before doing this.

--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -8,7 +8,6 @@ comments: false
 sharing: true
 footer: true
 logo: mqtt.png
-redirect_from: /components/mqtt/#picking-a-broker
 ---
 
 The MQTT component needs you to run an MQTT broker for Home Assistant to connect to. There are four options, each with various degrees of ease of setup and privacy.

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -8,7 +8,6 @@ comments: false
 sharing: true
 footer: true
 logo: mqtt.png
-redirect_from: /components/mqtt/#discovery
 ---
 
 The discovery of MQTT devices will enable one to use MQTT devices with only minimal configuration effort on the side of Home Assistant. The configuration is done on the device itself and the topic used by the device. Similar to the [HTTP binary sensor](/components/binary_sensor.http/) and the [HTTP sensor](/components/sensor.http/). The basic idea is that the device itself adds its configuration into your `configuration.yaml` automatically. To prevent multiple identical entries if a device reconnects a unique identifier is necessary. Two parts are required on the device side: The configuration topic which contains the necessary device type and unique identifier and the remaining device configuration without the device type.

--- a/source/_docs/mqtt/logging.markdown
+++ b/source/_docs/mqtt/logging.markdown
@@ -8,7 +8,6 @@ comments: false
 sharing: true
 footer: true
 logo: mqtt.png
-redirect_from: /components/mqtt/#logging
 ---
 
 The [logger](/components/logger/) component allow the logging of received MQTT messages.

--- a/source/_docs/mqtt/processing_json.markdown
+++ b/source/_docs/mqtt/processing_json.markdown
@@ -8,7 +8,6 @@ comments: false
 sharing: true
 footer: true
 logo: mqtt.png
-redirect_from: /components/mqtt/#processing-json
 ---
 
 The MQTT [switch](/components/switch.mqtt/) and [sensor](/components/sensor.mqtt/) platforms support processing JSON over MQTT messages and parsing them using JSONPath. JSONPath allows you to specify where in the JSON the value resides that you want to use. The following examples will always return the value `100`.

--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -8,7 +8,6 @@ comments: false
 sharing: true
 footer: true
 logo: mqtt.png
-redirect_from: /components/mqtt/#publish-service
 ---
 
 The MQTT component will register the service `publish` which allows publishing messages to MQTT topics. There are two ways of specifying your payload. You can either use `payload` to hard-code a payload or use `payload_template` to specify a [template](/topics/templating/) that will be rendered to generate the payload.

--- a/source/_docs/mqtt/testing.markdown
+++ b/source/_docs/mqtt/testing.markdown
@@ -8,7 +8,6 @@ comments: false
 sharing: true
 footer: true
 logo: mqtt.png
-redirect_from: /components/mqtt/#testing-your-setup
 ---
 
 The `mosquitto` broker package ships commandline tools (often as `*-clients` package) to send and receive MQTT messages. As an alternative have a look at [hbmqtt_pub](http://hbmqtt.readthedocs.org/en/latest/references/hbmqtt_pub.html) and [hbmqtt_sub](http://hbmqtt.readthedocs.org/en/latest/references/hbmqtt_sub.html) which are provided by HBMQTT. For sending test messages to a broker running on localhost check the example below:

--- a/source/_docs/tools/benchmark.markdown
+++ b/source/_docs/tools/benchmark.markdown
@@ -7,7 +7,6 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-redirect_from: /docs/tools/scripts/#benchmark
 ---
 
 For testing the performance of Home Assistant the Benchmark script runs until you exit using Control+C.

--- a/source/_docs/tools/check_config.markdown
+++ b/source/_docs/tools/check_config.markdown
@@ -7,7 +7,6 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-redirect_from: /docs/tools/scripts/#configuration-check
 ---
 
 Test any changes to your `configuration.yaml` file before launching Home Assistant. This script allows you to test changes without the need to restart Home Assistant.

--- a/source/_docs/tools/credstash.markdown
+++ b/source/_docs/tools/credstash.markdown
@@ -7,7 +7,6 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-redirect_from: /docs/configuration/secrets/#storing-passwords-securely-in-aws
 ---
 
 Using [Credstash](https://github.com/fugue/credstash) is an alternative way to `secrets.yaml`. They can be managed from the command line via the credstash script.

--- a/source/_docs/tools/db_migrator.markdown
+++ b/source/_docs/tools/db_migrator.markdown
@@ -7,7 +7,6 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-redirect_from: /components/influxdb/#data-migration
 ---
 
 <p class='note warning'>

--- a/source/_docs/tools/ensure_config.markdown
+++ b/source/_docs/tools/ensure_config.markdown
@@ -7,7 +7,6 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-redirect_from: /docs/tools/scripts/#existence-of-configuration
 ---
 
 This script checks if the `configuration.yaml` file exists. If the file is not available, one is created.

--- a/source/_docs/tools/influxdb_import.markdown
+++ b/source/_docs/tools/influxdb_import.markdown
@@ -7,7 +7,6 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-redirect_from: /components/influxdb/#data-import-script
 ---
 
 If you want to import all the recorded data from your recorder database you can use the data import script. It will read all your state_change events from the database and add them as data-points to the InfluxDB. You can specify the source database either by pointing the `--config` option to the config directory which includes the default SQLite database or by giving a sqlalchemy connection URI with `--uri`.

--- a/source/_docs/tools/keyring.markdown
+++ b/source/_docs/tools/keyring.markdown
@@ -7,7 +7,6 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-redirect_from: /docs/configuration/secrets/#storing-passwords-in-a-keyring-managed-by-your-os
 ---
 
 Using [Keyring](https://github.com/jaraco/keyring) is an alternative way to `secrets.yaml`. The secrets can be managed from the command line via the `keyring` script.


### PR DESCRIPTION
**Description:**
You cannot add hashtags to the redirect from url as the redirects are written and create actual files. And the files will never be hit.

It also breaks our netlify builds.
