### PR TITLE
Reminder don't mix http and https content in iframe cards

### DIFF
--- a/source/_lovelace/iframe.markdown
+++ b/source/_lovelace/iframe.markdown
@@ -44,6 +44,8 @@ title:
   default: none
 {% endconfiguration %}
 
+**Reminder**: you can't mix https and http content. So if your Home Assistant instance is accessed thru https, you won't be able to display http content in the iframe card.
+
 ## {% linkable_title Examples %}
 
 ```yaml


### PR DESCRIPTION
**Description:**
Add this reminder as it's not abvious for all users.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
