### PR TITLE
Update tuya.markdown

### DIFF
--- a/source/_components/tuya.markdown
+++ b/source/_components/tuya.markdown
@@ -21,9 +21,10 @@ To add your Tuya devices into your Home Assistant installation, add the followin
 
 ```yaml
 tuya:
-  username: YOUR_TUYA_USERNAME
-  password: YOUR_TUYA_PASSWORD
-  country_code: YOUR_ACCOUNT_COUNTRYCODE
+  username: 'YOUR_TUYA_USERNAME'
+  password: 'YOUR_TUYA_PASSWORD'
+  country_code: 'YOUR_ACCOUNT_COUNTRYCODE'
+  platform: 'YOUR_PLATFORM'
 ```
 
 {% configuration %}
@@ -40,8 +41,8 @@ country_code:
   required: true
   type: string
 platform:
-  description: "The app where your account register. `tuya` for Tuya Smart and `smart_life` for Smart Life."
-  required: false
+  description: "The app where your account register. `tuya` for Tuya Smart, `smart_life` for Smart Life, `jinvoo_smart` for Jinvoo Smart."
+  required: true
   type: string
   default: tuya
 {% endconfiguration %}


### PR DESCRIPTION
Values should be enclosed in single quotes so I updated the example accordingly. Platform required was set to false; it is required so I changed it to true and added it to the example. Only two platform options were given- tuya and smart_life. My devices required the platform to be set to 'jinvoo_smart' so I updated the platforms to include that option. If there are other known options, I suggest they be listed as well.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
