### PR TITLE
Update sensor.scrape.markdown

### DIFF
--- a/source/_components/sensor.scrape.markdown
+++ b/source/_components/sensor.scrape.markdown
@@ -36,6 +36,7 @@ Configuration variables:
 - **authentication** (*Optional*): Type of the HTTP authentication. Either `basic` or `digest`.
 - **username** (*Optional*): The username for accessing the website.
 - **password** (*Optional*): The password for accessing the website.
+- **scan_interval** (*Optional*): Defines number of seconds for polling interval (defaults to 60 seconds).
 
 ## {% linkable_title Examples %}
 


### PR DESCRIPTION
**Description:**

Added scan_interval. I tested with this snippet, with and without the scan_interval

  - platform: scrape
    resource: https://odditymall.com/random
    name: Random Test
    scan_interval: 900
    select: "h2 > a"

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
