### PR TITLE
Explain PostNL sensor value

### DIFF
--- a/source/_components/sensor.postnl.markdown
+++ b/source/_components/sensor.postnl.markdown
@@ -15,6 +15,8 @@ ha_iot_class: "Cloud Polling"
 
 The `postnl` platform allows one to track deliveries by [PostNL](https://www.postnl.nl) (Dutch Postal Services). To use this sensor, you need a [PostNL Account](https://jouw.postnl.nl). It is possible to add multiple accounts to your Home Assistant configuration.
 
+The sensor value shows the number of packages to be delivered. Each of the packages is available as an attribute.
+
 ## {% linkable_title Configuration %}
 
 To enable this sensor, add the following lines to your `configuration.yaml`:


### PR DESCRIPTION
The documentation did not state what the sensor is actually showing.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
