### PR TITLE
Documentation for home-assistant/home-assistant#17065

### DIFF
--- a/source/_components/camera.onvif.markdown
+++ b/source/_components/camera.onvif.markdown
@@ -43,8 +43,8 @@ If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your ca
 | Service data attribute | Description |
 | -----------------------| ----------- |
 | `entity_id` | String or list of strings that point at `entity_id`s of cameras. Else targets all.
-| `tilt` | Tilt direction. Allowed values: `UP`, `DOWN`
-| `pan` | Pan direction. Allowed values: `RIGHT`, `LEFT`
-| `zoom` | Zoom. Allowed values: `ZOOM_IN`, `ZOOM_OUT`
+| `tilt` | Tilt direction. Allowed values: `UP`, `DOWN`, `NONE`
+| `pan` | Pan direction. Allowed values: `RIGHT`, `LEFT`, `NONE`
+| `zoom` | Zoom. Allowed values: `ZOOM_IN`, `ZOOM_OUT`, `NONE`
 
 If you are running into trouble with this sensor, please refer to the [Troubleshooting section](/components/ffmpeg/#troubleshooting).


### PR DESCRIPTION
**Description:**
Documention update to go with home-assistant/home-assistant#17065.

New option `NONE` for input arguments `pan`, `tilt`, and `zoom`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17065

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
