### PR TITLE
Update konnected.markdown

### DIFF
--- a/source/_components/konnected.markdown
+++ b/source/_components/konnected.markdown
@@ -32,13 +32,13 @@ A `konnected` section must be present in the `configuration.yaml` file that spec
 konnected:
   access_token: REPLACE_ME_WITH_A_RANDOM_STRING
   devices:
-    - id: 8bcd53
+    - id: 438a388bcd53
       binary_sensors:
         - zone: 1
           type: door
       switches:
         - zone: out
-    - id: 438a38
+    - id: 8bcd53438a38
       binary_sensors:
         - pin: 2
           type: door
@@ -62,7 +62,7 @@ devices:
   type: list
   keys:
     id:
-      description: The MAC address of the WiFi module with colons/punctuation removed. You can either use the full 12-character MAC address or only the last 6 characters. This is visible in the device's WiFi SSID and hostname.
+      description: The MAC address of the WiFi module with colons/punctuation removed. You musst use the full 12-character MAC address with lower case letters. This is visible in the device's WiFi SSID and hostname.
       required: true
       type: string
     binary_sensors:

--- a/source/_components/konnected.markdown
+++ b/source/_components/konnected.markdown
@@ -62,7 +62,7 @@ devices:
   type: list
   keys:
     id:
-      description: The MAC address of the WiFi module with colons/punctuation removed. You musst use the full 12-character MAC address with lower case letters. This is visible in the device's WiFi SSID and hostname.
+      description: The MAC address of the WiFi module with colons/punctuation removed. You must use the full 12-character MAC address with lower case letters. This is visible in the device's WiFi SSID and hostname.
       required: true
       type: string
     binary_sensors:


### PR DESCRIPTION
**Description:**
Changed the instructions from use 6 character MAC address to using 12 character since the 6 character abbreviation does not work. Also added that the letters must be lower case since the configuration fails if using upper case letters.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
