### PR TITLE
Change mode to feature_list

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -35,11 +35,11 @@ homekit:
     alarm_control_panel.home:
       code: 1234
     media_player.living_room:
-      mode:
-        - on_off
-        - play_pause
-        - play_stop
-        - toggle_mute
+      feature_list:
+        - feature: on_off
+        - feature: play_pause
+        - feature: play_stop
+        - feature: toggle_mute
 ```
 
 {% configuration %}
@@ -102,11 +102,15 @@ homekit:
                 required: false
                 type: string
                 default: ''
-              mode:
-                description: Operation modes of switches within HomeKit. Valid modes are `on_off`, `play_pause`, `play_stop`, and `toggle_mute`. Only applicable for `media_player` entities.
+              feature_list:
+                description: Only for `media_player` entities. List of feature dictionaries to add for a given entity. Comparable to the platform schema.
                 required: false
                 type: list
-                default: '`<All supported modes>`'
+                keys:
+                  feature:
+                    description: Name of the feature to add to the entity representation. Valid features are `on_off`, `play_pause`, `play_stop` and `toogle_mute`. The media_player entity must support the feature to be valid.
+                    required: true
+                    type: string  
 {% endconfiguration %}
 
 <p class='note'>


### PR DESCRIPTION
**Description:**
Updated docs for the HomeKit `media_player` section. Instead of `mode`, `feature_list` should be used. For details, either see the `example config` section or the dev PR description.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14637
## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
