### PR TITLE
Update configuration.markdown's addon store image

### DIFF
--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -30,7 +30,7 @@ Hass.io add-ons are installed from the add-on store embedded in the Hass.io pane
 [local]: http://hassio.local:8123
 
 <p class='img'>
-<img src='/images/hassio/screenshots/main_panel_store_icon.png' />
+<img src='/images/hassio/screenshots/main_panel_addon_store.png' />
 From the Hass.io main panel open the add-on store.
 </p>
 


### PR DESCRIPTION
main_panel_store_icon.png appears to be removed or doesn't exist and maybe been replaced with main_panel_addon_store.png.
https://home-assistant.io/images/hassio/screenshots/main_panel_store_icon.png returns 404 and isn't displaying any image on 
https://home-assistant.io/getting-started/configuration/

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
