### PR TITLE
Add CO2/PM2.5/Light sensors in HomeKit

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -201,6 +201,9 @@ The following components are currently supported:
 | lock | DoorLock | Support for `lock / unlock`. |
 | sensor | TemperatureSensor | All sensors that have `Celsius` and `Fahrenheit` as their `unit_of_measurement`. |
 | sensor | HumiditySensor | All sensors that have `%` as their `unit_of_measurement` |
+| sensor | AirQualitySensor | All sensors that contains `pm25` in their `entity_id`, or `pm25` as their `device_class` |
+| sensor | CarbonDioxideSensor | All sensors that contains `co2` in their `entity_id`, or `co2` as their `device_class` |
+| sensor | LightSensor | All sensors that have `lm`/`lux` as their `unit_of_measurement`, or `lux` as their `device_class` |
 | switch / remote / input_boolean / script | Switch | All represented as switches. |
 
 

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -199,11 +199,11 @@ The following components are currently supported:
 | cover | WindowCovering | All covers that support `set_cover_position`. |
 | light | Light | Support for `on / off`, `brightness` and `rgb_color`. |
 | lock | DoorLock | Support for `lock / unlock`. |
-| sensor | TemperatureSensor | All sensors that have `Celsius` and `Fahrenheit` as their `unit_of_measurement`. |
-| sensor | HumiditySensor | All sensors that have `%` as their `unit_of_measurement` |
-| sensor | AirQualitySensor | All sensors that contains `pm25` in their `entity_id`, or `pm25` as their `device_class` |
-| sensor | CarbonDioxideSensor | All sensors that contains `co2` in their `entity_id`, or `co2` as their `device_class` |
-| sensor | LightSensor | All sensors that have `lm`/`lux` as their `unit_of_measurement`, or `lux` as their `device_class` |
+| sensor | TemperatureSensor | All sensors that have `Celsius` and `Fahrenheit` as their `unit_of_measurement` or `temperature` as their `device_class`. |
+| sensor | HumiditySensor | All sensors that have `%` as their `unit_of_measurement` or `humidity` as their `device_class`. |
+| sensor | AirQualitySensor | All sensors that have `pm25` as part of their `entity_id` or `pm25` as their `device_class` |
+| sensor | CarbonDioxideSensor | All sensors that have `co2` as part of their `entity_id` or `co2` as their `device_class` |
+| sensor | LightSensor | All sensors that have `lm`/`lux` as their `unit_of_measurement` or `light` as their `device_class` |
 | switch / remote / input_boolean / script | Switch | All represented as switches. |
 
 


### PR DESCRIPTION
**Description:**

Map sensors to HomeKit AirQuality/CarbonDioxideSensor/SensorLightSensor, based on the following rules :

	AirQualitySensor: `device_class == 'co2'` or `entity_id contains 'co2'`
	CarbonDioxideSensor: `device_class == 'pm25'` or `entity_id contains 'pm25'`
	LightSensor: `device_class == 'lux'` or `unit == 'lm'` or `unit == 'lux'`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13804

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
