### PR TITLE
Use the new style for configuration variables description for Plex pl…

### DIFF
--- a/source/_components/media_player.plex.markdown
+++ b/source/_components/media_player.plex.markdown
@@ -75,26 +75,26 @@ media_player:
 
 {% configuration %}
 entity_namespace:
-  description: Prefix for entity ID's. Useful when using overlapping components (ex. Apple TV and Plex components when you have Apple TV's you use as Plex clients). Go from _media_player.playroom2_ to _media_player.plex_playroom_
+  description: "Prefix for entity ID's. Useful when using overlapping components (ex. Apple TV and Plex components when you have Apple TV's you use as Plex clients). Go from _media_player.playroom2_ to _media_player.plex_playroom_"
   required: false
   type: string
 include_non_clients:
-  description: Display non-recontrollable clients (ex. remote clients, PlexConnect Apple TV's).
+  description: "Display non-recontrollable clients (ex. remote clients, PlexConnect Apple TV's)."
   required: false
   default: false
   type: boolean
 scan_interval:
-  description: Amount in seconds in between polling for device’s current activity.
+  description: "Amount in seconds in between polling for device’s current activity."
   required: false
   default: 10
   type: int
 show_all_controls:
-  description: Forces all controls to display. Ignores dynamic controls (ex. show volume controls for client A but not for client B) based on detected client capabilities. This option allows you to override this detection if you suspect it to be incorrect.
+  description: "Forces all controls to display. Ignores dynamic controls (ex. show volume controls for client A but not for client B) based on detected client capabilities. This option allows you to override this detection if you suspect it to be incorrect."
   required: false
   default: false
   type: boolean
 use_custom_entity_ids:
-  description: Name Entity ID's by client ID's instead of friendly names. HA assigns entity ID's on a first come first serve basis.  When you have identically named devices connecting (ex. media_player.plex_web_safari, media_player.plex_web_safari2), you can't reliably distinguish and or predict which device is which.  This option avoids this issue by using unique client ID's (ex. media_player.dy4hdna2drhn).
+  description: "Name Entity ID's by client ID's instead of friendly names. HA assigns entity ID's on a first come first serve basis.  When you have identically named devices connecting (ex. media_player.plex_web_safari, media_player.plex_web_safari2), you can't reliably distinguish and or predict which device is which.  This option avoids this issue by using unique client ID's (ex. media_player.dy4hdna2drhn)."
   required: false
   default: false
   type: boolean

--- a/source/_components/media_player.plex.markdown
+++ b/source/_components/media_player.plex.markdown
@@ -72,47 +72,47 @@ media_player:
     remove_unavailable_clients: true
     client_remove_interval: 600
 ```
+
 {% configuration %}
 entity_namespace:
   description: Prefix for entity ID's. Useful when using overlapping components (ex. Apple TV and Plex components when you have Apple TV's you use as Plex clients). Go from _media_player.playroom2_ to _media_player.plex_playroom_
   required: false
-  default: `null`
   type: string
 include_non_clients:
   description: Display non-recontrollable clients (ex. remote clients, PlexConnect Apple TV's).
   required: false
-  default: `false`
+  default: false
   type: boolean
 scan_interval:
   description: Amount in seconds in between polling for device’s current activity.
   required: false
-  default: `10`
+  default: 10
   type: int
 show_all_controls:
   description: Forces all controls to display. Ignores dynamic controls (ex. show volume controls for client A but not for client B) based on detected client capabilities. This option allows you to override this detection if you suspect it to be incorrect.
   required: false
-  default: `false`
+  default: false
   type: boolean
 use_custom_entity_ids:
   description: Name Entity ID's by client ID's instead of friendly names. HA assigns entity ID's on a first come first serve basis.  When you have identically named devices connecting (ex. media_player.plex_web_safari, media_player.plex_web_safari2), you can't reliably distinguish and or predict which device is which.  This option avoids this issue by using unique client ID's (ex. media_player.dy4hdna2drhn).
   required: false
-  default: `false`
+  default: false
   type: boolean
 use_episode_art:
   description: Display TV episode art instead of TV show art.
   required: false
-  default: `false`
+  default: false
   type: boolean
 remove_unavailable_clients:
   description: Remove stale plex clients from UI after interval.
   required: false
-  default: `true`
+  default: true
   type: boolean
 client_remove_interval:
-  description: How long a client is to be unavailable for before it is cleaned up.
+  description: How long a client is to be unavailable for before it is cleaned up in seconds.
   required: false
-  default: `600 seconds` (10min)
-  type: time
+  default: 600
+  type: integer
 {% endconfiguration %}
 
 ### {% linkable_title Service `play_media` %}

--- a/source/_components/media_player.plex.markdown
+++ b/source/_components/media_player.plex.markdown
@@ -72,14 +72,48 @@ media_player:
     remove_unavailable_clients: true
     client_remove_interval: 600
 ```
-- **entity_namespace** (*Optional*): Prefix for entity ID's. Defaults to `null`. Useful when using overlapping components (ex. Apple TV and Plex components when you have Apple TV's you use as Plex clients). Go from _media_player.playroom2_ to _media_player.plex_playroom_
-- **include_non_clients** (*Optional*): Display non-recontrollable clients (ex. remote clients, PlexConnect Apple TV's). Defaults to `false`.
-- **scan_interval** (*Optional*): Amount in seconds in between polling for device’s current activity. Defaults to `10` seconds.
-- **show_all_controls** (*Optional*): Forces all controls to display. Defaults to `false`. Ignores dynamic controls (ex. show volume controls for client A but not for client B) based on detected client capabilities. This option allows you to override this detection if you suspect it to be incorrect.
-- **use_custom_entity_ids** (*Optional*): Name Entity ID's by client ID's instead of friendly names. Defaults to `false`.  HA assigns entity ID's on a first come first serve basis.  When you have identically named devices connecting (ex. media_player.plex_web_safari, media_player.plex_web_safari2), you can't reliably distinguish and or predict which device is which.  This option avoids this issue by using unique client ID's (ex. media_player.dy4hdna2drhn).
-- **use_episode_art** (*Optional*): Display TV episode art instead of TV show art. Defaults to `false`.
-- **remove_unavailable_clients** (*Optional*): Remove stale plex clients from UI after interval. Defaults to `true`.
-- **client_remove_interval** (*Optional*): How long a client is to be unavailable for before it is cleaned up. Defaults to `600 seconds (10min)`.
+{% configuration %}
+entity_namespace:
+  description: Prefix for entity ID's. Useful when using overlapping components (ex. Apple TV and Plex components when you have Apple TV's you use as Plex clients). Go from _media_player.playroom2_ to _media_player.plex_playroom_
+  required: false
+  default: `null`
+  type: string
+include_non_clients:
+  description: Display non-recontrollable clients (ex. remote clients, PlexConnect Apple TV's).
+  required: false
+  default: `false`
+  type: boolean
+scan_interval:
+  description: Amount in seconds in between polling for device’s current activity.
+  required: false
+  default: `10`
+  type: int
+show_all_controls:
+  description: Forces all controls to display. Ignores dynamic controls (ex. show volume controls for client A but not for client B) based on detected client capabilities. This option allows you to override this detection if you suspect it to be incorrect.
+  required: false
+  default: `false`
+  type: boolean
+use_custom_entity_ids:
+  description: Name Entity ID's by client ID's instead of friendly names. HA assigns entity ID's on a first come first serve basis.  When you have identically named devices connecting (ex. media_player.plex_web_safari, media_player.plex_web_safari2), you can't reliably distinguish and or predict which device is which.  This option avoids this issue by using unique client ID's (ex. media_player.dy4hdna2drhn).
+  required: false
+  default: `false`
+  type: boolean
+use_episode_art:
+  description: Display TV episode art instead of TV show art.
+  required: false
+  default: `false`
+  type: boolean
+remove_unavailable_clients:
+  description: Remove stale plex clients from UI after interval.
+  required: false
+  default: `true`
+  type: boolean
+client_remove_interval:
+  description: How long a client is to be unavailable for before it is cleaned up.
+  required: false
+  default: `600 seconds` (10min)
+  type: time
+{% endconfiguration %}
 
 ### {% linkable_title Service `play_media` %}
 


### PR DESCRIPTION
**Description:**
Implement the new style for configuration variables description as requested by #6385  


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
