### PR TITLE
added a warning for possible memory leak

### DIFF
--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -31,6 +31,12 @@ Home Assistant contains an embedded MQTT broker. If no broker configuration is g
 mqtt:
 ```
 
+<p class='note warning'>
+There is an issue with the HBMQTT broker that can cause a memory leak (slowly increasing used memory). This causes an unstable system after memory is full (measure with system monitor). The issue is from 2016 and could already be resolved with newer versions. Use other broker when you experience this issue. <br>
+issue with the HBMQTT broker: https://github.com/beerfactory/hbmqtt/issues/62  <br>
+system monitor: https://www.home-assistant.io/components/sensor.systemmonitor/
+</p>
+
 ### {% linkable_title Owntracks%}
 
 To use Owntracks with the internal broker a small configuration change must be made in order for the app to use MQTT protocol 3.1.1 (Protocol Level 4).

--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -32,9 +32,10 @@ mqtt:
 ```
 
 <p class='note warning'>
-There is an issue with the HBMQTT broker that can cause a memory leak (slowly increasing used memory). This causes an unstable system after memory is full (measure with system monitor). The issue is from 2016 and could already be resolved with newer versions. Use other broker when you experience this issue. <br>
-issue with the HBMQTT broker: https://github.com/beerfactory/hbmqtt/issues/62  <br>
-system monitor: https://www.home-assistant.io/components/sensor.systemmonitor/
+There is an issue with the HBMQTT broker that can cause a memory leak (slowly increasing used memory). This causes an unstable system after the memory is full. You could measure/monitor this with a system monitor. The issue is from 2016 and could already be resolved with newer versions. Use another broker when you experience this issue, for example, Mosquitto. <br>
+<br>
+Issue with the HBMQTT broker: https://github.com/beerfactory/hbmqtt/issues/62  <br>
+System monitor: https://www.home-assistant.io/components/sensor.systemmonitor/
 </p>
 
 ### {% linkable_title Owntracks%}


### PR DESCRIPTION
as discussed here https://github.com/home-assistant/home-assistant/issues/11594#issuecomment-408083266

**Description:**
I was not able to correctly link within the text to the 2 sources as:
[issue with the HBMQTT broker](https://github.com/beerfactory/hbmqtt/issues/62)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
