### PR TITLE
Fix string quoting in yaml of notify.telegram

### DIFF
--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -99,7 +99,7 @@ action:
   service: notify.NOTIFIER_NAME
   data:
     title: '*Send a message*'
-    message: 'That's an example that _sends_ a *formatted* message with a custom inline keyboard.'
+    message: "That's an example that _sends_ a *formatted* message with a custom inline keyboard."
     data:
       inline_keyboard:
         - 'Task 1:/command1, Task 2:/command2'
@@ -121,7 +121,7 @@ action:
   service: notify.NOTIFIER_NAME
   data:
     title: Send an images
-    message: That's an example that sends an image.
+    message: "That's an example that sends an image."
     data:
       photo:
         - url: http://192.168.1.28/camera.jpg
@@ -164,7 +164,7 @@ action:
   service: notify.NOTIFIER_NAME
   data:
     title: Send a video
-    message: That's an example that sends a video.
+    message: "That's an example that sends a video."
     data:
       video:
         - url: http://192.168.1.28/camera.mp4
@@ -194,7 +194,7 @@ action:
   service: notify.NOTIFIER_NAME
   data:
     title: Send a document
-    message: That's an example that sends a document and a custom keyboard.
+    message: "That's an example that sends a document and a custom keyboard."
     data:
       document:
         file: /tmp/whatever.odf


### PR DESCRIPTION
**Description:**
Strings containing a single quote must be enclosed in double quotes to generate valid YAML.


## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
