### PR TITLE
Include link to media_player.play_media

### DIFF
--- a/source/_components/media_player.spotify.markdown
+++ b/source/_components/media_player.spotify.markdown
@@ -71,7 +71,7 @@ After the prerequisites and configuration are complete, restart Home Assistant. 
 The sources are based on if you have streamed to these devices before in Spotify. If you don't have any sources, then simply stream from your phone to another device in your house, Bluetooth, echo, etc. Once you do the sources will show up in the developer console as a device to cast/stream to. Also know that the devices won't show up in the dev-console as sources unless they are powered on as well.
 
 ## {% linkable_title URI Links For Playlists/Etc %}
-You can send playlists to spotify via the "media_content_type": "playlist" and "media_content_id": "spotify:user:spotify:playlist:37i9dQZF1DWSkkUxEhrBdF" which are a part of the media_player.play_media service, you can test this from the services control panel in the Home Assistant frontend.
+You can send playlists to spotify via the "media_content_type": "playlist" and "media_content_id": "spotify:user:spotify:playlist:37i9dQZF1DWSkkUxEhrBdF" which are a part of the [media_player.play_media](https://www.home-assistant.io/components/media_player/#service-media_playerplay_media) service, you can test this from the services control panel in the Home Assistant frontend.
 
 In this example this is a URI link to the Reggae Infusions playlist, [this support document from Spotify](https://support.spotify.com/us/using_spotify/share_music/why-do-you-have-two-different-link-formats/) explains how to get this URI value to use for playlists in the Spotify component.
 

--- a/source/_components/media_player.spotify.markdown
+++ b/source/_components/media_player.spotify.markdown
@@ -71,7 +71,7 @@ After the prerequisites and configuration are complete, restart Home Assistant. 
 The sources are based on if you have streamed to these devices before in Spotify. If you don't have any sources, then simply stream from your phone to another device in your house, Bluetooth, echo, etc. Once you do the sources will show up in the developer console as a device to cast/stream to. Also know that the devices won't show up in the dev-console as sources unless they are powered on as well.
 
 ## {% linkable_title URI Links For Playlists/Etc %}
-You can send playlists to spotify via the "media_content_type": "playlist" and "media_content_id": "spotify:user:spotify:playlist:37i9dQZF1DWSkkUxEhrBdF" which are a part of the [media_player.play_media](https://www.home-assistant.io/components/media_player/#service-media_playerplay_media) service, you can test this from the services control panel in the Home Assistant frontend.
+You can send playlists to spotify via the "media_content_type": "playlist" and "media_content_id": "spotify:user:spotify:playlist:37i9dQZF1DWSkkUxEhrBdF" which are a part of the [media_player.play_media](/components/media_player/#service-media_playerplay_media) service, you can test this from the services control panel in the Home Assistant frontend.
 
 In this example this is a URI link to the Reggae Infusions playlist, [this support document from Spotify](https://support.spotify.com/us/using_spotify/share_music/why-do-you-have-two-different-link-formats/) explains how to get this URI value to use for playlists in the Spotify component.
 


### PR DESCRIPTION
**Description:**

Adds a useful link to the "URI Links For Playlists/Etc" section of the Spotify page at:

https://www.home-assistant.io/components/media_player.spotify/

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
