### PR TITLE
Media player webostv next/previous buttons

### DIFF
--- a/source/_components/media_player.webostv.markdown
+++ b/source/_components/media_player.webostv.markdown
@@ -96,3 +96,10 @@ Any other [actions](/docs/automation/action/) to power on the device can be conf
 *Sources*
 
 To obtain complete list of available sources currently configured on the TV, once the webOS TV is configured and linked, while its powered on head to the **Developer Tools** > **States**, find your `media_player.<name>` and use the sources listed in `source_list:` remembering to split them per line into your `sources:` configuration.
+
+
+*Next/Previous buttons*
+
+The behaviour of the next and previsous buttons is different depending on the active source:
+ - if the source is 'LiveTV' (television): next/previous buttons act as channel up/down
+ - otherwise: next/previsous buttons act as next/previous track

--- a/source/_components/media_player.webostv.markdown
+++ b/source/_components/media_player.webostv.markdown
@@ -19,7 +19,7 @@ The `webostv` platform allows you to control a [LG](http://www.lg.com/) webOS Sm
 
 To begin with enable *LG Connect Apps* feature in *Network* settings of the TV [instructions](http://www.lg.com/uk/support/product-help/CT00008334-1437131798537-others).
 
-Once basic configuration is added to your `configuration.yaml` *Configuration* card should prompt on your HA's States. Follow the instructions and accept pairing request on your TV.
+Once basic configuration is added to your `configuration.yaml` *Configuration* card should prompt on your Home Assistants's states. Follow the instructions and accept pairing request on your TV.
 
 Pairing information will be saved to the `filename:` provided in configuration; this process is IP sensitive, in case the IP address of your TV would change in future.
 
@@ -42,9 +42,11 @@ Configuration variables:
 - **timeout** (*Optional*): The timeout for connections to the TV in seconds.
 - **filename** (*Optional*): The filename where the pairing key with the TV should be stored. This path is relative to Home Assistant's config directory. It defaults to `webostv.conf`.
 - **customize** array (*Optional*): List of options to customize.
-  - ***sources** array (*Optional*): List of hardware and webOS App inputs.
+  - **sources** array (*Optional*): List of hardware and webOS App inputs.
 
 If you do not specify `host:`, all LG webOS Smart TVs within your network will be auto-discovered.
+
+### {% linkable_title Example %}
 
 A full configuration example will look like the sample below:
 
@@ -67,15 +69,15 @@ media_player:
         - makotv
         - netflix
 ```
-** avoid using `[ ]` in the `name:` of your device.
 
+Avoid using `[ ]` in the `name:` of your device.
 
-*Turn On Action*
+### {% linkable_title Turn on action %}
 
 Home Assistant is able to turn on a LG webOS Smart TV if you specify an action, like HDMI-CEC or WakeOnLan.
 
 Common for webOS 3.0 and higher would be to use WakeOnLan feature. 
-To use this feature your TV should be connected to your network via Ethernet rather than Wireless and you should enable *LG Connect Apps* feature in *Network* settings of the TV [instructions](http://www.lg.com/uk/support/product-help/CT00008334-1437131798537-others) (or *Mobile App* in *General* settings for older models) (*may vary by version).
+To use this feature your TV should be connected to your network via Ethernet rather than Wireless and you should enable *LG Connect Apps* feature in *Network* settings of the TV [instructions](http://www.lg.com/uk/support/product-help/CT00008334-1437131798537-others) (or *Mobile App* in *General* settings for older models).
 
 ```yaml
 # Example configuration.yaml entry
@@ -90,16 +92,16 @@ media_player:
       data:
         mac: B4:E6:2A:1E:11:0F
 ```
+
 Any other [actions](/docs/automation/action/) to power on the device can be configured. 
 
-
-*Sources*
+### {% linkable_title Sources %}
 
 To obtain complete list of available sources currently configured on the TV, once the webOS TV is configured and linked, while its powered on head to the **Developer Tools** > **States**, find your `media_player.<name>` and use the sources listed in `source_list:` remembering to split them per line into your `sources:` configuration.
 
-
-*Next/Previous buttons*
+### {% linkable_title Next/Previous buttons %}
 
 The behaviour of the next and previsous buttons is different depending on the active source:
+
  - if the source is 'LiveTV' (television): next/previous buttons act as channel up/down
  - otherwise: next/previsous buttons act as next/previous track


### PR DESCRIPTION
Description of the change visibles in https://github.com/home-assistant/home-assistant/pull/13829

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13829

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
