### PR TITLE
add "framerate" parameter to generic camera 

### DIFF
--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -36,6 +36,7 @@ Configuration variables:
 - **authentication** (*Optional*): Type for authenticating the requests `basic` (default) or `digest`.
 - **limit_refetch_to_url_change** (*Optional*): True/false value (default: false). Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
 - **content_type** (*Optional*): Set the content type for the IP camera if it is not a jpg file (default: `image/jpeg`). Use `image/svg+xml` to add a dynamic svg file.
+- **framerate** (*Optional*): The number of frames-per-second (FPS) of the stream (setting this too high may cause too much traffic on the network or be heavy on the camera).
 
 <p class='img'>
   <a href='/cookbook/google_maps_card/'>


### PR DESCRIPTION
**Description:**
Add a "framerate" parameter to generic camera, to allow specifying the FPS to stream, instead of using the default 2 FPS.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14079

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
