### PR TITLE
Updated watering_minutes with the allowed values

### DIFF
--- a/source/_components/switch.raincloud.markdown
+++ b/source/_components/switch.raincloud.markdown
@@ -25,7 +25,7 @@ switch:
 
 Configuration variables:
 
-- **watering_minutes** (*Optional*): Value in minutes to watering your garden via frontend. Defaults to 15.
+- **watering_minutes** (*Optional*): Value in minutes to watering your garden via frontend. Defaults to 15. The values allowed are: 5, 10, 15, 30, 45, 60.
 - **monitored_conditions** array (*Optional*): Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
   - **auto_watering**: Toggle the watering scheduled per zone.
   - **manual_watering**: Toggle manually the watering per zone. It will inherent the value in minutes specified on the RainCloud hub component.


### PR DESCRIPTION
**Description:**
This PR added all values allowed to the `watering_minutes` param.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
