### PR TITLE
Document the addition of ssl to alarmdecoder

### DIFF
--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -13,7 +13,7 @@ ha_release: 0.43
 ha_iot_class: "Local Push"
 ---
 
-The `alarmdecoder` component will allow Home Assistant users who own either a DSC or Honeywell alarm panel to leverage their alarm system and its sensors to provide Home Assistant with rich information about their homes. Connectivity between Home Assistant and the alarm panel is accomplished through a device produced by Nu Tech Software Solutions, known as the AlarmDecoder. The AlarmDecoder devices provide a serial, TCP/IP socket or USB interface to the alarm panel, where it emulates an alarm keypad. 
+The `alarmdecoder` component will allow Home Assistant users who own either a DSC or Honeywell alarm panel to leverage their alarm system and its sensors to provide Home Assistant with rich information about their homes. Connectivity between Home Assistant and the alarm panel is accomplished through a device produced by Nu Tech Software Solutions, known as the AlarmDecoder. The AlarmDecoder devices provide a serial, TCP/IP socket or USB interface to the alarm panel, where it emulates an alarm keypad.
 
 Please visit the [AlarmDecoder website](https://www.alarmdecoder.com/) for further information about the AlarmDecoder devices.
 
@@ -52,8 +52,33 @@ Configuration variables:
 - **port** (*Optional*): The port of the AlarmDecoder device on your home network, if using socket type. Default: `10000`
 - **path** (*Optional*): The path of the AlarmDecoder device, if using socket type. Default: `/dev/ttyUSB0`
 - **baudrate** (*Optional*): The baud rate of the AlarmDecoder device, if using serial type. Default: `115200`
+- **ssl** (*Optional*): If using socket type, set to `on` or `true` if using an ssl certificate to encrypt the connection. Default: `off`
+- **ssl_self_signed** (*Optional*): If using socket type and ssl, set to `on` or `true` if the ssl certificate on the `ser2sock` server is self signed. Default: `off`
+- **ssl_ca** (*Optional*): If using socket type and ssl, the path to the certificate authority certificate file. Default: `ca.pem` in the root of the HomeAssistant config directory.
+- **ssl_key** (*Optional*): If using socket type and ssl, the path to the client key file. Default: `client.key` in the root of the HomeAssistant config directory.
+- **ssl_cert** (*Optional*): If using socket type and ssl, the path to the client certificate file. Default: `client.pem` in the root of the HomeAssistant config directory.
 - **panel_display** (*Optional*): Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
 - **zones** (*Optional*): AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.*
 - **rfid** (*Optional*): The RF serial-number associated with RF zones. Providing this field allows Home Assistant to associate raw sensor data to a given zone, allowing direct monitoring of the state, battery, and supervision status.
 - **relayaddr** (*Optional*): Address of the relay expander board to associate with the zone. (ex: 12, 13, 14, or 15). Typically used in cases where a panel will not send bypassed zones such as motion during an armed home state, the Vista 20P is an example of this. Alarmdecoder can emulate a zone expander board and the panel can be programmed to push zone events to this virtual expander. This allows the bypassed zone binary sensors to be utilized. One example is using bypassed motion sensors at night for motion-based automated lights while the system is armed with the motion sensor bypassed.
 - **relaychan** (*Optional*): Channel of the relay expander board to associate with the zone. (ex: 1, 2, 3, or 4)
+
+
+SSL Example:
+
+See the Readme for [ser2sock](https://github.com/nutechsoftware/ser2sock) for details in configuring that program with SSL and generating the necessary certificate files.
+
+**It's important to safeguard the client and server certificates. Anybody with the server certificate can generate their own client certificate and access the alarm system. Anybody with the existing client certificate can access the alarm system.**
+```yaml
+# Example configuration.yaml entry
+alarmdecoder:
+  device:
+    type: socket
+    host: 192.168.1.20
+    port: 10000
+    ssl: on
+    ssl_self_signed: on
+    ssl_ca: ca.pem
+    ssl_key: client.key
+    ssl_cert: client.pem
+```


### PR DESCRIPTION
**Description:**
This documents the changes to the alarmdecoder component to support the changes added to the underlying alarmdecoder library to add ssl functionality to that software. I opened an issue to track this: #6221 

AlarmDecoder PRs
https://github.com/nutechsoftware/alarmdecoder/pull/29
https://github.com/nutechsoftware/alarmdecoder/pull/30


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16483
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
