### PR TITLE
Ping Sensor configuration variable style

### DIFF
--- a/source/_components/device_tracker.ping.markdown
+++ b/source/_components/device_tracker.ping.markdown
@@ -31,9 +31,15 @@ device_tracker:
       hostone: 192.168.2.10
 ```
 
-Configuration variables:
-
-- **hosts** array (*Required*): List of device names and their corresponding IP address or hostname.
-- **count** (*Optional*): Number of packet used for each device (avoid false detection).
+{% configuration %}
+hosts:
+  description: List of device names and their corresponding IP address or hostname.
+  required: true
+  type: array
+count:
+  description: Number of packet used for each device (avoid false detection).
+  required: false
+  type: int
+{% endconfiguration %}
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
Change to new style for configuration variables description.

Related to #6385.

**Description:**

Configuration variable explanation style update.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
