### PR TITLE
Clarify titles of BMW Connected Drive components

### DIFF
--- a/source/_components/binary_sensor.bmw_connected_drive.markdown
+++ b/source/_components/binary_sensor.bmw_connected_drive.markdown
@@ -15,6 +15,6 @@ ha_release: 0.66
 
 The `bmw_connected_drive` platform allows you to import data on your BMW into Home Assistant.
 
-The binary sensors will be automatically configured if 'bmw_connected_drive' component is configured.
+The binary sensors will be automatically configured if `bmw_connected_drive` component is configured.
 
-For more configuration information see the [bmw_connected_drive component](/components/bmw_connected_drive/) documentation.
+For more configuration information see the [`bmw_connected_drive` component](/components/bmw_connected_drive/) documentation.

--- a/source/_components/binary_sensor.bmw_connected_drive.markdown
+++ b/source/_components/binary_sensor.bmw_connected_drive.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "BMW Connected Drive Binary Sensor"
-description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
+description: "Instructions on how to setup your BMW Connected Drive account with Home Assistant."
 date: 2018-02-22 23:00
 sidebar: true
 comments: false

--- a/source/_components/binary_sensor.bmw_connected_drive.markdown
+++ b/source/_components/binary_sensor.bmw_connected_drive.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "BMW connected drive"
+title: "BMW Connected Drive Binary Sensor"
 description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
 date: 2018-02-22 23:00
 sidebar: true

--- a/source/_components/bmw_connected_drive.markdown
+++ b/source/_components/bmw_connected_drive.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "BMW Connected Drive"
-description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
+description: "Instructions on how to setup your BMW Connected Drive account with Home Assistant."
 date: 2018-01-10 23:00
 sidebar: true
 comments: false

--- a/source/_components/bmw_connected_drive.markdown
+++ b/source/_components/bmw_connected_drive.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "BMW connected drive"
+title: "BMW Connected Drive"
 description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
 date: 2018-01-10 23:00
 sidebar: true

--- a/source/_components/device_tracker.bmw_connected_drive.markdown
+++ b/source/_components/device_tracker.bmw_connected_drive.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "BMW connected drive"
+title: "BMW Connected Drive Device Tracker"
 description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
 date: 2018-01-10 23:00
 sidebar: true

--- a/source/_components/device_tracker.bmw_connected_drive.markdown
+++ b/source/_components/device_tracker.bmw_connected_drive.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "BMW Connected Drive Device Tracker"
-description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
+description: "Instructions on how to setup your BMW Connected Drive account with Home Assistant."
 date: 2018-01-10 23:00
 sidebar: true
 comments: false

--- a/source/_components/lock.bmw_connected_drive.markdown
+++ b/source/_components/lock.bmw_connected_drive.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "BMW Connected Drive Lock"
-description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
+description: "Instructions on how to setup your BMW Connected Drive account with Home Assistant."
 date: 2018-02-22 23:00
 sidebar: true
 comments: false

--- a/source/_components/lock.bmw_connected_drive.markdown
+++ b/source/_components/lock.bmw_connected_drive.markdown
@@ -15,6 +15,6 @@ ha_release: 0.66
 
 The `bmw_connected_drive` platform allows you to import data on your BMW into Home Assistant.
 
-The lock will be automatically configured if 'bmw_connected_drive' component is configured.
+The lock will be automatically configured if `bmw_connected_drive` component is configured.
 
-For more configuration information see the [bmw_connected_drive component](/components/bmw_connected_drive/) documentation.
+For more configuration information see the [`bmw_connected_drive` component](/components/bmw_connected_drive/) documentation.

--- a/source/_components/lock.bmw_connected_drive.markdown
+++ b/source/_components/lock.bmw_connected_drive.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "BMW connected drive"
+title: "BMW Connected Drive Lock"
 description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
 date: 2018-02-22 23:00
 sidebar: true

--- a/source/_components/sensor.bmw_connected_drive.markdown
+++ b/source/_components/sensor.bmw_connected_drive.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "BMW Connected Drive Sensor"
-description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
+description: "Instructions on how to setup your BMW Connected Drive account with Home Assistant."
 date: 2018-01-10 23:00
 sidebar: true
 comments: false

--- a/source/_components/sensor.bmw_connected_drive.markdown
+++ b/source/_components/sensor.bmw_connected_drive.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "BMW connected drive"
+title: "BMW Connected Drive Sensor"
 description: "Instructions on how to setup your BMW connected drive account with Home Assistant."
 date: 2018-01-10 23:00
 sidebar: true


### PR DESCRIPTION
**Description:**
Clarify titles of BMW Connected Drive components.

Currently the title of all components is `BMW connected drive` which causes an indistinguishable list in Related components.
![screenshot_bmw](https://user-images.githubusercontent.com/11230573/38772231-2dc2c156-4032-11e8-9484-ed2c5f63b035.png)

And some updates to have the names consistent.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/