### PR TITLE
Add specific instructions for Meraki device tracker

### DIFF
--- a/source/_components/device_tracker.meraki.markdown
+++ b/source/_components/device_tracker.meraki.markdown
@@ -11,18 +11,21 @@ logo: meraki.png
 ha_category: Presence Detection
 ha_release: "0.60"
 ---
-Use your `Meraki AP` as device tracker. Note that Meraki will see all devices, not only connected to the network.
 
-### Config
+Use your Meraki AP as device tracker. Note that Meraki will see all devices, not only connected to the network.
 
-1. Go to Network-wide / General page, and find the Location and scanning section
-1. Make sure analytics and Scanning API are both enabled
-1. Make note of the Validator string, which will be used in the device_tracker config
-1. Click Add a Post URL
-    1. Set the Post URL to `https://{{YOUR HOSTNAME HERE}}/api/meraki?api_password={{YOUR HASS PASSWORD HERE}}`
-    1. Set the Secret to a randomly generated string, and make note of it for the device_tracker config
-    1. Make sure the API Version is set to `2.0`
-    1. Hit Save in the bottom right of the page
+### {% linkable_title Prerequisites %}
+
+1. Go to Network-wide/General page, and find the Location and scanning section.
+1. Make sure analytics and Scanning API are both enabled.
+1. Make note of the Validator string, which will be used in the `device_tracker` configuration.
+1. Click **Add a Post URL**:
+  1. Set the Post URL to `https://YOUR_HOSTNAME/api/meraki?api_password=YOUR_HASS_PASSWORD`
+  1. Set the Secret to a randomly generated string, and make note of it for the `device_tracker` configuration.
+  1. Make sure the API Version is set to `2.0`.
+  1. Hit **Save** in the bottom right of the page.
+
+## {% linkable_title Configuration %}
 
 After you configure access to the Meraki CMX API, add the following to your `configuration.yaml` file:
 
@@ -34,14 +37,13 @@ device_tracker:
     validator: meraki_validator
 ```
 
-
 {% configuration %}
   secret:
-    description: Secret code added in Meraki
+    description: Secret code added in Meraki.
     required: true
     type: string
   validator:
-    description: Validation string from Meraki
+    description: Validation string from Meraki.
     required: true
     type: string
 {% endconfiguration %}

--- a/source/_components/device_tracker.meraki.markdown
+++ b/source/_components/device_tracker.meraki.markdown
@@ -12,7 +12,17 @@ ha_category: Presence Detection
 ha_release: "0.60"
 ---
 Use your `Meraki AP` as device tracker. Note that Meraki will see all devices, not only connected to the network.
-Follow instructions [here](https://meraki.cisco.com/technologies/location-analytics-api) how to enable Location Analytics. 
+
+### Config
+
+1. Go to Network-wide / General page, and find the Location and scanning section
+1. Make sure analytics and Scanning API are both enabled
+1. Make note of the Validator string, which will be used in the device_tracker config
+1. Click Add a Post URL
+    1. Set the Post URL to `https://{{YOUR HOSTNAME HERE}}/api/meraki?api_password={{YOUR HASS PASSWORD HERE}}`
+    1. Set the Secret to a randomly generated string, and make note of it for the device_tracker config
+    1. Make sure the API Version is set to `2.0`
+    1. Hit Save in the bottom right of the page
 
 After you configure access to the Meraki CMX API, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
The current instructions aren't really complete, and require you to have both an understanding of how the Home Assistant API works, as well as be able to read through the code for the Meraki component to find the API endpoint you're supposed to use.
