### PR TITLE
Clarify MQTT light RGB color format

### DIFF
--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -122,11 +122,11 @@ rgb_command_template:
   required: false
   type: string
 rgb_command_topic:
-  description: "The MQTT topic to publish commands to change the light's RGB state. Please note that the color value sent by home-assistant is normalized to full brightness if `brightness_command_topic` is set. Brightness information is in this case sent separately in the `brightness_command_topic`. This will cause a a light that expects an absolute color value (including brightness) to flicker."
+  description: "The MQTT topic to publish commands to change the light's RGB state. Please note that the color value sent by Home Assistant is normalized to full brightness if `brightness_command_topic` is set. Brightness information is in this case sent separately in the `brightness_command_topic`. This will cause a light that expects an absolute color value (including brightness) to flicker."
   required: false
   type: string
 rgb_state_topic:
-  description: "The MQTT topic subscribed to receive RGB state updates. The expected payload is the RGB values separated by commas, for example `255,0,127`. Please note that the color value received by home-assistant is normalized to full brightness. Brightness information is received separately in the `brightness_state_topic`."
+  description: "The MQTT topic subscribed to receive RGB state updates. The expected payload is the RGB values separated by commas, for example, `255,0,127`. Please note that the color value received by Home Assistant is normalized to full brightness. Brightness information is received separately in the `brightness_state_topic`."
   required: false
   type: string
 rgb_value_template:

--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -123,7 +123,7 @@ rgb_command_template:
   type: string
 rgb_command_topic:
   description: "The MQTT topic to publish commands to change the light's RGB state."
-  note: The color value sent by home-assistant is normalized to full brightness if `brightness_command_topic`is set. Brightness information is in this case sent separately in the `brightness_command_topic`. This will cause a a light that expects an absolute color value (including brightness) to flicker.
+  note: The color value sent by home-assistant is normalized to full brightness if `brightness_command_topic` is set. Brightness information is in this case sent separately in the `brightness_command_topic`. This will cause a a light that expects an absolute color value (including brightness) to flicker.
   required: false
   type: string
 rgb_state_topic:

--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -123,10 +123,12 @@ rgb_command_template:
   type: string
 rgb_command_topic:
   description: "The MQTT topic to publish commands to change the light's RGB state."
+  note: The color value sent by home-assistant is normalized to full brightness. Brightness information is sent separately in the `brightness_value_topic`. This will cause a a light that expects an absolute color value (including brightness) to flicker.
   required: false
   type: string
 rgb_state_topic:
   description: The MQTT topic subscribed to receive RGB state updates. The expected payload is the RGB values separated by commas, for example `255,0,127`.
+  note: The color value received by home-assistant is normalized to full brightness. Brightness information is received separately in the `brightness_state_topic`.
   required: false
   type: string
 rgb_value_template:

--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -123,7 +123,7 @@ rgb_command_template:
   type: string
 rgb_command_topic:
   description: "The MQTT topic to publish commands to change the light's RGB state."
-  note: The color value sent by home-assistant is normalized to full brightness. Brightness information is sent separately in the `brightness_value_topic`. This will cause a a light that expects an absolute color value (including brightness) to flicker.
+  note: The color value sent by home-assistant is normalized to full brightness if `brightness_command_topic`is set. Brightness information is in this case sent separately in the `brightness_command_topic`. This will cause a a light that expects an absolute color value (including brightness) to flicker.
   required: false
   type: string
 rgb_state_topic:

--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -122,13 +122,11 @@ rgb_command_template:
   required: false
   type: string
 rgb_command_topic:
-  description: "The MQTT topic to publish commands to change the light's RGB state."
-  note: The color value sent by home-assistant is normalized to full brightness if `brightness_command_topic` is set. Brightness information is in this case sent separately in the `brightness_command_topic`. This will cause a a light that expects an absolute color value (including brightness) to flicker.
+  description: "The MQTT topic to publish commands to change the light's RGB state. Please note that the color value sent by home-assistant is normalized to full brightness if `brightness_command_topic` is set. Brightness information is in this case sent separately in the `brightness_command_topic`. This will cause a a light that expects an absolute color value (including brightness) to flicker."
   required: false
   type: string
 rgb_state_topic:
-  description: The MQTT topic subscribed to receive RGB state updates. The expected payload is the RGB values separated by commas, for example `255,0,127`.
-  note: The color value received by home-assistant is normalized to full brightness. Brightness information is received separately in the `brightness_state_topic`.
+  description: "The MQTT topic subscribed to receive RGB state updates. The expected payload is the RGB values separated by commas, for example `255,0,127`. Please note that the color value received by home-assistant is normalized to full brightness. Brightness information is received separately in the `brightness_state_topic`."
   required: false
   type: string
 rgb_value_template:


### PR DESCRIPTION
Clarify that RGB color received and sent by MQTT light is normalized to full brightness

## Checklist:

- [x] Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
