### PR TITLE
Discovery info for nanoleaf aurora panels

### DIFF
--- a/source/_components/light.nanoleaf_aurora.markdown
+++ b/source/_components/light.nanoleaf_aurora.markdown
@@ -16,7 +16,11 @@ ha_release: 0.67
 
 ### {% linkable_title Configuration Sample %}
 
-To enable the Aurora lights, add the following lines to your `configuration.yaml` file:
+The `nanoleaf_aurora` platform allows you to control [Nanoleaf Aurora Light Panels](https://nanoleaf.me) from Home Assistant.
+
+The preferred way to set up this platform is by enabling the [discovery component](https://www.home-assistant.io/components/discovery/). Make sure to press and hold the *ON* button for 5 seconds (the LED will start flashing) on your Nanoleaf Aurora Panel while Home Assistant is starting.
+
+To configure the Aurora lights manually, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
**Description:** Added discovery to the nanoleaf aurora platform, still needs one manual step unfortunately (to press and hold the on button on the panel while discovery takes place)


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14301
## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
