### PR TITLE
fixed a typo in the postnl sensor

### DIFF
--- a/source/_components/sensor.postnl.markdown
+++ b/source/_components/sensor.postnl.markdown
@@ -45,5 +45,5 @@ password:
 {% endconfiguration %}
 
 <p class='note warning'>
-This component is not affiliated with PostNL and retrieves date from the endpoints of the mobile application. Use at your own risk.
+This component is not affiliated with PostNL and retrieves data from the endpoints of the mobile application. Use at your own risk.
 </p>


### PR DESCRIPTION
**Description:**
Fixed a typo which was discovered in a shameless copy paste in PR #5805

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
