### PR TITLE
Add room to google assistant config

### DIFF
--- a/source/cloud/google_assistant.markdown
+++ b/source/cloud/google_assistant.markdown
@@ -37,6 +37,7 @@ cloud:
         aliases:
          - bright lights
          - entry lights
+        room: living room
 ```
 
 {% configuration cloud %}
@@ -84,5 +85,8 @@ google_actions:
               description: Aliases that can also be used to refer to this entity
               required: false
               type: list
+            room:
+              description: Hint for Google Assistant in which room this entity is.
+              required: false
+              type: string
 {% endconfiguration %}
-


### PR DESCRIPTION
**Description:**
Allow configuring room hints for the Google Assistant skill via HASS Cloud.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/14180

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
