### PR TITLE
fix pi3-64 link

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -78,7 +78,7 @@ A detailed guide about running Hass.io as a virtual machine is available in the 
 [pi1]: https://github.com/home-assistant/hassos/releases/download/1.5/hassos_rpi-1.5.img.gz
 [pi2]: https://github.com/home-assistant/hassos/releases/download/1.5/hassos_rpi2-1.5.img.gz
 [pi3-32]: https://github.com/home-assistant/hassos/releases/download/1.5/hassos_rpi3-1.5.img.gz
-[pi3-64]: https://github.com/home-assistant/hassos/releases/download/1.5/hassos_rpi3-1.5.img.gz
+[pi3-64]: https://github.com/home-assistant/hassos/releases/download/1.5/hassos_rpi3-64-1.5.img.gz
 [vmdk]: https://github.com/home-assistant/hassos/releases/download/1.5/hassos_ova-1.5.vmdk
 [linux]: https://github.com/home-assistant/hassio-build/tree/master/install#install-hassio
 [local]: http://hassio.local:8123


### PR DESCRIPTION
fixed url for pi3-64 image download

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
