### PR TITLE
sensor.command_line: Round example CPU temperature value

### DIFF
--- a/source/_components/sensor.command_line.markdown
+++ b/source/_components/sensor.command_line.markdown
@@ -61,6 +61,7 @@ sensor:
 
 Thanks to the [`proc`](https://en.wikipedia.org/wiki/Procfs) file system, various details about a system can be retrieved. Here the CPU temperature is of interest. Add something similar to your `configuration.yaml` file:
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 sensor:
@@ -69,8 +70,9 @@ sensor:
     command: "cat /sys/class/thermal/thermal_zone0/temp"
     # If errors occur, remove degree symbol below
     unit_of_measurement: "°C"
-    value_template: '{% raw %}{{ value | multiply(0.001) | round(1) }}{% endraw %}'
+    value_template: '{{ value | multiply(0.001) | round(1) }}'
 ```
+{% endraw %}
 
 ### {% linkable_title Monitoring failed login attempts on Home Assistant %}
 
@@ -149,11 +151,13 @@ sensor:
 
 [Templates](/docs/configuration/templating/) are supported in the `command:` configuration variable. This could be used if you want to include the state of a specific sensor as an argument to your external script.
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 sensor:
   - platform: command_line
     name: wind direction
-    command: 'sh /home/pi/.homeassistant/scripts/wind_direction.sh {% raw %}{{ states.sensor.wind_direction.state }}{% endraw %}'
+    command: 'sh /home/pi/.homeassistant/scripts/wind_direction.sh {{ states.sensor.wind_direction.state }}'
     unit_of_measurement: "Direction"
 ```
+{% endraw %}

--- a/source/_components/sensor.command_line.markdown
+++ b/source/_components/sensor.command_line.markdown
@@ -69,7 +69,7 @@ sensor:
     command: "cat /sys/class/thermal/thermal_zone0/temp"
     # If errors occur, remove degree symbol below
     unit_of_measurement: "°C"
-    value_template: '{% raw %}{{ value | multiply(0.001) }}{% endraw %}'
+    value_template: '{% raw %}{{ value | multiply(0.001) | round(1) }}{% endraw %}'
 ```
 
 ### {% linkable_title Monitoring failed login attempts on Home Assistant %}


### PR DESCRIPTION
**Description:**

multiply returns a float, which is inexact and sometimes gets rendered with a lot of decimal places. Round additionally to get cleaner result.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
