### PR TITLE
Update prometheus documentation

### DIFF
--- a/source/_components/prometheus.markdown
+++ b/source/_components/prometheus.markdown
@@ -23,7 +23,7 @@ prometheus:
 
 Configuration variables:
 
-- **namespace** (*Optional*): The "namespace" that will be assigned to all the Prometheus metrics. This is the prefix of the metric name. E.g., having `myhass` as the namespace will cause the device tracker metrics to be `myhass_device_tracker_state`, the switch metrics to be `myhass_switch_state` and so on. The default is to not add any prefix to the metrics name.
+- **namespace** (*Optional*): The "namespace" that will be assigned to all the Prometheus metrics. This is the prefix of the metric name. E.g., having `myhass` as the namespace will cause the device tracker metrics to be `myhass_device_tracker_state`, the switch metrics to be `myhass_switch_state` and so on. The default is to not add any prefix to the metrics name. (available in version 0.73.0 and later)
 - **filter** (*Optional*): Filtering directives for the components which should be included or excluded from recording.
   - **exclude** (*Optional*): Excluded from recording.
     - **entities** (*Optional*): The list of entity ids to be excluded from recording.


### PR DESCRIPTION
Clarify that the "namespace" option is available in version 0.73 and later. Earlier version will error out.

**Description:**

This is a small clarification in the docs.
