### PR TITLE
Fixing formatting

### DIFF
--- a/source/_docs/installation/hassbian.markdown
+++ b/source/_docs/installation/hassbian.markdown
@@ -23,4 +23,5 @@ When instructions tell you to activate the virtual environment to install a Pyth
 
 ```bash
 $ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate```
+$ source /srv/homeassistant/bin/activate
+```


### PR DESCRIPTION
With the three ticks on the same line as the command it collapsed to a single line

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
