### PR TITLE
Add documentation for new shopping_list services

### DIFF
--- a/source/_components/shopping_list.markdown
+++ b/source/_components/shopping_list.markdown
@@ -18,3 +18,18 @@ The `shopping_list` component allows you to keep track of shopping list items. I
 # Example configuration.yaml entry
 shopping_list:
 ```
+
+### Services
+You can add or remove items on your shopping list by using the following services.
+
+#### {% linkable_title Service `shopping_list.add_item` %}
+
+| Service data attribute | Optional | Description                                            |
+|------------------------|----------|--------------------------------------------------------|
+| `name`                 |       no | Name of the item to add. Example: "Beer"               |
+
+#### {% linkable_title Service `shopping_list.complete_item` %}
+
+| Service data attribute | Optional | Description                                            |
+|------------------------|----------|--------------------------------------------------------|
+| `name`                 |       no | Name of the item to mark as completed. Example: "Beer" |


### PR DESCRIPTION
**Description:**
This PR adds documentation for two new services of the shopping list component:

- `shopping_list.add_item`
- `shopping_list.complete_item`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):**
home-assistant/home-assistant#14574

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
