### PR TITLE
Extend packages support

### DIFF
--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -73,7 +73,7 @@ There are some rules for packages that will be merged:
     input_boolean:
       my_input:
     ```
-4. Any component that is not a platform [2], or dictionaries with Entity ID keys [3] cannot be merged and can only occur once between all packages and the main configuration.
+4. Any component that is not a platform [2], or dictionaries with Entity ID keys [3] can only be merged if its keys, except those for lists, are solely defined once.
 
 <p class='note tip'>
 Components inside packages can only specify platform entries using configuration style 1, where all the platforms are grouped under the component name.


### PR DESCRIPTION
**Description:**
Extend support for packages to include components not covered currently.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14611

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
