### PR TITLE
Added default update

### DIFF
--- a/source/_components/tellduslive.markdown
+++ b/source/_components/tellduslive.markdown
@@ -31,6 +31,6 @@ tellduslive:
 Configuration variables:
 
 - **host** (*Optional*): Host address to Tellstick Net or Tellstick ZNet for Local API, only useful when automatic discovery is not enabled.
-- **update_interval** (*Optional*): Interval (in seconds) for polling the Telldus Live server (or the local server).
+- **update_interval** (*Optional*): Interval (in seconds) for polling the Telldus Live server (or the local server). Default update_interval is 60 seconds.
 
 The component will offer configuration through the Home Assistant user interface where it will let you associate it with your Telldus Live account.

--- a/source/_components/tellduslive.markdown
+++ b/source/_components/tellduslive.markdown
@@ -31,6 +31,6 @@ tellduslive:
 Configuration variables:
 
 - **host** (*Optional*): Host address to Tellstick Net or Tellstick ZNet for Local API, only useful when automatic discovery is not enabled.
-- **update_interval** (*Optional*): Interval (in seconds) for polling the Telldus Live server (or the local server). Default update_interval is 60 seconds.
+- **update_interval** (*Optional*): Interval (in seconds) for polling the Telldus Live server (or the local server). Defaults to 60 seconds.
 
 The component will offer configuration through the Home Assistant user interface where it will let you associate it with your Telldus Live account.


### PR DESCRIPTION
Added the default update interval to the component page.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
