### PR TITLE
Update openuv.markdown

### DIFF
--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -80,7 +80,7 @@ sensors:
       description: the conditions to create sensors from
       required: false
       type: list
-      default: all ( `current_ozone_index`, `current_uv_index`, `max_uv_index`, `safe_exposure_time_type_1`, `safe_exposure_time_type_2`, `safe_exposure_time_type_3`, `safe_exposure_time_type_4`, `safe_exposure_time_type_5`, `safe_exposure_time_type_6` )
+      default: all ( `current_ozone_level`, `current_uv_index`, `max_uv_index`, `safe_exposure_time_type_1`, `safe_exposure_time_type_2`, `safe_exposure_time_type_3`, `safe_exposure_time_type_4`, `safe_exposure_time_type_5`, `safe_exposure_time_type_6` )
 {% endconfiguration %}
 
 ## {% linkable_title Binary Sensor Types %}


### PR DESCRIPTION
Incorrect monitored condition listed for ozone level

**Description:**
Attempted to setup this platform and found that the listed monitored condition was incorrect.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
