### PR TITLE
Clarify potential security issues; use safer example config

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -36,7 +36,7 @@ Configuration variables:
 - **ssl_certificate** (*Optional*): Path to your TLS/SSL certificate to serve Home Assistant over a secure connection.
 - **ssl_key** (*Optional*): Path to your TLS/SSL key to serve Home Assistant over a secure connection.
 - **cors_allowed_origins** (*Optional*): A list of origin domain names to allow [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) requests from. Enabling this will set the `Access-Control-Allow-Origin` header to the Origin header if it is found in the list, and the `Access-Control-Allow-Headers` header to `Origin, Accept, X-Requested-With, Content-type, X-HA-access`. You must provide the exact Origin, i.e. `https://www.home-assistant.io` will allow requests from `https://www.home-assistant.io` but __not__ `http://www.home-assistant.io`.
-- **use_x_forwarded_for** (*Optional*): Enable parsing of the `X-Forwarded-For` header, passing on the client's correct IP address in proxied setups. You should only enable this in a trustworthy network environment, as clients passing that header could easily spoof their source IP address. Defaults to False.
+- **use_x_forwarded_for** (*Optional*): Enable parsing of the `X-Forwarded-For` header, passing on the client's correct IP address in proxied setups. You should only enable this in a trustworthy network environment where only the proxy can access Home Assistant, as clients passing this header can easily spoof their IP address to gain access via `trusted_networks` or bypass the `login_attempts_threshold`. Defaults to False.
 - **trusted_networks** (*Optional*): List of trusted networks, consisting of IP addresses or networks, that are allowed to bypass password protection when accessing Home Assistant. It should be noted that if you use a reverse proxy, all requests to Home Assistant, regardless of source, will arrive from the reverse proxy IP address. Therefore in a reverse proxy scenario, this option should be used with extreme care.
 - **ip_ban_enabled** (*Optional*): Flag indicating whether additional IP filtering is enabled. Defaults to False.
 - **login_attempts_threshold** (*Optional*): Number of failed login attempt from single IP after which it will be automatically banned if `ip_ban_enabled` is True. Defaults to -1, meaning that no new automatic bans will be added.
@@ -53,12 +53,12 @@ http:
   cors_allowed_origins:
     - https://google.com
     - https://www.home-assistant.io
-  use_x_forwarded_for: True
+  use_x_forwarded_for: False
   trusted_networks:
     - 127.0.0.1
     - ::1
     - 192.168.0.0/24
-    - 2001:DB8:ABCD::/48
+    - fd00::/8
   ip_ban_enabled: True
   login_attempts_threshold: 5
 ```


### PR DESCRIPTION
**Description:**

This PR has two goals:

1. Clarify exactly what can happen if `use_x_forwarded_for` is enabled
2. Update the example configuration to be safer in case somebody blindly copy-pastes it

See https://github.com/home-assistant/home-assistant/issues/14345#issuecomment-400854569 for why a misconfigured setting can be a problem.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
