### PR TITLE
Update mailgun.markdown

### DIFF
--- a/source/_components/mailgun.markdown
+++ b/source/_components/mailgun.markdown
@@ -12,7 +12,7 @@ ha_category: Notifications
 ha_release: 0.38
 ---
 
-The component supports push messages and generates events based on inbound data. To use, add a Route set to Store and Notify with a URL of the following form: `https://<home-assistant-domain>/api/mailgun?api_password=<password>`
+The component supports push messages and generates events based on inbound data. To generate inbound events, add a Route set to Store and Notify with a URL of the following form: `https://<home-assistant-domain>/api/mailgun?api_password=<password>`
 
 To send messages, use the [Mailgun notify platform][notify].
 
@@ -24,11 +24,11 @@ To send messages, use the [Mailgun notify platform][notify].
 # Example configuration.yaml entry
 mailgun:
   domain: mg.example.com
-  api_key: token-XXXXXXXXX
+  api_key: XXXXXXXXXXXXX
 ```
 
 Configuration variables:
 
 - **domain** (*Required*): This is the domain name to be used when sending out mail. Defaults to the first custom domain you have set up.
 - **api_key** (*Required*): This is the API token that has been generated in your Mailgun account.
-- **sandbox** (*Optional*): Whether to use the sandboxed domain for outgoing mail. The `domain` item takes precedence over this. Defaults to `False`.
+- **sandbox** (*Deprecated*): Whether to use the sandboxed domain for outgoing mail. Since the `domain` item is required, it should be set to the sandbox domain name, so this isn't needed.  Defaults to `False`.


### PR DESCRIPTION
Fix inconsistency where "domain" is required but "sandbox" can also be used to specify the domain.  It appears that the package https://github.com/pschmitt/pymailgunner in  def guess_domain allows multiple domains and "sandbox" can be used to choose a sandbox domain over a normal domain.  As far as I can tell, this feature isn't used by the Mailgun component.  There are also updates to the Mailgun Notify doc.

The "domain" also should not talk about a default if specifying one is required.

**Description:**

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
