### PR TITLE
Updated setup steps and added testing steps notify.html5.markdown

### DIFF
--- a/source/_components/notify.html5.markdown
+++ b/source/_components/notify.html5.markdown
@@ -72,7 +72,7 @@ The `html5` platform can only function if all of the following requirements are 
 Assuming you have already added the platform to your configuration:
 
 1. Open Home Assistant in Chrome or Firefox.
-2. Assuming you have met all the [requirements](#requirements) above, you should see a new slider for Push Notifications through the profile page Profile > Push notifications.
+2. Load profile page by clicking on the badge next to the Home Assistant title in the sidebar. Assuming you have met all the [requirements](#requirements) above then you should see a new slider for Push Notifications. If the slider is greyed out, ensure you are viewing Home Assistant via its external HTTPS address. If the slider is not visible, ensure you are not in the user configuration (Sidebar, Configuration, Users, View User).
 3. Slide it to the on position.
 4. Within a few seconds you should be prompted to allow notifications from Home Assistant.
 5. Assuming you accept, that's all there is to it!

--- a/source/_components/notify.html5.markdown
+++ b/source/_components/notify.html5.markdown
@@ -79,6 +79,17 @@ Assuming you have already added the platform to your configuration:
 6. (Optional, but highly recommended!) Open the `html5_push_registrations.conf` file in your configuration directory. You will see a new entry for the browser you just added. Rename it from `unnamed device` to a name of your choice, which will make it easier to identify later. _Do not change anything else in this file!_ You need to restart Home Assistant after making any changes to the file.
 
 
+### {% linkable_title Testing %}
+
+Assuming the previous test completed successfully and your browser was registered, you can test the notification as follows:
+
+1. Open Home Assistant in Chrome or Firefox.
+2. Open the sidebar and click the Services button at the bottom (shaped like a remote control), located below the Developer Tools.
+3. From the Services dropdown, search for your HTML5 notify service (E.G. notify.NOTIFIER_NAME) and select it.
+4. In the Service Data text box enter: {"message":"hello world"}, then press the CALL SERVICE button.
+5. If everything worked you should see a popup notification.
+
+
 ### {% linkable_title Usage %}
 
 The `html5` platform accepts a standard notify payload. However, there are also some special features built in which you can control in the payload.


### PR DESCRIPTION
Added more detail to navigating to the enable slider

Ref: https://community.home-assistant.io/t/html5-push-notifications-slider-missing-how-to-debug/67807 


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
