### PR TITLE
Tweaked automations

### DIFF
--- a/source/_docs/automation/examples.markdown
+++ b/source/_docs/automation/examples.markdown
@@ -38,6 +38,7 @@ automation:
         after: '16:00:00'
         before: '23:00:00'
     action:
+      # With a single service call, we don't need a '-' before service - though you can if you want to
       service: homeassistant.turn_on
       entity_id: group.living_room
 
@@ -76,9 +77,9 @@ automation:
       event_data:
         entity_id: binary_sensor.cube_158d000103a3de
     action:
-      - service_template: notify.pushover
-        data_template: 
-          title: "Cube event detected"
-          message: "Cube has triggered this event: {{ trigger.event }}"
+      service_template: notify.pushover
+      data_template: 
+        title: "Cube event detected"
+        message: "Cube has triggered this event: {{ trigger.event }}"
 ```
 {% endraw %}


### PR DESCRIPTION
Added comment about why we don't use `-` before the first `service:` line.

Removed the `-` from the last example's service_template
