### PR TITLE
Added lovelace example for links in the markdown card.

### DIFF
--- a/source/_lovelace/markdown.markdown
+++ b/source/_lovelace/markdown.markdown
@@ -33,7 +33,9 @@ title:
   default: none
 {% endconfiguration %}
 
-## {% linkable_title Example %}
+## {% linkable_title Examples %}
+
+### {% linkable_title Text with formating %}
 
 ```yaml
 - type: markdown
@@ -42,3 +44,15 @@ title:
 
     Starting with Home Assistant 0.72, we're experimenting with a new way of defining your interface. We're calling it the **Lovelace UI**.
 ```
+
+### {% linkable_title Links %}
+
+```yaml
+- type: markdown
+  content: >
+    - [Home-Assistant website](https://www.home-assistant.io/)
+    
+    - [Home-Assistant GitHbub](https://github.com/home-assistant/home-assistant/)
+```
+
+_For multiple links in a list, add a blank line between them_


### PR DESCRIPTION
**Description:**
Added example for links in the markdown card

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
