### PR TITLE
Update picture-entity.markdown

### DIFF
--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -104,6 +104,7 @@ Example with night/day:
 ```yaml
 - type: picture-entity
   entity: light.bed_light
+  tap_action: toggle
   image: http://farm7.static.flickr.com/6153/6220100622_88e64ec5d8_b.jpg
   state_image:
     "on": http://farm7.static.flickr.com/6220/6220100616_a877f41a66_b.jpg


### PR DESCRIPTION
In the example with night/day, it misses the 'tap_action:toggle' option. That way the example mentioned above is working correct.
That's why this pull request.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
