### PR TITLE
Add default_zoom to map card docs.

### DIFF
--- a/source/_lovelace/map.markdown
+++ b/source/_lovelace/map.markdown
@@ -40,10 +40,21 @@ aspect_ratio:
   description: "The map's height:width ratio."
   type: string
   default: "100%"
+default_zoom:
+  required: false
+  description: The default zoom level of the map.
+  type: integer
+  default: 14 (or whatever zoom level is required to fit all visible markers)
 {% endconfiguration %}
 
 <p class='note'>
   Only entities that have latitude and longitude attributes will be displayed on the map.
+</p>
+
+<p class="note">
+  The `default_zoom` value will be ignored if it is set higher than the current zoom level
+  after fitting all visible entity markers in the map window. In other words, this can only 
+  be used to zoom the map _out_ by default.
 </p>
 
 ## {% linkable_title Examples %}
@@ -51,6 +62,7 @@ aspect_ratio:
 ```yaml
 - type: map
   aspect_ratio: 100%
+  default_zoom: 8
   entities:
     - device_tracker.demo_paulus
     - zone.home


### PR DESCRIPTION
**Description:**
Adds `default_zoom` option to map card documentation. 

From frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/1592

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
