### PR TITLE
Restore link to dev docs

### DIFF
--- a/source/_includes/custom/navigation.html
+++ b/source/_includes/custom/navigation.html
@@ -13,6 +13,7 @@
   <li><a href="/components/">Components</a></li>
   <li><a href="/docs/">Docs</a></li>
   <li><a href="/cookbook/">Examples</a></li>
+  <li><a href="https://developers.home-assistant.io/">Developers</a></li>
   <li><a href="/blog/">Blog</a></li>
   <li><a href="/help/">Need help?</a></li>
   <li><a href='#' class='show-search'><i class="icon-search"></i></a></li>


### PR DESCRIPTION
Now that it's "hidden" at the bottom of the page we've had a few questions about whether there's any developer docs. Suggesting restoring it to the top so that people don't assume there's none ;)
