### PR TITLE
add mention of new ZoneMinder run state sensor and set_run_state service

### DIFF
--- a/source/_components/sensor.zoneminder.markdown
+++ b/source/_components/sensor.zoneminder.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Polling"
 ---
 
 
-The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of events and the current state of the cameras.
+The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of events, the current state of the cameras, and ZoneMinder's run state.
 
 <p class='note'>
 You must have the [ZoneMinder component](/components/zoneminder/) configured to use this sensor.
@@ -38,4 +38,3 @@ Configuration variables:
   - **week**: Events in the last week.
   - **day**: Events in the last day.
   - **hour**: Events in the last hour.
-

--- a/source/_components/zoneminder.markdown
+++ b/source/_components/zoneminder.markdown
@@ -42,3 +42,20 @@ zoneminder:
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
 ```
+
+### {% linkable_title Service %}
+
+Once loaded, the `zoneminder` platform will expose a service (`set_run_state`) that can be used to change the current run state of ZoneMinder.
+
+| Service data attribute | Optional | Description                       |
+|:-----------------------|:---------|:----------------------------------|
+| `name`                 | no       | Name of the new run state to set. |
+
+For example, if your ZoneMinder instance was configured with a run state called "Home", you could write an [automation](/getting-started/automation/) that changes ZoneMinder to the "Home" run state by including the following [action](/getting-started/automation-action/):
+
+```yaml
+action:
+  service: zoneminder.set_run_state
+  data:
+    name: Home
+```


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/15324

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
