### PR TITLE
Compatible with yeelight II

### DIFF
--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -59,6 +59,7 @@ This component is tested to work with the following models. If you have a differ
 - **YLDP01YL**: LED Bulb (White)
 - **YLDP02YL**: LED Bulb (Color)
 - **YLDP03YL**: LED Bulb (Color) - E26
+- **YLDP06YL**: LED Bulb (Color) II
 - **YLDD01YL**: Lightstrip (Color)
 - **YLDD02YL**: Lightstrip (Color)
 - **MJCTD01YL**: Xiaomi Mijia Bedside Lamp - WIFI Version!


### PR DESCRIPTION
**Description:**
Just added this one to hass and looks to work the same as the first gen :)
I'm kind of assuming YLDP05YL (white version of the 2nd gen bulb) will work as well, but have not added it because I haven't tested it.
If you do want me to add it just shout.

Product on aliexpress:
https://b0.is/Ps0fG

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
