### PR TITLE
Updated SCL command to Python 3.6 instead of 3.5

### DIFF
--- a/source/_docs/installation/centos.markdown
+++ b/source/_docs/installation/centos.markdown
@@ -30,7 +30,7 @@ $ yum install rh-python36
 Once installed, switch to your `homeassistant` user (if you've set one up), enable the software collection and check that it has set up the new version of Python:
 
 ```bash
-$ scl enable rh-python35 bash
+$ scl enable rh-python36 bash
 $ python --version
 Python 3.6.3
 ```

--- a/source/_docs/installation/centos.markdown
+++ b/source/_docs/installation/centos.markdown
@@ -55,7 +55,7 @@ User=homeassistant
 Environment=VIRTUAL_ENV="/srv/homeassistant"
 Environment=PATH="$VIRTUAL_ENV/bin:$PATH"
 # ExecStart using software collection:
-ExecStart=/usr/bin/scl enable rh-python35 -- /srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
+ExecStart=/usr/bin/scl enable rh-python36 -- /srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Instructions are for installing Python 3.6 but the scl command given assumes you have Python 3.5

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
