### PR TITLE
Small correction from home to base

### DIFF
--- a/source/_components/vacuum.neato.markdown
+++ b/source/_components/vacuum.neato.markdown
@@ -24,5 +24,5 @@ Currently supported features are:
 - `start`
 - `pause`
 - `stop`
-- `return_to_home`
+- `return_to_base`
 - `locate`


### PR DESCRIPTION
**Description:**

Just a small correction as the actual service call is `return_to_base`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
