### PR TITLE
Make edit links GitHub aware

### DIFF
--- a/plugins/environment_variables.rb
+++ b/plugins/environment_variables.rb
@@ -2,7 +2,6 @@ module Jekyll
   class EnvironmentVariablesGenerator < Generator
     def generate(site)
       # https://www.netlify.com/docs/continuous-deployment/#build-environment-variables
-      # These values will be available as {{ site.NLY_IS_PROD }}
       repo_url = ENV['REPOSITORY_URL'] || 'https://github.com/home-assistant/home-assistant.github.io'
 
       # Rewrite urls if repo url is the ssh format.
@@ -10,6 +9,7 @@ module Jekyll
         repo_url = repo_url.sub 'git@github.com:', 'https://github.com'
       end
 
+      # These values will be available as {{ site.NLY_REPOSITORY_URL }}
       site.config['NLY_REPOSITORY_URL'] = repo_url
       site.config['NLY_HEAD'] = ENV['HEAD'] || 'current'
     end

--- a/plugins/environment_variables.rb
+++ b/plugins/environment_variables.rb
@@ -3,10 +3,15 @@ module Jekyll
     def generate(site)
       # https://www.netlify.com/docs/continuous-deployment/#build-environment-variables
       # These values will be available as {{ site.NLY_IS_PROD }}
-      site.config['NLY_REPOSITORY_URL'] = ENV['REPOSITORY_URL'] || 'https://github.com/home-assistant/home-assistant.github.io'
-      site.config['NLY_BRANCH'] = ENV['BRANCH'] || 'current'
-      site.config['NLY_CONTEXT'] = ENV['CONTEXT'] || 'production'
-      site.config['NLY_IS_PROD'] = site.config['NLY_CONTEXT'] == 'production'
+      repo_url = ENV['REPOSITORY_URL'] || 'https://github.com/home-assistant/home-assistant.github.io'
+
+      # Rewrite urls if repo url is the ssh format.
+      if repo_url.start_with? 'git@github.com:'
+        repo_url.sub! 'git@github.com:', 'https://github.com'
+      end
+
+      site.config['NLY_REPOSITORY_URL'] = repo_url
+      site.config['NLY_HEAD'] = ENV['HEAD'] || 'current'
     end
   end
 end

--- a/plugins/environment_variables.rb
+++ b/plugins/environment_variables.rb
@@ -1,0 +1,12 @@
+module Jekyll
+  class EnvironmentVariablesGenerator < Generator
+    def generate(site)
+      # https://www.netlify.com/docs/continuous-deployment/#build-environment-variables
+      # These values will be available as {{ site.NLY_IS_PROD }}
+      site.config['NLY_REPOSITORY_URL'] = ENV['REPOSITORY_URL'] || 'https://github.com/home-assistant/home-assistant.github.io'
+      site.config['NLY_BRANCH'] = ENV['BRANCH'] || 'current'
+      site.config['NLY_CONTEXT'] = ENV['CONTEXT'] || 'production'
+      site.config['NLY_IS_PROD'] = site.config['NLY_CONTEXT'] == 'production'
+    end
+  end
+end

--- a/plugins/environment_variables.rb
+++ b/plugins/environment_variables.rb
@@ -7,7 +7,7 @@ module Jekyll
 
       # Rewrite urls if repo url is the ssh format.
       if repo_url.start_with? 'git@github.com:'
-        repo_url.sub! 'git@github.com:', 'https://github.com'
+        repo_url = repo_url.sub 'git@github.com:', 'https://github.com'
       end
 
       site.config['NLY_REPOSITORY_URL'] = repo_url

--- a/plugins/environment_variables.rb
+++ b/plugins/environment_variables.rb
@@ -6,7 +6,7 @@ module Jekyll
 
       # Rewrite urls if repo url is the ssh format.
       if repo_url.start_with? 'git@github.com:'
-        repo_url = repo_url.sub 'git@github.com:', 'https://github.com'
+        repo_url = repo_url.sub 'git@github.com:', 'https://github.com/'
       end
 
       # These values will be available as {{ site.NLY_REPOSITORY_URL }}

--- a/source/_includes/edit_github.html
+++ b/source/_includes/edit_github.html
@@ -1,4 +1,4 @@
 {% assign url_parts = page.url | split: '/' %}
 {% if page.hide_github_edit != true %}
-<div class='edit-github'><a href='https://github.com/home-assistant/home-assistant.github.io/tree/current/source/{{ page.path }}'>Edit this page on GitHub</a></div>
+<div class='edit-github'><a href='{{ site.NLY_REPOSITORY_URL }}/tree/{{ site.NLY_BRANCH }}/source/{{ page.path }}'>Edit this page on GitHub</a></div>
 {% endif %}

--- a/source/_includes/edit_github.html
+++ b/source/_includes/edit_github.html
@@ -1,4 +1,4 @@
 {% assign url_parts = page.url | split: '/' %}
 {% if page.hide_github_edit != true %}
-<div class='edit-github'><a href='{{ site.NLY_REPOSITORY_URL }}/tree/{{ site.NLY_BRANCH }}/source/{{ page.path }}'>Edit this page on GitHub</a></div>
+<div class='edit-github'><a href='{{ site.NLY_REPOSITORY_URL }}/tree/{{ site.NLY_HEAD }}/source/{{ page.path }}'>Edit this page on GitHub</a></div>
 {% endif %}


### PR DESCRIPTION
**Description:**
Makes the edit in GitHub links aware of the current branch via the Netlify environment variables. So the "Edit in GitHub" link on a PR will point at the source repo / branch. This will also help us make those edit links actually work for the `next` and `rc` subdomains.

