### PR TITLE
Update Centos Installation Include Dependencies

### DIFF
--- a/source/_docs/installation/centos.markdown
+++ b/source/_docs/installation/centos.markdown
@@ -20,6 +20,11 @@ First of all install the software collection repository as root. For example, on
 ```bash
 $ yum install centos-release-scl
 ```
+Install some dependencies you'll need later.
+
+```bash
+$ yum install gcc gcc-c++ systemd-devel
+```
 
 Then install the Python 3.6 package:
 


### PR DESCRIPTION
I attempted to follow the documentation to install HASS on to Centos 7.5 minimal. I found gcc gcc-c++ were required for hass to complete the auto install of various python packages and systemd-devel for zwave. Figure this information/step should be included in the installation wiki for centos.

**Description:**

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
