### PR TITLE
Fix a typo in date which hide configuration page

### DIFF
--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Configuring Home Assistant"
 description: "Configuring Home Assistant."
-date: 2018-09-18 16:15
+date: 2018-09-08 16:15
 sidebar: true
 comments: false
 sharing: true


### PR DESCRIPTION
**Description:**
Fix a typo in date facade which hide configuration page from current

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
