### PR TITLE
Added new device classes to binary_sensor - HomeKit

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -194,7 +194,7 @@ The following components are currently supported:
 | Component | Type Name | Description |
 | --------- | --------- | ----------- |
 | alarm_control_panel | SecuritySystem | All security systems. |
-| binary_sensor | Sensor | Support for `CO2`, `Gas`, `Moisture`, `Motion`, `Occupancy`, `Opening` and `Smoke` device classes. Defaults to the `Occupancy` device class for everything else. |
+| binary_sensor | Sensor | Support for `co2`, `door`, `garage_door`, `gas`, `moisture`, `motion`, `occupancy`, `opening`, `smoke` and `window` device classes. Defaults to the `occupancy` device class for everything else. |
 | climate | Thermostat | All climate devices. |
 | cover | GarageDoorOpener | All covers that support `open` and `close` and have `garage` as their `device_class`. |
 | cover | WindowCovering | All covers that support `set_cover_position`. |


### PR DESCRIPTION
**Description:**
Added doc for new supported device classes for binary_sensor for the HomeKit component.
Also changed the device class names to lowercase.
Base set to `rc` since the parent PR was a `beta fix` and is already merged.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14051

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
