### PR TITLE
Fix MyQ doc typo

### DIFF
--- a/source/_components/cover.myq.markdown
+++ b/source/_components/cover.myq.markdown
@@ -37,7 +37,7 @@ password:
   description: Your MyQ account password.
   required: true
   type: string
-password:
+type:
   description: "Your device type/brand. Supported types are `chamberlain`, `liftmaster`, `craftsman` and `merlin`."
   required: true
   type: string


### PR DESCRIPTION
**Description:**

Fixed MyQ typo around "type" and "password"

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
