### PR TITLE
Remove stale version warning

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -11,10 +11,6 @@ footer: true
 ---
 
 <p class='note warning'>
-This page only apply to release 0.77 and above.
-</p>
-
-<p class='note warning'>
 This is an advanced feature. If misconfigured, you will not be able to access Home Assistant anymore!
 </p>
 


### PR DESCRIPTION
**Description:**

This feature is now released, so this warning isn't necessary any longer.