### PR TITLE
update Konnected configuration example for device id format validation

### DIFF
--- a/source/_components/konnected.markdown
+++ b/source/_components/konnected.markdown
@@ -23,7 +23,7 @@ The component currently supports the following device types in Home Assistant:
 
 This component requires the [`discovery`](https://www.home-assistant.io/components/discovery) component to be enabled.
 
-## {% linkable_title Configuration %}
+### {% linkable_title Configuration %}
 
 A `konnected` section must be present in the `configuration.yml` file that specifies the Konnected devices on the network and the sensors or actuators attached to them:
 
@@ -32,13 +32,13 @@ A `konnected` section must be present in the `configuration.yml` file that speci
 konnected:
   access_token: REPLACE_ME_WITH_A_RANDOM_STRING
   devices:
-    - id: 8bcd53
+    - id: 6001948bcd53
       binary_sensors:
         - zone: 1
           type: door
       switches:
         - zone: out
-    - id: 438a38
+    - id: 5ccf7f438a38
       binary_sensors:
         - pin: 2
           type: door
@@ -62,7 +62,7 @@ devices:
   type: list
   keys:
     id:
-      description: The MAC address of the WiFi module with colons/punctuation removed. You can either use the full 12-character MAC address or only the last 6 characters. This is visible in the device's WiFi SSID and hostname.
+      description: The MAC address of the NodeMCU WiFi module with colons/punctuation removed, for example `68c63a8bcd53`. You can usually find the mac address in your router's client list. Or, check the home-assistant.log for log messages from automatically discovered devices. 
       required: true
       type: string
     binary_sensors:
@@ -118,14 +118,14 @@ devices:
 - Either **pin** or **zone** is required for each actuator or sensor. Do not use both in the same definition.
 - Pin `D8` or the `out` zone will only work when activation is set to high (the default).
 
-## {% linkable_title Full Configuration  %}
+### {% linkable_title Extended Configuration  %}
 
 ```yaml
 # Example configuration.yaml entry
 konnected:
   access_token: REPLACE_ME_WITH_A_RANDOM_STRING
   devices:
-    - id: 8bcd53
+    - id: 6001948bcd53
       binary_sensors:
         - zone: 1
           type: door
@@ -149,7 +149,7 @@ konnected:
           momentary: 65
           pause: 55
           repeat: -1
-    - id: 438a38
+    - id: 5ccf7f438a38
       binary_sensors:
         - pin: 1
           type: motion
@@ -179,3 +179,16 @@ Konnected runs on an ESP8266 board with the NodeMCU firmware. It is commonly use
 | 5 | D7  | 7  | GPIO13 |
 | 6 | RX  | 9  | GPIO3  |
 | ALARM or OUT | D8 | 8 | GPIO15 |
+
+### {% linkable_title Revision History %}
+
+#### 0.77
+* Added support for momentary and beep/blink switches. [[#15973](https://github.com/home-assistant/home-assistant/pull/15973)]
+* Decouple entity initialization from discovery, enabling devices to recover faster after a Home Assistant reboot. [[#16146](https://github.com/home-assistant/home-assistant/pull/16146)]
+* **Breaking change:** Device `id` in `configuration.yaml` must now be the full 12-character device MAC address. Previously, omitting the first 6 characters was allowed.
+
+#### 0.72
+* Adds `api_host` configuration option [[#14896](https://github.com/home-assistant/home-assistant/pull/14896)]
+
+#### 0.70
+* Initial release 


### PR DESCRIPTION
**Description:**
The linked PR adds some stricter validation on device `id` in the Konnected configuration. This updates the examples and docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/16146

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
