### PR TITLE
Password Quotes and and correct button names

### DIFF
--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -38,11 +38,33 @@ From the Hass.io main panel open the add-on store.
 
 The first add-on we should install is the HASS Configurator. With the HASS Configurator you'll be able to edit your Home Assistant configuration from the web interface.
 
-Go to the add-on store (see previous step), click on Configurator and click on INSTALL. When installation is complete the UI will go to the add-on details page for the configurator. Here you will be able to change settings, start and stop the add-on.
+Go to the add-on store (see previous step), click on Configurator and click on "INSTALL". When installation is complete the UI will go to the add-on details page for the configurator. Here you will be able to change settings, start and stop the add-on. Follow the steps bellow to setup the add-on.
 
- - Change the settings to set a password and click on save
- - Start the add-on
- - You will be able to click the "WEB UI" link to open the Web UI
+ - Set a password on the Config box, don't forget to use quotes on your password like on the example bellow
+ ```
+{
+  "username": "admin",
+  "password": "YOUR_PASSWORD_WITH_QUOTES",
+  "certfile": "fullchain.pem",
+  "keyfile": "privkey.pem",
+  "ssl": false,
+  "allowed_networks": [
+    "192.168.0.0/16"
+  ],
+  "banned_ips": [
+    "8.8.8.8"
+  ],
+  "banlimit": 0,
+  "ignore_pattern": [
+    "__pycache__"
+  ],
+  "dirsfirst": false
+}
+```
+ - Click on "SAVE" to save your new password
+ - "START" the add-on
+ - You will be able to click the "OPEN WEB UI" link to open the Web UI on a new window
+ - Type your username and password that you recently save
 
 Time for the first practice with the configurator. Add the following to `configuration.yaml` file to add a link to the Configurator in the sidebar:
 

--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -40,8 +40,9 @@ The first add-on we should install is the HASS Configurator. With the HASS Confi
 
 Go to the add-on store (see previous step), click on Configurator and click on "INSTALL". When installation is complete the UI will go to the add-on details page for the configurator. Here you will be able to change settings, start and stop the add-on. Follow the steps bellow to setup the add-on.
 
- - Set a password on the Config box, don't forget to use quotes on your password 
- ```
+ - Set a password on the Config box, don't forget to use quotes on your password
+ 
+ ```json
 {
   "username": "admin",
   "password": "YOUR_PASSWORD_WITH_QUOTES",
@@ -61,6 +62,7 @@ Go to the add-on store (see previous step), click on Configurator and click on "
   "dirsfirst": false
 }
 ```
+
  - Click on "SAVE" to save your new password
  - "START" the add-on
  - You will be able to click the "OPEN WEB UI" link to open the Web UI on a new window

--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -40,7 +40,7 @@ The first add-on we should install is the HASS Configurator. With the HASS Confi
 
 Go to the add-on store (see previous step), click on Configurator and click on "INSTALL". When installation is complete the UI will go to the add-on details page for the configurator. Here you will be able to change settings, start and stop the add-on. Follow the steps bellow to setup the add-on.
 
- - Set a password on the Config box, don't forget to use quotes on your password like on the example bellow
+ - Set a password on the Config box, don't forget to use quotes on your password 
  ```
 {
   "username": "admin",


### PR DESCRIPTION
**Description:**
Little corrections and reminder to the user to use "quotes" on the password
Feel free to change any vocabulary.

-Added the name of the box "Config" where the user should edit 
-Added a reminder that the password should have quotes around to work. The default setup does not have it
-Added example of the config with the "YOUR_PASSWORD_WITH_QUOTES"
-Added quotes to differentiate the buttons from the text, "INSTALL", "SAVE", "OPEN WEB UI"
-Move "SAVE" for clarity
-"START" now reflects the button
-"OPEN WEB UI" reflects the button, instead of just "WEB UI"
-Add the comment that a new window should open and they should type their password and username

It's my first attempt at the project documentation. I could do more if reflects with the project.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
