### PR TITLE
fritzbox_callmonitor build dependencies

### DIFF
--- a/source/_components/sensor.fritzbox_callmonitor.markdown
+++ b/source/_components/sensor.fritzbox_callmonitor.markdown
@@ -22,13 +22,16 @@ It can also access the internal phone book of the router to look up the names co
 To build the package you have to install some dependencies first.
 
 ```bash
-apt-get update
-apt-get install libxml2-dev libxslt-dev python3-setuptools zlib1g-dev build-essential
+$ sudo apt-get update
+$ sudo apt-get install libxml2-dev libxslt-dev \
+  python3-setuptools zlib1g-dev build-essential
 ```
 
-## {% linkable_title Configuration %}
+## {% linkable_title Setup%}
 
 To activate the call monitor on your Fritz!Box, dial #96\*5\* from any phone connected to it.
+
+## {% linkable_title Configuration %}
 
 To use the Fritz!Box call monitor in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/sensor.fritzbox_callmonitor.markdown
+++ b/source/_components/sensor.fritzbox_callmonitor.markdown
@@ -17,6 +17,15 @@ ha_iot_class: "Local Polling"
 The `fritzbox_callmonitor` sensor monitors the call monitor exposed by [AVM Fritz!Box](http://avm.de/produkte/fritzbox/) routers on TCP port 1012. It will assume the values `idle`, `ringing`, `dialing` or `talking` with the phone numbers involved contained in the state attributes.
 It can also access the internal phone book of the router to look up the names corresponding to the phone numbers and store them in the state attributes.
 
+## {% linkable_title Prerequisites %}
+
+To build the package you have to install some dependencies first.
+
+```bash
+apt-get update
+apt-get install libxml2-dev libxslt-dev python3-setuptools zlib1g-dev build-essential
+```
+
 ## {% linkable_title Configuration %}
 
 To activate the call monitor on your Fritz!Box, dial #96\*5\* from any phone connected to it.


### PR DESCRIPTION
**Description:**

On enabling the fritzbox_callmonitor the package fritzconnection should have been built. But it depends on various other packages that have to be installed before. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** 

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
