### PR TITLE
:pencil2: Fixes typo configuration.yml -> configuration.yaml

### DIFF
--- a/source/_components/konnected.markdown
+++ b/source/_components/konnected.markdown
@@ -25,7 +25,7 @@ This component requires the [`discovery`](https://www.home-assistant.io/componen
 
 ## {% linkable_title Configuration %}
 
-A `konnected` section must be present in the `configuration.yml` file that specifies the Konnected devices on the network and the sensors or actuators attached to them:
+A `konnected` section must be present in the `configuration.yaml` file that specifies the Konnected devices on the network and the sensors or actuators attached to them:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
**Description:**

Fixes #6233

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
