### PR TITLE
Removed automation: line

### DIFF
--- a/source/_components/input_number.markdown
+++ b/source/_components/input_number.markdown
@@ -179,9 +179,8 @@ automation:
         entity_id: input_number.target_temp
         value: "{{ trigger.payload }}"
 
-# This automation script runs when the target temperature slider is moved.
+# This second automation script runs when the target temperature slider is moved.
 # It publishes its value to the same MQTT topic it is also subscribed to.
-automation:
   - alias: Temp slider moved
     trigger:
       platform: state


### PR DESCRIPTION
One of the examples has two `automation:` lines, which clearly doesn't work. Removed after somebody had issues with it