### PR TITLE
Correct typo for suggest image path in examples from 'locale' to 'local'

### DIFF
--- a/source/lovelace/index.markdown
+++ b/source/lovelace/index.markdown
@@ -131,6 +131,6 @@ This is because for IOS devices by default javascript served is `es5`. You can a
 
 ### I would like to add an image to my card, but I do not know where to put them.
 
-Given examples refer to `/locale/example_image.jpg`. That means you should have `www` directory next to your HA `configuration.yaml`. An image kept in `HA_configuration_dir/www/example_image.jpg` will be shown after refreshing Lovelace page.
+Given examples refer to `/local/example_image.jpg`. That means you should have `www` directory next to your HA `configuration.yaml`. An image kept in `HA_configuration_dir/www/example_image.jpg` will be shown after refreshing Lovelace page.
 
 > Note: Remember to restart Home Assistant right after creating `www` directory. Otherwise, HA will not know that you created this directory.


### PR DESCRIPTION
**Description:**
The example path used are image: `/local/living_room.png` not `image: /locale/living_room.png`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
