### PR TITLE
Added example of pushbullet target

### DIFF
--- a/source/_components/notify.pushbullet.markdown
+++ b/source/_components/notify.pushbullet.markdown
@@ -99,6 +99,18 @@ action:
 
 - **file_url** (*Required*): File to send with Pushbullet.
 
+### {% linkable_title Single target %}
+```yaml
+  action:
+    service: notify.NOTIFIER_NAME
+    data:
+      title: "Send to one device"
+      message: "This only goes to one specific device"
+      target: device/DEVICE_NAME
+```
+- **target**: Pushbullet device to recive the notification.
+
+
 <p class='note'>
 Don't forget to [whitelist external directories](/docs/configuration/basic/), so Home Assistant has access to them.
 </p>


### PR DESCRIPTION
**Description:**
Added config for sending a notification to only one pushbullet device, using an automation.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
