### PR TITLE
Add api_host option to Konnected config

### DIFF
--- a/source/_components/konnected.markdown
+++ b/source/_components/konnected.markdown
@@ -51,6 +51,11 @@ access_token:
   description: Any random string. This is used to ensure that only those devices which you have configured can authenticate to Home Assistant to change a device state.
   required: true
   type: string
+api_host:
+  description: Override the IP address/host (and port number) of Home Assistant that the Konnected device(s) will use to communicate sensor state updates. If omitted, this is defaulted to the value of `base_url` in the `http` component. If you've set `base_url` to an external hostname, then you'll want to set this value back to your _local_ IP address and port (e.g. `http://192.168.1.101:8123`).
+  required: false
+  type: url
+  default: value of `base_url`  
 devices:
   description: A list of Konnected devices that you have on your network.
   required: true


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** https://github.com/home-assistant/home-assistant/pull/14896

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
