### PR TITLE
Tip to use external broker for more stability

### DIFF
--- a/source/_components/mqtt.markdown
+++ b/source/_components/mqtt.markdown
@@ -33,6 +33,10 @@ mqtt:
   broker: IP_ADDRESS_BROKER
 ```
 
+<p class='note'>
+The minimal setup uses the embedded MQTT broker, however a separate broker is advised for more stability.
+</p>
+
 ## {% linkable_title Additional features %}
 
 - [Certificate](/docs/mqtt/certificate/)


### PR DESCRIPTION
**Description:**
An external broker is more stable, this is something I did not know as a beginner.
Especially because the embedded broker has a memory leak.
It would have saved me a bunch of time and WAF trust issues if I would have had this piece of knowledge.
[Issue on memory leak.](https://github.com/home-assistant/home-assistant/issues/11594)

If you want to know more,[ see post in forum here.](https://community.home-assistant.io/t/mqtt-unstable-home-assistant-easy-fix)


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
