### PR TITLE
rainbird config example update

### DIFF
--- a/source/_components/switch.rainbird.markdown
+++ b/source/_components/switch.rainbird.markdown
@@ -19,16 +19,18 @@ Once you have enabled the [Rain Bird component](/components/rainbird), add the f
 
 ```yaml
 switch:
-    sprinkler_1:
-      zone: 1
-      friendly_name: "Front sprinklers"
-      trigger_time: 20
-      scan_interval: 10
-    sprinkler_2:
-      friendly_name: "Back sprinklers"
-      zone: 2
-      trigger_time: 20
-      scan_interval: 10
+  - platform: rainbird
+    switches:
+      sprinkler_1:
+        zone: 1
+        friendly_name: "Front sprinklers"
+        trigger_time: 10
+        scan_interval: 10
+      sprinkler_2:
+        friendly_name: "Back sprinklers"
+        zone: 2
+        trigger_time: 20
+        scan_interval: 10
 ```
 
 Configuration variables:


### PR DESCRIPTION
The configuration didn't work as listed. Required addition of platform and switches lines, along with indent fixes.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
