### PR TITLE
Hue configuration variable style

### DIFF
--- a/source/_components/hue.markdown
+++ b/source/_components/hue.markdown
@@ -33,12 +33,24 @@ hue:
     - host: DEVICE_IP_ADDRESS
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address of the device, eg. 192.168.1.10. Required if not using the `discovery` component to discover Hue bridges.
-- **allow_unreachable** (*Optional*): (true/false)  This will allow unreachable bulbs to report their state correctly.
-- **filename** (*Optional*): Make this unique if specifying multiple Hue hubs.
-- **allow_hue_groups** (*Optional*): (true/false) Enable this to stop Home Assistant from importing the groups defined on the Hue bridge.
+{% configuration %}
+host:
+  description: The IP address of the device, eg. 192.168.1.10. Required if not using the `discovery` component to discover Hue bridges.
+  required: true
+  type: string
+allow_unreachable:
+  description: This will allow unreachable bulbs to report their state correctly.
+  required: false
+  type: boolean
+filename:
+  description: Make this unique if specifying multiple Hue hubs.
+  required: false
+  type: string
+allow_hue_groups:
+  description: Enable this to stop Home Assistant from importing the groups defined on the Hue bridge.
+  required: false
+  type: boolean
+{% endconfiguration %}
 
 ## {% linkable_title Examples %}
 


### PR DESCRIPTION
**Description:**

Update style of hue documentation to follow new configuration variables description.

Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
