### PR TITLE
Update zha.markdown - baudrate property

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -45,7 +45,7 @@ Configuration variables:
 
  - **radio_type** (*Optional*): One of `ezsp` (default) or `xbee`
  - **usb_path** (*Required*): Path to the serial device for the radio.
- - **baud_rate** (*Optional*): Baud rate of the serial device.
+ - **baudrate** (*Optional*): Baud rate of the serial device.
  - **database_path** (*Required*): Path to the database which will keep persistent network data.
 
 To add new devices to the network, call the `permit` service on the `zha` domain, and then follow the device instructions for doing a scan or factory reset. In case you want to add Philips Hue bulbs that have previously been added to another bridge, have a look at: [https://github.com/vanviegen/hue-thief/](https://github.com/vanviegen/hue-thief/)


### PR DESCRIPTION
Though the docs referenced baud_rate, but the code is baudrate.  When using baud_rate in the config homeassistant for the zha component fails to load.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
