### PR TITLE
Correct possible typo

### DIFF
--- a/source/_components/device_tracker.google_maps.markdown
+++ b/source/_components/device_tracker.google_maps.markdown
@@ -20,7 +20,7 @@ You first need to create an additional Google account and share your location wi
 This platform will create a file named `google_maps_location_sharing.conf` where it caches your login session.
 
 <p class='note warning'>
-Since this platform is using an official API with the help of [locationsharinglib](https://github.com/costastf/locationsharinglib), Google seems to block access to your data the first time you've logged in with this component.
+Since this platform is using an unofficial API with the help of [locationsharinglib](https://github.com/costastf/locationsharinglib), Google seems to block access to your data the first time you've logged in with this component.
 This issue can be fixed by logging in with your new account and approving your login on the [Device Activity](https://myaccount.google.com/device-activity) page.
 </p>
 


### PR DESCRIPTION
**Description:**

I think this might be a typo? `official` -> `unofficial`.
Unless it _is_ using an official API, then go ahead and close.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
