### PR TITLE
Add songpal to ignore list

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -79,6 +79,7 @@ Valid values for ignore are:
  * `sabnzbd`: SABnzbd downloader
  * `samsung_tv`: Samsung TVs
  * `sonos`: Sonos speakers
+ * `songpal` : Songpal
  * `tellduslive`: Telldus Live
  * `wink`: Wink Hub
  * `yamaha`: Yamaha media player


### PR DESCRIPTION

**Description:**

After updating 0.65.4 I kept seeing errors about a component I am not using or even have.  This change is to make sure the discovery docs are kept to upto date with devices added to the discovery component.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
