### PR TITLE
Update wording for Arch Linux

### DIFF
--- a/source/_docs/installation/archlinux.markdown
+++ b/source/_docs/installation/archlinux.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 ---
 
-[Arch Linux](https://www.archlinux.org/) is a lightweight and flexible Linux distribution. There are official packages optimized for the i686 and x86-64 architectures available.
+[Arch Linux](https://www.archlinux.org/) is a lightweight and flexible Linux distribution for x86_64.
 
 Install the needed Python packages.
 


### PR DESCRIPTION
**Description:**

The current wording has two problems:

1) It says that there is still i686 but that is wrong incorrect. i686 has been dropped.
2) It implies that there official Home Assistant packages which is also not the case.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A
## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
