### PR TITLE
Add HomematicIP Cloud alarm control panel documentation

### DIFF
--- a/source/_components/alarm_control_panel.homematicip_cloud.markdown
+++ b/source/_components/alarm_control_panel.homematicip_cloud.markdown
@@ -1,0 +1,21 @@
+---
+layout: page
+title: "HomematicIP Cloud Alarm Control Panel"
+description: "Instructions on how to integrate HomematicIP alarm control panel into Home Assistant."
+date: 2018-05-18 22:40
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: homematicip_cloud.png
+ha_category: Sensor
+ha_release: 0.73
+ha_iot_class: "Cloud Push"
+---
+
+The `homematicip_cloud` alarm_control_panel platform allows you to control your [HomematicIP](https://www.homematic-ip.com) `Security Zones` through Home Assistant.
+
+This component will automatically add `Security Zones` configured in your HomematicIP cloud.
+
+Please refer to the
+[component](/components/homematicip_cloud/) configuration on how to setup HomematicIP Cloud.


### PR DESCRIPTION
**Description:**
Add documentation for HomematicIP Cloud - alarm control panel

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15342

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/