### PR TITLE
IP address is no longer required for Enphase Envoy component

### DIFF
--- a/source/_components/sensor.enphase_envoy.markdown
+++ b/source/_components/sensor.enphase_envoy.markdown
@@ -51,7 +51,7 @@ monitored_conditions:
       description: The power in W being produced by the solar panels
     daily_production:
       description: The energy in Wh produced that day
-    7_days_production:
+    seven_days_production:
       description: The energy in Wh produced the last 7 days
     lifetime_production:
       description: The energy in Wh produced in the lifetime of the Envoy
@@ -59,7 +59,7 @@ monitored_conditions:
       description: The power in W being consumed in the whole house
     daily_consumption:
       description: The energy in Wh consumed that day
-    7_days_consumption:
+    seven_days_consumption:
       description: The energy in Wh consumed the last 7 days
     lifetime_consumption:
       description: The energy in Wh consumed in the lifetime of the Envoy

--- a/source/_components/sensor.enphase_envoy.markdown
+++ b/source/_components/sensor.enphase_envoy.markdown
@@ -23,13 +23,24 @@ To enable this sensor, add the following lines to your `configuration.yaml` file
 # Example configuration.yaml entry
 sensor:
   - platform: enphase_envoy
-    ip_address: ENVOY_LOCAL_IP_ADDRESS
+```
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: enphase_envoy
+    ip_address: LOCAL_IP_FOR_ENVOY
+    monitored_conditions:
+      - production
+      - consumption
+      - lifetime_production
+      - lifetime_consumption
 ```
 
 {% configuration %}
 ip_address:
-  description: The local IP Address of your Envoy
-  required: true
+  description: The local IP Address of your Envoy. Leave blank to search for it, but this may not always be reliable
+  required: false
   type: string
 monitored_conditions:
   description: The list of conditions to monitor

--- a/source/_components/sensor.enphase_envoy.markdown
+++ b/source/_components/sensor.enphase_envoy.markdown
@@ -39,28 +39,28 @@ sensor:
 
 {% configuration %}
 ip_address:
-  description: The local IP Address of your Envoy. Leave blank to search for it, but this may not always be reliable
+  description: The local IP Address of your Envoy. Leave blank to search for it, but this may not always be reliable.
   required: false
   type: string
 monitored_conditions:
-  description: The list of conditions to monitor
+  description: The list of conditions to monitor.
   required: false
   type: list
   keys:
     production:
-      description: The power in W being produced by the solar panels
+      description: The power in W being produced by the solar panels.
     daily_production:
-      description: The energy in Wh produced that day
+      description: The energy in Wh produced that day.
     seven_days_production:
-      description: The energy in Wh produced the last 7 days
+      description: The energy in Wh produced the last 7 days.
     lifetime_production:
-      description: The energy in Wh produced in the lifetime of the Envoy
+      description: The energy in Wh produced in the lifetime of the Envoy.
     consumption:
-      description: The power in W being consumed in the whole house
+      description: The power in W being consumed in the whole house.
     daily_consumption:
-      description: The energy in Wh consumed that day
+      description: The energy in Wh consumed that day.
     seven_days_consumption:
-      description: The energy in Wh consumed the last 7 days
+      description: The energy in Wh consumed the last 7 days.
     lifetime_consumption:
-      description: The energy in Wh consumed in the lifetime of the Envoy
+      description: The energy in Wh consumed in the lifetime of the Envoy.
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**

ip_address no longer required with updated component


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16212

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
