### PR TITLE
Update docs for notify.rest component

### DIFF
--- a/source/_components/notify.rest.markdown
+++ b/source/_components/notify.rest.markdown
@@ -30,6 +30,7 @@ Configuration variables:
 - **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
 - **resource** (*Required*): The resource or endpoint that will receive the value.
 - **method** (*Optional*): The method of the request. Default is GET.
+- **headers** (*Optional*): The headers for the request.
 - **message_param_name** (*Optional*): Parameter name for the message. Defaults to `message`.
 - **title_param_name** (*Optional*): Parameter name for the title. Defaults to none.
 - **target_param_name** (*Optional*): Parameter name for the target. Defaults to none.


### PR DESCRIPTION
**Description:**
Added new configuration variable `headers` to `notify.rest` component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
