### PR TITLE
Lovelace changelog Markdownlint & spelling fixes

### DIFF
--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -10,24 +10,29 @@ footer: true
 ---
 
 ## {% linkable_title Changes in 0.73.1 %}
+
 - Setting Lovelace as default now updates `Overview` button to point to `/lovelace`
 - Allow setting background styles (global and per view)
 
 ### Cards
+
 - 📣 New card: `map` that allows showing `device_tracker` entities on a map card
 - 📣 `entities` card now support `type: custom:state-card-custom` for the entities list
 
 ## {% linkable_title Changes in 0.73.0 %}
 
 ### Views
+
 - 📣 New button to show unused entities in Lovelace
 
 ## Changes in 0.73.0b5 %}
+
 - 🏁 Only minor fixes in this release
 
 ## {% linkable_title Changes in 0.73.0b4 %}
 
 ### Cards
+
 - 📣 `picture-entity` allow hiding of infobar using `show_info: false`
 - 📣 `picture-entity` now supports `tap_action` parameter allowing you to switch from `on`/`off` to `more-info-dialog`
 - 📣 `picture-glance` now supports `navigation_path`
@@ -38,9 +43,11 @@ footer: true
 ## {% linkable_title Changes in 0.73.0b3 %}
 
 ### Views
-- 📣 Added panel mode for a view to use 1st card to fill whole screen
+
+- 📣 Added panel mode for a view to use the 1st card to fill the whole screen
 
 ### Cards
+
 - 📣 New card: `picture` for triggering navigation and services
 - 📣 `picture-elements` now supports `navigation` type
 - 📣 `picture-entity` now supports `camera_image`
@@ -54,11 +61,13 @@ footer: true
 - ‼️ `entity-filter` no longer allows to show all entities or a full domain
 
 ## {% linkable_title Changes in 0.73.0b2 %}
+
 - :zap: Went by too fast :zap:
 
 ## {% linkable_title Changes in 0.73.0b1 %}
 
 ### Cards
+
 - `column` renamed to `vertical-stack`
 - `row` renamed to `horizontal-stack`
 - `picture-elements` new `state-badge` using `ha-state-label-badge`
@@ -71,30 +80,34 @@ footer: true
 - 🔧 Fix card size calculation `horizontal-stack`/`vertical-stack` 
 
 ## {% linkable_title Changes in 0.73.0b0 %}
+
 - 📣 New feature to allow Lovelace to be default for `/`
 
 ### Views
+
 - 📣 Now views have deep-links: `/lovelace/3` will link to the tab with id `3`
 - `name` renamed `title` to match cards setup
 - `tab_icon` renamed `icon` for simplicity
 
 ### Cards
+
 - 📣 New card: `picture-elements`
 - 📣 New card: `column`
 - 📣 New card: `row`
 - 📣 `glance` allow custom title for entities - rename your entity only in this card
-- 📣 `entities` toggle button in header can now be hidden using `show_header_toggle: false`
+- 📣 `entities` toggle button in a header can now be hidden using `show_header_toggle: false`
 - `entity-picture` renamed `picture-entity` to be consistent with `picture-glance`
 - `entity-filter` removed `card_config` and made `card` property an object
 - 🔧 Fix use of groups in `picture-entity`
-- 🔧 Fix title in `glance` to avoid overlapping
+- 🔧 Fix the title in `glance` to avoid overlapping
 
 ## {% linkable_title Changes in 0.72.1 %}
 
 ### Cards
+
 - 🐞 Bug introduced in `glance` card - titles now overlap
 - 📣 New card: `iframe`
 
 ## {% linkable_title Changes in 0.72 %}
-- Initial release of the Lovelace UI
 
+- Initial release of the Lovelace UI


### PR DESCRIPTION
**Description:**

Fixes Markdownlint warnings and some small spelling issues in the Lovelace changelog.

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
