### PR TITLE
Fix Templates URL and other minor format issues

### DIFF
--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -92,7 +92,7 @@ In this section you find some real life examples of how to use this sensor.
 
 ### {% linkable_title JSON attributes configuration %}
 
-The example sensor below shows a configuration example which uses JSON in the state topic to add extra attributes. It also makes use of the availability topic. Attributes can then be extracted in [Templates](/docs/configuration/templating/#attributes); Example to extract data from the sensor below {% raw %}'{{ state_attr('sensor.bs_client_name', 'ClientName') }}'{% endraw %}.
+The example sensor below shows a configuration example which uses JSON in the state topic to add extra attributes. It also makes use of the availability topic. Attributes can then be extracted in [Templates](/docs/configuration/templating/#attributes). For example, to extract the `ClientName` attribute from the sensor below, use a template similar to: {% raw %}`{{ state_attr('sensor.bs_rssi', 'ClientName') }}`{% endraw %}.
 
 {% raw %}
 ```yaml

--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -19,7 +19,7 @@ This `mqtt` sensor platform uses the MQTT message payload as the sensor value. I
 To use your MQTT sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: mqtt
     state_topic: "home/bedroom/temperature"
@@ -92,17 +92,17 @@ In this section you find some real life examples of how to use this sensor.
 
 ### {% linkable_title JSON attributes configuration %}
 
-The example sensor below shows a configuration example which uses JSON in the state topic to add extra attributes. It also makes use of the availability topic. Attributes can then be extracted in [Templates](configuration/templating/#attributes); Example to extract data from the sensor below {% raw %}'{{ states.sensor.bs_client_name.attributes.ClientName }}'{% endraw %}.
+The example sensor below shows a configuration example which uses JSON in the state topic to add extra attributes. It also makes use of the availability topic. Attributes can then be extracted in [Templates](/docs/configuration/templating/#attributes); Example to extract data from the sensor below {% raw %}'{{ state_attr('sensor.bs_client_name', 'ClientName') }}'{% endraw %}.
 
 {% raw %}
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: mqtt
-    state_topic: "HUISHS/BunnyShed/NodeHealthJSON"
     name: "BS RSSI"
-    unit_of_measurement: "dBm"
-    value_template: '{{ value_json.RSSI }}'
+    state_topic: "HUISHS/BunnyShed/NodeHealthJSON"
+    unit_of_measurement: 'dBm'
+    value_template: "{{ value_json.RSSI }}"
     availability_topic: "HUISHS/BunnyShed/status"
     payload_available: "online"
     payload_not_available: "offline"
@@ -118,7 +118,7 @@ sensor:
 
 ### {% linkable_title Get battery level %}
 
-If you are using the [Owntracks](/components/device_tracker.owntracks/) and enable the reporting of the battery level then you can use a MQTT sensor to keep track of your battery. A regular MQTT message from Owntracks looks like this: 
+If you are using the [OwnTracks](/components/device_tracker.owntracks/) and enable the reporting of the battery level then you can use a MQTT sensor to keep track of your battery. A regular MQTT message from OwnTracks looks like this: 
 
 ```bash
 owntracks/tablet/tablet {"_type":"location","lon":7.21,"t":"u","batt":92,"tst":144995643,"tid":"ta","acc":27,"lat":46.12}
@@ -128,13 +128,13 @@ Thus the trick is extracting the battery level from the payload.
 
 {% raw %}
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: mqtt
-    state_topic: "owntracks/tablet/tablet"
     name: "Battery Tablet"
-    unit_of_measurement: "%"
-    value_template: '{{ value_json.batt }}'
+    state_topic: "owntracks/tablet/tablet"
+    unit_of_measurement: '%'
+    value_template: "{{ value_json.batt }}"
 ```
 {% endraw %}
 
@@ -154,18 +154,18 @@ Then use this configuration example to extract the data from the payload:
 
 {% raw %}
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: mqtt
-    state_topic: 'office/sensor1'
-    name: 'Temperature'
+    name: "Temperature"
+    state_topic: "office/sensor1"
     unit_of_measurement: '°C'
-    value_template: '{{ value_json.temperature }}'
+    value_template: "{{ value_json.temperature }}"
   - platform: mqtt
-    state_topic: 'office/sensor1'
-    name: 'Humidity'
+    name: "Humidity"
+    state_topic: "office/sensor1"
     unit_of_measurement: '%'
-    value_template: '{{ value_json.humidity }}'
+    value_template: "{{ value_json.humidity }}"
 ```
 {% endraw %}
 
@@ -190,10 +190,10 @@ The configuration will look like the example below:
 
 {% raw %}
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: mqtt
-    state_topic: 'home/bathroom/analog/brightness'
-    name: Brightness
+    name: "Brightness"
+    state_topic: "home/bathroom/analog/brightness"
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**
Templates URL under JSON Attributes Configuration header was pointed to an invalid location.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
