### PR TITLE
Fixes minor bug in dyson configuration example

### DIFF
--- a/source/_components/dyson.markdown
+++ b/source/_components/dyson.markdown
@@ -27,9 +27,9 @@ dyson:
   language: YOUR_DYSON_ACCOUNT_LANGUGAGE
   devices:
     - device_id: DEVICE_ID_1 # eg. Serial number: XXX-XX-XXXXXXXX
-      device_ip: DEVICE_ID_1
+      device_ip: DEVICE_IP_1
     - device_id: DEVICE_ID_2
-      device_ip: DEVICE_ID_2
+      device_ip: DEVICE_IP_2
 ```
 
 Configuration variables:


### PR DESCRIPTION
**Description:**

Fixes minor bug in dyson configuration example.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
