### PR TITLE
Add verify_ssl option to generic camera docs

### DIFF
--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -37,6 +37,7 @@ Configuration variables:
 - **limit_refetch_to_url_change** (*Optional*): True/false value (default: false). Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
 - **content_type** (*Optional*): Set the content type for the IP camera if it is not a jpg file (default: `image/jpeg`). Use `image/svg+xml` to add a dynamic svg file.
 - **framerate** (*Optional*): The number of frames-per-second (FPS) of the stream (setting this too high may cause too much traffic on the network or be heavy on the camera).
+- **verify_ssl** (*Optional*): True/false value (default: true). Enable or disable ssl certificate verification.
 
 <p class='img'>
   <a href='/cookbook/google_maps_card/'>
@@ -68,6 +69,7 @@ camera:
   - platform: generic
     name: Some Image
     still_image_url: https://127.0.0.1:8123/local/your_image.png
+    verify_ssl: false
 ```
 
 ### {% linkable_title Sharing a camera feed from one Home Assistant instance to another %}

--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -37,7 +37,7 @@ Configuration variables:
 - **limit_refetch_to_url_change** (*Optional*): True/false value (default: false). Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
 - **content_type** (*Optional*): Set the content type for the IP camera if it is not a jpg file (default: `image/jpeg`). Use `image/svg+xml` to add a dynamic svg file.
 - **framerate** (*Optional*): The number of frames-per-second (FPS) of the stream (setting this too high may cause too much traffic on the network or be heavy on the camera).
-- **verify_ssl** (*Optional*): True/false value (default: true). Enable or disable ssl certificate verification.
+- **verify_ssl** (*Optional*): True/false value (default: true). Enable or disable SSL certificate verification.
 
 <p class='img'>
   <a href='/cookbook/google_maps_card/'>


### PR DESCRIPTION
**Description: Add a `verify_ssl` option to the generic camera component**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15949

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
