### PR TITLE
Update google_assistant.markdown

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -102,7 +102,7 @@ entity_config:
           required: false
           type: list
         room:
-          description: Allows for associating this device to a Room in Google Assistant.  This is currently non-functional, but will be enabled in the near future.
+          description: Allows for associating this device to a Room in Google Assistant.
           required: false
           type: string
 {% endconfiguration %}


### PR DESCRIPTION
Since RoomHints are now live in the Google Assistant API, I’m removing the “not yet” disclaimer.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
