### PR TITLE
service call typo

### DIFF
--- a/source/_components/vacuum.markdown
+++ b/source/_components/vacuum.markdown
@@ -99,7 +99,7 @@ Tell the vacuum cleaner to do a spot clean-up.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
 
-#### {% linkable_title Service `vacuum.set_fanspeed` %}
+#### {% linkable_title Service `vacuum.set_fan_speed` %}
 
 Set the fan speed of the vacuum. The `fanspeed` can be a label, as `balanced` or `turbo`, or be a number; it depends on the `vacuum` platform.
 


### PR DESCRIPTION
hass service call is vacuum.set_fan_speed

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
