### PR TITLE
Clarify what components work with weather-card

### DIFF
--- a/source/_lovelace/weather-forecast.markdown
+++ b/source/_lovelace/weather-forecast.markdown
@@ -34,3 +34,9 @@ entity:
 - type: weather-forecast
   entity: weather.demo_weather_north
 ```
+
+<p class="note">
+  This card works only with platforms that define a `weather.` entity.
+  
+  E.g. it works with [Dark Sky](https://www.home-assistant.io/components/weather.darksky/) but not [Dark Sky Sensor](https://www.home-assistant.io/components/sensor.darksky/)
+</p>

--- a/source/_lovelace/weather-forecast.markdown
+++ b/source/_lovelace/weather-forecast.markdown
@@ -36,7 +36,7 @@ entity:
 ```
 
 <p class="note">
-  This card works only with platforms that define a `weather.` entity.
+  This card works only with platforms that define a `weather` entity.
   
-  E.g. it works with [Dark Sky](https://www.home-assistant.io/components/weather.darksky/) but not [Dark Sky Sensor](https://www.home-assistant.io/components/sensor.darksky/)
+  E.g., it works with [Dark Sky](https://www.home-assistant.io/components/weather.darksky/) but not [Dark Sky Sensor](https://www.home-assistant.io/components/sensor.darksky/)
 </p>


### PR DESCRIPTION
**Description:**
The lovelace weather card only works with weather components, not weather sensors - a fact that seems to be causing a bit of confusion judging from the frequent questions on discord. I know it took me a while to figure out...

I hope I used the correct nomenclature.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: Fixes, changes and adjustments should be created against `current`. New documentation for platforms/components and features should go to `next`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
