### PR TITLE
Name property (breaking change)

### DIFF
--- a/source/_components/sensor.dnsip.markdown
+++ b/source/_components/sensor.dnsip.markdown
@@ -34,6 +34,7 @@ sensor:
 Configuration variables:
 
 - **hostname** (*Optional*): The hostname for which to perform the DNS query. Default: `myip.opendns.com` (special hostname that resolves to your public IP)
+- **name** (*Optional*): Name of the sensor. Default `myip` or hostname without dots if specified.
 - **resolver** (*Optional*): The DNS server to target the query at. Default: `208.67.222.222` (OpenDNS)
 - **ipv6** (*Optional*): Set this to `true` or `false` if IPv6 should be used. When resolving the public IP, this will be the IP of the machine where Home Assistant is running on.
 - **resolver_ipv6** (*Optional*): The IPv6 DNS server to target the query at. Default: `2620:0:ccc::2` (OpenDNS)
@@ -49,5 +50,6 @@ sensor:
   # Resolve IP address of home-assistant.io via Google DNS
   - platform: dnsip
     hostname: home-assistant.io
+    name: hass
     resolver: 8.8.8.8
 ```


### PR DESCRIPTION
Adressing [comment](https://github.com/home-assistant/home-assistant/pull/16205#issuecomment-423811182) to reflect actual behaviour.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant/) (if applicable):** home-assistant/home-assistant#16205

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
