### PR TITLE
Update docs for scrape component to add optional headers

### DIFF
--- a/source/_components/sensor.scrape.markdown
+++ b/source/_components/sensor.scrape.markdown
@@ -36,6 +36,7 @@ Configuration variables:
 - **authentication** (*Optional*): Type of the HTTP authentication. Either `basic` or `digest`.
 - **username** (*Optional*): The username for accessing the website.
 - **password** (*Optional*): The password for accessing the website.
+- **headers** (*Optional*): Headers to use for the web request
 
 ## {% linkable_title Examples %}
 
@@ -128,5 +129,25 @@ sensor:
     select: ".elspot-content"
     value_template: '{{ ((value.split(" ")[0]) | replace (",", ".")) }}'
     unit_of_measurement: "öre/kWh"
+```
+{% endraw %}
+
+### {% linkable_title BOM Weather %}
+
+The Australian Bureau of Meterology website returns an error if the User Agent header is not sent.
+
+{% raw %}
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: scrape
+    resource: http://www.bom.gov.au/vic/forecasts/melbourne.shtml
+    name: Melbourne Forecast Summary
+    select: ".main .forecast p"
+    value_template: '{{ value | truncate(255) }}'
+    # Request every hour
+    scan_interval: 3600
+    headers:
+      User-Agent: Mozilla/5.0
 ```
 {% endraw %}


### PR DESCRIPTION
Added docs for headers optional parameter, plus example for BOM

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17085

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
