### PR TITLE
sun trigger - Link fix, wording tweak

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -119,13 +119,13 @@ condition:
 
 The sun condition can test if the sun has already set or risen when a trigger occurs. The `before` and `after` keys can only be set to `sunset` or `sunrise`. They have a corresponding optional offset value (`before_offset`, `after_offset`) that can be added, similar to the [sun trigger][sun_trigger].
 
-[sun_trigger]: /getting-started/automation-trigger/#sun-trigger
+[sun_trigger]: /docs/automation/trigger/#sun-trigger
 
 ```yaml
 condition:
   condition: sun
   after: sunset
-  # Optional offset value
+  # Optional offset value - in this case it must from -1 hours relative to sunset, or after
   after_offset: "-1:00:00"
 ```
 


### PR DESCRIPTION
Fixed the link to the actual sun trigger. Tried to add some clarity to the wording over offsets, but I think that needs expansion.