### PR TITLE
Adding WiFi note

### DIFF
--- a/source/_components/device_tracker.ping.markdown
+++ b/source/_components/device_tracker.ping.markdown
@@ -15,6 +15,10 @@ ha_release: 0.36
 
 The `ping` device tracker platform offers presence detection by using `ping` to send ICMP echo requests. This can be useful when devices are running a firewall and are blocking UDP or TCP packets but responding to ICMP requests (like Android phones). This tracker doesn't need to know the MAC address since the host can be on a different subnet. This makes this an option to detect hosts on a different subnet when `nmap` or other solutions don't work since `arp` doesn't work.
 
+<p class='note'>
+  Please keep in mind that modern smart phones will usually turn off WiFi when they are idle. Simple trackers like this may not be reliable on their own.
+</p>
+
 ## {% linkable_title Configuration %}
 
 To use this presence detection in your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
Adding a note that modern smart phones may turn off their WiFi when idle, so this tracker may not be reliable when used by itself.
