### PR TITLE
Adds rel nofollow to external links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,4 @@ group :jekyll_plugins do
 end
 
 gem 'sinatra', '~> 1.4.2'
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,9 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
     method_source (0.8.2)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     octopress (3.0.11)
       jekyll (>= 2.0)
       mercenary (~> 0.3.2)
@@ -100,6 +103,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-sitemap
   jekyll-time-to-read
+  nokogiri
   octopress (~> 3.0)
   octopress-include-tag
   pry
@@ -113,4 +117,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/plugins/no_follow.rb
+++ b/plugins/no_follow.rb
@@ -1,0 +1,32 @@
+# Jekyll Auto Nofollow Plugin
+# Automatically adds rel='external nofollow' to outgoing links.
+
+require 'jekyll'
+require 'nokogiri'
+
+module Jekyll
+    module NoFollow
+        def nofollow(content)
+            dom = Nokogiri::HTML.fragment(content)
+
+            # Find all links
+            dom.css('a').each do |link|
+
+                # All external links start with 'http', skip when this one does not
+                next unless link.get_attribute('href') =~ /\Ahttp/i
+
+                # Play nice with links that already have a rel attribute set, skip it
+                next if link.get_attribute('rel')
+
+                # Play nice with our own links
+                next if link.get_attribute('href') =~ /\Ahttps?:\/\/\w*.?home-assistant.io/i
+
+                # Add rel attribute to link
+                link.set_attribute('rel', 'external nofollow')
+            end
+            dom.to_s
+        end
+    end
+end
+
+Liquid::Template.register_filter(Jekyll::NoFollow)

--- a/plugins/no_follow.rb
+++ b/plugins/no_follow.rb
@@ -11,18 +11,19 @@ module Jekyll
 
             # Find all links
             dom.css('a').each do |link|
+                rel = ['external', 'nofollow']
 
                 # All external links start with 'http', skip when this one does not
                 next unless link.get_attribute('href') =~ /\Ahttp/i
 
-                # Play nice with links that already have a rel attribute set, skip it
-                next if link.get_attribute('rel')
-
                 # Play nice with our own links
                 next if link.get_attribute('href') =~ /\Ahttps?:\/\/\w*.?home-assistant.io/i
 
+                # Play nice with links that already have a rel attribute set
+                rel.unshift(link.get_attribute('rel'))
+
                 # Add rel attribute to link
-                link.set_attribute('rel', 'external nofollow')
+                link.set_attribute('rel', rel.join(' ').strip)
             end
             dom.to_s
         end

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -24,7 +24,7 @@ layout: compress
         <div class="grid__item two-thirds lap-one-whole palm-one-whole">
         {% endif %}
 
-          {{ content }}
+          {{ content | nofollow }}
 
         </div>
 


### PR DESCRIPTION
**Description:**

Adds `rel="external nofollow"` to all external links on the website.

Fixes #4583 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/