### PR TITLE
Update device_tracker.snmp.markdown

### DIFF
--- a/source/_components/device_tracker.snmp.markdown
+++ b/source/_components/device_tracker.snmp.markdown
@@ -34,6 +34,8 @@ The following OID examples pull the current MAC Address table from a router. Thi
 | EdgeRouter | Lite v1.9.0 | `1.3.6.1.2.1.4.22.1.2` |
 | Ruckus | ZoneDirector 9.13.3 | `1.3.6.1.4.1.25053.1.2.2.1.1.3.1.1.1.6` |
 | DD-WRT | unknown RouterOS version/model |  `1.3.6.1.2.1.4.22.1.2` |
+| Apple Airport Express (2nd gen.) | 7.6.9 |  `1.3.6.1.2.1.3.1.1.2`
+`1.3.6.1.2.1.4.22.1.2.16`|
 
 To use the SNMP version 1 platform in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
Base OID's for Apple Airport Express (2nd gen.) router

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
