### PR TITLE
pi_hole sensor also supports a list for monitored_conditions

### DIFF
--- a/source/_components/sensor.pi_hole.markdown
+++ b/source/_components/sensor.pi_hole.markdown
@@ -50,7 +50,7 @@ verify_ssl:
 monitored_conditions:
   description: Defines the stats to monitor as sensors.
   required: false
-  type: string
+  type: string|list
   default: ads_blocked_today
   keys:
     ads_blocked_today:

--- a/source/_components/sensor.pi_hole.markdown
+++ b/source/_components/sensor.pi_hole.markdown
@@ -50,7 +50,7 @@ verify_ssl:
 monitored_conditions:
   description: Defines the stats to monitor as sensors.
   required: false
-  type: string|list
+  type: list
   default: ads_blocked_today
   keys:
     ads_blocked_today:
@@ -74,4 +74,3 @@ monitored_conditions:
 {% endconfiguration %}
 
 This sensor platform was not made by Pi-hole LLC or the Pi-hole community. They didn't provide support, feedback, testing or helped in any way while it was created. This is third party, may not work if Pi-hole is breaking their API with the latest release, not official, not developed, not supported and not endorsed Pi-hole LLC or the Pi-hole community. The trademark `Pi-hole` and the logo is used here to describe the platform and only to describe. `Pi-hole` is a registered trademark of Pi-hole LLC. 
-


### PR DESCRIPTION
**Description:** Supply a list as for monitored_conditions is also supported but not mentioned in the doc.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** -

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
