### PR TITLE
Corrected explanatory comment in example.

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -178,7 +178,7 @@ automation:
 automation 2:
   trigger:
     platform: time
-    # When 'at' is used, you cannot also match on hour, minute, seconds.
+    # When 'at' is used, you can also match on hour, minute, seconds.
     # Military time format.
     at: '15:32:00'
 


### PR DESCRIPTION
Time trigger example comment was incorrect. Had "cannot' instead of 'can' trigger on hours, minutes and seconds.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
