### PR TITLE
Add documentation for homekit controller component

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -51,6 +51,8 @@ discovery:
   ignore:
     - sonos
     - samsung_tv
+  enable:
+    - homekit
 ```
 
 Configuration variables:
@@ -85,6 +87,12 @@ Valid values for ignore are:
  * `wink`: Wink Hub
  * `yamaha`: Yamaha media player
  * `yeelight`: Yeelight Sunflower bulb
+
+- **enable** (*Optional*): A list of platforms not enabled by default that `discovery` should discover.
+
+Valid values for enable are:
+
+ * `homekit`: HomeKit accessories
 
 <p class='note'>
 Home Assistant must be on the same network as the devices for uPnP discovery to work.

--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -23,6 +23,7 @@ Home Assistant can discover and automatically configure [zeroconf](https://en.wi
  * [DirecTV receivers](/components/media_player.directv/)
  * [Frontier Silicon internet radios](/components/media_player.frontier_silicon/)
  * [Google Cast](/components/media_player.cast/)
+ * [HomeKit](/components/homekit_controller/)
  * [IKEA Trådfri (Tradfri)](/components/tradfri/)
  * [Linn / Openhome](/components/media_player.openhome/)
  * [Logitech Harmony Hub](/components/remote.harmony/)

--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -1,0 +1,28 @@
+---
+layout: page
+title: "Homekit controller support"
+description: "Instructions how to integrate your Homekit devices within Home Assistant."
+date: 2018-03-19 21:04
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: apple-homekit.png
+ha_category: Hub
+ha_release: 0.66
+ha_iot_class: "Local Polling"
+---
+
+[HomeKit](https://developer.apple.com/homekit/) controller integration for Home Assistant allows you to connect HomeKit accessories to Home Assistant. This component should not be confused with the [HomeKit](homekit) component, which allows you to control Home Assistant devices via HomeKit.
+
+There is currently support for the following device types within Home Assistant:
+
+- [Light](../light.homekit_controller)
+
+The component will be automatically configured if the [`discovery:`](components/discovery/) component is enabled. For each detected Homekit accessory, a configuration prompt will appear in the web front end. Use this to provide the HomeKit PIN. It can be disabled by adding the following configuration:
+
+```yaml
+discovery:
+  ignore:
+    - homekit
+```

--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -20,7 +20,7 @@ There is currently support for the following device types within Home Assistant:
 - [Light](../light.homekit_controller)
 - [Switch](../switch.homekit_controller)
 
-The component will be automatically configured if the [`discovery:`](components/discovery/) component is enabled and an enable entry added for homekit:
+The component will be automatically configured if the [`discovery:`](components/discovery/) component is enabled and an enable entry added for HomeKit:
 
 ```yaml
 discovery:

--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "Homekit controller support"
-description: "Instructions how to integrate your Homekit devices within Home Assistant."
+title: "HomeKit controller support"
+description: "Instructions how to integrate your HomeKit devices within Home Assistant."
 date: 2018-03-19 21:04
 sidebar: true
 comments: false
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: apple-homekit.png
 ha_category: Hub
-ha_release: 0.66
+ha_release: 0.67
 ha_iot_class: "Local Polling"
 ---
 
@@ -18,11 +18,14 @@ ha_iot_class: "Local Polling"
 There is currently support for the following device types within Home Assistant:
 
 - [Light](../light.homekit_controller)
+- [Switch](../switch.homekit_controller)
 
-The component will be automatically configured if the [`discovery:`](components/discovery/) component is enabled. For each detected Homekit accessory, a configuration prompt will appear in the web front end. Use this to provide the HomeKit PIN. It can be disabled by adding the following configuration:
+The component will be automatically configured if the [`discovery:`](components/discovery/) component is enabled and an enable entry added for homekit:
 
 ```yaml
 discovery:
-  ignore:
+  enable:
     - homekit
 ```
+
+For each detected HomeKit accessory, a configuration prompt will appear in the web front end. Use this to provide the HomeKit PIN.

--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: apple-homekit.png
 ha_category: Hub
-ha_release: 0.67
+ha_release: 0.68
 ha_iot_class: "Local Polling"
 ---
 

--- a/source/_components/light.homekit_controller.markdown
+++ b/source/_components/light.homekit_controller.markdown
@@ -1,0 +1,15 @@
+---
+layout: page
+title: "Homekit Light"
+description: "Instructions how to setup Homekit lights within Home Assistant."
+date: 2017-03-19 21:08
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: apple-homekit.png
+ha_category: Light
+ha_iot_class: "Local Polling"
+---
+
+To get your Homekit lights working with Home Assistant, follow the instructions for the general [Homekit controller component](/components/homekit_controller/).

--- a/source/_components/light.homekit_controller.markdown
+++ b/source/_components/light.homekit_controller.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: apple-homekit.png
 ha_category: Light
 ha_iot_class: "Local Polling"
+ha_release: 0.68
 ---
 
 To get your HomeKit lights working with Home Assistant, follow the instructions for the general [HomeKit controller component](/components/homekit_controller/).

--- a/source/_components/light.homekit_controller.markdown
+++ b/source/_components/light.homekit_controller.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "Homekit Light"
-description: "Instructions how to setup Homekit lights within Home Assistant."
+title: "HomeKit Light"
+description: "Instructions how to setup HomeKit lights within Home Assistant."
 date: 2017-03-19 21:08
 sidebar: true
 comments: false
@@ -12,4 +12,4 @@ ha_category: Light
 ha_iot_class: "Local Polling"
 ---
 
-To get your Homekit lights working with Home Assistant, follow the instructions for the general [Homekit controller component](/components/homekit_controller/).
+To get your HomeKit lights working with Home Assistant, follow the instructions for the general [HomeKit controller component](/components/homekit_controller/).

--- a/source/_components/switch.homekit_controller.markdown
+++ b/source/_components/switch.homekit_controller.markdown
@@ -1,0 +1,15 @@
+---
+layout: page
+title: "HomeKit Light"
+description: "Instructions how to setup HomeKit switches within Home Assistant."
+date: 2017-03-19 21:08
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: apple-homekit.png
+ha_category: Light
+ha_iot_class: "Local Polling"
+---
+
+To get your HomeKit switches working with Home Assistant, follow the instructions for the general [HomeKit controller component](/components/homekit_controller/).

--- a/source/_components/switch.homekit_controller.markdown
+++ b/source/_components/switch.homekit_controller.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: apple-homekit.png
 ha_category: Light
 ha_iot_class: "Local Polling"
+ha_release: 0.68
 ---
 
 To get your HomeKit switches working with Home Assistant, follow the instructions for the general [HomeKit controller component](/components/homekit_controller/).


### PR DESCRIPTION
**Description:**
Documentation for Homekit accessories.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) :** home-assistant/home-assistant#13346

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
