### PR TITLE
generate a robots.txt file that blocks search engines if not prod site

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,6 +60,13 @@ task :generate do
   abort("Generating CSS failed") unless success
   success = system "jekyll build"
   abort("Generating site failed") unless success
+  if ENV["CONTEXT"] != 'production'
+    File.open("#{public_dir}robots.txt", 'w') do |f|
+      f.write "User-agent: *\n"
+      f.write "Disallow: /\n"
+    end
+  end
+  public_dir
 end
 
 desc "Watch the site and regenerate when it changes"


### PR DESCRIPTION
**Description:**
Add a robots.txt that declines search engines for any build that is not production.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
