### PR TITLE
Small comment added to expose_by_default

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -71,7 +71,7 @@ api_key:
   required: false
   type: string
 expose_by_default:
-  description: Expose devices in all supported domains by default.
+  description: Expose devices in all supported domains by default. If set to false, you need to either expose domains or add `expose: true` to each entity in entity_config.
   required: false
   default: True
   type: boolean

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -71,7 +71,7 @@ api_key:
   required: false
   type: string
 expose_by_default:
-  description: Expose devices in all supported domains by default. If set to false, you need to either expose domains or add `expose: true` to each entity in entity_config.
+  description: Expose devices in all supported domains by default. If set to false, you need to either expose domains or add the expose configuration option to each entity in entity_config and set it to true.
   required: false
   default: True
   type: boolean


### PR DESCRIPTION
It's not entirely clear that listing specific entities in entity_config is not enough to expose an entity if expose_by_default is set to false.
(This is my first PR so I hope I've done it correctly)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
