### PR TITLE
Wether Underground clarification

### DIFF
--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -195,4 +195,8 @@ group:
 Note: While the platform is called “wunderground” the sensors will show up in Home Assistant as “PWS” (eg: sensor.pws_weather).
 </p>
 
+Note that the Weather Underground sensor is added to the entity_registry. Note also that second and subsequent Personal Weather Station ID (pws_id) will have their monitored conditions suffixed with an index number e.g.
+
+      - sensor.pws_weather_1d_metric_2
+
 Additional details about the API are available [here](https://www.wunderground.com/weather/api/d/docs).

--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -195,7 +195,7 @@ group:
 Note: While the platform is called “wunderground” the sensors will show up in Home Assistant as “PWS” (eg: sensor.pws_weather).
 </p>
 
-Note that the Weather Underground sensor is added to the entity_registry. Note also that second and subsequent Personal Weather Station ID (pws_id) will have their monitored conditions suffixed with an index number e.g.
+Note that the Weather Underground sensor is added to the entity_registry, so second and subsequent Personal Weather Station ID (pws_id) will have their monitored conditions suffixed with an index number e.g.
 
       - sensor.pws_weather_1d_metric_2
 


### PR DESCRIPTION
Added a note to clarify that the WU sensor is added to the entity_registry  and that numbers are appended to subsequent weather stations after the first one. Nowhere as far as I know is this documented or made clear.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
