### PR TITLE
Adding detail about initial state

### DIFF
--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -49,7 +49,7 @@ Actions are all about calling services. To explore the available services open t
 
 ### {% linkable_title Automation initial state %}
 
-You have to set an initial state in your automations in order for Home Assistant to enable them upon restart.
+You have to set an initial state in your automations in order for Home Assistant to always enable them upon restart.
 
 ```text
 automation:
@@ -58,3 +58,5 @@ automation:
   trigger:
   ...
 ```
+
+If you don't set this the previous state is restored. If you shut Home Assistant down before it finishes starting, the automation will be stored as being off, and your automations will be disabled at the next startup.


### PR DESCRIPTION
It's always been a bit of mystery why automations sometimes get turned off. This should shed some light on it.

I appreciate the intent is to fix this, but until it's fixed, it makes sense to document it.
