### PR TITLE
Update note about default auth_providers

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -27,7 +27,7 @@ To make the transition from API password to authentication system easier, we've 
 ## {% linkable_title Configuring auth providers %}
 
 <p class='note warning'>
-  Home Assistant automatically configures the standard auth providers, and you <b>do not</b> need to specify auth_providers in your configuration.yaml. Specifying auth_providers in your configuration will disable all auth_providers that are not listed and can reduce your security or create difficulties logging in.
+Home Assistant automatically configures the standard auth providers and you **do not** need to specify `auth_providers` in your `configuration.yaml` file. Specifying `auth_providers` in your configuration will disable all auth providers that are not listed and can reduce your security or create difficulties logging in.
 </p>
 
 Authentication providers are configured in your `configuration.yaml` under the `homeassistant:` block:

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -27,7 +27,7 @@ To make the transition from API password to authentication system easier, we've 
 ## {% linkable_title Configuring auth providers %}
 
 <p class='note warning'>
-By configuring your own instead of using the default configuration, you take full responsibility for the authentication of the system.
+  Home Assistant automatically configures the standard auth providers, and you <b>do not</b> need to specify auth_providers in your configuration.yaml. Specifying auth_providers in your configuration will disable all auth_providers that are not listed and can reduce your security or create difficulties logging in.
 </p>
 
 Authentication providers are configured in your `configuration.yaml` under the `homeassistant:` block:


### PR DESCRIPTION
**Description:**
Update the warning note to specify that HA automatically configures auth_providers, and manually specifying auth_providers in configuration.yaml can cause issues

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
