### PR TITLE
Fix misleading numeric_state trigger documentation

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -59,7 +59,7 @@ automation:
 
 ### {% linkable_title Numeric state trigger %}
 
-Triggers when numeric value of an entity's state crosses a given threshold. On state change of a specified entity, attempts to parse the state as a number and triggers once if value is changing from above to below or from below to above the given threshold.
+Triggers when numeric value of an entity's state satisfies given condition(s.) On state change of a specified entity, attempts to parse the state as a number and triggers if value is above and/or below given threshold(s.)
 
 {% raw %}
 ```yaml
@@ -83,7 +83,7 @@ automation:
 
 <p class='note'>
 Listing above and below together means the numeric_state has to be between the two values.
-In the example above, a numeric_state that goes to 17.1-24.9 (from 17 or below, or 25 or above) would fire this trigger.
+In the example above, a numeric_state that is between 17 and 25 would fire this trigger.
 </p>
 
 ### {% linkable_title State trigger %}


### PR DESCRIPTION
**Description:**

Existing documentation says numeric_state trigger will fire once when the numeric value of an entity's state "crosses a threshold." However, that's not how the code actually works. It will fire for any state change (from any of the specified entities) if the numeric value of the new state satisfies the above and/or below conditions.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
