### PR TITLE
Add supported_features property

### DIFF
--- a/source/developers/platform_example_light.markdown
+++ b/source/developers/platform_example_light.markdown
@@ -31,7 +31,7 @@ import logging
 import voluptuous as vol
 
 # Import the device class from the component that you want to support
-from homeassistant.components.light import ATTR_BRIGHTNESS, Light, PLATFORM_SCHEMA
+from homeassistant.components.light import ATTR_BRIGHTNESS, Light, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 
@@ -94,6 +94,15 @@ class AwesomeLight(Light):
         that brightness is not supported for this light.
         """
         return self._brightness
+    
+    @property
+    def supported_features(self):
+        """Flag supported features.
+        This method is optional. Removing it indicates to Home Assistant
+        that brightness is not supported for this light.
+        """
+        return SUPPORT_BRIGHTNESS
+
 
     @property
     def is_on(self):


### PR DESCRIPTION
Without this property, by default, the component will not have UI Brightness slider. Having just brightness property is not enough for UI.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
