### PR TITLE
Correct cache_value

### DIFF
--- a/source/_components/sensor.mitemp_bt.markdown
+++ b/source/_components/sensor.mitemp_bt.markdown
@@ -70,7 +70,7 @@ sensor:
 - **median** (*Optional*): Sometimes the sensor measurements show spikes. Using this parameter, the poller will report the median of the last 3 (you can also use larger values) measurements. This filters out single spikes. Median: 5 will also filter double spikes. If you never have problems with spikes, `median: 1` will work fine.
 - **timeout** (*Optional*): Define the timeout value in seconds when polling (defaults to 10 if not defined)
 - **retries** (*Optional*): Define the number of retries when polling (defaults to 2 if not defined)
-- **cache_value** (*Optional*): Define cache expiration value in seconds (defaults to 1200 if not defined)
+- **cache_value** (*Optional*): Define cache expiration value in seconds (defaults to 300 if not defined)
 - **adapter** (*Optional*): Define the Bluetooth adapter to use (defaults to hci0). Run `hciconfig` to get a list of available adapters.
 
 Note that by default the sensor is only polled once every 5 minutes. This means with the `median: 3` setting will take as least 15 minutes before the sensor will report a value after a Home Assistant restart. Even though the hardware is able to provide new values every second, room temperatures don't change that quickly.


### PR DESCRIPTION
The default cache_value is 300, not 1200: https://github.com/home-assistant/home-assistant/blob/fecce206a9ce3e869938478feb32ddede533dffd/homeassistant/components/sensor/mitemp_bt.py#L30

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
