### PR TITLE
Change IOT Class to Local Polling

### DIFF
--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: rainmachine.png
 ha_category: Irrigation
 ha_release: 0.69
-ha_iot_class: "Cloud Polling"
+ha_iot_class: "Local Polling"
 ---
 
 The `rainmachine` component is the main component to integrate all platforms


### PR DESCRIPTION
I browsed through the code and I don't think this component is reaching out beyond the local network to talk to the Rainmachine device.

**Description:**
Changed Cloud Polling to Local Polling

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
