### PR TITLE
Lovelace: Make cards[] optional in a view

### DIFF
--- a/source/lovelace/views.markdown
+++ b/source/lovelace/views.markdown
@@ -26,13 +26,13 @@ views:
       required: true
       description: The title or name.
       type: string
-    cards:
-      required: true
-      description: Cards to display in this view.
-      type: list
     badges:
       required: false
       description: List of entities IDs to display as badge.
+      type: list
+    cards:
+      required: false
+      description: Cards to display in this view.
       type: list
     id:
       required: false


### PR DESCRIPTION
**Description:**

https://github.com/home-assistant/home-assistant-polymer/pull/1471

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
