### PR TITLE
Vacuum: Updated start_pause to individual start and pause commands

### DIFF
--- a/source/_components/vacuum.markdown
+++ b/source/_components/vacuum.markdown
@@ -23,7 +23,7 @@ vacuum:
 
 ### {% linkable_title Component services %}
 
-Available services: `turn_on`, `turn_off`, `start_pause`, `stop`, `return_to_home`, `locate`, `clean_spot`, `set_fanspeed` and `send_command`.
+Available services: `turn_on`, `turn_off`, `start_pause`, `start`, `pause`, `stop`, `return_to_home`, `locate`, `clean_spot`, `set_fanspeed` and `send_command`.
 
 Before calling one of these services, make sure your vacuum platform supports it.
 
@@ -46,6 +46,22 @@ Stop the current cleaning task and return to the dock.
 #### {% linkable_title Service `vacuum.start_pause` %}
 
 Start, pause or resume a cleaning task.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+
+#### {% linkable_title Service `vacuum.start` %}
+
+Start or resume a cleaning task.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+
+#### {% linkable_title Service `vacuum.pause` %}
+
+Pause a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|


### PR DESCRIPTION
**Description:**
Updated the documentation to reflect that vacuums now use individual start and pause service calls.

Part of: https://github.com/home-assistant/architecture/issues/29

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15751<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
