### PR TITLE
Skip nest security state sensor if no Nest Cam exists

### DIFF
--- a/source/_components/sensor.nest.markdown
+++ b/source/_components/sensor.nest.markdown
@@ -42,7 +42,7 @@ The following conditions are available by device:
 
 - Nest Home:
   - eta: Estimated time of arrival.
-  - security\_state: `ok` or `deter`. [Security State](#security-state)
+  - security\_state: `ok` or `deter`. [Security State](#security-state). Only available when Nest Camera exists.
 - Nest Thermostat:
   - humidity
   - operation\_mode


### PR DESCRIPTION
**Description:**
Skip nest security state sensor if no Nest Cam exists

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15112

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
