### PR TITLE
Change Page Title to "Homekit Switch"

### DIFF
--- a/source/_components/switch.homekit_controller.markdown
+++ b/source/_components/switch.homekit_controller.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "HomeKit Switch"
-description: "Instructions how to setup HomeKit switches within Home Assistant."
+description: "Instructions on how to setup HomeKit switches within Home Assistant."
 date: 2017-03-19 21:08
 sidebar: true
 comments: false

--- a/source/_components/switch.homekit_controller.markdown
+++ b/source/_components/switch.homekit_controller.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "HomeKit Light"
+title: "HomeKit Switch"
 description: "Instructions how to setup HomeKit switches within Home Assistant."
 date: 2017-03-19 21:08
 sidebar: true


### PR DESCRIPTION
It was left titled "Homekit Light" when first published.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
