### PR TITLE
Start HomeKit on network_ready or network_complete

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -152,6 +152,8 @@ automation:
     trigger:
       - platform: event
         event_type: zwave.network_ready
+      - platform: event
+        event_type: zwave.network_complete
     action:
       - service: homekit.start
 ```


### PR DESCRIPTION
**Description:** Some setups will emit `zwave.network_complete` instead of `zwave.network_ready` -- the example displayed in the docs should work for either.

See: https://github.com/home-assistant/home-assistant/issues/14270

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
