### PR TITLE
Allow TodoistAPI date_string in service call

### DIFF
--- a/source/_components/calendar.todoist.markdown
+++ b/source/_components/calendar.todoist.markdown
@@ -142,10 +142,11 @@ Here are two example JSON payloads resulting in the same task:
 
 - **priority** (*Optional*): The priority of the task, from 1-4. Again, 1 means least important, and 4 means most important.
 
-- **date_string** (*Optional*): When the task should be due, in [natural language](https://support.todoist.com/hc/en-us/articles/205325931-Dates-and-Times).
+- **due_date_string** (*Optional*): When the task should be due, in [natural language](https://support.todoist.com/hc/en-us/articles/205325931-Dates-and-Times). Mutually exclusive with `due_date`
 
-- **date_lang** (*Optional*): When `date_string` is set, it is posisble to set the language.
+- **due_date_lang** (*Optional*): When `due_date_string` is set, it is posisble to set the language. 
+  Valid languages are: `en`, `da`, `pl`, `zh`, `ko`, `de`, `pt`, `ja`, `it`, `fr`, `sv`, `ru`, `es`, `nl` 
 
-- **due_date** (*Optional*): When the task should be due, in either YYYY-MM-DD format or YYYY-MM-DD HH:MM format. This will override `date_string` if both are set.
+- **due_date** (*Optional*): When the task should be due, in either YYYY-MM-DD format or YYYY-MM-DD HH:MM format. Mutually exclusive with `due_date_string`.
 
 Note that there's (currently) no way to mark tasks as done through Home Assistant; task names do not necessarily have to be unique, so you could find yourself in a situation where you close the wrong task.

--- a/source/_components/calendar.todoist.markdown
+++ b/source/_components/calendar.todoist.markdown
@@ -129,8 +129,8 @@ Here are two example JSON payloads resulting in the same task:
     "project": "Errands",
     "labels":"Homework,School",
     "priority":3,
-    "date_string":"tomorrow at 14:00",
-    "date_lang":"en"
+    "due_date_string":"tomorrow at 14:00",
+    "due_date_lang":"en"
 }
 ```
 

--- a/source/_components/calendar.todoist.markdown
+++ b/source/_components/calendar.todoist.markdown
@@ -111,7 +111,7 @@ Home Assistant does its best to determine what task in each project is "most" im
 
 Todoist also comes with access to a service, `calendar.todoist_new_task`. This service can be used to create a new Todoist task. You can specify labels and a project, or you can leave them blank, and the task will go to your "Inbox" project.
 
-Here's an example JSON payload:
+Here are two example JSON payloads resulting in the same task:
 
 ```json
 {
@@ -123,6 +123,17 @@ Here's an example JSON payload:
 }
 ```
 
+```json
+{
+    "content": "Pick up the mail",
+    "project": "Errands",
+    "labels":"Homework,School",
+    "priority":3,
+    "date_string":"tomorrow at 14:00",
+    "date_lang":"en"
+}
+```
+
 - **content** (*Required*): The name of the task you want to create.
 
 - **project** (*Optional*): The project to put the task in.
@@ -131,6 +142,10 @@ Here's an example JSON payload:
 
 - **priority** (*Optional*): The priority of the task, from 1-4. Again, 1 means least important, and 4 means most important.
 
-- **due_date** (*Optional*): When the task should be due, in either YYYY-MM-DD format or YYYY-MM-DD HH:MM format.
+- **date_string** (*Optional*): When the task should be due, in [natural language](https://support.todoist.com/hc/en-us/articles/205325931-Dates-and-Times).
+
+- **date_lang** (*Optional*): When `date_string` is set, it is posisble to set the language.
+
+- **due_date** (*Optional*): When the task should be due, in either YYYY-MM-DD format or YYYY-MM-DD HH:MM format. This will override `date_string` if both are set.
 
 Note that there's (currently) no way to mark tasks as done through Home Assistant; task names do not necessarily have to be unique, so you could find yourself in a situation where you close the wrong task.


### PR DESCRIPTION
**Description:**
In the original implementation of the Todoist calendar component it was not possible to allow Todoist natural language for due dates. This PR adds this capability.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13256

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/