### PR TITLE
add relative time option to simulated sensors

### DIFF
--- a/source/_components/sensor.simulated.markdown
+++ b/source/_components/sensor.simulated.markdown
@@ -81,6 +81,11 @@ spread:
   required: false
   default: None
   type: float
+relative_to_epoch:
+  description: Whether to simulate from epoch time (00:00:00, 1970-01-01), or relative to when the sensor was started.
+  required: false
+  default: true
+  type: boolean
 {% endconfiguration %}
 
 ## {% linkable_title Example %}
@@ -96,4 +101,5 @@ sensor:
     mean: 50
     spread: 10
     seed: 999
+    relative_to_epoch: false
 ```


### PR DESCRIPTION
**Description:**

This is the documentation for the change outlined below.

By default simulated sensors are relative to when they're activated,
instead we change this default to a new toggleable option,
'relative_to_epoch', and instead they become 'absolute', or relative
to 1970-01-01 00:00:00.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14038

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
