### PR TITLE
Remove .gz from URI for HASSOS OVA.

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -84,7 +84,7 @@ A detailed guide about running Hass.io as a virtual machine is available in the 
 [pi3-64]: https://github.com/home-assistant/hassos/releases/download/1.10/hassos_rpi3-64-1.10.img.gz
 [tinker]: https://github.com/home-assistant/hassos/releases/download/2.2/hassos_tinker-2.2.img.gz
 [odroid-c2]: https://github.com/home-assistant/hassos/releases/download/2.2/hassos_odroid-c2-2.2.img.gz
-[vmdk]: https://github.com/home-assistant/hassos/releases/download/1.10/hassos_ova-1.10.vmdk.gz
+[vmdk]: https://github.com/home-assistant/hassos/releases/download/1.10/hassos_ova-1.10.vmdk
 [linux]: https://github.com/home-assistant/hassio-build/tree/master/install#install-hassio
 [local]: http://hassio.local:8123
 [samba]: /addons/samba/


### PR DESCRIPTION
The current URL of https://github.com/home-assistant/hassos/releases/download/1.10/hassos_ova-1.10.vmdk.gz results in a 404. The correct URL is https://github.com/home-assistant/hassos/releases/download/1.10/hassos_ova-1.10.vmdk .

**Description:**
In source/hassio/installation.markdown, the current URL of https://github.com/home-assistant/hassos/releases/download/1.10/hassos_ova-1.10.vmdk.gz results in a 404. The correct URL is https://github.com/home-assistant/hassos/releases/download/1.10/hassos_ova-1.10.vmdk . This pull request updates the URI of the variable in the markdown.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
