### PR TITLE
Z-Wave indicator services to support Cooper Scene Controllers

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -440,62 +440,72 @@ switch:
       button_1_led:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(1) > 0 }}"
         turn_on:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 1 }}"
         turn_off:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 1 }}"
       button_2_led:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(2) > 0 }}"
         turn_on:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 2 }}"
         turn_off:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 2 }}"
       button_3_led:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(4) > 0 }}"
         turn_on:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 4 }}"
         turn_off:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 4 }}"
       button_4_led:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(8) > 0 }}"
         turn_on:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states(scene_contrl_indicator)|int + 8 }}"
         turn_off:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 8 }}"
       button_5_led:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(16) > 0 }}"
         turn_on:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 16 }}"
         turn_off:
-          service: zwave.set_indicator
+          service: zwave.set_node_value
           data_template:
             node_id: 3
+            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 16 }}"
 ```
 {% endraw %}

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -385,3 +385,116 @@ Button three release|Circle|3|1
 Button four tap|Circle with Line|4|0
 Button four hold|Circle with Line|4|2
 Button four release|Circle with Line|4|1
+
+### {% linkable_title RFWDC Cooper 5-button Scene Control Keypad %}
+
+For the RFWDC Cooper 5-button Scene Control Keypad, you may need to update the `COMMAND_CLASS_CENTRAL_SCENE` for each node in your `zwcfg` file with the following:
+
+```xml
+<CommandClass id="91" name="COMMAND_CLASS_CENTRAL_SCENE" version="1" request_flags="5" innif="true" scenecount="0">
+  <Instance index="1" />
+  <Value type="int" genre="system" instance="1" index="0" label="Scene Count" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+  <Value type="int" genre="system" instance="1" index="1" label="Button One" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+  <Value type="int" genre="system" instance="1" index="2" label="Button Two" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+  <Value type="int" genre="system" instance="1" index="3" label="Button Three" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+  <Value type="int" genre="system" instance="1" index="4" label="Button Four" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+  <Value type="int" genre="system" instance="1" index="5" label="Button Five" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+</CommandClass>
+```
+
+Below is a table of the action/scenes for the Buttons:
+
+**Action**|**scene\_id**
+:-----:|:-----:
+Button one tap|1
+Button two tap|2
+Button three tap|3
+Button four tap|4
+Button five tap|5
+
+When a button turns off, the controller sends `basic_set` in a generic `node_event` and does not specify which button was pressed. The status of the buttons is encoded into the `indicator` value, so in order to determine the status of each button, you need to refresh the indicator value. You can also control the LEDs for each button by setting the indicator value. For responsiveness, automations should be triggered with `zwave.scene_activated` events rather than the switch status.
+
+Here is an example configuration needed for the scene controller:
+
+{% raw %}
+```yaml
+automation:
+  - alias: Sync the indicator value on button events
+    trigger:
+      - platform: event
+        event_type: zwave.scene_activated
+        event_data:
+          entity_id: zwave.scene_contrl
+      - platform: event
+        event_type: zwave.node_event
+        event_data:
+          entity_id: zwave.scene_contrl
+    action:
+      - service: zwave.refresh_indicator
+        data: 
+          node_id: 3
+switch:
+  - platform: template
+    switches:
+      button_1_led:
+        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(1) > 0 }}"
+        turn_on:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int + 1 }}"
+        turn_off:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int - 1 }}"
+      button_2_led:
+        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(2) > 0 }}"
+        turn_on:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int + 2 }}"
+        turn_off:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int - 2 }}"
+      button_3_led:
+        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(4) > 0 }}"
+        turn_on:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int + 4 }}"
+        turn_off:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int - 4 }}"
+      button_4_led:
+        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(8) > 0 }}"
+        turn_on:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int + 8 }}"
+        turn_off:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int - 8 }}"
+      button_5_led:
+        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(16) > 0 }}"
+        turn_on:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int + 16 }}"
+        turn_off:
+          service: zwave.set_indicator
+          data_template:
+            node_id: 3
+            value: "{{ states.sensor.scene_contrl_indicator.state | int - 16 }}"
+```
+{% endraw %}

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -430,9 +430,10 @@ automation:
         event_data:
           entity_id: zwave.scene_contrl
     action:
-      - service: zwave.refresh_indicator
-        data: 
+      - service: zwave.refresh_node_value
+        data_template: 
           node_id: 3
+          value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
 switch:
   - platform: template
     switches:

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -437,64 +437,64 @@ switch:
   - platform: template
     switches:
       button_1_led:
-        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(1) > 0 }}"
+        value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(1) > 0 }}"
         turn_on:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int + 1 }}"
+            value: "{{ states('sensor.scene_contrl_indicator')|int + 1 }}"
         turn_off:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int - 1 }}"
+            value: "{{ states('sensor.scene_contrl_indicator')|int - 1 }}"
       button_2_led:
-        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(2) > 0 }}"
+        value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(2) > 0 }}"
         turn_on:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int + 2 }}"
+            value: "{{ states('sensor.scene_contrl_indicator')|int + 2 }}"
         turn_off:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int - 2 }}"
+            value: "{{ states('sensor.scene_contrl_indicator')|int - 2 }}"
       button_3_led:
-        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(4) > 0 }}"
+        value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(4) > 0 }}"
         turn_on:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int + 4 }}"
+            value: "{{ states('sensor.scene_contrl_indicator')|int + 4 }}"
         turn_off:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int - 4 }}"
+            value: "{{ states('sensor.scene_contrl_indicator')|int - 4 }}"
       button_4_led:
-        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(8) > 0 }}"
+        value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(8) > 0 }}"
         turn_on:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int + 8 }}"
+            value: "{{ states(scene_contrl_indicator)|int + 8 }}"
         turn_off:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int - 8 }}"
+            value: "{{ states('sensor.scene_contrl_indicator')|int - 8 }}"
       button_5_led:
-        value_template: "{{ states.sensor.scene_contrl_indicator.state | int | bitwise_and(16) > 0 }}"
+        value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(16) > 0 }}"
         turn_on:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int + 16 }}"
+            value: "{{ states('sensor.scene_contrl_indicator')|int + 16 }}"
         turn_off:
           service: zwave.set_indicator
           data_template:
             node_id: 3
-            value: "{{ states.sensor.scene_contrl_indicator.state | int - 16 }}"
+            value: "{{ states('sensor.scene_contrl_indicator')|int - 16 }}"
 ```
 {% endraw %}

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -433,7 +433,7 @@ automation:
       - service: zwave.refresh_node_value
         data_template: 
           node_id: 3
-          value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+          value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
 switch:
   - platform: template
     switches:
@@ -443,13 +443,13 @@ switch:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 1 }}"
         turn_off:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 1 }}"
       button_2_led:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(2) > 0 }}"
@@ -457,13 +457,13 @@ switch:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 2 }}"
         turn_off:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 2 }}"
       button_3_led:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(4) > 0 }}"
@@ -471,13 +471,13 @@ switch:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 4 }}"
         turn_off:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 4 }}"
       button_4_led:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(8) > 0 }}"
@@ -485,13 +485,13 @@ switch:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states(scene_contrl_indicator)|int + 8 }}"
         turn_off:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 8 }}"
       button_5_led:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(16) > 0 }}"
@@ -499,13 +499,13 @@ switch:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 16 }}"
         turn_off:
           service: zwave.set_node_value
           data_template:
             node_id: 3
-            value_id: "{{ states.sensor.scene_contrl_indicator.attributes.value_id }}"
+            value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 16 }}"
 ```
 {% endraw %}

--- a/source/_docs/z-wave/services.markdown
+++ b/source/_docs/z-wave/services.markdown
@@ -22,6 +22,7 @@ The `zwave` component exposes multiple services to help maintain the network. Al
 | print_config_parameter | Prints Z-Wave node's config parameter value to the (console) log.                                                                            |
 | print_node             | Print all states of Z-Wave node.                                                                                                             |
 | refresh_entity         | Refresh the Z-Wave entity by refreshing dependent values.                                                                                    |
+| refresh_indicator      | Refresh the indicator value of a Z-Wave node.                                                                                                |
 | refresh_node           | Refresh the Z-Wave node.                                                                                                                     |
 | remove_node            | Put the Z-Wave controller in exclusion mode. Allows you to remove a device from the Z-Wave network.                                          |
 | rename_node            | Sets a node's name. Requires a `node_id` and `name` field.                                                                                   |
@@ -30,6 +31,7 @@ The `zwave` component exposes multiple services to help maintain the network. Al
 | replace_failed_node    | Replace a failed device with another. If the node is not in the controller's Failed Node List, or the node responds, this command will fail. |
 | reset_node_meters      | Reset a node's meter values. Only works if the node supports this.                                                                           |
 | set_config_parameter   | Lets the user set a config parameter to a node. NOTE: Use the parameter option's `label` string as the `value` for list parameters (e.g., `"value": "Off"`). For all other parameters use the relevant integer `value` (e.g., `"value": 1`). |
+| set_indicator          | Set the indicator value of a Z-Wave node.                                                                                                    |
 | soft_reset             | Tells the controller to do a "soft reset." This is not supposed to lose any data, but different controllers can behave differently to a "soft reset" command. |
 | start_network          | Starts the Z-Wave network.                                                                                                                   |
 | stop_network           | Stops the Z-Wave network.                                                                                                                    |

--- a/source/_docs/z-wave/services.markdown
+++ b/source/_docs/z-wave/services.markdown
@@ -31,7 +31,7 @@ The `zwave` component exposes multiple services to help maintain the network. Al
 | replace_failed_node    | Replace a failed device with another. If the node is not in the controller's Failed Node List, or the node responds, this command will fail. |
 | reset_node_meters      | Reset a node's meter values. Only works if the node supports this.                                                                           |
 | set_config_parameter   | Lets the user set a config parameter to a node. NOTE: Use the parameter option's `label` string as the `value` for list parameters (e.g., `"value": "Off"`). For all other parameters use the relevant integer `value` (e.g., `"value": 1`). |
-| set_indicator          | Set the indicator value of a Z-Wave node.                                                                                                    |
+| set_node_value         | Set the specified value of a Z-Wave node.                                                                                                    |
 | soft_reset             | Tells the controller to do a "soft reset." This is not supposed to lose any data, but different controllers can behave differently to a "soft reset" command. |
 | start_network          | Starts the Z-Wave network.                                                                                                                   |
 | stop_network           | Stops the Z-Wave network.                                                                                                                    |

--- a/source/_docs/z-wave/services.markdown
+++ b/source/_docs/z-wave/services.markdown
@@ -22,8 +22,8 @@ The `zwave` component exposes multiple services to help maintain the network. Al
 | print_config_parameter | Prints Z-Wave node's config parameter value to the (console) log.                                                                            |
 | print_node             | Print all states of Z-Wave node.                                                                                                             |
 | refresh_entity         | Refresh the Z-Wave entity by refreshing dependent values.                                                                                    |
-| refresh_indicator      | Refresh the indicator value of a Z-Wave node.                                                                                                |
 | refresh_node           | Refresh the Z-Wave node.                                                                                                                     |
+| refresh_node_value     | Refresh the specified value of a Z-Wave node.                                                                                                |
 | remove_node            | Put the Z-Wave controller in exclusion mode. Allows you to remove a device from the Z-Wave network.                                          |
 | rename_node            | Sets a node's name. Requires a `node_id` and `name` field.                                                                                   |
 | rename_value           | Sets a value's name. Requires a `node_id`, `value_id`, and `name` field.                                                                     |


### PR DESCRIPTION
**Description:**
Added documentation for using Cooper 5-button Scene Control Keypads and the services used to enable it be integrated.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16638

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
