### PR TITLE
Raspberry Pi 3 B+ note

### DIFF
--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -24,12 +24,12 @@ We will need a few things to get started with installing Home Assistant. Links b
 
 ### {% linkable_title Software requirements %}
 
-- Download [Hass.io image for Raspberry Pi 3][pi3]
+- Download [Hass.io image for Raspberry Pi 3][pi3] <p class='note'>(It's not working with 3B+ yet)</p>
 - Download [Etcher] to write the image to an SD card
 - Text Editor like [Visual Studio Code](https://code.visualstudio.com/)
 
 [Etcher]: https://etcher.io/
-[pi3]: https://github.com/home-assistant/hassio-build/releases/download/1.1/resinos-hassio-1.1-raspberrypi3.img.bz2
+[pi3]: https://github.com/home-assistant/hassio-build/releases/download/1.3/resinos-hassio-1.3-raspberrypi3.img.bz2
 
 ### {% linkable_title Installing Hass.io %}
 

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -22,9 +22,13 @@ We will need a few things to get started with installing Home Assistant. Links b
 - SD Card reader. Part of most laptops, and also available as [standalone USB sticks](http://a.co/5FCyb0N) (the brand doesn't matter, just pick the cheapest)
 - Ethernet cable (optional, Hass.io can work with WiFi too)
 
+<p class='note warning'>
+  The recently released Raspberry Pi 3 model B+ is not yet supported.
+</p>
+
 ### {% linkable_title Software requirements %}
 
-- Download [Hass.io image for Raspberry Pi 3][pi3] <p class='note'>(It's not working with 3B+ yet)</p>
+- Download [Hass.io image for Raspberry Pi 3][pi3]
 - Download [Etcher] to write the image to an SD card
 - Text Editor like [Visual Studio Code](https://code.visualstudio.com/)
 


### PR DESCRIPTION
Added note that Raspberry Pi 3 B+ is not yet supported

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
