### PR TITLE
Revert "Changed documentation to comply with https://github.com/home-…

### DIFF
--- a/source/_components/device_tracker.keenetic_ndms2.markdown
+++ b/source/_components/device_tracker.keenetic_ndms2.markdown
@@ -29,8 +29,7 @@ device_tracker:
 Configuration variables:
 
 - **host** (*Required*): The IP address of your router, e.g., 192.168.1.1.
-- **port** (*Optional*): The Telnet port of your router. Default is 23.
-- **username** (*Required*): The username to login into the router (user should have read access to telnet interface of the router).
+- **username** (*Required*): The username to login into the router (user should have read access to web interface of the router).
 - **password** (*Required*): The password for the specified username.
 - **interface** (*Optional*): Ihe internal name of the interface to get devices connected to. Default is 'Home'. For expert users only. 
 


### PR DESCRIPTION
…assistant/home-assistant/pull/15511 (#5813)"

This reverts commit 3e240c20d61dcb0e59203bd0348a0c4c5e58a27d.

**Description:**

This PR reverts PR #5813, since it has been accidentally merged.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15511

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
