### PR TITLE
MyTotalConnectComfort.com Compatibility

### DIFF
--- a/source/_components/climate.honeywell.markdown
+++ b/source/_components/climate.honeywell.markdown
@@ -17,7 +17,7 @@ ha_iot_class: "Cloud Polling"
 The `honeywell` climate platform let you control [Honeywell Connected](http://getconnected.honeywell.com/en/) thermostats from Home Assistant.
 
 <p class='note'>
-This platform does NOT connect to MyTotalConnectComfort.com.  If you have a Honeywell WIFI thermostat that is connected through MyTotalConnectComfort.com, you may want to take a lookt at the IFTTT component which can bridge the gap between Home Assistant and MyTotalConnectComfort.com WIFI thermostats on a limited basis.
+This platform does NOT connect to MyTotalConnectComfort.com.  If you have a Honeywell WIFI thermostat that is connected through MyTotalConnectComfort.com, you may might to take a look at the IFTTT component which can bridge the gap between Home Assistant and MyTotalConnectComfort.com WIFI thermostats on a limited basis.
 </p>
 
 To set it up, add the following information to your `configuration.yaml` file:

--- a/source/_components/climate.honeywell.markdown
+++ b/source/_components/climate.honeywell.markdown
@@ -16,6 +16,10 @@ ha_iot_class: "Cloud Polling"
 
 The `honeywell` climate platform let you control [Honeywell Connected](http://getconnected.honeywell.com/en/) thermostats from Home Assistant.
 
+<p class='note'>
+This platform does NOT connect to MyTotalConnectComfort.com.  If you have a Honeywell WIFI thermostat that is connected through MyTotalConnectComfort.com, you may want to take a lookt at the IFTTT component which can bridge the gap between Home Assistant and MyTotalConnectComfort.com WIFI thermostats on a limited basis.
+</p>
+
 To set it up, add the following information to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
Clarification for those who are looking to control other Honeywell WIFI Thermostats.

**Description:**
I was only able to get my Honeywell Thermostat to work by controlling it through IFTTT with a webhook.  The MyTotalConnectComfort.com site is not the same site that the Honeywell component uses.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
