### PR TITLE
Added light color_temp HomeKit

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -162,7 +162,7 @@ The following components are currently supported:
 | alarm_control_panel | SecuritySystem | All security systems. |
 | climate | Thermostat | All climate devices. |
 | cover | WindowCovering | All covers that support `set_cover_position`. |
-| light | Light | Support for `on / off`, `brightness` and `rgb_color`. |
+| light | Light | Support for `on / off`, `brightness`, `color_temp` and `rgb_color`. |
 | sensor | TemperatureSensor | All sensors that have `Celsius` and `Fahrenheit` as their `unit_of_measurement`. |
 | sensor | HumiditySensor | All sensors that have `%` as their `unit_of_measurement` |
 | switch / remote / input_boolean / script | Switch | All represented as switches. |


### PR DESCRIPTION
**Description:**
Follow up to home-assistant/home-assistant#13658. Add support for `color_temp` for HomeKit. The feature PR is already merged.
I chose `color_temp` instead of `color_temperature`, because that's what is used here:
https://www.home-assistant.io/components/light/

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13658

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
