### PR TITLE
Adding link to Hassbian scripts

### DIFF
--- a/source/_docs/ecosystem/hadashboard.markdown
+++ b/source/_docs/ecosystem/hadashboard.markdown
@@ -37,6 +37,4 @@ HADashboard is a modular, skinnable dashboard for [Home Assistant](/) that is in
     Glassic Theme
 </p>
 
-
-
-For full installation instructions see the HADashboard section in the [AppDaemon Project Documentation](http://appdaemon.readthedocs.io/en/stable/DASHBOARD_INSTALL.html). If you're using Hassbian then the [Hassbian scripts](https://github.com/home-assistant/hassbian-scripts/blob/dev/docs/appdaemon.md) make it easy to install AppDaemon.
+For full installation instructions see the HADashboard section in the [AppDaemon Project Documentation](http://appdaemon.readthedocs.io/en/stable/DASHBOARD_INSTALL.html). If you're using Hassbian, then the [Hassbian scripts](https://github.com/home-assistant/hassbian-scripts/blob/dev/docs/appdaemon.md) make it easy to install AppDaemon.

--- a/source/_docs/ecosystem/hadashboard.markdown
+++ b/source/_docs/ecosystem/hadashboard.markdown
@@ -39,4 +39,4 @@ HADashboard is a modular, skinnable dashboard for [Home Assistant](/) that is in
 
 
 
-For full installation instructions see the HADashboard section in the [AppDaemon Project Documentation](http://appdaemon.readthedocs.io/en/stable/DASHBOARD_INSTALL.html)
+For full installation instructions see the HADashboard section in the [AppDaemon Project Documentation](http://appdaemon.readthedocs.io/en/stable/DASHBOARD_INSTALL.html). If you're using Hassbian then the [Hassbian scripts](https://github.com/home-assistant/hassbian-scripts/blob/dev/docs/appdaemon.md) make it easy to install AppDaemon.


### PR DESCRIPTION
Making it more likely people using Hassbian won't break their installs by installing in the same venv as HA
