### PR TITLE
added note python_script not allowed in Hass.io

### DIFF
--- a/source/_components/python_script.markdown
+++ b/source/_components/python_script.markdown
@@ -60,5 +60,6 @@ The above `python_script` can be called using the following JSON as an input.
 ```json
 {"entity_id": "light.bedroom", "rgb_color": [255, 0, 0] }
 ```
+Note: Python Scripts are not currently exposed/available in Hass.io
 
 For more examples, visit the [Scripts section](https://community.home-assistant.io/c/projects/scripts) in our forum.


### PR DESCRIPTION
I've been banging my head against the wall with this simple hello_world.py just to find a small reference in a forum saying it isn't allowed in Hass.io

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
