### PR TITLE
Updated example indentation

### DIFF
--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -337,10 +337,10 @@ state_filter:
       filter: saturate(.8)
       state_filter:
         'on': brightness(120%) saturate(1.2)
-       style: 
-         top: 25%
-         left: 75%
-         width: 15%
+      style: 
+        top: 25%
+        left: 75%
+        width: 15%
     # Camera, red border, rounded-rectangle - show more-info on click
     - type: image
       entity: camera.driveway_camera


### PR DESCRIPTION
Picture elements example indentation was off.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
