### PR TITLE
Calling out that devices are still added

### DIFF
--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -40,6 +40,10 @@ The following optional parameters can be used with any platform. However device 
 | `consider_home`      | 180     | Seconds to wait till marking someone as not home after not being seen. This parameter is most useful for households with Apple iOS devices that go into sleep mode while still at home to conserve battery life. iPhones will occasionally drop off the network and then re-appear. `consider_home` helps prevent false alarms in presence detection when using IP scanners such as Nmap. `consider_home` accepts various time representations, (e.g., the following all represents 3 minutes: `180`, `0:03`, `0:03:00`)  |
 | `new_device_defaults`|         | Default values for new discovered devices. Available options `track_new_devices` (default: `True`), `hide_if_away` (default: `False`)                                                                                                                                                                                                                                                     |
 
+<p class='note'>
+  Note that setting `track_new_devices: False` will still result in new devices being recorded in `known_devices.yaml`, but they won't be tracked (`track: no`).
+</p>
+
 The extended example from above would look like the following sample:
 
 ```yaml


### PR DESCRIPTION
It's a common source of confusion that with `track_new_devices: False` devices are still added to `known_devices.yaml`. This adds a note to say that this is to be expected.
