### PR TITLE
Added additional log settings HomeKit

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -212,6 +212,7 @@ logger:
   default: warning
   logs:
        homeassistant.components.homekit: debug
+       pyhap: debug
 ```
 2. Reproduce the bug / problem you have encountered.
 3. Stop Home Assistant and copy the log from the log file. That is necessary since some errors only get logged, when Home Assistant is being shutdown.


### PR DESCRIPTION
**Description:**
Adding log settings for `pyhap` to the error reporting section.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
