### PR TITLE
Update device_tracker.fritz.markdown

### DIFF
--- a/source/_components/device_tracker.fritz.markdown
+++ b/source/_components/device_tracker.fritz.markdown
@@ -15,11 +15,13 @@ ha_release: "0.10"
 
 The `fritz` platform offers presence detection by looking at connected devices to a [AVM Fritz!Box](http://avm.de/produkte/fritzbox/) based router.
 
-## {% linkable_title Configuration %}
+## {% linkable_title Setup %}
 
 <p class='note warning'>
 It might be necessary to install additional packages: <code>$ sudo apt-get install python3-lxml</code>
-If you installed home assistant in a virtualenv, run the following commands inside it: <code>$ sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev; pip install lxml</code>; be patient this will take a while.</p>
+If you installed Home Assistant in a virtualenv, run the following commands inside it: <code>$ sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev; pip install lxml</code>; be patient this will take a while.</p>
+
+## {% linkable_title Configuration %}
 
 To use an Fritz!Box router in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/device_tracker.fritz.markdown
+++ b/source/_components/device_tracker.fritz.markdown
@@ -18,8 +18,8 @@ The `fritz` platform offers presence detection by looking at connected devices t
 ## {% linkable_title Configuration %}
 
 <p class='note warning'>
-It might be necessary to install additional packages: <code>$ sudo apt-get install libxslt-dev libxml2-dev python3-lxml</code>
-If you are working with the All-in-One installation, you may also need to execute also within your virtual environment the command <code> pip install lxml</code>; be patient this will take a while.</p>
+It might be necessary to install additional packages: <code>$ sudo apt-get install python3-lxml</code>
+If you installed home assistant in a virtualenv, run the following commands inside it: <code>$ sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev; pip install lxml</code>; be patient this will take a while.</p>
 
 To use an Fritz!Box router in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
Added zlib1g-dev, which is needed to link lxml. Rephrased to make clear that one either needs to install lxml from a repository or build it from sources.