### PR TITLE
Adds update file_path service to the local_file camera

### DIFF
--- a/source/_components/camera.local_file.markdown
+++ b/source/_components/camera.local_file.markdown
@@ -41,4 +41,5 @@ Use this service to change the file displayed by the camera.
 
 | Service data attribute | Description |
 | -----------------------| ----------- |
+| `entity_id` | String of the `entity_id` of the camera to update.
 | `file_path` | The full path to the new image file to be displayed.

--- a/source/_components/camera.local_file.markdown
+++ b/source/_components/camera.local_file.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Local File"
-description: "Instructions on how to use Local File as a Camera within Home Assistant."
+description: "Instructions how to use Local File as a Camera within Home Assistant."
 date: 2016-06-12 17:00
 sidebar: true
 comments: false
@@ -13,9 +13,9 @@ ha_iot_class: "Local Polling"
 ha_release: 0.22
 ---
 
-The `local_file` camera platform allows you to integrate any readable image file from disk into Home Assistant as a camera. If the image is updated on the file system the image displayed in Home Assistant will also be updated.
+The `local_file` camera platform allows you to integrate an image file from disk into Home Assistant as a camera. If the image is updated on the file system the image displayed in Home Assistant will also be updated. The service `local_file_update_file_path` can be used to update the image using an automation.
 
-This can for example be used with various camera platforms that save a temporary images locally. It can also be used to display a graph that you render periodically and will then be displayed in Home Assistant.
+The `local_file` camera can for example be used with various camera platforms that save a temporary images locally. It can also be used to display a graph that you render periodically and will then be displayed in Home Assistant.
 
 To enable this camera in your installation, add the following to your `configuration.yaml` file:
 
@@ -30,10 +30,6 @@ Configuration variables:
 
  - **file_path** (*Required*): File to serve as the camera.
  - **name** (*Optional*): Name of the camera
-
-<p class='note'>
-The given `file_path` must be an existing file because the camera platform setup make a readable check on it.
-</p>
 
 ### {% linkable_title Service `camera.local_file_update_file_path` %}
 

--- a/source/_components/camera.local_file.markdown
+++ b/source/_components/camera.local_file.markdown
@@ -35,3 +35,10 @@ Configuration variables:
 The given `file_path` must be an existing file because the camera platform setup make a readable check on it.
 </p>
 
+### {% linkable_title Service `camera.update_file_path` %}
+
+Use this service to change the file displayed by the camera.
+
+| Service data attribute | Description |
+| -----------------------| ----------- |
+| `file_path` | The full path to the new image file to be displayed.

--- a/source/_components/camera.local_file.markdown
+++ b/source/_components/camera.local_file.markdown
@@ -35,7 +35,7 @@ Configuration variables:
 The given `file_path` must be an existing file because the camera platform setup make a readable check on it.
 </p>
 
-### {% linkable_title Service `camera.update_file_path` %}
+### {% linkable_title Service `camera.local_file_update_file_path` %}
 
 Use this service to change the file displayed by the camera.
 

--- a/source/_components/camera.local_file.markdown
+++ b/source/_components/camera.local_file.markdown
@@ -37,5 +37,5 @@ Use this service to change the file displayed by the camera.
 
 | Service data attribute | Description |
 | -----------------------| ----------- |
-| `entity_id` | String of the `entity_id` of the camera to update.
-| `file_path` | The full path to the new image file to be displayed.
+| `entity_id` | String of the `entity_id` of the camera to update. |
+| `file_path` | The full path to the new image file to be displayed. |


### PR DESCRIPTION
**Description:**
Adds camera.update_file_path service for the local_file camera.

Note that when I set the target as `next` some homekit docs get included in the PR and I have no idea why..


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant/pull/13976) (if applicable):** home-assistant/home-assistant#<13976>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
