### PR TITLE
Update configuration variables description

### DIFF
--- a/source/_components/binary_sensor.wirelesstag.markdown
+++ b/source/_components/binary_sensor.wirelesstag.markdown
@@ -15,6 +15,8 @@ ha_release: 0.68
 
 To get your [wirelesstag.net](http://wirelesstag.net) binary sensors working within Home Assistant, please follow the instructions for the general [WirelessTag component](/components/wirelesstag).
 
+## {% linkable_title Configuration %}
+
 To enable tags set up with your [wirelesstag.net](http://wirelesstag.net) account, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -28,21 +30,30 @@ binary_sensor:
 ```
 
 {% configuration %}
-  monitored_conditions:
-    description: The conditions types to monitor; valid values are specified below
-    required: true
-    type: list
+monitored_conditions:
+  description: The conditions types to monitor.
+  required: true
+  type: map
+  keys:
+    presence:
+      description: On means in range, Off means out of range.
+    motion:
+      description: On when a movement was detected, Off when clear.
+    door:
+      description: On when a door is open, Off when the door is closed.
+    cold:
+      description: On means temperature become too cold, Off means normal.
+    heat:
+      description: On means hot, Off means normal.
+    dry:
+      description: On means too dry (humidity), Off means normal.
+    wet:
+      description: On means too wet (humidity), Off means normal.
+    light:
+      description: On means light detected, Off means no light.
+    moisture:
+      description: On means moisture detected (wet), Off means no moisture (dry).
+    battery:
+      description: On means tag battery is low, Off means normal.
 {% endconfiguration %}
 
-The following conditions can be monitored:
-
-* (`presence`): On means in range, Off means out of range.
-* (`motion`): On when a movement was detected, Off when clear.
-* (`door`): On when a door is open, Off when the door is closed.
-* (`cold`): On means temperature become too cold, Off means normal.
-* (`heat`): On means hot, Off means normal.
-* (`dry`): On means too dry (humidity), Off means normal.
-* (`wet`): On means too wet (humidity), Off means normal.
-* (`light`): On means light detected, Off means no light.
-* (`moisture`): On means moisture detected (wet), Off means no moisture (dry).
-* (`battery`): On means tag battery is low, Off means normal.

--- a/source/_components/binary_sensor.wirelesstag.markdown
+++ b/source/_components/binary_sensor.wirelesstag.markdown
@@ -33,7 +33,7 @@ binary_sensor:
 monitored_conditions:
   description: The conditions types to monitor.
   required: true
-  type: map
+  type: list
   keys:
     presence:
       description: On means in range, Off means out of range.

--- a/source/_components/sensor.wirelesstag.markdown
+++ b/source/_components/sensor.wirelesstag.markdown
@@ -39,7 +39,7 @@ monitored_conditions:
     humidity:
       description: "Humidity level in %."
     moisture:
-      description:" Water level/soil moisture in % (applicable for Water Tag only)."
+      description: "Water level/soil moisture in % (applicable for Water Tag only)."
     light:
       description: Brightness in lux (if supported by tag).
 {% endconfiguration %}

--- a/source/_components/sensor.wirelesstag.markdown
+++ b/source/_components/sensor.wirelesstag.markdown
@@ -15,6 +15,8 @@ ha_release: 0.68
 
 To get your [wirelesstag.net](http://wirelesstag.net) sensors working within Home Assistant, please follow the instructions for the general [WirelessTag component](/components/wirelesstag).
 
+## {% linkable_title Configuration %}
+
 To enable tags set up with your [wirelesstag.net](http://wirelesstag.net) account, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -27,15 +29,18 @@ sensor:
 ```
 
 {% configuration %}
-  monitored_conditions:
-    description: The metrics types to monitor; valid values are specified below
-    required: true
-    type: list
+monitored_conditions:
+  description: The metrics types to monitor.
+  required: true
+  type: map
+  keys:
+    temperature:
+      description: Value is in Celsius or Fahrenheit (according to your settings at Tag Manager).
+    humidity:
+      description: "Humidity level in %."
+    moisture:
+      description:" Water level/soil moisture in % (applicable for Water Tag only)."
+    light:
+      description: Brightness in lux (if supported by tag).
 {% endconfiguration %}
 
-The following metrics can be monitored:
-
-* (`temperature`): Value is in Celsius or Fahrenheit (according to your settings at Tag Manager).
-* (`humidity`): Humidity level in %.
-* (`moisture`): Water level/soil moisture in % (applicable for Water Tag only).
-* (`light`): Brightness in lux (if supported by tag).

--- a/source/_components/sensor.wirelesstag.markdown
+++ b/source/_components/sensor.wirelesstag.markdown
@@ -32,7 +32,7 @@ sensor:
 monitored_conditions:
   description: The metrics types to monitor.
   required: true
-  type: map
+  type: list
   keys:
     temperature:
       description: Value is in Celsius or Fahrenheit (according to your settings at Tag Manager).

--- a/source/_components/switch.wirelesstag.markdown
+++ b/source/_components/switch.wirelesstag.markdown
@@ -30,7 +30,7 @@ switch:
 monitored_conditions:
   description: The metrics types to control.
   required: true
-  type: map
+  type: list
   keys:
     temperature:
       description: Control arm/disarm temperature monitoring.

--- a/source/_components/switch.wirelesstag.markdown
+++ b/source/_components/switch.wirelesstag.markdown
@@ -27,19 +27,22 @@ switch:
 ```
 
 {% configuration %}
-  monitored_conditions:
-    description: The metrics types to control; valid values are specified below
-    required: true
-    type: list
+monitored_conditions:
+  description: The metrics types to control.
+  required: true
+  type: map
+  keys:
+    temperature:
+      description: Control arm/disarm temperature monitoring.
+    humidity:
+      description: Control arm/disarm humidity monitoring.
+    motion:
+      description: Control arm/disarm motion and door open/close events monitoring.
+    light:
+      description: Control monitoring of light changes.
+    moisture:
+      description: Control monitoring of water level/soil moisture for water sensor.
 {% endconfiguration %}
-
-The following metrics can be controlled:
-
-* (`temperature`): Control arm/disarm temperature monitoring.
-* (`humidity`): Control arm/disarm humidity monitoring.
-* (`motion`): Control arm/disarm motion and door open/close events monitoring.
-* (`light`): Control monitoring of light changes.
-* (`moisture`): Control monitoring of water level/soil moisture for water sensor.
 
 Arm/Disarm of motion switch is required to receive motion and door binary sensors events.
 Others are only needed if you want to receive push notifications from tags on a specific range of changes in temperature, humidity, light or moisture.


### PR DESCRIPTION
**Description:**
Fix for the configuration variables description

Related to #6385.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
