### PR TITLE
Fixed incorrect description in sensor list

### DIFF
--- a/source/_components/spaceapi.markdown
+++ b/source/_components/spaceapi.markdown
@@ -108,7 +108,7 @@ sensors:
       required: true
       type: entity_id
     humidity:
-      description: The Twitter account of the Hackerspace.
+      description: List of humidity sensors.
       required: true
       type: entity_id
 {% endconfiguration %}


### PR DESCRIPTION
Humidity sensor description incorrectly asked for Twitter account info

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ x ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ x ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
