### PR TITLE
Updated BT Home Hub 5 Device Tracker Documentation

### DIFF
--- a/source/_components/device_tracker.bt_home_hub_5.markdown
+++ b/source/_components/device_tracker.bt_home_hub_5.markdown
@@ -25,6 +25,6 @@ device_tracker:
 
 Configuration variables:
 
-- **host** (*Required*): The IP address of your router, e.g., 192.168.1.254.
+- **host** (Optional): The IP address of your router, Default: 192.168.1.254.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.bt_home_hub_5.markdown
+++ b/source/_components/device_tracker.bt_home_hub_5.markdown
@@ -25,6 +25,6 @@ device_tracker:
 
 Configuration variables:
 
-- **host** (Optional): The IP address of your router, Default: 192.168.1.254.
+- **host** (*Optional*): The IP address of your router, Default: 192.168.1.254.
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
Documentation updated to fit a pull request that is about to be closed:
https://github.com/home-assistant/home-assistant/pull/15096