### PR TITLE
Support control of away mode and hold mode in Venstar component

### DIFF
--- a/source/_components/climate.venstar.markdown
+++ b/source/_components/climate.venstar.markdown
@@ -25,7 +25,13 @@ Currently supported functionality:
 - Setting heat/cool temperature when the thermostat is in the appropriate mode.
 - Changing the operation mode of the thermostat (heat/cool/off/auto)
 - Turning the fan on/off
-- Setting the humidity level
+- Reading and setting the humidity level and limits
+- Turning away mode on/off
+- Turning hold mode on/off
+
+The following values are supported for the hold_mode state attribute:
+- `off`: *Enables* the scheduling functionality.
+- `temperature`: *Disables* the schedule and holds the set temperature indefinitely.
 
 Note - Please ensure you update your thermostat to the latest firmware. Currently tested on firmware 5.10.
 
@@ -61,6 +67,11 @@ timeout:
   required: false
   type: int
   default: 5
+humidifier:
+  description: Report humidity and expose humidifier setpoints.
+  required: false
+  type: boolean
+  default: true
 {% endconfiguration %}
 
 ## {% linkable_title Full configuration sample %}
@@ -74,4 +85,5 @@ climate:
     username: OPTIONAL_AUTH_USER_HERE
     password: OPTIONAL_AUTH_PASS_HERE
     timeout: 5
+    humidifier: False
 ```


### PR DESCRIPTION
**Description:**
This PR documents the changes implemented in home assistant PR #14256: 
Support control of away mode and hold mode in Venstar component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14256

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
