### PR TITLE
wirelesstag: update low_battery to battery

### DIFF
--- a/source/_components/binary_sensor.wirelesstag.markdown
+++ b/source/_components/binary_sensor.wirelesstag.markdown
@@ -24,7 +24,7 @@ binary_sensor:
     monitored_conditions:
       - presence
       - door
-      - low_battery
+      - battery
 ```
 
 {% configuration %}
@@ -45,4 +45,4 @@ The following conditions can be monitored:
 * (`wet`): On means too wet (humidity), Off means normal.
 * (`light`): On means light detected, Off means no light.
 * (`moisture`): On means moisture detected (wet), Off means no moisture (dry).
-* (`low_battery`): On means tag battery is low, Off means normal.
+* (`battery`): On means tag battery is low, Off means normal.


### PR DESCRIPTION
**Description:**

Updates docs to the new condition name as of this commit:

https://github.com/home-assistant/home-assistant/commit/657b34f4bb89ea62093ef0f783551cbf6a21e53e#diff-b1619cfacd2bce39d63ad3617b4ab5efR55

## Related issue this fixes

#6393 

## Additional

I cannot test this is correct, as I do not have this `binary_sensor`, but according to the latest [python file](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/binary_sensor/wirelesstag.py) this should be correct.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
