### PR TITLE
Update documentation for MySensors force update support

### DIFF
--- a/source/_components/mysensors.markdown
+++ b/source/_components/mysensors.markdown
@@ -70,6 +70,11 @@ mysensors:
             description: The name the node will be renamed to. This node name becomes part of the entity_id. Default entity_id is [sketch_name]\_[node_id]\_[child_id] and when this name is set, the entity_id becomes [name]\_[child_id].
             required: true
             type: string
+          force_update:
+            description: Enable or disable forced updates for the node.
+            required: false
+            type: bool
+            default: false
   persistence:
     description: Enable or disable local persistence of sensor information. If this is disabled, then each sensor will need to send presentation messages after Home Assistant starts.
     required: false


### PR DESCRIPTION
**Description:**
Update documentation for MySensors configuration to enable/disable force_update for nodes.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14646

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
