### PR TITLE
Fix link to supported currencies

### DIFF
--- a/source/_components/sensor.fixer.markdown
+++ b/source/_components/sensor.fixer.markdown
@@ -16,7 +16,7 @@ ha_release: 0.23
 
 The `fixer` sensor will show you the current exchange rate from [Fixer.io](http://fixer.io/) which is using data from the [European Central Bank (ECB)](https://www.ecb.europa.eu).
 
-To get an overview about the available [currencies](http://api.fixer.io/latest).
+To get an overview about the available [currencies](https://fixer.io/symbols).
 
 ## {% linkable_title Setup %}
 


### PR DESCRIPTION
Fix a link in documentation to point to supported currencies by fixer.io