### PR TITLE
Fix ON/OFF being interpreted in binary_sensor.mqtt

### DIFF
--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -42,12 +42,12 @@ payload_on:
   description: The payload that represents the on state.
   required: false
   type: string
-  default: ON
+  default: "ON"
 payload_off:
   description: The payload that represents the off state.
   required: false
   type: string
-  default: OFF
+  default: "OFF"
 availability_topic:
   description: "The MQTT topic subscribed to receive birth and LWT messages from the MQTT device. If `availability_topic` is not defined, the binary sensor availability state will always be `available`. If `availability_topic` is defined, the binary sensor availability state will be `unavailable` by default."
   required: false

--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -17,6 +17,8 @@ The `mqtt` binary sensor platform uses an MQTT message payload to set the binary
 
 The binary sensor state will be updated only after a new message is published on `state_topic` matching `payload_on` or `payload_off`. If these messages are published with the `retain` flag set, the binary sensor will receive an instant state update after subscription and Home Assistant will display the correct state on startup. Otherwise, the initial state displayed in Home Assistant will be `unknown`.
 
+## {% linkable_title Configuration %}
+
 The `mqtt` binary sensor platform optionally supports an `availability_topic` to receive online and offline messages (birth and LWT messages) from the MQTT device. During normal operation, if the MQTT cover device goes offline (i.e., publishes `payload_not_available` to `availability_topic`), Home Assistant will display the binary sensor as `unavailable`. If these messages are published with the `retain` flag set, the binary sensor will receive an instant update after subscription and Home Assistant will display the correct availability state of the binary sensor when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the binary sensor as `unavailable` when Home Assistant starts up. If no `availability_topic` is defined, Home Assistant will consider the MQTT device to be available.
 
 To use an MQTT binary sensor in your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**
YAML interprets `ON` and `OFF` to `true` and `false`. This causes the site to show that instead of the actual default payloads.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
