### PR TITLE
Add hint about user rights for GPIO

### DIFF
--- a/source/_components/sensor.dht.markdown
+++ b/source/_components/sensor.dht.markdown
@@ -15,6 +15,11 @@ ha_iot_class: "Local Polling"
 
 
 The `dht` sensor platform allows you to get the current temperature and humidity from a DHT11, DHT22, or AM2302 device.
+The user who starts Home Assistant needs the rights to access GPIOs. This can be done by adding it the GPIO group.
+
+```
+sudo adduser homeassistant gpio
+```
 
 To use your DHTxx sensor in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
The user running Home Assistant needs to access GPIO.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
