### PR TITLE
Update upgrading.markdown

### DIFF
--- a/source/_docs/installation/hassbian/upgrading.markdown
+++ b/source/_docs/installation/hassbian/upgrading.markdown
@@ -20,7 +20,7 @@ $ sudo apt-get -y upgrade
 
 #### {% linkable_title Updating Home Assistant %}
 <p class='note'>
-You can use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade homeassistant`
+You can use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade home-assistant`
 </p>
 
 To update the Home Assistant installation execute the following command as the `pi` user.


### PR DESCRIPTION
**Description:**
The Note on Upgrading Hassbian has a hyphen missing.

On page is:  sudo hassbian-config upgrade homeassistant
should be:    sudo hassbian-config upgrade home-assistant
See URL https://www.home-assistant.io/docs/installation/hassbian/upgrading/

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
