### PR TITLE
Added Smart Meter

### DIFF
--- a/source/_components/sensor.dsmr.markdown
+++ b/source/_components/sensor.dsmr.markdown
@@ -32,6 +32,7 @@ This component is known to work for:
 - Landis+Gyr ZCF110 / ZM F110 (DSMR 4.2)
 - Kaifa E0026
 - Kamstrup 382JxC (DSMR 2.2)
+- Sagemcom XS210 ESMR5
 
 USB serial converters:
 


### PR DESCRIPTION
Sagemcom XS210 ESMR5 works at home out of the box with this component.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
