### PR TITLE
Lovelace changelog updates

### DIFF
--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -9,14 +9,14 @@ sharing: true
 footer: true
 ---
 
-## {% linkable_title Changes in 0.75.0b0 %}
+## {% linkable_title Changes in 0.75.0 %}
 
 ### Breaking changes 
 - 📣 [glance card]: `turn-on` replaced with `call-service`
 
 ### All changes
 - 📣 Add support for CSS imports ❤️
-- 📣 New card type: `conditional-card` ❤️ - Drop your [entities filter card] hacks
+- 📣 New card type: `conditional-card` ❤️ - Drop your [entity filter card] hacks
 - 📣 [picture glance card]: Add support for custom icons
 - 📣 [picture entity card]: Supports hiding name and/or state
 - 📣 [glance card]: `turn-on` replaced with `call-service`


### PR DESCRIPTION
- Removed b0 as it's also final
- Fixed link for entity filter card

Maybe someone to merge this in current as well

**Description:**
Lovelace changelog updates

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
