### PR TITLE
Fix typos in Homematic documentation

### DIFF
--- a/source/_addons/homematic.markdown
+++ b/source/_addons/homematic.markdown
@@ -11,7 +11,7 @@ footer: true
 
 Set up a [HomeMatic](https://github.com/eq-3/occu) hardware layer. At the moment we don't support hmIP, but that is in progress. For learning and handling devices use our internal HomeMatic panel and services (in progress) or use [Homematic-Manager](https://github.com/hobbyquaker/homematic-manager) > 2.0.
 
-The logic layer will be Home-Assistant. There is no ReGa or other logic layer installed. You can't import an existing configuration, you'll need re-learn it into Home-Assistant.
+The logic layer will be Home Assistant. There is no ReGa or other logic layer installed. You can't import an existing configuration, you'll need re-learn it into Home Assistant.
 
 Follow devices will be supported and tested:
 - [HM-MOD-RPI-PCB](https://www.elv.ch/homematic-funkmodul-fuer-raspberry-pi-bausatz.html)

--- a/source/_addons/homematic.markdown
+++ b/source/_addons/homematic.markdown
@@ -14,6 +14,7 @@ Set up a [HomeMatic](https://github.com/eq-3/occu) hardware layer. At the moment
 The logic layer will be Home Assistant. There is no ReGa or other logic layer installed. You can't import an existing configuration, you'll need re-learn it into Home Assistant.
 
 Follow devices will be supported and tested:
+
 - [HM-MOD-RPI-PCB](https://www.elv.ch/homematic-funkmodul-fuer-raspberry-pi-bausatz.html)
 
 ```json
@@ -41,11 +42,13 @@ Configuration variables:
 - **rf_enable** (*Require*): Boolean. Enable or disable BidCoS-RF.
 - **wired_enable** (*Require*): Boolean. Enable or disable BidCoS-Wired.
 
-For RF devices
+For RF devices:
+
 - **type** (*Require*): Device type for RFD service. Look into the manual of your device.
 - **device** (*Require*): Device on the host.
 
-For wired devices
+For wired devices:
+
 - **serial** (*Require*): Serial number of the device.
 - **key** (*Require*): Encrypted key.
 - **ip** (*Require*): IP address of LAN gateway.
@@ -65,6 +68,7 @@ homematic:
 ## {% linkable_title Raspberry Pi3 %}
 
 With HM-MOD-RPI-PCB you need to add follow into your `config.txt` on boot partition:
-```
+
+```text
 dtoverlay=pi3-miniuart-bt
 ```

--- a/source/_addons/homematic.markdown
+++ b/source/_addons/homematic.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 ---
 
-Set up a [HomeMatic](https://github.com/eq-3/occu) hardware layer. At the moment we don't support hmIP, but that is in progress. For learning and handling devices use our internal HomeMatic panel and services (in progress) or use [Homematic-Manager](https://github.com/hobbyquaker/homematic-manager) > 2.0.
+Set up a [HomeMatic](https://github.com/eq-3/occu) hardware layer. For learning and handling devices use [Homematic-Manager](https://github.com/hobbyquaker/homematic-manager) > 2.0.
 
 The logic layer will be Home Assistant. There is no ReGa or other logic layer installed. You can't import an existing configuration, you'll need re-learn it into Home Assistant.
 
@@ -39,19 +39,19 @@ Follow devices will be supported and tested:
 
 Configuration variables:
 
-- **rf_enable** (*Require*): Boolean. Enable or disable BidCoS-RF.
-- **wired_enable** (*Require*): Boolean. Enable or disable BidCoS-Wired.
+- **rf_enable** (*Required*): Boolean. Enable or disable BidCoS-RF.
+- **wired_enable** (*Required*): Boolean. Enable or disable BidCoS-Wired.
 
 For RF devices:
 
-- **type** (*Require*): Device type for RFD service. Look into the manual of your device.
-- **device** (*Require*): Device on the host.
+- **type** (*Required*): Device type for RFD service. Look into the manual of your device.
+- **device** (*Required*): Device on the host.
 
 For wired devices:
 
-- **serial** (*Require*): Serial number of the device.
-- **key** (*Require*): Encrypted key.
-- **ip** (*Require*): IP address of LAN gateway.
+- **serial** (*Required*): Serial number of the device.
+- **key** (*Required*): Encrypted key.
+- **ip** (*Required*): IP address of LAN gateway.
 
 ## {% linkable_title Home Assistant configuration %}
 

--- a/source/_addons/homematic.markdown
+++ b/source/_addons/homematic.markdown
@@ -45,7 +45,7 @@ For RF devices
 - **type** (*Require*): Device type for RFD service. Look into the manual of your device.
 - **device** (*Require*): Device on the host.
 
-For RF devices
+For wired devices
 - **serial** (*Require*): Serial number of the device.
 - **key** (*Require*): Encrypted key.
 - **ip** (*Require*): IP address of LAN gateway.
@@ -64,7 +64,7 @@ homematic:
 
 ## {% linkable_title Raspberry Pi3 %}
 
-With HM-MOD-PRI-PCB you need to add follow into your `config.txt` on boot partition:
+With HM-MOD-RPI-PCB you need to add follow into your `config.txt` on boot partition:
 ```
 dtoverlay=pi3-miniuart-bt
 ```


### PR DESCRIPTION
## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
