### PR TITLE
Update coinmarketcap configuration to support v2 API and configurable decimal rounding

### DIFF
--- a/source/_components/sensor.coinmarketcap.markdown
+++ b/source/_components/sensor.coinmarketcap.markdown
@@ -25,17 +25,22 @@ sensor:
 ```
 
 {% configuration %}
-currency:
-  description: The cryptocurrency to use.
+currency_id:
+  description: The ID of the cryptocurrency to use, default is the ID of Bitcoin.
   required: false
-  type: string
-  default: Bitcoin
+  type: int
+  default: 1
 display_currency:
   description: The currency to display.
   required: false
   type: string
   default: USD
+display_currency_decimals:
+  description: The amount of decimals to round to.
+  required: false
+  type: int
+  default: 2
 {% endconfiguration %}
 
-All supported currencies can be found [here](https://coinmarketcap.com/api/).
+All supported currencies can be found [here](https://coinmarketcap.com/api/), a list of currency IDs can be found [here](https://api.coinmarketcap.com/v2/ticker/).
 


### PR DESCRIPTION
**Description:**
Upgraded coinmarketcap to 5.0.3 which supports the new public v2 API, with that comes a few changes to how the API handles input. It is no longer possible to query a ticker by the name of the currency (i.e. `bitcoin`). The API instead uses IDs (integers) for these tickers (i.e. `bitcoin` -> `1`).

I also made the rounding of decimals configurable, because it made no sense to round to 2 decimals if `display_currency` was set to `BTC`, some values showed up as `0.00`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14604

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
