### PR TITLE
Fix default values in REST switch

### DIFF
--- a/source/_components/switch.rest.markdown
+++ b/source/_components/switch.rest.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "RESTful Switch"
-description: "Instructions how to integrate REST switches into Home Assistant."
+description: "Instructions on how to integrate REST switches into Home Assistant."
 date: 2015-09-14 19:10
 sidebar: true
 comments: false
@@ -12,7 +12,6 @@ ha_category: Switch
 ha_release: 0.7.6
 ha_iot_class: "Local Polling"
 ---
-
 
 The `rest` switch platform allows you to control a given endpoint that supports a [RESTful API](https://en.wikipedia.org/wiki/Representational_state_transfer). The switch can get the state via GET and set the state via POST on a given REST resource.
 
@@ -34,12 +33,12 @@ method:
   description: "The method of the request. Supported `post` or `put`."
   required: false
   type: string
-  default: "post"
+  default: post
 name:
   description: Name of the REST Switch.
   required: false
   type: string
-  default: "REST Switch"
+  default: REST Switch
 timeout:
   description: Timeout for the request.
   required: false
@@ -49,12 +48,12 @@ body_on:
   description: "The body of the POST request that commands the switch to become enabled. This value can be a [template](/topics/templating/)."
   required: false
   type: string
-  default: "ON"
+  default: ON
 body_off:
   description: "The body of the POST request that commands the switch to become disabled. This value can also be a [template](/topics/templating/)."
   required: false
   type: string
-  default: "OFF"
+  default: OFF
 is_on_template:
   description: "A [template](/docs/configuration/templating/#processing-incoming-data) that determines the state of the switch from the value returned by the GET request on the resource URL. This template should compute to a boolean (True or False). If the value is valid JSON, it will be available in the template as the variable `value_json`. Default is equivalent to `'{% raw %}{{ value_json == body_on }}{% endraw %}'`. This means that by default, the state of the switch is on if and only if the response to the GET request matches."
   required: false
@@ -77,12 +76,11 @@ Make sure that the URL matches exactly your endpoint or resource.
 
 ### {% linkable_title Switch with templated value %}
 
-This example shows a switch that uses a [template](/topics/templating/) to allow Home Assistant to determine its state. In this example the REST endpoint returns this JSON response with true indicating the switch is on.
+This example shows a switch that uses a [template](/topics/templating/) to allow Home Assistant to determine its state. In this example, the REST endpoint returns this JSON response with true indicating the switch is on.
 
 ```json
 {"is_active": "true"}
 ```
-
 
 ```yaml
 switch:
@@ -94,4 +92,3 @@ switch:
 ```
 
 `body_on` and `body_off` can also depend on the state of the system. For example, to enable a remote temperature sensor tracking on a radio thermostat, one has to send the current value of the remote temperature sensor. This can be achieved by using the template `{% raw %}'{"rem_temp":{{states.sensor.bedroom_temp.state}}}'{% endraw %}`.
-

--- a/source/_components/switch.rest.markdown
+++ b/source/_components/switch.rest.markdown
@@ -30,17 +30,16 @@ resource:
   description: The resource or endpoint that contains the value.
   required: true
   type: string
-  default: string
 method:
   description: "The method of the request. Supported `post` or `put`."
   required: false
   type: string
-  default: POST
+  default: "post"
 name:
   description: Name of the REST Switch.
   required: false
   type: string
-  default: REST Binary Switch
+  default: "REST Switch"
 timeout:
   description: Timeout for the request.
   required: false
@@ -50,12 +49,12 @@ body_on:
   description: "The body of the POST request that commands the switch to become enabled. This value can be a [template](/topics/templating/)."
   required: false
   type: string
-  default: ON
+  default: "ON"
 body_off:
   description: "The body of the POST request that commands the switch to become disabled. This value can also be a [template](/topics/templating/)."
   required: false
   type: string
-  default: OFF
+  default: "OFF"
 is_on_template:
   description: "A [template](/docs/configuration/templating/#processing-incoming-data) that determines the state of the switch from the value returned by the GET request on the resource URL. This template should compute to a boolean (True or False). If the value is valid JSON, it will be available in the template as the variable `value_json`. Default is equivalent to `'{% raw %}{{ value_json == body_on }}{% endraw %}'`. This means that by default, the state of the switch is on if and only if the response to the GET request matches."
   required: false


### PR DESCRIPTION
According to https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/switch/rest.py
* Resource does not have any default value.
* Method is set in lowercase "post"
* Default name is not "REST Binary Switch" but "REST Switch"
* Default body_on is "ON" not true
* Default body_off is "OFF" not false

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [/] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [/] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
