### PR TITLE
Fixed broken link in weather.markdown

### DIFF
--- a/source/_components/weather.markdown
+++ b/source/_components/weather.markdown
@@ -15,7 +15,7 @@ Home Assistant currently supports free web services and such which require a reg
 
 ## {% linkable_title Condition mapping %}
 
-The `weather` platform only knows the below listed conditions. The reason for this is that for these conditions is an icon from [Material Design Icons](https://materialdesignicons.com/) available and mapped in the [frontend](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/cards/ha-weather-card.html#L77).
+The `weather` platform only knows the below listed conditions. The reason for this is that for these conditions is an icon from [Material Design Icons](https://materialdesignicons.com/) available and mapped in the [frontend](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/cards/ha-weather-card.js#L170).
 
 - 'cloudy'
 - 'fog'


### PR DESCRIPTION
Link was broken, pointed to old html version of file. Updated to point to the current JavaScript file to allow curious people like me to find it more easily without having to track it down.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
