### PR TITLE
Added HomeKit lock pin option

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -91,10 +91,10 @@ homekit:
                 required: false
                 type: string
               code:
-                description: Code to arm or disarm the alarm in the frontend. Only applicable for `alarm_control_panel` entities.
+                description: Code to `arm / disarm` an alarm or `lock / unlock` a lock. Only applicable for `alarm_control_panel` or `lock` entities.
                 required: false
                 type: string
-                default: ''
+                default: '`<No code>`'
 {% endconfiguration %}
 
 <p class='note'>


### PR DESCRIPTION
**Description:**
Added documentation for `code` option for `lock` entities. The parent PR is already merged. Didn't open a PR earlier due to possible merge conflicts.
Merging into `rc`, since already included in the current beta.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14524

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
