### PR TITLE
Add Template Sensor device_class support

### DIFF
--- a/source/_components/device_tracker.owntracks_http.markdown
+++ b/source/_components/device_tracker.owntracks_http.markdown
@@ -32,7 +32,7 @@ Open OwnTracks and go to Connection preferences:
  - Mode: Select **Private HTTP**
  - Host: [Home Assistant URL]:[port]/api/owntracks/[your name]/[device name]
  - Identification: Turn **Authentication** on, username `homeassistant` and password is your API password that you use to login to Home Assistant.
- 
+
 Host example: If I host my Home Assistant at `https://example.duckdns.org`, my name is Paulus and my phone is a Pixel I would set the host to be `https://example.duckdns.org/api/owntracks/paulus/pixel`. This will result in an entity with an ID of `device_tracker.paulus_pixel`. You can pick any name for the user and the device.
 
 Since the battery data is available as an attribute of the device tracker entity, it can be tracked with a [`template` sensor](/components/sensor.template/).
@@ -47,17 +47,6 @@ sensor:
         friendly_name: Pixel of Paulus
         unit_of_measurement: "%"
         value_template: '{{ states.device_tracker.paulus_pixel.attributes.battery|int }}'
-        icon_template: >-
-          {% set battery_level = states.device_tracker.paulus_pixel.attributes.battery|default(0)|int %}
-          {% set battery_round = (battery_level / 10) |int * 10 %}
-          {% if battery_round >= 100 %}
-            mdi:battery
-          {% elif battery_round > 0 %}
-            mdi:battery-{{ battery_round }}
-          {% else %}
-            mdi:battery-alert
-          {% endif %}
-        entity_id: 
-        - device_tracker.paulus_pixel
+        device_class: battery
 ```
 {% endraw %}

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -69,6 +69,11 @@ sensor:
         description: Defines a template for the entity picture of the sensor.
         required: false
         type: template
+      device_class:
+        description: The type/class of the sensor to set the icon in the frontend.
+        required: false
+        type: device_class
+        default: None
 {% endconfiguration %}
 
 ## {% linkable_title Considerations %}

--- a/source/_cookbook/track_battery_level.markdown
+++ b/source/_cookbook/track_battery_level.markdown
@@ -12,7 +12,7 @@ ha_category: Automation Examples
 
 ### {% linkable_title iOS Devices %}
 
-If you have a device running iOS (iPhone, iPad, etc), The [iCloud](/components/device_tracker.icloud/) is gathering various details about your device including the battery level. To display it in the Frontend use a [template sensor](/components/sensor.template/). You can also the `battery` [sensor device class](/components/binary_sensor/) to dynamically change the icon with the battery level.
+If you have a device running iOS (iPhone, iPad, etc), The [iCloud](/components/device_tracker.icloud/) is gathering various details about your device including the battery level. To display it in the Frontend use a [template sensor](/components/sensor.template/). You can also the `battery` [sensor device class](/components/sensor/#device-class) to dynamically change the icon with the battery level.
 
 {% raw %}
 ```yaml
@@ -21,8 +21,6 @@ sensor:
     sensors:
       battery_iphone:
         friendly_name: iPhone Battery
-        # "entity_id:" ensures that this sensor will only update when your device tracker does.
-        entity_id: device_tracker.iphone
         unit_of_measurement: '%'
         value_template: >-
             {%- if states.device_tracker.iphone.attributes.battery %}
@@ -46,5 +44,6 @@ sensor:
     name: "Battery Tablet"
     unit_of_measurement: "%"
     value_template: '{{ value_json.batt }}'
+    device_class: battery
 ```
 {% endraw %}

--- a/source/_cookbook/track_battery_level.markdown
+++ b/source/_cookbook/track_battery_level.markdown
@@ -12,7 +12,7 @@ ha_category: Automation Examples
 
 ### {% linkable_title iOS Devices %}
 
-If you have a device running iOS (iPhone, iPad, etc), The [iCloud](/components/device_tracker.icloud/) is gathering various details about your device including the battery level. To display it in the Frontend use a [template sensor](/components/sensor.template/). You can also use the icon template option to create a dynamic icon that changes with the battery level.
+If you have a device running iOS (iPhone, iPad, etc), The [iCloud](/components/device_tracker.icloud/) is gathering various details about your device including the battery level. To display it in the Frontend use a [template sensor](/components/sensor.template/). You can also the `battery` [sensor device class](/components/binary_sensor/) to dynamically change the icon with the battery level.
 
 {% raw %}
 ```yaml
@@ -30,20 +30,9 @@ sensor:
             {% else %}
                 {{ states.sensor.battery_iphone.state }}
             {%- endif %}
-        icon_template: >
-            {% set battery_level = states.sensor.battery_iphone.state|default(0)|int %}
-            {% set battery_round = (battery_level / 10) |int * 10 %}
-            {% if battery_round >= 100 %}
-              mdi:battery
-            {% elif battery_round > 0 %}
-              mdi:battery-{{ battery_round }}
-            {% else %}
-              mdi:battery-alert
-            {% endif %}
+        device_class: battery
 ```
 {% endraw %}
-
-The `else` part is used to have the sensor keep its last state if the newest [iCloud](/components/device_tracker.icloud/) update doesn't have any battery state in it (which happens sometimes). Otherwise the sensor will be blank.
 
 ### {% linkable_title Android and iOS Devices %}
 


### PR DESCRIPTION
**Description:**

Add a `device_class` attribute to the `sensor.template` platform. Requires #5219 for sensor `device_class` docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14034

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
