### PR TITLE
Update notify.mailgun.markdown

### DIFF
--- a/source/_components/notify.mailgun.markdown
+++ b/source/_components/notify.mailgun.markdown
@@ -22,22 +22,21 @@ The Mailgun notification service allows you to send emails via Mailgun's REST AP
 # Example configuration.yaml entry
 mailgun:
   domain: mg.example.com
-  api_key: token-XXXXXXXXX
-  sandbox: False
+  api_key: XXXXXXXXXXXXXX
 
 notify:
   - name: mailgun
-    platform: mailgun
+    platform: mailgun_me
     recipient: me@example.com
 ```
 
 Configuration variables:
 
-- **domain** (*Optional*): This is the domain name to be used when sending out mail. Defaults to the first custom domain you have set up.
-- **sandbox** (*Optional*): Whether to use the sandboxed domain for outgoing mail. The `domain` item takes precedence over this. Defaults to `False`.
-- **token** (*Required*): This is the API token that has been generated in your Mailgun account.
+- **domain** (*Required*): This is the domain name to be used when sending out mail.
+- **sandbox** (*Deprecated*): If a sandboxed domain is used, specify it in `domain`. Defaults to `False`.
+- **api_key** (*Required*): This is the API Key that has been generated in your Mailgun account.
 - **recipient** (*Required*): The email address of the recipient.
-- **sender** (*Optional*): The sender's email address. Defaults to `hass@DOMAIN`, where `DOMAIN` is outgoint mail domain, as defined by the `domain` and `sanbox` configuration entries.
+- **sender** (*Optional*): The sender's email address. Defaults to `hass@DOMAIN`, where `DOMAIN` is the outgoint mail domain, as defined by the `domain` configuration entry.
 
 ## {% linkable_title Example automation %}
 
@@ -50,7 +49,7 @@ automation:
     platform: event
     event_type: SPECIAL_EVENT
   action:
-    service: notify.mailgun
+    service: notify.mailgun_me
     data:
       title: "Something special has happened"
       message: "This a test message from Home Assistant"

--- a/source/_components/notify.mailgun.markdown
+++ b/source/_components/notify.mailgun.markdown
@@ -26,7 +26,7 @@ mailgun:
 
 notify:
   - name: mailgun
-    platform: mailgun_me
+    platform: mailgun
     recipient: me@example.com
 ```
 
@@ -36,7 +36,7 @@ Configuration variables:
 - **sandbox** (*Deprecated*): If a sandboxed domain is used, specify it in `domain`. Defaults to `False`.
 - **api_key** (*Required*): This is the API Key that has been generated in your Mailgun account.
 - **recipient** (*Required*): The email address of the recipient.
-- **sender** (*Optional*): The sender's email address. Defaults to `hass@DOMAIN`, where `DOMAIN` is the outgoint mail domain, as defined by the `domain` configuration entry.
+- **sender** (*Optional*): The sender's email address. Defaults to `hass@DOMAIN`, where `DOMAIN` is the outgoing mail domain, as defined by the `domain` configuration entry.
 
 ## {% linkable_title Example automation %}
 
@@ -49,7 +49,7 @@ automation:
     platform: event
     event_type: SPECIAL_EVENT
   action:
-    service: notify.mailgun_me
+    service: notify.mailgun
     data:
       title: "Something special has happened"
       message: "This a test message from Home Assistant"


### PR DESCRIPTION
Fix inconsistency where "domain" is required in the Mailgun Component https://www.home-assistant.io/components/mailgun/ but "sandbox" can also be used to specify the domain.  It appears that the package https://github.com/pschmitt/pymailgunner in  def guess_domain(...) allows multiple domains and "sandbox" can be used to choose a sandbox domain over a normal domain.  As far as I can tell, this feature isn't used by the Mailgun component.  Also removed all references to the obsolete word "token" to avoid confusion.  Also used a different name for the notify service to differentiate it from the mailgun component.  Note: There are also updates to the aforementioned Mailgun Component doc.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
