### PR TITLE
Remove note about mjpeg camera errors

### DIFF
--- a/source/_components/camera.mjpeg.markdown
+++ b/source/_components/camera.mjpeg.markdown
@@ -34,10 +34,6 @@ Configuration variables:
 - **password** (*Optional*): The password for accessing your camera.
 - **authentication** (*Optional*): `basic` (default) or `digest` auth for requests.
 
-<p class='note'>
-There is a <a href="https://github.com/shazow/urllib3/issues/800" target="_blank">known issue in urllib3</a> that you will get error messages in your logs like <code>[StartBoundaryNotFoundDefect(), MultipartInvariantViolationDefect()], unparsed data: ''</code> but the component still works fine. You can ignore the messages. 
-</p>
-
 ## {% linkable_title Examples %}
 
 Example of using a DCS-930L Wireless N Network Camera from D-Link:


### PR DESCRIPTION
**Description:**
home-assistant/home-assistant#17042 suppresses the errors mentioned in the note. Once it is merged this note can be removed.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17042

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
