### PR TITLE
Update supported samsung TV models

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -57,6 +57,7 @@ Currently known supported models:
 - U6300 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - K5579 (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 - K6500AF (port must be set to 8001)
+- KS8000 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - KS8005 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - KU6020 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - KU6290 (port must be set to 8001)


### PR DESCRIPTION
Add KS8000 to the list of supported Samsung TV models

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
