### PR TITLE
Fix mixed up documentation URLs

### DIFF
--- a/source/_docs/installation/hassbian.markdown
+++ b/source/_docs/installation/hassbian.markdown
@@ -14,8 +14,8 @@ Hassbian is our customized operating system for the Raspberry Pi Zero, 2,3 and 3
 
  - [Install Hassbian](/docs/hassbian/installation/)
  - [Customize your installation](/docs/hassbian/customization/)
- - [Pi specific integrations](/docs/hassbian/common-tasks/)
- - [Learn how to perform common tasks](/docs/hassbian/integrations/)
+ - [Pi specific integrations](/docs/hassbian/integrations/)
+ - [Learn how to perform common tasks](/docs/hassbian/common-tasks/)
 
 ### {% linkable_title Activating the virtual environment %}
 


### PR DESCRIPTION
**Description:**

Simple documentation fix

## Checklist:

- [ x ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ x ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
