### PR TITLE
Required / recommended generic Linux packages

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -54,7 +54,22 @@ If you copy over your existing Home Assistant configuration, make sure to enable
 
 ## {% linkable_title Alternative: install on generic Linux server %}
 
-For advanced users, it is also possible to try Hass.io on your [Linux server or inside a virtual machine][linux]. To do so, run the following command as root:
+For advanced users, it is also possible to try Hass.io on your [Linux server or inside a virtual machine][linux].
+
+This is the list of packages you need to have available on your system that will run Hass.io if you are using Debian/Ubuntu:
+
+ - apparmor-utils
+ - apt-transport-https
+ - avahi-daemon
+ - ca-certificates
+ - curl
+ - dbus
+ - jq
+ - network-manager
+ - socat
+ - software-properties-common
+
+To perform the Hass.io installation, run the following command as root:
 
 ```bash
 curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install | bash -s
@@ -62,20 +77,6 @@ curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/in
 
 <p class='note'>
 When you use this installation method, the core SSH add-on may not function correctly. If that happens, use the community SSH add-on. Some of the documentation might not work for your installation either.
-</p>
-
-<p class='note'>
-  This is the list of packages that Hass.io would like to have / require:
-    apparmor-utils
-    apt-transport-https
-    avahi-daemon
-    ca-certificates
-    curl
-    dbus
-    jq
-    network-manager
-    socat
-    software-properties-common
 </p>
 
 A detailed guide about running Hass.io as a virtual machine is available in the [blog](/blog/2017/11/29/hassio-virtual-machine/).

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -64,6 +64,20 @@ curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/in
 When you use this installation method, the core SSH add-on may not function correctly. If that happens, use the community SSH add-on. Some of the documentation might not work for your installation either.
 </p>
 
+<p class='note'>
+  This is the list of packages that Hass.io would like to have / require:
+    apparmor-utils
+    apt-transport-https
+    avahi-daemon
+    ca-certificates
+    curl
+    dbus
+    jq
+    network-manager
+    socat
+    software-properties-common
+</p>
+
 A detailed guide about running Hass.io as a virtual machine is available in the [blog](/blog/2017/11/29/hassio-virtual-machine/).
 
 [Etcher]: https://etcher.io/


### PR DESCRIPTION
As per Frenck's advice this is the current list of packages that Hass.io would like to have / require:
  apparmor-utils
  apt-transport-https
  avahi-daemon
  ca-certificates
  curl
  dbus
  jq
  network-manager
  socat
  software-properties-common

It would be helpful if this was mentioned in the generic Linux server install section.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
