### PR TITLE
Added documentation to support HTTPS URLs for SynologyDSM

### DIFF
--- a/source/_components/sensor.synologydsm.markdown
+++ b/source/_components/sensor.synologydsm.markdown
@@ -36,10 +36,10 @@ sensor:
 Configuration variables:
 
 - **host** (*Required*): The IP address of the Synology NAS to monitor.
-- **port** (*Optional*): The port number on which the Synology NAS is reachable. Defaults to `5000`.
+- **port** (*Optional*): The port number on which the Synology NAS is reachable. Defaults to `5001`.
 - **username** (*Required*): An user to connect to the Synology NAS (a separate account is advised, see the Separate User Configuration section below for details).
 - **password** (*Required*): The password of the user to connect to the Synology NAS.
-- **ssl** (*Optional*): Determine if HTTPS should be used. Defaults to `False` which means standard HTTP.
+- **ssl** (*Optional*): Determine if HTTPS should be used. Defaults to `True` which by default runs on port `5001`.
 - **volumes** (*Optional*): Array of volumes to monitor. Defaults to all volumes.
 - **disks** (*Optional*): Array of disks to monitor. Defaults to all disks.
 - **monitored_conditions** (*Required*): Defines a [template](/topics/templating/) to extract a value from the payload.

--- a/source/_components/sensor.synologydsm.markdown
+++ b/source/_components/sensor.synologydsm.markdown
@@ -39,6 +39,7 @@ Configuration variables:
 - **port** (*Optional*): The port number on which the Synology NAS is reachable. Defaults to `5000`.
 - **username** (*Required*): An user to connect to the Synology NAS (a separate account is advised, see the Separate User Configuration section below for details).
 - **password** (*Required*): The password of the user to connect to the Synology NAS.
+- **ssl** (*Optional*): Determine if HTTPS should be used. Defaults to `False` which means standard HTTP.
 - **volumes** (*Optional*): Array of volumes to monitor. Defaults to all volumes.
 - **disks** (*Optional*): Array of disks to monitor. Defaults to all disks.
 - **monitored_conditions** (*Required*): Defines a [template](/topics/templating/) to extract a value from the payload.


### PR DESCRIPTION
**Description:**

Added documentation to support HTTPS URLs for SynologyDSM

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15270

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].
