### PR TITLE
Add static host:port config for Wemo

### DIFF
--- a/source/_components/wemo.markdown
+++ b/source/_components/wemo.markdown
@@ -37,7 +37,7 @@ Note that if you use this, you may want to set up your router (or whatever runs 
 
 If the device doesn't seem to work and all you see is the state "unavailable" on your dashboard, check that your firewall doesn't block incoming request on port 8989 since this is the address to which the WeMo devices send their update.
 
-{% linkable_title Emulated devices %}
+## {% linkable_title Emulated devices %}
 
 Various software that emulates WeMo devices often uses alternative ports. Static configuration should include the port value:
 

--- a/source/_components/wemo.markdown
+++ b/source/_components/wemo.markdown
@@ -36,3 +36,14 @@ Any WeMo devices that are not statically configured but reachable via discovery 
 Note that if you use this, you may want to set up your router (or whatever runs your DHCP server) to force your WeMo devices to use a static IP address. Check the DHCP section of your router configuration for this ability.
 
 If the device doesn't seem to work and all you see is the state "unavailable" on your dashboard, check that your firewall doesn't block incoming request on port 8989 since this is the address to which the WeMo devices send their update.
+
+{% linkable_title Emulated devices %}
+
+Various software that emulates WeMo devices often uses alternative ports. Static configuration should include the port value:
+
+```yaml
+wemo:
+  static:
+    - 192.168.1.23:52001
+    - 192.168.52.172:52002
+```


### PR DESCRIPTION
**Description:**
Add Emulated Devices section with static host:port config example

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14516

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
