### PR TITLE
Update xiaomi incorrect service return call

### DIFF
--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -20,7 +20,7 @@ Currently supported features are:
 - `start`
 - `pause`
 - `stop`
-- `return_to_home`
+- `return_to_base`
 - `locate`
 - `clean_spot`
 - `set_fan_speed`


### PR DESCRIPTION
The vacuum service return_to_home should be return_to_base as listed in the services tool. Users using return_to_home will result in the service failing.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
