### PR TITLE
Update URL to Lets Encrypt blog

### DIFF
--- a/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
@@ -11,7 +11,7 @@ redirect_from: /cookbook/tls_self_signed_certificate/
 ---
 
 If your Home Assistant instance is only accessible from your local network you can still protect the communication between your browsers and the frontend with SSL/TLS. 
-[Let's encrypt]({{site_root}}/blog/2015/12/13/setup-encryption-using-lets-encrypt/) will only work if you have a DNS entry and remote access is allowed. 
+[Let's encrypt]({{site_root}}/blog/2017/09/27/effortless-encryption-with-lets-encrypt-and-duckdns/) will only work if you have a DNS entry and remote access is allowed. 
 The solution is to use a self-signed certificate. As you most likely don't have a certification authority (CA) your browser will complain about the security. If you have a CA then this will not be an issue.
 
 To create a certificate locally, you need the [OpenSSL](https://www.openssl.org/) command-line tool.


### PR DESCRIPTION
The current link takes you to a page which tells you it is outdated.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
