### PR TITLE
Component media_player.spotify doenst support sonos device

### DIFF
--- a/source/_components/media_player.spotify.markdown
+++ b/source/_components/media_player.spotify.markdown
@@ -77,4 +77,4 @@ In this example this is a URI link to the Reggae Infusions playlist, [this suppo
 
 ## {% linkable_title Unsupported devices %}
 
-- **Sonos**: Although its a spotify connect device, its not supported by the offcial spotify API
+- **Sonos**: Although its a Spotify Connect device, it is not supported by the official Spotify API.

--- a/source/_components/media_player.spotify.markdown
+++ b/source/_components/media_player.spotify.markdown
@@ -75,3 +75,6 @@ You can send playlists to spotify via the "media_content_type": "playlist" and "
 
 In this example this is a URI link to the Reggae Infusions playlist, [this support document from Spotify](https://support.spotify.com/us/using_spotify/share_music/why-do-you-have-two-different-link-formats/) explains how to get this URI value to use for playlists in the Spotify component.
 
+## {% linkable_title Unsupported devices %}
+
+- **Sonos**: Although its a spotify connect device, its not supported by the offcial spotify API


### PR DESCRIPTION
**Description:**
For users its not obvious that spotify doesnt support sonos devices, because they normally support spotify connect. See issue home-assistant/home-assistant#15891

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#15891

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
