### PR TITLE
MQTT Sensor Unique ID feature

### DIFF
--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -76,6 +76,10 @@ json_attributes:
   description: A list of keys to extract values from a JSON dictionary payload and then set as sensor attributes.
   reqired: false
   type: list, string
+unique_id:
+  description: "An id that uniquely identifies this sensor. If 2 sensors have the same unique id, Home Assistant will raise an exception.**"
+  required: false
+  type: string
 {% endconfiguration %}
 
 ## {% linkable_title Examples %}


### PR DESCRIPTION
**Description:**

Documentation for the new MQTT Sensor `unique_id` feature.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/13318

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
