### PR TITLE
Add requisites for gpio ( usergroup ) 

### DIFF
--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -49,10 +49,10 @@ $ sudo apt-get install python3 python3-venv python3-pip
 ```
 
 Add an account for Home Assistant called `homeassistant`.
-Since this account is only for running Home Assistant the extra arguments of `-rm` is added to create a system account and create a home directory. The arguments `-G dialout` adds the user to the `dialout` group. This is required for using Z-Wave and Zigbee controllers.
+Since this account is only for running Home Assistant the extra arguments of `-rm` is added to create a system account and create a home directory. The arguments `-G dialout,gpio` adds the user to the `dialout` and the `gpio` group. The first is required for using Z-Wave and Zigbee controllers, while the second is required to communicate with Raspberry's GPIO.
 
 ```bash
-$ sudo useradd -rm homeassistant -G dialout
+$ sudo useradd -rm homeassistant -G dialout,gpio
 ```
 
 Next we will create a directory for the installation of Home Assistant and change the owner to the `homeassistant` account.


### PR DESCRIPTION
**Description:**
Since homeassistant user is required to be in gpio group in order to use them, let's fix this during installation.
No other mentions in installation are done.


## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
