### PR TITLE
Update documentation to allow for milliseconds

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -74,7 +74,7 @@ Delays are useful for temporarily suspending your script and start it at a later
 {% raw %}
 ```yaml
 # Waits however many minutes input_number.minute_delay is set to
-# Valid formats include HH:MM and HH:MM:SS
+# Valid formats include HH:MM, HH:MM:SS and HH:MM:SS:SSS
 - delay: "{{ states('input_number.minute_delay') | multiply(60) | timestamp_custom('%H:%M:%S',False) }}"
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**
Time period strings can now support milliseconds, update documentation to match

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16401

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
