### PR TITLE
Add mode to darksky

### DIFF
--- a/source/_components/weather.darksky.markdown
+++ b/source/_components/weather.darksky.markdown
@@ -59,15 +59,14 @@ name:
   type: string
   default: Open Sky
 mode:
-  description: Can specify `hourly` or `daily`.
+  description: "The forecast type. Can be `hourly` or `daily`."
   required: false
   type: string
-  default: `hourly`
+  default: hourly
 {% endconfiguration %}
 
 <p class='note'>
-This platform is an alternative to the [`darksky`](/components/sensor.darksky/)
-sensor.
+This platform is an alternative to the [`darksky`](/components/sensor.darksky/) sensor.
 </p>
 
 Details about the API are available in the [Dark Sky documentation](https://darksky.net/dev/docs).

--- a/source/_components/weather.darksky.markdown
+++ b/source/_components/weather.darksky.markdown
@@ -58,6 +58,11 @@ name:
   required: false
   type: string
   default: Open Sky
+mode:
+  description: Can specify `hourly` or `daily`.
+  required: false
+  type: string
+  default: `hourly`
 {% endconfiguration %}
 
 <p class='note'>


### PR DESCRIPTION
**Description:**
Adds mode to darksky weather component

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16719

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
