### PR TITLE
Add set_default_level documentation

### DIFF
--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -15,13 +15,12 @@ The `logger` component lets you define the level of logging activities in Home A
 
 To enable the `logger` component in your installation, add the following to your `configuration.yaml` file:
 
-To have a full log and log everything only this entry is needed (without any qualifier):
-
 ```yaml
+# Example configuration.yaml entry
 logger:
 ```
 
-To log all messages and ignore events lower than critical for specified components.
+To log all messages and ignore events lower than critical for specified components:
 
 ```yaml
 # Example configuration.yaml entry
@@ -32,7 +31,7 @@ logger:
     homeassistant.components.camera: critical
 ```
 
-To ignore all messages lower than critical and log event for specified components.
+To ignore all messages lower than critical and log event for specified components:
 
 ```yaml
 # Example configuration.yaml entry
@@ -45,7 +44,25 @@ logger:
     homeassistant.components.camera: critical
 ```
 
-Possible log severities are:
+{% configuration %}
+  default:
+    description: Default log level.
+    required: false
+    type: '[log_level](#log-levels)'
+    default: debug
+  logs:
+    description: List of components and their log level.
+    required: false
+    type: map
+    keys:
+      '&lt;component_namespace&gt;':
+        description: Logger namespace of the component.
+        type: '[log_level](#log-levels)'
+{% endconfiguration %}
+
+### {% linkable_title Log Levels %}
+
+Possible log severity levels are:
 
 - critical
 - fatal
@@ -55,7 +72,9 @@ Possible log severities are:
 - info
 - debug
 - notset
- 
+
+## {% linkable_title Services %}
+
 ### {% linkable_title Service `set_default_level` %}
 
 You can alter the default log level (for components without a specified log
@@ -85,7 +104,7 @@ data:
 
 The log information are stored in the [configuration directory](/docs/configuration/)
 as `home-assistant.log` and you can read it with the command-line tool `cat` or
-follow it dynamically with `tail -f`. 
+follow it dynamically with `tail -f`.
 
 If you are a Hassbian user you can use the example below:
 

--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -16,9 +16,11 @@ The `logger` component lets you define the level of logging activities in Home A
 To enable the `logger` component in your installation, add the following to your `configuration.yaml` file:
 
 To have a full log and log everything only this entry is needed (without any qualifier):
+
 ```yaml
 logger:
 ```
+
 To log all messages and ignore events lower than critical for specified components.
 
 ```yaml
@@ -91,7 +93,7 @@ If you are a Hassbian user you can use the example below:
 $ tail -f /home/homeassistant/.homeassistant/home-assistant.log
 ```
 
-If you are a Hass.io user you can use the example below, when logged in through
+If you are a Hass.io user, you can use the example below, when logged in through
 the [SSH add-on](/addons/ssh/):
 
 ```bash

--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -11,9 +11,9 @@ logo: home-assistant.png
 ha_category: "Utility"
 ---
 
-The logger component lets you define the level of logging activities in Home Assistant.
+The `logger` component lets you define the level of logging activities in Home Assistant.
 
-To enable the logger in your installation, add the following to your `configuration.yaml` file:
+To enable the `logger` component in your installation, add the following to your `configuration.yaml` file:
 
 To have a full log and log everything only this entry is needed (without any qualifier):
 ```yaml
@@ -54,10 +54,23 @@ Possible log severities are:
 - debug
 - notset
  
+### {% linkable_title Service `set_default_level` %}
+
+You can alter the default log level (for components without a specified log
+level) using the service `logger.set_default_level`.
+
+An example call might look like this:
+
+```yaml
+service: logger.set_default_level
+data:
+  level: info
+```
+
 ### {% linkable_title Service `set_level` %}
 
 You can alter log level for one or several components using the service
-``logger.set_level``. It accepts the same format as ``logs`` in the configuration.
+`logger.set_level`. It accepts the same format as `logs` in the configuration.
 
 An example call might look like this:
 
@@ -68,7 +81,9 @@ data:
   homeassistant.components.media_player.yamaha: debug
 ```
 
-The log information are stored in the [configuration directory](/docs/configuration/) as `home-assistant.log` and you can read it with the command-line tool `cat` or follow it dynamically with `tail -f`. 
+The log information are stored in the [configuration directory](/docs/configuration/)
+as `home-assistant.log` and you can read it with the command-line tool `cat` or
+follow it dynamically with `tail -f`. 
 
 If you are a Hassbian user you can use the example below:
 
@@ -76,7 +91,8 @@ If you are a Hassbian user you can use the example below:
 $ tail -f /home/homeassistant/.homeassistant/home-assistant.log
 ```
 
-If you are a Hass.io user you can use the example below, whenlogged in through the ssh addon:
+If you are a Hass.io user you can use the example below, when logged in through
+the [SSH add-on](/addons/ssh/):
 
 ```bash
 $ tail -f /config/home-assistant.log


### PR DESCRIPTION
**Description:**
Update `logger` documentation to include the new `set_default_level` service.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14703

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/