### PR TITLE
Fixes capatalization of Home Assistant.

### DIFF
--- a/source/_components/matrix.markdown
+++ b/source/_components/matrix.markdown
@@ -31,7 +31,7 @@ Configuration variables:
 
 {% configuration %}
 username:
-  description: "The matrix username that home assistant should use to log in. *Note*: You must specify a full matrix ID here, including the homeserver domain, e.g. '@my_matrix_bot:matrix.org'. Please note also that the '@' character has a special meaning in YAML, so this must always be given in quotes."
+  description: "The matrix username that Home Assistant should use to log in. *Note*: You must specify a full matrix ID here, including the homeserver domain, e.g. '@my_matrix_bot:matrix.org'. Please note also that the '@' character has a special meaning in YAML, so this must always be given in quotes."
   required: true
   type: string
 password:


### PR DESCRIPTION
**Description:**

Home Assistant was spelled wrong on the Matrix component page

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
