### PR TITLE
document new behavior

### DIFF
--- a/source/_components/notify.yessssms.markdown
+++ b/source/_components/notify.yessssms.markdown
@@ -43,5 +43,7 @@ Configuration variables:
 - **recipient** (*Required*): This is the phone number you want to send the SMS notification to.
 
 <p class='note warning'>
-Verify that your credentials work on [Yesss.at's website](https://yesss.at). Using the wrong credentials three times in a row will get you blocked for one hour.
+Verify that your credentials work on [Yesss.at's website](https://yesss.at). Using the wrong credentials three times in a row will get you suspended for one hour.
+Home Assistant will not try to login after the account has been suspended.
+Re-check the credentials and restart Home Assistant.
 </p>


### PR DESCRIPTION
notify.yessssms will not reconnect to yesss.at when the account is
suspended, because of wrong credentials. Restart with new credentials
is required.


**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17052

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
