### PR TITLE
Confusing as it uses a non-default TTS platform

### DIFF
--- a/source/_cookbook/sonos_say.markdown
+++ b/source/_cookbook/sonos_say.markdown
@@ -61,7 +61,7 @@ Note that this example uses the `voicerss` text-to-speech platform. There are ma
     - platform: google
 ```
 
-If you want to use this TTS engine, change the line above to
+If you want to use this TTS engine, change the line in the example provided to:
 ```
 - service: tts.google_say
 ```

--- a/source/_cookbook/sonos_say.markdown
+++ b/source/_cookbook/sonos_say.markdown
@@ -54,3 +54,14 @@ automation:
           message: 'Your husband coming home!'
           delay: '00:00:05'
 ```
+Note that this example uses the `voicerss` text-to-speech platform. There are many platforms that can be used. The one installed by default with Home Assistant is Google TTS. This appears in your `configuration.yaml` file as:
+
+```
+  tts:
+    - platform: google
+```
+
+If you want to use this TTS engine, change the line above to
+```
+- service: tts.google_say
+```


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
