### PR TITLE
Spelling fix

### DIFF
--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -26,7 +26,7 @@ featured: true
 
 Configuration variables:
 
-- **lets_encrypt.accept_terms** (*Optional*): If you accept the [Let's Encrypt Subscriber Agreement][le], it will generate and update Let's Enrypt certificates for your DuckDNS domain.
+- **lets_encrypt.accept_terms** (*Optional*): If you accept the [Let's Encrypt Subscriber Agreement][le], it will generate and update Let's Encrypt certificates for your DuckDNS domain.
 - **token** (*Required*): Your Duck DNS API key.
 - **domains** (*Required*): A list of domains to update DNS.
 - **seconds** (*Required*): Seconds between updates to Duck DNS.


### PR DESCRIPTION
`c` was missing.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
