### PR TITLE
Fix filename of netgear_lte logo

### DIFF
--- a/source/_components/netgear_lte.markdown
+++ b/source/_components/netgear_lte.markdown
@@ -7,7 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: netgear.jpg
+logo: netgear.png
 ha_release: 0.72
 ha_category: Other
 ha_iot_class: "Local Polling"

--- a/source/_components/sensor.netgear_lte.markdown
+++ b/source/_components/sensor.netgear_lte.markdown
@@ -7,7 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: netgear.jpg
+logo: netgear.png
 ha_release: 0.72
 ha_category: Sensor
 ha_iot_class: "Local Polling"


### PR DESCRIPTION
**Description:**

I noticed a few broken images in the rc documentation, this should fix them.

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
