### PR TITLE
Added instructions for custom UIs to show up in the HA dev info panel

### DIFF
--- a/source/developers/frontend_creating_custom_ui.markdown
+++ b/source/developers/frontend_creating_custom_ui.markdown
@@ -53,6 +53,20 @@ frontend:
 </dom-module>
 
 <script>
+// show the version of your custom UI in the HA dev info panel (HA 0.66.0+):
+const CUSTOM_UI_NAME = 'state-card-my-custom-light';
+const CUSTOM_UI_VERSION = '20180312';
+const CUSTOM_UI_URL = 'https://home-assistant.io/developers/frontend_creating_custom_ui/';
+
+if (!window.CUSTOM_UI_LIST) {
+  window.CUSTOM_UI_LIST = [];
+}
+window.CUSTOM_UI_LIST.push({
+  name: CUSTOM_UI_NAME,
+  version: CUSTOM_UI_VERSION,
+  url: CUSTOM_UI_URL
+}); 
+
 class StateCardMyCustomLight extends Polymer.Element {
   static get is() { return 'state-card-my-custom-light'; }
   
@@ -77,5 +91,6 @@ class StateCardMyCustomLight extends Polymer.Element {
 customElements.define(StateCardMyCustomLight.is, StateCardMyCustomLight);
 </script>
 ```
+Note: Some browsers don't support latest ECMAScript standards, these require a separate ES5 compatible file (`extra_html_url_es5`).
 
 For more possibilities, see the [Custom UI section](/cookbook/#user-interface) on our Examples page.

--- a/source/developers/frontend_creating_custom_ui.markdown
+++ b/source/developers/frontend_creating_custom_ui.markdown
@@ -91,6 +91,8 @@ class StateCardMyCustomLight extends Polymer.Element {
 customElements.define(StateCardMyCustomLight.is, StateCardMyCustomLight);
 </script>
 ```
-Note: Some browsers don't support latest ECMAScript standards, these require a separate ES5 compatible file (`extra_html_url_es5`).
+<p class='note'>
+SomeSome browsers don't support latest ECMAScript standards, these require a separate ES5 compatible file (`extra_html_url_es5`).
+</p>
 
 For more possibilities, see the [Custom UI section](/cookbook/#user-interface) on our Examples page.

--- a/source/developers/frontend_creating_custom_ui.markdown
+++ b/source/developers/frontend_creating_custom_ui.markdown
@@ -92,7 +92,7 @@ customElements.define(StateCardMyCustomLight.is, StateCardMyCustomLight);
 </script>
 ```
 <p class='note'>
-SomeSome browsers don't support latest ECMAScript standards, these require a separate ES5 compatible file (`extra_html_url_es5`).
+Some browsers don't support latest ECMAScript standards, these require a separate ES5 compatible file (`extra_html_url_es5`).
 </p>
 
 For more possibilities, see the [Custom UI section](/cookbook/#user-interface) on our Examples page.


### PR DESCRIPTION
**Description:**
Added instructions for custom UIs to show up in the HA dev info panel

https://github.com/home-assistant/home-assistant-polymer/pull/981

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
