### PR TITLE
add supporting info for 2nd gen august lock

### DIFF
--- a/source/_components/august.markdown
+++ b/source/_components/august.markdown
@@ -13,7 +13,8 @@ ha_release: "0.64"
 ha_iot_class: "Cloud Polling"
 ---
 
-The `august` component allows you to integrate your [August](http://august.com) devices in Home Assistant. Currently this component supports August Lock and Doorbell.
+The `august` component allows you to integrate your [August](http://august.com) devices in Home Assistant. Currently this component supports August Lock and Doorbell. 
+NOTE: August Lock 2nd Gen will need either August Connect or Doorbell to connect to Home Assistant.
 
 ## {% linkable_title Configuration %}
 

--- a/source/_components/august.markdown
+++ b/source/_components/august.markdown
@@ -13,8 +13,11 @@ ha_release: "0.64"
 ha_iot_class: "Cloud Polling"
 ---
 
-The `august` component allows you to integrate your [August](http://august.com) devices in Home Assistant. Currently this component supports August Lock and Doorbell. 
-NOTE: August Lock 2nd Gen will need either August Connect or Doorbell to connect to Home Assistant.
+The `august` component allows you to integrate your [August](http://august.com) devices in Home Assistant. Currently this component supports August Lock and Doorbell.
+
+<p class='note'>
+August Lock 2nd Gen will need either August Connect or Doorbell to connect to Home Assistant.
+</p>
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
2nd Gen August Lock needs to have the August Connect Module to be able to talk to home-assistant. If you have Doorbell then you don't need to have Connect. Just trying to help people troubleshoot in case they don't know whats going wrong.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
