### PR TITLE
Doorbird auth and event data updates

### DIFF
--- a/source/_components/deconz.markdown
+++ b/source/_components/deconz.markdown
@@ -173,6 +173,36 @@ automation:
 
 ### {% linkable_title Appdaemon %}
 
+#### {% linkable_title Appdaemon event helper %}
+Helper app that creates a sensor `sensor.deconz_event` with a state that represents the id from the last event and an attribute to show the event data.
+
+{% raw %}
+```yaml
+deconz_helper:
+  module: deconz_helper
+  class: DeconzHelper
+```
+
+```python
+import appdaemon.plugins.hass.hassapi as hass
+import datetime
+from datetime import datetime
+
+class DeconzHelper(hass.Hass):
+    def initialize(self) -> None:
+        self.listen_event(self.event_received, "deconz_event")
+
+    def event_received(self, event_name, data, kwargs):
+        event_data = data["event"]
+        event_id = data["id"]
+        event_received = datetime.now()
+
+        self.log("Deconz event received from {}. Event was: {}".format(event_id, event_data))
+        self.set_state("sensor.deconz_event", state = event_id, attributes = {"event_data": event_data, "event_received": str(event_received)})
+```
+{% endraw %}
+
+
 #### {% linkable_title Appdaemon remote template %}
 
 {% raw %}

--- a/source/_components/doorbird.markdown
+++ b/source/_components/doorbird.markdown
@@ -22,6 +22,7 @@ To connect your device, add the following to your `configuration.yaml` file:
 ```yaml
 # Example configuration.yaml entry
 doorbird:
+  token: RANDOM_STRING
   devices:
     - host: DOORBIRD_IP_OR_HOSTNAME
       username: YOUR_USERNAME
@@ -38,6 +39,10 @@ doorbird:
 ```
 
 {% configuration %}
+token:
+  description: Token to be used to authenticate Doorbird calls to Home Assistant.
+  required: true
+  type: string
 devices:
   description: List of doorbird devices.
   required: true
@@ -86,6 +91,9 @@ Home Assistant will fire an event any time a `monitored_condition` happens on a 
 <p class="note warning">
 Enabling any monitored condition will delete all registered notification services on the doorstation every time Home Assistant starts. This will not affect notifications delivered by the DoorBird mobile app.
 </p>
+
+#### {% linkable_title Event Data %}
+Each event includes live image and live video URLs for the Doorbird device that triggered the event. These URLs can be found on the event data and can be useful in automation actions.  For example, you could use `html5_viewer_url` on a notification to be linked directly to the live view of the device that triggered the automation.  NOTE: The URLs on the event will be based on the configuration used to connect to your Doorbird devices.  Connectivity will depend on your network configuration.
 
 ### {% linkable_title Automation Example %}
 ```yaml

--- a/source/_components/vacuum.markdown
+++ b/source/_components/vacuum.markdown
@@ -29,7 +29,7 @@ Before calling one of these services, make sure your vacuum platform supports it
 
 #### {% linkable_title Service `vacuum.turn_on` %}
 
-Start a new cleaning task.
+Start a new cleaning task. For the Xiaomi Vacuum and neato use `vacuum.start` instead.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
@@ -37,7 +37,7 @@ Start a new cleaning task.
 
 #### {% linkable_title Service `vacuum.turn_off` %}
 
-Stop the current cleaning task and return to the dock.
+Stop the current cleaning task and return to the dock. For the Xiaomi Vacuum and neato use `vacuum.stop` instead.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|

--- a/source/_components/vacuum.neato.markdown
+++ b/source/_components/vacuum.neato.markdown
@@ -19,7 +19,7 @@ The status will contain attributes on the robots last clean session.
 
 To add `neato` vacuum to your installation, please follow instructions in [Neato component](/components/neato/).
 
-Currently supported features are:
+Currently supported services are:
 
 - `start`
 - `pause`

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -15,7 +15,7 @@ ha_iot_class: "Local Polling"
 
 The `xiaomi miio` vacuum platform allows you to control the state of your [Xiaomi Mi Robot Vacuum](http://www.mi.com/roomrobot/).
 
-Currently supported features are:
+Currently supported services are:
 
 - `start`
 - `pause`

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -44,6 +44,7 @@ On Raspberry Pi you will need to enable the serial interface in the `raspi-confi
 # Example configuration.yaml entry
 zwave:
   usb_path: /dev/ttyACM0
+  device_config: !include zwave_device_config.yaml
 ```
 
 {% configuration zwave %}
@@ -78,7 +79,7 @@ debug:
   type: boolean
   default: False
 device_config / device_config_domain / device_config_glob:
-  description: This attribute contains node-specific override values. (For releases prior to 0.39 this variable is called **customize**) See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format.
+  description: This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the bellow options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format.
   required: false
   type: string, list
   keys:

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -79,7 +79,7 @@ debug:
   type: boolean
   default: False
 device_config / device_config_domain / device_config_glob:
-  description: This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the bellow options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format.
+  description: "This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the bellow options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format."
   required: false
   type: string, list
   keys:

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -79,7 +79,7 @@ debug:
   type: boolean
   default: False
 device_config / device_config_domain / device_config_glob:
-  description: "This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the bellow options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format."
+  description: "This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the following options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format."
   required: false
   type: string, list
   keys:


### PR DESCRIPTION
Adds token/auth config details as well as event_data details.

**Description:**
Update documentation to match Doorbird auth and event data changes.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16504

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
