### PR TITLE
KNX Scene needs to be zero-indexed

### DIFF
--- a/source/_components/scene.knx.markdown
+++ b/source/_components/scene.knx.markdown
@@ -32,6 +32,6 @@ scene:
 Configuration variables:
 
 - **address** (*Required*): KNX group address of the binary sensor.
-- **scene_number** (*Required*): KNX scene number to be activated.
+- **scene_number** (*Required*): Zero-indexed KNX scene number to be activated.
 - **name** (*Optional*): A name for this device used within Home Assistant.
 


### PR DESCRIPTION
**Description:**
Fixed docs for KNX scenes by stating they need to be zero-indexed.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
