### PR TITLE
Enhance description and usage examples

### DIFF
--- a/source/_components/lock.markdown
+++ b/source/_components/lock.markdown
@@ -14,6 +14,44 @@ Keeps track which locks are in your environment, their state and allows you to c
  * Maintains a state per lock and a combined state `all_locks`.
  * Registers services `lock.lock` and `lock.unlock` to control locks.
 
+### {% linkable_title Services %}
+
+A lock component provides the following services:
+
+#### {% linkable_title Service `lock.lock` %} 
+
+Lock your door, the attribute should appear under a 'data' attribute for the service.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |       no | Entity of the relevant lock.                          |
+
+##### {% linkable_title Example %}
+
+```yaml
+action:
+  service: lock.lock
+  data:
+    entity_id: lock.my_place
+```
+
+#### {% linkable_title Service `lock.unlock` %} 
+
+Unlock your door, the attribute should appear under a 'data' attribute for the service.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |       no | Entity of the relevant lock.                          |
+
+##### {% linkable_title Example %}
+
+```yaml
+action:
+  service: lock.unlock
+  data:
+    entity_id: lock.my_place
+```
+
 ### {% linkable_title Use the services %}
 
 Go to the **Developer Tools**, then to **Call Service** in the frontend, and choose `lock.lock` or `lock.unlock` from the list of available services (**Services:** on the left). Enter something like the sample below into the **Service Data** field and hit **CALL SERVICE**.


### PR DESCRIPTION
After trying to write some automations to Sesame lock, I noticed documentation of this component was a bit lacking...

**Description:**

Added some specific sections for the prominent service lock & unlock + examples of use in automation.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `current`
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
