### PR TITLE
specify security concerns and actions to mitigate them.

### DIFF
--- a/source/_docs/configuration/securing.markdown
+++ b/source/_docs/configuration/securing.markdown
@@ -20,7 +20,7 @@ One major advantage of Home Assistant is that it's not dependent on cloud servic
 - Don't run Home Assistant as root – consider the Principle of Least Privilege.
 - Keep your [secrets](/topics/secrets/) safe.
 
-If you want to allow remote access, consider taking the additional steps as listed below. They are listed from the most secure to the least secure. <b>It is highly recommended that if you are going to be opening your Home Assistant (hence, the control of your home) to the outside world that you should secure it with a VPN at the minimum</b>:
+If you want to allow remote access, consider taking the additional steps as listed below. They are generally listed with the more secure options first. <b>It is highly recommended that if you are going to be opening your Home Assistant (hence, the control of your home) to the outside world and you don't need remote access to the API (for example, for a device tracker) that you should secure it using one of the first three options</b>:
 
 - Protect your communication with [Tor](/cookbook/tor_configuration/).
 - Set up a VPN

--- a/source/_docs/configuration/securing.markdown
+++ b/source/_docs/configuration/securing.markdown
@@ -20,16 +20,16 @@ One major advantage of Home Assistant is that it's not dependent on cloud servic
 - Don't run Home Assistant as root – consider the Principle of Least Privilege.
 - Keep your [secrets](/topics/secrets/) safe.
 
-If you want to allow remote access, consider these additional points:
+If you want to allow remote access, consider taking the additional steps as listed below. They are listed from the most secure to the least secure. IT IS HIGHLY RECOMMENDED THAT IF YOU ARE GOING TO BE OPENING YOUR HOME ASSISTANT (HENCE THE CONTROL OF YOUR HOME) TO THE OUTSIDE WORLD THAT YOU SHOULD SECURE IT WITH A VPN AT THE MINIMUM:
 
-- Protect your communication with [TLS/SSL](/docs/ecosystem/certificates/lets_encrypt/).
-- Enable IP Filtering and configure a low [Login Attempts Threshold](/components/http/)
 - Protect your communication with [Tor](/cookbook/tor_configuration/).
-- Protect your communication with a [self-signed certificate](/cookbook/tls_self_signed_certificate/).
-- Use a [proxy](/cookbook/apache_configuration/).
 - Set up a VPN
 - Use a [SSH tunnel](/blog/2017/11/02/secure-shell-tunnel/) to connect to your frontend.
+- Protect your communication with [TLS/SSL](/docs/ecosystem/certificates/lets_encrypt/).
+- Protect your communication with a [self-signed certificate](/cookbook/tls_self_signed_certificate/).
+- Use a [proxy](/cookbook/apache_configuration/).
+- Enable IP Filtering and configure a low [Login Attempts Threshold](/components/http/)
 
 <p class='note warning'>
-  If you've forwarded any ports to your Home Assistant system from the Internet then it *will* be found by others. Whether through services like Shodan, or direct port scanning, all systems on the Internet are routinely probed for accessible services. If you fail to set a password then it is simply a matter of time before somebody finds your system - potentially as little as a few hours.
+  If you've forwarded any ports to your Home Assistant system from the Internet then it *will* be found by others. Whether through services like Shodan, or direct port scanning, all systems on the Internet are routinely probed for accessible services. If you fail to set a password then it is simply a matter of time before somebody finds your system - potentially as little as a few hours. Setting a password should be considered the bare minimum security precaution and, as such, shouldn't be relied upon as the sole security action taken to protect your home from outside hackers. PASSWORDS CAN BE BROKEN!
 </p>

--- a/source/_docs/configuration/securing.markdown
+++ b/source/_docs/configuration/securing.markdown
@@ -20,7 +20,7 @@ One major advantage of Home Assistant is that it's not dependent on cloud servic
 - Don't run Home Assistant as root – consider the Principle of Least Privilege.
 - Keep your [secrets](/topics/secrets/) safe.
 
-If you want to allow remote access, consider taking the additional steps as listed below. They are listed from the most secure to the least secure. IT IS HIGHLY RECOMMENDED THAT IF YOU ARE GOING TO BE OPENING YOUR HOME ASSISTANT (HENCE THE CONTROL OF YOUR HOME) TO THE OUTSIDE WORLD THAT YOU SHOULD SECURE IT WITH A VPN AT THE MINIMUM:
+If you want to allow remote access, consider taking the additional steps as listed below. They are listed from the most secure to the least secure. <b>It is highly recommended that if you are going to be opening your Home Assistant (hence, the control of your home) to the outside world that you should secure it with a VPN at the minimum</b>:
 
 - Protect your communication with [Tor](/cookbook/tor_configuration/).
 - Set up a VPN
@@ -31,5 +31,5 @@ If you want to allow remote access, consider taking the additional steps as list
 - Enable IP Filtering and configure a low [Login Attempts Threshold](/components/http/)
 
 <p class='note warning'>
-  If you've forwarded any ports to your Home Assistant system from the Internet then it *will* be found by others. Whether through services like Shodan, or direct port scanning, all systems on the Internet are routinely probed for accessible services. If you fail to set a password then it is simply a matter of time before somebody finds your system - potentially as little as a few hours. Setting a password should be considered the bare minimum security precaution and, as such, shouldn't be relied upon as the sole security action taken to protect your home from outside hackers. PASSWORDS CAN BE BROKEN!
+  If you've forwarded any ports to your Home Assistant system from the Internet then it *will* be found by others. Whether through services like Shodan, or direct port scanning, all systems on the Internet are routinely probed for accessible services. If you fail to set a password then it is simply a matter of time before somebody finds your system - potentially as little as a few hours. Setting a password should be considered the bare minimum security precaution and, as such, shouldn't be relied upon as the sole security action taken to protect your home from outside hackers. <b>Passwords can be broken!</b>
 </p>


### PR DESCRIPTION
With the focus on security concerns in the forums recently I think it would benefit users to be more aggressive in recommending actions to take to secure home assistant when exposing it to the internet. Vague warnings don't always catch the eye of the casual user. I was one of those users and the forum threads on security caused me to examine my own security and I then realized how potentially lacking that it was.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
