### PR TITLE
Link to correct holidays version

### DIFF
--- a/source/_components/binary_sensor.workday.markdown
+++ b/source/_components/binary_sensor.workday.markdown
@@ -32,8 +32,8 @@ binary_sensor:
 Configuration variables:
 
 - **name** (*Optional*): A name for this sensor. Defaults to *Workday Sensor*
-- **country** (*Required*): Country code according to [holidays](https://pypi.python.org/pypi/holidays/0.9.3) notation.
-- **province** (*Optional*): Province code according to [holidays](https://pypi.python.org/pypi/holidays/0.9.3) notation. Defaults to None.
+- **country** (*Required*): Country code according to [holidays](https://pypi.python.org/pypi/holidays/0.9.4) notation.
+- **province** (*Optional*): Province code according to [holidays](https://pypi.python.org/pypi/holidays/0.9.4) notation. Defaults to None.
 - **workdays** (*Optional*): List of workdays. Defaults to `mon`, `tue`, `wed`, `thu`, `fri`.
 - **excludes** (*Optional*): List of workday excludes. Defaults to `sat`, `sun`, `holiday`.
 - **days_offset** (*Optional*): Set days offset. Defaults to `0`.


### PR DESCRIPTION
**Description:**
Link to the version that's actually used, since Switzerland was only added in 0.9.4 of holidays.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
