### PR TITLE
Change url to be prefixed with www.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 #      Main Configs       #
 # ----------------------- #
 
-url: https://home-assistant.io
+url: https://www.home-assistant.io
 title: Home Assistant
 subtitle: Open-source home automation platform running on Python 3
 author: Home Assistant

--- a/plugins/filters.rb
+++ b/plugins/filters.rb
@@ -24,7 +24,7 @@ module Jekyll
     # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 
     def site_url
-      'https://home-assistant.io'
+      'https://www.home-assistant.io'
     end
 
     # Prepend a url with the full site url


### PR DESCRIPTION
This will change our base url and all canonical urls to point at our www domain. Once merged:

 - Update netlify to change primary domain to be www.home-assistant.io. This will start 301 on home-assistant.io
 - Update Google Analytics: Admin -> Property Settings -> Default url
 - Update Google Webmaster Tools -> Change preferred domain
 - Bing Wembaster Tools: https://www.bing.com/webmaster/diagnostics/site/move?url=https%3A%2F%2Fhome-assistant.io%2F


This is to work around a limitation of CNAME flattening, more info here: https://www.netlify.com/blog/2017/02/28/to-www-or-not-www/ . Basically everyone is getting currently served the US CDN

In another PR we will need to make sure that all mentions of `https://home-assistant.io` are removed from links. We should instead use relative urls so that we don't break our rc.home-assistant.io and next.home-assistant.io doc builds.
