### PR TITLE
Add excluded_entities syntax for Lovelace UI

### DIFF
--- a/source/lovelace/index.markdown
+++ b/source/lovelace/index.markdown
@@ -45,6 +45,9 @@ Create a new file `<config>/ui-lovelace.yaml` and add the following content. Adj
 
 ```yaml
 title: My Awesome Home
+# Exclude entites from "Unused entities" view
+excluded_entities:
+  - weblink.router
 views:
     # View tab title.
   - title: Example


### PR DESCRIPTION
https://github.com/home-assistant/home-assistant-polymer/blob/master/src/panels/lovelace/common/compute-unused-entities.js#L27

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
