### PR TITLE
Add platform param

### DIFF
--- a/source/_components/tuya.markdown
+++ b/source/_components/tuya.markdown
@@ -24,7 +24,6 @@ tuya:
   username: YOUR_TUYA_USERNAME
   password: YOUR_TUYA_PASSWORD
   country_code: YOUR_ACCOUNT_COUNTRYCODE
-  platform: YOUR_ACCOUNT_TYPE
 ```
 
 {% configuration %}
@@ -41,9 +40,10 @@ country_code:
   required: true
   type: string
 platform:
-  description: "The app where your account register. 'tuya' for Tuya Smart and 'smart_life' for Smart Life. Default is tuya"
+  description: "The app where your account register. `tuya` for Tuya Smart and `smart_life` for Smart Life."
   required: false
   type: string
+  default: tuya
 {% endconfiguration %}
 
 ## {% linkable_title Service %}

--- a/source/_components/tuya.markdown
+++ b/source/_components/tuya.markdown
@@ -24,6 +24,7 @@ tuya:
   username: YOUR_TUYA_USERNAME
   password: YOUR_TUYA_PASSWORD
   country_code: YOUR_ACCOUNT_COUNTRYCODE
+  platform: YOUR_ACCOUNT_TYPE
 ```
 
 {% configuration %}
@@ -38,6 +39,10 @@ password:
 country_code:
   description: "Your account [country code](https://www.countrycode.org/) (e.g., 1 for USA or 86 for China)."
   required: true
+  type: string
+platform:
+  description: "The app where your account register. 'tuya' for Tuya Smart and 'smart_life' for Smart Life. Default is tuya"
+  required: false
   type: string
 {% endconfiguration %}
 


### PR DESCRIPTION
Add platform to distinguish accounts from different apps
The value could be 'tuya' or 'smart_life'. Default is 'tuya'.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16058

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
