### PR TITLE
Re-adds entity_picture_template information to the template switch

### DIFF
--- a/source/_components/switch.template.markdown
+++ b/source/_components/switch.template.markdown
@@ -75,6 +75,10 @@ switch:
         description: Defines a template for the icon of the switch.
         required: false
         type: template
+      entity_picture_template:
+        description: Defines a template for the picture of the switch.
+        required: false
+        type: template
 {% endconfiguration %}
 
 ## {% linkable_title Considerations %}


### PR DESCRIPTION
**Description:**
The `entity_picture_template` key was missing from the "Configuration Variables" section of the Template Switch documentation. This re-adds it.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
