### PR TITLE
Additional troubleshooting step to fix PIN error

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -242,7 +242,7 @@ logger:
 
 ## {% linkable_title Troubleshooting PIN not appearing %}
 
-In some instances, the PIN will not appear as a persistant status or in the log files despite deleting .homekit.state, enabling logging, and reboot.
+In some instances, the PIN will not appear as a persistant status or in the log files despite deleting .homekit.state, enabling logging, and reboot.  The log files will include the error ```Duplicate AID found when attempting to add accessory```.
 
 In such cases, modifying your configuration.yaml to add a filter limiting the included entities similar to the folowing:
 

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -242,9 +242,9 @@ logger:
 
 ## {% linkable_title Troubleshooting PIN not appearing %}
 
-In some instances, the PIN will not appear as a persistant status or in the log files despite deleting .homekit.state, enabling logging, and reboot.  The log files will include the error ```Duplicate AID found when attempting to add accessory```.
+In some instances, the PIN will not appear as a persistent status or in the log files despite deleting `.homekit.state`, enabling logging, and reboot.  The log files will include the error ```Duplicate AID found when attempting to add accessory```.
 
-In such cases, modifying your configuration.yaml to add a filter limiting the included entities similar to the folowing:
+In such cases, modifying your configuration.yaml to add a filter limiting the included entities similar to the following:
 
 ```yaml
 filter:
@@ -252,4 +252,4 @@ filter:
     - light
 ```
 
-Restart Home-Assistant and re-attempt pairing - a persistant status should now properly appear.
+Restart Home-Assistant and re-attempt pairing - a persistent status should now correctly appear.

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -239,3 +239,17 @@ logger:
    - The configuration entries for `homekit` and the `component` that is causing the issue.
    - The log / traceback you have generated before.
    - Screenshots of the failing entity in the `states` panel.
+
+## {% linkable_title Troubleshooting PIN not appearing %}
+
+In some instances, the PIN will not appear as a persistant status or in the log files despite deleting .homekit.state, enabling logging, and reboot.
+
+In such cases, modifying your configuration.yaml to add a filter limiting the included entities similar to the folowing:
+
+```yaml
+filter:
+  include_domains:
+    - light
+```
+
+Restart Home-Assistant and re-attempt pairing - a persistant status should now properly appear.


### PR DESCRIPTION
Persistent notification of PIN doesn't appear when too many entities are included on initial start.  Adding a filter allows the PIN to properly present.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
