### PR TITLE
MAC Address only works when both quoted and separated with hythens

### DIFF
--- a/source/_components/media_player.webostv.markdown
+++ b/source/_components/media_player.webostv.markdown
@@ -90,7 +90,7 @@ media_player:
     turn_on_action:
       service: wake_on_lan.send_magic_packet
       data:
-        mac: B4:E6:2A:1E:11:0F
+        mac: "B4-E6-2A-1E-11-0F"
 ```
 
 Any other [actions](/docs/automation/action/) to power on the device can be configured.
@@ -128,4 +128,4 @@ data:
 The behaviour of the next and previsous buttons is different depending on the active source:
 
  - if the source is 'LiveTV' (television): next/previous buttons act as channel up/down
- - otherwise: next/previsous buttons act as next/previous track
+ - otherwise: next/previous buttons act as next/previous track


### PR DESCRIPTION
MAC Address only works when both quoted and separated with hythens, which conincidently is how it's formatted in the [switch.wake_on_lan](https://www.home-assistant.io/components/switch.wake_on_lan/) component documentation 

also, fix a minor typo

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
