### PR TITLE
Activation of the notifications

### DIFF
--- a/source/_components/notify.html5.markdown
+++ b/source/_components/notify.html5.markdown
@@ -72,7 +72,7 @@ The `html5` platform can only function if all of the following requirements are 
 Assuming you have already added the platform to your configuration:
 
 1. Open Home Assistant in Chrome or Firefox.
-2. Assuming you have met all the [requirements](#requirements) above, you should see a new slider for Push Notifications through the sidebar Configuration > General.
+2. Assuming you have met all the [requirements](#requirements) above, you should see a new slider for Push Notifications through the profile page Profile > Push notifications.
 3. Slide it to the on position.
 4. Within a few seconds you should be prompted to allow notifications from Home Assistant.
 5. Assuming you accept, that's all there is to it!


### PR DESCRIPTION
Changed the place where notifications can be activated (update since 0.77)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
