### PR TITLE
Added Transporter digital input

### DIFF
--- a/source/_components/media_player.squeezebox.markdown
+++ b/source/_components/media_player.squeezebox.markdown
@@ -34,6 +34,22 @@ Configuration variables:
 
 <p class='note'>This platform now uses the web interface of the Logitech Media Server to send commands. The default port of the web interface is 9000. It is the same port that you use to access the LMS through your web browser. Originally, this platform used the telnet interface, which defaults to 9090. If you previously specified the port in your configuration file, you will likely need to update it.</p>
 
+
+The Logitech Transporter which have two digital inputs can be activated using a script. The following example turns on the Transporter and activates the toslink input interface:
+
+```yaml
+# Turn on Transporter and activate toslink interface
+transporter_toslink:
+  sequence:
+    - service: homeassistant.turn_on
+      entity_id: media_player.transporter
+    - service: media_player.play_media
+      data:
+        entity_id: media_player.transporter
+        media_content_id: "source:toslink"
+        media_content_type: "music"    
+```
+
 ### {% linkable_title Service `squeezebox_call_method` %}
 
 Call a custom Squeezebox JSONRPC API.


### PR DESCRIPTION
**Description:**
Added Transporter digital input script

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
