### PR TITLE
Changelog updated

### DIFF
--- a/source/_posts/2018-07-06-release-73.markdown
+++ b/source/_posts/2018-07-06-release-73.markdown
@@ -17,7 +17,7 @@ In the meanwhile, we're also working hard on the new authentication system. A pr
 
 This release also includes a TON of love for the new Lovelace UI. Yes, it's still experimental but daaang, it's already so awesome that you should probably just go ahead and try it out. Thanks to all the devs who have jumped on this: [@c727], [@ciotlosm] and [@jeradM].
 
-We don't have time to go through all the changes in this release, but [@ciotlosm] has been keeping [a very detailed changelog](https://github.com/ciotlosm/docs-lovelace/blob/0.73.0/changelog.md). I'll just leave this screenshot by [@arsaboo] of the new picture-elements card and [the Lovelace configuration](https://github.com/arsaboo/homeassistant-config/blob/master/ui-lovelace.yaml#L15-L158):
+We don't have time to go through all the changes in this release, but [@ciotlosm] has been keeping [a very detailed changelog](https://www.home-assistant.io/lovelace/changelog/). I'll just leave this screenshot by [@arsaboo] of the new picture-elements card and [the Lovelace configuration](https://github.com/arsaboo/homeassistant-config/blob/master/ui-lovelace.yaml#L15-L158):
 
 <p class='img'>
 <img src='/images/blog/2018-07-0.73/lovelace-elements.png' alt='Screenshot of a floorplan with sensor info and light/camera controls overlayed.'>

--- a/source/_posts/2018-07-06-release-73.markdown
+++ b/source/_posts/2018-07-06-release-73.markdown
@@ -17,7 +17,7 @@ In the meanwhile, we're also working hard on the new authentication system. A pr
 
 This release also includes a TON of love for the new Lovelace UI. Yes, it's still experimental but daaang, it's already so awesome that you should probably just go ahead and try it out. Thanks to all the devs who have jumped on this: [@c727], [@ciotlosm] and [@jeradM].
 
-We don't have time to go through all the changes in this release, but [@ciotlosm] has been keeping [a very detailed changelog](https://www.home-assistant.io/lovelace/changelog/). I'll just leave this screenshot by [@arsaboo] of the new picture-elements card and [the Lovelace configuration](https://github.com/arsaboo/homeassistant-config/blob/master/ui-lovelace.yaml#L15-L158):
+We don't have time to go through all the changes in this release, but [@ciotlosm] has been keeping [a very detailed changelog](/lovelace/changelog/). I'll just leave this screenshot by [@arsaboo] of the new picture-elements card and [the Lovelace configuration](https://github.com/arsaboo/homeassistant-config/blob/master/ui-lovelace.yaml#L15-L158):
 
 <p class='img'>
 <img src='/images/blog/2018-07-0.73/lovelace-elements.png' alt='Screenshot of a floorplan with sensor info and light/camera controls overlayed.'>

--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -11,7 +11,7 @@ footer: true
 
 ## Changes in 0.73.1
 - Setting Lovelace as default now updates `Overview` button to point to `/lovelace`
-- Allow setting background style on all levels (global, view, card)
+- Allow setting background styles (global and per view)
 
 ### Cards
 - 📣 New card: `map` that allows showing `device_tracker` entities on a map card

--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -10,7 +10,7 @@ footer: true
 ---
 
 ## Changes in 0.73.1
-- Setting Lovelace as default updated Overview button to point to lovelace
+- Setting Lovelace as default now updates `Overview` button to point to `/lovelace`
 - Allow setting background style on all levels (global, view, card)
 
 ### Cards
@@ -20,7 +20,7 @@ footer: true
 ## Changes in 0.73.0
 
 ### Views
-- 📣 New button to show unused entities in lovelace
+- 📣 New button to show unused entities in Lovelace
 
 ## Changes in 0.73.0b5
 - 🏁 Only minor fixes in this release

--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -9,41 +9,49 @@ sharing: true
 footer: true
 ---
 
+## Changes in 0.73.1
+- Setting Lovelace as default updated Overview button to point to lovelace
+- Allow setting background style on all levels (global, view, card)
+
+### Cards
+- 📣 New card: `map` that allows showing `device_tracker` entities on a map card
+- 📣 `entities` card now support `type: custom:state-card-custom` for the entities list
+
 ## Changes in 0.73.0
 
 ### Views
-- :mega: New button to show unused entities in lovelace
+- 📣 New button to show unused entities in lovelace
 
 ## Changes in 0.73.0b5
-- :checkered_flag: Only minor fixes in this release
+- 🏁 Only minor fixes in this release
 
 ## Changes in 0.73.0b4
 
 ### Cards
-- :mega: `picture-entity` allow hiding of infobar using `show_info: false`
-- :mega: `picture-entity` now supports `tap_action` parameter allowing you to switch from `on`/`off` to `more-info-dialog`
-- :mega: `picture-glance` now supports `navigation_path`
+- 📣 `picture-entity` allow hiding of infobar using `show_info: false`
+- 📣 `picture-entity` now supports `tap_action` parameter allowing you to switch from `on`/`off` to `more-info-dialog`
+- 📣 `picture-glance` now supports `navigation_path`
 - `picture-entity` renamed `title` to `name`
 - `picture-elements` renamed `path` to `navigation_path`
-- :bangbang: `camera-preview` card removed, features added to `picture-entity` and `picture-glance`
+- ‼️ `camera-preview` card removed, features added to `picture-entity` and `picture-glance`
 
 ## Changes in 0.73.0b3
 
 ### Views
-- :mega: Added panel mode for a view to use 1st card to fill whole screen
+- 📣 Added panel mode for a view to use 1st card to fill whole screen
 
 ### Cards
-- :mega: New card: `picture` for triggering navigation and services
-- :mega: `picture-elements` now supports `navigation` type
-- :mega: `picture-entity` now supports `camera_image`
-- :mega: `picture-glance` now supports `camera_image`
-- :mega: `picture-glance` now supports `state_image` and `entity` like `picture-entity`
-- :mega: `entity-filter` now supports custom name for entities like `glance` and `entities`
+- 📣 New card: `picture` for triggering navigation and services
+- 📣 `picture-elements` now supports `navigation` type
+- 📣 `picture-entity` now supports `camera_image`
+- 📣 `picture-glance` now supports `camera_image`
+- 📣 `picture-glance` now supports `state_image` and `entity` like `picture-entity`
+- 📣 `entity-filter` now supports custom name for entities like `glance` and `entities`
 - `entities` and `glance` custom titles now use `name` not `title`
 - `entity-filter` now uses `entities` as a static list to filter state against
 - `entity-filter` uses `state_filter` array instead of `filter` object
-- :wrench: Fix wrapping and padding for `service-button` in `picture-elements`
-- :bangbang: `entity-filter` no longer allows to show all entities or a full domain
+- 🔧 Fix wrapping and padding for `service-button` in `picture-elements`
+- ‼️ `entity-filter` no longer allows to show all entities or a full domain
 
 ## Changes in 0.73.0b2
 - :zap: Went by too fast :zap:
@@ -58,34 +66,34 @@ footer: true
 - `picture-elements` renamed `state-text` to `state-label`
 - `picture-elements` moved/renamed `service.data` to `service_data`
 - `picture-elements` combined `service.domain` and `service.server` into `service`
-- :mega: `entities` allow custom title just like `glance`
-- :mega: `entity-filter` allow auto-hide if empty using `show_empty: false`
-- :wrench: Fix card size calculation `horizontal-stack`/`vertical-stack` 
+- 📣 `entities` allow custom title just like `glance`
+- 📣 `entity-filter` allow auto-hide if empty using `show_empty: false`
+- 🔧 Fix card size calculation `horizontal-stack`/`vertical-stack` 
 
 ## Changes in 0.73.0b0
-- :mega: New feature to allow Lovelace to be default for `/`
+- 📣 New feature to allow Lovelace to be default for `/`
 
 ### Views
-- :mega: Now views have deep-links: `/lovelace/3` will link to the tab with id `3`
+- 📣 Now views have deep-links: `/lovelace/3` will link to the tab with id `3`
 - `name` renamed `title` to match cards setup
 - `tab_icon` renamed `icon` for simplicity
 
 ### Cards
-- :mega: New card: `picture-elements`
-- :mega: New card: `column`
-- :mega: New card: `row`
-- :mega: `glance` allow custom title for entities - rename your entity only in this card
-- :mega: `entities` toggle button in header can now be hidden using `show_header_toggle: false`
+- 📣 New card: `picture-elements`
+- 📣 New card: `column`
+- 📣 New card: `row`
+- 📣 `glance` allow custom title for entities - rename your entity only in this card
+- 📣 `entities` toggle button in header can now be hidden using `show_header_toggle: false`
 - `entity-picture` renamed `picture-entity` to be consistent with `picture-glance`
 - `entity-filter` removed `card_config` and made `card` property an object
-- :wrench: Fix use of groups in `picture-entity`
-- :wrench: Fix title in `glance` to avoid overlapping
+- 🔧 Fix use of groups in `picture-entity`
+- 🔧 Fix title in `glance` to avoid overlapping
 
 ## Changes in 0.72.1
 
 ### Cards
-- :beetle: Bug introduced in `glance` card - titles now overlap
-- :mega: New card: `iframe`
+- 🐞 Bug introduced in `glance` card - titles now overlap
+- 📣 New card: `iframe`
 
 ## Changes in 0.72
 - Initial release of the Lovelace UI


### PR DESCRIPTION
**Description:**
Updated 0.73 changelog link to point to official docs
Updated changelog to avoid text that used to be markdown icons
Added 0.73.1 changes to changelog

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
