### PR TITLE
Fixed invalid YAML example

### DIFF
--- a/source/_components/sensor.nederlandse_spoorwegen.markdown
+++ b/source/_components/sensor.nederlandse_spoorwegen.markdown
@@ -24,16 +24,16 @@ Add the data to your `configuration.yaml` file as shown in the example:
 # Example configuration.yaml entry
 sensor:
 - platform: nederlandse_spoorwegen
-    email: you@example.com
-    password: !secret ns_password
-    routes:
-      - name: Rotterdam-Amsterdam
-        from: Rtd
-        to: Asd
-      - name: Groningen-Zwolle-Maastricht
-        from: Gn
-        to: Mt
-        via: Zl
+  email: you@example.com
+  password: !secret ns_password
+  routes:
+    - name: Rotterdam-Amsterdam
+      from: Rtd
+      to: Asd
+    - name: Groningen-Zwolle-Maastricht
+      from: Gn
+      to: Mt
+      via: Zl
 ```
 
 Configuration variables:


### PR DESCRIPTION
**Description:**
Fixed invalid YAML in example

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
