### PR TITLE
include required "sensor_type:" in example - remove duplicate total_rain

### DIFF
--- a/source/_components/sensor.rflink.markdown
+++ b/source/_components/sensor.rflink.markdown
@@ -31,19 +31,18 @@ sensor:
   - platform: rflink
     devices:
       alectov1_0334_temp:
-        name: Temperature Outside
         sensor_type: temperature
 ```
 
 Configuration variables:
 
 - **automatic_add** (*Optional*): Automatically add new/unconfigured devices to HA if detected (default: True).
-- **devices**  (*Optional*): A list of devices with their name to use in the frontend.
+- **devices** (*Optional*): A list of devices with their name to use in the frontend.
 
 Device configuration variables:
 
-- **name** (*Optional*): Name for the device, defaults to RFLink ID.
 - **sensor_type** (*Required*): Override automatically detected type of sensor. For list of values see below.
+- **name** (*Optional*): Name for the device, defaults to RFLink ID.
 - **unit_of_measurement** (*Optional*): Override automatically detected unit of sensor.
 - **aliases** (*Optional*): Alternative RFLink ID's this device is known by.
 

--- a/source/_components/sensor.rflink.markdown
+++ b/source/_components/sensor.rflink.markdown
@@ -32,6 +32,7 @@ sensor:
     devices:
       alectov1_0334_temp:
         name: Temperature Outside
+        sensor_type: temperature
 ```
 
 Configuration variables:
@@ -68,7 +69,6 @@ Sensor type values:
 - meter_value
 - total_rain
 - rain_rate
-- total_rain
 - revision
 - noise_level
 - temperature


### PR DESCRIPTION
Just tidying up the documentation after I reconfigured my hass and noticed some problems with the documentation. 

updated the example to include sensor type as this is a required part of the configuration and is needed to make it a valid example

also removed duplicate sensor type for total_rain

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
