### PR TITLE
Inform of zwave config service

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -58,7 +58,7 @@ network_key:
   type: string
   default: None
 config_path:
-  description: The path to the Python OpenZWave configuration files. NOTE: there is also the [update_config service](https://www.home-assistant.io/docs/z-wave/services/) to perform updating this within python-openzwave automatically.
+  description: The path to the Python OpenZWave configuration files. NOTE: there is also the [update_config service](https://www.home-assistant.io/docs/z-wave/services/) to perform updating the config within python-openzwave automatically.
   required: false
   type: string
   default: the 'config' that is installed by python-openzwave

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -58,10 +58,10 @@ network_key:
   type: string
   default: None
 config_path:
-  description: The path to the Python OpenZWave configuration files.
+  description: The path to the Python OpenZWave configuration files. NOTE: there is also the [update_config service](https://www.home-assistant.io/docs/z-wave/services/) to perform updating this within python-openzwave automatically.
   required: false
   type: string
-  default: the 'config' that is installed by python-openzwave, note there is also a [service](https://www.home-assistant.io/docs/z-wave/services/) to perform updating this config
+  default: the 'config' that is installed by python-openzwave
 autoheal:
   description: Allows disabling auto Z-Wave heal at midnight.
   required: false

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -58,7 +58,7 @@ network_key:
   type: string
   default: None
 config_path:
-  description: The path to the Python OpenZWave configuration files. NOTE: there is also the [update_config service](https://www.home-assistant.io/docs/z-wave/services/) to perform updating the config within python-openzwave automatically.
+  description: "The path to the Python OpenZWave configuration files. NOTE: there is also the [update_config service](https://www.home-assistant.io/docs/z-wave/services/) to perform updating the config within python-openzwave automatically."
   required: false
   type: string
   default: the 'config' that is installed by python-openzwave

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -61,7 +61,7 @@ config_path:
   description: The path to the Python OpenZWave configuration files.
   required: false
   type: string
-  default: the 'config' that is installed by python-openzwave
+  default: the 'config' that is installed by python-openzwave, note there is also a [service](https://www.home-assistant.io/docs/z-wave/services/) to perform updating this config
 autoheal:
   description: Allows disabling auto Z-Wave heal at midnight.
   required: false


### PR DESCRIPTION
**Description:**
Inform the user of update_config in the zwave installation config_path documentation.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
