### PR TITLE
Fix typos in file name

### DIFF
--- a/source/_components/binary_sensor.modbus.markdown
+++ b/source/_components/binary_sensor.modbus.markdown
@@ -15,10 +15,12 @@ ha_iot_class: "Local Push"
 
 The `modbus` binary sensor allows you to gather data from [Modbus](http://www.modbus.org/) coils.
 
+## {% linkable_title Configuration %}
+
 To use your Modbus binary sensors in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 binary_sensor:
   - platform: modbus
     coils:
@@ -39,7 +41,7 @@ Configuration variables:
   
 It's possible to change the default 30 seconds scan interval for the sensor updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.
 
-### {% linkable_title Full example %}
+## {% linkable_title Full example %}
 
 Example a sensor with a 10 seconds scan interval:
 

--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -133,7 +133,7 @@ The configuration will look like the example below:
 
 {% raw %}
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 binary_sensor:
   - platform: mqtt
     name: Bathroom

--- a/source/_components/binary_sensor.pilight.markdown
+++ b/source/_components/binary_sensor.pilight.markdown
@@ -15,10 +15,12 @@ ha_iot_class: "Local Polling"
 
 The `pilight` binary sensor platform implement the [pilight hub](/components/pilight/) binary sensor functionality. Two type of Pilight binary sensor configuration available. A normal sensor which send the on and off state cyclical and a trigger sensor which send only a trigger when an event happened (for example lots of cheap PIR motion detector).
 
+
+
 To enable a Pilight binary sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 binary_sensor:
   - platform: pilight
     variable: 'state'

--- a/source/_components/climate.modbus.markdown
+++ b/source/_components/climate.modbus.markdown
@@ -14,20 +14,20 @@ ha_iot_class: "Local Polling"
 ---
 
 
-The `modbus` thermostat allows you to use a sensor value (current temperature)
-and target value (target temperature) from [Modbus](http://www.modbus.org/)
-registers.
+The `modbus` thermostat allows you to use a sensor value (current temperature) and target value (target temperature) from [Modbus](http://www.modbus.org/) registers.
+
+## {% linkable_title Configuration %}
 
 To use your Modbus thermostat in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
+# Example configuration.yaml entry
 climate:
   - platform: modbus
     name: Watlow F4T
     slave: 1
     target_temp_register: 2782
     current_temp_register: 27586
-
 ```
 
 {% configuration %}
@@ -49,17 +49,18 @@ current_temp_register:
   type: int
 data_type:
   description: Response representation (int, uint, float, custom). If float selected, value will converted to IEEE 754 floating point format.
-    Default float.
   required: false
   type: string
+  default: float
 count:
   description: Number of registers to read.
   required: false
   type: int
 precision:
-  description: Number of valid decimals, default 0.
+  description: Number of valid decimals.
   required: false
   type: int
+  default: 0
 {% endconfiguration %}
 
 

--- a/source/_components/cover.gogogate2.markdown
+++ b/source/_components/cover.gogogate2.markdown
@@ -20,7 +20,7 @@ The `gogogate2` cover platform lets you control Gogogate2-Enabled garage doors t
 To use your Gogogate2 cover in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 cover:
   - platform: gogogate2
     username: email@email.com

--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -15,6 +15,8 @@ ha_release: 0.18
 
 The `mqtt` cover platform allows you to control an MQTT cover (such as blinds, a rollershutter, or a garage door).
 
+## {% linkable_title Configuration %}
+
 The device state (`open` or `closed`) will be updated only after a new message is published on `state_topic` matching `state_open` or `state_closed`. If these messages are published with the `retain` flag set, the cover will receive an instant state update after subscription and Home Assistant will display the correct state on startup. Otherwise, the initial state displayed in Home Assistant will be `unknown`.
 
 There is an attribute that stores the relative position of the device, where 0 means the device is `closed` and all other intermediate positions means the device is `open`.
@@ -164,7 +166,7 @@ In this section you will find some real life examples of how to use this platfor
 The example below shows a full configuration for a cover without tilt.
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 cover:
   - platform: mqtt
     name: "MQTT Cover"
@@ -188,8 +190,9 @@ cover:
 
 The example below shows a full configuration for a cover.
 
+{% raw %}
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 cover:
   - platform: mqtt
     name: "MQTT Cover"
@@ -206,7 +209,7 @@ cover:
     payload_available: "online"
     payload_not_available: "offline"
     optimistic: false
-    value_template: '{% raw %}{{ value.x }}{% endraw %}'
+    value_template: '{{ value.x }}'
     tilt_command_topic: 'home-assistant/cover/tilt'
     tilt_status_topic: 'home-assistant/cover/tilt-state'
     tilt_min: 0
@@ -214,6 +217,7 @@ cover:
     tilt_closed_value: 70
     tilt_opened_value: 180
 ```
+{% endraw %}
 
 To test, you can use the command line tool `mosquitto_pub` shipped with `mosquitto` or the `mosquitto-clients` package to send MQTT messages. This allows you to operate your cover manually:
 

--- a/source/_components/cover.myq.markdown
+++ b/source/_components/cover.myq.markdown
@@ -15,10 +15,12 @@ ha_iot_class: Cloud Polling
 
 The `myq` cover platform lets you control MyQ-Enabled garage doors through Home Assistant. Device names in Home Assistant are generated based on the names defined in your MyQ Device mobile app.
 
+## {% linkable_title Configuration %}
+
 To use your MyQ cover in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 cover:
   - platform: myq
     username: YOUR_USERNAME

--- a/source/_components/device_tracker.fritz.markdown
+++ b/source/_components/device_tracker.fritz.markdown
@@ -15,6 +15,8 @@ ha_release: "0.10"
 
 The `fritz` platform offers presence detection by looking at connected devices to a [AVM Fritz!Box](http://avm.de/produkte/fritzbox/) based router.
 
+## {% linkable_title Configuration %}
+
 <p class='note warning'>
 It might be necessary to install additional packages: <code>$ sudo apt-get install libxslt-dev libxml2-dev python3-lxml</code>
 If you are working with the All-in-One installation, you may also need to execute also within your virtual environment the command <code> pip install lxml</code>; be patient this will take a while.</p>

--- a/source/_components/discoverable.markdown
+++ b/source/_components/discoverable.markdown
@@ -23,7 +23,7 @@ for state in hass.states():
 To enable `discovery` in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 discoverable:
   expose_password: yes
 ```

--- a/source/_components/fan.mqtt.markdown
+++ b/source/_components/fan.mqtt.markdown
@@ -15,6 +15,8 @@ ha_iot_class: depends
 
 The `mqtt` fan platform lets you control your MQTT enabled fans.
 
+## {% linkable_title Configuration %}
+
 In an ideal scenario, the MQTT device will have a `state_topic` to publish state changes. If these messages are published with a `RETAIN` flag, the MQTT fan will receive an instant state update after subscription and will start with the correct state. Otherwise, the initial state of the fan will be `false` / `off`.
 
 When a `state_topic` is not available, the fan will work in optimistic mode. In this mode, the fan will immediately change state after every command. Otherwise, the fan will wait for state confirmation from the device (message from `state_topic`).
@@ -24,7 +26,7 @@ Optimistic mode can be forced even if a `state_topic` is available. Try to enabl
 To enable MQTT fans in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 fan:
   - platform: mqtt
     command_topic: "bedroom_fan/on/set"
@@ -155,7 +157,7 @@ In this section you find some real life examples of how to use this fan.
 The example below shows a full configuration for a MQTT fan.
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 fan:
   - platform: mqtt
     name: "Bedroom Fan"

--- a/source/_components/fritzbox.markdown
+++ b/source/_components/fritzbox.markdown
@@ -35,21 +35,21 @@ fritzbox:
 ```
 
 {% configuration %}
-  devices:
-    description: A list of Fritzbox devices.
-    required: true
-    type: map
-    keys:
-      host:
-        description: The hostname or IP address of the Fritzbox.
-        required: true
-        type: optional
-      username:
-        description: The username for Smart Home access.
-        required: true
-        type: string
-      password:
-        description: The password of the user.
-        required: true
-        type: string
+devices:
+  description: A list of Fritzbox devices.
+  required: true
+  type: map
+  keys:
+    host:
+      description: The hostname or IP address of the Fritzbox.
+      required: true
+      type: optional
+    username:
+      description: The username for Smart Home access.
+      required: true
+      type: string
+    password:
+      description: The password of the user.
+      required: true
+      type: string
 {% endconfiguration %}

--- a/source/_components/juicenet.markdown
+++ b/source/_components/juicenet.markdown
@@ -15,10 +15,12 @@ ha_release: 0.47
 
 The `juicenet` sensor platform pulls data from a [JuiceNet](https://emotorwerks.com/products/juicenet/) charging station equipped with a wifi connection. It will access and make available all of the devices attached to your account.
 
+## {% linkable_title Configuration %}
+
 To enable the platform in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 juicenet:
     access_token: ACCESS_TOKEN
 ```

--- a/source/_components/light.mochad.markdown
+++ b/source/_components/light.mochad.markdown
@@ -11,13 +11,14 @@ ha_category: Light
 ha_release: 0.51
 ---
 
-The `mochad` light platform lets you control an X10 enabled dimmer/light
-device.
+The `mochad` light platform lets you control an X10 enabled dimmer/light device.
+
+
 
 To enable this sensor, you first have to set up the [mochad component](/components/mochad/) and then add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 light:
   - platform: mochad
     devices:

--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -14,6 +14,8 @@ ha_iot_class: depends
 
 The `mqtt` light platform lets you control your MQTT enabled lights. It supports setting brightness, color temperature, effects, flashing, on/off, RGB colors, transitions, XY colors and white values.
 
+## {% linkable_title Configuration %}
+
 In an ideal scenario, the MQTT device will have a state topic to publish state changes. If these messages are published with a `RETAIN` flag, the MQTT light will receive an instant state update after subscription and will start with the correct state. Otherwise, the initial state of the switch will be `false` / `off`.
 
 When a state topic is not available, the light will work in optimistic mode. In this mode, the light will immediately change state after every command. Otherwise, the light will wait for state confirmation from the device (message from `state_topic`).
@@ -21,7 +23,7 @@ When a state topic is not available, the light will work in optimistic mode. In 
 Optimistic mode can be forced, even if the `state_topic` is available. Try to enable it, if experiencing incorrect light operation.
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 light:
   - platform: mqtt
     command_topic: "office/rgb1/light/switch"
@@ -206,7 +208,7 @@ To enable a light with brightness and RGB support in your installation, add the 
 
 {% raw %}
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 light:
   - platform: mqtt
     name: "Office Light RGB"
@@ -231,7 +233,7 @@ light:
 To enable a light with brightness (no RGB version) in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 light:
   - platform: mqtt
     name: "Office light"
@@ -250,7 +252,7 @@ light:
 To enable a light that sends only brightness topics to turn it on, add the following to your `configuration.yaml` file. The `command_topic` is only used to send an off command in this case:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 light:
   - platform: mqtt
     name: "Brightness light"

--- a/source/_components/lock.mqtt.markdown
+++ b/source/_components/lock.mqtt.markdown
@@ -24,7 +24,7 @@ Optimistic mode can be forced, even if state topic is available. Try to enable i
 To enable MQTT locks in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 lock:
   - platform: mqtt
     command_topic: "home/frontdoor/set"

--- a/source/_components/mochad.markdown
+++ b/source/_components/mochad.markdown
@@ -13,6 +13,8 @@ ha_release: 0.32
 
 The `mochad` component is the main component to integrate all X10 platforms being controlled by [mochad](https://sourceforge.net/projects/mochad/). Besides this component you will have to setup your X10 devices separately.
 
+## {% linkable_title Configuration %}
+
 To integrate your Mochad units with Home Assistant, add the following section to your `configuration.yaml` file:
 
 ```yaml
@@ -20,10 +22,20 @@ To integrate your Mochad units with Home Assistant, add the following section to
 mochad:
 ```
 
-Configuration variables:
+{% configuration %}
+host:
+  description: The host that mochad is running on.
+  required: false
+  type: string
+  default: localhost
+port:
+  description: The port that mochad is running on.
+  required: false
+  type: int
+  default: 1099
+{% endconfiguration %}
 
-- **host** (*Optional*): The host that mochad is running on. Defaults to `localhost`.
-- **port** (*Optional*): The port that mochad is running on. Defaults to `1099`.
+## {% linkable_title Example %}
 
 A full configuration sample could look like the one below:
 

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -16,6 +16,8 @@ ha_iot_class: "Local Push"
 
 [Modbus](http://www.modbus.org/) is a serial communication protocol to control PLCs (Programmable logic controller). It currently supports sensors and switches which can be controlled over serial, TCP, and UDP connections.
 
+## {% linkable_title Configuration %}
+
 To add modbus to your installation, add the following to your `configuration.yaml` file:
 
 For a network connection:

--- a/source/_components/pilight.markdown
+++ b/source/_components/pilight.markdown
@@ -19,6 +19,8 @@ This pilight hub connects to the [pilight-daemon](https://manual.pilight.org/pro
 
 The received and supported RF codes are put on the event bus of Home Assistant and are therefore directly usable by other components (e.g., automation). Additionally a send service is provided to send RF codes.
 
+## {% linkable_title Configuration %}
+
 To integrate pilight into Home Assistant, add the following section to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_components/sensor.fritzbox_callmonitor.markdown
+++ b/source/_components/sensor.fritzbox_callmonitor.markdown
@@ -14,9 +14,10 @@ ha_iot_class: "Local Polling"
 ---
 
 
-The `fritzbox_callmonitor` sensor monitors the call monitor exposed by [AVM Fritz!Box](http://avm.de/produkte/fritzbox/) routers
-on TCP port 1012. It will assume the values `idle`, `ringing`, `dialing`, or `talking` with the phone numbers involved contained in the state attributes.
+The `fritzbox_callmonitor` sensor monitors the call monitor exposed by [AVM Fritz!Box](http://avm.de/produkte/fritzbox/) routers on TCP port 1012. It will assume the values `idle`, `ringing`, `dialing` or `talking` with the phone numbers involved contained in the state attributes.
 It can also access the internal phone book of the router to look up the names corresponding to the phone numbers and store them in the state attributes.
+
+## {% linkable_title Configuration %}
 
 To activate the call monitor on your Fritz!Box, dial #96\*5\* from any phone connected to it.
 
@@ -44,7 +45,7 @@ Configuration variables:
 The example below shows a full configuration for a call monitor with phone book support.
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: fritzbox_callmonitor
     name: Phone
@@ -61,8 +62,9 @@ sensor:
 
 This example shows how to send notifications whenever the sensor's state changes. You will get notified both when you receive a call and also when a call is placed.
 
+{% raw %}
 ```yaml
-# Example configuration.yml entry.
+# Example configuration.yaml entry.
 automation:
   - alias: "Notify about phone state"
     trigger:
@@ -73,7 +75,7 @@ automation:
         data:
           title: "Phone"
           message: >-
-            {% raw %}{% if is_state("sensor.phone", "idle") %}
+            {% if is_state("sensor.phone", "idle") %}
               Phone is idle
             {% elif is_state("sensor.phone", "dialing") %}
               Calling {{ states.sensor.phone.attributes.to_name }} ({{ states.sensor.phone.attributes.to }})
@@ -81,5 +83,6 @@ automation:
               Incoming call from {{ states.sensor.phone.attributes.from_name }} ({{ states.sensor.phone.attributes.from }})
             {% else %}
               Talking to {{ states.sensor.phone.attributes.with_name }} ({{ states.sensor.phone.attributes.with }})
-            {% endif %}{% endraw %}
+            {% endif %}
 ```
+{% endraw %}

--- a/source/_components/sensor.gitter.markdown
+++ b/source/_components/sensor.gitter.markdown
@@ -15,19 +15,27 @@ ha_release: 0.47
 
 This `gitter` sensor allows one to monitor a [Gitter.im](https://gitter.im) chatroom for unread messages.
 
+## {% linkable_title Configuration %}
+
 Visit [Gitter Developer Apps](https://developer.gitter.im/apps) to retrieve your "Personal Access Token".
 
 To use a Gitter sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: gitter
     api_key: YOUR_API_TOKEN
 ```
 
-Configuration variables:
-
-- **api_key** (*Required*): Your Gitter.im API token.
-- **room** (*Optional*): Gitter room to monitor. Defaults to `home-assistant/home-assistant`
-
+{% configuration %}
+api_key:
+  description: Your Gitter.im API token.
+  required: true
+  type: string
+room:
+  description: Gitter room to monitor.
+  required: false
+  type: string
+  default: home-assistant/home-assistant
+{% endconfiguration %}

--- a/source/_components/sensor.modbus.markdown
+++ b/source/_components/sensor.modbus.markdown
@@ -16,10 +16,12 @@ ha_iot_class: "Local Push"
 
 The `modbus` sensor allows you to gather data from [Modbus](http://www.modbus.org/) registers.
 
+## {% linkable_title Configuration %}
+
 To use your Modbus sensors in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   platform: modbus
   registers:

--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -16,6 +16,8 @@ ha_iot_class: depends
 
 This `mqtt` sensor platform uses the MQTT message payload as the sensor value. If messages in this `state_topic` are published with *RETAIN* flag, the sensor will receive an instant update with last known value. Otherwise, the initial state will be undefined.
 
+## {% linkable_title Configuration %}
+
 To use your MQTT sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_components/sensor.mqtt_room.markdown
+++ b/source/_components/sensor.mqtt_room.markdown
@@ -16,6 +16,8 @@ ha_iot_class: depends
 
 The `mqtt_room` sensor platform allows you to detect the indoor location of devices using MQTT clients.
 
+## {% linkable_title Configuration %}
+
 To use this device tracker in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_components/sensor.mvglive.markdown
+++ b/source/_components/sensor.mvglive.markdown
@@ -16,6 +16,8 @@ ha_iot_class: "Cloud Polling"
 
 The `mvglive` sensor will give you the departure time of the next bus, tram, subway, or train at the next station or stop in the Munich public transport network. Additional details such as the line number and destination are present in the attributes.
 
+## {% linkable_title Configuration %}
+
 To enable this sensor, add the following lines to your `configuration.yaml` file:
 
 ```yaml
@@ -42,7 +44,7 @@ Configuration variables:
 The example below shows a full configuration with three sensors that showcase the various configuration options.
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: mvglive
     nextdeparture:

--- a/source/_components/sensor.openevse.markdown
+++ b/source/_components/sensor.openevse.markdown
@@ -16,10 +16,12 @@ ha_iot_class: "Local Polling"
 
 This `openevse` sensor platform pulls data from an [OpenEVSE](https://www.openevse.com/) Charging station equipped with an ESP8266-based wifi connection.
 
+## {% linkable_title Configuration %}
+
 To enable this sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: openevse
     host: IP_ADDRESS

--- a/source/_components/sensor.pilight.markdown
+++ b/source/_components/sensor.pilight.markdown
@@ -16,10 +16,12 @@ ha_iot_class: depends
 
 This `pilight` sensor platform for 433 MHz devices uses a value in the message payload as the sensor value. Unique identifiers (e.g., _uuid_) can be set to distinguish between multiple pilight devices. To use a pilight sensor the pilight Home Assistant hub has to be set up.
 
+## {% linkable_title Configuration %}
+
 To use your sensor via pilight, make sure it is [supported](https://wiki.pilight.org/doku.php/protocols) and add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: pilight
     variable: temperature

--- a/source/_components/sensor.qnap.markdown
+++ b/source/_components/sensor.qnap.markdown
@@ -16,10 +16,12 @@ ha_iot_class: "Local Polling"
 
 This `qnap` sensor allows getting various statistics from your [QNAP NAS](https://www.qnap.com/en-us/).
 
+## {% linkable_title Configuration %}
+
 To use the `qnap` sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: qnap
     host: IP_ADDRESS_OF_QNAP_NAS

--- a/source/_components/sensor.radarr.markdown
+++ b/source/_components/sensor.radarr.markdown
@@ -15,10 +15,12 @@ ha_release: 0.47
 
 This `radarr` sensor platform pulls data from a given [Radarr](https://radarr.video/) instance.
 
+## {% linkable_title Configuration %}
+
 To use your Radarr sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: radarr
     api_key: YOUR_API_KEY

--- a/source/_components/sensor.sonarr.markdown
+++ b/source/_components/sensor.sonarr.markdown
@@ -16,10 +16,12 @@ ha_iot_class: "Local Polling"
 
 This `sonarr` sensor platform pulls data from a given [Sonarr](https://sonarr.tv/) instance.
 
+## {% linkable_title Configuration %}
+
 To use your Sonarr sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: sonarr
     api_key: YOUR_API_KEY

--- a/source/_components/sensor.synologydsm.markdown
+++ b/source/_components/sensor.synologydsm.markdown
@@ -16,10 +16,12 @@ ha_iot_class: "Local Polling"
 
 The `synologydsm` sensor platform allows getting various statistics from your [Synology NAS](https://www.synology.com).
 
+## {% linkable_title Configuration %}
+
 To use the `synologydsm` sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 sensor:
   - platform: synologydsm
     host: IP_ADDRESS_OF_SYNOLOGY_NAS
@@ -33,7 +35,7 @@ sensor:
 
 Configuration variables:
 
-- **host** (*Required*): The IP address of the Synology NAS to monitor
+- **host** (*Required*): The IP address of the Synology NAS to monitor.
 - **port** (*Optional*): The port number on which the Synology NAS is reachable. Defaults to `5000`.
 - **username** (*Required*): An user to connect to the Synology NAS (a separate account is advised, see the Separate User Configuration section below for details).
 - **password** (*Required*): The password of the user to connect to the Synology NAS.

--- a/source/_components/switch.fritzdect.markdown
+++ b/source/_components/switch.fritzdect.markdown
@@ -35,11 +35,21 @@ switch:
     password: YOUR_PASSWORD
 ```
 
-Configuration variables:
-
-- **username** (*Required*): The username for your Fritz!Box.
-- **password** (*Required*): The password for your Fritz!Box.
-- **host** (*Optional*): The IP address/hostname of your Fritz!Box. Defaults to `fritz.box`.
+{% configuration %}
+username:
+  description: The username for your Fritz!Box.
+  required: true
+  type: string
+password:
+  description: The password for your Fritz!Box.
+  required: true
+  type: string
+host:
+  description:  The IP address/hostname of your Fritz!Box.
+  required: false
+  type: string
+  default: fritz.box
+{% endconfiguration %}
 
 It is recommended to create a dedicated user for Home Assistant and only allow access to "Smart Home".
 

--- a/source/_components/switch.mochad.markdown
+++ b/source/_components/switch.mochad.markdown
@@ -14,10 +14,12 @@ ha_release: 0.32
 
 The `mochad` switch platform lets you control an X10 enabled switch device.
 
+## {% linkable_title Configuration %}
+
 To enable this sensor, you first have to set up the [mochad component](/components/mochad/) and then add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 switch:
   - platform: mochad
     devices:
@@ -30,4 +32,6 @@ Configuration variables:
 - **address** (*Required*): The X10 address of the switch.
 - **name** (*Optional*): The name of the switch. Default is: x10_switch_dev_*address*.
 - **comm_type** (*Optional*): pl (powerline) or rf (radio frequency). Default is pl.
+
+
 

--- a/source/_components/switch.modbus.markdown
+++ b/source/_components/switch.modbus.markdown
@@ -16,10 +16,12 @@ ha_iot_class: "Local Push"
 
 The `modbus` switch platform allows you to control [Modbus](http://www.modbus.org/) coils or registers.
 
+## {% linkable_title Configuration %}
+
 To use your Modbus switches in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 switch:
   platform: modbus
   slave: 1

--- a/source/_components/switch.mqtt.markdown
+++ b/source/_components/switch.mqtt.markdown
@@ -15,6 +15,8 @@ ha_iot_class: depends
 
 The `mqtt` switch platform lets you control your MQTT enabled switches.
 
+## {% linkable_title Configuration %}
+
 In an ideal scenario, the MQTT device will have a `state_topic` to publish state changes. If these messages are published with a `RETAIN` flag, the MQTT switch will receive an instant state update after subscription, and will start with the correct state. Otherwise, the initial state of the switch will be `false` / `off`.
 
 When a `state_topic` is not available, the switch will work in optimistic mode. In this mode, the switch will immediately change state after every command. Otherwise, the switch will wait for state confirmation from the device (message from `state_topic`).
@@ -24,7 +26,7 @@ Optimistic mode can be forced, even if the `state_topic` is available. Try to en
 To enable this switch in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 switch:
   - platform: mqtt
     command_topic: "home/bedroom/switch1/set"
@@ -106,7 +108,7 @@ In this section you will find some real life examples of how to use this sensor.
 The example below shows a full configuration for a switch.
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 switch:
   - platform: mqtt
     name: "Bedroom Switch"
@@ -140,7 +142,7 @@ The configuration will look like the example below:
 
 {% raw %}
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 switch:
   - platform: mqtt
     name: bathroom

--- a/source/_components/switch.pilight.markdown
+++ b/source/_components/switch.pilight.markdown
@@ -19,6 +19,8 @@ Additionally, RF commands can be defined that trigger this switch to turn on and
 
 To be really sure that Home Assistant knows the actual state of your device it is recommended to use the RF remote with codes unknown to any of your 433 MHz devices. Thus you use the remote to trigger this switch to send the correct RF code to the device.
 
+## {% linkable_title Configuration %}
+
 To define a Pilight switch, add the following lines to your `configuration.yaml`:
 
 ```yaml

--- a/source/_components/switch.wake_on_lan.markdown
+++ b/source/_components/switch.wake_on_lan.markdown
@@ -15,6 +15,8 @@ ha_iot_class: "Local Polling"
 
 The `wake_on_lan` (WOL) switch platform allows you to turn on a [WOL](https://en.wikipedia.org/wiki/Wake-on-LAN) enabled computer.
 
+## {% linkable_title Configuration %}
+
 <p class='note warning'>
 The WOL switch can only turn on your computer and monitor the state. There is no universal way to turn off a computer remotely. The `turn_off` variable is there to help you call a script when you have figured out how to remotely turn off your computer.
 See below for suggestions on how to do this.
@@ -23,7 +25,7 @@ See below for suggestions on how to do this.
 To enable this switch in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yml entry
+# Example configuration.yaml entry
 switch:
   - platform: wake_on_lan
     mac_address: "00-01-02-03-04-05"
@@ -42,7 +44,8 @@ Configuration variables:
 Here are some real life examples of how to use the **turn_off** variable.
 
 ### {% linkable_title Suspending Linux %}
-Suggested recipe for letting the turn_off script suspend a Linux computer (the **target**)
+
+Suggested recipe for letting the `turn_off` script suspend a Linux computer (the **target**)
 from Home Assistant running on another Linux computer (the **server**).
 
 1. On the **server**, log in as the user account Home Assistant is running under. (I'm using `hass` in this example)

--- a/source/_posts/2015-08-31-version-7-revamped-ui-and-improved-distribution.markdown
+++ b/source/_posts/2015-08-31-version-7-revamped-ui-and-improved-distribution.markdown
@@ -61,12 +61,12 @@ __MQTT Sensors and Switches__
 [mqtt-switch]: /components/switch.mqtt/
 
 ```yaml
-# Example configuration.yml entr
+# Example configuration.yaml entry
 sensor:
   platform: mqtt
   name: "MQTT Sensor"
   state_topic: "home/bedroom/temperature"
-  unit_of_measurement: "ºC"
+  unit_of_measurement: "°C"
 
 switch:
   platform: mqtt


### PR DESCRIPTION
**Description:**
Fix typos in file name

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
