### PR TITLE
Add more math functions to templates

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -80,6 +80,13 @@ Home Assistant adds extensions to allow templates to access all of the current s
 - `float` will format the output as float.
 - `strptime(string, format)` will parse a string to a datetime based on a [format][strp-format].
 - `log(value, base)` will take the logarithm of the input. When the base is omitted, it defaults to `e` - the natural logarithm. Can also be used as a filter.
+- `sin(value)` will return the sine of the input. Can be used as a filter.
+- `cos(value)` will return the cosine of the input. Can be used as a filter.
+- `tan(value)` will return the tangent of the input. Can be used as a filter.
+- `sqrt(value)` will return the square root of the input. Can be used as a filter.
+- `e` mathematical constant, approximately 2.71828.
+- `pi` mathematical constant, approximately 3.14159.
+- `tau` mathematical constant, approximately 6.28318.
 - Filter `round(x)` will convert the input to a number and round it to `x` decimals.
 - Filter `timestamp_local`  will convert an UNIX timestamp to local time/data.
 - Filter `timestamp_utc` will convert an UNIX timestamp to UTC time/data.
@@ -274,6 +281,10 @@ The following overview contains a couple of options to get the needed values:
 {% raw %}{{ float(value_json) * (2**10) }}{% endraw %}
 {% raw %}{{ value_json | log }}{% endraw %}
 {% raw %}{{ log(1000, 10) }}{% endraw %}
+{% raw %}{{ sin(pi / 2) }}{% endraw %}
+{% raw %}{{ cos(tau) }}{% endraw %}
+{% raw %}{{ tan(pi) }}{% endraw %}
+{% raw %}{{ sqrt(e) }}{% endraw %}
 
 # Timestamps
 {% raw %}{{ value_json.tst | timestamp_local }}{% endraw %}


### PR DESCRIPTION
Document usage of `sin`, `cos`, `tan`, and `sqrt`, and the `e`, `pi`,
and `tau` constants.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13915

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
