### PR TITLE
Add instructions on running MQTT ssl/nonssl simultaneously

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -59,3 +59,15 @@ mqtt:
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
 ```
+
+### Listening Simultaneously on SSL/TLS (8883) and insecure (1883) ports
+1. Configure SSL as normal.
+2. Set customize flag true in your config.
+3. Create a file in `/share/mosquitto` named `insecure.conf` with the following contents:
+```
+listener 1883
+protocol mqtt
+```
+4. Restart MQTT
+
+Note: It's recommened you only open your firewall to the SSL port (8883) and only use the insecure port (1883) for local devices.

--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -60,14 +60,19 @@ mqtt:
   password: YOUR_PASSWORD
 ```
 
-### Listening Simultaneously on SSL/TLS (8883) and insecure (1883) ports
-1. Configure SSL as normal.
-2. Set customize flag true in your config.
+### {% linkable_title Listening simultaneously on SSL/TLS (8883) and insecure (1883) ports %}
+
+1. Configure SSL/TLS as normal.
+2. Set `customize` flag to `true` in your configuration.
 3. Create a file in `/share/mosquitto` named `insecure.conf` with the following contents:
-```
+
+```text
 listener 1883
 protocol mqtt
 ```
+
 4. Restart MQTT
 
-Note: It's recommened you only open your firewall to the SSL port (8883) and only use the insecure port (1883) for local devices.
+<p class='note warning'>
+It's recommened that you only open your firewall to the SSL/TLS port (8883) and only use the insecure port (1883) for local devices.
+</p>

--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -43,7 +43,7 @@ Configuration variables:
 
 ### {% linkable_title Home Assistant configuration %}
 
-To use the Mosquitto as [broker](/docs/mqtt/broker/#run-your-own) add the following entry to the `configuration.yaml` file.
+To use the Mosquitto as [broker](/docs/mqtt/broker/#run-your-own), add the following entry to the `configuration.yaml` file.
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
I wanted to be able to recieve MQTT from my cell phone over SSL, but wanted local things that have limited RAM to be able to connect without the burden of SSL code.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
