### PR TITLE
Tidy Folder Watcher component page automation.

### DIFF
--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -62,19 +62,19 @@ Automations can be triggered on filesystem event data using a `data_template`. T
 
 {% raw %}
 ```yaml
-- action:
-  - data_template:
-      message: 'Created {{ trigger.event.data.file }} in {{ trigger.event.data.folder }}'
-      title: New image captured!
-      data:
-        file: " {{ trigger.event.data.path }} "
-    service: notify.pushbullet
-  alias: New file alert
-  condition: []
-  id: '1520092824697'
-  trigger:
-  - event_data: {"event_type":"created"}
-    event_type: folder_watcher
-    platform: event
+#Send notification for new image (including the image itself)
+alias: New file alert
+trigger:
+  platform: event
+  event_type: folder_watcher
+  event_data:
+    event_type: created
+action:
+  service: notify.notify
+  data_template:
+    title: New image captured!
+    message: "Created {{ trigger.event.data.file }} in {{ trigger.event.data.folder }}"
+    data:
+      file: "{{ trigger.event.data.path }}"
 ```
 {% endraw %}

--- a/source/_components/folder_watcher.markdown
+++ b/source/_components/folder_watcher.markdown
@@ -63,18 +63,19 @@ Automations can be triggered on filesystem event data using a `data_template`. T
 {% raw %}
 ```yaml
 #Send notification for new image (including the image itself)
-alias: New file alert
-trigger:
-  platform: event
-  event_type: folder_watcher
-  event_data:
-    event_type: created
-action:
-  service: notify.notify
-  data_template:
-    title: New image captured!
-    message: "Created {{ trigger.event.data.file }} in {{ trigger.event.data.folder }}"
-    data:
-      file: "{{ trigger.event.data.path }}"
+automation:
+  alias: New file alert
+  trigger:
+    platform: event
+    event_type: folder_watcher
+    event_data:
+      event_type: created
+  action:
+    service: notify.notify
+    data_template:
+      title: New image captured!
+      message: "Created {{ trigger.event.data.file }} in {{ trigger.event.data.folder }}"
+      data:
+        file: "{{ trigger.event.data.path }}"
 ```
 {% endraw %}


### PR DESCRIPTION
The automation on this page was obviously created by the automation editor and was super-ugly!!

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
