### PR TITLE
Add iOS page (fixes #4972)

### DIFF
--- a/source/_components/ios.markdown
+++ b/source/_components/ios.markdown
@@ -1,0 +1,17 @@
+---
+layout: page
+title: "iOS"
+description: "Instructions on how to use the iOS companion app with Home Assistant."
+date: 2018-04-06 08:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: apple.png
+ha_category: Hub
+featured: true
+ha_release: 0.31
+ha_iot_class: depends
+---
+
+The `ios` component is the Home Assistant part for using the iOS companion app. For further details please check the [iOS section](/docs/ecosystem/ios/) in the documentation for further details.

--- a/source/_docs/ecosystem/ios.markdown
+++ b/source/_docs/ecosystem/ios.markdown
@@ -8,7 +8,6 @@ comments: false
 sharing: true
 footer: true
 redirect_from: /ecosystem/ios/
-redirect_from: /components/ios/
 ---
 
 The Home Assistant for iOS app offers a companion app for iOS which is deeply integrated into both Home Assistant and iOS. Its basic features include:
@@ -22,7 +21,7 @@ The app is available on the iOS App Store in every country that Apple supports.
 
 <p style="text-align: center;"><a target="_blank" href="https://itunes.apple.com/us/app/home-assistant-open-source-home-automation/id1099568401?mt=8" style="display:inline-block;overflow:hidden;background:url(//linkmaker.itunes.apple.com/assets/shared/badges/en-us/appstore-lrg.svg) no-repeat;width:135px;height:40px;background-size:contain;"></a></p>
 
-## Basic requirements
+## {% linkable_title Basic requirements %}
 
 * iOS device running at least iOS 9, but iOS 10 is greatly preferred.
 * Home Assistant 0.42.4 or higher for push notification support.
@@ -34,7 +33,7 @@ Loading the `ios` component will also load the [`device_tracker`][device-tracker
 
 ## {% linkable_title Setup %}
 
-### Automated Setup
+### {% linkable_title Automated Setup %}
 
 The `ios` component will automatically be loaded under the following circumstances:
 
@@ -45,7 +44,7 @@ Automated discovery and component loading only happens at first install of the a
 
 After the first automated setup you need to add `ios:` to your configuration so that the component loads by default even after restarting Home Assistant.
 
-### Manual Setup
+### {% linkable_title Manual Setup %}
 
 You may also manually load the `ios` component by adding the following to your configuration:
 


### PR DESCRIPTION
**Description:**
Replace redirect with a page for iOS.

**Related issue (if applicable):** fixes #4972
## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
