### PR TITLE
Clarify MQTT Advanced Configuration

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -89,10 +89,11 @@ See the following links for more information:
 
 Add the following configuration to enable ACLs:
 
-1. Set `customize` flag to `true` in your configuration.
+1. Set the `active` flag within the `customize` section to `true` in your configuration.
 2. Create a file in `/share/mosquitto` named `acl.conf` with the following contents:
-
 ```text
 acl_file /share/mosquitto/accesscontrollist
 ```
 3. Create a file in `/share/mosquitto` named `accesscontrollist` and add contents according to your requirements.
+
+The `/share` folder can be found on the host filesystem under `/usr/share/hassio/share`, or via the `Share` folder through SMB (Samba).


### PR DESCRIPTION
Properly describe the flag that needs to be changed and provide additional info on where the .conf files need to live. (Information that took me far longer than necessary to figure out.)

**Description:**
This is a simple documentation update to save the next guy or gal some time when they travel down the same path I just did. The folder path is technically impacted by the 'folder' value within the 'customize' section, but if following the instructions as-written then there isn't an issue.

(Side note: This is my first PR on GitHub, please pardon any mistakes in my process/submission.)

## Checklist:

- [X] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
