### PR TITLE
Adding user details

### DIFF
--- a/source/_docs/installation/fedora.markdown
+++ b/source/_docs/installation/fedora.markdown
@@ -27,7 +27,8 @@ To isolate the Home Assistant installation a [venv](https://docs.python.org/3/li
 
 ```bash
 $ sudo mkdir -p /opt/homeassistant
-$ sudo chown -R user:group /opt/homeassistant
+$ sudo useradd -rm homeassistant -G dialout,gpio
+$ sudo chown -R homeassistant:homeassistant /opt/homeassistant
 ```
 Now switch to the new directory, setup the venv, and activate it.
 


### PR DESCRIPTION
Existing instructions are generic `user:group` which causes confusion. Adding a line to create a `homeassistant` user, and then adjusting the following line to use that user.
