### PR TITLE
Add IoT class to Unifi device trackers

### DIFF
--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -9,6 +9,7 @@ sharing: true
 footer: true
 logo: ubiquiti.png
 ha_category: Presence Detection
+ha_iot_class: "Local Polling"
 ha_release: 0.14
 ---
 

--- a/source/_components/device_tracker.unifi_direct.markdown
+++ b/source/_components/device_tracker.unifi_direct.markdown
@@ -9,6 +9,7 @@ sharing: true
 footer: true
 logo: ubiquiti.png
 ha_category: Presence Detection
+ha_iot_class: "Local Polling"
 ha_release: 0.59
 ---
 


### PR DESCRIPTION
**Description:**
IoT classes missing from Unifi device trackers

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** /

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
