### PR TITLE
Added example for using templates

### DIFF
--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -41,3 +41,46 @@ Configuration variables:
 
 The commands can be dynamic, using templates to insert values of other entities. 
 Service call support variables for template stuff.
+
+
+```yaml
+# Example configuration.yaml entry
+rest_command:
+  my_request:
+    url: https://slack.com/api/users.profile.set
+    method: POST
+    headers: 
+      authorization: !secret rest_headers_secret
+      accept: 'application/json, text/html'
+    payload: '{"profile":{"status_text": "{{ status }}","status_emoji": "{{ emoji }}"}}'
+    content_type:  'application/json; charset=utf-8'
+```
+
+In this example entry, you can see some simple [templates] in use for dynamic parameters.
+
+[templates]: /docs/configuration/templating/
+
+Call the new service from [developer tools] in the sidebar with some `data` like:
+
+[developer tools]: /docs/tools/dev-tools/
+
+```json
+{"status":"My Status Goes Here",
+"emoji":":plex:"}
+```
+Or in an example `automation`
+
+```yaml
+automation:
+- alias: 'Arrive at Work'
+  trigger:
+    platform: zone
+    entity_id: device_tracker.my_device
+    zone: zone.work
+    event: enter
+  action:
+    - service: rest_command.my_request
+      data:
+        status: "At Work"
+        emoji: ":calendar:"
+```

--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -39,10 +39,11 @@ Configuration variables:
   - **timeout** (*Optional*): Timeout for requests. Defaults to 10 seconds.
   - **content_type** (*Optional*): Content type for the request.
 
-The commands can be dynamic, using templates to insert values of other entities. 
-Service call support variables for template stuff.
+## {% linkable_title Examples %}
 
+The commands can be dynamic, using templates to insert values of other entities. Service call support variables for doing things with templates.
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 rest_command:
@@ -55,18 +56,17 @@ rest_command:
     payload: '{"profile":{"status_text": "{{ status }}","status_emoji": "{{ emoji }}"}}'
     content_type:  'application/json; charset=utf-8'
 ```
+{% endraw %}
 
-In this example entry, you can see some simple [templates] in use for dynamic parameters.
+In this example entry, you can see some simple [templates](/docs/configuration/templating/) in use for dynamic parameters.
 
-[templates]: /docs/configuration/templating/
-
-Call the new service from [developer tools] in the sidebar with some `data` like:
-
-[developer tools]: /docs/tools/dev-tools/
+Call the new service from [developer tools](/docs/tools/dev-tools/) in the sidebar with some `data` like:
 
 ```json
-{"status":"My Status Goes Here",
-"emoji":":plex:"}
+{
+  "status":"My Status Goes Here",
+  "emoji":":plex:"
+}
 ```
 Or in an example `automation`
 


### PR DESCRIPTION
Also added example automation with using templates and some sample headers in the configuration.

**Description:**
I added some configuration options that are not clear from the current documentation along with a few examples of how to format the configuration to work with templates and template data.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
