### PR TITLE
Add image support for hangouts notification

### DIFF
--- a/source/_components/hangouts.markdown
+++ b/source/_components/hangouts.markdown
@@ -165,5 +165,5 @@ Sends a message to the given conversations.
 |------------------------|----------|--------------------------------------------------|
 | target                 | List of targets with id or name. [Required] | [{"id": "UgxrXzVrARmjx_C6AZx4AaABAagBo-6UCw"}, {"name": "Test Conversation"}] |
 | message                | List of message segments, only the "text" field is required in every segment. [Required] | [{"text":"test", "is_bold": false, "is_italic": false, "is_strikethrough": false, "is_underline": false, "parse_str": false, "link_target": "http://google.com"}, ...] |
-| data                   | Extra options | {"image": "path or url"} |
+| data                   | Extra options | {"image_file": "path"} / {"image_url": "url"} |
 

--- a/source/_components/hangouts.markdown
+++ b/source/_components/hangouts.markdown
@@ -165,5 +165,5 @@ Sends a message to the given conversations.
 |------------------------|----------|--------------------------------------------------|
 | target                 | List of targets with id or name. [Required] | [{"id": "UgxrXzVrARmjx_C6AZx4AaABAagBo-6UCw"}, {"name": "Test Conversation"}] |
 | message                | List of message segments, only the "text" field is required in every segment. [Required] | [{"text":"test", "is_bold": false, "is_italic": false, "is_strikethrough": false, "is_underline": false, "parse_str": false, "link_target": "http://google.com"}, ...] |
-
+| data                   | Extra options | {"image": "path or url"} |
 


### PR DESCRIPTION
**Description:**
Add image support for hangouts notifications

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16560

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
