### PR TITLE
Add pressure sensor device class

### DIFF
--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -22,6 +22,7 @@ The way these sensors are displayed in the frontend can be modified in the [cust
 - **humidity**: Percentage of humidity in the air.
 - **illuminance**: The current light level in lx or lm.
 - **temperature**: Temperature in °C or °F.
+- **pressure**: Pressure in hPa or mbar.
 
 <p class='img'>
 <img src='/images/screenshots/sensor_device_classes_icons.png' />


### PR DESCRIPTION
**Description:**

Add pressure sensor device class. See https://github.com/home-assistant/architecture/issues/24

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16965

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
