### PR TITLE
Added list of routers that is known to work with the libary

### DIFF
--- a/source/_components/huawei_lte.markdown
+++ b/source/_components/huawei_lte.markdown
@@ -50,11 +50,11 @@ password:
 
 ### {% linkable_title Tested routers %}
 
-Routers we know to be working with this component are from the Libarys readme and some users in the Homeassistant discord:
+Routers we know to be working with this component based on the documentation of used libraries and reports by users:
 
-* Huawei B310s-22
-* Huawei B525s-23a
-* Huawei E5186s-22a
-* Huawei B618
+- Huawei B310s-22
+- Huawei B525s-23a
+- Huawei E5186s-22a
+- Huawei B618
 
-This is not a complete list and the component can probably connect to other Huawei LTE routers running simular firmware
+This is not a complete list. The component can probably connect to other Huawei LTE routers running similar firmware.

--- a/source/_components/huawei_lte.markdown
+++ b/source/_components/huawei_lte.markdown
@@ -50,10 +50,11 @@ password:
 
 ### {% linkable_title Tested routers %}
 
-The [libary](https://pypi.org/project/huawei-lte-api/) that this component uses has been tested with these routers:
+Routers we know to be working with this component are from the Libarys readme and some users in the Homeassistant discord:
 
 * Huawei B310s-22
 * Huawei B525s-23a
 * Huawei E5186s-22a
+* Huawei B618
 
 This is not a complete list and the component can probably connect to other Huawei LTE routers running simular firmware

--- a/source/_components/huawei_lte.markdown
+++ b/source/_components/huawei_lte.markdown
@@ -47,3 +47,13 @@ password:
     required: true
     type: string
 {% endconfiguration %}
+
+### {% linkable_title Tested routers %}
+
+The [libary](https://pypi.org/project/huawei-lte-api/) that this component uses has been tested with these routers:
+
+* Huawei B310s-22
+* Huawei B525s-23a
+* Huawei E5186s-22a
+
+This is not a complete list and the component can probably connect to other Huawei LTE routers running simular firmware


### PR DESCRIPTION
**Description:**

added list of know working routers, based off of the list on the modules github

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
