### PR TITLE
Rake isolate - expanded to components

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,11 +16,12 @@ deploy_branch  = "master"
 
 ## -- Misc Configs -- ##
 
-public_dir      = "public/"    # compiled site directory
+public_dir      = "public/"   # compiled site directory
 source_dir      = "source"    # source file directory
 blog_index_dir  = 'source/blog'    # directory for your blog's index page (if you put your index in source/blog/index.html, set this to 'source/blog')
 deploy_dir      = "_deploy"   # deploy directory (for Github pages deployment)
 stash_dir       = "_stash"    # directory to stash posts for speedy generation
+components_dir  = "_components"    #  directory for component files
 posts_dir       = "_posts"    # directory for blog files
 themes_dir      = ".themes"   # directory for blog files
 new_post_ext    = "markdown"  # default new post file extension when using the new_post task
@@ -169,18 +170,26 @@ task :new_page, :filename do |t, args|
 end
 
 # usage rake isolate[my-post]
-desc "Move all other posts than the one currently being worked on to a temporary stash location (stash) so regenerating the site happens much more quickly."
+desc "Move all other components and posts than the one currently being worked on to a temporary stash location (stash) so regenerating the site happens much more quickly."
 task :isolate, :filename do |t, args|
   stash_dir = "#{source_dir}/#{stash_dir}"
+  s_posts_dir = "#{stash_dir}/#{posts_dir}"
+  s_components_dir = "#{stash_dir}/#{components_dir}"
   FileUtils.mkdir(stash_dir) unless File.exist?(stash_dir)
+  FileUtils.mkdir(s_posts_dir) unless File.exist?(s_posts_dir)
+  FileUtils.mkdir(s_components_dir) unless File.exist?(s_components_dir)
   Dir.glob("#{source_dir}/#{posts_dir}/*.*") do |post|
-    FileUtils.mv post, stash_dir unless post.include?(args.filename)
+    FileUtils.mv post, s_posts_dir unless post.include?(args.filename)
+  end
+  Dir.glob("#{source_dir}/#{components_dir}/*.*") do |component|
+    FileUtils.mv component, s_components_dir unless component.include?(args.filename)
   end
 end
 
 desc "Move all stashed posts back into the posts directory, ready for site generation."
 task :integrate do
-  FileUtils.mv Dir.glob("#{source_dir}/#{stash_dir}/*.*"), "#{source_dir}/#{posts_dir}/"
+  FileUtils.mv Dir.glob("#{source_dir}/#{stash_dir}/#{posts_dir}/*.*"), "#{source_dir}/#{posts_dir}/"
+  FileUtils.mv Dir.glob("#{source_dir}/#{stash_dir}/#{components_dir}/*.*"), "#{source_dir}/#{components_dir}/"
 end
 
 desc "Clean out caches: .pygments-cache, .gist-cache, .sass-cache"


### PR DESCRIPTION
**Description:**
Currently `rake generate` is by far the slowest command during working on a component doc. It was already possible to `isolate` blog posts from the source folder, to speed it up. However this can even be improved by also moving the components files to the stash folder.