### PR TITLE
Ritassist dependency update to 0.9.2

### DIFF
--- a/source/_components/device_tracker.ritassist.markdown
+++ b/source/_components/device_tracker.ritassist.markdown
@@ -81,4 +81,6 @@ See the [device tracker component page](/components/device_tracker/) for instruc
 | distance_from_home |  How far is your vehicle located from your Home Assistant Home location |
 | current_max_speed | The maximum speed on the road the device is currently on (if available) |
 | current_address | Object with address information the device is currently on. This resolves to the closest address to the coordinates of the device. |
+
+
 [1] Only available on certain cars and hardware revisions.

--- a/source/_components/device_tracker.ritassist.markdown
+++ b/source/_components/device_tracker.ritassist.markdown
@@ -78,5 +78,7 @@ See the [device tracker component page](/components/device_tracker/) for instruc
 | coolant_temperature | Temperature of the coolant [1] |
 | power_voltage | Power voltage measured by the hardware [1] |
 | distance_from_home |  How far is your vehicle located from your Home Assistant Home location |
-
+| distance_from_home |  How far is your vehicle located from your Home Assistant Home location |
+| current_max_speed | The maximum speed on the road the device is currently on (if available) |
+| current_address | Object with address information the device is currently on. This resolves to the closest address to the coordinates of the device. |
 [1] Only available on certain cars and hardware revisions.

--- a/source/_components/device_tracker.ritassist.markdown
+++ b/source/_components/device_tracker.ritassist.markdown
@@ -78,7 +78,6 @@ See the [device tracker component page](/components/device_tracker/) for instruc
 | coolant_temperature | Temperature of the coolant [1] |
 | power_voltage | Power voltage measured by the hardware [1] |
 | distance_from_home |  How far is your vehicle located from your Home Assistant Home location |
-| distance_from_home |  How far is your vehicle located from your Home Assistant Home location |
 | current_max_speed | The maximum speed on the road the device is currently on (if available) |
 | current_address | Object with address information the device is currently on. This resolves to the closest address to the coordinates of the device. |
 


### PR DESCRIPTION
**Description:**
Ritassist dependency update to 0.9.2. This so we support the current maximum speed and address for a device

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16037

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
