### PR TITLE
clarify default db_url

### DIFF
--- a/source/_components/sensor.sql.md
+++ b/source/_components/sensor.sql.md
@@ -37,7 +37,7 @@ sensor:
 db_url:
   description: The URL which points to your database. See [supported engines](/components/recorder/#custom-database-engines).
   required: false
-  default: Defaults to the default recorder db_url (not the current db_url of recorder).
+  default: "Defaults to the default recorder `db_url` (not the current `db_url` of recorder)."
   type: string
 queries:
   description: List of your queries.

--- a/source/_components/sensor.sql.md
+++ b/source/_components/sensor.sql.md
@@ -37,7 +37,7 @@ sensor:
 db_url:
   description: The URL which points to your database. See [supported engines](/components/recorder/#custom-database-engines).
   required: false
-  default: Defaults to the recorder db_url.
+  default: Defaults to the default recorder db_url (not the current db_url of recorder).
   type: string
 queries:
   description: List of your queries.


### PR DESCRIPTION
**Description:**

Addresses https://github.com/home-assistant/home-assistant/issues/13424

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/