### PR TITLE
Fix typo in Lovelace docs - picture-elements

### DIFF
--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -90,7 +90,7 @@ style:
   description: See "Style options"
   type: object
 tap_action:
-  required: true
+  required: false
   description: "Set to `toggle` to change state"
   type: string
   default: more-info


### PR DESCRIPTION
**Description:**
Fix typo in Lovelace docs - picture-elements

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
