### PR TITLE
Reworking the customize docs

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -10,7 +10,85 @@ footer: true
 redirect_from: /getting-started/customizing-devices/
 ---
 
+## {% linkable_title Changing the entity_id %}
+
+You can use the UI to change the `entity_id` and friendly name of supported entities. To do this:
+
+1. Select the entity, either from or from the frontend, or by clicking <img src='/images/frontend/entity_box.png' /> next to the entity in the dev-states menu
+2. Click on the cog in the right corner of the entity's dialog
+3. Enter the new name or the new entity ID (remember not to change the domain of the entity - the part before the `.`)
+4. Select *Save*
+
+## {% linkable_title Customizing entities %}
+
 By default, all of your devices will be visible and have a default icon determined by their domain. You can customize the look and feel of your front page by altering some of these parameters. This can be done by overriding attributes of specific entities.
+
+### {% linkable_title Customization using the UI %}
+
+Under the *Configuration* menu you'll find the *Customization* menu. When you select an entity to customize, you'll see all the existing attributes listed and you can customize those, or select an additional supported attribute ([see below](/docs/configuration/customizing-devices/#possible-values)).
+
+#### {% linkable_title Possible values %}
+
+{% configuration customize %}
+friendly_name:
+  description: Name of the entity as displayed in the UI.
+  required: false
+  type: string
+homebridge_name:
+  description: Name of the entity in `HomeBridge`.
+  required: false
+  type: string
+hidden:
+  description: Set to `true` to hide the entity.
+  required: false
+  type: boolean
+  default: False
+homebridge_hidden:
+  description: Set to `true` to hide the entity from `HomeBridge`.
+  required: false
+  type: boolean
+  default: False
+emulated_hue_hidden:
+  description: Set to `true` to hide the entity from `emulated_hue` (this will be deprecated in the near future and should be configured in [`emulated_hue`](/components/emulated_hue)).
+  required: false
+  type: boolean
+  default: False
+entity_picture:
+  description: URL to use as picture for entity.
+  required: false
+  type: string
+icon:
+  description: Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://materialdesignicons.com/cheatsheet)). Prefix name with `mdi:`, ie `mdi:home`.
+  required: false
+  type: string
+assumed_state:
+  description: For switches with an assumed state two buttons are shown (turn off, turn on) instead of a switch. By setting `assumed_state` to `false` you will get the default switch icon.
+  required: false
+  type: boolean
+  default: True
+device_class:
+  description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below).
+  required: false
+  type: boolean
+initial_state:
+  description: Sets the initial state for automations, `on` or `off`.
+  required: false
+  type: string
+unit_of_measurement:
+  description: Defines the units of measurement, if any.
+  required: false
+  type: string
+{% endconfiguration %}
+
+#### {% linkable_title Device Class %}
+
+Device class is currently supported by the following components:
+
+* [Binary Sensor](/components/binary_sensor/)
+* [Sensor](/components/sensor/)
+* [Cover](/components/cover/)
+
+### {% linkable_title Manual customization %}
 
 <p class='note'>
 If you implement `customize`, `customize_domain`, or `customize_glob` you must make sure it is done inside of `homeassistant:` or it will fail.
@@ -53,30 +131,6 @@ homeassistant:
       homebridge_hidden: true
 ```
 
-### {% linkable_title Possible values %}
-
-| Attribute | Description |
-| --------- | ----------- |
-| `friendly_name` | Name of the entity.
-| `homebridge_name` | Name of the entity in `HomeBridge`.
-| `hidden`    | Set to `true` to hide the entity.
-| `homebridge_hidden` | Set to `true` to hide the entity from `HomeBridge`.
-| `emulated_hue_hidden` | Set to `true` to hide the entity from `emulated_hue` (this will be deprecated in the near future and should be configured in [`emulated_hue`](/components/emulated_hue)).
-| `entity_picture` | Url to use as picture for entity.
-| `icon` | Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://materialdesignicons.com/cheatsheet)). Prefix name with `mdi:`, ie `mdi:home`.
-| `assumed_state` | For switches with an assumed state two buttons are shown (turn off, turn on) instead of a switch. By setting `assumed_state` to `false` you will get the default switch icon.
-| `device_class` | Sets the class of the device, changing the device state and icon that is displayed on the UI (see below).
-| `initial_state` | Sets the initial state for automations. `on` or `off`.
-| `unit_of_measurement` | Defines the units of measurement, if any.
-
-### {% linkable_title Device Class %}
-
-Device class is currently supported by the following components:
-
-* [Binary Sensor](/components/binary_sensor/)
-* [Sensor](/components/sensor/)
-* [Cover](/components/cover/)
-
 ### {% linkable_title Reloading customize %}
 
 Home Assistant offers a service to reload the core configuration while Home Assistant is running called `homeassistant.reload_core_config`. This allows you to change your customize section and see it being applied without having to restart Home Assistant. To call this service, go to the <img src='/images/screenshots/developer-tool-services-icon.png' alt='service developer tool icon' class="no-shadow" height="38" /> service developer tools, select the service `homeassistant.reload_core_config` and click "CALL SERVICE".
@@ -84,4 +138,3 @@ Home Assistant offers a service to reload the core configuration while Home Assi
 <p class='note warning'>
 New customize information will be applied the next time the state of the entity gets updated.
 </p>
-


### PR DESCRIPTION
Reworking the customize docs:

1. Add information on using the UI to change the entity ID and name (where supported)
2. Document the use of the UI to customize
3. Rewrite the configuration block to use the new configuration block standard
4. Move the manual editing section towards the end

[This change](https://github.com/home-assistant/home-assistant.io/pull/6188) provides the image referenced
