### PR TITLE
Typo in lovelace docs secial -> special

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -59,7 +59,7 @@ secondary_info:
   type: string
 {% endconfiguration %}
 
-## {% linkable_title Secial Row Elements %}
+## {% linkable_title Special Row Elements %}
 
 ### {% linkable_title Call Service %}
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
