### PR TITLE
Improve warning for yi-hack-v3 versions

### DIFF
--- a/source/_components/camera.yi.markdown
+++ b/source/_components/camera.yi.markdown
@@ -31,7 +31,7 @@ In order to integrate the camera with Home Assistant, it is necessary to install
 Once installed, please ensure that you have enabled FTP and Telnet on your device.
 
  <p class='note warning'>
-Currently, version 0.1.4-beta2 of the custom firmware is the highest supported. Firmwares higher than this version use [Pure-FTPd](https://www.pureftpd.org/project/pure-ftpd), which has a bug that prevents FFmpeg from correctly rendering video files.
+Currently, version 0.1.4-beta2 of the custom firmware is the highest supported without having to made additional modifications. Firmwares higher than this version use [Pure-FTPd](https://www.pureftpd.org/project/pure-ftpd), which has a bug that prevents FFmpeg from correctly rendering video files. To use higher firmware versions you must also follow [this workaround](https://github.com/shadow-1/yi-hack-v3/issues/129#issuecomment-361723075) to revert back to ftpd.
 </p>
 
 <p class='note warning'>

--- a/source/_components/camera.yi.markdown
+++ b/source/_components/camera.yi.markdown
@@ -31,7 +31,7 @@ In order to integrate the camera with Home Assistant, it is necessary to install
 Once installed, please ensure that you have enabled FTP and Telnet on your device.
 
  <p class='note warning'>
-Currently, version 0.1.4-beta2 of the custom firmware is the highest supported without having to made additional modifications. Firmwares higher than this version use [Pure-FTPd](https://www.pureftpd.org/project/pure-ftpd), which has a bug that prevents FFmpeg from correctly rendering video files. To use higher firmware versions you must also follow [this workaround](https://github.com/shadow-1/yi-hack-v3/issues/129#issuecomment-361723075) to revert back to ftpd.
+Currently, version 0.1.4-beta2 of the custom firmware is the highest supported without having to make additional modifications. Firmwares higher than this version use [Pure-FTPd](https://www.pureftpd.org/project/pure-ftpd), which has a bug that prevents FFmpeg from correctly rendering video files. To use higher firmware versions you must also follow [this workaround](https://github.com/shadow-1/yi-hack-v3/issues/129#issuecomment-361723075) to revert back to ftpd.
 </p>
 
 <p class='note warning'>


### PR DESCRIPTION
Today I followed the Yi Home Camera instructions without fully reading the warning about supported versions and accidentally flashed a version which is higher than the currently supported version. 

Rather than downgrading my firmware I found [a workaround](https://github.com/shadow-1/yi-hack-v3/issues/129#issuecomment-361723075) in the `yi-hack-v3` issues. Thanks to this workaround I have successfully set up my camera using the latest firmware.

I thought I would update the docs here to let people know they can also successfully follow this workaround, but I've left it stating that the older version is the highest supported without additional work.

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
