### PR TITLE
Update notify.lametric.markdown

### DIFF
--- a/source/_components/notify.lametric.markdown
+++ b/source/_components/notify.lametric.markdown
@@ -80,3 +80,18 @@ To add a notification sound or an icon override, it has to be done via service d
         sound: 'notification'
         icon: 'i51'
  ```
+
+If you have more than one La Metric device, you can specify which will recieve the message by adding the "target" parameter to the service data:
+
+```yaml
+  action:
+    service: notify.lametric
+    data:
+      message: "Son has arrived at school!"
+      target: "Office LaMetric"
+      data:
+        sound: 'notification'
+        icon: 'i51'
+ ```
+ 
+ If target is not specified, all la metric devices will be notified

--- a/source/_components/notify.lametric.markdown
+++ b/source/_components/notify.lametric.markdown
@@ -79,9 +79,11 @@ To add a notification sound or an icon override, it has to be done via service d
       data:
         sound: 'notification'
         icon: 'i51'
- ```
+```
 
-If you have more than one La Metric device, you can specify which will recieve the message by adding the "target" parameter to the service data:
+### {% linkable_title Only notify specific device %}
+
+If you have more than one La Metric device, you can specify which will recieve the message by adding `target:` to the service data:
 
 ```yaml
   action:
@@ -94,4 +96,4 @@ If you have more than one La Metric device, you can specify which will recieve t
         icon: 'i51'
  ```
  
- If target is not specified, all la metric devices will be notified
+ If target is not specified, all LaMetric devices will be notified.


### PR DESCRIPTION
**Description:**
LaMetric notify function does not mention that specific LaMetric devices can be targeted

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
