### PR TITLE
Add xiaomi_gwto ignore list

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -87,6 +87,7 @@ Valid values for ignore are:
  * `wink`: Wink Hub
  * `yamaha`: Yamaha media player
  * `yeelight`: Yeelight Sunflower bulb
+ * `xiaomi_gw`: Xiaomi Aqara gateway
 
 - **enable** (*Optional*): A list of platforms not enabled by default that `discovery` should discover.
 


### PR DESCRIPTION
Add missing Xiaomi Aqara gateway (xiaomi_gw) to ignore list

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
