### PR TITLE
Add fire_event details

### DIFF
--- a/source/_components/system_log.markdown
+++ b/source/_components/system_log.markdown
@@ -27,6 +27,11 @@ max_entries:
   required: false
   type: int
   default: 50
+fire_event:
+  description: Whether events are fired (required when used for triggers).
+  required: false
+  type: string
+  default: false
 {% endconfiguration %}
 
 ## {% linkable_title Services %}
@@ -55,7 +60,7 @@ The message ("Unable to find service..."), source (`core.py`) and level (`WARNIN
 
 ## {% linkable_title Examples  %}
 
-Here are some examples using the events posted by `system_log`.
+Here are some examples using the events posted by `system_log`. `fire_event` must be set to `true` for these to work.
 
 ### {% linkable_title Counting Number of Warnings %}
 


### PR DESCRIPTION
Add the need for fire_event:true added per https://github.com/home-assistant/home-assistant/pull/14102 if expecting the included example to work.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
