### PR TITLE
Fix Duck DNS configuration example

### DIFF
--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -15,7 +15,9 @@ featured: true
 ```json
 {
   "lets_encrypt": {
-    "accept_terms": true
+    "accept_terms": true,
+    "certfile": "fullchain.pem",
+    "keyfile": "privkey.pem"
   },
   "token": "sdfj-2131023-dslfjsd-12321",
   "domains": ["my-domain.duckdns.org"]


### PR DESCRIPTION
**Description:**

Adds certfile and keyfile to the lets_encrypt configuration example.
Without these parameters hassio doesn't allow to save configuration.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
