### PR TITLE
Update git_pull documentation for v4.8 of addon

### DIFF
--- a/source/_addons/git_pull.markdown
+++ b/source/_addons/git_pull.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "GIT pull"
+title: "Git pull"
 description: "Load and update configuration files for Home Assistant from a GIT repository."
 date: 2017-09-25 14:00
 sidebar: true
@@ -15,6 +15,9 @@ Load and update configuration files for Home Assistant from a GIT repository.
 {
   "repository": "https://example.com/my_configs.git",
   "auto_restart": false,
+  "git_branch": "master",
+  "git_command": "pull",
+  "git_remote": "origin",
   "repeat": {
     "active": false,
     "interval": 300
@@ -32,9 +35,20 @@ Load and update configuration files for Home Assistant from a GIT repository.
 }
 ```
 
-- **repository** (*Required*): GIT url to your repository. You have to add .git to your GITHub-Repository-URL (see example Config)
+- **repository** (*Required*): Git url to your repository (make sure to use double quotes). You have to add .git to your GITHub-Repository-URL (see example Config)
+- **git_branch** (*Required*): Branch name of the git repo, leave this as 'master' if you are unsure.
+- **git_remote** (*Requried*): Name of the tracked repository, leave this as 'origin' if you are unsure.
+- **git_command** (*Required*): Must be either 'pull' or 'reset', leave this as 'pull' if you are unsure.
+
+  * **pull**: Incorporates changes from a remote repository into the current branch. Will preserve any local changes to tracked files.
+  * **reset**: Will execute ```git reset --hard``` and overwrite any local changes to tracked files and update from the remote repository.
+
+<p class='note warning'>
+  Using the <b>reset</b> option will overwrite changes to tracked files.  Tracked files are those visible in the Github repository or those given by the output on this command: ```git ls-tree -r master --name-only```
+</p>
+  
 - **auto_restart** (*Optional*): Make a restart of Home-Assistant if the config have change and is valid.
-- **repeat/active** (*Optional*): Pull periodic for GIT updates.
+- **repeat/active** (*Optional*): Pull periodic for git updates.
 - **repeat/interval** (*Optional*): Pull all x seconds and look for changes.
 - **deployment_user** (*Optional*): Username to use when authenticating to a repo with a username and password.
 - **deployment_password** (*Optional*): Password to use when authenticating to a repo.  Ignored if deployment_user is not set.

--- a/source/_addons/git_pull.markdown
+++ b/source/_addons/git_pull.markdown
@@ -35,9 +35,9 @@ Load and update configuration files for Home Assistant from a GIT repository.
 }
 ```
 
-- **repository** (*Required*): Git url to your repository (make sure to use double quotes). You have to add .git to your GITHub-Repository-URL (see example Config)
+- **repository** (*Required*): Git URL to your repository (make sure to use double quotes). You have to add .git to your GitHub repository URL (see example config)
 - **git_branch** (*Required*): Branch name of the git repo, leave this as 'master' if you are unsure.
-- **git_remote** (*Requried*): Name of the tracked repository, leave this as 'origin' if you are unsure.
+- **git_remote** (*Required*): Name of the tracked repository, leave this as 'origin' if you are unsure.
 - **git_command** (*Required*): Must be either 'pull' or 'reset', leave this as 'pull' if you are unsure.
 
   * **pull**: Incorporates changes from a remote repository into the current branch. Will preserve any local changes to tracked files.
@@ -47,7 +47,7 @@ Load and update configuration files for Home Assistant from a GIT repository.
   Using the <b>reset</b> option will overwrite changes to tracked files.  Tracked files are those visible in the Github repository or those given by the output on this command: ```git ls-tree -r master --name-only```
 </p>
   
-- **auto_restart** (*Optional*): Make a restart of Home-Assistant if the config have change and is valid.
+- **auto_restart** (*Optional*): Restart Home Assistant when the configuration has changed (and is valid).
 - **repeat/active** (*Optional*): Pull periodic for git updates.
 - **repeat/interval** (*Optional*): Pull all x seconds and look for changes.
 - **deployment_user** (*Optional*): Username to use when authenticating to a repo with a username and password.


### PR DESCRIPTION
**Description:**
Update to git_pull documentation following merge of PR below.  Specified options for git_command, git_branch & git_origin.  Added warning when using git reset option.

**Pull request in [hassio-addons](https://github.com/home-assistant/hassio-addons) (if applicable):** home-assistant/hassio-addons#350

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
