### PR TITLE
light.group: Added example for usage in scripts.

### DIFF
--- a/source/_components/light.group.markdown
+++ b/source/_components/light.group.markdown
@@ -46,3 +46,18 @@ Example of the light group "Kitchen Lights".
 </p>
 
 The supported features of all lights will be added together. For example, if you have one RGB light in a group of otherwise brightness-only lights, the light group will be shown with a color picker.
+
+## {% linkable_title Script Example %}
+
+Here's an example of an script using the above light group.
+
+```yaml
+script:
+  turn_on_kitchen_lights:
+    alias: Kitchen lights on
+    sequence:
+      service: light.turn_on
+      data:
+        entity_id: light.kitchen_lights
+        brightness: 100
+```

--- a/source/_components/light.group.markdown
+++ b/source/_components/light.group.markdown
@@ -49,7 +49,7 @@ The supported features of all lights will be added together. For example, if you
 
 ## {% linkable_title Script Example %}
 
-Here's an example of an script using the above light group.
+Here's an example of a script using the above light group.
 
 ```yaml
 script:


### PR DESCRIPTION
**Description:**
There can be confusion of which domain to use `light`/`group` for this.
## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
