### PR TITLE
Propose edits to DuckDNS docs

### DIFF
--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -26,7 +26,7 @@ featured: true
 
 Configuration variables:
 
-- **lets_encrypt.accept_terms** (*Optional*): If you accept the [Let's Encrypt Subscriber Agreement][le], it will generate & update Let's Enrypt certificates for your DuckDNS domain.
+- **lets_encrypt.accept_terms** (*Optional*): If you accept the [Let's Encrypt Subscriber Agreement][le], it will generate and update Let's Enrypt certificates for your DuckDNS domain.
 - **token** (*Required*): Your Duck DNS API key.
 - **domains** (*Required*): A list of domains to update DNS.
 - **seconds** (*Required*): Seconds between updates to Duck DNS.
@@ -44,7 +44,7 @@ http:
   ssl_key: /ssl/privkey.pem
 ```
 
-If you use a port other than `8123` or an SSL proxy, change the port number accordingly. 
+If you use a port other than `8123` or an SSL proxy, change the port number accordingly.
 
 ## {% linkable_title Router configuration %}
 
@@ -52,4 +52,4 @@ You'll need to forward the port you listed in your configuration (8123 in the ex
 
 Ensure that you allocate the Home Assistant system a fixed IP on your network before you configure port forwarding. You can do this either on the computer itself (see the [install guide](/hassio/installation/) or via a static lease on your router.
 
-Restart Home Assistant for the configured changes to take effect. When you access the HA front-end you will now need to use `https`, even when accessing local instances, for example at `https://192.168.0.1:8123`. 
+Restart Home Assistant for the configured changes to take effect. When you access the Home Assistant frontend you will now need to use `https`, even when accessing local instances, for example at `https://192.168.0.1:8123`. 

--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -26,10 +26,10 @@ featured: true
 
 Configuration variables:
 
+- **lets_encrypt.accept_terms** (*Optional*): If you accept the [Let's Encrypt Subscriber Agreement][le], it will generate & update Let's Enrypt certificates for your DuckDNS domain.
 - **token** (*Required*): Your Duck DNS API key.
 - **domains** (*Required*): A list of domains to update DNS.
 - **seconds** (*Optional*): Seconds between updates to Duck DNS.
-- **lets_encrypt.accept_terms** (*Optional*): If you accept the [Let's Encrypt Subscriber Agreement][le], it will generate & update Let's Enrypt certificates for your DuckDNS domain.
 
 [le]: https://letsencrypt.org/repository/
 

--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -29,7 +29,7 @@ Configuration variables:
 - **lets_encrypt.accept_terms** (*Optional*): If you accept the [Let's Encrypt Subscriber Agreement][le], it will generate & update Let's Enrypt certificates for your DuckDNS domain.
 - **token** (*Required*): Your Duck DNS API key.
 - **domains** (*Required*): A list of domains to update DNS.
-- **seconds** (*Optional*): Seconds between updates to Duck DNS.
+- **seconds** (*Required*): Seconds between updates to Duck DNS.
 
 [le]: https://letsencrypt.org/repository/
 
@@ -44,10 +44,12 @@ http:
   ssl_key: /ssl/privkey.pem
 ```
 
-If you use a port other than `8123` or an SSL proxy, change the port number accordingly.
+If you use a port other than `8123` or an SSL proxy, change the port number accordingly. 
 
 ## {% linkable_title Router configuration %}
 
 You'll need to forward the port you listed in your configuration (8123 in the example above) on your router to your Home Assistant system. You can find guides on how to do this on [Port Forward](https://portforward.com/) - noting that you'll only need to forward the TCP port.
 
 Ensure that you allocate the Home Assistant system a fixed IP on your network before you configure port forwarding. You can do this either on the computer itself (see the [install guide](/hassio/installation/) or via a static lease on your router.
+
+Restart Home Assistant for the configured changes to take effect. When you access the HA front-end you will now need to use `https`, even when accessing local instances, for example at `https://192.168.0.1:8123`. 


### PR DESCRIPTION
I've found this docs confusing. `lets_encrypt.accept_terms` should appear at the top of the list as it's the first entered variable. Also this should become `required` as typically `optional` config variables are not displayed in the example config, but it is here. I've also noticed that seconds are not optional, but are required. I've also added a comment about the need to use `https`, as this wasn't obvious to me (when accessing locally). Please see [this thread](https://community.home-assistant.io/t/effortless-encryption-with-lets-encrypt-and-duckdns/42492/33).