### PR TITLE
Update index.markdown

### DIFF
--- a/source/lovelace/index.markdown
+++ b/source/lovelace/index.markdown
@@ -116,6 +116,6 @@ This is probably because your version of Firefox doesn't have custom components 
 
 ### Custom components don't load on my IOS device?
 
-This is because for IOS devices by default javascript served is `es5`. You can allow custom components to load by forcing `javascript: latest` in your `configuration.yaml` under `frontend:`. 
+This is because for IOS devices by default javascript served is `es5`. You can allow custom components to load by forcing `javascript_version: latest` in your `configuration.yaml` under `frontend:`. 
 
 > Note: Enabling `latest` on IOS could cause automation and script editor to crash.


### PR DESCRIPTION
**Description:**
I believe that 'javascript: latest' is a type and should be 'javascript_version: latest'

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
