### PR TITLE
Add unique_id to mqtt_json light

### DIFF
--- a/source/_components/light.mqtt_json.markdown
+++ b/source/_components/light.mqtt_json.markdown
@@ -56,6 +56,10 @@ name:
   required: false
   type: string
   default: MQTT JSON Light
+unique_id:
+   description: An ID that uniquely identifies this light. If two lights have the same unique ID, Home Assistant will raise an exception.
+   required: false
+   type: string
 command_topic:
   description: The MQTT topic to publish commands to change the light’s state.
   required: true


### PR DESCRIPTION
**Description:**
Add unique_id to mqtt_json light. Applies changes from #6121 to mqtt_json component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16721
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/