### PR TITLE
Fix typos and style

### DIFF
--- a/source/_docs/asterisk_mbox.markdown
+++ b/source/_docs/asterisk_mbox.markdown
@@ -9,28 +9,30 @@ sharing: true
 footer: true
 ---
 
-Asterisk Voicemail integration allows Home Assistant to view, listen-to, and delete voicemails from a Asterisk voicemail mailbox.
+Asterisk Voicemail integration allows Home Assistant to view, listen to and delete voicemails from a Asterisk voicemail mailbox.
 
 There are two components to the integration:
+
 - A server that runs on the Asterisk PBX host and communicates over an open port.
 - A client which can request inormation from the server.
 
 Both parts are necessary for Asterisk voicemail integration.
 
-The server installation is documented below.  The client is [integrated inside Home Assistant](/components/asterisk_mbox)
+The server installation is documented below. The client is [integrated inside Home Assistant](/components/asterisk_mbox)
 
 <p class='note'>
-Currently this module can only monitor a single Asterisk PBX mailbox.  Multiple mailbox support is planned for the future
+Currently this module can only monitor a single Asterisk PBX mailbox.
 </p>
 
 ### {% linkable_title Prerequisites %}
 
 Before beginning make sure that you have the following:
-- A functional Asterisk PBX setup which is using the default `voicemail` application
-- Both Home Assistant and Asterisk PBX running on the same LAN (or the same server)
-- The Asterisk PBX server has python 3.4 or newer installed
-- Administrator access on the Asterisk PBX (for python module installation)
-- Account Access to the `asterisk` user that runs the Asterisk PBX software
+
+- A functional Asterisk PBX setup which is using the default `voicemail` application.
+- Both Home Assistant and Asterisk PBX running on the same LAN (or the same server).
+- The Asterisk PBX server has Python 3.5 or newer installed.
+- Administrator access on the Asterisk PBX (for python module installation).
+- Account access to the `asterisk` user that runs the Asterisk PBX software.
 
 ### {% linkable_title Installation %}
 
@@ -44,7 +46,7 @@ Before beginning make sure that you have the following:
 
 3. Create a configuration file for the server
 
-   As the `asterisk` user create an `asterisk_mbox.ini` file (You can place this in any directory you choose, but the rommended location is `/etc/asterisk/asterisk_mbox.ini`)
+   As the `asterisk` user create an `asterisk_mbox.ini` file. You can place this in any directory you choose, but the recommended location is `/etc/asterisk/asterisk_mbox.ini`.
 
    ```ini
    [default]
@@ -56,14 +58,14 @@ Before beginning make sure that you have the following:
    google_key = GOOGLE_API_KEY
    ```
 
-   - **host** (*Optional*): The IP address to listen on for client requests.  This defaults to all IP addresses on the server.  To listen only locally, choose `127.0.0.1`
-   - **port** (*Optional*): The port to listen on for client requests.  (default: 12345)
-   - **password** (*Required*):  A password shared between client and server.  Use only alpha-numeric characters and spaces
-   - **mbox\_path** (*Required*): The path to the storage location of mailbox files.  This is typically `/var/spool/asterisk/voicemail/default/<mailbox>/`
-   - **cache\_file** (*Required*): A fully-qualified path to a file thht can be written by the server containing transcriptions of voicemails.  Example: `/var/spool/asterisk/transcription.cache`
-   - **google\_key** (*Required*): Your 40 character Google API key
+   - **host** (*Optional*): The IP address to listen on for client requests. This defaults to all IP addresses on the server. To listen only locally, choose `127.0.0.1`
+   - **port** (*Optional*): The port to listen on for client requests. Defaults to 12345.
+   - **password** (*Required*): A password shared between client and server.  Use only alpha-numeric characters and spaces
+   - **mbox\_path** (*Required*): The path to the storage location of mailbox files. This is typically `/var/spool/asterisk/voicemail/default/<mailbox>/`
+   - **cache\_file** (*Required*): A fully-qualified path to a file thht can be written by the server containing transcriptions of voicemails. Example: `/var/spool/asterisk/transcription.cache`
+   - **google\_key** (*Required*): Your 40 characters Google API key.
 
-   Once complete, ensure this file is only accessible by the asterisk user:
+   Once complete, ensure this file is only accessible by the Asterisk user:
 
    ```bash
    $ sudo chown asterisk:asterisk /etc/asterisk/asterisk_mbox.ini
@@ -77,7 +79,7 @@ Before beginning make sure that you have the following:
 
    Now complete the [Home Assistant configuration](/components/asterisk_mbox) and verify that Home Assistant can communicate with the server
 
-   You can use `Ctrl-C` to terminate the server when done testing
+   You can use `Ctrl-c` to terminate the server when done testing
 
 5. Configure the server to start automatically
 
@@ -100,5 +102,5 @@ Before beginning make sure that you have the following:
    ```
 
 <p class='note'>
-This assumes that your Asterisk PBX server is using `systemd` for init handling.  If not, you will need to create the appropriate configuration files yourself.
+This assumes that your Asterisk PBX server is using `systemd` for init handling. If not, you will need to create the appropriate configuration files yourself.
 </p>


### PR DESCRIPTION
**Description:**
Fix typos and style.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
