### PR TITLE
Rename light platform from aurora to nanoleaf_aurora

### DIFF
--- a/source/_components/light.nanoleaf_aurora.markdown
+++ b/source/_components/light.nanoleaf_aurora.markdown
@@ -21,7 +21,7 @@ To enable the Aurora lights, add the following lines to your `configuration.yaml
 ```yaml
 # Example configuration.yaml entry
 light:
-  - platform: aurora
+  - platform: nanoleaf_aurora
     host: 192.168.1.10
     token: xxxxxxxxxxxxxxxxxxxxx
 ```


### PR DESCRIPTION
**Description:**
Renamed aurora platform to nanoleaf_aurora as to not clash with the existing binary sensor aurora after review comments from @MartinHjelmare . I hope the branch is still the correct one.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13831

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
