### PR TITLE
Add note on yeelight music mode

### DIFF
--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -43,6 +43,7 @@ Configuration variables:
 
 #### {% linkable_title Music mode  %}
 Per default the bulb limits the amount of requests per minute to 60, a limitation which can be bypassed by enabling the music mode. In music mode the bulb is commanded to connect back to a socket provided by the component and it tries to keep the connection open, which may not be wanted in all use-cases.
+**Also note that bulbs in music mode will not update their state to "unavailable" if they are disconnected, which can cause delays in Home Assistant**.
 
 ### {% linkable_title Initial setup %}
 <p class='note'>


### PR DESCRIPTION
**Description:**
Music mode makes the light always available. This causes HA to try to turn it on/off which may delay other operations, since yeelight will take a while to respond.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
