### PR TITLE
WIP: Add STATE_AUTO support to generic_thermostat

### DIFF
--- a/source/_components/climate.generic_thermostat.markdown
+++ b/source/_components/climate.generic_thermostat.markdown
@@ -43,7 +43,7 @@ Configuration variables:
 
 A full configuration example looks like the one below. `min_cycle_duration` and `keep_alive` must contain at least one of the following entries: `days:`, `hours:`, `minutes:`, `seconds:` or `milliseconds:`.
 
-Currently the `generic_thermostat` climate platform supports 'heat', 'cool' and 'off' operation modes. You can force your `generic_thermstat` to avoid starting by setting Operation to 'off'. 
+Currently the `generic_thermostat` climate platform supports 'auto', 'heat', 'cool' and 'off' operation modes. If you set the operation mode to 'auto' it will switch to the matching mode 'heat' or 'cool' (`ac_mode`) automatically. You can force your `generic_thermostat` to avoid starting by setting `initial_operation_mode` to 'off'.
 
 Please note that changing Away Mode you will force a target temperature change as well that will get restored once the Away Mode is turned off. 
 


### PR DESCRIPTION
**Description:**
Make the user aware of what `STATE_AUTO` does.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15678

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/