### PR TITLE
Tuya Docs: Added note that username may be phone number

### DIFF
--- a/source/_components/tuya.markdown
+++ b/source/_components/tuya.markdown
@@ -28,7 +28,7 @@ tuya:
 
 {% configuration %}
 username:
-  description: Your username to login to Tuya.
+  description: Your username to login to Tuya. Note: This may be your phone number.
   required: true
   type: string
 password:
@@ -36,7 +36,7 @@ password:
   required: true
   type: string
 country_code:
-  description: Your account country code (i.e.,1 for USA and 86 for China).
+  description: Your account [country code](https://www.countrycode.org/) (i.e.,1 for USA and 86 for China).
   required: true
   type: string
 {% endconfiguration %}

--- a/source/_components/tuya.markdown
+++ b/source/_components/tuya.markdown
@@ -36,7 +36,7 @@ password:
   required: true
   type: string
 country_code:
-  description: Your account [country code](https://www.countrycode.org/) (i.e.,1 for USA and 86 for China).
+  description: "Your account [country code](https://www.countrycode.org/) (e.g., 1 for USA or 86 for China)."
   required: true
   type: string
 {% endconfiguration %}

--- a/source/_components/tuya.markdown
+++ b/source/_components/tuya.markdown
@@ -28,7 +28,7 @@ tuya:
 
 {% configuration %}
 username:
-  description: Your username to login to Tuya. Note: This may be your phone number.
+  description: Your username to login to Tuya. This may be your phone number.
   required: true
   type: string
 password:


### PR DESCRIPTION
Added a note that the username may be a phone number and a link to countrycode.org to remove ambiguity and help users find their country code.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
