### PR TITLE
Add docs for device_tracker.unifi extra_attributes config

### DIFF
--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -23,6 +23,7 @@ device_tracker:
     host: unifi
     username: username
     password: password
+    extra_attributes: true
     ssid_filter:
       - 'HomeSSID'
       - 'IoTSSID'
@@ -62,6 +63,11 @@ detection_time:
     type: int
     required: false
     default: 300
+extra_attributes:
+    description: Whether to include additional attributes for tracked devices, such as rx/tx rates, access point, signal strength, etc.
+    type: boolean
+    required: false
+    default: false
 ssid_filter:
     description: Filter the SSIDs that tracking will occur on.
     type: list of strings


### PR DESCRIPTION
**Description:**
Adds documentation for the `extra_attributes` configuration variable.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15711

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
