### PR TITLE
Update link to Google TTS Supported Languages

### DIFF
--- a/source/_components/tts.google.markdown
+++ b/source/_components/tts.google.markdown
@@ -25,7 +25,7 @@ tts:
 Configuration variables:
 
 - **language** (*Optional*): The language to use. Defaults to `en`.
-  - [Complete list of supported languages](https://cloud.google.com/speech-to-text/docs/languages).
+  - [Complete list of supported languages (Languages where "Talk" feature is enabled in Google Translate)](https://translate.google.com/intl/en_ALL/about/languages/), use 2 digit language code which you can find at the end of url when you click on Language name.
 
 A full configuration sample:
 


### PR DESCRIPTION
**Description:**
Looking at the implementation, it uses Google Translate as backend and not Google Cloud Speech engine, updating the link where supported languages can be seen.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
