### PR TITLE
Added docs for state attributes in Dyson fan

### DIFF
--- a/source/_components/fan.dyson.markdown
+++ b/source/_components/fan.dyson.markdown
@@ -22,3 +22,12 @@ You have first to setup the [Dyson component](/components/dyson/)
 
 - Pure Cool link (desk and tower)
 - Pure Hot+cool link (but heating is not yet supported)
+
+### {% linkable_title Attributes %}
+
+The are several attributes that can be useful for automations and templates.
+
+| Attribute | Description |
+| --------- | ----------- |
+| `is_night_mode` | A boolean that indicates if the night mode of the fan device is on.
+| `is_auto_mode` | A boolean that indicates if the auto mode of the fan device is on.


### PR DESCRIPTION
**Description:**
Added descriptino of the newly added state attributes in dyson fan devices.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15716

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
