### PR TITLE
Fix init.d for safe shell variables

### DIFF
--- a/source/_docs/autostart/init.d.markdown
+++ b/source/_docs/autostart/init.d.markdown
@@ -86,10 +86,10 @@ PRE_EXEC=""
 HASS_BIN="hass"
 RUN_AS="USER"
 PID_DIR="/var/run"
-PID_FILE="$PID_DIR/hass.pid"
+PID_FILE="${PID_DIR}/hass.pid"
 CONFIG_DIR="/var/opt/homeassistant"
 LOG_DIR="/var/log/homeassistant"
-LOG_FILE="$LOG_DIR/home-assistant.log"
+LOG_FILE="${LOG_DIR}/home-assistant.log"
 FLAGS="-v --config $CONFIG_DIR --pid-file $PID_FILE --log-file $LOG_FILE --daemon"
 
 


### PR DESCRIPTION
Use curly braces around variable names embedded in strings.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
