### PR TITLE
Homekit: Added dependency note warning

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -14,6 +14,11 @@ logo: apple-homekit.png
 
 The `HomeKit` component allows you to forward entities from Home Assistant to Apple `HomeKit`, so they could be controlled from Apple `Home` app and `Siri`. Please make sure that you have read the [considerations](#considerations) listed below to save you some trouble later.
 
+<p class="note warning">
+  It might be necessary to install an additional package:  
+  `$ sudo apt-get install libavahi-compat-libdnssd-dev`
+</p>
+
 {% configuration %}
   homekit:
     description: HomeKit configuration.


### PR DESCRIPTION
**Description:**
In some cases `pyhap` might require that an additional package is installed.
Base branch set to `rc` not `current` due to previously made changes for new features.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
