### PR TITLE
Update Lovelace docs

### DIFF
--- a/source/_lovelace/glance.markdown
+++ b/source/_lovelace/glance.markdown
@@ -10,8 +10,6 @@ sharing: true
 footer: true
 ---
 
-### Glance
-
 Glance cards are a very compact. Very useful to group together multiple sensors for a quick and easy to use view. Keep in mind that this can be used together with [entity-filter](/lovelace/entity-filter/) cards to create dynamic cards.
 
 <p class='img'>
@@ -19,22 +17,38 @@ Glance cards are a very compact. Very useful to group together multiple sensors 
 Screenshot of the glance card.
 </p>
 
-**Options**
+{% linkable_title Options %}
 
-| Name | Type | Default | Description
-| ---- | ---- | ------- | -----------
-| type | string | **Required** | `glance`
-| entities | list | **Required** | Entity id's or an `entity` object (see structure below).
-| title | string | Optional | Card title
+{% configuration %}
+type:
+  required: true
+  description: glance
+  type: string
+entities:
+  required: true
+  description: "Entity id's or an `entity` object (see structure below)."
+  type: list
+title:
+  required: false
+  description: Card title
+  type: string
+  default: none
+{% endconfiguration %}
 
 `entity` object type
 
-| Name | Type | Default | Description
-| ---- | ---- | ------- | -----------
-| entity | string | **Required** | An entity_id. Example: 'device_tracker.demo_paulus'.
-| name | string | **Required** | A new name for the entity_id
+{% configuration %}
+entity:
+  required: true
+  description: "An entity_id. Example: 'device_tracker.demo_paulus'."
+  type: string
+name:
+  required: true
+  description: A new name for the entity_id
+  type: string
+{% endconfiguration %}
 
-**Examples**
+{% linkable_title Examples %}
 
 Basic example
 


### PR DESCRIPTION
Minor cleanup and fixing typos
Changed all config sections to use {% configuration %} tag.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
