### PR TITLE
Update light.nanoleaf_aurora.markdown

### DIFF
--- a/source/_components/light.nanoleaf_aurora.markdown
+++ b/source/_components/light.nanoleaf_aurora.markdown
@@ -21,7 +21,7 @@ To enable the Aurora lights, add the following lines to your `configuration.yaml
 ```yaml
 # Example configuration.yaml entry
 light:
-  - platform: aurora
+  - platform: nanoleaf_aurora
     host: 192.168.1.10
     token: xxxxxxxxxxxxxxxxxxxxx
 ```


### PR DESCRIPTION
in current build `- platform: aurora` is not found however `- platform: nanoleaf_aurora` works ok!

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
