### PR TITLE
Standardised entity name throughout page

### DIFF
--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -44,7 +44,7 @@ Increments the counter with 1 or the given value for the steps.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.count0`. |
+| `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.my_custom_counter`. |
 
 #### {% linkable_title Service `counter.decrement` %}
 
@@ -52,7 +52,7 @@ Decrements the counter with 1 or the given value for the steps.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.count0`. |
+| `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.my_custom_counter`. |
 
 #### {% linkable_title Service `counter.reset` %}
 
@@ -60,7 +60,7 @@ With this service the counter is reset to its initial value.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.count0`. |
+| `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.my_custom_counter`. |
 
 
 ### {% linkable_title Use the service %}
@@ -69,7 +69,7 @@ Select <img src='/images/screenshots/developer-tool-services-icon.png' alt='serv
 
 ```json
 {
-  "entity_id": "counter.count0"
+  "entity_id": "counter.my_custom_counter"
 }
 ```
 


### PR DESCRIPTION
**Description:**
from count0 and my_custom_counter to all be my_custom_counter in examples.

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
