### PR TITLE
Change order or ProxyPass in first example

### DIFF
--- a/source/_docs/ecosystem/apache.markdown
+++ b/source/_docs/ecosystem/apache.markdown
@@ -35,10 +35,10 @@ To be able to access to your Home Assistant instance by using https://home.examp
   ServerName home.example.org
   ProxyPreserveHost On
   ProxyRequests off
-  ProxyPass / http://localhost:8123/
-  ProxyPassReverse / http://localhost:8123/
   ProxyPass /api/websocket ws://localhost:8123/api/websocket
   ProxyPassReverse /api/websocket ws://localhost:8123/api/websocket
+  ProxyPass / http://localhost:8123/
+  ProxyPassReverse / http://localhost:8123/
 
   RewriteEngine on
   RewriteCond %{HTTP:Upgrade} =websocket [NC]


### PR DESCRIPTION
I was not able to login to Home Assistant till I change he Home Assistant config to place the Websocket reverse proxy info BEFORE the web UI info.  In the other order it loads, but never lets me log in.  If I reverse them, then I login just fine.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
