### PR TITLE
According to the matrix documentation the `name` field is required.

### DIFF
--- a/source/_components/matrix.markdown
+++ b/source/_components/matrix.markdown
@@ -79,7 +79,7 @@ commands:
 
 ### {% linkable_title Event Data %}
 
-If a command is triggered, a `matrix_command` event is fired. The event contains the name of the command in the `name` field. If the command is a word command that has no name set, the `name` field contains the word instead.
+If a command is triggered, a `matrix_command` event is fired. The event contains the name of the command in the `name` field.
 
 If the command is a word command, the `data` field contains a list of the command's arguments, i.e., everything that stood behind the word, split at spaces. If the command is an expression command, the `data` field contains the [group dictionary](https://docs.python.org/3.6/library/re.html?highlight=re#re.match.groupdict) of the regular expression that matched the message.
 


### PR DESCRIPTION
**Description:**
I am removing this sentence because it contradicts other parts of the
documentation.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
