### PR TITLE
Change steam docs to use configuration tag

### DIFF
--- a/source/_components/sensor.steam_online.markdown
+++ b/source/_components/sensor.steam_online.markdown
@@ -14,11 +14,15 @@ ha_release: 0.14
 ---
 
 
-The Steam component will allow you to track the online status of public [Steam](https://steamcommunity.com) accounts.
+The `steam` sensor platform will allow you to track the online status of public [Steam](https://steamcommunity.com) accounts.
 
-You need a [free API key](https://steamcommunity.com/dev/apikey) to use the component
+## {% linkable_title Setup %}
+
+You need a [free API key](https://steamcommunity.com/dev/apikey) to use the platform.
 
 To find an account's 64-bit SteamID on profiles without a custom URL you can check the URL of the profile page, the long string of numbers at the end is the 64-bit SteamID. If the profile has a custom URL you will have to copy the URL into [STEAMID I/O](https://steamid.io/) to find the 64-bit SteamID.
+
+## {% linkable_title Configuration %}
 
 To use Steam in your installation, add the following to your `configuration.yaml` file:
 
@@ -39,13 +43,16 @@ api_key:
   type: string
 accounts:
   required: true
-  description: Array of accounts.
-  type: array
-account_id:
-  required: true
-  description:  64-bit SteamID.
-  type: string
+  description: List of accounts.
+  type: map
+  keys:
+    account_id:
+      required: true
+      description: The 64-bit SteamID.
+      type: string
 {% endconfiguration %}
+
+## {% linkable_title Examples %}
 
 If you want to add the accounts to a group for example you will have to use:
 

--- a/source/_components/sensor.steam_online.markdown
+++ b/source/_components/sensor.steam_online.markdown
@@ -40,7 +40,7 @@ api_key:
 accounts:
   required: true
   description: Array of accounts.
-  type: list
+  type: array
 account_id:
   required: true
   description:  64-bit SteamID.

--- a/source/_components/sensor.steam_online.markdown
+++ b/source/_components/sensor.steam_online.markdown
@@ -32,12 +32,20 @@ sensor:
       - account2
 ```
 
-Configuration variables:
-
-- **api_key** (*Required*): Your API key from [https://steamcommunity.com/dev/apikey](https://steamcommunity.com/dev/apikey).
-- **accounts** array (*Required*): Array of accounts.
-  - **account_id** (*Required*): 64-bit SteamID.
-
+{% configuration %}
+api_key:
+  required: true
+  description: Your API key from [https://steamcommunity.com/dev/apikey](https://steamcommunity.com/dev/apikey).
+  type: string
+accounts:
+  required: true
+  description: Array of accounts.
+  type: list
+account_id:
+  required: true
+  description:  64-bit SteamID.
+  type: string
+{% endconfiguration %}
 
 If you want to add the accounts to a group for example you will have to use:
 


### PR DESCRIPTION
**Description:**
Update steam docs to use proper {% configuration %} tags

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
