### PR TITLE
 Added ip_address to HomeKit

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -39,6 +39,10 @@ The `HomeKit` component allows you to forward entities from Home Assistant to Ap
         required: false
         type: int
         default: 51827
+      ip_address:
+        description: The local network IP address. Only necessary if the default from Home Assistant does not work.
+        required: false
+        type: string
       filter:
         description: Filter entities to available in the `Home` app. ([Configure Filter](#configure-filter))
         required: false


### PR DESCRIPTION
**Description:**
Added the `ip_address` option to the `HomeKit` doc. Parent PR is already merged. Replaces #5269.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14163

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
