### PR TITLE
Update fail2ban.markdown

### DIFF
--- a/source/_cookbook/fail2ban.markdown
+++ b/source/_cookbook/fail2ban.markdown
@@ -8,12 +8,12 @@ comments: false
 sharing: true
 footer: true
 ha_category: Infrastructure
-
 ---
 
 This is a quick guide on how to setup fail2ban for Home Assistant. Contains extracts from [Is there a log file for invalid logins? \(Blocking hackers\)](https://community.home-assistant.io/t/is-there-a-log-file-for-invalid-logins-blocking-hackers/2892).
 
 **Installing fail2ban**
+
 Debian/Ubuntu:
 ```bash
 sudo apt-get install fail2ban
@@ -31,6 +31,7 @@ sudo dnf install -y fail2ban
 For other package managers use the appropriate commands.
 
 **Enable Home Assistant Logging**
+
 First, enable http.ban logging in `configuration.yaml` file for your Home Assistant instance:
 ```yaml
 logger:
@@ -51,6 +52,7 @@ tail -f /home/homeassistant/.homeassistant/home-assistant.log | grep WARNING
 ```
 
 **Configure fail2ban**
+
 Next we will create a filter and jail file for fail2ban:
 - `/etc/fail2ban/filter.d/ha.conf`
 - `/etc/fail2ban/jail.d/ha.conf`
@@ -107,6 +109,7 @@ Status
 ```
 
 **Testing fail2ban**
+
 Tail the fail2ban log file then log out of the Home Assistant web interface and attempt to log in again with an incorrect password.
 ```bash
 sudo tail -f -n 20 /var/log/fail2ban.log

--- a/source/_cookbook/fail2ban.markdown
+++ b/source/_cookbook/fail2ban.markdown
@@ -1,3 +1,4 @@
+
 ---
 layout: page
 title: "fail2ban"
@@ -8,39 +9,53 @@ comments: false
 sharing: true
 footer: true
 ha_category: Infrastructure
+
 ---
 
-This is a quick guide on how to setup fail2ban for Home Assistant. Contains extracts from [forum](https://community.home-assistant.io/t/is-there-a-log-file-for-invalid-logins-blocking-hackers/2892).
+This is a quick guide on how to setup fail2ban for Home Assistant. Contains extracts from [Is there a log file for invalid logins? \(Blocking hackers\)](https://community.home-assistant.io/t/is-there-a-log-file-for-invalid-logins-blocking-hackers/2892).
 
-Install `fail2ban`. 
+Installing fail2ban.
 Debian/Ubuntu:
-`sudo apt-get install fail2ban`.
-CentOS/RHEL/Fedora (use dnf on Fedora):
-```sudo yum install epel-release
-sudo yum install -y fail2ban```
+```bash
+sudo apt-get install fail2ban
+```
+CentOS/RHEL:
+```bash
+sudo yum install epel-release
+sudo yum install -y fail2ban
+```
+Fedora:
+```bash
+sudo dnf install -y fail2ban
+```
 
 For other package managers use the appropriate commands.
 
 First, enable http.ban logging in `configuration.yaml` file for your Home Assistant instance:
-```logger:
+```yaml
+logger:
   default: critical
   logs:
     homeassistant.components.http.ban: warning
 ```
 
 Restart Home Assistant to activate the changes.
-`sudo systemctl restart home-assistant`
+```bash
+sudo systemctl restart home-assistant
+```
 
-Tail the Home Assistant log then log out of the Home Assistant web interface and attempt logging in with an incorrect password, look for a line like "Login attempt or request with invalid authentication from xxx.xxx.xxx.xxx"
-```tail -f /home/homeassistant/.homeassistant/home-assistant.log | grep WARNING
-2018-08-29 14:28:15 WARNING (MainThread) [homeassistant.components.http.ban] Login attempt or request with invalid authentication from 203.176.101.1```
+Tail the Home Assistant log then log out of the Home Assistant web interface and attempt logging in with an incorrect password, look for a line like `Login attempt or request with invalid authentication from xxx.xxx.xxx.xxx`
+```bash
+tail -f /home/homeassistant/.homeassistant/home-assistant.log | grep WARNING
+2018-08-29 14:28:15 WARNING (MainThread) [homeassistant.components.http.ban] Login attempt or request with invalid authentication from xxx.xxx.xxx.xxx
+```
 
 Next we will create a filter and jail file for fail2ban:
 - `/etc/fail2ban/filter.d/ha.conf`
 - `/etc/fail2ban/jail.d/ha.conf`
 
 Contents of `/etc/fail2ban/filter.d/ha.conf`:
-```text
+```ini
 [INCLUDES]
 before = common.conf
 
@@ -51,15 +66,8 @@ ignoreregex =
 
 Contents of `/etc/fail2ban/jail.d/ha.conf` (Note that you'll need to change the `logpath` to match your logfile which will be different from the path listed.):
 
-```text
+```ini
 [DEFAULT]
-# 3600 seconds = 1 hour
-bantime = 3600
-bantime = 30 # during testing it is useful to have a short ban interval, comment out this line later
-
-# Maximum amount of login attempts before IP is blocked
-maxretry = 3
-
 # Email config
 sender = email@address.com
 destemail = email@address.com
@@ -71,29 +79,42 @@ action = %(action_mwl)s
 enabled = true
 filter = ha
 logpath = /home/homeassistant/.homeassistant/home-assistant.log
+
+# 3600 seconds = 1 hour
+bantime = 3600
+bantime = 30 # during testing it is useful to have a short ban interval, comment out this line later
+
+# Maximum amount of login attempts before IP is blocked
+maxretry = 3
 ```
 
 Restart fail2ban:
-`sudo systemctl restart fail2ban`
+```bash
+sudo systemctl restart fail2ban
+```
 
 Confirm fail2ban is running:
-`sudo systemctl status fail2ban`
+```bash
+sudo systemctl status fail2ban
+```
 
 Check that the ha jail is active:
-```sudo fail2ban-client status
+```bash
+sudo fail2ban-client status
 Status
 |- Number of jail:	1
 `- Jail list:	ha
 ```
 
 Tail the fail2ban log file then log out of the Home Assistant web interface and attempt to log in again with an incorrect password.
-```sudo tail -f -n 20 /var/log/fail2ban.log
+```bash
+sudo tail -f -n 20 /var/log/fail2ban.log
 2018-08-29 13:25:37,907 fail2ban.server         [10208]: INFO    Starting Fail2ban v0.10.3.fix1
 2018-08-29 13:25:37,916 fail2ban.database       [10208]: INFO    Connected to fail2ban persistent database '/var/lib/fail2ban/fail2ban.sqlite3'
 2018-08-29 13:25:37,918 fail2ban.jail           [10208]: INFO    Creating new jail 'ha'
 2018-08-29 13:25:37,922 fail2ban.jail           [10208]: INFO    Jail 'ha' uses poller {}
 2018-08-29 13:25:37,922 fail2ban.jail           [10208]: INFO    Initiated 'polling' backend
-2018-08-29 13:25:37,932 fail2ban.filter         [10208]: INFO    Added logfile: '/opt/homeassistant/.homeassistant/home-assistant.log' (pos = 5873, hash = 02ec3aefc005465a6cd8db91eff2d5e57c45757e)
+2018-08-29 13:25:37,932 fail2ban.filter         [10208]: INFO    Added logfile: '/home/homeassistant/.homeassistant/home-assistant.log' (pos = 5873, hash = 02ec3aefc005465a6cd8db91eff2d5e57c45757e)
 2018-08-29 13:25:37,932 fail2ban.filter         [10208]: INFO      encoding: UTF-8
 2018-08-29 13:25:37,933 fail2ban.filter         [10208]: INFO      maxRetry: 3
 2018-08-29 13:25:37,934 fail2ban.filter         [10208]: INFO      findtime: 600
@@ -103,18 +124,24 @@ Tail the fail2ban log file then log out of the Home Assistant web interface and 
 2018-08-29 13:27:51,330 fail2ban.filter         [10208]: INFO    [ha] Found xxx.xxx.xxx.xxx - 2018-08-29 13:27:51
 2018-08-29 13:27:52,533 fail2ban.filter         [10208]: INFO    [ha] Found xxx.xxx.xxx.xxx - 2018-08-29 13:27:52
 2018-08-29 13:27:52,678 fail2ban.actions        [10208]: NOTICE  [ha] Ban xxx.xxx.xxx.xxx
-2018-08-29 13:28:23,941 fail2ban.actions        [10208]: NOTICE  [ha] Unban xxx.xxx.xxx.xxx```
+2018-08-29 13:28:23,941 fail2ban.actions        [10208]: NOTICE  [ha] Unban xxx.xxx.xxx.xxx
+```
 
 Now that fail2ban is working it can be enabled for startup at boot time, also raise the bantime from 30 seconds to what ever you would like, I used 8 hours which is 28800 seconds:
-```sudo sed -i 's/bantime = 30/bantime = 28800/g' /etc/fail2ban/jail.d/ha.conf
+```bash
+sudo sed -i 's/bantime = 30/bantime = 28800/g' /etc/fail2ban/jail.d/ha.conf
 sudo systemctl enable fail2ban
 sudo systemctl restart fail2ban
 ```
 
 A final note, if you need to unban an IP it can be done with fail2ban-client:
-`sudo fail2ban-client set JAILNAME unbanip IPADDRESS`
+```bash
+sudo fail2ban-client set JAILNAME unbanip IPADDRESS
+```
 eg:
-`sudo fail2ban-client set ha unbanip xxx.xxx.xxx.xxx`
+```bash
+sudo fail2ban-client set ha unbanip xxx.xxx.xxx.xxx
+```
 
 Fail2ban should now be configured and running, if an IP address is banned you will recieve an email with whois details about the IP address that attempted to connect, if not you will need configure postfix or another MTA (Mail Transport Agent).
 

--- a/source/_cookbook/fail2ban.markdown
+++ b/source/_cookbook/fail2ban.markdown
@@ -15,6 +15,7 @@ ha_category: Infrastructure
 This is a quick guide on how to setup fail2ban for Home Assistant. Contains extracts from [Is there a log file for invalid logins? \(Blocking hackers\)](https://community.home-assistant.io/t/is-there-a-log-file-for-invalid-logins-blocking-hackers/2892).
 
 Installing fail2ban.
+
 Debian/Ubuntu:
 ```bash
 sudo apt-get install fail2ban

--- a/source/_cookbook/fail2ban.markdown
+++ b/source/_cookbook/fail2ban.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "fail2ban"
 description: "Setting up fail2ban to read Home Assistant's log files to improve security."
-date: 2017-05-24 10:05
+date: 2018-08-29 15:30 AEST
 sidebar: true
 comments: false
 sharing: true
@@ -10,95 +10,113 @@ footer: true
 ha_category: Infrastructure
 ---
 
-This is a quick guide on how to setup fail2ban for Home Assistant. This was originally in the [forum](https://community.home-assistant.io/t/is-there-a-log-file-for-invalid-logins-blocking-hackers/2892) but I created this here for people.
+This is a quick guide on how to setup fail2ban for Home Assistant. Contains extracts from [forum](https://community.home-assistant.io/t/is-there-a-log-file-for-invalid-logins-blocking-hackers/2892).
 
-First install `fail2ban`. On Debian/Ubuntu this would be `apt-get install fail2ban`. On other distros you can google it.
+Install `fail2ban`. 
+Debian/Ubuntu:
+`sudo apt-get install fail2ban`.
+CentOS/RHEL/Fedora (use dnf on Fedora):
+```sudo yum install epel-release
+sudo yum install -y fail2ban```
 
-Then make sure logging is enabled in your `configuration.yaml` file for your Home Assistant instance:
+For other package managers use the appropriate commands.
 
-```yaml
-logger:
+First, enable http.ban logging in `configuration.yaml` file for your Home Assistant instance:
+```logger:
   default: critical
   logs:
     homeassistant.components.http.ban: warning
 ```
 
-Next we will be creating these three files :
+Restart Home Assistant to activate the changes.
+`sudo systemctl restart home-assistant`
 
-- `/etc/fail2ban/fail2ban.local`
-- `/etc/fail2ban/filter.d/hass.local`
-- `/etc/fail2ban/jail.local`
+Tail the Home Assistant log then log out of the Home Assistant web interface and attempt logging in with an incorrect password, look for a line like "Login attempt or request with invalid authentication from xxx.xxx.xxx.xxx"
+```tail -f /home/homeassistant/.homeassistant/home-assistant.log | grep WARNING
+2018-08-29 14:28:15 WARNING (MainThread) [homeassistant.components.http.ban] Login attempt or request with invalid authentication from 203.176.101.1```
 
-Contents of `/etc/fail2ban/fail2ban.local`:
+Next we will create a filter and jail file for fail2ban:
+- `/etc/fail2ban/filter.d/ha.conf`
+- `/etc/fail2ban/jail.d/ha.conf`
 
-```text
-[Definition]
-logtarget = SYSLOG
-```
-
-Contents of `/etc/fail2ban/filter.d/hass.local`:
-
+Contents of `/etc/fail2ban/filter.d/ha.conf`:
 ```text
 [INCLUDES]
 before = common.conf
 
 [Definition]
 failregex = ^%(__prefix_line)s.*Login attempt or request with invalid authentication from <HOST>.*$
-
 ignoreregex =
 ```
 
-Contents of `/etc/fail2ban/jail.local` (Note that you'll need to change the `logpath` to match your logfile which will be different from the path listed.):
+Contents of `/etc/fail2ban/jail.d/ha.conf` (Note that you'll need to change the `logpath` to match your logfile which will be different from the path listed.):
 
 ```text
-[hass-iptables]
+[DEFAULT]
+# 3600 seconds = 1 hour
+bantime = 3600
+bantime = 30 # during testing it is useful to have a short ban interval, comment out this line later
+
+# Maximum amount of login attempts before IP is blocked
+maxretry = 3
+
+# Email config
+sender = email@address.com
+destemail = email@address.com
+
+# Action "%(action_mwl)s" will ban the IP and send an email notification including whois data and log entries.
+action = %(action_mwl)s
+
+[ha]
 enabled = true
-filter = hass
-action = iptables-allports[name=HASS]
+filter = ha
 logpath = /home/homeassistant/.homeassistant/home-assistant.log
-maxretry = 5
 ```
 
-Finally restart fail2ban : `sudo systemctl restart fail2ban`
+Restart fail2ban:
+`sudo systemctl restart fail2ban`
 
-Check your log to make sure it read in your settings : `tail -100 /var/log/syslog|grep fail`
+Confirm fail2ban is running:
+`sudo systemctl status fail2ban`
 
-If all is well you should see this from your syslog:
-
-```bash
-May 24 20:58:01 homeauto fail2ban.server[14997]: INFO Stopping all jails
-May 24 20:58:02 homeauto fail2ban.jail[14997]: INFO Jail 'sshd' stopped
-May 24 20:58:02 homeauto fail2ban-client[15206]: Shutdown successful
-May 24 20:58:02 homeauto fail2ban.server[14997]: INFO Exiting Fail2ban
-May 24 20:58:02 homeauto fail2ban-client[15213]: 2017-05-24 20:58:02,342 fail2ban.server         [15215]: INFO    Starting Fail2ban v0.9.6
-May 24 20:58:02 homeauto fail2ban-client[15213]: 2017-05-24 20:58:02,343 fail2ban.server         [15215]: INFO    Starting in daemon mode
-May 24 20:58:02 homeauto fail2ban.server[15217]: INFO Changed logging target to SYSLOG (/dev/log) for Fail2ban v0.9.6
-May 24 20:58:02 homeauto fail2ban.database[15217]: INFO Connected to fail2ban persistent database '/var/lib/fail2ban/fail2ban.sqlite3'
-May 24 20:58:02 homeauto fail2ban.jail[15217]: INFO Creating new jail 'sshd'
-May 24 20:58:02 homeauto fail2ban.jail[15217]: INFO Jail 'sshd' uses pyinotify {}
-May 24 20:58:02 homeauto fail2ban.jail[15217]: INFO Initiated 'pyinotify' backend
-May 24 20:58:02 homeauto fail2ban.actions[15217]: INFO Set banTime = 600
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Set findtime = 600
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Set maxRetry = 5
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Added logfile = /var/log/auth.log
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Set jail log file encoding to UTF-8
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Set maxlines = 10
-May 24 20:58:02 homeauto fail2ban.server[15217]: INFO Jail sshd is not a JournalFilter instance
-May 24 20:58:02 homeauto fail2ban.jail[15217]: INFO Creating new jail 'hass-iptables'
-May 24 20:58:02 homeauto fail2ban.jail[15217]: INFO Jail 'hass-iptables' uses pyinotify {}
-May 24 20:58:02 homeauto fail2ban.jail[15217]: INFO Initiated 'pyinotify' backend
-May 24 20:58:02 homeauto fail2ban.actions[15217]: INFO Set banTime = 600
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Set findtime = 600
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Set maxRetry = 5
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Added logfile = /opt/hass-prod-cfg/home-assistant.log
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Set jail log file encoding to UTF-8
-May 24 20:58:02 homeauto fail2ban.filter[15217]: INFO Date pattern set to `'^%y-%m-%d %H:%M:%S'`: `^Year2-Month-Day 24hour:Minute:Second`
-May 24 20:58:02 homeauto fail2ban.jail[15217]: INFO Jail 'sshd' started
-May 24 20:58:02 homeauto fail2ban.jail[15217]: INFO Jail 'hass-iptables' started
+Check that the ha jail is active:
+```sudo fail2ban-client status
+Status
+|- Number of jail:	1
+`- Jail list:	ha
 ```
 
-That's it!
+Tail the fail2ban log file then log out of the Home Assistant web interface and attempt to log in again with an incorrect password.
+```sudo tail -f -n 20 /var/log/fail2ban.log
+2018-08-29 13:25:37,907 fail2ban.server         [10208]: INFO    Starting Fail2ban v0.10.3.fix1
+2018-08-29 13:25:37,916 fail2ban.database       [10208]: INFO    Connected to fail2ban persistent database '/var/lib/fail2ban/fail2ban.sqlite3'
+2018-08-29 13:25:37,918 fail2ban.jail           [10208]: INFO    Creating new jail 'ha'
+2018-08-29 13:25:37,922 fail2ban.jail           [10208]: INFO    Jail 'ha' uses poller {}
+2018-08-29 13:25:37,922 fail2ban.jail           [10208]: INFO    Initiated 'polling' backend
+2018-08-29 13:25:37,932 fail2ban.filter         [10208]: INFO    Added logfile: '/opt/homeassistant/.homeassistant/home-assistant.log' (pos = 5873, hash = 02ec3aefc005465a6cd8db91eff2d5e57c45757e)
+2018-08-29 13:25:37,932 fail2ban.filter         [10208]: INFO      encoding: UTF-8
+2018-08-29 13:25:37,933 fail2ban.filter         [10208]: INFO      maxRetry: 3
+2018-08-29 13:25:37,934 fail2ban.filter         [10208]: INFO      findtime: 600
+2018-08-29 13:25:37,934 fail2ban.actions        [10208]: INFO      banTime: 30
+2018-08-29 13:25:37,938 fail2ban.jail           [10208]: INFO    Jail 'ha' started
+2018-08-29 13:27:49,125 fail2ban.filter         [10208]: INFO    [ha] Found xxx.xxx.xxx.xxx - 2018-08-29 13:27:48
+2018-08-29 13:27:51,330 fail2ban.filter         [10208]: INFO    [ha] Found xxx.xxx.xxx.xxx - 2018-08-29 13:27:51
+2018-08-29 13:27:52,533 fail2ban.filter         [10208]: INFO    [ha] Found xxx.xxx.xxx.xxx - 2018-08-29 13:27:52
+2018-08-29 13:27:52,678 fail2ban.actions        [10208]: NOTICE  [ha] Ban xxx.xxx.xxx.xxx
+2018-08-29 13:28:23,941 fail2ban.actions        [10208]: NOTICE  [ha] Unban xxx.xxx.xxx.xxx```
 
+Now that fail2ban is working it can be enabled for startup at boot time, also raise the bantime from 30 seconds to what ever you would like, I used 8 hours which is 28800 seconds:
+```sudo sed -i 's/bantime = 30/bantime = 28800/g' /etc/fail2ban/jail.d/ha.conf
+sudo systemctl enable fail2ban
+sudo systemctl restart fail2ban
+```
+
+A final note, if you need to unban an IP it can be done with fail2ban-client:
+`sudo fail2ban-client set JAILNAME unbanip IPADDRESS`
+eg:
+`sudo fail2ban-client set ha unbanip xxx.xxx.xxx.xxx`
+
+Fail2ban should now be configured and running, if an IP address is banned you will recieve an email with whois details about the IP address that attempted to connect, if not you will need configure postfix or another MTA (Mail Transport Agent).
 
 If you want to read more about fail2ban, some links are below:
  - [fail2ban Split config](http://www.fail2ban.org/wiki/index.php/FEATURE_Split_config)

--- a/source/_cookbook/fail2ban.markdown
+++ b/source/_cookbook/fail2ban.markdown
@@ -40,12 +40,12 @@ logger:
     homeassistant.components.http.ban: warning
 ```
 
-Restart Home Assistant to activate the changes.
+Restart Home Assistant to activate the changes:
 ```bash
 sudo systemctl restart home-assistant
 ```
 
-Tail the Home Assistant log then log out of the Home Assistant web interface and attempt logging in with an incorrect password, look for a line like `Login attempt or request with invalid authentication from xxx.xxx.xxx.xxx`
+Tail the Home Assistant log then log out of the Home Assistant web interface and attempt logging in with an incorrect password, look for a line like `Login attempt or request with invalid authentication from xxx.xxx.xxx.xxx`:
 ```bash
 tail -f /home/homeassistant/.homeassistant/home-assistant.log | grep WARNING
 2018-08-29 14:28:15 WARNING (MainThread) [homeassistant.components.http.ban] Login attempt or request with invalid authentication from xxx.xxx.xxx.xxx
@@ -66,7 +66,6 @@ ignoreregex =
 ```
 
 Contents of `/etc/fail2ban/jail.d/ha.conf` (Note that you'll need to change the `logpath` to match your logfile which will be different from the path listed.):
-
 ```ini
 [DEFAULT]
 # Email config

--- a/source/_cookbook/fail2ban.markdown
+++ b/source/_cookbook/fail2ban.markdown
@@ -1,4 +1,3 @@
-
 ---
 layout: page
 title: "fail2ban"
@@ -14,8 +13,7 @@ ha_category: Infrastructure
 
 This is a quick guide on how to setup fail2ban for Home Assistant. Contains extracts from [Is there a log file for invalid logins? \(Blocking hackers\)](https://community.home-assistant.io/t/is-there-a-log-file-for-invalid-logins-blocking-hackers/2892).
 
-Installing fail2ban.
-
+**Installing fail2ban**
 Debian/Ubuntu:
 ```bash
 sudo apt-get install fail2ban
@@ -32,6 +30,7 @@ sudo dnf install -y fail2ban
 
 For other package managers use the appropriate commands.
 
+**Enable Home Assistant Logging**
 First, enable http.ban logging in `configuration.yaml` file for your Home Assistant instance:
 ```yaml
 logger:
@@ -51,6 +50,7 @@ tail -f /home/homeassistant/.homeassistant/home-assistant.log | grep WARNING
 2018-08-29 14:28:15 WARNING (MainThread) [homeassistant.components.http.ban] Login attempt or request with invalid authentication from xxx.xxx.xxx.xxx
 ```
 
+**Configure fail2ban**
 Next we will create a filter and jail file for fail2ban:
 - `/etc/fail2ban/filter.d/ha.conf`
 - `/etc/fail2ban/jail.d/ha.conf`
@@ -106,6 +106,7 @@ Status
 `- Jail list:	ha
 ```
 
+**Testing fail2ban**
 Tail the fail2ban log file then log out of the Home Assistant web interface and attempt to log in again with an incorrect password.
 ```bash
 sudo tail -f -n 20 /var/log/fail2ban.log


### PR DESCRIPTION
Updated using more consistent paths for the filter and jail configuration.
Added additional checks to help confirm everything working as expected.
Added steps to unblock an IP address.
Updated jail conf file includes email alerts.
Removed the syslog section, this step is not required for fail2ban thus optional and only required if you want HA logs to be sent to syslog, should be covered by another page.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
