### PR TITLE
Making the warning clearer, and linkable

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -99,8 +99,10 @@ Home Assistant adds extensions to allow templates to access all of the current s
 If your template uses an `entity_id` that begins with a number (example: `states.device_tracker.2008_gmc`) you must use a bracket syntax to avoid errors caused by rendering the `entity_id` improperly. In the example given, the correct syntax for the device tracker would be: `states.device_tracker['2008_gmc']`
 </p>
 
+## {% linkable_title Templates using `now()` %}
+
 <p class='note warning'>
-Rendering templates with time is dangerous as updates only trigger templates in sensors based on entity state changes.
+Rendering templates with time (`now()`) is dangerous as updates only trigger templates in sensors based on entity state changes.
 </p>
 
 ## {% linkable_title Home Assistant template extensions %}


### PR DESCRIPTION
Making the warning clearer (I'll add something similar to the template trigger docs), and putting a title in so that we can link to it.