### PR TITLE
Minor Synology docker documentation updates

### DIFF
--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -56,14 +56,14 @@ As Synology within DSM now supports Docker (with a neat UI), you can simply inst
 The steps would be:
 * Install "Docker" package on your Synology NAS
 * Launch Docker-app and move to "Registry"-section
-* Find "homeassistant/home-assistant" with registry and click on "Download"
+* Find "homeassistant/home-assistant" within registry and click on "Download". Choose the "latest" tag, this will make verison updates easier later on.
 * Wait for some time until your NAS has pulled the image
 * Move to the "Image"-section of the Docker-app
 * Click on "Launch"
 * Choose a container-name you want (e.g., "homeassistant")
 * Click on "Advanced Settings"
 * Set "Enable auto-restart" if you like
-* Within "Volume" click on "Add Folder" and choose either an existing folder or add a new folder. The "mount point" has to be "/config", so that Home Assistant will use it for the configs and logs.
+* Within "Volume" click on "Add Folder" and choose either an existing folder or add a new folder. The "mount path" has to be "/config", so that Home Assistant will use it for the configs and logs.
 * Within "Network" select "Use same network as Docker Host"
 * To ensure that Home Assistant displays the correct timezone go to the "Environment" tab and click the plus sign then add `variable` = `TZ` & `value` = `Europe/London` choosing [your correct timezone](http://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 * Confirm the "Advanced Settings"
@@ -71,9 +71,9 @@ The steps would be:
 * Your Home Assistant within Docker should now run and will serve the web interface from port 8123 on your Docker host (this will be your Synology NAS IP address - for example `http://192.168.1.10:8123`)
 
 Remark: to update your Home Assistant on your Docker within Synology NAS, you just have to do the following:
-* Go to the Docker-app and move to "Image"-section
-* Download the "homeassistant/home-assistant" image - don't care, that it is already there
-* wait until the system-message/-notification comes up, that the download is finished (there is no progress bar)
+* Go to the Docker-app and move to "Registry"-section
+* Find "homeassistant/home-assistant" within registry and click on "Download". Choose the "latest" tag, this will overwrite your current image to the latest version.
+* Wait until the system-message/-notification comes up, that the download is finished (there is no progress bar)
 * Move to "Container"-section
 * Stop your container if it's running
 * Right-click on it and select "Action"->"Clear". You won't lose any data, as all files are stored in your config-directory


### PR DESCRIPTION
Minor updates based on my experience of installing Home Assistant on docker on a Synology NAS (DS218+) running DSM version 6.2-23739.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
