### PR TITLE
Adding link to Hassbian scripts

### DIFF
--- a/source/_docs/ecosystem/appdaemon.markdown
+++ b/source/_docs/ecosystem/appdaemon.markdown
@@ -107,4 +107,4 @@ Of course, if I wanted to make this App or its predecessor reusable, I would hav
 
 In addition, Apps can write to `AppDaemon`'s log files, and there is a system of constraints that allows you to control when and under what circumstances Apps and callbacks are active to keep the logic clean and simple.
 
-For full installation instructions, see the [AppDaemon Project Documentation pages](http://appdaemon.readthedocs.io/en/stable/). If you're using Hassbian then the [Hassbian scripts](https://github.com/home-assistant/hassbian-scripts/blob/dev/docs/appdaemon.md) make it easy to install.
+For full installation instructions, see the [AppDaemon Project Documentation pages](http://appdaemon.readthedocs.io/en/stable/). If you're using Hassbian, then the [Hassbian scripts](https://github.com/home-assistant/hassbian-scripts/blob/dev/docs/appdaemon.md) make it easy to install.

--- a/source/_docs/ecosystem/appdaemon.markdown
+++ b/source/_docs/ecosystem/appdaemon.markdown
@@ -107,4 +107,4 @@ Of course, if I wanted to make this App or its predecessor reusable, I would hav
 
 In addition, Apps can write to `AppDaemon`'s log files, and there is a system of constraints that allows you to control when and under what circumstances Apps and callbacks are active to keep the logic clean and simple.
 
-For full installation instructions, see the [AppDaemon Project Documentation pages](http://appdaemon.readthedocs.io/en/stable/).
+For full installation instructions, see the [AppDaemon Project Documentation pages](http://appdaemon.readthedocs.io/en/stable/). If you're using Hassbian then the [Hassbian scripts](https://github.com/home-assistant/hassbian-scripts/blob/dev/docs/appdaemon.md) make it easy to install.


### PR DESCRIPTION
Making it more likely people using Hassbian won't break their installs by installing in the same venv as HA
