### PR TITLE
Added description for markdown in persistent notifications

### DIFF
--- a/source/_components/persistent_notification.markdown
+++ b/source/_components/persistent_notification.markdown
@@ -55,6 +55,26 @@ action:
     notification_id: "1234"
 ```
 
+
+### {% linkable_title Markdown support %}
+
+The message attribute supports the Markdown language. For a list of supported markdown commands, see: [pagedown-extra](https://github.com/jmcmanus/pagedown-extra/blob/master/README.md#usage). Some examples are:
+
+| Type | Message |
+| ---- | ------- |
+| Headline 1 | `# Headline` |
+| Headline 2 | `## Headline` |
+| Newline | `\n` |
+| Bold | `**My bold text**` |
+| Cursive | `*My cursive text*` |
+| Link | `[Link](https://home-assistant.io/)` |
+| Image | `![image](/local/my_image.jpg)` |
+
+<p class="note">
+  `/local/` in this context refers to the `.homeassistant/www/` folder.
+</p>
+
+
 ### {% linkable_title Create a persistent notification %}
 
 Choose <img src='/images/screenshots/developer-tool-services-icon.png' alt='service developer tool icon' class="no-shadow" height="38" /> **Services** from the **Developer Tools** to call the `persistent_notification` service. Select `persistent_notification/create` from the list of **Available services:** and enter something like the sample below into the **Service Data** field and hit **CALL SERVICE**.

--- a/source/_components/persistent_notification.markdown
+++ b/source/_components/persistent_notification.markdown
@@ -58,7 +58,7 @@ action:
 
 ### {% linkable_title Markdown support %}
 
-The message attribute supports the Markdown language. For a list of supported markdown commands, see: [pagedown-extra](https://github.com/jmcmanus/pagedown-extra/blob/master/README.md#usage). Some examples are:
+The message attribute supports the [Markdown formatting syntax](https://daringfireball.net/projects/markdown/syntax). Some examples are:
 
 | Type | Message |
 | ---- | ------- |


### PR DESCRIPTION
**Description:**
Added description for using Markdown in `persistent_notifications`.


## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
