### PR TITLE
Add HomeKit support for media players

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -95,6 +95,11 @@ homekit:
                 required: false
                 type: string
                 default: ''
+              mode:
+                description: Operation mode of switch within HomeKit. Valid modes are `on_off`, `play_pause`, `play_stop`, and `toggle_mute`. If the entity does not support the specified `mode`, the first supported `mode` will be used. Only applicable for `media_player` entities.
+                required: false
+                type: string
+                default: Depends on `supported_features` of entity.
 {% endconfiguration %}
 
 <p class='note'>
@@ -229,6 +234,7 @@ The following components are currently supported:
 | fan | Fan | Support for `on / off`, `direction` and `oscillating`. | 
 | light | Light | Support for `on / off`, `brightness` and `rgb_color`. |
 | lock | DoorLock | Support for `lock / unlock`. |
+| media_player | MediaPlayer | Represented as a switch which controls `on / off`, `play / pause`, `play / stop`, or `mute` depending on `supported_features` of entity and the `mode` specified in `entity_config`. |
 | sensor | TemperatureSensor | All sensors that have `Celsius` or `Fahrenheit` as their `unit_of_measurement` or `temperature` as their `device_class`. |
 | sensor | HumiditySensor | All sensors that have `%` as their `unit_of_measurement` and `humidity` as their `device_class`. |
 | sensor | AirQualitySensor | All sensors that have `pm25` as part of their `entity_id` or `pm25` as their `device_class` |

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -52,12 +52,12 @@ homekit:
         description: Flag if the HomeKit Server should start automatically after the Home Assistant Core Setup is done. ([Disable Auto Start](#disable-auto-start))
         required: false
         type: boolean
-        default: `true`
+        default: true
       port:
         description: Port for the HomeKit extension.
         required: false
         type: int
-        default: `51827`
+        default: 51827
       ip_address:
         description: The local network IP address. Only necessary if the default from Home Assistant does not work.
         required: false
@@ -106,7 +106,7 @@ homekit:
                 description: Operation modes of switches within HomeKit. Valid modes are `on_off`, `play_pause`, `play_stop`, and `toggle_mute`. Only applicable for `media_player` entities.
                 required: false
                 type: list
-                default: All supported modes
+                default: '`<All supported modes>`'
 {% endconfiguration %}
 
 <p class='note'>

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -96,10 +96,10 @@ homekit:
                 type: string
                 default: ''
               mode:
-                description: Operation mode of switch within HomeKit. Valid modes are `on_off`, `play_pause`, `play_stop`, and `toggle_mute`. If the entity does not support the specified `mode`, the first supported `mode` will be used. Only applicable for `media_player` entities.
+                description: Operation mode of switches within HomeKit. Valid modes are `on_off`, `play_pause`, `play_stop`, and `toggle_mute`. The entity will ignore any `mode` which is not supported. If not specified, all supported modes will be added. Only applicable for `media_player` entities.
                 required: false
-                type: string
-                default: Depends on `supported_features` of entity.
+                type: list
+                default: `on_off`, `play_pause`, `play_stop`, `toggle_mute`
 {% endconfiguration %}
 
 <p class='note'>
@@ -234,7 +234,7 @@ The following components are currently supported:
 | fan | Fan | Support for `on / off`, `direction` and `oscillating`. | 
 | light | Light | Support for `on / off`, `brightness` and `rgb_color`. |
 | lock | DoorLock | Support for `lock / unlock`. |
-| media_player | MediaPlayer | Represented as a switch which controls `on / off`, `play / pause`, `play / stop`, or `mute` depending on `supported_features` of entity and the `mode` specified in `entity_config`. |
+| media_player | MediaPlayer | Represented as a series of switches which control `on / off`, `play / pause`, `play / stop`, or `mute` depending on `supported_features` of entity and the `mode` list specified in `entity_config`. |
 | sensor | TemperatureSensor | All sensors that have `Celsius` or `Fahrenheit` as their `unit_of_measurement` or `temperature` as their `device_class`. |
 | sensor | HumiditySensor | All sensors that have `%` as their `unit_of_measurement` and `humidity` as their `device_class`. |
 | sensor | AirQualitySensor | All sensors that have `pm25` as part of their `entity_id` or `pm25` as their `device_class` |

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -30,9 +30,16 @@ homekit:
     include_domains:
       - alarm_control_panel
       - light
+      - media_player
   entity_config:
     alarm_control_panel.home:
       code: 1234
+    media_player.living_room:
+      mode:
+        - on_off
+        - play_pause
+        - play_stop
+        - toggle_mute
 ```
 
 {% configuration %}

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -52,12 +52,12 @@ homekit:
         description: Flag if the HomeKit Server should start automatically after the Home Assistant Core Setup is done. ([Disable Auto Start](#disable-auto-start))
         required: false
         type: boolean
-        default: true
+        default: `true`
       port:
         description: Port for the HomeKit extension.
         required: false
         type: int
-        default: 51827
+        default: `51827`
       ip_address:
         description: The local network IP address. Only necessary if the default from Home Assistant does not work.
         required: false
@@ -103,10 +103,10 @@ homekit:
                 type: string
                 default: ''
               mode:
-                description: Operation mode of switches within HomeKit. Valid modes are `on_off`, `play_pause`, `play_stop`, and `toggle_mute`. The entity will ignore any `mode` which is not supported. If not specified, all supported modes will be added. Only applicable for `media_player` entities.
+                description: Operation modes of switches within HomeKit. Valid modes are `on_off`, `play_pause`, `play_stop`, and `toggle_mute`. Only applicable for `media_player` entities.
                 required: false
                 type: list
-                default: `on_off`, `play_pause`, `play_stop`, `toggle_mute`
+                default: All supported modes
 {% endconfiguration %}
 
 <p class='note'>


### PR DESCRIPTION
**Description:**
Adds support for media players in HomeKit.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14446

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/