### PR TITLE
Add warning about recovery model with MSSQL Server

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -168,7 +168,8 @@ Unix Socket connections always bring performance advantages over TCP, if the dat
 If you want to use Unix Sockets for PostgreSQL you need to modify the `pg_hba.conf`. See [PostgreSQL](#postgresql)</p>
 
 <p class='note warning'>
-If you are using the default FULL recovery model for MS SQL Server you will need to manually backup your log file to prevent your transaction log from growing too large.  It is recommended you change the recovery model to SIMPLE unless you are worried about data loss between backups. </p>
+If you are using the default `FULL` recovery model for MS SQL Server you will need to manually backup your log file to prevent your transaction log from growing too large. It is recommended you change the recovery model to `SIMPLE` unless you are worried about data loss between backups.
+</p>
 
 ### {% linkable_title Database startup %}
 

--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -167,6 +167,9 @@ Unix Socket connections always bring performance advantages over TCP, if the dat
 <p class='note warning'>
 If you want to use Unix Sockets for PostgreSQL you need to modify the `pg_hba.conf`. See [PostgreSQL](#postgresql)</p>
 
+<p class='note warning'>
+If you are using the default FULL recovery model for MS SQL Server you will need to manually backup your log file to prevent your transaction log from growing too large.  It is recommended you change the recovery model to SIMPLE unless you are worried about data loss between backups. </p>
+
 ### {% linkable_title Database startup %}
 
 If you are running a database server instance on the same server as Home Assistant then you must ensure that this service starts before Home Assistant. For a Linux instance running Systemd (Raspberry Pi, Debian, Ubuntu and others) then you should edit the service file.


### PR DESCRIPTION
Added warning to make users aware that the default recovery model in MSSQL server will grow the transaction log until the disk runs out of space.  Suggested that users switch to simple recovery to prevent this issue.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
