### PR TITLE
Update troubleshooting.markdown

### DIFF
--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -20,7 +20,7 @@ Whenever a component or configuration option results in a warning, it will be st
 
 When a component does not show up, many different things can be the case. Before you try any of these steps, make sure to look at the `home-assistant.log` file and see if there are any errors related to your component you are trying to set up.
 
-If you have incorrect entries in your configuration files you can use the `check_config` script to assist in identifying them: `hass --script check_config`.
+If you have incorrect entries in your configuration files you can use the `check_config` script to assist in identifying them: `hass --script check_config`. If you need to provide the path for you config you can do this using the `-c` argument like this: `hass --script check_config -c /path/to/your/config/dir`.
 
 #### {% linkable_title Problems with the configuration %}
 

--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -20,7 +20,7 @@ Whenever a component or configuration option results in a warning, it will be st
 
 When a component does not show up, many different things can be the case. Before you try any of these steps, make sure to look at the `home-assistant.log` file and see if there are any errors related to your component you are trying to set up.
 
-If you have incorrect entries in your configuration files you can use the `check_config` script to assist in identifying them: `hass --script check_config`. If you need to provide the path for your configuration you can do this using the `-c` argument like this: `hass --script check_config -c /path/to/your/config/dir`.
+If you have incorrect entries in your configuration files you can use the [`check_config`](/docs/tools/check_config/) script to assist in identifying them: `hass --script check_config`. If you need to provide the path for your configuration you can do this using the `-c` argument like this: `hass --script check_config -c /path/to/your/config/dir`.
 
 #### {% linkable_title Problems with the configuration %}
 

--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -20,7 +20,7 @@ Whenever a component or configuration option results in a warning, it will be st
 
 When a component does not show up, many different things can be the case. Before you try any of these steps, make sure to look at the `home-assistant.log` file and see if there are any errors related to your component you are trying to set up.
 
-If you have incorrect entries in your configuration files you can use the `check_config` script to assist in identifying them: `hass --script check_config`. If you need to provide the path for you config you can do this using the `-c` argument like this: `hass --script check_config -c /path/to/your/config/dir`.
+If you have incorrect entries in your configuration files you can use the `check_config` script to assist in identifying them: `hass --script check_config`. If you need to provide the path for your configuration you can do this using the `-c` argument like this: `hass --script check_config -c /path/to/your/config/dir`.
 
 #### {% linkable_title Problems with the configuration %}
 


### PR DESCRIPTION
By default the check_config script only search `~/.homeassistent` for a configuration.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
