### PR TITLE
Added a link to the text 'this site'

### DIFF
--- a/source/_components/history.markdown
+++ b/source/_components/history.markdown
@@ -120,7 +120,7 @@ When the `history` component queries the states table it only selects states whe
 
 #### {% linkable_title On dates %} 
 
-SQLite databases do not support native dates. That's why all the dates are saved in seconds since the UNIX epoch. Convert them manually using this site or in Python:
+SQLite databases do not support native dates. That's why all the dates are saved in seconds since the UNIX epoch. Convert them manually using [this site](https://www.epochconverter.com/) or in Python:
 
 ```python
 from datetime import datetime


### PR DESCRIPTION
This text:

SQLite databases do not support native dates. That's why all the dates are saved in seconds since the UNIX epoch. Convert them manually using this site or in Python:

should have a link where it says "this text"

It now reads:

SQLite databases do not support native dates. That's why all the dates are saved in seconds since the UNIX epoch. Convert them manually using [this site](https://www.epochconverter.com/) or in Python:

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/

This is my first pull request, let me know if I'm doing something wrong here. 
