### PR TITLE
Update lovelace docs - picture-entity

### DIFF
--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -67,12 +67,12 @@ tap_action:
 `state_image` object structure
 
 {% configuration %}
-on:
+"on":
   required: true
   description: URL of an image used for on state.
   type: string
   default: None
-off:
+"off":
   required: true
   description: URL of an image used for off state.
   type: string
@@ -90,7 +90,7 @@ not_home:
 any:
   required: false
   description: Any state that is supported by the entity works
-  type: 'object'
+  type: object
   default: None
 {% endconfiguration %}
 

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -87,7 +87,7 @@ not_home:
   description: URL of an image used for not_home state.
   type: string
   default: None
-...:
+OTHER:
   required: false
   description: Any state that is supported by the entity works
   type: object

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -87,10 +87,10 @@ not_home:
   description: URL of an image used for not_home state.
   type: string
   default: None
-OTHER:
+any:
   required: false
   description: Any state that is supported by the entity works
-  type: object
+  type: 'object'
   default: None
 {% endconfiguration %}
 

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -53,10 +53,10 @@ name:
   type: string
   default: None
 show_info:
-  required: 'false'
+  required: false
   description: Set to false to hide infobar
   type: boolean
-  default: 'true'
+  default: True
 tap_action:
   required: false
   description: "Set to `toggle` for turning entity on/off without opening a dialog"

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -10,8 +10,6 @@ sharing: true
 footer: true
 ---
 
-### Entity picture
-
 A very useful card for controling entities. By default you will get `more-info-dialog` but using `tap_action` you can directly control entities that have `on`/`off` states. It allows you to generate a very nice looking card with a big touch area, highly recommended for mobile dashboards on small screens.
 
 You can use different image combination to get a more realistic view for images with lights. The image setup also allows enough flexibility to get your garage picture with the door opened and closed.
@@ -23,30 +21,80 @@ You can also use `camera` domain entities to use that as `camera_image`.
 Screenshot of the picture entity card.
 </p>
 
-**Options**
+{% linkable_title Options %}
 
-| Name | Type | Default | Description
-| ---- | ---- | ------- | -----------
-| type | string | **Required** | `picture-entity`
-| entity | string | **Required** | Entity id to control via picture.
-| camera_image | string | Optional | camera domain entity_id 'camera.demo_camera'
-| image | string | Optional| URL of an image.
-| state_image | object | Optional | See `state_image` object structure.
-| name | string | Optional | Custom name for entity
-| show_info | boolean | Optional | Set to false to hide infobar
-| tap_action | string | dialog | Set to `toggle` for turning entity on/off without opening a dialog
+{% configuration %}
+type:
+  required: true
+  description: picture-entity
+  type: string
+entity:
+  required: true
+  description: Entity id to control via picture.
+  type: string
+camera_image:
+  required: false
+  description: "Camera domain entity_id 'camera.demo_camera'"
+  type: string
+  default: None
+image:
+  required: false
+  description: URL of an image.
+  type: string
+  default: None
+state_image:
+  required: false
+  description: "See `state_image` object structure."
+  type: object
+  default: None
+name:
+  required: false
+  description: Custom name for entity
+  type: string
+  default: None
+show_info:
+  required: 'false'
+  description: Set to false to hide infobar
+  type: boolean
+  default: 'true'
+tap_action:
+  required: false
+  description: "Set to `toggle` for turning entity on/off without opening a dialog"
+  type: string
+  default: dialog
+{% endconfiguration %}
 
 `state_image` object structure
 
-| Name | Type | Default | Description
-| ---- | ---- | ------- | -----------
-| on | string | Optional | URL of an image used for on state.
-| off | string | Optional | URL of an image used for off state.
-| home | string | Optional | URL of an image used for home state.
-| not_home | string | Optional | URL of an image used for not_home state.
-| ... | string | Optional | Any state that is supported by the entity works
+{% configuration %}
+on:
+  required: true
+  description: URL of an image used for on state.
+  type: string
+  default: None
+off:
+  required: true
+  description: URL of an image used for off state.
+  type: string
+  default: None
+home:
+  required: false
+  description: URL of an image used for home state.
+  type: string
+  default: None
+not_home:
+  required: false
+  description: URL of an image used for not_home state.
+  type: string
+  default: None
+...:
+  required: false
+  description: Any state that is supported by the entity works
+  type: object
+  default: None
+{% endconfiguration %}
 
-**Examples**
+{% linkable_title Examples %}
 
 Basic example:
 


### PR DESCRIPTION
Minor cleanup and fixing typos
Changed all config sections to use {% configuration %} tag.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
