### PR TITLE
Fixed typo

### DIFF
--- a/source/_components/media_player.kodi.markdown
+++ b/source/_components/media_player.kodi.markdown
@@ -196,7 +196,7 @@ media_player:
 ```
 
 <p class='note'>
-This example and the following requires to have the [script.json-cec](https://github.com/joshjowen/script.json-cec) plugin installed on your kodi player. It'll also expose th endpoints standy, toggle and activate without authentication on your kodi player. Use this with caution.
+This example and the following requires to have the [script.json-cec](https://github.com/joshjowen/script.json-cec) plugin installed on your kodi player. It'll also expose the endpoints standby, toggle and activate without authentication on your kodi player. Use this with caution.
 </p>
 
 ### {% linkable_title Kodi services samples %}


### PR DESCRIPTION
**Description:**
Fixed typo


## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
