### PR TITLE
Add support for outlets in HomeKit

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -40,6 +40,8 @@ homekit:
         - feature: play_pause
         - feature: play_stop
         - feature: toggle_mute
+    switch.bedroom_outlet:
+      type: outlet
 ```
 
 {% configuration %}
@@ -111,6 +113,11 @@ homekit:
                     description: Name of the feature to add to the entity representation. Valid features are `on_off`, `play_pause`, `play_stop` and `toogle_mute`. The media_player entity must support the feature to be valid.
                     required: true
                     type: string  
+              type:
+                description: Type of accessory to be created within HomeKit. The only valid type is `outlet`. Only applicable for `switch` entities.
+                required: false
+                type: string
+                default: ''
 {% endconfiguration %}
 
 <p class='note'>
@@ -235,7 +242,7 @@ The following components are currently supported:
 | Component | Type Name | Description |
 | --------- | --------- | ----------- |
 | alarm_control_panel | SecuritySystem | All security systems. |
-| automation / input_boolean / remote / script / switch | Switch | All represented as switches. |
+| automation / input_boolean / remote / script | Switch | All represented as switches. |
 | binary_sensor | Sensor | Support for `co2`, `door`, `garage_door`, `gas`, `moisture`, `motion`, `occupancy`, `opening`, `smoke` and `window` device classes. Defaults to the `occupancy` device class for everything else. |
 | climate | Thermostat | All climate devices. |
 | cover | GarageDoorOpener | All covers that support `open` and `close` and have `garage` as their `device_class`. |
@@ -252,6 +259,7 @@ The following components are currently supported:
 | sensor | AirQualitySensor | All sensors that have `pm25` as part of their `entity_id` or `pm25` as their `device_class` |
 | sensor | CarbonDioxideSensor | All sensors that have `co2` as part of their `entity_id` or `co2` as their `device_class` |
 | sensor | LightSensor | All sensors that have `lm` or `lx` as their `unit_of_measurement` or `illuminance` as their `device_class` |
+| switch | Switch | Represented as a switch by default but can be changed by using `type` within `entity_config`. |
 
 
 ## {% linkable_title Error reporting %}

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -117,7 +117,7 @@ homekit:
                 description: Only for `switch` entities. Type of accessory to be created within HomeKit. Valid types are `switch` and `outlet`.
                 required: false
                 type: string
-                default: `switch`
+                default: switch
 {% endconfiguration %}
 
 <p class='note'>

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -114,10 +114,10 @@ homekit:
                     required: true
                     type: string  
               type:
-                description: Type of accessory to be created within HomeKit. The only valid type is `outlet`. Only applicable for `switch` entities.
+                description: Only for `switch` entities. Type of accessory to be created within HomeKit. Valid types are `switch` and `outlet`.
                 required: false
                 type: string
-                default: ''
+                default: `switch`
 {% endconfiguration %}
 
 <p class='note'>


### PR DESCRIPTION
**Description:**
Add support to display `switch` entities as outlets within HomeKit.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14628

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/