### PR TITLE
Update console log instructions

### DIFF
--- a/source/_components/device_tracker.tplink.markdown
+++ b/source/_components/device_tracker.tplink.markdown
@@ -41,7 +41,7 @@ For Archer C9 models running firmware version 150811 or later please use the enc
 2. Type in the password you use to login into the password field.
 3. Click somewhere else on the page so that the password field is not selected anymore.
 4. Open the JavaScript console of your browser (usually by pressing F12 and then clicking on "Console").
-5. Type ```document.getElementById("login-password").value;```.
+5. Type ```document.getElementById("login-password").value;``` or ```document.getElementById("pcPassword").value;```, depending on your firmware version.
 6. Copy the returned value to your Home Assistant configuration as password.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.tplink.markdown
+++ b/source/_components/device_tracker.tplink.markdown
@@ -41,7 +41,7 @@ For Archer C9 models running firmware version 150811 or later please use the enc
 2. Type in the password you use to login into the password field.
 3. Click somewhere else on the page so that the password field is not selected anymore.
 4. Open the JavaScript console of your browser (usually by pressing F12 and then clicking on "Console").
-5. Type ```document.getElementById("login-password").value;``` or ```document.getElementById("pcPassword").value;```, depending on your firmware version.
+5. Type `document.getElementById("login-password").value;` or `document.getElementById("pcPassword").value;`, depending on your firmware version.
 6. Copy the returned value to your Home Assistant configuration as password.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
**Description:**
Some firmware versions have changed the id in the DOM from login-password to pcPassword.

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
