### PR TITLE
Update addon_tutorial.markdown's addon store image

### DIFF
--- a/source/developers/hassio/addon_tutorial.markdown
+++ b/source/developers/hassio/addon_tutorial.markdown
@@ -81,7 +81,7 @@ Now comes the fun part, time to open the Hass.io UI and install and run your add
  - On the top right click the shopping basket to go to the add-on store.
 
 <p class='img'>
-<img src='/images/hassio/screenshots/main_panel_store_icon.png' />
+<img src='/images/hassio/screenshots/main_panel_addon_store.png' />
 From the Hass.io main panel open the add-on store.
 </p>
 


### PR DESCRIPTION
Same as #4929 found another reference, should have searched for all references before I submitted #4929 I guess.

main_panel_store_icon.png appears to be removed or doesn't exist and maybe been replaced with main_panel_addon_store.png.
https://home-assistant.io/images/hassio/screenshots/main_panel_store_icon.png returns 404 and isn't displaying any image on
https://home-assistant.io/developers/hassio/addon_tutorial/

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
