### PR TITLE
Update vacuum docs to be more generic

### DIFF
--- a/source/_components/vacuum.markdown
+++ b/source/_components/vacuum.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Vacuum cleaner robots"
-description: "Instructions on how to setup a botvac in Home Assistant."
+description: "Instructions on how to setup and use vacuum's in Home Assistant."
 date: 2017-07-28 15:00
 sidebar: true
 comments: false
@@ -25,7 +25,7 @@ vacuum:
 
 Available services: `turn_on`, `turn_off`, `start_pause`, `stop`, `return_to_home`, `locate`, `clean_spot`, `set_fanspeed` and `send_command`.
 
-Before calling one of these services, make sure your botvac platform supports it.
+Before calling one of these services, make sure your vacuum platform supports it.
 
 #### {% linkable_title Service `vacuum.turn_on` %}
 
@@ -33,7 +33,7 @@ Start a new cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 
 #### {% linkable_title Service `vacuum.turn_off` %}
 
@@ -41,7 +41,7 @@ Stop the current cleaning task and return to the dock.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 
 #### {% linkable_title Service `vacuum.start_pause` %}
 
@@ -49,23 +49,23 @@ Start, pause or resume a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 
 #### {% linkable_title Service `vacuum.stop` %}
 
-Stop the current activity of the botvac.
+Stop the current activity of the vacuum.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 
 #### {% linkable_title Service `vacuum.return_to_home` %}
 
-Tell the botvac to return home.
+Tell the vacuum to return home.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 
 #### {% linkable_title Service `vacuum.locate` %}
 
@@ -73,7 +73,7 @@ Locate the vacuum cleaner robot.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 
 #### {% linkable_title Service `vacuum.clean_spot` %}
 
@@ -81,15 +81,15 @@ Tell the vacuum cleaner to do a spot clean-up.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 
 #### {% linkable_title Service `vacuum.set_fanspeed` %}
 
-Set the fan speed of the botvac. The `fanspeed` can be a label, as `balanced` or `turbo`, or be a number; it depends on the `vacuum` platform.
+Set the fan speed of the vacuum. The `fanspeed` can be a label, as `balanced` or `turbo`, or be a number; it depends on the `vacuum` platform.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 | `fanspeed`                |       no | Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium', or by percentage, between 0 and 100. |
 
 #### {% linkable_title Service `vacuum.send_command` %}
@@ -98,6 +98,6 @@ Send a platform-specific command to the vacuum cleaner.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific botvac. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 | `command`                 |       no | Command to execute.                                   |
 | `params`                  |      yes | Parameters for the command.                           |


### PR DESCRIPTION
**Description:**

Docs kept mentioned `botvac` instead of `vacuum` so they are updated to be more generic.  They still tell the user that the services depend on their platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
