### PR TITLE
Update device_tracker.ubus.markdown

### DIFF
--- a/source/_components/device_tracker.ubus.markdown
+++ b/source/_components/device_tracker.ubus.markdown
@@ -22,6 +22,12 @@ Before this scanner can be used you have to install the ubus RPC package on Open
 opkg install rpcd-mod-file
 ```
 
+For OpenWRT version 18.06.x the package uhttpd-mod-ubus should also be installed:
+
+```bash
+opkg install uhttpd-mod-ubus
+```
+
 And create a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/user.json`.
 
 ```json


### PR DESCRIPTION
Several HA users encountered a problem after upgrading OpenWRT to version 18.06.x. UBUS did not function anymore (TypeError: ‘NoneType’ object is not subscriptable). At https://community.home-assistant.io/t/problem-with-ubus-device-tracker/46072/18     user rf3141 analyzed the problem (besides the https issue the thread was started for) and solved it by installing the additional package uhttpd-mod-ubus. Maybe this needs to be analyzed more careful but for now the addional package solves the problem.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
