### PR TITLE
Document flag for enabling scaling of RGB values in line with brightness

### DIFF
--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -175,6 +175,11 @@ payload_not_available:
   required: false
   type: string
   default: offline
+scale_rgb_with_brightness:
+  description: Flag to specify if the RGB values published to MQTT should be scaled using the brightness. (legacy method)
+  required: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 <p class='note warning'>


### PR DESCRIPTION
**Description:**

This PR adds documentation for the flag to re-enable the legacy scaling of RGB values in line with brightness on MQTT lights. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14972

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
