### PR TITLE
Change to advertise esphomeyaml

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -56,7 +56,7 @@ The `<node_id>` level can be used by clients to only subscribe to their own (com
 The following firmware for ESP8266, ESP32 and Sonoff unit has built-in support for MQTT discovery:
 
 - [Sonoff-Tasmota](https://github.com/arendst/Sonoff-Tasmota) (starting with 5.11.1e)
-- [esphomelib](https://github.com/OttoWinter/esphomelib)
+- [esphomeyaml](https://esphomelib.com/esphomeyaml/index.html)
 - [ESPurna](https://github.com/xoseperez/espurna)
 - [Arilux AL-LC0X LED controllers](https://github.com/mertenats/Arilux_AL-LC0X)
 


### PR DESCRIPTION
**Description:**

The MQTT discovery docs pointed to [esphomelib](https://github.com/OttoWinter/esphomelib). But since that was added in the docs I released another, easier-to-use project called [esphomeyaml](https://esphomelib.com/esphomeyaml/index.html). Basically, it creates custom firmwares for ESP8266/ESP32 nodes from YAML configuration files.

So on the MQTT discovery site, I'd like to advertise esphomeyaml. There's another link to esphomelib on the MQTT JSON Light page. But, as the people navigating to that component page probably prefer customizability, I think keeping the link esphomelib there is fine.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
