### PR TITLE
New netdata config syntax to allow for multiple elements per group

### DIFF
--- a/source/_components/sensor.netdata.markdown
+++ b/source/_components/sensor.netdata.markdown
@@ -51,9 +51,11 @@ To add this platform to your installation, add the following to your `configurat
 sensor:
   - platform: netdata
     resources:
-      system.load:
+      load:
+        data_group: system.load
         element: load15
-      system.cpu:
+      cpu:
+        data_group: system.cpu
         element: system
 ```
 
@@ -78,19 +80,19 @@ resources:
   required: true
   type: map
   keys:
-    data_group:
-      description: "Name of the data group to monitor, e.g., `system.cpu`." 
+    name:
+      description: Name to use for the sensor in the frontend.
       required: true
+      type: string
       keys:
+        data_group:
+          description: "Name of the data group to monitor, e.g., `system.cpu`." 
+          required: true
+          type: string
         element:
           description: The element of the group to monitor.
           required: true
           type: string
-        name:
-          description: Name to use for the sensor in the frontend.
-          required: false
-          type: string
-          default: element name
         icon:
           description: Icon to use for the sensor.
           required: false


### PR DESCRIPTION
**Description:**

Description of a new syntax that allows multiple elements per group by removing the use of the group as a key.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16656

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/