### PR TITLE
Add supported features and small fixes for Neato

### DIFF
--- a/source/_components/vacuum.neato.markdown
+++ b/source/_components/vacuum.neato.markdown
@@ -14,11 +14,15 @@ ha_iot_class: "Cloud Polling"
 redirect_from: /components/sensor.neato/
 ---
 
-<p class='note'>
-Starting with 0.57 the `neato` sensor was migrated to a vacuum platform.
-</p>
-
-The `neato` vacuum platform allows you to control your [Neato Botvac Connected](https://www.neatorobotics.com/robot-vacuum/botvac-connected-series/botvac-connected/).
+The `neato` vacuum platform allows you to control your [Neato Botvac Connected](https://www.neatorobotics.com/robot-vacuum/botvac-connected-series/).
 The status will contain attributes on the robots last clean session.
 
-To add `neato` sensors to your installation, follow instructions in [Neato component](/components/neato/).
+To add `neato` vacuum to your installation, please follow instructions in [Neato component](/components/neato/).
+
+Currently supported features are:
+
+- `turn_on`
+- `pause`
+- `stop`
+- `return_to_home`
+- `turn_off` (stop all activity and return to dock)


### PR DESCRIPTION
**Description:**

Replace reference of `sensor` to `vacuum` and add a list of all currently supported features.  Remove old note referencing 0.57 as it was confusing.  Update Neato URL to link to all supported botvacs as we support more than the 1 previously linked model.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
