### PR TITLE
Homematic: Removed deprecated options from example

### DIFF
--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -66,8 +66,6 @@ homematic:
       resolvenames: json
       username: Admin
       password: secret
-      primary: true
-      variables: true
     wired:
       host: 127.0.0.1
       port: 2000


### PR DESCRIPTION
**Description:**
The current documentation uses deprecated options in the example configuration.yaml. This PR removes those to provide a valid configuration.
At this point the documentation doesn't follow the (new) standards 100%. But this PR is just to fix a broken example, not to fix the documentation itself.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
