### PR TITLE
Add examples for whitelist_external_dirs

### DIFF
--- a/source/_docs/configuration/basic.markdown
+++ b/source/_docs/configuration/basic.markdown
@@ -20,6 +20,9 @@ homeassistant:
   unit_system: metric
   time_zone: America/Los_Angeles
   name: Home
+  whitelist_external_dirs:
+    - /home/user/HASS/.homeassistant/dumping-ground
+    - /tmp
 ```
 
 Configuration variables:

--- a/source/_docs/configuration/basic.markdown
+++ b/source/_docs/configuration/basic.markdown
@@ -21,7 +21,7 @@ homeassistant:
   time_zone: America/Los_Angeles
   name: Home
   whitelist_external_dirs:
-    - /home/user/HASS/.homeassistant/dumping-ground
+    - /usr/var/dumping-ground
     - /tmp
 ```
 


### PR DESCRIPTION
Added examples for whitelist_external_dirs as I found it difficult to figure out 
a) it had to follow homeassistant:
b) drop the last slash for the directory i.e. /tmp/exampledir NOT /tmp/exampledir/

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
