### PR TITLE
Update sensor.rest.markdown

### DIFF
--- a/source/_components/sensor.rest.markdown
+++ b/source/_components/sensor.rest.markdown
@@ -237,7 +237,7 @@ sensor:
     sensors:
       owm_weather:
         value_template: '{{ states.sensor.owm_report.attributes.weather[0]["description"].title() }}'
-        icon_template: '{{ "http://openweathermap.org/img/w/"+states.sensor.owm_report.attributes.weather[0]["icon"]+".png" }}'
+        entity_picture_template: '{{ "http://openweathermap.org/img/w/"+states.sensor.owm_report.attributes.weather[0]["icon"].lower()+".png" }}'
         entity_id: sensor.owm_report
       owm_temp:
         friendly_name: 'Outside temp'


### PR DESCRIPTION
The example for sensor.owm_weather does not work. It must be „entity_picture_template“ instead of „icon_template“, the protocol can be „//:“ and the icon name must be lowercase because of //:openweathermap.org server is case sensitive.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
