### PR TITLE
fix link to the TTN sensor page

### DIFF
--- a/source/_components/thethingsnetwork.markdown
+++ b/source/_components/thethingsnetwork.markdown
@@ -20,7 +20,7 @@ The Things network support various integrations to make the data available:
 | The Things Network Integration | Home Assistant platform |
 |---|---|
 | [MQTT](https://www.thethingsnetwork.org/docs/applications/mqtt/) | |
-| [Storage](https://www.thethingsnetwork.org/docs/applications/storage/) | [`thethingsnetwork`](/component/sensor.thethingsnetwork/) |
+| [Storage](https://www.thethingsnetwork.org/docs/applications/storage/) | [`thethingsnetwork`](/components/sensor.thethingsnetwork/) |
 | [HTTP](https://www.thethingsnetwork.org/docs/applications/http/) | |
 
 ### {% linkable_title Setup %}


### PR DESCRIPTION
**Description:**
Fix broken link to TTN Sensor Page

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** -

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
