### PR TITLE
Vasttrafik sensor configuration variable style

### DIFF
--- a/source/_components/sensor.vasttrafik.markdown
+++ b/source/_components/sensor.vasttrafik.markdown
@@ -49,7 +49,7 @@ departures:
       type: string
     from:
       description: "The start station."
-      required: false
+      required: true
       type: string
     heading:
       description: "Direction of the traveling."

--- a/source/_components/sensor.vasttrafik.markdown
+++ b/source/_components/sensor.vasttrafik.markdown
@@ -29,16 +29,42 @@ sensor:
       - from: Musikvägen
 ```
 
-Configuration variables:
-
-- **key** (*Required*): The API key to access your Västtrafik account.
-- **secret** (*Required*): The API secret to access your Västtrafik account.
-- **departures** array (*Required*): List of travel routes.
-  - **name** (*Optional*): Name of the route.
-  - **from** (*Required*): The start station.
-  - **heading** (*Optional*): Direction of the traveling.
-  - **lines** (*Optional*): Only consider these lines.
-  - **delay** (*Optional*): Delay in minutes. Defaults to 0.
+{% configuration %}
+key:
+  description: "The API key to access your Västtrafik account."
+  required: true
+  type: string
+secret:
+  description: "The API secret to access your Västtrafik account."
+  required: true
+  type: string
+departures:
+  description: "List of travel routes."
+  required: true
+  type: map
+  keys:
+    name:
+      description: "Name of the route."
+      required: false
+      type: string
+    from:
+      description: "The start station."
+      required: false
+      type: string
+    heading:
+      description: "Direction of the traveling."
+      required: false
+      type: string
+    lines:
+      description: "Only consider these lines."
+      required: false
+      type: string
+    delay:
+      description: "Delay in minutes."
+      required: false
+      type: string
+      default: 0
+{% endconfiguration %}
 
 The data are coming from [Västtrafik](https://vasttrafik.se/).
 

--- a/source/_components/sensor.vasttrafik.markdown
+++ b/source/_components/sensor.vasttrafik.markdown
@@ -58,7 +58,7 @@ departures:
     lines:
       description: Only consider these lines.
       required: false
-      type: string
+      type: [list, string]
     delay:
       description: Delay in minutes.
       required: false

--- a/source/_components/sensor.vasttrafik.markdown
+++ b/source/_components/sensor.vasttrafik.markdown
@@ -23,8 +23,8 @@ Add the data to your `configuration.yaml` file as shown in the example:
 # Example configuration.yaml entry
 sensor:
   - platform: vasttrafik
-    key: XXXXXXXXXXXXXXXXXXX
-    secret: YYYYYYYYYYYYYYYYY
+    key: YOUR_API_KEY
+    secret: YOUR_API_SECRET
     departures:
       - from: Musikvägen
 ```
@@ -74,8 +74,8 @@ A full configuration example could look like this:
 # Example configuration.yaml entry
 sensor:
   - platform: vasttrafik
-    key: XXXXXXXXXXXXXXXXXXX
-    secret: YYYYYYYYYYYYYYYYY
+    key: YOUR_API_KEY
+    secret: YOUR_API_SECRET
     departures:
       - name: Mot järntorget
         from: Musikvägen

--- a/source/_components/sensor.vasttrafik.markdown
+++ b/source/_components/sensor.vasttrafik.markdown
@@ -41,7 +41,7 @@ secret:
 departures:
   description: List of travel routes.
   required: true
-  type: map
+  type: list
   keys:
     name:
       description: Name of the route.

--- a/source/_components/sensor.vasttrafik.markdown
+++ b/source/_components/sensor.vasttrafik.markdown
@@ -35,7 +35,8 @@ key:
   required: true
   type: string
 secret:
-  description: The API secret to access your Västtrafik account.  required: true
+  description: The API secret to access your Västtrafik account.
+  required: true
   type: string
 departures:
   description: List of travel routes.

--- a/source/_components/sensor.vasttrafik.markdown
+++ b/source/_components/sensor.vasttrafik.markdown
@@ -31,36 +31,35 @@ sensor:
 
 {% configuration %}
 key:
-  description: "The API key to access your Västtrafik account."
+  description: The API key to access your Västtrafik account.
   required: true
   type: string
 secret:
-  description: "The API secret to access your Västtrafik account."
-  required: true
+  description: The API secret to access your Västtrafik account.  required: true
   type: string
 departures:
-  description: "List of travel routes."
+  description: List of travel routes.
   required: true
   type: map
   keys:
     name:
-      description: "Name of the route."
+      description: Name of the route.
       required: false
       type: string
     from:
-      description: "The start station."
+      description: The start station.
       required: true
       type: string
     heading:
-      description: "Direction of the traveling."
+      description: Direction of the traveling.
       required: false
       type: string
     lines:
-      description: "Only consider these lines."
+      description: Only consider these lines.
       required: false
       type: string
     delay:
-      description: "Delay in minutes."
+      description: Delay in minutes.
       required: false
       type: string
       default: 0


### PR DESCRIPTION
Change to new style for configuration variables description.

Related to #6385.

**Description:**

Update style of Västtrafik sensor documentation to follow new configuration variables description.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
