### PR TITLE
Raspberry Pi 3 B+ note

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -11,6 +11,10 @@ footer: true
 
 Hass.io images are available for all available Raspberry Pi and Intel NUC platforms.
 
+<p class='note warning'>
+  The recently released Raspberry Pi 3 model B+ is not yet supported.
+</p>
+
 - Download the appropriate image for your Raspberry Pi / Intel NUC:
   - [Raspberry Pi / Zero][pi1]
   - [Raspberry Pi 2][pi2]

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -18,7 +18,7 @@ Hass.io images are available for all available Raspberry Pi and Intel NUC platfo
 - Download the appropriate image for your Raspberry Pi / Intel NUC:
   - [Raspberry Pi / Zero][pi1]
   - [Raspberry Pi 2][pi2]
-  - [Raspberry Pi 3][pi3] <p class='note'>(It's not working with Raspberry pi 3 B+ yet)</p>
+  - [Raspberry Pi 3][pi3]
   - [Intel NUC][nuc]
 
 - Flash the downloaded image to an SD card using [Etcher].

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -14,7 +14,7 @@ Hass.io images are available for all available Raspberry Pi and Intel NUC platfo
 - Download the appropriate image for your Raspberry Pi / Intel NUC:
   - [Raspberry Pi / Zero][pi1]
   - [Raspberry Pi 2][pi2]
-  - [Raspberry Pi 3][pi3]
+  - [Raspberry Pi 3][pi3] <p class='note'>(It's not working with Raspberry pi 3 B+ yet)</p>
   - [Intel NUC][nuc]
 
 - Flash the downloaded image to an SD card using [Etcher].


### PR DESCRIPTION
Added note that pi 3 image does not work with pi 3 b+ yet

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
