### PR TITLE
Update climate.generic_thermostat.markdown

### DIFF
--- a/source/_components/climate.generic_thermostat.markdown
+++ b/source/_components/climate.generic_thermostat.markdown
@@ -43,7 +43,7 @@ Configuration variables:
 
 A full configuration example looks like the one below. `min_cycle_duration` and `keep_alive` must contain at least one of the following entries: `days:`, `hours:`, `minutes:`, `seconds:` or `milliseconds:`.
 
-Currently the `generic_thermostat` climate platform supports 'heat', 'cool' and 'off' operation modes. You can force your `generic_thermstat` to avoid starting by setting Operation to 'off'. 
+Currently the `generic_thermostat` climate platform supports 'heat', 'cool' and 'off' operation modes. You can force your `generic_thermostat` to avoid starting by setting Operation to 'off'. 
 
 Please note that changing Away Mode you will force a target temperature change as well that will get restored once the Away Mode is turned off. 
 


### PR DESCRIPTION
changed misspelled 'generic_thermstat' to 'generic_thermostat'

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
