### PR TITLE
Add unique_id to mqtt cover

### DIFF
--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -43,6 +43,10 @@ name:
   required: false
   type: string
   default: MQTT Cover
+unique_id:
+  description: An ID that uniquely identifies this cover. If two covers have the same unique ID, Home Assistant will raise an exception.
+  required: false
+  type: string
 command_topic:
   description: The MQTT topic to publish commands to control the cover.
   required: false


### PR DESCRIPTION
**Description:**
Add unique_id documentation to mqtt cover

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16568

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
