### PR TITLE
:fire: Removes bluetooth add-on reference

### DIFF
--- a/source/_components/device_tracker.bluetooth_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_tracker.markdown
@@ -15,10 +15,6 @@ ha_release: 0.18
 
 This tracker discovers new devices on boot and tracks Bluetooth devices periodically based on `interval_seconds` value. It is not required to pair the devices with each other! Devices discovered are stored with 'bt_' as the prefix for device MAC addresses in `known_devices.yaml`.
 
-<p class='note'>
-[Hass.io](/hassio/) only supports Bluetooth on Raspberry Pi 3 via the Bluetooth BCM43xx (/addons/bluetooth_bcm43xx/) addon. [Hass.io](/hassio/) doesn't support external Bluetooth dongles.
-</p>
-
 To use the Bluetooth tracker in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
**Description:**

Removes bluetooth add-on requirement/reference, since that is no longer valid for HassOS

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
