### PR TITLE
Added note about SSH

### DIFF
--- a/source/_docs/installation/hassbian/installation.markdown
+++ b/source/_docs/installation/hassbian/installation.markdown
@@ -26,7 +26,7 @@ Additional information is available in this [video](https://www.youtube.com/watc
 
 After initial boot an installer will run in the background, this will download and install the newest version of [hassbian-config](https://github.com/home-assistant/hassbian-scripts) and Home-Assistant, this takes around 10 minutes to complete, after it has finished, you will be prompted to login: `hassbian login:`. Installation is complete at this point. The default username is `pi` and the password is `raspberry`.
 
-Open a browser on a device that's connected to the same network as your Raspberry Pi and point it to Home Assistant at [http://hassbian.local:8123]. If you want to login via SSH, the default username is `pi` and password is `raspberry` (please change this by running `passwd`). The Home Assistant configuration is located at `/home/homeassistant/.homeassistant/`.
+Open a browser on a device that's connected to the same network as your Raspberry Pi and point it to Home Assistant at [http://hassbian.local:8123]. If you want to login via SSH, create an empty file on the boot partition called ssh (no extension). The default username is `pi` and password is `raspberry` (please change this by running `passwd`). The Home Assistant configuration is located at `/home/homeassistant/.homeassistant/`.
 
 If you find that the web page is not reachable after 30 minutes or so, check that you have files in `/home/homeassistant/.homeassistant/`, if there are no files in this location then run the installer manually using this command: `sudo systemctl start install_homeassistant.service`.
 


### PR DESCRIPTION
SSH does not seem to be enabled by default.  These seem to work to enable it, though: https://www.raspberrypi.org/documentation/remote-access/ssh/

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
