### PR TITLE
Typo correction in the 'set_fanspeed' params

### DIFF
--- a/source/_components/vacuum.markdown
+++ b/source/_components/vacuum.markdown
@@ -106,7 +106,7 @@ Set the fan speed of the vacuum. The `fanspeed` can be a label, as `balanced` or
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
-| `fanspeed`                |       no | Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium', or by percentage, between 0 and 100. |
+| `fan_speed`               |       no | Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium', or by percentage, between 0 and 100. |
 
 #### {% linkable_title Service `vacuum.send_command` %}
 


### PR DESCRIPTION
**Description:**
It's not `fanspeed` but `fan_speed` in `set_fanspeed` params

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
