### PR TITLE
Embedded MQTT broker needs setup its own password

### DIFF
--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -25,7 +25,7 @@ Home Assistant contains an embedded MQTT broker. If no broker configuration is g
 | Password       | no default value |
 | Websocket port | 8080 |
 
-> Since 0.77 release, the embedded broker doesn't use your [API password](/components/http/) as default password. The MQTT component will fail to setup if you have API password configured, but don't have MQTT password configured as in the following example.
+> Since release 0.77, the embedded broker does not use your [API password](/components/http/) as the default password. The MQTT component will fail to set up if you have API password configured, but don't have MQTT password configured as in the following example.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -25,7 +25,7 @@ Home Assistant contains an embedded MQTT broker. If no broker configuration is g
 | Password       | no default value |
 | Websocket port | 8080 |
 
-> Since 0.77 release, embedded broker doesn't use your [API password](/components/http/) as default value. MQTT component will fail to setup if you have API passowrd configured, but don't have MQTT password confgiured likes following example.
+> Since 0.77 release, the embedded broker doesn't use your [API password](/components/http/) as default password. The MQTT component will fail to setup if you have API password configured, but don't have MQTT password configured as in the following example.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -22,13 +22,15 @@ Home Assistant contains an embedded MQTT broker. If no broker configuration is g
 | Port           | 1883 |
 | Protocol       | 3.1.1 |
 | User           | homeassistant |
-| Password       | Your API [password](/components/http/) |
+| Password       | no default value |
 | Websocket port | 8080 |
 
+> Since 0.77 release, embedded broker doesn't use your [API password](/components/http/) as default value. MQTT component will fail to setup if you have API passowrd configured, but don't have MQTT password confgiured likes following example.
 
 ```yaml
 # Example configuration.yaml entry
 mqtt:
+  password: YOUR_MQTT_PASSWORD
 ```
 
 <p class='note warning'>


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15929

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
