### PR TITLE
Escape special characters in credits

### DIFF
--- a/credits_generator/update_credits.js
+++ b/credits_generator/update_credits.js
@@ -58,7 +58,12 @@ github.repos.getForOrg({
           cb(err);
           return;
         }
-        if(userInfo.login == 'RubenKelevra') userInfo.name = 'RubenKelevra'; // ugh, because his name is `@RubenKelevra`
+	if (userInfo.name) {
+	  userInfo.name = userInfo.name.replace(/^@/, '')
+	  .replace(/</g, '&lt;')
+	  .replace(/>/g, '&gt;')
+	  .replace(/[\\`*_{}[\]()#+-.!~|]/g, '\\$&');
+	}
         usersMap[login].info.name = userInfo.name || userInfo.login;
         usersMap[login].info.username = userInfo.login;
         cb();


### PR DESCRIPTION
**Description:**
Full names on GitHub can contain control characters for HTML or Markdown. Escape these before they reach the Markdown parser for the credits page.