### PR TITLE
Egardia: Adding configuration tag according to new docs 

### DIFF
--- a/source/_components/egardia.markdown
+++ b/source/_components/egardia.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Egardia"
 description: "Instructions how to setup Egardia / Woonveilig within Home Assistant."
-date: 2018-03-12 09:00
+date: 2018-03-13 09:00
 sidebar: true
 comments: false
 sharing: true
@@ -16,7 +16,8 @@ The `egardia` platform enables the ability to control an [Egardia](http://egardi
 
 You will need to know the IP of your alarm panel on your local network. Test if you can login to the panel by browsing to the IP address and log in using your Egardia/Woonveilig account.
 
-{% linkable_title Basic configuration %}
+## {% linkable_title Basic configuration %}
+
 To enable the integration with your alarm panel, add the following lines to your `configuration.yaml` file:
  ```yaml
     # Example configuration.yaml entry
@@ -89,7 +90,8 @@ report_server_codes:
 Note that this basic configuration will only enable you to read the armed/armed away/disarmed status of your alarm and will **not** update the status if the alarm is triggered. This is because of how Egardia built their system. The alarm triggers normally go through their servers.
 You can change this, however, using the following procedure. This is a more advanced (and more useful) configuration.
 
-{% linkable_title Advanced configuration %}
+##{% linkable_title Advanced configuration %}
+
 1. Log in to your alarm system's control panel. You will need to access http://[IP of your control panel]. You know this already since you need it in the basic configuration from above. Log in to the control panel with your Egardia/Woonveilig username and password.
 2. Once logged in, go to *System Settings*, *Report* and change the Server Address for your primary server to the IP or hostname of your Home Assistant machine. You can leave the port number set to 52010 or change it to anything you like. **Make sure to change the settings of the primary server otherwise the messages will not come through. Note that this will limit (or fully stop) the number of alarm messages you will get through Egardia's / Woonveilig services.** Maybe, that is just what you want. Make sure to save your settings by selecting 'OK'.
 3. The Egardia component relies on capturing the status codes that your alarm emits when something happens (status change or trigger). These codes will be unique for every situation - i.e. the code emitted by the alarm when a sensor is triggered is unique to that sensor. Also, if you have multiple users or remotes, each remote has unique codes that are emitted by the alarm when status is changed using that remote or by that user. For the Egardia component to work correctly you will need to capture the codes. To do this, on your Home Assistant machine run `$ sudo python3 egardiaserver.py`. Refer to the [python-egardia repository](https://github.com/jeroenterheerdt/python-egardia) for detailed documentation on parameters. This will receive status codes from your alarm control panel and display them. Record the codes shown as well as the status they relate to (see step 4 below). Make sure to change the status of your alarm to all states (disarm, arm, home) by all means possible (all users, remotes, web login, app) as well as trigger the alarm in all ways possible to get 100% coverage of all the codes the alarm system generates. You will need to run this script once and stop it once you have captured all the possible codes. Also, if you ever add users, remotes or sensors to your alarm system, make sure to re-run the script to capture the extra codes so you can update your configuration (see step 4 below). **For comfort, before triggering the alarm it might be good to disable the siren temporarily (can be done in Panel Settings).**

--- a/source/_components/egardia.markdown
+++ b/source/_components/egardia.markdown
@@ -90,7 +90,7 @@ report_server_codes:
 Note that this basic configuration will only enable you to read the armed/armed away/disarmed status of your alarm and will **not** update the status if the alarm is triggered. This is because of how Egardia built their system. The alarm triggers normally go through their servers.
 You can change this, however, using the following procedure. This is a more advanced (and more useful) configuration.
 
-##{% linkable_title Advanced configuration %}
+## {% linkable_title Advanced configuration %}
 
 1. Log in to your alarm system's control panel. You will need to access http://[IP of your control panel]. You know this already since you need it in the basic configuration from above. Log in to the control panel with your Egardia/Woonveilig username and password.
 2. Once logged in, go to *System Settings*, *Report* and change the Server Address for your primary server to the IP or hostname of your Home Assistant machine. You can leave the port number set to 52010 or change it to anything you like. **Make sure to change the settings of the primary server otherwise the messages will not come through. Note that this will limit (or fully stop) the number of alarm messages you will get through Egardia's / Woonveilig services.** Maybe, that is just what you want. Make sure to save your settings by selecting 'OK'.

--- a/source/_components/egardia.markdown
+++ b/source/_components/egardia.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Egardia"
 description: "Instructions how to setup Egardia / Woonveilig within Home Assistant."
-date: 2018-03-02 09:00
+date: 2018-03-12 09:00
 sidebar: true
 comments: false
 sharing: true
@@ -16,30 +16,80 @@ The `egardia` platform enables the ability to control an [Egardia](http://egardi
 
 You will need to know the IP of your alarm panel on your local network. Test if you can login to the panel by browsing to the IP address and log in using your Egardia/Woonveilig account.
 
+{% linkable_title Basic configuration %}
 To enable the integration with your alarm panel, add the following lines to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-egardia:
-  host: YOUR_HOST
-  username: YOUR_USERNAME
-  password: YOUR_PASSWORD
+ ```yaml
+    # Example configuration.yaml entry
+    egardia:
+      host: YOUR_HOST
+      username: YOUR_USERNAME
+      password: YOUR_PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The local IP address of the Egardia/Woonveilig alarm panel.
-- **username** (*Required*): Username for the Egardia/Woonveilig account.
-- **password** (*Required*): Password for Egardia/Woonveilig account.
-- **version** (*Optional*): The version of the Egardia system. `GATE-01`, `GATE-02` and `GATE-03` are currently supported. Defaults to `GATE-01`.
-- **port** (*Optional*): The port of the alarm panel. Defaults to 80.
-- **report_server_enabled** (*Optional*): Enable reporting by server. Defaults to `False`.
-- **report_server_port** (*Optional*): Port of the Egardia server. Defaults to 52010.
-- **report_server_codes** list (*Optional*): List of codes for the different states.
+{% configuration %}
+host:
+  description: The local IP address of the Egardia/Woonveilig alarm panel.
+  required: true
+  type: string
+username:
+  description: Username for the Egardia/Woonveilig account.
+  required: true
+  type: string
+password:
+  description: Password for Egardia/Woonveilig account.
+  required: true
+  type: string
+version:
+  description: The version of the Egardia system. `GATE-01`, `GATE-02` and `GATE-03` are currently supported.
+  required: false
+  type: string
+  default: 'GATE-01'
+port:
+  description: The port of the alarm panel.
+  required: false
+  type: int
+  default: 80
+report_server_enabled:
+  description: Enable reporting by server.
+  required: false
+  type: string
+  default: false
+report_server_port:
+  description:  Port of the Egardia server.
+  required: false
+  type: int
+  default: 52010
+report_server_codes:
+  description: Map of list of codes for the different states.
+  required: false
+  type: map
+  keys:
+    arm:
+      description: List of codes for the 'arm' state.
+      required: false
+      type: list
+    disarm:
+      description: List of codes for the 'disarm' state.
+      required: false
+      type: list
+    armhome:
+      description: List of codes for the 'armhome' state.
+      required: false
+      type: list
+    triggered:
+      description: List of codes for the 'triggered' state.
+      required: false
+      type: list
+    ignore:
+      description: List of codes that will be ignored.
+      required: false
+      type: list
+{% endconfiguration %}
 
 Note that this basic configuration will only enable you to read the armed/armed away/disarmed status of your alarm and will **not** update the status if the alarm is triggered. This is because of how Egardia built their system. The alarm triggers normally go through their servers.
-You can change this, however, using the following procedure. This is a more advanced configuration.
+You can change this, however, using the following procedure. This is a more advanced (and more useful) configuration.
 
+{% linkable_title Advanced configuration %}
 1. Log in to your alarm system's control panel. You will need to access http://[IP of your control panel]. You know this already since you need it in the basic configuration from above. Log in to the control panel with your Egardia/Woonveilig username and password.
 2. Once logged in, go to *System Settings*, *Report* and change the Server Address for your primary server to the IP or hostname of your Home Assistant machine. You can leave the port number set to 52010 or change it to anything you like. **Make sure to change the settings of the primary server otherwise the messages will not come through. Note that this will limit (or fully stop) the number of alarm messages you will get through Egardia's / Woonveilig services.** Maybe, that is just what you want. Make sure to save your settings by selecting 'OK'.
 3. The Egardia component relies on capturing the status codes that your alarm emits when something happens (status change or trigger). These codes will be unique for every situation - i.e. the code emitted by the alarm when a sensor is triggered is unique to that sensor. Also, if you have multiple users or remotes, each remote has unique codes that are emitted by the alarm when status is changed using that remote or by that user. For the Egardia component to work correctly you will need to capture the codes. To do this, on your Home Assistant machine run `$ sudo python3 egardiaserver.py`. Refer to the [python-egardia repository](https://github.com/jeroenterheerdt/python-egardia) for detailed documentation on parameters. This will receive status codes from your alarm control panel and display them. Record the codes shown as well as the status they relate to (see step 4 below). Make sure to change the status of your alarm to all states (disarm, arm, home) by all means possible (all users, remotes, web login, app) as well as trigger the alarm in all ways possible to get 100% coverage of all the codes the alarm system generates. You will need to run this script once and stop it once you have captured all the possible codes. Also, if you ever add users, remotes or sensors to your alarm system, make sure to re-run the script to capture the extra codes so you can update your configuration (see step 4 below). **For comfort, before triggering the alarm it might be good to disable the siren temporarily (can be done in Panel Settings).**
@@ -47,9 +97,9 @@ You can change this, however, using the following procedure. This is a more adva
     ```yaml
     # Example configuration.yaml entry
     egardia:
-      host: YOUR_HOST
-      username: YOUR_USERNAME
-      password: YOUR_PASSWORD
+      host: YOUR_HOST
+      username: YOUR_USERNAME
+      password: YOUR_PASSWORD
       report_server_enabled: True
       report_server_port: PORT_OF_EGARDIASERVER (optional, defaults to 52010)
       report_server_codes:
@@ -63,5 +113,3 @@ You can change this, however, using the following procedure. This is a more adva
 Note that for all code groups (*arm*,*disarm*, etc) multiple codes can be entered since each sensor triggers with a different code and each user of the system has its own arm and disarm codes. Also note that your system will do regular system checks which will be reported as well. Since Home Assistant provides no way of handling them properly, you can enter those codes as *ignore* (again, multiple codes can be used here). The egardia component will ignore these codes and continue returning the old status if it receives any of the codes that are listed as ignore. This is useful for example when you have armed your alarm at night: normally a system check will occur at least once during the night and if that code is not specified anywhere Home Assistant will set the status of the alarm to its default, which is unarmed. This is in fact wrong. Listing the code as ignore changes this behavior and Home Assistant will continue to show the status the alarm is in (disarm, arm, home, triggered) even when system checks occur.
 
 5. Test your setup and enjoy. The component will update if the alarm status changes, including triggers. You can use this to build your own automations and send notifications as you wish. *Note*: previous versions required a separate egardiaserver to be set up. This is no longer necessary and corresponding system services can be removed (using systemctl).
-
-


### PR DESCRIPTION
**Description:**
**Replacement of #4894 .**
A request was made in the last doc review to start using the %configuration% tag (PR: https://github.com/home-assistant/home-assistant.github.io/pull/4803). This PR does that. 
One thing is missing (need help!): I did not find a sample of how to specify the keys for the map type in configuration. The component accepts a list of states that can contain lists of codes, like this:
```yaml
report_server_codes:
  arm: XXXXXXXXXXXXXXXX, XXXXXXXXXXXXXXXX
  disarm: XXXXXXXXXXXXXXXX, XXXXXXXXXXXXXXXX
  armhome: XXXXXXXXXXXXXXXX
  triggered: XXXXXXXXXXXXXXXX, XXXXXXXXXXXXXXXX, XXXXXXXXXXXXXXXX
  ignore: XXXXXXXXXXXXXXXX
```
not sure how to put this in the %configuration% tag. For now, I left both the old version and the {%configuration%} tag in.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
