### PR TITLE
Adds attributes table to VeSync wiki

### DIFF
--- a/source/_components/switch.vesync.markdown
+++ b/source/_components/switch.vesync.markdown
@@ -12,7 +12,9 @@ ha_category: Switch
 ha_release: 0.66
 ---
 
-The `vesync` switch platform enabled integration with Etekcity VeSync smart switches.
+The `vesync` switch platform enables integration with Etekcity VeSync smart switches.
+
+VeSync switches are low-cost wifi smart plugs that offer energy monitoring and work with popular voice assistants.
 
 To use your VeSync switches, you must first register your switches with the VeSync app. Once registration is complete you must add the following to your `configuration.yaml` file:
 
@@ -20,8 +22,8 @@ To use your VeSync switches, you must first register your switches with the VeSy
 # Example configuration.yaml entry
 switch:
   - platform: vesync
-    username: username
-    password: password
+    username: YOUR_USERNAME
+    password: YOUR_PASSWORD
 ```
 
 {% configuration %}
@@ -34,3 +36,16 @@ password:
   required: true
   type: string
 {% endconfiguration %}
+
+### {% linkable_title Exposed Attributes %}
+
+VeSync switches will expose the following details.
+
+| Attribute           | Description                                                         | Example         |
+| ------------------- | ------------------------------------------------------------------- | --------------- |
+| `current_power_w`   | The present power consumption of the switch in watts.               | 100             |
+| `today_energy_kwh`  | The kilowatt hours used by the switch during the previous 24 hours. | 0.12            |
+| `connection_status` | The connection status of the switch.                                | online          |
+| `connection_type`   | The connection type of the switch.                                  | wifi            |
+| `device_type`       | The device type of the switch.                                      | wifi-switch-1.3 |
+| `model`             | The model of the switch.                                            | wifi-switch     |


### PR DESCRIPTION
**Description:**

- Adds in table that explains the exposed attributes by the platform. 
- Cleanup of configuration.yaml entry

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13816

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
