### PR TITLE
Add aspect_ratio documentation

### DIFF
--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -38,6 +38,10 @@ state_image:
   required: false
   description: "Map entity states to images (`state: image URL`, check the example below)."
   type: object
+aspect_ratio:
+  required: false
+  description: "Forces the height of the image to be a ratio of the width. You may enter a value such as: `16x9`, `16:9`, `1.78`."
+  type: string
 name:
   required: false
   description: Overwrite entity name.

--- a/source/_lovelace/picture-glance.markdown
+++ b/source/_lovelace/picture-glance.markdown
@@ -51,6 +51,10 @@ state_image:
       type: string
       required: false
       description: "`state: image-url`, check the example below."
+aspect_ratio:
+  required: false
+  description: "Forces the height of the image to be a ratio of the width. You may enter a value such as: `16x9`, `16:9`, `1.78`."
+  type: string
 entity:
   required: false
   description: Entity to use for `state_image`.


### PR DESCRIPTION
**Description:** Adds documentation for aspect_ratio for Picture Entity and Picture Glance


**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** home-assistant/home-assistant-polymer#1665

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
