### PR TITLE
Update HomematicIP Cloud logo and change to cloud push type

### DIFF
--- a/source/_components/binary_sensor.homematicip_cloud.markdown
+++ b/source/_components/binary_sensor.homematicip_cloud.markdown
@@ -7,10 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: homematic.png
+logo: homematicip_cloud.png
 ha_category: Binary Sensor
 ha_release: 0.70
-ha_iot_class: "Local Push"
+ha_iot_class: "Cloud Push"
 ---
 
 The `homematicip_cloud` binary_switch platform allows you to control

--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -7,8 +7,9 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: homematicip_cloud.png
 ha_category: Hub
-ha_iot_class: "Cloud Polling"
+ha_iot_class: "Cloud Push"
 ha_release: 0.66
 featured: false
 ---

--- a/source/_components/light.homematicip_cloud.markdown
+++ b/source/_components/light.homematicip_cloud.markdown
@@ -7,10 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: homematic.png
+logo: homematicip_cloud.png
 ha_category: Switch
 ha_release: 0.70
-ha_iot_class: "Local Push"
+ha_iot_class: "Cloud Push"
 ---
 
 The `homematicip_cloud` light platform allows you to control

--- a/source/_components/sensor.homematicip_cloud.markdown
+++ b/source/_components/sensor.homematicip_cloud.markdown
@@ -7,10 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: homematic.png
+logo: homematicip_cloud.png
 ha_category: Sensor
 ha_release: 0.66
-ha_iot_class: "Local Push"
+ha_iot_class: "Cloud Push"
 ---
 
 The `homematicip_cloud` sensor platform allows you to control

--- a/source/_components/switch.homematicip_cloud.markdown
+++ b/source/_components/switch.homematicip_cloud.markdown
@@ -7,10 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: homematic.png
+logo: homematicip_cloud.png
 ha_category: Switch
 ha_release: 0.70
-ha_iot_class: "Local Push"
+ha_iot_class: "Cloud Push"
 ---
 
 The `homematicip_cloud` switch platform allows you to control


### PR DESCRIPTION
**Description:**
- Change logo to homematicip_cloud.png
- Change type to Cloud Push

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/