### PR TITLE
Support parsing mqtt nested json payload into attributes

### DIFF
--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -73,7 +73,7 @@ payload_not_available:
   type: string
   default: offline
 json_attributes:
-  description: A list of keys to extract values from a JSON dictionary payload and then set as sensor attributes.
+  description: A list of keys to extract values from a JSON dictionary payload and then set as sensor attributes. Use the "." operator to access nested JSON keys.
   reqired: false
   type: list, string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**

Often mqtt messages with json payloads are far too long to be directly set as status.
This PR uses flatten_json to intuitively handle parsing long nested json payloads into attributes.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13177

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
