### PR TITLE
Add information about Hassbian being available for the Raspberry Pi 3B+

### DIFF
--- a/source/_docs/installation/hassbian.markdown
+++ b/source/_docs/installation/hassbian.markdown
@@ -10,7 +10,7 @@ footer: true
 redirect_from: /getting-started/hassbian/
 ---
 
-Hassbian is our customized operating system for the Raspberry Pi 3. It is the easiest way of installing Home Assistant.
+Hassbian is our customized operating system for the Raspberry Pi Zero, 2,3 and 3B+. It is one of the easiest ways of installing Home Assistant.
 
  - [Install Hassbian][install]
  - [Customize your installation][customize]

--- a/source/_docs/installation/hassbian/installation.markdown
+++ b/source/_docs/installation/hassbian/installation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Installing Hassbian"
-description: "Instructions to flash the Home Assistant HASSbian image on a Raspberry Pi."
+description: "Instructions to flash the Home Assistant Hassbian image on a Raspberry Pi."
 date: 2016-09-26 21:00
 sidebar: true
 comments: false
@@ -10,7 +10,7 @@ footer: true
 redirect_from: /docs/hassbian/installation/
 ---
 
-The easiest way to install Home Assistant on your Raspberry Pi is by using HASSbian: a Raspberry Pi image with Home Assistant built-in. The image will install the latest version of Home Assistant on initial boot (~10 minutes).
+One of the easiest ways to install Home Assistant on your Raspberry Pi Zero, 2 ,3 and 3B+ is by using Hassbian: a Raspberry Pi image with Home Assistant built-in. The image will install the latest version of Home Assistant on initial boot (~10 minutes).
 
  1. [Download the Hassbian image][image-download]
  2. Use [Etcher][etcher] to flash the image to your SD card

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -23,7 +23,9 @@ We will need a few things to get started with installing Home Assistant. Links b
 - Ethernet cable (optional, Hass.io can work with WiFi too)
 
 <p class='note warning'>
-  The recently released Raspberry Pi 3 model B+ is not yet supported.
+  Support for the Raspberry Pi 3 model B+ is available in the alternative installation method [Hassbian](/docs/hassbian/installation/).
+
+  The recently released Raspberry Pi 3 model B+ is not yet supported by Hass.io
 </p>
 
 ### {% linkable_title Software requirements %}


### PR DESCRIPTION
**Description:**
Add information about Hassbian being available for the Raspberry Pi 3B+

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
