### PR TITLE
Fixed MariaDB example

### DIFF
--- a/source/_components/sensor.sql.markdown
+++ b/source/_components/sensor.sql.markdown
@@ -132,9 +132,9 @@ SELECT * FROM states WHERE entity_id='binary_sensor.xyz789' GROUP BY state ORDER
 ```yaml
 sensor:
 - platform: sql
+  db_url: mysql://user:password@localhost/hass
   queries:
     - name: DB size
-      db_url: mysql://user:password@localhost/hass
       query: 'SELECT table_schema "database", Round(Sum(data_length + index_length) / 1024, 1) "value" FROM information_schema.tables WHERE table_schema="hass" GROUP BY table_schema;'
       column: 'value'
       unit_of_measurement: kB


### PR DESCRIPTION
**Description:**

MariaDB example had 'db_url' in the incorrect location under 'queries'.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
