### PR TITLE
Added format to two digits

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -75,7 +75,7 @@ Delays are useful for temporarily suspending your script and start it at a later
 ```yaml
 # Waits however many minutes input_number.minute_delay is set to
 # Valid formats include HH:MM and HH:MM:SS
-- delay: "00:{{ states('input_number.minute_delay')|int }}:00"
+- delay: "00:{{ '%02d' % (states('input_number.minute_delay')|int) }}:00"
 ```
 {% endraw %}
 


### PR DESCRIPTION
Formatted the digit for the delay to two digits, rather than a random one or two. There have been multiple reports of the example in the doc not working for 1 through 9, and it needing formatted to two digits.
