### PR TITLE
Documentation for MQTT binary_sensor expire_after

### DIFF
--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -50,6 +50,11 @@ payload_off:
   required: false
   type: string
   default: "OFF"
+expire_after:
+  description: Defines the number of seconds after which value expires if it's not updated and sensor is set to OFF.
+  required: false
+  type: int
+  default: 0
 availability_topic:
   description: "The MQTT topic subscribed to receive birth and LWT messages from the MQTT device. If `availability_topic` is not defined, the binary sensor availability state will always be `available`. If `availability_topic` is defined, the binary sensor availability state will be `unavailable` by default."
   required: false


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16090

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
