### PR TITLE
Update sensor.mold_indicator.markdown

### DIFF
--- a/source/_components/sensor.mold_indicator.markdown
+++ b/source/_components/sensor.mold_indicator.markdown
@@ -21,6 +21,7 @@ The sensor data may be used e.g., to signal bad air quality (too high air humidi
 # Example configuration.yaml entry
 sensor:
   - platform: mold_indicator
+    name: Mould Sensor
     indoor_temp_sensor: sensor.temp
     indoor_humidity_sensor: sensor.humidity
     outdoor_temp_sensor: sensor.weather_temperature
@@ -29,6 +30,7 @@ sensor:
 
 Configuration variables:
 
+- **name** (*Optional*): The name of the sensor.
 - **indoor_temp_sensor** (*Required*): The entity ID of the indoor temperature sensor.
 - **indoor_humidity_sensor** (*Required*): The entity ID of the indoor humidity sensor.
 - **outdoor_temp_sensor** (*Required*): The entity ID of the outdoor temperature sensor.

--- a/source/_components/sensor.mold_indicator.markdown
+++ b/source/_components/sensor.mold_indicator.markdown
@@ -21,20 +21,34 @@ The sensor data may be used e.g., to signal bad air quality (too high air humidi
 # Example configuration.yaml entry
 sensor:
   - platform: mold_indicator
-    name: Mould Sensor
     indoor_temp_sensor: sensor.temp
     indoor_humidity_sensor: sensor.humidity
     outdoor_temp_sensor: sensor.weather_temperature
     calibration_factor: 2.0
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): The name of the sensor.
-- **indoor_temp_sensor** (*Required*): The entity ID of the indoor temperature sensor.
-- **indoor_humidity_sensor** (*Required*): The entity ID of the indoor humidity sensor.
-- **outdoor_temp_sensor** (*Required*): The entity ID of the outdoor temperature sensor.
-- **calibration_factor** (*Required*): Needs to be calibrated to the critical point in the room.
+{% configuration %}
+name:
+  description: The name of the sensor.
+  required: false
+  type: string
+indoor_temp_sensor:
+  description: The entity ID of the indoor temperature sensor.
+  required: true
+  type: string
+indoor_humidity_sensor: 
+  description: The entity ID of the indoor humidity sensor.
+  required: true
+  type: string
+outdoor_temp_sensor:
+  description: The entity ID of the outdoor temperature sensor.
+  required: true
+  type: string
+calibration_factor: 
+  description: Needs to be calibrated to the critical point in the room.
+  required: true
+  type: int
+{% endconfiguration %}
 
 In this case, the weather forecast temperature sensor is used for the outside temperature.
 

--- a/source/_components/sensor.mold_indicator.markdown
+++ b/source/_components/sensor.mold_indicator.markdown
@@ -47,7 +47,7 @@ outdoor_temp_sensor:
 calibration_factor: 
   description: Needs to be calibrated to the critical point in the room.
   required: true
-  type: int
+  type: float
 {% endconfiguration %}
 
 In this case, the weather forecast temperature sensor is used for the outside temperature.


### PR DESCRIPTION
Added optional 'name' configuration variable. I have confirmed this is supported but undocumented.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
