### PR TITLE
Waze Travel Time: optional inclusive/exclusive filters

### DIFF
--- a/source/_components/sensor.waze_travel_time.markdown
+++ b/source/_components/sensor.waze_travel_time.markdown
@@ -48,4 +48,12 @@ name:
   required: false
   default: "Waze Travel Time"
   type: string
+inc_filter:
+  description: A substring that has to be present in the description of the selected route (a simple case-insensitive matching).
+  required: false
+  type: string
+excl_filter:
+  description: A substring that has to be NOT present in the description of the selected route (a simple case-insensitive matching).
+  required: false
+  type: string
 {% endconfiguration %}

--- a/source/_components/sensor.waze_travel_time.markdown
+++ b/source/_components/sensor.waze_travel_time.markdown
@@ -48,7 +48,7 @@ name:
   required: false
   default: "Waze Travel Time"
   type: string
-inc_filter:
+incl_filter:
   description: A substring that has to be present in the description of the selected route (a simple case-insensitive matching).
   required: false
   type: string


### PR DESCRIPTION
documentation update about the new optional filtering params

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14000

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
