### PR TITLE
Fix faulty link to AVM homepage

### DIFF
--- a/source/_components/fritzbox.markdown
+++ b/source/_components/fritzbox.markdown
@@ -13,7 +13,7 @@ ha_release: 0.68
 ha_iot_class: "Local Polling"
 ---
 
-The [AVM](www.avm.de) Fritzbox component for Home Assistant allows you to integrate the switch and climate devices.
+The [AVM](https://en.avm.de) Fritzbox component for Home Assistant allows you to integrate the switch and climate devices.
 
 #### {% linkable_title Tested Devices %}
 


### PR DESCRIPTION
**Description:**

The introductory text to the Fritz!Box component contained an inline link to the homepage of AVM (manufacturer). It was missing its `https://`, and therefore redirected internally, leading to a 404 error. I fixed the link, and replaced it with the international version of the site (as per #5270).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** not applicable.

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
