### PR TITLE
Update on velbus docu

### DIFF
--- a/source/_components/sensor.velbus.markdown
+++ b/source/_components/sensor.velbus.markdown
@@ -13,6 +13,6 @@ ha_iot_class: "Local Push"
 ha_release: 0.78
 ---
 
-The `velbus` sensor allows you to control [Velbus](http://www.velbus.eu) connected temperature sensors.
+The `velbus` sensor allows you to control [Velbus](http://www.velbus.eu) connected sensors.
 
 For hub configuration, see [the Velbus component](/components/velbus/).

--- a/source/_components/velbus.markdown
+++ b/source/_components/velbus.markdown
@@ -13,21 +13,27 @@ ha_iot_class: "Local Push"
 ha_release: "0.50"
 ---
 
-The `velbus` component supports the Velbus USB and serial gateways.
+The `velbus` component supports the Velbus USB, Velbus serial and a TCP/IP gateway.
 
 ## {% linkable_title Configuration %}
 
 The gateway needs to be configured by adding the following lines to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry for a USB or serial interface
 velbus:
   port: '/dev/ttyUSB00'
 ```
 
+```yaml
+# Example configuration.yaml entry for a TCP/IP interface
+velbus:
+  port: '127.0.0.1:3678'
+```
+
 {% configuration %}
 port:
-  description: The port where your board is connected to your Home Assistant host. The port will be most likely named `ttyUSB*`.
+  description: The port where your board is connected to your Home Assistant host.
   required: true
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
update velbus docu:
- document the tcp/ip gateway
- remove the temperature from the sensor, as this is not true anymore

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
