### PR TITLE
Fix duplicated title

### DIFF
--- a/source/_components/device_tracker.tesla.markdown
+++ b/source/_components/device_tracker.tesla.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Tesla"
+title: "Tesla Device Tracker"
 description: "Instructions on for how to integrate Tesla into Home Assistant."
 date: 2017-08-02 12:20
 sidebar: true


### PR DESCRIPTION
**Description:**

There are currently 2 pages with "Tesla" as title as you can see here:

![image](https://user-images.githubusercontent.com/2886913/40022374-17da6e72-57c8-11e8-820c-f004eede3636.png)

I've renamed the device tracker page to "Testla Device Tracker"

https://www.home-assistant.io/components/device_tracker.tesla/
https://www.home-assistant.io/components/tesla/


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
