### PR TITLE
The W for the Zero W image was missing

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -13,7 +13,7 @@ Hass.io images are available for:
 
 - Download the appropriate image for your IoT:
   - [Raspberry Pi / Zero][pi1]
-  - [Raspberry Pi / Zero][pi0-w]
+  - [Raspberry Pi / Zero W][pi0-w]
   - [Raspberry Pi 2][pi2]
   - [Raspberry Pi 3 32bit][pi3-32]
   - [Raspberry Pi 3 64bit][pi3-64]


### PR DESCRIPTION
The W for the Zero W image was missing

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
