### PR TITLE
Fix incorrect path in Group Visibility example

### DIFF
--- a/source/_docs/configuration/group_visibility.markdown
+++ b/source/_docs/configuration/group_visibility.markdown
@@ -104,7 +104,7 @@ sensor:
     command: "python3 occasion.py"
 ```
 <p class='note'>
-If you are using docker to run Home Assistant then the occasion.py script will be placed under /config. Your command should instead be: command: "python3 /command/occasion.py"
+If you are using docker to run Home Assistant then the occasion.py script will be placed under /config. Your command should instead be: command: "python3 /config/occasion.py"
 </p>
 
 


### PR DESCRIPTION
Hi there, just a minor but quite confusing typo.

The path for calling the occasion.py script referenced in the Group Visibility example when using docker should be /config/occasion.py and not /command/occasion.py

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
