### PR TITLE
Fix styling, trailing slash at NGINX config

### DIFF
--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -85,7 +85,7 @@ Forward ports 443 and 80 to your server on your router. Do not forward port 8123
 
 ### {% linkable_title NGINX Config %}
 
-```text
+```nginx
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;

--- a/source/_docs/ecosystem/nginx_subdomain.markdown
+++ b/source/_docs/ecosystem/nginx_subdomain.markdown
@@ -34,7 +34,7 @@ server {
     ssl_prefer_server_ciphers on;
 
     location / {
-        proxy_pass http://localhost:8123/;
+        proxy_pass http://localhost:8123;
         proxy_set_header Host $host;
 
         proxy_http_version 1.1;
@@ -78,7 +78,7 @@ Start Home Assistant: Now, you have another instance running on http://localhost
 
 To access this instance by using https://countryside.example.org create the file `/etc/nginx/sites-enabled/countryside.example.org` (or symlink via `/etc/nginx/sites-available`) and add the following:
 
-```bash
+```nginx
 server {
     listen       443 ssl;
     server_name  countryside.example.org;
@@ -89,7 +89,7 @@ server {
     ssl_prefer_server_ciphers on;
 
     location / {
-        proxy_pass http://localhost:8124/;
+        proxy_pass http://localhost:8124;
         proxy_set_header Host $host;
     }
 
@@ -109,7 +109,7 @@ server {
 
 Add to your `/etc/nginx/sites-enabled/default`
 
-```bash
+```nginx
 server {
     listen       80 default_server;
     server_name  example.tld;


### PR DESCRIPTION
**Description:**

- fix text highlighting
- removed trailing slash because of https://www.home-assistant.io/components/google_assistant/#troubleshooting-with-nginx


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
