### PR TITLE
Typo in 0.65.4 release notes

### DIFF
--- a/source/_posts/2018-03-09-release-65.markdown
+++ b/source/_posts/2018-03-09-release-65.markdown
@@ -146,7 +146,7 @@ intent_script:
 - Bump pyvera to 0.2.42. Improve event loop robustness. ([@pavoni] - [#13095]) ([vera docs])
 - Fix Kodi by updateding jsonrpc-websocket to 0.6 ([@Tadly] - [#13096]) ([media_player.kodi docs])
 
-## {% linkable_title Release 0.65.3 - March 12 %}
+## {% linkable_title Release 0.65.4 - March 12 %}
 
 - Fix unavailable property for wemo switch ([@balloob] - [#13106]) ([switch.wemo docs])
 - Hue: Catch if bridge goes unavailable ([@balloob] - [#13109]) ([hue docs]) ([light.hue docs])


### PR DESCRIPTION
**Description:**
Changes 0.65.3 to 0.65.4

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
