### PR TITLE
Doorbird auth and event data

### DIFF
--- a/source/_components/doorbird.markdown
+++ b/source/_components/doorbird.markdown
@@ -22,6 +22,7 @@ To connect your device, add the following to your `configuration.yaml` file:
 ```yaml
 # Example configuration.yaml entry
 doorbird:
+  token: RANDOM_STRING
   devices:
     - host: DOORBIRD_IP_OR_HOSTNAME
       username: YOUR_USERNAME
@@ -38,6 +39,10 @@ doorbird:
 ```
 
 {% configuration %}
+token:
+  description: Token to be used to authenticate Doorbird calls to Home Assistant.
+  required: true
+  type: string
 devices:
   description: List of doorbird devices.
   required: true
@@ -85,6 +90,13 @@ Home Assistant will fire an event any time a `monitored_condition` happens on a 
 
 <p class="note warning">
 Enabling any monitored condition will delete all registered notification services on the doorstation every time Home Assistant starts. This will not affect notifications delivered by the DoorBird mobile app.
+</p>
+
+#### {% linkable_title Event Data %}
+Each event includes live image and live video URLs for the Doorbird device that triggered the event. These URLs can be found on the event data and can be useful in automation actions.  For example, you could use `html5_viewer_url` on a notification to be linked directly to the live view of the device that triggered the automation.
+
+<p class="note">
+The URLs on the event will be based on the configuration used to connect to your Doorbird device.  Ability to connect from outside your network will depend on your configuration.
 </p>
 
 ### {% linkable_title Automation Example %}


### PR DESCRIPTION
Adds token/auth config details as well as event_data details.

**Description:**
Update documentation to match Doorbird auth and event data changes.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#14933

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
