### PR TITLE
Promoting timezone issue to warning

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -16,7 +16,9 @@ The `alert` component is designed to notify you when problematic issues arise. F
 
 Alerts will add an entity to the front end only when they are firing. This entity allows you to silence an alert until it is resolved.
 
+<p class='note warning'>
 When using the `alert` component, it is important that the time zone used for Home Assistant and the underlying operating system match. Failing to do so may result in multiple alerts being sent at the same time (such as when Home Assistant is set to the `America/Detroit` time zone but the operating system uses `UTC`).
+</P>
 
 ### {% linkable_title Basic Example %}
 


### PR DESCRIPTION
Given the long standing bug with the alert component - where the timezone in HA differs from the timezone of the OS when starting HA it either fires rapidly, or very slowly - promoting this to a warning.

See [this bug](https://github.com/home-assistant/home-assistant/issues/13609) and [this thread](https://community.home-assistant.io/t/error-alert-component/56242) which reminded me about it.