### PR TITLE
Pi naming convention

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -14,6 +14,7 @@ Hass.io images are available for:
 - Download the appropriate image for your device:
   - [Raspberry Pi Zero][pi1]
   - [Raspberry Pi Zero W][pi0-w]
+  - [Raspberry Pi 1 Model B][pi1]
   - [Raspberry Pi 2 Model B][pi2]
   - [Raspberry Pi 3 Model B and B+ 32bit][pi3-32] (recommended)
   - [Raspberry Pi 3 Model B and B+ 64bit][pi3-64]

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -12,11 +12,11 @@ footer: true
 Hass.io images are available for:
 
 - Download the appropriate image for your device:
-  - [Raspberry Pi / Zero][pi1]
+  - [Raspberry Pi Zero][pi1]
   - [Raspberry Pi Zero W][pi0-w]
-  - [Raspberry Pi 2][pi2]
-  - [Raspberry Pi 3 32bit][pi3-32] (recommended)
-  - [Raspberry Pi 3 64bit][pi3-64]
+  - [Raspberry Pi 2 Model B][pi2]
+  - [Raspberry Pi 3 Model B and B+ 32bit][pi3-32] (recommended)
+  - [Raspberry Pi 3 Model B and B+ 64bit][pi3-64]
 - As [Virtual Appliance]:
   - [VMDK][vmdk]
 


### PR DESCRIPTION
Following the https://www.raspberrypi.org/products/
1. Removed the Pi / Zero from the name to follow how raspberrypi.org
2. Raspberry Pi 2 Model B 
3. Raspberry Pi 3 Model B and B+. Added the B+ to clarify and avoid confusion since the hassio did not supported.

Maybe just use 3B and 3B+.

**Description:**
Following the https://www.raspberrypi.org/products/ name convention.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/