### PR TITLE
Update development_validation.markdown

### DIFF
--- a/source/developers/development_validation.markdown
+++ b/source/developers/development_validation.markdown
@@ -21,7 +21,7 @@ Besides [voluptuous](https://pypi.python.org/pypi/voluptuous) default types, man
 - Time: `time`, `time_zone`
 - Misc: `template`, `slug`, `temperature_unit`, `latitude`, `longitude`, `isfile`, `sun_event`, `ensure_list`, `port`, `url`,  and `icon`
  
-To validate plaforms using [MQTT](/components/mqtt/), `valid_subscribe_topic` and `valid_publish_topic` are available.
+To validate platforms using [MQTT](/components/mqtt/), `valid_subscribe_topic` and `valid_publish_topic` are available.
 
 Some things to keep in mind:
 


### PR DESCRIPTION
Spelling Mistake

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
