### PR TITLE
Add broadlink media_player example documentation

### DIFF
--- a/source/_components/media_player.broadlink.md
+++ b/source/_components/media_player.broadlink.md
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: broadlink.png
 ha_category: Media Player
-ha_release: 0.76
+ha_release: 0.77
 ha_iot_class: "Local Polling"
 ---
 

--- a/source/_components/media_player.broadlink.md
+++ b/source/_components/media_player.broadlink.md
@@ -16,23 +16,9 @@ ha_iot_class: "Local Polling"
 
 The `broadlink` media_player platform let you control a media system like a TV using RM2 broadlink devices.
 
-Configuration options:
-
-- **host** (*Required*): The IP address to connect to.
-- **mac** (*Required*):  Device mac address.
-- **name** (*Optional*): Default BL. name
-- **command_on** (*Optional*): Hex string for command to turn on tv
-- **command_off** (*Optional*): Hex string for command to turn off tv
-- **volume_up** (*Optional*): Hex string for command to turn the volume up
-- **volume_down** (*Optional*): Hex string for command to turn the volume down
-- **previous_track** (*Optional*): Hex string for command to switch track or channel
-- **next_track** (*Optional*): Hex string for command to switch track or channel
-- **digits** (*Optional*): Dictionary of hex strings for digits
-- **sources** (*Optional*): Dictionary of hex strings for different input sources
-
-To set it up, add the following information to your `configuration.yaml` file:
 
 ```yaml
+# Example base configuration.yaml entry
 media_player:
   - platform: broadlink
     host: 192.168.0.2
@@ -65,3 +51,102 @@ media_player:
       dtv   : 'JgBGAJSTEjgSOBI4EhMSExITEhMSExI4EjgSNxMTEhQRFBEUERQRORE4EhQSExITEhMSOBITEhMSExI4EjgSOBI4EhMSOBIADQUAAA=='
 ```
 
+
+{% configuration %}
+port:
+  description: The port number to connect to.
+  required: false
+  type: int
+  default: 80
+host:
+  description: The IP address to connect to.
+  required: true
+  type: string
+mac:
+  description: The MAC address of the RM2 device
+  required: true
+  type: string
+name:
+  description: Name of the entity
+  required: false
+  type: string
+  default: Broadlink IR Media Player
+command_on:
+  description: Command to turn device on
+  required: false
+  type: string
+command_off:
+  description: Command to turn device off
+  required: false
+  type: string
+volume_up:
+  description: Command to turn volume up
+  required: false
+  type: string
+volume_down:
+  description: Command to turn volume down
+  required: false
+  type: string
+previous_track:
+  description: Command to turn volume up
+  required: false
+  type: string
+next_track:
+  description: Command to turn volume down
+  required: false
+  type: string
+sources:
+  description: The list of sources available.
+  required: false
+  type: map
+  keys:
+    "[identifier]":
+      description: The command to trigger this source.
+      required: false
+      type: string
+digits:
+  description: Digits for remote control.
+  required: false
+  type: map
+  keys:
+    '1':
+      description: The command to trigger key.
+      required: true
+      type: string
+    '2':
+      description: The command to trigger key.
+      required: true
+      type: string
+    '3':
+      description: The command to trigger key.
+      required: true
+      type: string
+    '4':
+      description: The command to trigger key.
+      required: true
+      type: string
+    '5':
+      description: The command to trigger key.
+      required: true
+      type: string
+    '6':
+      description: The command to trigger key.
+      required: true
+      type: string
+    '7':
+      description: The command to trigger key.
+      required: true
+      type: string
+    '8':
+      description: The command to trigger key.
+      required: true
+      type: string
+    '9':
+      description: The command to trigger key.
+      required: true
+      type: string
+    '0':
+      description: The command to trigger key.
+      required: true
+      type: string
+{% endconfiguration %}

--- a/source/_components/media_player.broadlink.md
+++ b/source/_components/media_player.broadlink.md
@@ -1,0 +1,67 @@
+---
+layout: page
+title: "Broadlink RM2 media player"
+description: "Instructions on how to integrate Broadlink RM2 media players within Home Assistant."
+date: 2018-07-14
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: broadlink.png
+ha_category: Media Player
+ha_release: 0.74
+ha_iot_class: "Local Polling"
+---
+
+
+The `broadlink` media_player platform let you control a media system like a TV using RM2 broadlink devices.
+
+Configuration options:
+
+- **host** (*Required*): The IP address to connect to.
+- **mac** (*Required*):  Device mac address.
+- **name** (*Optional*): Default BL. name
+- **command_on** (*Optional*): Hex string for command to turn on tv
+- **command_off** (*Optional*): Hex string for command to turn off tv
+- **volume_up** (*Optional*): Hex string for command to turn the volume up
+- **volume_down** (*Optional*): Hex string for command to turn the volume down
+- **previous_track** (*Optional*): Hex string for command to switch track or channel
+- **next_track** (*Optional*): Hex string for command to switch track or channel
+- **digits** (*Optional*): Dictionary of hex strings for digits
+- **sources** (*Optional*): Dictionary of hex strings for different input sources
+
+To set it up, add the following information to your `configuration.yaml` file:
+
+```yaml
+media_player:
+  - platform: broadlink
+    host: 192.168.0.2
+    mac: '11:22:33:44:55:66'
+    name: 'Samsung Living Room TV'
+
+    command_on    : 'JgBGAJKVETkRORA6ERQRFBEUERQRFBE5ETkQOhAVEBUQFREUEBUQOhEUERQRORE5EBURFBA6EBUQOhE5EBUQFRA6EDoRFBEADQUAAA=='
+    command_off   : 'JgBGAJOVEDoQOhA6DxYPFhAVEBUQFRA6ETkROREUERQRFBEUEBUQFREUERQRORE5EBUQFRE5ETkRORE5ERUQFRA6DzsPFhAADQUAAA=='
+
+    volume_up     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISNxI3EjcSEhISEhISEhISEhISEhISEjcSNxI3EjcSNxIABfgNBQ=='
+    volume_down   : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISNxI3EhISNxISEhISEhISEhISEhI3EhISNxI3EjcSNxIABfgNBQ=='
+
+    previous_track: 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhI3EhISEhISEjcSNxI3EjcSEhI3EjcSNxIABfgNBQ=='
+    next_track    : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhI3EhISEhI3EhISEhISEjcSEhI3EjcSEhI3EjcSNxIABfgNBQ=='
+
+    digits:
+      '0'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+      '1'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+      '2'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+      '3'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+      '4'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+      '5'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+      '6'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+      '7'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+      '8'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+      '9'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
+
+    sources:
+      hdmi  : 'JgBGAJGWETkRORI4ERQRFBAVERQRFBE5ETkROREUEBURFBEUERQQOxA6EBUPOw8WDxYQFRA6DxYQFRA6EBUPOxA6ETkRFBEADQUAAA=='
+      dtv   : 'JgBGAJSTEjgSOBI4EhMSExITEhMSExI4EjgSNxMTEhQRFBEUERQRORE4EhQSExITEhMSOBITEhMSExI4EjgSOBI4EhMSOBIADQUAAA=='
+```
+

--- a/source/_components/media_player.broadlink.md
+++ b/source/_components/media_player.broadlink.md
@@ -101,6 +101,15 @@ sources:
       description: The command to trigger this source.
       required: false
       type: string
+sound_modes:
+  description: The list of sound modes available.
+  required: false
+  type: map
+  keys:
+    "[identifier]":
+      description: The command to trigger this sound mode.
+      required: false
+      type: string
 digits:
   description: Digits for remote control.
   required: false

--- a/source/_components/media_player.broadlink.md
+++ b/source/_components/media_player.broadlink.md
@@ -9,13 +9,11 @@ sharing: true
 footer: true
 logo: broadlink.png
 ha_category: Media Player
-ha_release: 0.74
+ha_release: 0.76
 ha_iot_class: "Local Polling"
 ---
 
-
-The `broadlink` media_player platform let you control a media system like a TV using RM2 broadlink devices.
-
+The `broadlink` media_player platform lets you control a media system like a TV using RM2 Broadlink devices.
 
 ```yaml
 # Example base configuration.yaml entry
@@ -50,7 +48,6 @@ media_player:
       hdmi  : 'JgBGAJGWETkRORI4ERQRFBAVERQRFBE5ETkROREUEBURFBEUERQQOxA6EBUPOw8WDxYQFRA6DxYQFRA6EBUPOxA6ETkRFBEADQUAAA=='
       dtv   : 'JgBGAJSTEjgSOBI4EhMSExITEhMSExI4EjgSNxMTEhQRFBEUERQRORE4EhQSExITEhMSOBITEhMSExI4EjgSOBI4EhMSOBIADQUAAA=='
 ```
-
 
 {% configuration %}
 port:


### PR DESCRIPTION
**Description:**
This adds documentation for the media_player component

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15466

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
