### PR TITLE
Added documentation for SSL option for OpenWRT(luci)

### DIFF
--- a/source/_components/device_tracker.luci.markdown
+++ b/source/_components/device_tracker.luci.markdown
@@ -33,7 +33,9 @@ To use this device tracker in your installation, add the following to your `conf
 device_tracker:
   - platform: luci
     host: ROUTER_IP_ADDRESS
+    ssl: False
     username: YOUR_ADMIN_USERNAME
+    password: YOUR_ADMIN_PASSWORD
     password: YOUR_ADMIN_PASSWORD
 ```
 
@@ -42,6 +44,7 @@ Configuration variables:
 - **host** (*Required*): The IP address of your router, e.g., `192.168.1.1`.
 - **username** (*Required*): The username of an user with administrative privileges, usually `admin`.
 - **password** (*Required*): The password for your given admin account.
+- **ssl** (*Optional*): If your router enforces SSL connections, set to `true`. Defaults to `false`.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.
 

--- a/source/_components/device_tracker.luci.markdown
+++ b/source/_components/device_tracker.luci.markdown
@@ -33,9 +33,7 @@ To use this device tracker in your installation, add the following to your `conf
 device_tracker:
   - platform: luci
     host: ROUTER_IP_ADDRESS
-    ssl: False
     username: YOUR_ADMIN_USERNAME
-    password: YOUR_ADMIN_PASSWORD
     password: YOUR_ADMIN_PASSWORD
 ```
 


### PR DESCRIPTION
**Description:**

Added documentation for SSL option for OpenWRT(luci) which is a new feature currently waiting as PR to be merged

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#14627

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/