### PR TITLE
deCONZ cover documentation

### DIFF
--- a/source/_components/cover.deconz.markdown
+++ b/source/_components/cover.deconz.markdown
@@ -1,0 +1,26 @@
+---
+layout: page
+title: "deCONZ Covers"
+description: "Instructions on how to integrate Zigbee covers from deCONZ into Home Assistant."
+date: 2018-09-20 23:32
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: deconz.jpeg
+ha_category: Cover
+ha_release: "0.79"
+ha_iot_class: "Local Push"
+---
+
+See the [deCONZ main component](/components/deconz/) for configuration instructions.
+
+Covers are devices like ventilation dampers.
+
+Note that devices in the cover platform identify as lights, so there is a manually curated list that defines which "lights" are covers.
+
+The `entity_id` name will be `cover.device_name`, where `device_name` is defined in deCONZ.
+
+#### {% linkable_title Verified supported covers %}
+
+- Keen vents

--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -15,7 +15,7 @@ The display style of each entity can be modified in the [customize section](/get
  
 | Attribute | Default | Description |
 | --------- | ------- | ----------- |
-| `device_class` | | `none` Generic cover device<br>`window` Window controller<br>`garage` Garage door controller
+| `device_class` | | `none` Generic cover device<br>`damper` Ventilation damper controller<br>`garage` Garage door controller<br>`window` Window controller
 | `assumed_state` | `false` | If set to `true`, cover buttons will always be enabled
 
 ## {% linkable_title Services %}


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16759

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
