### PR TITLE
int -> integer

### DIFF
--- a/source/_components/ads.markdown
+++ b/source/_components/ads.markdown
@@ -32,7 +32,7 @@ ads:
   port:
     required: true
     description: The port that runs the AMS server on the device, typically this would be 801 or 851.
-    type: int
+    type: integer
   ip_address:
     required: false
     description: The IP address of the ADS device, if not set the first 4 bytes of the device id will be used.

--- a/source/_components/amcrest.markdown
+++ b/source/_components/amcrest.markdown
@@ -68,7 +68,7 @@ name:
 port:
   description: The port that the camera is running on.
   required: false
-  type: int
+  type: integer
   default: 80
 resolution:
   description: >
@@ -103,7 +103,7 @@ authentication:
 scan_interval:
   description: Defines the update interval of the sensor in seconds.
   required: false
-  type: int
+  type: integer
   default: 10
 sensors:
   description: >

--- a/source/_components/apcupsd.markdown
+++ b/source/_components/apcupsd.markdown
@@ -32,7 +32,7 @@ host:
 port:
   description: The port on which the APCUPSd NIS is listening.
   required: false
-  type: int
+  type: integer
   default: 3551
 {% endconfiguration %}
 

--- a/source/_components/arlo.markdown
+++ b/source/_components/arlo.markdown
@@ -38,7 +38,7 @@ password:
 scan_interval:
   description: How frequently to query for new data. Defaults to 60 seconds.
   required: false
-  type: int
+  type: integer
 {% endconfiguration %}
 
 It is recommended to create a dedicated user on Arlo website to be used within Home Assistant and then share your Arlo cameras.

--- a/source/_components/august.markdown
+++ b/source/_components/august.markdown
@@ -49,7 +49,7 @@ password:
 timeout:
   description: Timeout to wait for connections.
   required: false
-  type: int
+  type: integer
   default: 10
 {% endconfiguration %}
 

--- a/source/_components/binary_sensor.arest.markdown
+++ b/source/_components/binary_sensor.arest.markdown
@@ -36,7 +36,7 @@ resource:
 pin:
   description: Number of the pin to monitor.
   required: true
-  type: int
+  type: integer
 name:
   description: Let you overwrite the name of the device. By default *name* from the device is used.
   required: false

--- a/source/_components/binary_sensor.hikvision.markdown
+++ b/source/_components/binary_sensor.hikvision.markdown
@@ -94,7 +94,7 @@ name:
 port:
   description: The port to connect to the camera on.
   required: false
-  type: int
+  type: integer
   default: 80
 ssl:
   description: "`true` if you want to connect with https. Be sure to set the port also."
@@ -119,7 +119,7 @@ customize:
         Home Assistant in seconds. This is useful to catch multiple quick trips
         in one window without the state toggling on and off.
       required: false
-      type: int
+      type: integer
       default: 5
 {% endconfiguration %}
 

--- a/source/_components/binary_sensor.ihc.markdown
+++ b/source/_components/binary_sensor.ihc.markdown
@@ -51,7 +51,7 @@ binary_sensors:
     id:
       description: The IHC resource id.
       required: true
-      type: int
+      type: integer
     inverting:
       description: If True the sensor will be inverted.
       required: false

--- a/source/_components/binary_sensor.netatmo.markdown
+++ b/source/_components/binary_sensor.netatmo.markdown
@@ -57,7 +57,7 @@ timeout:
     The Welcome/Presence binary sensors will
     stay on for X seconds after detection.
   required: false
-  type: int
+  type: integer
   default: 90
 cameras:
   description: List of cameras entity IDs to display.

--- a/source/_components/binary_sensor.pilight.markdown
+++ b/source/_components/binary_sensor.pilight.markdown
@@ -63,7 +63,7 @@ reset_delay_sec:
     Seconds before the sensor is disarmed if
     `disarm_after_trigger` is set to true.
   required: false
-  type: int
+  type: integer
   default: 30
 {% endconfiguration %}
 

--- a/source/_components/binary_sensor.trend.markdown
+++ b/source/_components/binary_sensor.trend.markdown
@@ -70,7 +70,7 @@ sensors:
     max_samples:
       description: Limit the maximum number of stored samples.
       required: false
-      type: int
+      type: integer
       default: 2
     min_gradient:
       description: >
@@ -85,7 +85,7 @@ sensors:
         The duration **in seconds** to store samples for.
         Samples older than this value will be discarded.
       required: false
-      type: int
+      type: integer
       default: 0
 {% endconfiguration %}
 

--- a/source/_components/binary_sensor.workday.markdown
+++ b/source/_components/binary_sensor.workday.markdown
@@ -66,7 +66,7 @@ excludes:
 days_offset:
   description: Set days offset.
   required: false
-  type: int
+  type: integer
   default: 0
 {% endconfiguration %}
 

--- a/source/_components/camera.rpi_camera.markdown
+++ b/source/_components/camera.rpi_camera.markdown
@@ -31,7 +31,7 @@ image_width:
   description: Set the image width.
   required: false
   default: 640
-  type: int
+  type: integer
 name:
   description: Name of the camera.
   required: false
@@ -41,32 +41,32 @@ image_height:
   description: Set the image height.
   required: false
   default: 480
-  type: int
+  type: integer
 image_quality:
   description: Set the image quality (from 0 to 100).
   required: false
   default: 7
-  type: int
+  type: integer
 image_rotation:
   description: Set image rotation (0-359).
   required: false
   default: 0
-  type: int
+  type: integer
 horizontal_flip:
   description: Set horizontal flip (0 to disable, 1 to enable).
   required: false
   default: 0
-  type: int
+  type: integer
 vertical_flip:
   description: Set vertical flip (0 to disable, 1 to enable).
   required: false
   default: 0
-  type: int
+  type: integer
 timelapse:
   description: Takes a picture every this many milliseconds (thousands of a second) - the default means one picture a second.
   required: false
   default: 1000
-  type: int
+  type: integer
 file_path:
   description: Save the picture in a custom file path.
   required: false

--- a/source/_components/camera.uvc.markdown
+++ b/source/_components/camera.uvc.markdown
@@ -44,7 +44,7 @@ nvr:
 port:
   description: The port number to use for accessing the NVR.
   required: false
-  type: int
+  type: integer
   default: 7080
 key:
   description: The API key available from the NVR web interface.

--- a/source/_components/canary.markdown
+++ b/source/_components/canary.markdown
@@ -40,7 +40,7 @@ canary:
   timeout:
     description: Timeout to wait for connections.
     required: false
-    type: int
+    type: integer
     default: 10
 {% endconfiguration %}
 

--- a/source/_components/climate.modbus.markdown
+++ b/source/_components/climate.modbus.markdown
@@ -38,15 +38,15 @@ name:
 slave:
   description: The number of the slave (Optional for tcp and upd Modbus, use 1).
   required: true
-  type: int
+  type: integer
 target_temp_register:
   description: Register number for target temperature (Setpoint).
   required: true
-  type: int
+  type: integer
 current_temp_register:
   description: Register number for current temperature (Process value).
   required: true
-  type: int
+  type: integer
 data_type:
   description: Response representation (int, uint, float, custom). If float selected, value will converted to IEEE 754 floating point format.
   required: false
@@ -55,11 +55,11 @@ data_type:
 count:
   description: Number of registers to read.
   required: false
-  type: int
+  type: integer
 precision:
   description: Number of valid decimals.
   required: false
-  type: int
+  type: integer
   default: 0
 {% endconfiguration %}
 

--- a/source/_components/climate.venstar.markdown
+++ b/source/_components/climate.venstar.markdown
@@ -65,7 +65,7 @@ ssl:
 timeout:
   description: Number of seconds for API timeout.
   required: false
-  type: int
+  type: integer
   default: 5
 humidifier:
   description: Report humidity and expose humidifier setpoints.

--- a/source/_components/climate.zhong_hong.markdown
+++ b/source/_components/climate.zhong_hong.markdown
@@ -33,12 +33,12 @@ port:
   description: The port of your controller.
   required: false
   default: 9999
-  type: int
+  type: integer
 gateway_address:
   description: The gateway address for the gateway (Settings in the controller itself).
   required: false
   default: 1
-  type: int
+  type: integer
 
 {% endconfiguration %}
 

--- a/source/_components/device_tracker.asuswrt.markdown
+++ b/source/_components/device_tracker.asuswrt.markdown
@@ -52,7 +52,7 @@ protocol:
 port:
   description: SSH port to use.
   required: false
-  type: int
+  type: integer
   default: 22
 mode:
   description: "The operating mode of the router (`router` or `ap`)."

--- a/source/_components/device_tracker.ping.markdown
+++ b/source/_components/device_tracker.ping.markdown
@@ -39,7 +39,7 @@ hosts:
 count:
   description: Number of packet used for each device (avoid false detection).
   required: false
-  type: int
+  type: integer
 {% endconfiguration %}
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -46,7 +46,7 @@ host:
 port:
   description: "The port number of your router, e.g., `443`."
   required: false
-  type: int
+  type: integer
   default: 80/443 (automatically detected)
 ssl:
   description: "Whether to connect via `https`."

--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -46,7 +46,7 @@ host:
 port:
     description: The port of your controller's web interface
     default: 8443
-    type: int
+    type: integer
     required: false
 site_id:
     description: For multisite installations, you can specify `site_id` to specify which is used
@@ -60,7 +60,7 @@ verify_ssl:
     default: true
 detection_time:
     description: How long since the last seen time before the device is marked away, specified in seconds.
-    type: int
+    type: integer
     required: false
     default: 300
 ssid_filter:

--- a/source/_components/egardia.markdown
+++ b/source/_components/egardia.markdown
@@ -48,7 +48,7 @@ version:
 port:
   description: The port of the alarm panel.
   required: false
-  type: int
+  type: integer
   default: 80
 report_server_enabled:
   description: Enable reporting by server.
@@ -58,7 +58,7 @@ report_server_enabled:
 report_server_port:
   description:  Port of the Egardia server.
   required: false
-  type: int
+  type: integer
   default: 52010
 report_server_codes:
   description: Map of list of codes for the different states.

--- a/source/_components/feedreader.markdown
+++ b/source/_components/feedreader.markdown
@@ -39,7 +39,7 @@ feedreader:
     description: The maximum number of entries to extract from each feed.
     required: false
     default: 20
-    type: int
+    type: integer
 {% endconfiguration %}
 
 The following configuration example shows how to configure update interval and maximum number of entries:

--- a/source/_components/hive.markdown
+++ b/source/_components/hive.markdown
@@ -41,7 +41,7 @@ password:
 scan_interval:
   description: The time in minutes between Hive API calls
   required: false
-  type: int
+  type: integer
   default: 2
 {% endconfiguration %}
 

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -62,7 +62,7 @@ homekit:
       port:
         description: Port for the HomeKit extension.
         required: false
-        type: int
+        type: integer
         default: 51827
       name:
         description: Need to be individual for each instance of Home Assistant using the component on the same local network. Between `3` and `25` characters. Alphanumeric and spaces allowed.

--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -43,7 +43,7 @@ server_host:
 server_port:
   description: Let you set a port to use.
   required: false
-  type: int
+  type: integer
   default: 8123
 base_url:
   description: "The URL that Home Assistant is available on the internet. For example: `hass-example.duckdns.org:8123`. The iOS app finds local installations, if you have an outside URL use this so that you can auto-fill when discovered in the app."
@@ -87,7 +87,7 @@ ip_ban_enabled:
 login_attempts_threshold:
   description: "Number of failed login attempt from single IP after which it will be automatically banned if `ip_ban_enabled` is `true`. When set to -1 no new automatic bans will be added."
   required: false
-  type: int
+  type: integer
   default: -1
 ssl_profile:
   description: The [Mozilla SSL profile](https://wiki.mozilla.org/Security/Server_Side_TLS) to use. Only lower if you are experiencing integrations causing SSL handshake errors.

--- a/source/_components/hydrawise.markdown
+++ b/source/_components/hydrawise.markdown
@@ -33,7 +33,7 @@ access_token:
 scan_interval:
   description: The time interval, in seconds, to poll the Hydrawise cloud.
   required: false
-  type: int
+  type: integer
   default: 30
 {% endconfiguration %}
 

--- a/source/_components/image_processing.microsoft_face_detect.markdown
+++ b/source/_components/image_processing.microsoft_face_detect.markdown
@@ -38,7 +38,7 @@ image_processing:
 confidence:
   description: The minimum of confidence in percent to process with Home Assistant.
   required: false
-  type: int
+  type: integer
   default: 80
 source:
   description: List of image sources.

--- a/source/_components/image_processing.microsoft_face_identify.markdown
+++ b/source/_components/image_processing.microsoft_face_identify.markdown
@@ -43,7 +43,7 @@ group:
 confidence:
   description: The minimum of confidence in percent to process with Home Assistant.
   required: false
-  type: int
+  type: integer
   default: 80
 source:
   description: List of image sources.

--- a/source/_components/image_processing.openalpr_cloud.markdown
+++ b/source/_components/image_processing.openalpr_cloud.markdown
@@ -44,7 +44,7 @@ api_key:
 confidence:
   description: The minimum of confidence in percent to process with Home Assistant.
   required: false
-  type: int
+  type: integer
   default: 80
 source:
   description: List of image sources.

--- a/source/_components/image_processing.openalpr_local.markdown
+++ b/source/_components/image_processing.openalpr_local.markdown
@@ -71,7 +71,7 @@ alpr_bin:
 confidence:
   description: The minimum of confidence in percent to process with Home Assistant.
   required: false
-  type: int
+  type: integer
   default: 80
 source:
   description: List of image sources.

--- a/source/_components/input_text.markdown
+++ b/source/_components/input_text.markdown
@@ -46,12 +46,12 @@ input_text:
       min:
         description: Minimum length for the text value.
         required: false
-        type: int
+        type: integer
         default: 0
       max:
         description: Maximum length for the text value.
         required: false
-        type: int
+        type: integer
         default: 100
       initial:
         description: Initial value when Home Assistant starts.

--- a/source/_components/light.ihc.markdown
+++ b/source/_components/light.ihc.markdown
@@ -55,7 +55,7 @@ lights:
     id:
       description: The IHC resource id.
       required: true
-      type: int
+      type: integer
     name:
       description: The name of the component
       required: false

--- a/source/_components/light.lw12wifi.markdown
+++ b/source/_components/light.lw12wifi.markdown
@@ -34,7 +34,7 @@ host:
 port:
   description: Some firmware versions of the LW-12 controller listen on different ports.
   required: false
-  type: int
+  type: integer
   default: 5000
 name:
   description: Name to use in the frontend.

--- a/source/_components/maxcube.markdown
+++ b/source/_components/maxcube.markdown
@@ -56,11 +56,11 @@ maxcube:
   port:
     description: The UDP port number.
     required: false
-    type: int
+    type: integer
     default: 62910
   scan_interval:
     description: The update interval in seconds
     required: false
-    type: int
+    type: integer
     default: 300
 {% endconfiguration %}

--- a/source/_components/media_player.blackbird.markdown
+++ b/source/_components/media_player.blackbird.markdown
@@ -42,14 +42,14 @@ host:
 zones:
   description: This is the list of zones available. Valid zones are 1, 2, 3, 4, 5, 6, 7, 8. Each zone must have a name assigned to it.
   required: true
-  type: int
+  type: integer
   keys:
     name:
       description: The name of the zone.
 sources:
   description: The list of sources available. Valid source numbers are 1, 2, 3, 4, 5, 6, 7, 8. Each source number corresponds to the input number on the Blackbird matrix switch. Similar to zones, each source must have a name assigned to it.
   required: true
-  type: int
+  type: integer
   keys:
     name:
       description: The name of the source.

--- a/source/_components/media_player.dlna_dmr.markdown
+++ b/source/_components/media_player.dlna_dmr.markdown
@@ -42,7 +42,7 @@ listen_port:
   description: Port to listen on for events from the device.
   required: false
   default: 8301
-  type: int
+  type: integer
 name:
   description: The name you would like to give to the device, e.g., `TV living room`.
   required: false

--- a/source/_components/media_player.epson.markdown
+++ b/source/_components/media_player.epson.markdown
@@ -34,7 +34,7 @@ host:
 port:
   description: The HTTP port number.
   required: false
-  type: int
+  type: integer
   default: 80
 name:
   description: The name of the device used in the frontend.

--- a/source/_components/media_player.horizon.markdown
+++ b/source/_components/media_player.horizon.markdown
@@ -32,7 +32,7 @@ media_player:
   port:
     description: The port of the device to connect to.
     required: false
-    type: int
+    type: integer
   name:
     description: The name of the device used in the frontend.
     required: false

--- a/source/_components/media_player.pjlink.markdown
+++ b/source/_components/media_player.pjlink.markdown
@@ -34,7 +34,7 @@ host:
 port:
   description: port on which the PJLink service runs on the device.
   required: false
-  type: int
+  type: integer
   default: 4352
 name:
   description: Name of the device.

--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -38,7 +38,7 @@ host:
 port:
   description: The port of the Samsung Smart TV. If set to 8001, the new websocket connection will be used (required for 2016+ TVs).
   required: false
-  type: int
+  type: integer
   default: 55000
 name:
   description: The name you would like to give to the Samsung Smart TV.

--- a/source/_components/mochad.markdown
+++ b/source/_components/mochad.markdown
@@ -31,7 +31,7 @@ host:
 port:
   description: The port that mochad is running on.
   required: false
-  type: int
+  type: integer
   default: 1099
 {% endconfiguration %}
 

--- a/source/_components/mysensors.markdown
+++ b/source/_components/mysensors.markdown
@@ -39,7 +39,7 @@ mysensors:
       baud_rate:
         description: Specifies the baud rate of the connected serial gateway.
         required: false
-        type: int
+        type: integer
         default: 115200
       persistence_file:
         description: The path to a file to save sensor information. The file extension determines the file type. Currently supported file types are 'pickle' and 'json'.
@@ -49,7 +49,7 @@ mysensors:
       tcp_port:
         description: Specifies the port of the connected TCP Ethernet gateway.
         required: false
-        type: int
+        type: integer
         default: 5003
       topic_in_prefix:
         description: Set the prefix of the MQTT topic for messages coming from the MySensors gateway in to Home Assistant.
@@ -73,7 +73,7 @@ mysensors:
   persistence:
     description: Enable or disable local persistence of sensor information. If this is disabled, then each sensor will need to send presentation messages after Home Assistant starts.
     required: false
-    type: int
+    type: integer
     default: true
   version:
     description: Specifies the MySensors protocol version to use. Supports 1.4, 1.5 and 2.0.
@@ -83,12 +83,12 @@ mysensors:
   optimistic:
     description: Enable or disable optimistic mode for actuators (switch/light). Set this to true if no state feedback from actuators is possible. Home Assistant will assume that the command succeeded and change state.
     required: false
-    type: int
+    type: integer
     default: false
   retain:
     description: Enable or disable retain flag for published messages from Home Assistant when using the MQTT gateway.
     required: false
-    type: int
+    type: integer
     default: true
 {% endconfiguration %}
 

--- a/source/_components/notify.lametric.markdown
+++ b/source/_components/notify.lametric.markdown
@@ -32,7 +32,7 @@ name:
 lifetime:
   description: Defines how long the message remains in LaMetric notification queue (in seconds).
   required: false
-  type: int
+  type: integer
   default: 10
 icon:
   description: An icon or animation.
@@ -41,7 +41,7 @@ icon:
 cycles:
   description: Defines how often the notification is displayed.
   required: false
-  type: int
+  type: integer
   default: 1
 priority:
   description: Defines the priority of the notification.

--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -53,7 +53,7 @@ api_key:
 scan_interval:
   description: the frequency (in seconds) between data updates
   required: false
-  type: int
+  type: integer
   default: 1800
 binary_sensors:
   description: binary sensor-related configuration options

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -55,7 +55,7 @@ password:
 port:
   description: the TCP port used by your unit for the REST API
   required: false
-  type: int
+  type: integer
   default: 8080
 ssl:
   description: whether communication with the local device should occur over HTTPS
@@ -65,7 +65,7 @@ ssl:
 scan_interval:
   description: the frequency (in seconds) between data updates
   required: false
-  type: int
+  type: integer
   default: 60
 binary_sensors:
   description: binary sensor-related configuration options
@@ -95,7 +95,7 @@ switches:
     zone_run_time:
       description: the default number of seconds that a zone should run when turned on
       required: false
-      type: int
+      type: integer
       default: 600
 {% endconfiguration %}
 

--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -39,12 +39,12 @@ recorder:
       description: Specify the number of history days to keep in recorder database after a purge.
       required: false
       default: 10
-      type: int
+      type: integer
     purge_interval:
       description: How often (in days) the purge task runs. If a scheduled purge is missed (e.g., if Home Assistant was not running), the schedule will resume soon after Home Assistant restarts. You can use the [service](#service-purge) call `purge` when required without impacting the purge schedule. If this is set to `0` (zero), automatic purging is disabled.
       required: false
       default: 1
-      type: int
+      type: integer
     exclude:
       description: Configure which components should be excluded
       required: false

--- a/source/_components/remote.xiaomi_miio.markdown
+++ b/source/_components/remote.xiaomi_miio.markdown
@@ -43,12 +43,12 @@ name:
 slot:
   description: The slot used to save learned command.
   required: false
-  type: int
+  type: integer
   default: 1
 timeout:
   description: Timeout for learning a new command.
   required: false
-  type: int
+  type: integer
   default: 30
 hidden:
   description: Hide the entity from UI. There is currently no reason to show the entity in UI as turning it off or on does nothing.

--- a/source/_components/sensor.ads.markdown
+++ b/source/_components/sensor.ads.markdown
@@ -24,7 +24,7 @@ sensor:
   - platform: ads
     adsvar: GVL.temperature
     unit_of_measurement: '°C'
-    adstype: int
+    adstype: integer
 ```
 
 {% configuration %}

--- a/source/_components/sensor.airvisual.markdown
+++ b/source/_components/sensor.airvisual.markdown
@@ -61,12 +61,12 @@ show_on_map:
 scan_interval:
   description: "The rate at which AirVisual should be polled for new data."
   required: optional
-  type: int
+  type: integer
   default: 600
 latitude:
   description: The latitude of the location to monitor.
   required: optional
-  type: str
+  type: string
   default: "The latitude defined under the `homeassistant` key in `configuration.yaml`."
 longitude:
   description: The longitude of the location to monitor.

--- a/source/_components/sensor.bme680.markdown
+++ b/source/_components/sensor.bme680.markdown
@@ -40,12 +40,12 @@ i2c_bus:
   description: I2C bus that the sensor is connected to. 
   required: false
   default: 1
-  type: int
+  type: integer
 i2c_address:
   description: I2C address of the sensor. It is 0x76 or 0x77. 
   required: false
   default: 0x77
-  type: int
+  type: integer
 monitored_conditions:
   description: Conditions to monitor.
   required: false
@@ -70,47 +70,47 @@ oversampling_temperature:
   description: Oversampling multiplier as described in the sensor datasheet. Can be 0 (no sampling), 1, 2, 4, 8, or 16.
   required: false
   default: 8
-  type: int
+  type: integer
 oversampling_pressure:
   description: Oversampling multiplier as described in the sensor datasheet. Can be 0 (no sampling), 1, 2, 4, 8, or 16.
   required: false
   default: 2
-  type: int
+  type: integer
 oversampling_humidity:
   description: Oversampling multiplier as described in the sensor datasheet. Can be 0 (no sampling), 1, 2, 4, 8, or 16.
   required: false
   default: 4
-  type: int
+  type: integer
 filter_size:
   description: IIR filter size as described in the sensor datasheet. Can be 0 (off), 1, 3, 7, 15, 31, 63 or 127. 
   required: false
   default: 3
-  type: int
+  type: integer
 gas_heater_temperature:
   description: The temperature to heat the hotplate to for gas resistance measurements as described in the sensor datasheet.  Can be between 200-400&deg;C.
   required: false
   default: 320
-  type: int
+  type: integer
 gas_heater_duration:
   description: The duration to heat the hotplate in milliseconds for gas resistance measurements as described in the sensor datasheet.  Can be between 1-4032 ms. In reality, you will likely need between 80-100ms to reach a stable temperature.  Using a duration greater than 1000ms is inadvisable as it will essentially result in the heater being continually on due to the 1-second update interval.
   required: false
   default: 150
-  type: int
+  type: integer
 aq_burn_in_time:
   description: The duration to perform gas resistance measurements to establish a stable baseline measurements for Air Quality calculations in seconds. The burn in time is only performed when the sensor component is first initialized. 
   required: false
   default: 300
-  type: int
+  type: integer
 aq_humidity_baseline:
   description: The baseline *ideal* relative humidity value for the air quality calculations. 
   required: false
   default: 40
-  type: int
+  type: integer
 aq_humidity_bias:
   description: The bias for humidity to the gas resistance measurement in the air quality calculations expressed as a percentage of the total calculation e.g., 25% hudidtity to 75% gas. 
   required: false
   default: 25
-  type: int
+  type: integer
 {% endconfiguration %}
 
 ## {% linkable_title Full Examples %}

--- a/source/_components/sensor.coinmarketcap.markdown
+++ b/source/_components/sensor.coinmarketcap.markdown
@@ -28,7 +28,7 @@ sensor:
 currency_id:
   description: The ID of the cryptocurrency to use, default is the ID of Bitcoin.
   required: false
-  type: int
+  type: integer
   default: 1
 display_currency:
   description: The currency to display.
@@ -38,7 +38,7 @@ display_currency:
 display_currency_decimals:
   description: The amount of decimals to round to.
   required: false
-  type: int
+  type: integer
   default: 2
 {% endconfiguration %}
 

--- a/source/_components/sensor.cups.markdown
+++ b/source/_components/sensor.cups.markdown
@@ -46,7 +46,7 @@ host:
 port:
   description: Port of the CUPS print server.
   required: false
-  type: int
+  type: integer
   default: 631
 {% endconfiguration %}
 

--- a/source/_components/sensor.filter.markdown
+++ b/source/_components/sensor.filter.markdown
@@ -81,12 +81,12 @@ filters:
     precision:
       description: See [_lowpass_](#low-pass) filter. Defines the precision of the filtered state, through the argument of round().
       required: false
-      type: int
+      type: integer
       default: None
     time_constant: 
       description: See [_lowpass_](#low-pass) filter. Loosely relates to the amount of time it takes for a state to influence the output.
       required: false
-      type: int
+      type: integer
       default: 10
     radius: 
       description: See [_outlier_](#outlier) filter. Band radius from median of previous states.

--- a/source/_components/sensor.gearbest.markdown
+++ b/source/_components/sensor.gearbest.markdown
@@ -40,7 +40,7 @@ items:
     id:
       description: The ID of the product.
       required: false
-      type: int
+      type: integer
     url:
       description: The URL of the product.
       required: false

--- a/source/_components/sensor.glances.markdown
+++ b/source/_components/sensor.glances.markdown
@@ -59,7 +59,7 @@ host:
 port:
   description: The port where Glances is listening.
   required: false
-  type: int
+  type: integer
   default: 61208
 name:
   description: The prefix for the sensors.
@@ -69,7 +69,7 @@ name:
 version:
   description: "The version of the Glances API. Supported version: `2` and `3`."
   required: false
-  type: int
+  type: integer
   default: 2
 resources:
   description: Entries to monitor.

--- a/source/_components/sensor.gpsd.markdown
+++ b/source/_components/sensor.gpsd.markdown
@@ -61,7 +61,7 @@ host:
 port:
   description: The port which GPSD is using.
   required: false
-  type: int
+  type: integer
   default: 2947
 name:
   description: Friendly name to use for the frontend.

--- a/source/_components/sensor.ihc.markdown
+++ b/source/_components/sensor.ihc.markdown
@@ -45,7 +45,7 @@ sensors:
     id:
       description: The IHC resource id.
       required: true
-      type: int
+      type: integer
     name:
       description: The name of the component
       required: false

--- a/source/_components/sensor.iperf3.markdown
+++ b/source/_components/sensor.iperf3.markdown
@@ -52,11 +52,11 @@ sensor:
     description: Specify the test duration in seconds. Default is 10 and the valid range is from 5 to 10.
     required: false
     default: 10
-    type: int
+    type: integer
   parallel:
     description: Specify the number of concurrent streams to connect to the server. Default is 1 and the valid range is from 1 to 20.
     default: 1
-    type: int
+    type: integer
   protocol:
     description: Specify the protocol to be used on the test. Default is TCP and the valid values are TCP or UDP. If your Iperf3 server is located in the Internet, consider to use TCP instead of UDP. If the protocol is set to use UDP, the sensor may not get updated due to package retransmission issues due to its nature.
     required: false
@@ -66,7 +66,7 @@ sensor:
     description: Specify the frequency in seconds which the test will be perfomed. Default value is 1 hour.
     required: false
     default: 3600
-    type: int
+    type: integer
 {% endconfiguration %}
 
 You can find a list of public Iperf3 servers [here](https://iperf.fr/iperf-servers.php). You can also start your own Iperf3 server using the [mlabbe/iperf3's](https://hub.docker.com/r/mlabbe/iperf3/) docker image or just refer to your `iperf3` command's man page.

--- a/source/_components/sensor.jewish_calendar.markdown
+++ b/source/_components/sensor.jewish_calendar.markdown
@@ -34,12 +34,12 @@ latitude:
   required: false
   description: Latitude for time calculations of the sensor.
   default: Home Assistant location
-  type: int
+  type: integer
 longitude:
   required: false
   description: Longitude for time calculations of the sensor.
   default: Home Assistant location
-  type: int
+  type: integer
 disapora:
   required: false
   description: Consider the location as diaspora or not for calculation of the weekly portion and holidays.

--- a/source/_components/sensor.lacrosse.markdown
+++ b/source/_components/sensor.lacrosse.markdown
@@ -51,7 +51,7 @@ sensor:
   baud:
     description: The serial baudrate.
     required: true
-    type: int
+    type: integer
     default: 57600
   led:
     description: Activate or deactivate the Jeelink LED.
@@ -60,19 +60,19 @@ sensor:
   frequency:
     description: Initial frequency in 5kHz steps.
     required: false
-    type: int
+    type: integer
   datarate:
     description: "Set the data rate in kbps. Special values for well-known settings are: `0`: 17.241 kbps, `1`: 9.579 kbps, `2`: 8.842 kbps."
     required: false
-    type: int
+    type: integer
   toggle_mask:
     description: "The following values can be combined bitwise: `1` = 17.241 kbps, `2` = 9.579 kbps, `4` = 8.842 kbps"
     required: false
-    type: int
+    type: integer
   toggle_interval:
     description: Enable the toggle mode and set the interval in seconds.
     required: false
-    type: int
+    type: integer
   sensors:
     description: A list of your sensors.
     required: true
@@ -89,7 +89,7 @@ sensor:
       id:
         description: The LaCrosse Id of the sensor.
         required: true
-        type: int
+        type: integer
 {% endconfiguration %}
 
 

--- a/source/_components/sensor.modbus.markdown
+++ b/source/_components/sensor.modbus.markdown
@@ -81,5 +81,5 @@ sensor:
       scale: 0.1
       offset: 0
       precision: 1
-      data_type: int
+      data_type: integer
 ```

--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -40,7 +40,7 @@ name:
 qos:
   description: The maximum QoS level of the state topic.
   required: false
-  type: int
+  type: integer
   default: 0
 unit_of_measurement:
   description: Defines the units of measurement of the sensor, if any.
@@ -53,7 +53,7 @@ icon:
 expire_after:
   description: Defines the number of seconds after the value expires if it's not updated.
   required: false
-  type: int
+  type: integer
   default: 0
 value_template:
   description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the value."

--- a/source/_components/sensor.netdata.markdown
+++ b/source/_components/sensor.netdata.markdown
@@ -68,7 +68,7 @@ host:
 port:
   description: The port that the Netdata instance is running on.
   required: false
-  type: int
+  type: integer
   default: 19999
 name:
   description: Name of the monitored Netdata instance.

--- a/source/_components/sensor.nut.markdown
+++ b/source/_components/sensor.nut.markdown
@@ -43,7 +43,7 @@ sensor:
     description: The port number.
     required: false
     default: 3493
-    type: int
+    type: integer
   alias:
     description: Name of the ups on the NUT server.
     required: false

--- a/source/_components/sensor.openhardwaremonitor.markdown
+++ b/source/_components/sensor.openhardwaremonitor.markdown
@@ -33,7 +33,7 @@ sensor:
   port:
     description: The port of your Open Hardware Monitor API. Defaults to 8085.
     required: false
-    type: int
+    type: integer
 {% endconfiguration %}
 
 <p class='note'>

--- a/source/_components/sensor.pyload.markdown
+++ b/source/_components/sensor.pyload.markdown
@@ -32,7 +32,7 @@ host:
 port:
   description: The port your pyLoad interface uses.
   required: false
-  type: int
+  type: integer
   default: 8000
 name:
   description: The name to use when displaying this pyLoad instance.

--- a/source/_components/sensor.random.markdown
+++ b/source/_components/sensor.random.markdown
@@ -41,7 +41,7 @@ minimum:
 maximum:
   description: Upper limit for the values.
   required: false
-  type: int
+  type: integer
   default: 20
 unit_of_measurement:
   description: Defines the units of measurement of the sensor, if any.

--- a/source/_components/sensor.rmvtransport.markdown
+++ b/source/_components/sensor.rmvtransport.markdown
@@ -55,7 +55,7 @@ time_offset:
   description: Do not display departures leaving sooner than this number of minutes. Useful if you are a couple of minutes away from the stop.
   required: false
   default: The defaults is 0.
-  type: int
+  type: integer
 max_journeys:
   description: Specify the maximal number of journeys.
   required: false

--- a/source/_components/sensor.serial.markdown
+++ b/source/_components/sensor.serial.markdown
@@ -43,7 +43,7 @@ baudrate:
   description: Baudrate of the serial port.
   required: false
   default: 9600 Bps
-  type: int
+  type: integer
 value_template:
   description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the serial line."
   required: false

--- a/source/_components/sensor.sht31.markdown
+++ b/source/_components/sensor.sht31.markdown
@@ -40,7 +40,7 @@ sensor:
     description: I2C address of the sensor.
     required: false
     default: "`0x44`"
-    type: int
+    type: integer
   monitored_conditions:
     description: Conditions to monitor.
     required: false

--- a/source/_components/sensor.simulated.markdown
+++ b/source/_components/sensor.simulated.markdown
@@ -75,7 +75,7 @@ seed:
   description: The [seed](https://docs.python.org/3.6/library/random.html#random.seed) value for the random noise component.
   required: false
   default: 999
-  type: int
+  type: integer
 spread:
   description: The spread is the range of the randomly distributed values about their mean. This is sometimes referred to as the Full Width at Half Maximum ([FWHM](https://en.wikipedia.org/wiki/Full_width_at_half_maximum)) of the random distribution.
   required: false

--- a/source/_components/sensor.speedtest.markdown
+++ b/source/_components/sensor.speedtest.markdown
@@ -54,7 +54,7 @@ sensor:
   server_id:
     description: Specify the speed test server to perform the test against.
     required: false
-    type: int
+    type: integer
   day:
     description: Specify the day(s) of the month to schedule the speed test. Use a list for multiple entries.
     required: false

--- a/source/_components/sensor.spotcrime.markdown
+++ b/source/_components/sensor.spotcrime.markdown
@@ -46,7 +46,7 @@ api_key:
 days:
   description: Number of days you'd like see to crime statistics for.
   required: false
-  type: int
+  type: integer
 include:
   description: Event types you want statistics for.
   required: false

--- a/source/_components/sensor.temper.markdown
+++ b/source/_components/sensor.temper.markdown
@@ -28,12 +28,12 @@ sensor:
 offset:
   description: The offset to fix reported vales.
   required: false
-  type: int
+  type: integer
   default: o
 scale:
   description: The scale for the sensor.
   required: false
-  type: int
+  type: integer
   default: 1
 name:
   description: The name to use when displaying this switch.

--- a/source/_components/sensor.transmission.markdown
+++ b/source/_components/sensor.transmission.markdown
@@ -56,7 +56,7 @@ host:
 port:
   description: The port your Transmission daemon uses.
   required: false
-  type: int
+  type: integer
   default: 9091
 name:
   description: The name to use when displaying this Transmission instance in the frontend.

--- a/source/_components/sensor.viaggiatreno.markdown
+++ b/source/_components/sensor.viaggiatreno.markdown
@@ -39,11 +39,11 @@ sensor:
 train_id:
   description: The ID of the train.
   required: true
-  type: int
+  type: integer
 station_id:
   description: The ID of the starting station.
   required: true
-  type: int
+  type: integer
 train_name:
   description: The name of the sensor. Defaults to 'Train <train id> from <station id>'.
   required: false

--- a/source/_components/sensor.volkszaehler.markdown
+++ b/source/_components/sensor.volkszaehler.markdown
@@ -39,7 +39,7 @@ host:
 port:
   description: The port where Volkszaehler is listening.
   required: false
-  type: int
+  type: integer
   default: 80
 name:
   description: The prefix for the sensors.

--- a/source/_components/sensor.yr.markdown
+++ b/source/_components/sensor.yr.markdown
@@ -35,7 +35,7 @@ name:
 forecast:
   description: If you want to get forecast data instead of the current weather data, set this to the number of hours that you want to look into the future.
   required: false
-  type: int
+  type: integer
 monitored_conditions:
   description: Conditions to display in the frontend.
   required: false

--- a/source/_components/snips.markdown
+++ b/source/_components/snips.markdown
@@ -105,12 +105,12 @@ By default, Snips runs its own MQTT broker. But we can also tell Snips to use an
 feedback_sounds:
   description: Turn on feedbacks sounds for Snips.
   required: false
-  type: str
+  type: string
   default: false
 site_ids:
   description: A list of siteIds if using multiple Snips instances. Used to make sure feedback is toggled on or off for all sites.
   required: false
-  type: str
+  type: string
 probability_threshold:
   description: Threshold for intent probability. Range is from 0.00 to 1.00, 1 being highest match. Intents under this level are discarded.
   require: false

--- a/source/_components/spider.markdown
+++ b/source/_components/spider.markdown
@@ -37,7 +37,7 @@ password:
 scan_interval:
   description: How frequently to query for new data. Defaults to 120 seconds.
   required: false
-  type: int
+  type: integer
 {% endconfiguration %}
 
 <p class='note warning'>

--- a/source/_components/sun.markdown
+++ b/source/_components/sun.markdown
@@ -24,7 +24,7 @@ sun:
 elevation:
   description: "The (physical) elevation of your location, in meters above sea level. Defaults to the `elevation` in `configuration.yaml`, which is retrieved from Google Maps if not set."
   required: false
-  type: int
+  type: integer
 {% endconfiguration %}
 
 <p class='img'>

--- a/source/_components/switch.hydrawise.markdown
+++ b/source/_components/switch.hydrawise.markdown
@@ -29,7 +29,7 @@ switch:
 watering_minutes:
   description: When manual watering is enabled this will determine the length of time in minutes that irrigation zone will run. The allowed values are 5, 10, 15, 30, 45, or 60.
   required: false
-  type: int
+  type: integer
   default: 15
 monitored_conditions:
   description: Selects the set of switches that should be enabled on the frontend. Also sets the length of time a zone will run under manual control.

--- a/source/_components/switch.ihc.markdown
+++ b/source/_components/switch.ihc.markdown
@@ -46,7 +46,7 @@ switches:
     id:
       description: The IHC resource id.
       required: true
-      type: int
+      type: integer
     name:
       description: The name of the component
       required: false

--- a/source/_components/switch.rest.markdown
+++ b/source/_components/switch.rest.markdown
@@ -44,7 +44,7 @@ name:
 timeout:
   description: Timeout for the request.
   required: false
-  type: int
+  type: integer
   default: 10
 body_on:
   description: "The body of the POST request that commands the switch to become enabled. This value can be a [template](/topics/templating/)."

--- a/source/_components/system_log.markdown
+++ b/source/_components/system_log.markdown
@@ -26,7 +26,7 @@ system_log:
 max_entries:
   description: Number of entries to store (older entries are discarded).
   required: false
-  type: int
+  type: integer
   default: 50
 fire_event:
   description: Whether events are fired (required when used for triggers).

--- a/source/_components/tts.baidu.markdown
+++ b/source/_components/tts.baidu.markdown
@@ -41,22 +41,22 @@ secret_key:
 speed:
   description: Audio speed from 0 to 9.
   required: false
-  type: int
+  type: integer
   default: 5
 pitch:
   description: Audio pitch from 0 to 9.
   required: false
-  type: int
+  type: integer
   default: 5
 volume:
   description: Audio volume from 0 to 15.
   required: false
-  type: int
+  type: integer
   default: 5
 person:
   description: Voice type. You choose one from 0, 1, 3 or 4.
   required: false
-  type: int
+  type: integer
   default: 0
 {% endconfiguration %}
 

--- a/source/_components/tts.markdown
+++ b/source/_components/tts.markdown
@@ -42,7 +42,7 @@ cache_dir:
 time_memory:
   description: Time to hold the voice data inside memory for fast play on a media player. Minimum is 60 s and the maximum 57600 s (16 hours).
   required: false
-  type: int
+  type: integer
   default: 300
 base_url:
   description: A base URL to use *instead* of the one set in the [http component](/components/http/). It is used as-is by the `tts` component. In particular, you need to include the protocol scheme `http://` or `https://` and the correct port number. They will not be automatically added for you.

--- a/source/_components/upcloud.markdown
+++ b/source/_components/upcloud.markdown
@@ -43,6 +43,6 @@ password:
 scan_interval:
   description: Update interval in seconds.
   required: false
-  type: int
+  type: integer
   default: 60
 {% endconfiguration %}

--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -116,7 +116,7 @@ xiaomi_aqara:
   discovery_retry:
     description: Number of times that Home Assistant should try to reconnect to the gateway.
     required: false
-    type: int
+    type: integer
     default: 3
   interface:
     description: Which network interface to use.

--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -75,7 +75,7 @@ broker:
 port:
   required: false
   description: The network port to connect to. Default is 1883.
-  type: int
+  type: integer
 client_id:
   required: false
   description: The client ID that Home Assistant will use. Has to be unique on the server. Default is a randomly generated one.
@@ -83,7 +83,7 @@ client_id:
 keepalive:
   required: false
   description: The time in seconds between sending keep alive messages for this client. Default is 60.
-  type: int
+  type: integer
 username:
   required: false
   description: The username to use with your MQTT broker.


### PR DESCRIPTION
**Description:**

As per developers documentation standards, correcting `type: int` occurrences in the configuration variables sections with `type: integer`.

(Also found a couple of `type: str` -> `type: string`)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
