### PR TITLE
Fix indentation for `microsoft_face_identify`-component

### DIFF
--- a/source/_components/image_processing.microsoft_face_identify.markdown
+++ b/source/_components/image_processing.microsoft_face_identify.markdown
@@ -24,10 +24,10 @@ For using the result inside an automation rule, take a look at the [component](/
 ```yaml
 # Example configuration.yaml entry
 image_processing:
- - platform: microsoft_face_identify
-   group: family
-   source:
-    - entity_id: camera.door
+  - platform: microsoft_face_identify
+    group: family
+    source:
+      - entity_id: camera.door
 ```
 
 Configuration variables:


### PR DESCRIPTION
**Description:**
Fixes indentation of the example configuration.yaml entry for the `microsoft_face_identify`-component

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
