### PR TITLE
Updated spelling dedicate to dedicated

### DIFF
--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -80,7 +80,7 @@ The Unifi controller allows you to create multiple users on it besides the main 
 
 The Unifi controller can either be a dedicated hardware device (Unifi's cloud key), or as software any Linux system. If you run the the Unifi controller on the same operating system as Home Assistant there may be conflicts in ports if you have the MQTT component as well.
 
-It is recommended that you run the Unifi controller in a dedicate virtual machine to avoid that situation.
+It is recommended that you run the Unifi controller in a dedicated virtual machine to avoid that situation.
 
 ### {% linkable_title Troubleshooting and Time Synchronization %}
 


### PR DESCRIPTION
Spelling mistake.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
