### PR TITLE
Correct commands for 'homeassistant' user

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Recorder"
 description: "Instructions on how to configure the data recorder for Home Assistant."
-date: 2017-09-24 09:00
+date: 2018-06-03 11:30
 sidebar: true
 comments: false
 sharing: true
@@ -189,7 +189,7 @@ Not all Python bindings for the chosen database engine can be installed directly
 If you are in a virtual environment, don't forget to activate it before installing the `mysqlclient` Python package described below.
 
 ```bash
-pi@homeassistant:~ $ sudo su homeassistant -s /bin/bash  
+pi@homeassistant:~ $ sudo -u homeassistant -H -s
 homeassistant@homeassistant:~$ source /srv/homeassistant/bin/activate
 (homeassistant) homeassistant@homeassistant:~$ pip3 install mysqlclient
 ```
@@ -235,7 +235,7 @@ $ pip3 install pymssql
 If you are in a virtual environment, don't forget to activate it before installing the pymssql package.
 
 ```bash
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ source /srv/homeassistant/bin/activate
 $ pip3 install pymssql
 ```

--- a/source/_components/sensor.sensehat.markdown
+++ b/source/_components/sensor.sensehat.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Sense HAT"
 description: "Instructions on how to integrate Sense HAT within Home Assistant."
-date: 2017-06-03 04:00
+date: 2018-06-03 11:30
 sidebar: true
 comments: false
 sharing: true
@@ -109,7 +109,7 @@ Here are the steps to make the _SenseHAT_ sensor work _successfully_ with the vi
 #### Install SenseHAT package to _homeassistant_venv_
 ```bash
 # switch to the homeassistant_venv environment
-sudo su -s /bin/bash homeassistant
+sudo -u homeassistant -H -s
 source /srv/homeassistant/homeassistant_venv/bin/activate
 
 # install the sense-hat lib

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Xiaomi Mi Robot Vacuum"
 description: "Instructions on how to integrate your Xiaomi Mi Robot Vacuum within Home Assistant."
-date: 2017-05-05 18:11
+date: 2018-06-03 11:30
 sidebar: true
 comments: false
 sharing: true
@@ -189,7 +189,7 @@ $ sudo apt-get install libffi-dev libssl-dev
 If your Home Assistant installation is running in a [Virtualenv](/docs/installation/virtualenv/#upgrading-home-assistant), make sure you activate it by running the commands below.
 
 ```bash
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ source /srv/homeassistant/bin/activate
 ```
 
@@ -219,7 +219,7 @@ $ sudo apt-get install libffi-dev libssl-dev
 If your Home Assistant installation is running in a [Virtualenv](/docs/installation/virtualenv/#upgrading-home-assistant), make sure you activate it by running the commands below.
 
 ```bash
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ source /srv/homeassistant/bin/activate
 ```
 

--- a/source/_docs/ecosystem/certificates/lets_encrypt.markdown
+++ b/source/_docs/ecosystem/certificates/lets_encrypt.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Remote Access with TLS/SSL via Let's Encrypt"
 description: "A guide to remotely accessing Home Assistant and securing the connection with an SSL certificate from Let's Encrypt"
-date: 2017-03-16 17:00
+date: 2018-06-03 11:00
 sidebar: true
 comments: false
 sharing: true
@@ -245,17 +245,17 @@ In cases where your ISP blocks port 80 you will need to change the port forward 
 Now SSH in to the device your Home Assistant is running on.
 
 <p class='note'>
-If you're running the 'standard' setup on a Raspberry Pi the chances are you just logged in as the 'pi' user. If not, you may have logged in as the Home Assistant user. There are commands below that require the Home Assistant user to be on the `sudoers` list. If you are not using the 'standard' Pi setup it is presumed you will know how to get your Home Assistant user on the `sudoers` list before continuing.  If you are running the 'standard' Pi setup, from your 'pi' user issue the following command (where `hass` is the Home Assistant user):
+If you're running the 'standard' setup on a Raspberry Pi the chances are you just logged in as the 'pi' user. If not, you may have logged in as the Home Assistant user. There are commands below that require the Home Assistant user to be on the `sudoers` list. If you are not using the 'standard' Pi setup it is presumed you will know how to get your Home Assistant user on the `sudoers` list before continuing.  If you are running the 'standard' Pi setup, from your 'pi' user issue the following command (where `homeassistant` is the Home Assistant user):
 
 ```
-$ sudo adduser hass sudo
+$ sudo adduser homeassistant sudo
 ```
 </p>
 
-If you did not already log in as the user that currently runs Home Assistant, change to that user (usually `hass` or `homeassistant` - you may have used a command similar to this in the past):
+If you did not already log in as the user that currently runs Home Assistant, change to that user (usually `homeassistant` or `hass` - you may have used a command similar to this in the past):
 
 ```bash
-$ sudo su -s /bin/bash hass
+$ sudo -u homeassistant -H -s
 ```
 
 Make sure you are in the home directory for the Home Assistant user:
@@ -449,10 +449,10 @@ Your certificate can be renewed as a 'cron job' - cron jobs are background tasks
 To set a cron job to run the script at regular intervals:
 
  * SSH in to your device running Home Assistant.
- * Change to your Home Assistant user (command similar to):
+ * Change to your Home Assistant user (where `homeassistant` is the name of the user):
 
 ```bash
-$ sudo su -s /bin/bash hass
+$ sudo -u homeassistant -H -s
 ```
 
  * Open the crontab:
@@ -506,10 +506,10 @@ You can manually update the certificate when your certificate is less than 30 da
 To manually update:
 
  * SSH in to your device running Home Assistant.
- * Change to your Home Assistant user (command similar to):
+ * Change to your Home Assistant user (where `homeassistant` is the name of the user):
 
 ```bash
-$ su - s /bin/bash hass
+$ sudo -u homeassistant -H -s
 ```
 
  * Change to your certbot folder

--- a/source/_docs/installation/hassbian/common-tasks.markdown
+++ b/source/_docs/installation/hassbian/common-tasks.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Common tasks on Hassbian"
 description: "Instructions on how to do common tasks on Hassbian."
-date: 2016-09-26 21:00
+date: 2018-06-03 11:00
 sidebar: true
 comments: false
 sharing: true
@@ -44,7 +44,7 @@ Log in as the `pi` account and execute the following commands:
 
 ```bash
 $ sudo systemctl stop home-assistant@homeassistant.service
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ source /srv/homeassistant/bin/activate
 $ pip3 install --upgrade homeassistant
 $ exit
@@ -64,7 +64,7 @@ This will in order do the following:
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ source /srv/homeassistant/bin/activate
 $ hass
 ```
@@ -75,7 +75,7 @@ This will start Home Assistant in your shell and output anything that ends up in
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ source /srv/homeassistant/bin/activate
 $ hass --script check_config
 ```
@@ -86,7 +86,7 @@ This will output any errors in your configuration files to console.
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ cd /home/homeassistant/.homeassistant
 $ nano home-assistant.log
 ```
@@ -109,7 +109,7 @@ $ sudo journalctl -fu home-assistant@homeassistant.service
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ cd /home/homeassistant/.homeassistant
 $ nano configuration.yaml
 ```

--- a/source/_docs/installation/hassbian/upgrading.markdown
+++ b/source/_docs/installation/hassbian/upgrading.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Upgrading Hassbian"
 description: "Instructions on how to upgrade Hassbian to the latest version."
-date: 2016-09-26 21:00
+date: 2018-06-03 11:00
 sidebar: true
 comments: false
 sharing: true
@@ -27,7 +27,7 @@ To update the Home Assistant installation execute the following command as the `
 
 ```bash
 $ sudo systemctl stop home-assistant@homeassistant.service
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ source /srv/homeassistant/bin/activate
 $ pip3 install --upgrade homeassistant
 $ exit

--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Manual installation on a Raspberry Pi"
 description: "Instructions to install Home Assistant on a Raspberry Pi running Raspbian Lite."
-date: 2016-09-05 16:00
+date: 2018-06-03 11:00
 sidebar: true
 comments: false
 sharing: true
@@ -66,7 +66,7 @@ $ sudo chown homeassistant:homeassistant homeassistant
 Next up is to create and change to a virtual environment for Home Assistant. This will be done as the `homeassistant` account.
 
 ```bash
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ cd /srv/homeassistant
 $ python3 -m venv .
 $ source bin/activate
@@ -101,7 +101,7 @@ If you want setup `hass` as a daemon and autostart it on boot please refer to [A
 To update to the latest version of Home Assistant follow these simple steps:
 
 ```bash
-$ sudo su -s /bin/bash homeassistant
+$ sudo -u homeassistant -H -s
 $ source /srv/homeassistant/bin/activate
 $ pip3 install --upgrade homeassistant
 ```


### PR DESCRIPTION
**Description:**
Correct commands for `homeassistant` user
* Update commands to start shell as `homeassistant` user
* Fix references to `hass` user

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
