### PR TITLE
Fix variable ha_release etc.

### DIFF
--- a/source/_components/asterisk_mbox.markdown
+++ b/source/_components/asterisk_mbox.markdown
@@ -9,8 +9,8 @@ sharing: true
 footer: true
 logo: asterisk.png
 ha_category: Other
-ha_version: 0.51
 ha_iot_class: "Local Push"
+ha_release: 0.51
 ---
 
 The `asterisk_mbox `Asterisk Voicemail integration for Home Assistant allows you to view, listen to, and delete voicemails from an Asterisk voicemail mailbox. The component includes a panel on the frontend that provides caller-id and speech-to-text transcription (using Google's API) of messages in addition to playback and message deletion. There is also an included sensor that indicates of the number of available messages. There is no requirement that the Asterisk PBX and Home Assistant are running on the same machine.
@@ -31,13 +31,21 @@ asterisk_mbox:
 
 This will add a new 'Mailbox' side-panel, as well as a sensor to indicate # of messages available.
 
-Configuration variables:
-
-- **password** (*Required*): The password that was set during Asterisk PBX configuration
-- **host** (*Required*): The ip-address of the server that is running the Asterisk PBX
-- **port** (*Required*): The port on the Asterisk PBX server that was configured during Asterisk PBX configuration
+{% configuration %}
+password:
+  description: The password that was set during Asterisk PBX configuration
+  required: true
+  type: string
+host:
+  description: The ip-address of the server that is running the Asterisk PBX
+  required: true
+  type: string
+port:
+  description: The port on the Asterisk PBX server that was configured during Asterisk PBX configuration
+  required: true
+  type: string
+{% endconfiguration %}
 
 <p class='note warning'>
 Communication between the Asterisk PBX server and the Home Assistant server is password-protected, but the data transmission is not encrypted. It is recommended to only use this component when communication is contained within a local area network.
 </p>
-

--- a/source/_components/device_tracker.mqtt_json.markdown
+++ b/source/_components/device_tracker.mqtt_json.markdown
@@ -9,10 +9,9 @@ sharing: true
 footer: true
 logo: mqtt.png
 ha_category: Presence Detection
-ha_version: 0.44
 ha_iot_class: depends
+ha_release: 0.44
 ---
-
 
 The `mqtt_json` device tracker platform allows you to detect presence by monitoring an MQTT topic for new locations. To use this platform, you specify a unique topic for each device.
 
@@ -27,10 +26,16 @@ device_tracker:
       annetherese_n4: location/annetherese
 ```
 
-Configuration variables:
-
-- **devices** (*Required*): List of devices with their topic.
-- **qos** (*Optional*): The QoS level of the topic.
+{% configuration %}
+devices:
+  description: List of devices with their topic.
+  required: true
+  type: list
+qos:
+  description: The QoS level of the topic.
+  required: false
+  type: string
+{% endconfiguration %}
 
 This platform receives JSON formatted payloads containing GPS information, for example:
 

--- a/source/_components/device_tracker.xiaomi_miio.markdown
+++ b/source/_components/device_tracker.xiaomi_miio.markdown
@@ -9,8 +9,8 @@ sharing: true
 footer: true
 logo: xiaomi.png
 ha_category: Presence Detection
-ha_version: 0.67
 ha_iot_class: "Local Polling"
+ha_release: 0.67
 ---
 
 The `xiaomi_miio` device tracker platform is observing your Xiaomi Mi WiFi Repeater 2 and reporting all associated WiFi clients.

--- a/source/_components/dominos.markdown
+++ b/source/_components/dominos.markdown
@@ -9,8 +9,8 @@ sharing: true
 footer: true
 logo: dominos.png
 ha_category: Other
-ha_version: 0.59
 ha_iot_class: "Cloud Polling"
+ha_release: 0.59
 ---
 
 The `dominos` component allows you to order Dominos Pizza from within your Home Assistant scripts and automations.

--- a/source/_components/fan.xiaomi_miio.markdown
+++ b/source/_components/fan.xiaomi_miio.markdown
@@ -9,8 +9,8 @@ sharing: true
 footer: true
 logo: xiaomi.png
 ha_category: Fan
-ha_version: 0.57
 ha_iot_class: "Local Polling"
+ha_release: 0.57
 ---
 
 The `xiaomi_miio` fan platform allows you to control the Xiaomi Air Purifier and Xiaomi Air Humidifier.
@@ -181,20 +181,20 @@ fan:
 
 {% configuration %}
 host:
-  description: The IP address of your fan.
+  description: The IP address of your miio fan.
   required: true
   type: string
 token:
-  description: The API token of your fan.
+  description: The API token of your miio fan.
   required: true
   type: string
 name:
-  description: The name of your fan.
+  description: The name of your miio fan.
   required: false
   type: string
   default: Xiaomi Air Purifier
 model:
-  description: The model of your device.
+  description: The model of your miio fan. Valid values are `zhimi.airpurifier.v6`, `zhimi.airpurifier.v3`, `zhimi.humidifier.v1` and `zhimi.humidifier.ca1`. This setting can be used to bypass the device model detection and is recommended if your device isn't always available.
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_components/goalfeed.markdown
+++ b/source/_components/goalfeed.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: goalfeed.png
 ha_category: Other
-ha_version: 0.63
+ha_release: 0.63
 ---
 
 The `goalfeed` component lets you use your Goalfeed account to trigger events in Home Assistant whenever a NHL or MLB team scores. 

--- a/source/_components/light.sensehat.markdown
+++ b/source/_components/light.sensehat.markdown
@@ -8,9 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: sense-hat.png
-ha_version: 0.44
 ha_category: Light
 ha_iot_class: "Assumed State"
+ha_release: 0.44
 ---
 
 The `sensehat` light platform lets you control the [Sense HAT](https://www.raspberrypi.org/products/sense-hat/) board's 8x8 RGB LED matrix on your Raspberry Pi from within Home Assistant.

--- a/source/_components/light.xiaomi_miio.markdown
+++ b/source/_components/light.xiaomi_miio.markdown
@@ -9,8 +9,8 @@ sharing: true
 footer: true
 logo: philips.png
 ha_category: Light
-ha_version: 0.53
 ha_iot_class: "Local Polling"
+ha_release: 0.53
 ---
 
 The `xiaomi_miio` platform allows you to control the state of your Xiaomi Philips LED Ball Lamp, Xiaomi Philips Zhirui LED Bulb E14 Candle Lamp, Xiaomi Philips LED Ceiling Lamp and Xiaomi Philips Eyecare Lamp 2.
@@ -76,28 +76,22 @@ light:
     model: philips.light.bulb
 ```
 
-Configuration variables:
-- **host** (*Required*): The IP of your light.
-- **token** (*Required*): The API token of your light.
-- **name** (*Optional*): The name of your light.
-- **model** (*Optional*): The model of your light. Valid values are `philips.light.bulb`, `philips.light.candle2`, `philips.light.sread1`, `philips.light.ceiling` and `philips.light.zyceiling`. This setting can be used to bypass the device model detection and is recommended if your device isn't always available.
-
 {% configuration %}
 host:
-  description: The IP address of your device.
+  description: The IP address of your miio light.
   required: true
   type: string
 token:
-  description: The API token of your device.
+  description: The API token of your miio light.
   required: true
   type: string
 name:
-  description: The name of your device.
+  description: The name of your miio light.
   required: false
   type: string
   default: Xiaomi Philips Light
 model:
-  description: The model of your device.
+  description: The model of your miio light. Valid values are `philips.light.bulb`, `philips.light.candle2`, `philips.light.sread1`, `philips.light.ceiling` and `philips.light.zyceiling`. This setting can be used to bypass the device model detection and is recommended if your device isn't always available.
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_components/mailbox.asterisk_mbox.markdown
+++ b/source/_components/mailbox.asterisk_mbox.markdown
@@ -9,8 +9,7 @@ sharing: true
 footer: true
 logo: asterisk.png
 ha_category: Mailbox
-ha_version: 0.51
+ha_release: 0.51
 ---
 
 The Asterisk Voicemail Mailbox provides visual and audio access to voicemail on the Asterisk PBX server. This mailbox is enabled automatically through the [Asterisk Voicemail component](/components/asterisk_mbox/) configuration.
-

--- a/source/_components/mailbox.markdown
+++ b/source/_components/mailbox.markdown
@@ -6,13 +6,12 @@ date: 2017-06-30 18:30
 sidebar: true
 comments: false
 sharing: true
-ha_version: 0.51
 footer: true
+ha_release: 0.51
 ---
 
-Mailboxes provide a list of messages with short information about each.  Mailbox messages appear on a separate panel in the frontend.
+Mailboxes provide a list of messages with short information about each. Mailbox messages appear on a separate panel in the frontend.
 
 Home Assistant currently supports only the [Asterisk Voicemail](/component/mailbox.asterisk_mbox) mailbox.
 
 Each mailbox also provides an entity to indicate the number of messages available on the main page.
-

--- a/source/_components/matrix.markdown
+++ b/source/_components/matrix.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: matrix.png
 ha_category: Hub
-ha_version: 0.69
+ha_release: 0.69
 ---
 
 This component allows you to send messages to matrix rooms, as well as to react to messages in matrix rooms. Reacting to commands is accomplished by firing an event when one of the configured commands is triggered.

--- a/source/_components/sensor.geo_rss_events.markdown
+++ b/source/_components/sensor.geo_rss_events.markdown
@@ -9,36 +9,27 @@ sharing: true
 footer: true
 logo: rss.png
 ha_category: Sensor
-ha_version: 0.55
 ha_iot_class: "Cloud Polling"
+ha_release: 0.55
 ---
 
-The `geo_rss_events` sensor retrieves events from a GeoRSS feed and
-shows information of those events filtered by distance to Home Assistant's
-location and grouped by category.
+The `geo_rss_events` sensor retrieves events from a GeoRSS feed and shows information of those events filtered by distance to Home Assistant's location and grouped by category.
 
-This sensor is particularly useful if events occur unexpectedly in the
-vicinity of the home while the GeoRSS feed also contains many events
-representing distant unrelated entries. Typical examples are bush fires
-alerts or earthquakes.
+This sensor is particularly useful if events occur unexpectedly in the vicinity of the home while the GeoRSS feed also contains many events representing distant unrelated entries. Typical examples are bush fires alerts or earthquakes.
 
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/geo-rss-incidents-group-screenshot.png' />
 </p>
 
-The reference point for comparing the distance is defined by `latitude`
-and `longitude` in the basic configuration.
+The reference point for comparing the distance is defined by `latitude` and `longitude` in the basic configuration.
 
-Only entries of the feed are considered that define a location as `point`
-or `polygon` in *georss.org* format or as *WGS84 latitude/longitude*.
+Only entries of the feed are considered that define a location as `point` or `polygon` in *georss.org* format or as *WGS84 latitude/longitude*.
 
 The data is updated every 5 minutes.
 
 ## {% linkable_title Configuration %}
 
-To enable the GeoRSS events sensor, add the following lines to your
-`configuration.yaml`. This is an example configuration showing bush fire
-incidents from the NSW Rural Fire Service.
+To enable the GeoRSS events sensor, add the following lines to your `configuration.yaml`. This is an example configuration showing bush fire incidents from the NSW Rural Fire Service.
 
 ```yaml
 # Example configuration.yaml entry
@@ -53,13 +44,32 @@ sensor:
       - 'Advice'
 ```
 
-Configuration variables:
-
-- **url** (*Required*): Full URL of the GeoRSS feed.
-- **name** (*Optional*): Name of the sensor used in generating the entity id. Default is 'Event Service'.
-- **radius** (*Optional*): The distance in kilometers around the Home Assistant's coordinates in which events are considered. Default is: 20km.
-- **categories** (*Optional*): List of event category names found in the GeoRSS feed. A separate sensor is created for each category defined. Default is to join events from all categories into an 'Any' category.
-- **unit_of_measurement** (*Optional*): The type of events found in the GeoRSS feed. Default is 'Events'.
+{% configuration %}
+url:
+  description: Full URL of the GeoRSS feed.
+  required: true
+  type: string
+name:
+  description: Name of the sensor used in generating the entity id.
+  required: false
+  type: string
+  default: Event Service
+radius:
+  description: The distance in kilometers around the Home Assistant's coordinates in which events are considered.
+  required: false
+  type: string
+  default: 20km
+categories:
+  description: List of event category names found in the GeoRSS feed. A separate sensor is created for each category defined.
+  required: false
+  type: list
+  default: Default is to join events from all categories into an 'Any' category.
+unit_of_measurement:
+  description: The type of events found in the GeoRSS feed.
+  required: false
+  type: string
+  default: Events
+{% endconfiguration %}
 
 ## {% linkable_title Example Feeds %}
 

--- a/source/_components/sensor.nut.markdown
+++ b/source/_components/sensor.nut.markdown
@@ -9,8 +9,8 @@ sharing: true
 footer: true
 logo: nut.png
 ha_category: System Monitor
-ha_version: 0.34
 ha_iot_class: "Local Polling"
+ha_release: 0.34
 ---
 
 The `nut` sensor platform allows you to monitor a UPS (battery backup) by using data from a [NUT](http://networkupstools.org/) (Network UPS Tools) server.

--- a/source/_components/sensor.xiaomi_miio.markdown
+++ b/source/_components/sensor.xiaomi_miio.markdown
@@ -9,8 +9,8 @@ sharing: true
 footer: true
 logo: xiaomi.png
 ha_category: Sensor
-ha_version: 0.66
 ha_iot_class: "Local Polling"
+ha_release: 0.66
 ---
 
 The `xiaomi_miio` sensor platform is observing your Xiaomi Mi Air Quality Monitor (PM2.5) and reporting the air quality index.

--- a/source/_components/switch.xiaomi_miio.markdown
+++ b/source/_components/switch.xiaomi_miio.markdown
@@ -9,8 +9,8 @@ sharing: true
 footer: true
 logo: xiaomi.png
 ha_category: Switch
-ha_version: 0.56
 ha_iot_class: "Local Polling"
+ha_release: 0.56
 ---
 
 The `xiaomi_miio` switch platform allows you to control the state of your Xiaomi Smart WiFi Socket aka Plug, Xiaomi Smart Power Strip and Xiaomi Chuangmi Plug V1.
@@ -57,28 +57,22 @@ switch:
     model: chuangmi.plug.m1
 ```
 
-Configuration variables:
-- **host** (*Required*): The IP of your miio device.
-- **token** (*Required*): The API token of your miio device.
-- **name** (*Optional*): The name of your miio device.
-- **model** (*Optional*): The model of your miio device. Valid values are `chuangmi.plug.v1`, `qmi.powerstrip.v1`, `zimi.powerstrip.v2`, `chuangmi.plug.m1` and `chuangmi.plug.v2`. This setting can be used to bypass the device model detection and is recommended if your device isn't always available.
-
 {% configuration %}
 host:
-  description: The IP address of your device.
+  description: The IP address of your miio device.
   required: true
   type: string
 token:
-  description: The API token of your device.
+  description: The API token of your miio device.
   required: true
   type: string
 name:
-  description: The name of your device.
+  description: The name of your miio device.
   required: false
   type: string
   default: Xiaomi Miio Switch
 model:
-  description: The model of your device.
+  description: The model of your miio device. Valid values are `chuangmi.plug.v1`, `qmi.powerstrip.v1`, `zimi.powerstrip.v2`, `chuangmi.plug.m1` and `chuangmi.plug.v2`. This setting can be used to bypass the device model detection and is recommended if your device isn't always available.
   required: false
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Some documentation used the ha_version variable instead of ha_release.
Also update those components documentation to use the new Configuration Variables section.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
