### PR TITLE
Modify delay example to support decimals and large numbers

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -75,7 +75,7 @@ Delays are useful for temporarily suspending your script and start it at a later
 ```yaml
 # Waits however many minutes input_number.minute_delay is set to
 # Valid formats include HH:MM and HH:MM:SS
-- delay: "00:{{ '%02d' % (states('input_number.minute_delay')|int) }}:00"
+- delay: {{ states('input_number.minute_delay') | multiply(60) | timestamp_custom('%H:%M:%S',False) }}
 ```
 {% endraw %}
 

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -75,7 +75,7 @@ Delays are useful for temporarily suspending your script and start it at a later
 ```yaml
 # Waits however many minutes input_number.minute_delay is set to
 # Valid formats include HH:MM and HH:MM:SS
-- delay: {{ states('input_number.minute_delay') | multiply(60) | timestamp_custom('%H:%M:%S',False) }}
+- delay: "{{ states('input_number.minute_delay') | multiply(60) | timestamp_custom('%H:%M:%S',False) }}"
 ```
 {% endraw %}
 


### PR DESCRIPTION
**Description:**

Modify delay example to support decimals and large numbers. Had to use it, might as wel share it.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
