### PR TITLE
Current

### DIFF
--- a/source/_components/sensor.filter.markdown
+++ b/source/_components/sensor.filter.markdown
@@ -99,7 +99,7 @@ The returned value is rounded to the number of decimals defined in (`precision`)
 
 ### {% linkable_title Band-pass %}
 
-The Band-pass filter (`bandpass`) cuts out any value outside a specific range.
+The Band-pass filter (`outlier`) cuts out any value outside a specific range.
 
 The included Outlier filter will discard any value beyond a band centered on the median of the previous values, replacing it with the median value of the previous values. If inside the band, the 
 

--- a/source/_components/sensor.filter.markdown
+++ b/source/_components/sensor.filter.markdown
@@ -97,9 +97,9 @@ LowPass(state) = A * previous_state + B * state
 
 The returned value is rounded to the number of decimals defined in (`precision`).
 
-### {% linkable_title Outlier %}
+### {% linkable_title Band-pass %}
 
-The Outlier filter (`outlier`) is a basic Band-stop filter, as it cuts out any value outside a specific range.
+The Band-pass filter (`bandpass`) cuts out any value outside a specific range.
 
 The included Outlier filter will discard any value beyond a band centered on the median of the previous values, replacing it with the median value of the previous values. If inside the band, the 
 


### PR DESCRIPTION
**Description:**
The outlier filter is wrongly described as band-stop filter while it is an band-pass filter (See https://en.m.wikipedia.org/wiki/Band-pass_filter for more information).
Also outliers and outlier detection is often interpreted slightly different (for example also concerning outliers within the accepted value range) so this should be renamed to band-pass on the long term.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
