### PR TITLE
Fix in the listing of all sensor types

### DIFF
--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -74,7 +74,7 @@ sensors:
       description: the conditions to create sensors from
       required: false
       type: list
-      default: all ( `current_ozone_index`, `current_uv_index`, `current_uv_level`, `max_uv_index`, `safe_exposure_time_type_1`, `safe_exposure_time_type_2`, `safe_exposure_time_type_3`, `safe_exposure_time_type_4`, `safe_exposure_time_type_5`, `safe_exposure_time_type_6` )
+      default: all ( `current_ozone_level`, `current_uv_index`, `current_uv_level`, `max_uv_index`, `safe_exposure_time_type_1`, `safe_exposure_time_type_2`, `safe_exposure_time_type_3`, `safe_exposure_time_type_4`, `safe_exposure_time_type_5`, `safe_exposure_time_type_6` )
 {% endconfiguration %}
 
 ## {% linkable_title Binary Sensor Types %}


### PR DESCRIPTION
In monitored_conditions key list of all items 'current_ozone_index' changed to 'current_ozone_level'.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
