### PR TITLE
Adds docs for RainMachine component/hub

### DIFF
--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -1,0 +1,83 @@
+---
+layout: page
+title: "RainMachine"
+description: "Instructions on how to integrate RainMachine units within Home Assistant."
+date: 2018-04-25 20:32
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: rainmachine.png
+ha_category: Hub
+ha_release: 0.68
+ha_iot_class: "Cloud Polling"
+---
+
+The `rainmachine` component is the main component to integrate all platforms
+related to [RainMachine smart Wi-Fi sprinkler controllers](http://www.rainmachine.com/).
+
+## {% linkable_title Configuration %}
+
+The platform allows for either local (i.e., directly across the LAN) or remote
+(i.e., through RainMachine's cloud API) access; the route you choose will
+dictate what your configuration should look like.
+
+For local access, specify the IP address/hostname of your RainMachine unit,
+your RainMachine password, and optionally, the device's HTTP port:
+
+```yaml
+rainmachine:
+  platform: rainmachine
+  ip_address: 192.168.1.100
+  password: YOUR_PASSWORD
+```
+
+For remote access, specify your RainMachine username/email and password:
+
+```yaml
+rainmachine:
+  platform: rainmachine
+  email: user@host.com
+  password: YOUR_PASSWORD
+```
+
+{% configuration %}
+password:
+  description: your RainMachine password.
+  required: true
+  type: string
+email:
+  description: your RainMachine username/email; cannot be used with the `ip_address` parameter
+  required: false
+  type: string
+ip_address:
+  description: the IP address or hostname of your RainMachine unit; cannot be used with the `email` parameter
+  required: optional
+  type: string
+port:
+  description: the TCP port used by your unit for the REST API
+  required: false
+  type: int
+  default: 8080
+ssl:
+  description: whether communication with the local device should occur over HTTPS
+  required: false
+  type: boolean
+  default: true
+{% endconfiguration %}
+
+## {% linkable_title Weblink %}
+
+If you would like to see and control more detailed information, create an
+[iFrame](/components/panel_iframe/) that renders the RainMachine web app:
+
+```yaml
+panel_iframe:
+  rainmachine:
+    title: RainMachine
+    url: "https://my.rainmachine.com/s/<YOUR_DEVICE_ID>/ui/"
+    icon: mdi:water
+```
+
+You can find `<YOUR_DEVICE_ID>` by logging into
+[your RainMachine dashboard](https://my.rainmachine.com) and noting it in the URL.

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -18,41 +18,23 @@ related to [RainMachine smart Wi-Fi sprinkler controllers](http://www.rainmachin
 
 ## {% linkable_title Configuration %}
 
-The platform allows for either local (i.e., directly across the LAN) or remote
-(i.e., through RainMachine's cloud API) access; the route you choose will
-dictate what your configuration should look like.
-
-For local access, specify the IP address/hostname of your RainMachine unit,
-your RainMachine password, and optionally, the device's HTTP port:
+To connect to your RainMachine device, add the following to your
+`configuration.yaml` file:
 
 ```yaml
 rainmachine:
-  platform: rainmachine
   ip_address: 192.168.1.100
   password: YOUR_PASSWORD
 ```
 
-For remote access, specify your RainMachine username/email and password:
-
-```yaml
-rainmachine:
-  platform: rainmachine
-  email: user@host.com
-  password: YOUR_PASSWORD
-```
-
 {% configuration %}
+ip_address:
+  description: the IP address or hostname of your RainMachine unit
+  required: optional
+  type: string
 password:
   description: your RainMachine password.
   required: true
-  type: string
-email:
-  description: your RainMachine username/email; cannot be used with the `ip_address` parameter
-  required: false
-  type: string
-ip_address:
-  description: the IP address or hostname of your RainMachine unit; cannot be used with the `email` parameter
-  required: optional
   type: string
 port:
   description: the TCP port used by your unit for the REST API
@@ -65,19 +47,3 @@ ssl:
   type: boolean
   default: true
 {% endconfiguration %}
-
-## {% linkable_title Weblink %}
-
-If you would like to see and control more detailed information, create an
-[iFrame](/components/panel_iframe/) that renders the RainMachine web app:
-
-```yaml
-panel_iframe:
-  rainmachine:
-    title: RainMachine
-    url: "https://my.rainmachine.com/s/<YOUR_DEVICE_ID>/ui/"
-    icon: mdi:water
-```
-
-You can find `<YOUR_DEVICE_ID>` by logging into
-[your RainMachine dashboard](https://my.rainmachine.com) and noting it in the URL.

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: rainmachine.png
 ha_category: Hub
-ha_release: 0.68
+ha_release: 0.69
 ha_iot_class: "Cloud Polling"
 ---
 

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -58,9 +58,14 @@ ssl:
   required: false
   type: boolean
   default: true
-zone_run_time:
-  description: the default number of seconds that a zone should run when turned on
+switches:
+  description: switch-related configuration options
   required: false
-  type: int
-  default: 600
+  type: map
+  keys:
+    zone_run_time:
+      description: the default number of seconds that a zone should run when turned on
+      required: false
+      type: int
+      default: 600
 {% endconfiguration %}

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -16,7 +16,7 @@ ha_iot_class: "Cloud Polling"
 The `rainmachine` component is the main component to integrate all platforms
 related to [RainMachine smart Wi-Fi sprinkler controllers](http://www.rainmachine.com/).
 
-## {% linkable_title Configuration %}
+## {% linkable_title Base Configuration %}
 
 To connect to your RainMachine device, add the following to your
 `configuration.yaml` file:
@@ -46,4 +46,26 @@ ssl:
   required: false
   type: boolean
   default: true
+{% endconfiguration %}
+
+## {% linkable_title Switch Configuration %}
+
+To configure switch-related functionality, add configuration options beneath
+a `switches` key within the `rainmachine` sections of `configuration.yaml`
+as below:
+
+```yaml
+rainmachine:
+  ip_address: 192.168.1.100
+  password: YOUR_PASSWORD
+  switches:
+    # switch configuration options
+```
+
+{% configuration %}
+zone_run_time:
+  description: the default number of seconds that a zone should run when turned on
+  required: false
+  type: int
+  default: 600
 {% endconfiguration %}

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -25,6 +25,10 @@ To connect to your RainMachine device, add the following to your
 rainmachine:
   ip_address: 192.168.1.100
   password: YOUR_PASSWORD
+  port: 8080
+  ssl: true
+  switches:
+    zone_run_time: 300
 ```
 
 {% configuration %}
@@ -46,23 +50,6 @@ ssl:
   required: false
   type: boolean
   default: true
-{% endconfiguration %}
-
-## {% linkable_title Switch Configuration %}
-
-To configure switch-related functionality, add configuration options beneath
-a `switches` key within the `rainmachine` sections of `configuration.yaml`
-as below:
-
-```yaml
-rainmachine:
-  ip_address: 192.168.1.100
-  password: YOUR_PASSWORD
-  switches:
-    # switch configuration options
-```
-
-{% configuration %}
 zone_run_time:
   description: the default number of seconds that a zone should run when turned on
   required: false

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -36,7 +36,7 @@ rainmachine:
   ip_address: 192.168.1.100
   password: YOUR_PASSWORD
   switches:
-    zone_run_time: 300
+    # switch configuration options...
 ```
 
 {% configuration %}

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -25,10 +25,6 @@ To connect to your RainMachine device, add the following to your
 rainmachine:
   ip_address: 192.168.1.100
   password: YOUR_PASSWORD
-  port: 8080
-  ssl: true
-  switches:
-    zone_run_time: 300
 ```
 
 {% configuration %}
@@ -50,6 +46,23 @@ ssl:
   required: false
   type: boolean
   default: true
+{% endconfiguration %}
+
+## {% linkable_title Switch Configuration %}
+
+To configure switch-related functionality, add configuration options beneath
+a `switches` key within the `rainmachine` sections of `configuration.yaml`
+as below:
+
+```yaml
+rainmachine:
+  ip_address: 192.168.1.100
+  password: YOUR_PASSWORD
+  switches:
+    # switch configuration options
+```
+
+{% configuration %}
 zone_run_time:
   description: the default number of seconds that a zone should run when turned on
   required: false

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -27,6 +27,18 @@ rainmachine:
   password: YOUR_PASSWORD
 ```
 
+To configure switch-related functionality, add configuration options beneath
+a `switches` key within the `rainmachine` sections of `configuration.yaml`
+as below:
+
+```yaml
+rainmachine:
+  ip_address: 192.168.1.100
+  password: YOUR_PASSWORD
+  switches:
+    zone_run_time: 300
+```
+
 {% configuration %}
 ip_address:
   description: the IP address or hostname of your RainMachine unit
@@ -46,21 +58,6 @@ ssl:
   required: false
   type: boolean
   default: true
-{% endconfiguration %}
-
-To configure switch-related functionality, add configuration options beneath
-a `switches` key within the `rainmachine` sections of `configuration.yaml`
-as below:
-
-```yaml
-rainmachine:
-  ip_address: 192.168.1.100
-  password: YOUR_PASSWORD
-  switches:
-    # switch configuration options
-```
-
-{% configuration %}
 zone_run_time:
   description: the default number of seconds that a zone should run when turned on
   required: false

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -48,8 +48,6 @@ ssl:
   default: true
 {% endconfiguration %}
 
-## {% linkable_title Switch Configuration %}
-
 To configure switch-related functionality, add configuration options beneath
 a `switches` key within the `rainmachine` sections of `configuration.yaml`
 as below:

--- a/source/_components/switch.rainmachine.markdown
+++ b/source/_components/switch.rainmachine.markdown
@@ -13,55 +13,27 @@ ha_iot_class: "Cloud Polling"
 ha_release: 0.51
 ---
 
-The `rainmachine` switch platform allows you to control programs and zones within a [RainMachine smart Wi-Fi sprinkler controller](http://www.rainmachine.com/).
+The `rainmachine` switch platform allows you to control programs and zones
+within a [RainMachine smart Wi-Fi sprinkler controller](http://www.rainmachine.com/). 
+
+<p class='note'>
+You must have the [RainMachine component](https://www.home-assistant.io/components/rainmachine/)
+configured to use this switch.
+</p>
 
 ## {% linkable_title Configuring the Platform %}
 
-The platform allows for either local (i.e., directly across the LAN) or remote (i.e., through RainMachine's cloud API) access; the route you choose will dictate what your configuration should look like.
-
-For local access, specify the IP address/hostname of your RainMachine unit, your RainMachine password, and optionally, the device's HTTP port:
-
-```yaml
-switch:
-  platform: rainmachine
-  ip_address: 192.168.1.100
-  password: YOUR_PASSWORD
-```
-
-For remote access, specify your RainMachine username/email and password:
+To enable the platform, add the following lines to your `configuration.yaml`
+file:
 
 ```yaml
 switch:
-  platform: rainmachine
-  email: user@host.com
-  password: YOUR_PASSWORD
+  - platform: rainmachine
 ```
 
 {% configuration %}
-password:
-  description: Your RainMachine password.
-  required: true
-  type: string
-email:
-  description: "Your RainMachine username/email. Cannot be used with the `ip_address` parameter."
-  required: false
-  type: string
-ip_address:
-  description: "The IP address of your RainMachine unit; cannot be used with the `email` parameter."
-  required: optional
-  type: string
-port:
-  description: The TCP port used by your unit for the REST API.
-  required: false
-  type: int
-  default: 8080
-ssl:
-  description: Whether communication with the local device should occur over HTTPS.
-  required: false
-  type: boolean
-  default: true
 zone_run_time:
-  description: The number of seconds that a zone should run when turned on.
+  description: the default number of seconds that a zone should run when turned on
   required: false
   type: int
   default: 600
@@ -70,27 +42,20 @@ zone_run_time:
 
 ## {% linkable_title Controlling Your Device %}
 
-After Home Assistant loads, you will see new switches for every enabled program and zone. These work as expected:
+After Home Assistant loads, new switches will be added for every enabled
+program and zone. These work as expected:
 
 - Program On/Off: starts/stops a program
-- Zone On/Off: starts/stops a zone (using the `zone_run_time` parameter to determine how long to run for)
+- Zone On/Off: starts/stops a zone (using the `zone_run_time` parameter to
+determine how long to run for)
 
-Programs and zones are linked. If a program is running its final zone, you will see both the program and zone switches turned on; turning either one off will turn the other one off (just like in the web app).
-
-## {% linkable_title Weblink %}
-
-If you would like to see and control more detailed information, create an [iFrame](/components/panel_iframe/) that renders the RainMachine web app:
-
-```yaml
-panel_iframe:
-  rainmachine:
-    title: RainMachine
-    url: "https://my.rainmachine.com/s/<YOUR_DEVICE_ID>/ui/"
-    icon: mdi:water-pump
-```
-
-You can find `<YOUR_DEVICE_ID>` by logging into [https://my.rainmachine.com](https://my.rainmachine.com ) and taking note of the URL.
+Programs and zones are linked. If a program is running its final zone,
+you will see both the program and zone switches turned on; turning either one
+off will turn the other one off (just like in the web app).
 
 ## {% linkable_title For Awareness %}
 
-The remote RainMachine API currently has two broken operations (i.e., they return error codes): starting a program and stopping a program. Please note that starting/stopping programs with the remote API is disabled until RainMachine can fix the issue.
+The remote RainMachine API currently has two broken operations (i.e., they
+return error codes): starting a program and stopping a program. Please note
+that starting/stopping programs with the remote API is disabled until
+RainMachine can fix the issue.

--- a/source/_components/switch.rainmachine.markdown
+++ b/source/_components/switch.rainmachine.markdown
@@ -52,10 +52,3 @@ determine how long to run for)
 Programs and zones are linked. If a program is running its final zone,
 you will see both the program and zone switches turned on; turning either one
 off will turn the other one off (just like in the web app).
-
-## {% linkable_title For Awareness %}
-
-The remote RainMachine API currently has two broken operations (i.e., they
-return error codes): starting a program and stopping a program. Please note
-that starting/stopping programs with the remote API is disabled until
-RainMachine can fix the issue.

--- a/source/_components/switch.rainmachine.markdown
+++ b/source/_components/switch.rainmachine.markdown
@@ -22,28 +22,6 @@ configured to use this switch. After configuring that component, switches will
 automatically appear.
 </p>
 
-## {% linkable_title Configuring the Platform %}
-
-To optionally extend the functionality of these switches, augment your 
-`configuration.yaml` as below:
-
-```yaml
-rainmachine:
-  ip_address: 192.168.1.100
-  password: YOUR_PASSWORD
-  switches:
-    zone_run_time: 240
-```
-
-{% configuration %}
-zone_run_time:
-  description: the default number of seconds that a zone should run when turned on
-  required: false
-  type: int
-  default: 600
-{% endconfiguration %}
-
-
 ## {% linkable_title Controlling Your Device %}
 
 After Home Assistant loads, new switches will be added for every enabled
@@ -53,6 +31,6 @@ program and zone. These work as expected:
 - Zone On/Off: starts/stops a zone (using the `zone_run_time` parameter to
 determine how long to run for)
 
-Programs and zones are linked. If a program is running its final zone,
-you will see both the program and zone switches turned on; turning either one
-off will turn the other one off (just like in the web app).
+Programs and zones are linked. While a program is running, you will see both
+the program and zone switches turned on; turning either one off will turn the
+other one off (just like in the web app).

--- a/source/_components/switch.rainmachine.markdown
+++ b/source/_components/switch.rainmachine.markdown
@@ -18,17 +18,21 @@ within a [RainMachine smart Wi-Fi sprinkler controller](http://www.rainmachine.c
 
 <p class='note'>
 You must have the [RainMachine component](https://www.home-assistant.io/components/rainmachine/)
-configured to use this switch.
+configured to use this switch. After configuring that component, switches will
+automatically appear.
 </p>
 
 ## {% linkable_title Configuring the Platform %}
 
-To enable the platform, add the following lines to your `configuration.yaml`
-file:
+To optionally extend the functionality of these switches, augment your 
+`configuration.yaml` as below:
 
 ```yaml
-switch:
-  - platform: rainmachine
+rainmachine:
+  ip_address: 192.168.1.100
+  password: YOUR_PASSWORD
+  switches:
+    zone_run_time: 240
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:**
Adds docs necessary for moving RainMachine to component/hub model.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/14085

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
