### PR TITLE
Convert Abode to new config style

### DIFF
--- a/source/_components/abode.markdown
+++ b/source/_components/abode.markdown
@@ -46,14 +46,33 @@ abode:
     - 'ZW:0000000022'
 ```
 
-Configuration variables:
-
-- **username** (*Required*): Username for your Abode account.
-- **password** (*Required*): Password for your Abode account.
-- **name** (*Optional*): The name for your alarm controller.
-- **polling** (*Optional*): Enable polling if cloud push updating is less reliable. Will update the devices once every 30 seconds. Defaults to False.
-- **exclude** (*Optional*): A list of devices to exclude from Home Assistant by their Abode `device_id` or `automation_id`, found within the component attributes.
-- **lights** (*Optional*): A list of switch devices that Home Assistant should treat as lights by the switches Abode `device_id`, found within the component attributes.
+{% configuration %}
+username:
+  description: Username for your Abode account.
+  required: true
+  type: string
+password:
+  description: Password for your Abode account.
+  required: true
+  type: string
+name:
+  description: The name for your alarm controller.
+  required: false
+  type: string
+polling:
+  description: Enable polling if cloud push updating is less reliable. Will update the devices once every 30 seconds.
+  required: false
+  type: boolean
+  default: false
+exclude:
+  description: A list of devices to exclude from Home Assistant by their Abode `device_id` or `automation_id`, found within the component attributes.
+  required: false
+  type: list
+lights:
+  description: A list of switch devices that Home Assistant should treat as lights by the switches Abode `device_id`, found within the component attributes.
+  required: false
+  type: list
+{% endconfiguration %}
 
 ## {% linkable_title Events %}
 


### PR DESCRIPTION
Fixes #6385 for Abode

**Description:**
Configuration variables defined as specified in https://developers.home-assistant.io/docs/en/documentation_create_page.html#configuration

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
