### PR TITLE
Changed save_on_change to default to False

### DIFF
--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -28,7 +28,7 @@ light:
         name: Living Room
         transition: 1000
         use_music_mode: True #(defaults to False)
-        save_on_change: False #(defaults to True)
+        save_on_change: True #(defaults to False)
       192.168.1.13:
         name: Front Door
 ```
@@ -39,7 +39,7 @@ Configuration variables:
 - **name** (*Optional*): A friendly name for the device.
 - **transition** (*Optional*, default 350): Smooth transitions over time (in ms).
 - **use_music_mode** (*Optional*, default False): Enable music mode.
-- **save_on_change** (*Optional*, default True): Saves the bulb state when changed from Home Assistant.
+- **save_on_change** (*Optional*, default False): Saves the bulb state in its nonvolatile memory when changed from Home Assistant.
 
 #### {% linkable_title Music mode  %}
 Per default the bulb limits the amount of requests per minute to 60, a limitation which can be bypassed by enabling the music mode. In music mode the bulb is commanded to connect back to a socket provided by the component and it tries to keep the connection open, which may not be wanted in all use-cases.


### PR DESCRIPTION
**Description:**
The default behavior to rewrite the configuration flash in the Yeelight lamps on *every state change* made from Home Assistant is a bad idea in my opinion. I have not tested how quickly the flash wears out, but it's probably between 1E4 and 1E5. cycles If it's EEPROM backed, it's still only 10 to 100 times more.

Documentation change to reflect proposed code change.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/16744

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
