### PR TITLE
Rachio modernization updates

### DIFF
--- a/source/_components/binary_sensor.rachio.markdown
+++ b/source/_components/binary_sensor.rachio.markdown
@@ -17,16 +17,4 @@ The `rachio` binary sensor platform allows you to view the status of your [Rachi
 
 Once configured, a binary sensor will be added that shows whether or not each controller in the account provided is online and reachable by Rachio's servers.
 
-<p class='note'>
-You must have the [Rachio component](/components/rachio/) configured to use this switch.
-</p>
-
-## {% linkable_title Configuration %}
-
-To add this platform to your installation, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-binary_sensor:
-  - platform: rachio
-```
+They will be automatically added if the [Rachio component](/components/rachio/) component is loaded.

--- a/source/_components/rachio.markdown
+++ b/source/_components/rachio.markdown
@@ -32,7 +32,17 @@ rachio:
   api_key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
-Follow the instructions on [Rachio Binary Sensor](/components/binary_sensor.rachio/) or [Rachio Switch](/components/switch.rachio/) to add Rachio platforms.
+Configuration variables:
+
+- **api_key** (*Required*): The API key for the Rachio account.
+- **manual_run_mins** (*Optional*): For how long, in minutes, to turn on a station when the switch is enabled. Defaults to 10 minutes.
+
+<p class='note'>
+**Water-saving suggestion:**<br>
+Set `manual_run_mins` to a high maximum failsafe value when using scripts to control zones. If something goes wrong with your script, Home Assistant, or you hit the Rachio API rate limit of 1700 calls per day, the controller will still turn off the zone after this amount of time.
+</p>
+
+Once configured, [Rachio Binary Sensor](/components/binary_sensor.rachio/) and [Rachio Switch](/components/switch.rachio/) platforms will be automatically loaded.
 
 ### {% linkable_title iFrame %}
 

--- a/source/_components/switch.rachio.markdown
+++ b/source/_components/switch.rachio.markdown
@@ -15,30 +15,9 @@ ha_release: 0.46
 
 The `rachio` switch platform allows you to toggle zones connected to your [Rachio irrigation system](http://rachio.com/) on and off.
 
-Once configured, a switch will be added for every zone that is enabled on every controller in the account provided, as well as a switch to toggle each controller's standby mode. 
+Once configured, a switch will be added for every zone that is enabled on every controller in the account provided, as well as a switch to toggle each controller's standby mode.
 
-<p class='note'>
-You must have the [Rachio component](/components/rachio/) configured to use this switch.
-</p>
-
-## {% linkable_title Configuration %}
-
-To add this platform to your installation, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-switch:
-  - platform: rachio
-```
-
-Configuration variables:
-
-- **manual_run_mins** (*Optional*): For how long, in minutes, to turn on a station when the switch is enabled. Defaults to 10 minutes.
-
-<p class='note'>
-**Water-saving suggestion:**<br>
-Set `manual_run_mins` to a high maximum failsafe value when using scripts to control zones. If something goes wrong with your script, Home Assistant, or you hit the Rachio API rate limit of 1700 calls per day, the controller will still turn off the zone after this amount of time.
-</p> 
+They will be automatically added if the [Rachio component](/components/rachio/) is loaded.
 
 ## {% linkable_title Examples %}
 


### PR DESCRIPTION
**Description:**

Removed instructions for configuring Rachio platforms, moved manual_run_time to Rachio component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16911

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
