### PR TITLE
Fixing formatting goof

### DIFF
--- a/source/_components/calendar.google.markdown
+++ b/source/_components/calendar.google.markdown
@@ -96,7 +96,7 @@ Variables:
   - **search**: (*Optional*): If set will only trigger for matched events.
   - **offset**: (*Optional*): A set of characters that precede a number in the event title for designating a pre-trigger state change on the sensor. (Default: `!!`)
   - **ignore_availability**: (*Optional*): Should we respect `free`/`busy` flags? (Defaults to `true`)
-  
+
 From this we will end up with the binary sensors `calendar.test_unimportant` and `calendar.test_important` which will toggle themselves on/off based on events on the same calendar that match the search value set for each. You'll also have a sensor `calendar.test_everything` that will not filter events out and always show the next event available.
 
 But what if you only wanted it to toggle based on all events? Just leave out the *search* parameter.


### PR DESCRIPTION
The two spaces after the list caused the description of the calendars to appear to be linked to the `ignore_availability` setting
