### PR TITLE
Typo Ubuntu

### DIFF
--- a/source/_docs/ecosystem/backup/backup_github.markdown
+++ b/source/_docs/ecosystem/backup/backup_github.markdown
@@ -35,7 +35,7 @@ Some best practices to consider before putting your configuration on GitHub:
 
 ### {% linkable_title Step 1: Installing and Initializing Git %}
 
-In order to put your configuration on GitHub, you must install the git package on your Home Assistant server (instructions below will work on Raspberry Pi, Ubunutu, or any Debian-based system) *note: this isn't required in Hass.io, it's included as default so proceed to step 2*:
+In order to put your configuration on GitHub, you must install the git package on your Home Assistant server (instructions below will work on Raspberry Pi, Ubuntu, or any Debian-based system) *note: this isn't required in Hass.io, it's included as default so proceed to step 2*:
 
 ```bash
 $ sudo apt-get update


### PR DESCRIPTION
Typo in Ubuntu word

**Description:** Typo Ubuntu Word


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
