### PR TITLE
Expand ecobee documentation for set_hold_mode

### DIFF
--- a/source/_components/climate.ecobee.markdown
+++ b/source/_components/climate.ecobee.markdown
@@ -245,7 +245,9 @@ canceled.
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
-| `hold_mode` | no | `temp`, `home`, `away`, `sleep`, `None`, etc. NOTE: If you create custom hold modes (also known as "Comfort Settings") on your ecobee.com dashboard, their hold_modes are 'smart1', 'smart2', 'smart3', etc. The number for each custom mode should match the mode's icon on your ecobee.com dashboard. Also note that the mode numbers/icons in the ecobee mobile app MAY NOT MATCH the numbers/icons from the ecobee.com web dashboard. The ones on the website are the ones you shoud use to determine the correct 'smartX' hold_mode IDs.
+| `hold_mode` | no | `temp`, `home`, `away`, `sleep`, `None`, `smart1`, `smart2`, etc.
+
+NOTE: If you create custom hold modes (also known as "Comfort Settings") on your ecobee.com dashboard, their hold_modes are `smart1`, `smart2`, `smart3`, etc. The number for each custom mode should match the mode's icon on your ecobee.com dashboard. Also note that the mode numbers/icons in the ecobee mobile app MAY NOT MATCH the numbers/icons from the ecobee.com web dashboard. The ones on the website are the ones you shoud use to determine the correct 'smartX' hold_mode IDs.
 
 ### {% linkable_title Service `set_temperature` %}
 

--- a/source/_components/climate.ecobee.markdown
+++ b/source/_components/climate.ecobee.markdown
@@ -247,7 +247,7 @@ canceled.
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
 | `hold_mode` | no | `temp`, `home`, `away`, `sleep`, `None`, `smart1`, `smart2`, etc.
 
-NOTE: If you create custom hold modes (also known as "Comfort Settings") on your ecobee.com dashboard, their hold_modes are `smart1`, `smart2`, `smart3`, etc. The number for each custom mode should match the mode's icon on your ecobee.com dashboard. Also note that the mode numbers/icons in the ecobee mobile app MAY NOT MATCH the numbers/icons from the ecobee.com web dashboard. The ones on the website are the ones you shoud use to determine the correct 'smartX' hold_mode IDs.
+NOTE: If you create custom hold modes (also known as "Comfort Settings") on your ecobee.com dashboard, their hold_modes are `smart1`, `smart2`, `smart3`, etc. The number for each custom mode should match the mode's icon on your ecobee.com dashboard. Also note that the mode numbers/icons in the ecobee mobile app *may not match* the numbers/icons from the ecobee.com web dashboard. The ones on the website are the ones you shoud use to determine the correct `smartX` hold_mode IDs.
 
 ### {% linkable_title Service `set_temperature` %}
 

--- a/source/_components/climate.ecobee.markdown
+++ b/source/_components/climate.ecobee.markdown
@@ -245,7 +245,7 @@ canceled.
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
-| `hold_mode` | no | 'temp', 'home', 'away', 'sleep', etc., None
+| `hold_mode` | no | `temp`, `home`, `away`, `sleep`, `None`, etc. NOTE: If you create custom hold modes (also known as "Comfort Settings") on your ecobee.com dashboard, their hold_modes are 'smart1', 'smart2', 'smart3', etc. The number for each custom mode should match the mode's icon on your ecobee.com dashboard. Also note that the mode numbers/icons in the ecobee mobile app MAY NOT MATCH the numbers/icons from the ecobee.com web dashboard. The ones on the website are the ones you shoud use to determine the correct 'smartX' hold_mode IDs.
 
 ### {% linkable_title Service `set_temperature` %}
 


### PR DESCRIPTION
Add some notes explaining how to access your custom ecobee Comfort Settings when using the 'set_hold_mode' service
Source: My own experimentation

**Description:**
Just minor documentation tweaks.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
