### PR TITLE
Add comment about alarm_type versions

### DIFF
--- a/source/_docs/z-wave/entities.markdown
+++ b/source/_docs/z-wave/entities.markdown
@@ -25,16 +25,32 @@ This is for a single purpose sensor, multi sensors are explained under Multi Sen
 
 Devices (usually sensors) that support the Alarm command class will create entities starting with `sensor`, and with some generic suffixes, and a suffix that relates to the supported alarm class. For example, the smoke detector `lounge` will have an entity `sensor.lounge_smoke`, and possibly also `sensor.lounge_alarm_type` and `sensor.lounge_alarm_level`. If the device creates a `binary_sensor` entity, it is recommended to use that rather then the `sensor` entity.
 
+Note that the older Z-Wave alarm command class version 1 didn't have standardized types, and so each manufacturer specified their own version and type info. With Version 2 the alarm type was standardized to the below list. See the [openzwave alarm command class documents](https://github.com/OpenZWave/open-zwave/wiki/Alarm-Command-Class) for more info. You can see which version your sensor supports via the zwcfg_0x\*.xml file. An example with version 2 support:
+```xml
+<CommandClass id="113" name="COMMAND_CLASS_ALARM" version="2" request_flags="2" innif="true">
+```
+
 ### {% linkable_title Alarm Type Entity %}
 
-- **alarm_type**: Reports the type of the sensor
+[//]: # (from the openzwave source found here: https://github.com/OpenZWave/open-zwave/blob/master/cpp/src/command_classes/Alarm.cpp#L56)
+
+- Version 2 **alarm_type**:
   - **0**: General purpose
   - **1**: Smoke sensor
   - **2**: Carbon Monoxide (CO) sensor
   - **3**: Carbon Dioxide (CO2) sensor
   - **4**: Heat sensor
-  - **5**: Water leak sensor
+  - **5**: Water leak (flood) sensor
   - **6**: Access control
+  - **7**: Burglar
+  - **8**: Power management
+  - **9**: System
+  - **10**: Emergency
+  - **11**: Clock
+  - **12**: Appliance
+  - **13**: Home Health
+
+- Version 1 (manufacturer-specific) **alarm_type**:
   - **9**: Lock jammed
   - **18**: Lock locked with user code
   - **19**: Lock unlocked with user code


### PR DESCRIPTION
**Description:**
Added info about the alarm_type from the openzwave code. I believe there is some mixed info based on older V1 alarms vs new V2 alarms. V2 have fixed alarm_types so I've separated the two to make it clear which one a user should look at.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
