### PR TITLE
Consistency update

### DIFF
--- a/source/_docs/automation/action.markdown
+++ b/source/_docs/automation/action.markdown
@@ -22,13 +22,12 @@ automation:
     event: sunset
   action:
     service: light.turn_on
-    entity_id:
-      - light.kitchen
-      - light.living_room
     data:
       brightness: 150
       rgb_color: [255, 0, 0]
-
+      entity_id:
+        - light.kitchen
+        - light.living_room
 automation 2:
   # Notify me on my mobile phone of an event
   trigger:


### PR DESCRIPTION
It was pointed out that everywhere else `entity_id:` is in the `data:` section for `light.turn_on`. Updating the example here to be consistent with that.
