### PR TITLE
Fix typo in SABnzbd documentation

### DIFF
--- a/source/_components/sensor.sabnzbd.markdown
+++ b/source/_components/sensor.sabnzbd.markdown
@@ -68,7 +68,7 @@ Note that this will create the following sensors:
  - sensor.sabnzbd_left
  - sensor.sabnzbd_disk
  - sensor.sabnzbd_disk_free
- - sensor.sabnzdb_queue_count
+ - sensor.sabnzbd_queue_count
 ```
 
 As always, you can determine the names of sensors by looking at the dev-state page `< >` in the web interface.


### PR DESCRIPTION
**Description:**
The list of sensors that will be created has a small typo in the `queue_count` entry

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
