### PR TITLE
Add support for Garage Doors in HomeKit

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -196,6 +196,7 @@ The following components are currently supported:
 | alarm_control_panel | SecuritySystem | All security systems. |
 | binary_sensor | Sensor | Support for `CO2`, `Gas`, `Moisture`, `Motion`, `Occupancy`, `Opening` and `Smoke` device classes. Defaults to the `Occupancy` device class for everything else. |
 | climate | Thermostat | All climate devices. |
+| cover | GarageDoorOpener | All covers that have `device_class: garage` and support at least open and close. |
 | cover | WindowCovering | All covers that support `set_cover_position`. |
 | light | Light | Support for `on / off`, `brightness` and `rgb_color`. |
 | lock | DoorLock | Support for `lock / unlock`. |

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -196,7 +196,7 @@ The following components are currently supported:
 | alarm_control_panel | SecuritySystem | All security systems. |
 | binary_sensor | Sensor | Support for `CO2`, `Gas`, `Moisture`, `Motion`, `Occupancy`, `Opening` and `Smoke` device classes. Defaults to the `Occupancy` device class for everything else. |
 | climate | Thermostat | All climate devices. |
-| cover | GarageDoorOpener | All covers that have `device_class: garage` and support at least open and close. |
+| cover | GarageDoorOpener | All covers that support `open` and `close` and have `garage` as their `device_class`. |
 | cover | WindowCovering | All covers that support `set_cover_position`. |
 | light | Light | Support for `on / off`, `brightness` and `rgb_color`. |
 | lock | DoorLock | Support for `lock / unlock`. |


### PR DESCRIPTION
**Description:**

Add documentation for Garage Door support in HomeKit.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13796

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
