### PR TITLE
Update light.knx.markdown with color option

### DIFF
--- a/source/_components/light.knx.markdown
+++ b/source/_components/light.knx.markdown
@@ -36,6 +36,7 @@ Configuration variables:
 - **brightness_address** (Optional): KNX group address for dimming light.
 - **state_address** (*Optional*): separate KNX group address for retrieving the switch state of the light.
 - **brightness_state_address** (*Optional*): separate KNX group address for retrieving the dimmed state of the light.
+- **color_address** (*Optional*): separate KNX group address for setting the color of the light.
 
 Some KNX devices can change their state internally without any messages on the KNX bus, e.g., if you configure a timer on a channel. The optional `state_address` can be used to inform Home Assistant about these state changes. If a KNX message is seen on the bus addressed to the given state address, this will overwrite the state of the switch object.
 For switching/light actuators that are only controlled by a single group address and can't change their state internally, you don't have to configure the state address.


### PR DESCRIPTION
**Description:**

Since the pull request #12411 the color is supported in KNX Light.

This solves issue #5385 (KNX Light : documentation not accurate )

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>
NONE

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
