### PR TITLE
Clarity update

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -18,7 +18,7 @@ Home Assistant uses [SQLAlchemy](http://www.sqlalchemy.org/) as Object Relationa
 
 The default database engine is [SQLite](https://www.sqlite.org/) which doesn't require any configuration. The database is stored in your Home Assistant configuration directory (`.homeassistant`) and called `home-assistant_v2.db`.
 
-To set up the `recorder` component in your installation, add the following to your `configuration.yaml` file:
+To change the defaults for `recorder` component in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -128,7 +128,7 @@ Call the service `recorder.purge` to start a purge task which deletes events and
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `keep_days`            |      yes | The number of history days to keep in recorder database (defaults to the component `purge_keep_days` configuration)
-| `repack`               |      yes | Rewrite the entire database, possibly saving some disk space (only supported for SQLite)
+| `repack`               |      yes | Rewrite the entire database, possibly saving some disk space. Only supported for SQLite and requires at least as much disk space free as the database currently uses.
 
 ### {% linkable_title Restore State %}
 


### PR DESCRIPTION
Even without `recorder:` in the config, the recorder is configured with the default settings. Updating the docs to reflect this.

This is something that others have commented on in confusion, and I got around to verifying today on my test (0.78) system.
