### PR TITLE
correct typo (hassbian-sctipts -> hassbian-scripts)

### DIFF
--- a/source/_docs/installation/hassbian/customization.markdown
+++ b/source/_docs/installation/hassbian/customization.markdown
@@ -35,7 +35,7 @@ These are some of the available suites:
 - [AppDaemon](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/appdaemon.md)
 - [Hassbian](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/hassbian.md)
 - [Home Assistant](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/homeassistant.md)
-- [hassbian-config (hassbian-sctipts)](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/hassbian_config.md)
+- [hassbian-config (hassbian-scripts)](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/hassbian_config.md)
 
 To upgrade any of them simply run `sudo hassbian-config upgrade SUITE`.
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
