### PR TITLE
Added Razberry Board to supported Z-Wave devices table

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -24,6 +24,7 @@ You need to have a [supported Z-Wave USB stick or module](https://github.com/Ope
 | Sigma Designs UZB Stick |                |                  |              |
 | Tricklestar             |                |                  |              |
 | Vision USB Stick        |                |                  |              |
+| ZWave.me Razberry Board |   &#10003;     |                  |              |
 | ZWave.me UZB1           |   &#10003;     |                  |              |
 
 <p class='note'>


### PR DESCRIPTION
**Description:**

Razberry Board support is mentioned below and it even has its own page, so it makes sense to add it to the support table.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [ ] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
