### PR TITLE
Google Static Maps new api key requirements

### DIFF
--- a/source/_cookbook/google_maps_card.markdown
+++ b/source/_cookbook/google_maps_card.markdown
@@ -10,6 +10,8 @@ footer: true
 ha_category: User Interface
 ---
 
+As of June 2018, Google has changed the API limits for static maps.  You now need to have a Google Maps API key.  Instructions for registering a key can be found  [here](https://github.com/googlemaps/google-maps-services-python#api-keys).  Replace `YOUR_API_KEY` with the key you registered.
+
 Using the [generic camera platform] you can present any image on the internet as a camera. Starting release 0.27 these urls can also be based on a template. This example uses this functionality to point a generic camera at the Google Maps static image API and pass in the location of a device.
 
 It also leverages the `limit_refetch_to_url_change` option to ensure that we do not make a lot of requests to the Google Maps API.
@@ -20,7 +22,7 @@ It also leverages the `limit_refetch_to_url_change` option to ensure that we do 
 camera:
   name: Paulus
   platform: generic
-  still_image_url: {% raw %}https://maps.googleapis.com/maps/api/staticmap?center={{ states.device_tracker.demo_paulus.attributes.latitude }},{{ states.device_tracker.demo_paulus.attributes.longitude }}&zoom=13&size=500x500&maptype=roadmap&markers=color:blue%7Clabel:P%7C{{ states.device_tracker.demo_paulus.attributes.latitude }},{{ states.device_tracker.demo_paulus.attributes.longitude }}{% endraw %}
+  still_image_url: {% raw %}https://maps.googleapis.com/maps/api/staticmap?center={{ states.device_tracker.demo_paulus.attributes.latitude }},{{ states.device_tracker.demo_paulus.attributes.longitude }}&zoom=13&size=500x500&maptype=roadmap&markers=color:blue%7Clabel:P%7C{{ states.device_tracker.demo_paulus.attributes.latitude }},{{ states.device_tracker.demo_paulus.attributes.longitude }}{% endraw %}&key=YOUR_API_KEY
   limit_refetch_to_url_change: true
 ```
 

--- a/source/_cookbook/google_maps_card.markdown
+++ b/source/_cookbook/google_maps_card.markdown
@@ -10,9 +10,9 @@ footer: true
 ha_category: User Interface
 ---
 
-As of June 2018, Google has changed the API limits for static maps.  You now need to have a Google Maps API key.  Instructions for registering a key can be found  [here](https://github.com/googlemaps/google-maps-services-python#api-keys).  Replace `YOUR_API_KEY` with the key you registered.
-
 Using the [generic camera platform] you can present any image on the internet as a camera. Starting release 0.27 these urls can also be based on a template. This example uses this functionality to point a generic camera at the Google Maps static image API and pass in the location of a device.
+
+As of June 2018, Google has changed the API limits for static maps. You now need to have a Google Maps API key. Instructions for registering a key can be found  [here](https://github.com/googlemaps/google-maps-services-python#api-keys). Replace `YOUR_API_KEY` with the key you registered.
 
 It also leverages the `limit_refetch_to_url_change` option to ensure that we do not make a lot of requests to the Google Maps API.
 


### PR DESCRIPTION
Google has changed the static-maps API to require a Google Maps API key.  There is now a required URL param `&key=`

https://developers.google.com/maps/documentation/maps-static/intro#quick_example
https://developers.google.com/maps/documentation/maps-static/usage-and-billing

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
