### PR TITLE
Fix a link in lets_encrypt howto re: password

### DIFF
--- a/source/_docs/ecosystem/certificates/lets_encrypt.markdown
+++ b/source/_docs/ecosystem/certificates/lets_encrypt.markdown
@@ -14,7 +14,7 @@ If you are using Hass.io or Hassbian, do not use this guide. Instead, use the [D
 </p>
 
 <p class='note warning'>
-Before exposing your Home Assistant instance to the outside world it is ESSENTIAL that you have set a password following the advice on the [http](/docs/configuration/basic/) page.
+Before exposing your Home Assistant instance to the outside world it is ESSENTIAL that you have set a password following the advice on the [http](/components/http/) page.
 </p>
 
 


### PR DESCRIPTION
The link points to the "basic information" config page but should point to the HTTP component config page. There is no password to be set in basic information.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
