### PR TITLE
Added details about emulated_hue_hidden

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -61,7 +61,7 @@ homeassistant:
 | `homebridge_name` | Name of the entity in `HomeBridge`.
 | `hidden`    | Set to `true` to hide the entity.
 | `homebridge_hidden` | Set to `true` to hide the entity from `HomeBridge`.
-| `emulated_hue_hidden` | Set to `true` to hide the entity from `emulated_hue`.
+| `emulated_hue_hidden` | Set to `true` to hide the entity from `emulated_hue` (this will be deprecated in the near future and should be configured in [`emulated_hue`](/components/emulated_hue)).
 | `entity_picture` | Url to use as picture for entity.
 | `icon` | Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://materialdesignicons.com/cheatsheet)). Prefix name with `mdi:`, ie `mdi:home`.
 | `assumed_state` | For switches with an assumed state two buttons are shown (turn off, turn on) instead of a switch. By setting `assumed_state` to `false` you will get the default switch icon.


### PR DESCRIPTION
Given that it mentions in the emulated_hue pages that `emulated_hue_hidden` is being deprecated, it seems sensible to actually mention that here ;)
