### PR TITLE
Use HA native OAuth2 flow for google assistant components

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -32,19 +32,22 @@ You need to create an API Key with the [Google Console](https://console.cloud.go
 1. Create a new project in the [developer console](https://console.actions.google.com/).  
   a. Add/Import project, give it a name    
   b. Click on `Home Control` card, select the `Smart home` recommendation.
-  c. Create an Action, under the build section. Add in your Home Assistant URL: `https://[YOUR HOME ASSISTANT URL:PORT]/api/google_assistant`, replace the `[YOUR HOME ASSISTANT URL:PORT]` with the domain / ip address and the port under which your Home Assistant is reachable. If you have set `api_password:` add this password to the URL. E.g., `https://[YOUR HOME ASSISTANT URL:PORT]/api/google_assistant?api_password=[YOUR API PASSWORD]`)  
+  c. Create an Action, under the build section. Add in your Home Assistant URL: `https://[YOUR HOME ASSISTANT URL:PORT]/api/google_assistant`, replace the `[YOUR HOME ASSISTANT URL:PORT]` with the domain / ip address and the port under which your Home Assistant is reachable.  
   d. Click `Done`. Then click on `Overview`, which will lead you back to the app details screen.  
 2. `Account linking` is required for your app to interact with Home Assistant. Set this up under the `Quick Setup` section
 	a. Leave it at the default `No, I only want to allow account creation on my website` and select Next  
-	b. For the `Linking type` select `OAuth` and `Implicit`  
-	c. Client ID: The `client_id` from your Home Assistant configuration above  
-	d. Authorization URL (replace with your actual URL): `https://[YOUR HOME ASSISTANT URL:PORT]/api/google_assistant/auth`. If you have set `api_password:` add this password to the URL `https://[YOUR HOME ASSISTANT URL:PORT]/api/google_assistant/auth?api_password=[YOUR API PASSWORD]`)  
-	e. Configure your client. Add scopes for `email` and `name`.  
-	f. Testing instructions: Enter anything. It doesn't matter since you won't submit this app.
-3. Back on the overview page. Click `Simulator` under `TEST`. You don't have to actually test .
+	b. For the `Linking type` select `OAuth` and `Authorization Code`  
+	c. Client ID: `https://oauth-redirect.googleusercontent.com/`, the trailing slash is important
+	d. Client Secret: Anything you like, Home Assistant don't need this field
+	e. Authorization URL (replace with your actual URL): `https://[YOUR HOME ASSISTANT URL:PORT]/auth/authorize`.
+	f. Token URL (replace with your actual URL): `https://[YOUR HOME ASSISTANT URL:PORT]/auth/token`.
+	g. Configure your client. Add scopes for `email` and `name`.  
+	h. Do NOT check `Google to transmit clientID and secret via HTTP basic auth header`
+	i. Testing instructions: Enter anything. It doesn't matter since you won't submit this app.
+3. Back on the overview page. Click `Simulator` under `TEST`. It will create a new draft version Test App. You don't have to actually test.
 4. If you haven't already added the component configuration to `configuration.yaml` file and restarted Home Assistant, you'll be unable to continue until you have.
 5. Open the Google Assistant app and go into `Settings > Home Control`
-6. Click the `+` sign, and near the bottom, you should have `[test] your app name`. Selecting that should lead you the screen where you can set rooms for your devices or nicknames for your devices.
+6. Click the `+` sign, and near the bottom, you should have `[test] your app name`. Selecting that should lead you to a browser to login your Home Assistant instance, then redirect back to a screen where you can set rooms for your devices or nicknames for your devices.
 7. If you want to allow other household users to control the devices:  
 	a. Go to the settings for the project you created in point 1 in the developer console.  
 	b. Under the gear icon, click `Permissions`  
@@ -64,9 +67,6 @@ To enable this, add the following lines to your `configuration.yaml` file:
 # Example configuration.yaml entry
 google_assistant:
   project_id: someproject-2d0b8
-  client_id: [long URL safe random string]
-  access_token: [a different long URL safe random string]
-  agent_user_id: [a string to identify user]
   api_key: [a Homegraph API Key generated for the Google Actions project]
   exposed_domains:
     - switch
@@ -90,18 +90,6 @@ Configuration variables:
 project_id:
   description: Project ID from the Google Developer console (looks like `words-2ab12`)
   required: true
-  type: string
-client_id:
-  description: A long random URL safe string (no spaces or special characters) that will be used for Implicit OAuth (example `aBcDeFgHiJkLmNoP`)
-  required: true
-  type: string
-access_token:
-  description: Another different long random URL safe string  (example `aBcDeFgHiJkLmNoP`)
-  required: true
-  type: string
-agent_user_id:
-  description: A string to identify the user, e.g., email address. If not provided, the component will generate one.
-  required: false
   type: string
 api_key:
   description: Your API key.


### PR DESCRIPTION
**Description:**
Use HA native OAuth2 flow for google assistant components 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16848

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
