### PR TITLE
Update onkyo media player

### DIFF
--- a/source/_components/media_player.onkyo.markdown
+++ b/source/_components/media_player.onkyo.markdown
@@ -28,12 +28,24 @@ media_player:
       pc: 'HTPC'
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): IP address of the device. Example:`192.168.1.2`. If not specified, the platform will load any discovered receivers.
-- **name** (*Required if host is specified*): Name of the device.
-- **sources** (*Optional*): A list of mappings from source to source name. Valid sources can be found below. A default list will be used if no source mapping is specified.
-- **zone2** (*Optional*): Set to true to enable control for the receiver's second zone.
+{% configuration %}
+host:
+  description: IP address of the device. Example:`192.168.1.2`. If not specified, the platform will load any discovered receivers.
+  required: false
+  type: string
+name:
+  description: Name of the device. (*Required if host is specified*)
+  required: false
+  type: string
+sources:
+  description: A list of mappings from source to source name. Valid sources can be found below. A default list will be used if no source mapping is specified.
+  required: false
+  type: list
+zone2:
+  description: Enables control for the receiver's second zone.
+  required: false
+  type: bool
+{% endconfiguration %}
 
 List of source names:
 

--- a/source/_components/media_player.onkyo.markdown
+++ b/source/_components/media_player.onkyo.markdown
@@ -33,6 +33,7 @@ Configuration variables:
 - **host** (*Optional*): IP address of the device. Example:`192.168.1.2`. If not specified, the platform will load any discovered receivers.
 - **name** (*Required if host is specified*): Name of the device.
 - **sources** (*Optional*): A list of mappings from source to source name. Valid sources can be found below. A default list will be used if no source mapping is specified.
+- **zone2** (*Optional*): Set to true to enable control for the receiver's second zone.
 
 List of source names:
 


### PR DESCRIPTION
**Description:**
Add configuration parameter to enable the receiver zone 2. Also updates to current documentation standards for configuration variables.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13551

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
