### PR TITLE
Fix code for custom UI version

### DIFF
--- a/source/developers/frontend_creating_custom_ui.markdown
+++ b/source/developers/frontend_creating_custom_ui.markdown
@@ -53,7 +53,7 @@ frontend:
   if (!window.CUSTOM_UI_LIST) window.CUSTOM_UI_LIST = [];
   window.CUSTOM_UI_LIST.push({
     name: _NAME,
-    url: _URL
+    url: _URL,
     version: _VERSION    
   });
 }

--- a/source/developers/frontend_creating_custom_ui.markdown
+++ b/source/developers/frontend_creating_custom_ui.markdown
@@ -46,15 +46,15 @@ frontend:
 <script>
 {
   // show the version of your custom UI in the HA dev info panel (HA 0.66.0+):
-  const NAME = 'My custom light';
-  const VERSION = '20180312';
-  const URL = 'https://home-assistant.io/developers/frontend_creating_custom_ui/';
+  const _NAME = 'My custom light';
+  const _URL = 'https://home-assistant.io/developers/frontend_creating_custom_ui/';
+  const _VERSION = '20180312';
 
   if (!window.CUSTOM_UI_LIST) window.CUSTOM_UI_LIST = [];
   window.CUSTOM_UI_LIST.push({
-    name: NAME,
-    url: URL
-    version: VERSION    
+    name: _NAME,
+    url: _URL
+    version: _VERSION    
   });
 }
 </script>

--- a/source/developers/frontend_creating_custom_ui.markdown
+++ b/source/developers/frontend_creating_custom_ui.markdown
@@ -54,7 +54,7 @@ frontend:
   window.CUSTOM_UI_LIST.push({
     name: _NAME,
     url: _URL,
-    version: _VERSION    
+    version: _VERSION
   });
 }
 </script>

--- a/source/developers/frontend_creating_custom_ui.markdown
+++ b/source/developers/frontend_creating_custom_ui.markdown
@@ -42,7 +42,22 @@ frontend:
 
 `www/custom_ui/state-card-my-custom-light.html`:
 
-```javascript
+```html
+<script>
+{
+  // show the version of your custom UI in the HA dev info panel (HA 0.66.0+):
+  const NAME = 'My custom light';
+  const VERSION = '20180312';
+  const URL = 'https://home-assistant.io/developers/frontend_creating_custom_ui/';
+
+  if (!window.CUSTOM_UI_LIST) window.CUSTOM_UI_LIST = [];
+  window.CUSTOM_UI_LIST.push({
+    name: NAME,
+    url: URL
+    version: VERSION    
+  });
+}
+</script>
 <dom-module id='state-card-my-custom-light'>
   <template>
     <style>
@@ -53,20 +68,6 @@ frontend:
 </dom-module>
 
 <script>
-// show the version of your custom UI in the HA dev info panel (HA 0.66.0+):
-const CUSTOM_UI_NAME = 'state-card-my-custom-light';
-const CUSTOM_UI_VERSION = '20180312';
-const CUSTOM_UI_URL = 'https://home-assistant.io/developers/frontend_creating_custom_ui/';
-
-if (!window.CUSTOM_UI_LIST) {
-  window.CUSTOM_UI_LIST = [];
-}
-window.CUSTOM_UI_LIST.push({
-  name: CUSTOM_UI_NAME,
-  version: CUSTOM_UI_VERSION,
-  url: CUSTOM_UI_URL
-}); 
-
 class StateCardMyCustomLight extends Polymer.Element {
   static get is() { return 'state-card-my-custom-light'; }
   
@@ -85,7 +86,7 @@ class StateCardMyCustomLight extends Polymer.Element {
   }
 
   _toStr(obj) {
-    return JSON.stringify(obj);
+    return JSON.stringify(obj, null, 2);
   }
 }
 customElements.define(StateCardMyCustomLight.is, StateCardMyCustomLight);


### PR DESCRIPTION
**Description:**
if you don't put the code in `{ }` `const`s are global and you get errors if you have more than 1 custom UI

related PRs:
https://github.com/home-assistant/home-assistant.github.io/pull/4903

https://github.com/home-assistant/home-assistant-polymer/pull/981

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
