### PR TITLE
Update google_assistant.markdown

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -148,10 +148,10 @@ If you're not using Linux, you can use sites such as [this one](https://www.brow
 6. Open the Google Assistant app and go into `Settings > Home Control`
 7. Click the `+` sign, and near the bottom, you should have `[test] your app name`. Selecting that should lead you the screen where you can set rooms for your devices or nicknames for your devices.
 8. If you want to allow other household users to control the devices:
-	a. Go to the developer console using the address from point 4.
+	a. Go to the settings for the project you created in point 1 in the developer console.
 	b. Under the gear icon, click `Permissions`
 	c. Click `Add`, type the new user's e-mail address and choose `Project -> Editor` role
-	d. Have the new user go to [developer console](https://console.actions.google.com/) and repeat steps starting from point 
+	d. Have the new user go to [developer console](https://console.actions.google.com/) and repeat steps starting from point 4
 9. If you want to use the `google_assistant.request_sync` service, to update devices without unlinking and relinking, in Home Assistant, then enable Homegraph API for your project:
 	a. Go to the [cloud console](https://console.cloud.google.com/apis/api/homegraph.googleapis.com/overview)
 	b. Select your project and click Enable Homegraph API


### PR DESCRIPTION
Proposing changes to steps 8a and 8d.  I looked back at previous versions and I don't think these steps were updated when the other steps it was originally referencing were moved/changed.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
