### PR TITLE
Correct lock service names

### DIFF
--- a/source/_components/lock.markdown
+++ b/source/_components/lock.markdown
@@ -12,11 +12,11 @@ footer: true
 Keeps track which locks are in your environment, their state and allows you to control them.
 
  * Maintains a state per lock and a combined state `all_locks`.
- * Registers services `lock/lock` and `lock/unlock` to control locks.
+ * Registers services `lock.lock` and `lock.unlock` to control locks.
 
 ### {% linkable_title Use the services %}
 
-Go to the **Developer Tools**, then to **Call Service** in the frontend, and choose `lock/lock` or `lock/unlock` from the list of available services (**Available services:** on the left). Enter something like the sample below into the **Service Data** field and hit **CALL SERVICE**.
+Go to the **Developer Tools**, then to **Call Service** in the frontend, and choose `lock.lock` or `lock.unlock` from the list of available services (**Services:** on the left). Enter something like the sample below into the **Service Data** field and hit **CALL SERVICE**.
 
 ```json
 {"entity_id":"lock.front_door"}


### PR DESCRIPTION
Service names are lock.lock and lock.unlock; not lock/lock and lock/unlock

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
