### PR TITLE
lovelace glance docs - should show_title actually be show_name?

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -141,9 +141,9 @@ social:
 
 # Home Assistant release details
 current_major_version: 0
-current_minor_version: 73
-current_patch_version: 1
-date_released: 2018-07-08
+current_minor_version: 74
+current_patch_version: 0
+date_released: 2018-07-21
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/source/_lovelace/glance.markdown
+++ b/source/_lovelace/glance.markdown
@@ -30,9 +30,9 @@ title:
   required: false
   description: Card title
   type: string
-show_title:
+show_name:
   required: false
-  description: Show entity titles.
+  description: Show entity names.
   type: boolean
   default: "true"
 show_state:

--- a/source/_posts/2018-07-21-release-74.markdown
+++ b/source/_posts/2018-07-21-release-74.markdown
@@ -1,0 +1,331 @@
+---
+layout: post
+title: "0.74: TBD - UPDATE DATE"
+description: "TBD"
+date: 2018-07-16 00:01:00
+date_formatted: "July 21, 2018"
+author: Paulus Schoutsen
+author_twitter: balloob
+comments: true
+categories: Release-Notes
+og_image: /images/blog/2018-07-0.74/components.png
+---
+
+## {% linkable_title New Platforms %}
+
+- Added support for Duke Energy smart meters ([@w1ll1am23] - [#15165]) ([sensor.duke_energy docs]) (new-platform)
+- Added Push Camera ([@dgomes] - [#15151]) ([camera.push docs]) (new-platform)
+- Use IndieAuth for client ID ([@balloob] - [#15369]) ([auth docs]) ([frontend docs]) (new-platform)
+- Add Cloudflare DNS component. ([@ludeeus] - [#15388]) ([cloudflare docs]) (new-platform)
+- Add Tuya component and switch support ([@huangyupeng] - [#15399]) ([tuya docs]) ([switch.tuya docs]) (new-platform)
+- Add HomematicIP alarm control panel ([@mxworm] - [#15342]) ([alarm_control_panel docs]) ([homematicip_cloud docs]) ([alarm_control_panel.homematicip_cloud docs]) (new-platform)
+- User management ([@balloob] - [#15420]) ([auth docs]) ([config docs]) ([http docs]) ([websocket_api docs]) (new-platform)
+- Add Tuya light platform ([@huangyupeng] - [#15444]) ([tuya docs]) ([light.tuya docs]) (new-platform)
+
+## {% linkable_title If you need help... %}
+
+...don't hesitate to use our very active [forums](https://community.home-assistant.io/) or join us for a little [chat](https://discord.gg/c5DvZ4e). The release notes have comments enabled but it's preferred if you use the former communication channels. Thanks.
+
+## {% linkable_title Reporting Issues %}
+
+Experiencing issues introduced by this release? Please report them in our [issue tracker](https://github.com/home-assistant/home-assistant/issues). Make sure to fill in all fields of the issue template.
+
+<!--more-->
+## {% linkable_title Breaking Changes %}
+
+- Add support for new API (fixes #14911) ([@fabaff] - [#15279]) ([sensor.fixer docs]) (breaking change)
+- Added support to HTTPS URLs on SynologyDSM ([@tchellomello] - [#15270]) ([sensor.synologydsm docs]) (breaking change)
+- Ignore some HomeKit devices ([@mjg59] - [#15316]) ([homekit_controller docs]) (breaking change)
+- Make LimitlessLED color/temperature attributes mutually exclusive ([@amelchio] - [#15298]) ([light.limitlessled docs]) (breaking change)
+
+## {% linkable_title All changes %}
+
+- deconz: fix light.turn_off with transition ([@lbschenkel] - [#15222]) ([light.deconz docs])
+- Add new RTS device ([@pepeEL] - [#15116]) ([tahoma docs])
+- Add additional parameters to NUT UPS sensor ([@carlchan] - [#15066]) ([sensor.nut docs])
+- Fix typos ([@fabaff] - [#15233]) ([watson_iot docs])
+- Use async syntax for cover platforms ([@cdce8p] - [#15230]) ([cover.lutron_caseta docs]) ([cover.mqtt docs]) ([cover.rflink docs]) ([cover.template docs]) ([cover.velbus docs]) ([cover.wink docs])
+- Upgrade pytest to 3.6.2 ([@scop] - [#15241])
+- Add precipitations to Openweathermap daily forecast mode ([@sgttrs] - [#15240]) ([weather.openweathermap docs])
+- deconz: proper fix light.turn_off with transition ([@lbschenkel] - [#15227]) ([light.deconz docs])
+- allow extra slot values in intents ([@dthulke] - [#15246])
+- Lint cleanups ([@scop] - [#15243]) ([google_assistant docs]) ([sensor.tibber docs])
+- Upgrade sqlalchemy to 1.2.9 ([@fabaff] - [#15250]) ([sensor.sql docs])
+- Upgrade WazeRouteCalculator to 0.6 ([@fabaff] - [#15251]) ([sensor.waze_travel_time docs])
+- Fix typo in Docker files ([@SConaway] - [#15256])
+- Switch to own packaged version of pylgnetcast ([@andrey-git] - [#15042]) ([media_player.lg_netcast docs])
+- Added setting cover tilt position in scene ([@kstaniek] - [#15255])
+- Pass tox posargs to pylint ([@scop] - [#15226])
+- Fix Roomba exception ([@arbreng] - [#15262]) ([vacuum.roomba docs])
+- Added support for Duke Energy smart meters ([@w1ll1am23] - [#15165]) ([sensor.duke_energy docs]) (new-platform)
+- Update image_processing async ([@dgomes] - [#15082]) ([image_processing docs])
+- Fix python-miio 0.4 compatibility of the xiaomi miio device tracker ([@serhtt] - [#15244]) ([device_tracker docs])
+- Upgrade keyring to 13.1.0 ([@fabaff] - [#15268])
+- deCONZ - new sensor attribute 'on' and new sensor GenericFlag ([@Kane610] - [#15247]) ([deconz docs]) ([binary_sensor.deconz docs]) ([sensor.deconz docs])
+- expose climate current temperature in prometeus metrics ([@stenius] - [#15232]) ([prometheus docs])
+- New device to support option MY in somfy ([@pepeEL] - [#15272]) ([cover.tahoma docs])
+- Add isort configuration ([@fabaff] - [#15278])
+- Add support for new API (fixes #14911) ([@fabaff] - [#15279]) ([sensor.fixer docs]) (breaking change)
+- Switch to own packaged version of suds-passworddigest ([@andrey-git] - [#15261]) ([camera.onvif docs])
+- Added Push Camera ([@dgomes] - [#15151]) ([camera.push docs]) (new-platform)
+- Added support to HTTPS URLs on SynologyDSM ([@tchellomello] - [#15270]) ([sensor.synologydsm docs]) (breaking change)
+- Add system generated users ([@balloob] - [#15291]) ([auth docs])
+- Add additional sensors for Arlo Baby camera ([@lukiffer] - [#15074]) ([sensor.arlo docs])
+- Add HomematicIP Cloud Config Flow and Entries loading ([@mxworm] - [#14861]) ([homematicip_cloud docs])
+- Upgrade youtube_dl to 2018.07.04 ([@fabaff] - [#15323]) ([media_extractor docs])
+- Upgrade keyring to 13.2.0 ([@fabaff] - [#15322])
+- Upgrade pytest to 3.6.3 ([@scop] - [#15332])
+- Add original message as dialogflow_query parameter ([@quazzie] - [#15304]) ([dialogflow docs])
+- Add python 3.7 to travis and tox ([@andrey-git] - [#14523])
+- Frontend: Allow overriding default url when added to home screen ([@sjabby] - [#15368]) ([frontend docs])
+- Add HomematicIP Cloud light power consumption and energie attributes ([@mxworm] - [#15343]) ([light.homematicip_cloud docs])
+- fix camera.push API overwrite ([@dgomes] - [#15334]) ([camera.push docs])
+- Add support for multi-channel enocean switches (D2-01-12 profile) ([@NoUsername] - [#14548]) ([enocean docs]) ([switch.enocean docs])
+- Add sound mode support ([@starkillerOG] - [#14910]) ([media_player.denonavr docs])
+- Fixed issue 15340. alexa/smart_home module can now skip properties that aren't supported in the current state, eg lowerSetpoint in Heat mode or targetSetpoint in Eco mode for Nest devices. ([@iliketoprogram14] - [#15352]) ([alexa docs])
+- Efergy ([@fabaff] - [#15380]) ([sensor.efergy docs])
+- Use IndieAuth for client ID ([@balloob] - [#15369]) ([auth docs]) ([frontend docs]) (new-platform)
+- Add httplib2 to h.c.google requirements ([@scop] - [#15385]) ([google docs]) ([calendar.google docs])
+- Remove some unneeded pylint import-error disables ([@scop] - [#15386]) ([device_tracker docs]) ([eufy docs]) ([light.eufy docs]) ([switch.eufy docs])
+- Update ha-philipsjs to 0.0.5 ([@danielperna84] - [#15378]) ([media_player.philips_js docs])
+- Add new voices to Amazon Polly ([@hanzoh] - [#15320]) ([tts docs])
+- Add Cloudflare DNS component. ([@ludeeus] - [#15388]) ([cloudflare docs]) (new-platform)
+- Add Facebox teach service ([@robmarkcole] - [#14998]) ([image_processing.facebox docs])
+- Expire auth code after 10 minutes ([@balloob] - [#15381]) ([auth docs])
+- Improve NetAtmo sensors update logic ([@glpatcern] - [#14866]) ([sensor.netatmo docs])
+- removed unused return ([@ludeeus] - [#15402]) ([cloudflare docs])
+- Fix confused brightness of xiaomi_aqara gateway light ([@amelchio] - [#15314]) ([light.xiaomi_aqara docs])
+- Fix liveboxplaytv empty channel list ([@pschmitt] - [#15404]) ([media_player.liveboxplaytv docs])
+- Fix credentials lookup ([@balloob] - [#15409])
+- Change Ring binary_sensor frequency polling to avoid rate limit exceeded errors ([@tchellomello] - [#15414]) ([binary_sensor.ring docs])
+- Add Tuya component and switch support ([@huangyupeng] - [#15399]) ([tuya docs]) ([switch.tuya docs]) (new-platform)
+- Fix HomeMatic variables ([@danielperna84] - [#15417]) ([homematic docs])
+- Ignore some HomeKit devices ([@mjg59] - [#15316]) ([homekit_controller docs]) (breaking change)
+- Make LimitlessLED color/temperature attributes mutually exclusive ([@amelchio] - [#15298]) ([light.limitlessled docs]) (breaking change)
+- Add HomematicIP alarm control panel ([@mxworm] - [#15342]) ([alarm_control_panel docs]) ([homematicip_cloud docs]) ([alarm_control_panel.homematicip_cloud docs]) (new-platform)
+- Include request.path in legacy api password warning message ([@awarecan] - [#15438]) ([http docs])
+- Add python 3.8-dev to travis and tox ([@andrey-git] - [#15347])
+- Reorg auth ([@balloob] - [#15443])
+- Make typing checks more strict ([@andrey-git] - [#14429])
+- upgrade-mypy ([@scop] - [#14904])
+- Fix comment formatting ([@balloob] - [#15447]) ([device_tracker docs])
+- User management ([@balloob] - [#15420]) ([auth docs]) ([config docs]) ([http docs]) ([websocket_api docs]) (new-platform)
+- More typing ([@andrey-git] - [#15449])
+- Catch the ValueError if the bulb was in the wrong mode ([@fabaff] - [#15434]) ([light.mystrom docs])
+- Upgrade keyring to 13.2.1 ([@fabaff] - [#15453])
+- Fix formatting pylint comments in test ([@balloob] - [#15450])
+- Add HomematicIP Cloud dimmer light device ([@mxworm] - [#15456]) ([light.homematicip_cloud docs])
+- Fix ZWave RGBW lights not producing color without explicit white_value ([@jantman] - [#15412]) ([light.zwave docs])
+- Add IPPassageSensor (HmIP-SPDR) ([@danielperna84] - [#15458]) ([homematic docs])
+- Implement is_on ([@teharris1] - [#15459]) ([switch.insteon_plm docs])
+- Remove unnecessary executable permissions ([@scop] - [#15469]) ([fritzbox docs]) ([climate.fritzbox docs]) ([cover.group docs]) ([sensor.wirelesstag docs]) ([switch.amcrest docs]) ([switch.fritzbox docs])
+- Add Tuya light platform ([@huangyupeng] - [#15444]) ([tuya docs]) ([light.tuya docs]) (new-platform)
+- Update homematicip_cloud with enum states ([@mxworm] - [#15460]) ([homematicip_cloud docs]) ([binary_sensor.homematicip_cloud docs]) ([light.homematicip_cloud docs]) ([sensor.homematicip_cloud docs])
+- Add user via cmd line creates owner ([@balloob] - [#15470]) ([auth docs]) ([http docs])
+- Switch to own packaged version of pygtfs ([@andrey-git] - [#15040]) ([sensor.gtfs docs])
+- Aware comments ([@balloob] - [#15480]) ([auth docs])
+- Fix flux_led turning on with color or effect ([@amelchio] - [#15472]) ([light.flux_led docs])
+- Update limitlessled to 1.1.2 ([@amelchio] - [#15481]) ([light.limitlessled docs])
+
+[#14429]: https://github.com/home-assistant/home-assistant/pull/14429
+[#14523]: https://github.com/home-assistant/home-assistant/pull/14523
+[#14548]: https://github.com/home-assistant/home-assistant/pull/14548
+[#14861]: https://github.com/home-assistant/home-assistant/pull/14861
+[#14866]: https://github.com/home-assistant/home-assistant/pull/14866
+[#14904]: https://github.com/home-assistant/home-assistant/pull/14904
+[#14910]: https://github.com/home-assistant/home-assistant/pull/14910
+[#14998]: https://github.com/home-assistant/home-assistant/pull/14998
+[#15040]: https://github.com/home-assistant/home-assistant/pull/15040
+[#15042]: https://github.com/home-assistant/home-assistant/pull/15042
+[#15066]: https://github.com/home-assistant/home-assistant/pull/15066
+[#15074]: https://github.com/home-assistant/home-assistant/pull/15074
+[#15082]: https://github.com/home-assistant/home-assistant/pull/15082
+[#15116]: https://github.com/home-assistant/home-assistant/pull/15116
+[#15151]: https://github.com/home-assistant/home-assistant/pull/15151
+[#15165]: https://github.com/home-assistant/home-assistant/pull/15165
+[#15222]: https://github.com/home-assistant/home-assistant/pull/15222
+[#15226]: https://github.com/home-assistant/home-assistant/pull/15226
+[#15227]: https://github.com/home-assistant/home-assistant/pull/15227
+[#15230]: https://github.com/home-assistant/home-assistant/pull/15230
+[#15232]: https://github.com/home-assistant/home-assistant/pull/15232
+[#15233]: https://github.com/home-assistant/home-assistant/pull/15233
+[#15240]: https://github.com/home-assistant/home-assistant/pull/15240
+[#15241]: https://github.com/home-assistant/home-assistant/pull/15241
+[#15243]: https://github.com/home-assistant/home-assistant/pull/15243
+[#15244]: https://github.com/home-assistant/home-assistant/pull/15244
+[#15246]: https://github.com/home-assistant/home-assistant/pull/15246
+[#15247]: https://github.com/home-assistant/home-assistant/pull/15247
+[#15250]: https://github.com/home-assistant/home-assistant/pull/15250
+[#15251]: https://github.com/home-assistant/home-assistant/pull/15251
+[#15255]: https://github.com/home-assistant/home-assistant/pull/15255
+[#15256]: https://github.com/home-assistant/home-assistant/pull/15256
+[#15261]: https://github.com/home-assistant/home-assistant/pull/15261
+[#15262]: https://github.com/home-assistant/home-assistant/pull/15262
+[#15268]: https://github.com/home-assistant/home-assistant/pull/15268
+[#15270]: https://github.com/home-assistant/home-assistant/pull/15270
+[#15272]: https://github.com/home-assistant/home-assistant/pull/15272
+[#15278]: https://github.com/home-assistant/home-assistant/pull/15278
+[#15279]: https://github.com/home-assistant/home-assistant/pull/15279
+[#15291]: https://github.com/home-assistant/home-assistant/pull/15291
+[#15298]: https://github.com/home-assistant/home-assistant/pull/15298
+[#15304]: https://github.com/home-assistant/home-assistant/pull/15304
+[#15314]: https://github.com/home-assistant/home-assistant/pull/15314
+[#15316]: https://github.com/home-assistant/home-assistant/pull/15316
+[#15320]: https://github.com/home-assistant/home-assistant/pull/15320
+[#15322]: https://github.com/home-assistant/home-assistant/pull/15322
+[#15323]: https://github.com/home-assistant/home-assistant/pull/15323
+[#15332]: https://github.com/home-assistant/home-assistant/pull/15332
+[#15334]: https://github.com/home-assistant/home-assistant/pull/15334
+[#15342]: https://github.com/home-assistant/home-assistant/pull/15342
+[#15343]: https://github.com/home-assistant/home-assistant/pull/15343
+[#15347]: https://github.com/home-assistant/home-assistant/pull/15347
+[#15352]: https://github.com/home-assistant/home-assistant/pull/15352
+[#15368]: https://github.com/home-assistant/home-assistant/pull/15368
+[#15369]: https://github.com/home-assistant/home-assistant/pull/15369
+[#15378]: https://github.com/home-assistant/home-assistant/pull/15378
+[#15380]: https://github.com/home-assistant/home-assistant/pull/15380
+[#15381]: https://github.com/home-assistant/home-assistant/pull/15381
+[#15385]: https://github.com/home-assistant/home-assistant/pull/15385
+[#15386]: https://github.com/home-assistant/home-assistant/pull/15386
+[#15388]: https://github.com/home-assistant/home-assistant/pull/15388
+[#15399]: https://github.com/home-assistant/home-assistant/pull/15399
+[#15402]: https://github.com/home-assistant/home-assistant/pull/15402
+[#15404]: https://github.com/home-assistant/home-assistant/pull/15404
+[#15409]: https://github.com/home-assistant/home-assistant/pull/15409
+[#15412]: https://github.com/home-assistant/home-assistant/pull/15412
+[#15414]: https://github.com/home-assistant/home-assistant/pull/15414
+[#15417]: https://github.com/home-assistant/home-assistant/pull/15417
+[#15420]: https://github.com/home-assistant/home-assistant/pull/15420
+[#15434]: https://github.com/home-assistant/home-assistant/pull/15434
+[#15438]: https://github.com/home-assistant/home-assistant/pull/15438
+[#15443]: https://github.com/home-assistant/home-assistant/pull/15443
+[#15444]: https://github.com/home-assistant/home-assistant/pull/15444
+[#15447]: https://github.com/home-assistant/home-assistant/pull/15447
+[#15449]: https://github.com/home-assistant/home-assistant/pull/15449
+[#15450]: https://github.com/home-assistant/home-assistant/pull/15450
+[#15453]: https://github.com/home-assistant/home-assistant/pull/15453
+[#15456]: https://github.com/home-assistant/home-assistant/pull/15456
+[#15458]: https://github.com/home-assistant/home-assistant/pull/15458
+[#15459]: https://github.com/home-assistant/home-assistant/pull/15459
+[#15460]: https://github.com/home-assistant/home-assistant/pull/15460
+[#15469]: https://github.com/home-assistant/home-assistant/pull/15469
+[#15470]: https://github.com/home-assistant/home-assistant/pull/15470
+[#15472]: https://github.com/home-assistant/home-assistant/pull/15472
+[#15480]: https://github.com/home-assistant/home-assistant/pull/15480
+[#15481]: https://github.com/home-assistant/home-assistant/pull/15481
+[@Kane610]: https://github.com/Kane610
+[@NoUsername]: https://github.com/NoUsername
+[@SConaway]: https://github.com/SConaway
+[@amelchio]: https://github.com/amelchio
+[@andrey-git]: https://github.com/andrey-git
+[@arbreng]: https://github.com/arbreng
+[@awarecan]: https://github.com/awarecan
+[@balloob]: https://github.com/balloob
+[@carlchan]: https://github.com/carlchan
+[@cdce8p]: https://github.com/cdce8p
+[@danielperna84]: https://github.com/danielperna84
+[@dgomes]: https://github.com/dgomes
+[@dthulke]: https://github.com/dthulke
+[@fabaff]: https://github.com/fabaff
+[@glpatcern]: https://github.com/glpatcern
+[@hanzoh]: https://github.com/hanzoh
+[@huangyupeng]: https://github.com/huangyupeng
+[@iliketoprogram14]: https://github.com/iliketoprogram14
+[@jantman]: https://github.com/jantman
+[@kstaniek]: https://github.com/kstaniek
+[@lbschenkel]: https://github.com/lbschenkel
+[@ludeeus]: https://github.com/ludeeus
+[@lukiffer]: https://github.com/lukiffer
+[@mjg59]: https://github.com/mjg59
+[@mxworm]: https://github.com/mxworm
+[@pepeEL]: https://github.com/pepeEL
+[@pschmitt]: https://github.com/pschmitt
+[@quazzie]: https://github.com/quazzie
+[@robmarkcole]: https://github.com/robmarkcole
+[@scop]: https://github.com/scop
+[@serhtt]: https://github.com/serhtt
+[@sgttrs]: https://github.com/sgttrs
+[@sjabby]: https://github.com/sjabby
+[@starkillerOG]: https://github.com/starkillerOG
+[@stenius]: https://github.com/stenius
+[@tchellomello]: https://github.com/tchellomello
+[@teharris1]: https://github.com/teharris1
+[@w1ll1am23]: https://github.com/w1ll1am23
+[alarm_control_panel docs]: /components/alarm_control_panel/
+[alarm_control_panel.homematicip_cloud docs]: /components/alarm_control_panel.homematicip_cloud/
+[alexa docs]: /components/alexa/
+[auth docs]: /components/auth/
+[binary_sensor.deconz docs]: /components/binary_sensor.deconz/
+[binary_sensor.homematicip_cloud docs]: /components/binary_sensor.homematicip_cloud/
+[binary_sensor.ring docs]: /components/binary_sensor.ring/
+[calendar.google docs]: /components/calendar.google/
+[camera.onvif docs]: /components/camera.onvif/
+[camera.push docs]: /components/camera.push/
+[climate.fritzbox docs]: /components/climate.fritzbox/
+[cloudflare docs]: /components/cloudflare/
+[config docs]: /components/config/
+[cover.group docs]: /components/cover.group/
+[cover.lutron_caseta docs]: /components/cover.lutron_caseta/
+[cover.mqtt docs]: /components/cover.mqtt/
+[cover.rflink docs]: /components/cover.rflink/
+[cover.tahoma docs]: /components/cover.tahoma/
+[cover.template docs]: /components/cover.template/
+[cover.velbus docs]: /components/cover.velbus/
+[cover.wink docs]: /components/cover.wink/
+[deconz docs]: /components/deconz/
+[device_tracker docs]: /components/device_tracker/
+[dialogflow docs]: /components/dialogflow/
+[enocean docs]: /components/enocean/
+[eufy docs]: /components/eufy/
+[fritzbox docs]: /components/fritzbox/
+[frontend docs]: /components/frontend/
+[google docs]: /components/google/
+[google_assistant docs]: /components/google_assistant/
+[homekit_controller docs]: /components/homekit_controller/
+[homematic docs]: /components/homematic/
+[homematicip_cloud docs]: /components/homematicip_cloud/
+[http docs]: /components/http/
+[image_processing docs]: /components/image_processing/
+[image_processing.facebox docs]: /components/image_processing.facebox/
+[light.deconz docs]: /components/light.deconz/
+[light.eufy docs]: /components/light.eufy/
+[light.flux_led docs]: /components/light.flux_led/
+[light.homematicip_cloud docs]: /components/light.homematicip_cloud/
+[light.limitlessled docs]: /components/light.limitlessled/
+[light.mystrom docs]: /components/light.mystrom/
+[light.tuya docs]: /components/light.tuya/
+[light.xiaomi_aqara docs]: /components/light.xiaomi_aqara/
+[light.zwave docs]: /components/light.zwave/
+[media_extractor docs]: /components/media_extractor/
+[media_player.denonavr docs]: /components/media_player.denonavr/
+[media_player.lg_netcast docs]: /components/media_player.lg_netcast/
+[media_player.liveboxplaytv docs]: /components/media_player.liveboxplaytv/
+[media_player.philips_js docs]: /components/media_player.philips_js/
+[prometheus docs]: /components/prometheus/
+[sensor.arlo docs]: /components/sensor.arlo/
+[sensor.deconz docs]: /components/sensor.deconz/
+[sensor.duke_energy docs]: /components/sensor.duke_energy/
+[sensor.efergy docs]: /components/sensor.efergy/
+[sensor.fixer docs]: /components/sensor.fixer/
+[sensor.gtfs docs]: /components/sensor.gtfs/
+[sensor.homematicip_cloud docs]: /components/sensor.homematicip_cloud/
+[sensor.netatmo docs]: /components/sensor.netatmo/
+[sensor.nut docs]: /components/sensor.nut/
+[sensor.sql docs]: /components/sensor.sql/
+[sensor.synologydsm docs]: /components/sensor.synologydsm/
+[sensor.tibber docs]: /components/sensor.tibber/
+[sensor.waze_travel_time docs]: /components/sensor.waze_travel_time/
+[sensor.wirelesstag docs]: /components/sensor.wirelesstag/
+[switch.amcrest docs]: /components/switch.amcrest/
+[switch.enocean docs]: /components/switch.enocean/
+[switch.eufy docs]: /components/switch.eufy/
+[switch.fritzbox docs]: /components/switch.fritzbox/
+[switch.insteon_plm docs]: /components/switch.insteon_plm/
+[switch.tuya docs]: /components/switch.tuya/
+[tahoma docs]: /components/tahoma/
+[tts docs]: /components/tts/
+[tuya docs]: /components/tuya/
+[vacuum.roomba docs]: /components/vacuum.roomba/
+[watson_iot docs]: /components/watson_iot/
+[weather.openweathermap docs]: /components/weather.openweathermap/
+[websocket_api docs]: /components/websocket_api/

--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -16,15 +16,14 @@ footer: true
 - Custom cards now work with `panel: true`
 
 ### Cards
-- `glance` card supports now `toggle` and `turn-on` besides showing more-info dialog
-- `glance` card supports now to hide `name` or `state`
-- `history-graph` supports override of entity names
-- Allow `picture-glance` to open more info for camera 
-- Show more-info for `media_players` in `picture-glance`
-- `picture-elements` card now supports also `image` as element type
-- `picture-elements` card now supports also `service-icon` as element type
-- Make Lovelace `entity-filter` card more robust (new use case: https://github.com/home-assistant/ui-schema/issues/82)
-- 🔧 Fix `picture-glance` crash when state of entity was unavailable
+- 📣 [glance card]: Entity `tap_action` can now be `toggle` and `turn-on` besides the default of showing the more info dialog
+- 📣 [glance card]: Support added to hide `name` or `state`
+- 📣 [history graph card]: Support added to override entity names
+- 📣 [picture glance card]: Support added to open the more info dialog for cameras and media players.
+- 📣 [picture elements card]: Support new element type `image`
+- 📣 [picture elements card]: Support new element type `service-icon`
+- 🔧 [entity filter card]: Fix edge cases that could make it crash ([supports this new use case](https://github.com/home-assistant/ui-schema/issues/82))
+- 🔧 [picture glance card]: Fix crash when the state of entity was unavailable
 
 ## {% linkable_title Changes in 0.73.1 %}
 
@@ -128,3 +127,9 @@ footer: true
 ## {% linkable_title Changes in 0.72 %}
 
 - Initial release of the Lovelace UI
+
+[glance card]: /lovelace/glance/
+[history graph card]: /lovelace/history-graph/
+[picture glance card]: /lovelace/picture-glance/
+[picture elements card]: /lovelace/picture-elements/
+[entity filter card]: /lovelace/entity-filter/

--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -9,6 +9,23 @@ sharing: true
 footer: true
 ---
 
+## {% linkable_title Changes in 0.74.0b0 %}
+
+### Views
+- Add basic support for `badges` like in old view style
+- Custom cards now work with `panel: true`
+
+### Cards
+- `glance` card supports now `toggle` and `turn-on` besides showing more-info dialog
+- `glance` card supports now to hide `name` or `state`
+- `history-graph` supports override of entity names
+- Allow `picture-glance` to open more info for camera 
+- Show more-info for `media_players` in `picture-glance`
+- `picture-elements` card now supports also `image` as element type
+- `picture-elements` card now supports also `service-icon` as element type
+- Make Lovelace `entity-filter` card more robust (new use case: https://github.com/home-assistant/ui-schema/issues/82)
+- 🔧 Fix `picture-glance` crash when state of entity was unavailable
+
 ## {% linkable_title Changes in 0.73.1 %}
 
 - Setting Lovelace as default now updates `Overview` button to point to `/lovelace`


### PR DESCRIPTION
**Description:**

I think the docs should say `show_name` and not `show_title`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
