### PR TITLE
[Vizio] Replace logger configuration with simple flag

### DIFF
--- a/source/_components/media_player.vizio.markdown
+++ b/source/_components/media_player.vizio.markdown
@@ -77,6 +77,7 @@ Configuration variables:
 
 - **host** (*Required*): IP address of your TV.
 - **access_token** (*Required*): Authentication token you received in the last step of the pairing process.
+- **suppress_warning** (*Optional*): Set to `true` to disable self-signed certificate warnings.
 
 ## Notes and limitations
 
@@ -91,13 +92,3 @@ Changing tracks works like channels switching. If you have source other than reg
 ### Sources
 
 Source list shows all external devices connected to the TV through HDMI plus list of internal devices (TV mode, Chrome Cast, etc.).
-
-<p class='note'>
-Vizio SmartCast service is accessible through HTTPS with self-signed certificate. If you have low LOGLEVEL in your Home Assistant configuration, you'll see a lot of warnings like this:
-`InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised.`
-
-You can adjust the log level for `media_player` components with the [logger](/components/logger/) component, or if you need to keep a low log level for `media_player` you could proxy calls to your TV through an NGINX reverse proxy.
-
-If you want to only ignore only this specific [python urllib3 SSL warning](https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings), you will need to run Home Assistant with the python flag `-W` or the environment variable `PYTHONWARNINGS` set to:
-`ignore:Unverified HTTPS request is being made`
-</p>


### PR DESCRIPTION
**Description:**

The Vizio component has an (to date) undocumented configuration flag which can be used to suppress the self-signed certificate warnings. IMO, this approach is preferable to the currently documented method of using the `logger` component, using a reverse proxy, or setting python environment variables.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

n/a

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
