### PR TITLE
Add section on Mosquitto ACLs

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -18,7 +18,8 @@ Set up [Mosquitto](https://mosquitto.org/) as MQTT broker.
   "ssl": false,
   "anonymous": true,
   "logins": [
-    {"username": "testuser", "password": "mypw"}
+    {"username": "testuser", "password": "mypw"},
+    {"username": "testuser2", "password": "mypw2"}
   ],
   "customize": {
     "active": false,
@@ -76,3 +77,21 @@ protocol mqtt
 <p class='note warning'>
 It's recommended that you only open your firewall to the SSL/TLS port (8883) and only use the insecure port (1883) for local devices. Also, disable `anonymous:` and set `logins:`.
 </p>
+
+### {% linkable_title Access Control Lists (ACLs) %}
+
+It is possible to restrict access to topics based upon the user logged in to Mosquitto. In this scenario it is recommended to create individual users for each of your clients and create an appropriate ACL.
+
+See the following links for more information:
+* [Mosquitto topic restrictions](http://www.steves-internet-guide.com/topic-restriction-mosquitto-configuration/)
+* [Mosquitto.conf man page](https://mosquitto.org/man/mosquitto-conf-5.html)
+
+Add the following configuraiton to enable ACLs:
+
+1. Set `customize` flag to `true` in your configuration.
+2. Create a file in `/share/mosquitto` named `acl.conf` with the following contents:
+
+```text
+acl_file /share/mosquitto/accesscontrollist
+```
+3. Create a file in `/share/mosquitto` named `accesscontrollist` and add contents according to your requirements.

--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -83,10 +83,11 @@ It's recommended that you only open your firewall to the SSL/TLS port (8883) and
 It is possible to restrict access to topics based upon the user logged in to Mosquitto. In this scenario it is recommended to create individual users for each of your clients and create an appropriate ACL.
 
 See the following links for more information:
+
 * [Mosquitto topic restrictions](http://www.steves-internet-guide.com/topic-restriction-mosquitto-configuration/)
 * [Mosquitto.conf man page](https://mosquitto.org/man/mosquitto-conf-5.html)
 
-Add the following configuraiton to enable ACLs:
+Add the following configuration to enable ACLs:
 
 1. Set `customize` flag to `true` in your configuration.
 2. Create a file in `/share/mosquitto` named `acl.conf` with the following contents:


### PR DESCRIPTION
**Description:**
Added section on enabling ACLs in Mosquitto.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
