### PR TITLE
Update URL To Link To All Supported Botvacs

### DIFF
--- a/source/_components/neato.markdown
+++ b/source/_components/neato.markdown
@@ -12,7 +12,7 @@ ha_category: Hub
 ha_release: 0.33
 ---
 
-The `neato` component allows you to control your [Neato Botvac Connected](https://www.neatorobotics.com/robot-vacuum/botvac-connected-series/botvac-connected/).
+The `neato` component allows you to control your [Neato Botvac Connected Robots](https://www.neatorobotics.com/robot-vacuum/botvac-connected-series/).
 
 To enable `neato` in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**

Update the URL to link to all supported botvacs as it was only linking to one model.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
