### PR TITLE
NUT sensor: Default to using all available resources.

### DIFF
--- a/source/_components/sensor.nut.markdown
+++ b/source/_components/sensor.nut.markdown
@@ -61,7 +61,8 @@ sensor:
     type: string
   resources:
     description: Contains all entries to display.
-    required: true
+    required: false
+    default: all supported entries
     type: list
 {% endconfiguration %}
 


### PR DESCRIPTION
**Description:**
NUT sensor: Default to using all available resources.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15433

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
