### PR TITLE
Fix DLNA discovery entry

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -11,7 +11,6 @@ logo: home-assistant.png
 ha_category: Other
 ---
 
-
 Home Assistant can discover and automatically configure [zeroconf](https://en.wikipedia.org/wiki/Zero-configuration_networking)/[mDNS](https://en.wikipedia.org/wiki/Multicast_DNS) and [uPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play) devices on your network. Currently the `discovery` component can detect:
 
  * [Apple TV](/components/apple_tv/)
@@ -44,7 +43,8 @@ Home Assistant can discover and automatically configure [zeroconf](https://en.wi
  * [Yeelight Sunflower bulb](/components/light.yeelightsunflower/)
  * [Xiaomi Gateway (Aqara)](/components/xiaomi_aqara/)
 
-It will be able to add Google Chromecasts and Belkin WeMo switches automatically, for Philips Hue it will require some configuration from the user.
+It will be able to add Google Chromecasts and Belkin WeMo switches automatically,
+for Philips Hue it will require some configuration from the user.
 
 To load this component, add the following lines to your `configuration.yaml`:
 
@@ -64,11 +64,11 @@ discovery:
 ignore:
   description: A list of platforms that never will be automatically configured by `discovery`.
   required: false
-  type: string
+  type: list
 enable:
   description: A list of platforms not enabled by default that `discovery` should discover.
   required: false
-  type: string
+  type: list
 {% endconfiguration %}
 
 Valid values for ignore are:
@@ -80,7 +80,6 @@ Valid values for ignore are:
  * `bose_soundtouch`: Bose Soundtouch speakers
  * `denonavr`: Denon network receivers
  * `directv`: DirecTV receivers
- * `dlna`: DLNA DMR enabled devices
  * `frontier_silicon`: Frontier Silicon internet radios
  * `google_cast`: Google Cast
  * `harmony`: Logitech Harmony Hub
@@ -105,6 +104,7 @@ Valid values for ignore are:
 
 Valid values for enable are:
 
+ * `dlna_dmr`: DLNA DMR enabled devices
  * `homekit`: HomeKit accessories
 
 ## {% linkable_title Troubleshooting %}


### PR DESCRIPTION
**Description:**
0.76.0b5 makes the DLNA DMR component discovery opt-in. This PR fixes it in the documentation. The variable has been corrected from `dlna` to `dlna_dmr` as well.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16006

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
