### PR TITLE
Update Xiaomi Aqara Button documentation

### DIFF
--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -24,7 +24,8 @@ The `xiaomi_aqara` component allows you to integrate [Xiaomi](http://www.mi.com/
 - Temperature and Humidity Sensor (1st and 2nd generation)
 - Motion Sensor (1st and 2nd generation)
 - Door and Window Sensor (1st and 2nd generation)
-- Button (1st and 2nd generation)
+- Button 1st generation (Single, Double, long_click_press)
+- Button 2nd generation (Single, Double)
 - Plug aka Socket (Zigbee version, reports power consumed, power load, state and if device in use)
 - Wall Plug (reports power consumed, power load and state)
 - Aqara Wall Switch (Single)
@@ -195,9 +196,9 @@ Removes a specific device. The removal is required if a device shall be paired w
 
 ## {% linkable_title Examples %}
 
-### {% linkable_title Long Press on Smart Button %}
+### {% linkable_title Long Press on Smart Button 1st Generation %}
 
-This example plays the sound of a dog barking when the button is held down and stops the sound when the button is pressed once.
+This example plays the sound of a dog barking when the button is held down and stops the sound when the button is pressed once. Only works for the round button of the 1st generation.
 
 *Note: The sound will stop playing automatically when it has ended.*
 


### PR DESCRIPTION
**Description:**
Update the documentation to show the click event types supported by the 1st and 2nd generation.
As discussed here: https://github.com/home-assistant/home-assistant/issues/16097

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
