### PR TITLE
Notify my android shutdown.

### DIFF
--- a/source/_components/notify.nma.markdown
+++ b/source/_components/notify.nma.markdown
@@ -12,6 +12,9 @@ ha_category: Notifications
 ha_release: pre 0.7
 ---
 
+<p class='note warning'>
+As of May 24th 2018 [NMA has shut down](https://notifymyandroid.com/), this was due to the new GDPR european regulations. 
+</p>
 
 The `nma` platform uses [Notify My Android (NMA)](http://www.notifymyandroid.com/) to delivery notifications from Home Assistant to your Android device.
 


### PR DESCRIPTION
On NMA website they have announced they have shut down: https://notifymyandroid.com/ 

It might be worth deleting the entire component to avoid confusion, but if people arrive on home assistants documentation in the mean time it is worth clarifying.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
