### PR TITLE
trigger.entity_id should not be quoted

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -102,7 +102,7 @@ When using `wait_template` within an automation `trigger.entity_id` is supported
 
 {% raw %}
 ```yaml
-- wait_template: "{{ is_state('trigger.entity_id', 'on') }}"
+- wait_template: "{{ is_state(trigger.entity_id, 'on') }}"
 ```
 {% endraw %}
 


### PR DESCRIPTION
**Description:**

wait_template example shows trigger.entity_id being quoted, which, of course, it should not be since it is a variable.

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
