### PR TITLE
Suggested hardware instead of Hardware Requirements

### DIFF
--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 ---
 
-The goal of this getting started guide is to install [Hass.io](/hassio/) on a Raspberry Pi 3B+. Hass.io is our own all in one solution that turns your Raspberry Pi into the ultimate home automation hub. 
+The goal of this getting started guide is to install [Hass.io](/hassio/) on a Raspberry Pi. Hass.io is our own all in one solution that turns your Raspberry Pi into the ultimate home automation hub. 
 
 The following models are supported:
 - Raspberry Pi Zero and Zero W

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -9,7 +9,12 @@ sharing: true
 footer: true
 ---
 
-The goal of this getting started guide is to install [Hass.io](/hassio/) on a Raspberry Pi 3. Hass.io is our own all in one solution that turns your Raspberry Pi into the ultimate home automation hub.
+The goal of this getting started guide is to install [Hass.io](/hassio/) on a Raspberry Pi 3B+. Hass.io is our own all in one solution that turns your Raspberry Pi into the ultimate home automation hub. 
+
+The following models are supported:
+- Raspberry Pi Zero and Zero W
+- Raspberry Pi 2 Model B
+- Raspberry Pi 3 Model B and Model B+
 
 Follow this guide if you want to get started with Home Assistant easily, or if you have no or little Linux experience. For advanced users or if you have no Raspberry Pi at hand, check our [alternative installation methods](/docs/installation/). The [FAQ](/faq/#home-assistant-vs-hassio) explains more about the differences.
 
@@ -17,11 +22,11 @@ Follow this guide if you want to get started with Home Assistant easily, or if y
   Please remember to [secure your installation](/docs/configuration/securing/) once you've finished with the installation process.
 </p>
 
-### {% linkable_title Hardware requirements %}
+### {% linkable_title Suggested hardware%}
 
-We will need a few things to get started with installing Home Assistant. Links below are linking to Amazon US. If you're not in the US, you should be able to find these items in web stores in your country.
+We will need a few things to get started with installing Home Assistant. For best performance, we suggest the latest Raspberry Pi 3 Model B+. Links below are linking to Amazon US. If you're not in the US, you should be able to find these items in web stores in your country.
 
-- [Raspberry Pi 3 model B+](http://a.co/ak2SQor) + [Power Supply](https://www.raspberrypi.org/help/faqs/#powerReqs) (at least 2.5A)
+- [Raspberry Pi 3 Model B+](http://a.co/ak2SQor) + [Power Supply](https://www.raspberrypi.org/help/faqs/#powerReqs) (at least 2.5A)
 - [Micro SD Card](http://a.co/gslOydD). Get one that is Class 10 as they are more reliable. Size 32 GB or bigger recommended.
 - SD Card reader. Part of most laptops, and also available as [standalone USB sticks](http://a.co/5FCyb0N) (the brand doesn't matter, just pick the cheapest)
 - Ethernet cable (optional, Hass.io can work with WiFi as well)

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -13,6 +13,7 @@ The goal of this getting started guide is to install [Hass.io](/hassio/) on a Ra
 
 The following models are supported:
 - Raspberry Pi Zero and Zero W
+- Raspberry Pi 1 Model B
 - Raspberry Pi 2 Model B
 - Raspberry Pi 3 Model B and Model B+
 


### PR DESCRIPTION

**Description:**

- Change from 3B to 3B+ to reflect the hardware section.

- Add a list of models supported. A link could be used instead...

- "Hardware Requirements" gives the idea that will not run on older RPi. "Suggested Hardware" might be a better fit.

- Some small talk about the 3B+


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
