### PR TITLE
Adding warning regarding legacy_api password

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -31,7 +31,7 @@ Home Assistant automatically configures the standard auth providers and you **do
 </p>
 
 <p class='note warning'>
-Legacy API password auth provider wouldn't be loaded if your API password located in separete package. This is because Home Assistant process `auth_provider` during the `core` section loading, it is earlier then do the `packages` processing.
+The legacy API password auth provider won't be loaded if your API password is located in a package. This is because Home Assistant processes the `auth_provider` during the `core` section loading, which is earlier than the `packages` processing.
 </p>
 
 Authentication providers are configured in your `configuration.yaml` under the `homeassistant:` block:

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -31,7 +31,7 @@ Home Assistant automatically configures the standard auth providers and you **do
 </p>
 
 <p class='note warning'>
-The legacy API password auth provider won't be loaded if your API password is located in a package. This is because Home Assistant processes the `auth_provider` during the `core` section loading, which is earlier than the `packages` processing.
+[Issue 16441](https://github.com/home-assistant/home-assistant/issues/16441): the legacy API password auth provider won't be automatically configured if your API password is located in a package. This is because Home Assistant processes the `auth_provider` during the `core` section loading, which is earlier than the `packages` processing.
 </p>
 
 Authentication providers are configured in your `configuration.yaml` under the `homeassistant:` block:

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -30,6 +30,10 @@ To make the transition from API password to authentication system easier, we've 
 Home Assistant automatically configures the standard auth providers and you **do not** need to specify `auth_providers` in your `configuration.yaml` file. Specifying `auth_providers` in your configuration will disable all auth providers that are not listed and can reduce your security or create difficulties logging in.
 </p>
 
+<p class='note warning'>
+Legacy API password auth provider wouldn't be loaded if your API password located in separete package. This is because Home Assistant process `auth_provider` during the `core` section loading, it is earlier then do the `packages` processing.
+</p>
+
 Authentication providers are configured in your `configuration.yaml` under the `homeassistant:` block:
 
 ```yaml


### PR DESCRIPTION
Currently there is an issue home-assistant/home-assistant#16441. Leagacy_api password not loaded if api_password located in package.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
