### PR TITLE
Moved raincloud watering_minutes to the right component

### DIFF
--- a/source/_components/raincloud.markdown
+++ b/source/_components/raincloud.markdown
@@ -32,6 +32,10 @@ password:
   description: The password for accessing your Melnor RainCloud account.
   required: true
   type: string
+watering_minutes:
+  description: Value in minutes to watering your garden via frontend. Defaults to 15.
+  required: false
+  type: number
 {% endconfiguration %}
 
 Finish its configuration by visiting the [Raincloud binary sensor](/components/binary_sensor.raincloud/), [Raincloud sensor](/components/sensor.raincloud/) and [Raincloud switch](/components/switch.raincloud/) documentation.

--- a/source/_components/switch.raincloud.markdown
+++ b/source/_components/switch.raincloud.markdown
@@ -25,7 +25,6 @@ switch:
 
 Configuration variables:
 
-- **watering_minutes** (*Optional*): Value in minutes to watering your garden via frontend. Defaults to 15.
 - **monitored_conditions** array (*Optional*): Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
   - **auto_watering**: Toggle the watering scheduled per zone.
   - **manual_watering**: Toggle manually the watering per zone. It will inherent the value in minutes specified on the RainCloud hub component.


### PR DESCRIPTION
**Description:**
This patch moved the documentation of the parameter `watering_minutes` to the right component. 

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
