### PR TITLE
Allow wait template to run the remainder of the script

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -81,7 +81,7 @@ Delays are useful for temporarily suspending your script and start it at a later
 
 ### {% linkable_title Wait %}
 
-Wait until some things are complete. We support at the moment `wait_template` for waiting until a condition is `true`, see also on [Template-Trigger](/docs/automation/trigger/#template-trigger). It is possible to set a timeout after which the script will abort its execution if the condition is not satisfied. Timeout has the same syntax as `delay`.
+Wait until some things are complete. We support at the moment `wait_template` for waiting until a condition is `true`, see also on [Template-Trigger](/docs/automation/trigger/#template-trigger). It is possible to set a timeout after which the script will by default abort its execution if the condition is not satisfied. Timeout has the same syntax as `delay`.
 
 {% raw %}
 ```yaml
@@ -117,6 +117,17 @@ It is also possible to use dummy variables, e.g., in scripts, when using `wait_t
 
 # Inside the script
 - wait_template: "{{ is_state(dummy, 'off') }}"
+```
+{% endraw %}
+
+You can also get the script to continue to execute after the timeout by using `proceed`
+
+{% raw %}
+```yaml
+# wait until a valve is < 10 or abort after 1 minute.
+- wait_template: "{{ states.climate.kitchen.attributes.valve|int < 10 }}"
+  timeout: '00:01:00'
+  proceed: 'true'
 ```
 {% endraw %}
 

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -120,14 +120,14 @@ It is also possible to use dummy variables, e.g., in scripts, when using `wait_t
 ```
 {% endraw %}
 
-You can also get the script to continue to execute after the timeout by using `proceed`
+You can also get the script to continue to execute after the timeout by using `continue_on_timeout`
 
 {% raw %}
 ```yaml
-# wait until a valve is < 10 or proceed after 1 minute.
-- wait_template: "{{ states.climate.kitchen.attributes.valve|int < 10 }}"
+# wait for sensor or 1 minute.
+- wait_template: "{{ is_state('binary_sensor.entrance', 'on') }}"
   timeout: '00:01:00'
-  proceed: 'true'
+  continue_on_timeout: 'true'
 ```
 {% endraw %}
 

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -81,7 +81,7 @@ Delays are useful for temporarily suspending your script and start it at a later
 
 ### {% linkable_title Wait %}
 
-Wait until some things are complete. We support at the moment `wait_template` for waiting until a condition is `true`, see also on [Template-Trigger](/docs/automation/trigger/#template-trigger). It is possible to set a timeout after which the script will by default abort its execution if the condition is not satisfied. Timeout has the same syntax as `delay`.
+Wait until some things are complete. We support at the moment `wait_template` for waiting until a condition is `true`, see also on [Template-Trigger](/docs/automation/trigger/#template-trigger). It is possible to set a timeout after which the script will continue its execution if the condition is not satisfied. Timeout has the same syntax as `delay`.
 
 {% raw %}
 ```yaml
@@ -92,9 +92,10 @@ Wait until some things are complete. We support at the moment `wait_template` fo
 
 {% raw %}
 ```yaml
-# wait until a valve is < 10 or abort after 1 minute.
-- wait_template: "{{ states.climate.kitchen.attributes.valve|int < 10 }}"
+# wait for sensor to trigger or 1 minute before continuing to execute.
+- wait_template: "{{ is_state('binary_sensor.entrance', 'on') }}"
   timeout: '00:01:00'
+  continue_on_timeout: 'true'
 ```
 {% endraw %}
 
@@ -120,14 +121,14 @@ It is also possible to use dummy variables, e.g., in scripts, when using `wait_t
 ```
 {% endraw %}
 
-You can also get the script to continue to execute after the timeout by using `continue_on_timeout`
+You can also get the script to abort after the timeout by using `continue_on_timeout`
 
 {% raw %}
 ```yaml
-# wait for sensor or 1 minute.
-- wait_template: "{{ is_state('binary_sensor.entrance', 'on') }}"
+# wait until a valve is < 10 or continue after 1 minute.
+- wait_template: "{{ states.climate.kitchen.attributes.valve|int < 10 }}"
   timeout: '00:01:00'
-  continue_on_timeout: 'true'
+  continue_on_timeout: 'false'
 ```
 {% endraw %}
 

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -124,7 +124,7 @@ You can also get the script to continue to execute after the timeout by using `p
 
 {% raw %}
 ```yaml
-# wait until a valve is < 10 or abort after 1 minute.
+# wait until a valve is < 10 or proceed after 1 minute.
 - wait_template: "{{ states.climate.kitchen.attributes.valve|int < 10 }}"
   timeout: '00:01:00'
   proceed: 'true'


### PR DESCRIPTION
**Breaking changes**
The wait template will now continue to run the remainder of the script on timeout, the original functionality can be gained by setting continue_on_timeout: 'false'.

## Description:
This allows the Wait Template script to use a timer to continue running the script if timeout is reached vs the current behaviour of exiting.
This is achieved by setting a new flag 'proceed' to 'true' in the config.
By default this flag is set to 'false' and is optional to ensure this is not a breaking change.
For this flag to work the optional 'timeout' is required to be set also.


home-assistant/home-assistant#15836

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
