### PR TITLE
Add file attachment documentation for Pushover notifications

### DIFF
--- a/source/_components/notify.pushover.markdown
+++ b/source/_components/notify.pushover.markdown
@@ -47,13 +47,26 @@ Example Automation:
           url: "https://www.home-assistant.io/"
           sound: pianobar
           priority: 0
+          file:
+            url: !secret camera_still_image
+            auth: basic
+            username: !secret camera_username
+            password: !secret camera_password
 ```
 
 Component specific values in the nested `data` section are optional.
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
 
-When sending a notification, optional parameters can also be set as per the pushover [API documentation](https://pushover.net/api).
+When sending a notification, optional parameters can also be set as per the pushover [API documentation](https://pushover.net/api). 
+
+The `attachment` parameter in the Pushover API gets populated via the `file` section as follows:
+
+- **url** (*Optional*): The URL of the image to be attached. Must supply either `url` or `path`.
+- **path** (*Optional*): The local filesystem path of the image to be attached *(ex. /local/alert.png)*. Must supply either `url` or `path`.
+- **auth** (*Optional*): Valid options are `auth` *(default)* or `digest`
+- **username** (*Optional*): Username for remote resource if authentication is required.
+- **password** (*Optional*): Password for remote resource if authentication is required.
 
 Example notification triggered from the Alexa component for an intents is shown below which also uses [Automation Templating](/getting-started/automation-templating/) for the message:
 


### PR DESCRIPTION
**Description:**
Adding documentation to describe the new attachment functionality implemented in `homeassistant/components/notify/pushover.py`.  The documentation needs to wait on the code changes to be accepted as this is new functionality.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14915

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
