### PR TITLE
Update default Pilight port number

### DIFF
--- a/source/_components/pilight.markdown
+++ b/source/_components/pilight.markdown
@@ -30,8 +30,8 @@ pilight:
 
 Configuration variables:
 
-- **host** (*Required*): The IP address of the computer running the pilight-daemon, e.g., 192.168.1.32.
-- **port** (*Required*): The network port to connect to. The usual port is [5001](https://manual.pilight.org/development/api.html).
+- **host** (*Optional*): The IP address of the computer running the pilight-daemon, e.g., 192.168.1.32.
+- **port** (*Optional*): The network port to connect to. The usual port is [5001](https://manual.pilight.org/development/api.html).
 - **send_delay** (*Optional*): You can define a send delay as a fraction of seconds if you experience transmission problems when you try to switch multiple switches at once. This can happen when you use a [pilight USB Nano](https://github.com/pilight/pilight-usb-nano) as hardware and switches a whole group of multiple switches on or off. Tested values are between 0.3 and 0.8 seconds depending on the hardware.
 - **whitelist** (*Optional*): You can define a whitelist to prevent that too many unwanted RF codes (e.g., the neighbors weather station) are put on your HA event bus. All defined subsections have to be matched. A subsection is matched if one of the items are true.
 

--- a/source/_components/pilight.markdown
+++ b/source/_components/pilight.markdown
@@ -24,8 +24,6 @@ To integrate pilight into Home Assistant, add the following section to your `con
 ```yaml
 # Example configuration.yaml entry
 pilight:
-  host: 127.0.0.1
-  port: 5001
 ```
 
 Configuration variables:
@@ -43,7 +41,7 @@ A full configuration sample could look like the sample below:
 # Example configuration.yaml entry
 pilight:
   host: 127.0.0.1
-  port: 5001
+  port: 5000
   send_delay: 0.4
   whitelist:  # optional
     protocol:

--- a/source/_components/pilight.markdown
+++ b/source/_components/pilight.markdown
@@ -25,13 +25,13 @@ To integrate pilight into Home Assistant, add the following section to your `con
 # Example configuration.yaml entry
 pilight:
   host: 127.0.0.1
-  port: 5000
+  port: 5001
 ```
 
 Configuration variables:
 
 - **host** (*Required*): The IP address of the computer running the pilight-daemon, e.g., 192.168.1.32.
-- **port** (*Required*): The network port to connect to. The usual port is [5000](https://manual.pilight.org/development/api.html).
+- **port** (*Required*): The network port to connect to. The usual port is [5001](https://manual.pilight.org/development/api.html).
 - **send_delay** (*Optional*): You can define a send delay as a fraction of seconds if you experience transmission problems when you try to switch multiple switches at once. This can happen when you use a [pilight USB Nano](https://github.com/pilight/pilight-usb-nano) as hardware and switches a whole group of multiple switches on or off. Tested values are between 0.3 and 0.8 seconds depending on the hardware.
 - **whitelist** (*Optional*): You can define a whitelist to prevent that too many unwanted RF codes (e.g., the neighbors weather station) are put on your HA event bus. All defined subsections have to be matched. A subsection is matched if one of the items are true.
 
@@ -43,7 +43,7 @@ A full configuration sample could look like the sample below:
 # Example configuration.yaml entry
 pilight:
   host: 127.0.0.1
-  port: 5000
+  port: 5001
   send_delay: 0.4
   whitelist:  # optional
     protocol:


### PR DESCRIPTION
**Description:**
Based on the Pilight docs targeted the default port is 5001, 
As started here https://manual.pilight.org/development/api.html and in the original Home Assistant doc
I think they did a big refactor late last year to the code base and docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13419

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
