### PR TITLE
automations file has fixed name and location

### DIFF
--- a/source/_docs/automation/editor.markdown
+++ b/source/_docs/automation/editor.markdown
@@ -50,7 +50,9 @@ First check that you have activated the configuration editor.
 config:
 ```
 
-The automation editor reads and writes to the file `automations.yaml` in your [configuration](/docs/configuration/) folder. Make sure that you have set up the automation component to read from it:
+The automation editor reads and writes to the file `automations.yaml` in the root of your [configuration](/docs/configuration/) folder. 
+Currently both the name of this file and its location are fixed.
+Make sure that you have set up the automation component to read from it:
 
 ```yaml
 # Configuration.yaml example

--- a/source/_docs/automation/editor.markdown
+++ b/source/_docs/automation/editor.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 ---
 
-In Home Assistant 0.45 we introduced the first version of our automation editor. If you just created a new configuration with Home Assistant then you're all set! Go to the UI and enjoy.
+In Home Assistant 0.45 we introduced the first version of our automation editor. If you just created a new configuration with Home Assistant, then you're all set! Go to the UI and enjoy.
 
 From the UI choose **Configuration** which is located in the sidebar, then click on **Automation** to go to the automation editor. Press the **+** sign in the lower right corner to get started. This example is based on the manual steps described in the [Getting started section](/getting-started/automation/) for a [`random` sensor](/components/sensor.random/).
 
@@ -19,7 +19,7 @@ Choose a meaningful name for your automation rules.
   <img src='{{site_root}}/images/docs/automation-editor/new-automation.png' />
 </p>
 
-If the value of the sensor is greater than 10 then the automation rule should apply.
+If the value of the sensor is greater than 10, then the automation rule should apply.
 
 <p class='img'>
   <img src='{{site_root}}/images/docs/automation-editor/new-trigger.png' />
@@ -39,11 +39,11 @@ As "Service Data" we want a simple text that is shown as part of the notificatio
 }
 ```
 
-Don't forget to save your new automation rule. In order for your saved automation rule to come into effect you will need to go to the **Configuration** page and click on **Reload Automation**.
+Don't forget to save your new automation rule. For your saved automation rule to come into effect, you will need to go to the **Configuration** page and click on **Reload Automation**.
 
 ## {% linkable_title Updating your configuration to use the editor %}
 
-First check that you have activated the configuration editor.
+First, check that you have activated the configuration editor.
 
 ```yaml
 # Activate the configuration editor
@@ -51,7 +51,7 @@ config:
 ```
 
 The automation editor reads and writes to the file `automations.yaml` in the root of your [configuration](/docs/configuration/) folder. 
-Currently both the name of this file and its location are fixed.
+Currently, both the name of this file and its location are fixed.
 Make sure that you have set up the automation component to read from it:
 
 ```yaml
@@ -67,7 +67,7 @@ automation old:
     platform: ...
 ```
 
-You can use the `automation:` and `automation old:` sections in the same time:
+You can use the `automation:` and `automation old:` sections at the same time:
  - `automation old:` to keep your manual designed automations
  - `automation:` to save the automation created by the online editor
 
@@ -79,7 +79,7 @@ automation old: !include_dir_merge_list automations
 
 ## {% linkable_title Migrating your automations to `automations.yaml` %}
 
-If you want to migrate your old automations to use the editor, you'll have to copy them to `automations.yaml`. Make sure that `automations.yaml` remains a list! For each automation that you copy over you'll have to add an `id`. This can be any string as long as it's unique.
+If you want to migrate your old automations to use the editor, you'll have to copy them to `automations.yaml`. Make sure that `automations.yaml` remains a list! For each automation that you copy over, you'll have to add an `id`. This can be any string as long as it's unique.
 
 For example, the below automation will be triggered when the sun goes from below the horizon to above the horizon. Then, if the temperature is between 17 and 25 degrees, a light will be turned on.
 


### PR DESCRIPTION
The name and path of the automations file are fixed. Clarification for #13411

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
