### PR TITLE
Add additional working brands to iAlarm page

### DIFF
--- a/source/_components/alarm_control_panel.ialarm.markdown
+++ b/source/_components/alarm_control_panel.ialarm.markdown
@@ -46,3 +46,4 @@ alarm_control_panel:
     type: string
 {% endconfiguration %}
 
+This component has also been confirmed to work with the alarm system brands Meian and Emooluxr.

--- a/source/_components/alarm_control_panel.ialarm.markdown
+++ b/source/_components/alarm_control_panel.ialarm.markdown
@@ -46,4 +46,4 @@ alarm_control_panel:
     type: string
 {% endconfiguration %}
 
-This component has also been confirmed to work with the alarm system brands Meian and Emooluxr.
+This platform has also been confirmed to work with the alarm system brands Meian and Emooluxr.


### PR DESCRIPTION
List the other two brands that also work with the iAlarm component. Closes #6282

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
