### PR TITLE
Add asterisk_cdr platform

### DIFF
--- a/source/_components/mailbox.asterisk_cdr.markdown
+++ b/source/_components/mailbox.asterisk_cdr.markdown
@@ -1,0 +1,15 @@
+---
+layout: page
+title: "Asterisk Call Data Recorder"
+description: "Instructions on how to integrate an Asterisk CDR within Home Assistant."
+date: 2018-09-12 06:30
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: asterisk.png
+ha_category: Mailbox
+ha_release: 0.79
+---
+
+The Asterisk Call Data Recorder provides access to Asterisk call logs on the Asterisk PBX server. This mailbox is enabled automatically through the [Asterisk Voicemail component](/components/asterisk_mbox/) configuration if the `asterisk_mbox_server` is configured to provide CDR data.  More information on configuring the server can be found in the [Asterisk PBX configuration guide](/docs/asterisk_mbox/).

--- a/source/_docs/asterisk_mbox.markdown
+++ b/source/_docs/asterisk_mbox.markdown
@@ -56,6 +56,8 @@ Before beginning make sure that you have the following:
    mbox_path = PATH_TO_VOICEMAIL_FILES
    cache_file = PATH_TO_CACHE_FILE
    google_key = GOOGLE_API_KEY
+   cdr = mysql+pymysql://<mysql-user>:<mysql-password>@localhost/asterisk/cdr
+
    ```
 
    - **host** (*Optional*): The IP address to listen on for client requests. This defaults to all IP addresses on the server. To listen only locally, choose `127.0.0.1`
@@ -64,6 +66,7 @@ Before beginning make sure that you have the following:
    - **mbox\_path** (*Required*): The path to the storage location of mailbox files. This is typically `/var/spool/asterisk/voicemail/default/<mailbox>/`
    - **cache\_file** (*Required*): A fully-qualified path to a file thht can be written by the server containing transcriptions of voicemails. Example: `/var/spool/asterisk/transcription.cache`
    - **google\_key** (*Required*): Your 40 characters Google API key.
+   - **cdr** (*Optional*): Where to find CDR data.  Supports various SQL databases as well as a file log.  Configuring the CDR will enable the `asterisk_cdr` platfom.
 
    Once complete, ensure this file is only accessible by the Asterisk user:
 


### PR DESCRIPTION
**Description:**
Adds asterisk_cdr documentation.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16579

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

