### PR TITLE
Revert "Add example file attachment parameters"

### DIFF
--- a/source/_components/notify.pushover.markdown
+++ b/source/_components/notify.pushover.markdown
@@ -47,11 +47,6 @@ Example Automation:
           url: "https://www.home-assistant.io/"
           sound: pianobar
           priority: 0
-          file:
-            url: !secret camera_still_image
-            auth: basic
-            username: !secret camera_username
-            password: !secret camera_password
 ```
 
 Component specific values in the nested `data` section are optional.


### PR DESCRIPTION
Reverts home-assistant/home-assistant.github.io#5134

As it seems, it should not have been merged already!