### PR TITLE
Arlo Q not supported

### DIFF
--- a/source/_components/sensor.arlo.markdown
+++ b/source/_components/sensor.arlo.markdown
@@ -15,7 +15,9 @@ ha_iot_class: "Cloud Polling"
 
 To get your [Arlo](https://arlo.netgear.com/) sensors working within Home Assistant, please follow the instructions for the general [Arlo component](/components/arlo).
 
-Note: this component does not support Arlo Q - sensors will show status Unknown.
+This platform does not support Arlo Q.
+
+## {% linkable_title Configuration %}
 
 Once you have enabled the [Arlo component](/components/arlo), add the following to your `configuration.yaml` file:
 

--- a/source/_components/sensor.arlo.markdown
+++ b/source/_components/sensor.arlo.markdown
@@ -15,6 +15,8 @@ ha_iot_class: "Cloud Polling"
 
 To get your [Arlo](https://arlo.netgear.com/) sensors working within Home Assistant, please follow the instructions for the general [Arlo component](/components/arlo).
 
+Note: this component does not support Arlo Q - sensors will show status Unknown.
+
 Once you have enabled the [Arlo component](/components/arlo), add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
**Description:**

Add a note on the Arlo Sensor page that Arlo Q is not supported.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
