### PR TITLE
Enable missing octopress-filters gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :jekyll_plugins do
   gem 'jekyll-time-to-read'
   gem 'octopress', '~> 3.0'
   gem 'octopress-include-tag'
+  gem 'octopress-filters'
 end
 
 gem 'sinatra', '~> 1.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,11 @@ GEM
       colorator
     octopress-escape-code (2.1.1)
       jekyll (~> 3.0)
+    octopress-filters (1.4.0)
+      jekyll
+      octopress-hooks (~> 2.0)
+      rubypants-unicode
+      titlecase
     octopress-hooks (2.6.2)
       jekyll (>= 2.0)
     octopress-include-tag (1.1.3)
@@ -80,6 +85,7 @@ GEM
       ffi (>= 0.5.0)
     redcarpet (3.4.0)
     rouge (1.11.1)
+    rubypants-unicode (0.2.5)
     safe_yaml (1.0.4)
     sass (3.2.19)
     sass-globbing (1.1.5)
@@ -105,6 +111,7 @@ DEPENDENCIES
   jekyll-time-to-read
   nokogiri
   octopress (~> 3.0)
+  octopress-filters
   octopress-include-tag
   pry
   rake (~> 10.0)
@@ -117,4 +124,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.16.4


### PR DESCRIPTION
**Description:**

Fixes #5856 maybe?

The atom.xml template uses the `full_urls` filter which is part of the `octopress-filters` gem, which is missing from the Gemfile.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
