### PR TITLE
Updated sensor device_classes

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -206,7 +206,7 @@ The following components are currently supported:
 | sensor | HumiditySensor | All sensors that have `%` as their `unit_of_measurement` or `humidity` as their `device_class`. |
 | sensor | AirQualitySensor | All sensors that have `pm25` as part of their `entity_id` or `pm25` as their `device_class` |
 | sensor | CarbonDioxideSensor | All sensors that have `co2` as part of their `entity_id` or `co2` as their `device_class` |
-| sensor | LightSensor | All sensors that have `lm`/`lux` as their `unit_of_measurement` or `light` as their `device_class` |
+| sensor | LightSensor | All sensors that have `lm` or `lx` as their `unit_of_measurement` or `illuminance` as their `device_class` |
 | switch / remote / input_boolean / script | Switch | All represented as switches. |
 
 

--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -20,7 +20,7 @@ The way these sensors are displayed in the frontend can be modified in the [cust
 - **None**: Generic sensor. This is the default and doesn't need to be set.
 - **battery**: Percentage of battery that is left.
 - **humidity**: Percentage of humidity in the air.
-- **light**: The current light level in lx or lm.
+- **illuminance**: The current light level in lx or lm.
 - **temperature**: Temperature in °C or °F.
 
 <p class='img'>

--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -20,6 +20,7 @@ The way these sensors are displayed in the frontend can be modified in the [cust
 - **None**: Generic sensor. This is the default and doesn't need to be set.
 - **battery**: Percentage of battery that is left.
 - **humidity**: Percentage of humidity in the air.
+- **light**: The current light level in lx, lm or lux.
 - **temperature**: Temperature in °C or °F.
 
 <p class='img'>

--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -20,7 +20,7 @@ The way these sensors are displayed in the frontend can be modified in the [cust
 - **None**: Generic sensor. This is the default and doesn't need to be set.
 - **battery**: Percentage of battery that is left.
 - **humidity**: Percentage of humidity in the air.
-- **light**: The current light level in lx, lm or lux.
+- **light**: The current light level in lx or lm.
 - **temperature**: Temperature in °C or °F.
 
 <p class='img'>


### PR DESCRIPTION
**Description:**
Added doc for `light` device_class.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14282

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
