### PR TITLE
Add some more documentation around hassio CLI

### DIFF
--- a/source/hassio/index.markdown
+++ b/source/hassio/index.markdown
@@ -84,3 +84,31 @@ $ hassio supervisor info
 $ hassio supervisor reload
 $ hassio supervisor update
 ```
+
+You can get a better description of the CLI capabilities by typing `hassio help`:
+```NAME:
+   hassio - Commandline tool to allow interation with hass.io
+
+USAGE:
+   hassio [global options] command [command options] [arguments...]
+
+VERSION:
+   1.2.1
+
+AUTHOR:
+   Home-Assistant <hello@home-assistant.io>
+
+COMMANDS:
+     homeassistant, ha  info, logs, check, restart, start, stop, update
+     supervisor, su     info, logs, reload, update
+     host, ho           hardware, reboot, shutdown, update
+     network, ne        info, options
+     snapshots, sn      list, info, reload, new, restore, remove
+     addons, ad         list, info, logo, changelog, logs, stats,
+ reload, start, stop, install, uninstall, update
+     help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --debug, -d    Prints Debug information
+   --help, -h     show help
+   --version, -v  print the version```

--- a/source/hassio/index.markdown
+++ b/source/hassio/index.markdown
@@ -59,8 +59,9 @@ Hass.io upgrade process from the SSH command line
 
 On the SSH command line you can use the `hassio` command to retrieve logs, check the details of connected hardware, and more.
 
-HomeAssistant:
-```shell
+Home Assistant:
+
+```bash
 $ hassio homeassistant logs
 $ hassio homeassistant restart
 $ hassio homeassistant stop
@@ -70,7 +71,8 @@ $ hassio homeassistant check
 ```
 
 Host:
-```shell
+
+```bash
 $ hassio host hardware
 $ hassio host reboot
 $ hassio host shutdown
@@ -78,7 +80,8 @@ $ hassio host update
 ```
 
 Supervisor
-```shell
+
+```bash
 $ hassio supervisor logs
 $ hassio supervisor info
 $ hassio supervisor reload
@@ -86,7 +89,9 @@ $ hassio supervisor update
 ```
 
 You can get a better description of the CLI capabilities by typing `hassio help`:
-```NAME:
+
+```bash
+NAME:
    hassio - Commandline tool to allow interation with hass.io
 
 USAGE:
@@ -111,4 +116,5 @@ COMMANDS:
 GLOBAL OPTIONS:
    --debug, -d    Prints Debug information
    --help, -h     show help
-   --version, -v  print the version```
+   --version, -v  print the version
+```


### PR DESCRIPTION
This is rather basic, I think it needs it's own page.  

The CLI commands could also use some cleaning up.  For example, CLI help says use `-name` command when it actually wants you to provide the `slug` id in snapshot restore.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
