### PR TITLE
The path option is mandatory due to different cameras

### DIFF
--- a/source/_components/camera.xiaomi.markdown
+++ b/source/_components/camera.xiaomi.markdown
@@ -55,6 +55,7 @@ camera:
     name: Camera
     host: '192.168.1.100'
     model: 'yi'
+    path: '/tmp/sd/record'
     password: my_password_123
 ```
 
@@ -64,7 +65,7 @@ Configuration variables:
 - **host** (*Required*): The IP address or hostname of the camera.
 - **model** (*Required*): The model of Xiaomi Camera, currently supporting yi and xiaofang.
 - **password** (*Required*): The password to the FTP server on the camera (from above), can be any string as the current firmware doesn't allow setting ftp passwords.
-- **path** (*Optional*): The path to the raw MP4 files. Defaults to `/tmp/sd/record`.
+- **path** (*Required*): The path to the raw MP4 files. Defaults to `/media/mmcblk0p2/record`.
 - **username** (*Optional*): The user that can access the FTP server. Defaults to `root`.
 - **ffmpeg_arguments** (*Optional*): Extra options to pass to `ffmpeg` (e.g., image quality or video filter options).
 


### PR DESCRIPTION
The path option is mandatory, because each camera has its own path to record the mp4 files.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15260

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
