### PR TITLE
synology reverse proxy: add template patch

### DIFF
--- a/source/_docs/ecosystem/synology.markdown
+++ b/source/_docs/ecosystem/synology.markdown
@@ -10,11 +10,29 @@ footer: true
 redirect_from: /ecosystem/synology/
 ---
 
-Synology NAS are the perfect companion to running Home Assistant.
+Synology NAS are the perfect companion to running Home Assistant. But by default, the DSM Reverse Proxy does not configure its Nginx settings to allow WebSocket, and some extra configuration will be required to get the Home Assistant frontend working with the DSM.
 
-### {% linkable_title HTTP Configuration %}
+### {% linkable_title Template change %}
 
-Synology will require some extra configuration to get the Home Assistant frontend working.
+To allow Websocket by default for all service exposed by Nginx, you can enable it in the template file located in `/usr/syno/share/nginx/Portal.mustache`. Please be really careful in editing this file since you may break access to the DSM UI. Please backup this file before any edition.
+
+Open `/usr/syno/share/nginx/Portal.mustache` and add the followings in the `Location` section:
+```
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 86400;
+```
+
+Then restart the nginx with:
+```bash
+sudo synoservicecfg --restart nginx
+```
+This will restart ALL http service running, not only reverse proxy, as a single instance of NGinX runs everything.
+
+You can find more information [here](https://github.com/orobardet/dsm-reverse-proxy-websocket)
+
+
+#### {% linkable_title HTTP Configuration %}
 
 - Copy the Home Assistant specific Reverse Proxy settings from the existing `/etc/nginx/app.d/server.ReverseProxy.conf` to `/usr/local/etc/nginx/conf.d/http.HomeAssistant.conf`
 - Include these lines in the location declaration:

--- a/source/_docs/ecosystem/synology.markdown
+++ b/source/_docs/ecosystem/synology.markdown
@@ -10,31 +10,33 @@ footer: true
 redirect_from: /ecosystem/synology/
 ---
 
-Synology NAS are the perfect companion to running Home Assistant. But by default, the DSM Reverse Proxy does not configure its Nginx settings to allow WebSocket, and some extra configuration will be required to get the Home Assistant frontend working with the DSM.
+Synology NAS are the perfect companion to running Home Assistant. But by default, the DSM Reverse Proxy does not configure its NGINX settings to allow WebSocket, and some extra configuration will be required to get the Home Assistant frontend working with the DSM.
 
 ### {% linkable_title Template change %}
 
-To allow Websocket by default for all service exposed by Nginx, you can enable it in the template file located in `/usr/syno/share/nginx/Portal.mustache`. Please be really careful in editing this file since you may break access to the DSM UI. Please backup this file before any edition.
+To allow WebSocket by default for all service exposed by NGINX, you can enable it in the template file located in `/usr/syno/share/nginx/Portal.mustache`. Please be really careful in editing this file since you may break access to the DSM UI. Please backup this file before any edition.
 
 Open `/usr/syno/share/nginx/Portal.mustache` and add the followings in the `Location` section:
+
 ```
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 86400;
 ```
 
-Then restart the nginx with:
+Then restart the NGINX daemon:
+
 ```bash
 sudo synoservicecfg --restart nginx
 ```
-This will restart ALL http service running, not only reverse proxy, as a single instance of NGinX runs everything.
 
-You can find more information [here](https://github.com/orobardet/dsm-reverse-proxy-websocket)
+This will restart the running HTTP service, not only reverse proxy, as a single instance of NGINX runs everything.
 
+You can find more information [here](https://github.com/orobardet/dsm-reverse-proxy-websocket).
 
 #### {% linkable_title HTTP Configuration %}
 
-- Copy the Home Assistant specific Reverse Proxy settings from the existing `/etc/nginx/app.d/server.ReverseProxy.conf` to `/usr/local/etc/nginx/conf.d/http.HomeAssistant.conf`
+- Copy the Home Assistant specific Reverse Proxy settings from the existing `/etc/nginx/app.d/server.ReverseProxy.conf` file to `/usr/local/etc/nginx/conf.d/http.HomeAssistant.conf`.
 - Include these lines in the location declaration:
 
 ```


### PR DESCRIPTION
instruction from orobardet/dsm-reverse-proxy-websocket works with recent version of DSM. Current documentation does not seem to work