### PR TITLE
Clarify conditional card docs

### DIFF
--- a/source/_lovelace/conditional.markdown
+++ b/source/_lovelace/conditional.markdown
@@ -42,6 +42,8 @@ card:
 
 *one is required (`state` or `state_not`)
 
+Note: Conditions with more than one entity are treated as an 'and' condition. This means that for the card to show, *all* entities must meet the state requirements set.
+
 ### {% linkable_title Examples %}
 
 ```yaml


### PR DESCRIPTION
Clarify that conditions are processed as an 'and' condition, not an 'and/or' when using multiple entity conditions.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
