### PR TITLE
Mention possibility to support a "stop" group address.

### DIFF
--- a/source/_components/cover.knx.markdown
+++ b/source/_components/cover.knx.markdown
@@ -37,7 +37,7 @@ Configuration variables:
 
 - **name** (*Optional*): A name for this device used within Home Assistant.
 - **move_long_address**: KNX group address for moving the cover full up or down.
-- **move_short_address** (*Optional*): KNX group address for moving the cover short time up or down.
+- **move_short_address** (*Optional*): KNX group address for moving the cover short time up or down. If the KNX device has a stop group address you can use that here.
 - **position_address** (*Optional*): KNX group address for moving the cover to the dedicated position.
 - **position_state_address** (*Optional*): Separate KNX group address for requesting the current position of the cover.
 - **angle_address** (*Optional*): KNX group address for moving the cover to the dedicated angle.


### PR DESCRIPTION
My KNX device has a "start" (down/up) and a "stop" group address. It works perfectly if I enter the "start" group address in "move_long_address" and "stop" in "move_short_address". However, I only found out because I found issue #10624.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
