### PR TITLE
Add docs for additional Arlo Baby sensors

### DIFF
--- a/source/_components/sensor.arlo.markdown
+++ b/source/_components/sensor.arlo.markdown
@@ -33,6 +33,20 @@ sensor:
       - signal_strength
 ```
 
+Additionally, for Arlo Baby cameras that have additional sensors, you can add them to the `monitored_conditions` collection:
+
+```yaml
+# Additional sensors available for Arlo Baby cameras
+sensor:
+  - platform: arlo
+    monitored_conditions:
+      # ...
+      - temperature
+      - humidity
+      - air_quality
+```
+
+
 Configuration variables:
 
 - **monitored_conditions** array (*Optional*): Conditions to display in the frontend. The following conditions can be monitored.
@@ -41,5 +55,8 @@ Configuration variables:
   - **total_cameras**: Return the number of recognized and active cameras linked on your Arlo account.
   - **battery_level**: Return the battery level of your Arlo camera.
   - **signal_strength**: Return the wireless signal strength of your Arlo camera.
+  - **temperature**: Return the ambient temperature detected by your Arlo Baby camera.
+  - **humidity**: Return the ambient relative humidity detected by your Arlo Baby camera.
+  - **air_quality**: Return the ambient air quality (a reading of volatile organic compounds (VOCs) in parts per million) detected by your Arlo Baby camera.
 
 If no **monitored_conditions** are specified, all of above will be enabled by default.


### PR DESCRIPTION
**Description:**
Adds documentation for additional sensors added in `pyarlo==0.1.8` and in the below-referenced pull request.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15074

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
