### PR TITLE
Fixing recursive call in cookbook

### DIFF
--- a/source/_cookbook/automation_flashing_lights.markdown
+++ b/source/_cookbook/automation_flashing_lights.markdown
@@ -97,6 +97,14 @@ script:
         service: homeassistant.turn_off
         data:
           entity_id: switch.REL1
+      - alias: loop_room1
+        service: script.turn_on
+        data:
+          entity_id: script.flash_loop
+
+  flash_loop:
+    alias: Flash loop
+    sequence:
       - delay:
           # time for flash light off
           seconds: 1


### PR DESCRIPTION
**Description:**

Recursive calling is not allowed in home assistant. Splitting the script up was necessary.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
