### PR TITLE
Added example based on event platform

### DIFF
--- a/source/_components/persistent_notification.markdown
+++ b/source/_components/persistent_notification.markdown
@@ -57,6 +57,7 @@ action:
 ```
 
 This automation example shows a notification when the Z-Wave network is starting and removes it when the network is ready.
+
 ```yaml
 - alias: 'Z-Wave network is starting'
   trigger:
@@ -78,7 +79,6 @@ This automation example shows a notification when the Z-Wave network is starting
       data:
         notification_id: zwave
 ```
-
 
 ### {% linkable_title Markdown support %}
 

--- a/source/_components/persistent_notification.markdown
+++ b/source/_components/persistent_notification.markdown
@@ -56,6 +56,29 @@ action:
     notification_id: "1234"
 ```
 
+This automation example shows a notification when the Z-Wave network is starting and removes it when the network is ready.
+```yaml
+- alias: 'Z-Wave network is starting'
+  trigger:
+    - platform: event
+      event_type: zwave.network_start
+  action:
+    - service: persistent_notification.create
+      data:
+        title: "Z-Wave"
+        message: "Z-Wave network is starting..."
+        notification_id: zwave
+
+- alias: 'Z-Wave network is ready'
+  trigger:
+    - platform: event
+      event_type: zwave.network_ready
+  action:
+    - service: persistent_notification.dismiss
+      data:
+        notification_id: zwave
+```
+
 
 ### {% linkable_title Markdown support %}
 


### PR DESCRIPTION
**Description:**
Persistent notification automation example based on event platform

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
