### PR TITLE
Moved the note up

### DIFF
--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -16,6 +16,10 @@ The upgrade process differs depending on the installation you have, so please re
 
 Check what's new in the latest version and potentially impacts your system in [Home Assistant release notes](https://github.com/home-assistant/home-assistant/releases). It is good practice to review these release notes and pay close attention to the **Breaking Changes** that are listed there. If you haven't done an update for a while, you should also check previous release notes as they can also contain relevant **Breaking Changes**. **Breaking Changes** may require configuration updates for your components. If you missed this and Home Assistant refuses to start, check the log file in the [configuration](/docs/configuration/) directory, e.g., `.homeassistant/home-assistant.log`, for details about broken components.
 
+<p class='note'>
+To avoid permission errors, the upgrade must be run as the same user as the installation was completed, again review the documentation specific to your install [Hass.io](/hassio/), [Hassbian](/docs/hassbian/installation/), [Vagrant](/docs/installation/vagrant/), or [Virtualenv](/docs/installation/virtualenv).
+</p>
+
 The default way to update Home Assistant to the latest release, when available, is:
 
 ```bash
@@ -29,10 +33,6 @@ $ sudo docker pull homeassistant/home-assistant:latest
 ```
 
 After updating, you must start/restart Home Assistant for the changes to take effect. This means that you will have to restart `hass` itself or the [autostarting](/docs/autostart/) daemon (if applicable). Startup can take considerable amount of time (i.e. minutes) depending on your device. This is because all requirements are updated as well.
-
-<p class='note'>
-To avoid permission errors, the upgrade must be run as the same user as the installation was completed, again review the documentation specific to your install [Hass.io](/hassio/), [Hassbian](/docs/hassbian/installation/), [Vagrant](/docs/installation/vagrant/), or [Virtualenv](/docs/installation/virtualenv).
-</p>
 
 [BRUH automation](http://www.bruhautomation.com) has created [a tutorial video](https://www.youtube.com/watch?v=tuG2rs1Cl2Y) explaining how to upgrade Home Assistant.
 


### PR DESCRIPTION
It's easy for people to fail to notice the note, since it comes after the default upgrade instructions. Moved it up to make it harder to miss
