### PR TITLE
Update attributes table to reflect withdrawn PR

### DIFF
--- a/source/_components/switch.vesync.markdown
+++ b/source/_components/switch.vesync.markdown
@@ -45,7 +45,3 @@ VeSync switches will expose the following details.
 | ------------------- | ------------------------------------------------------------------- | --------------- |
 | `current_power_w`   | The present power consumption of the switch in watts.               | 100             |
 | `today_energy_kwh`  | The kilowatt hours used by the switch during the previous 24 hours. | 0.12            |
-| `connection_status` | The connection status of the switch.                                | online          |
-| `connection_type`   | The connection type of the switch.                                  | wifi            |
-| `device_type`       | The device type of the switch.                                      | wifi-switch-1.3 |
-| `model`             | The model of the switch.                                            | wifi-switch     |


### PR DESCRIPTION
**Description:**
The PR https://github.com/home-assistant/home-assistant/pull/13816 has been withdrawn since it exposed static attributes which are not supported. Updating wiki to reflect current state

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#13816

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
