### PR TITLE
Minor tweaks to Blink docs

### DIFF
--- a/source/_components/blink.markdown
+++ b/source/_components/blink.markdown
@@ -26,17 +26,6 @@ To enable devices linked in your [Blink](https://blinkforhome.com) account, add 
 blink:
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
-  scan_interval: 60
-  binary_sensors:
-    monitored_conditions:
-      - motion_enabled
-      - motion_detected
-  sensors:
-    monitored_conditions:
-      - battery
-      - temperature
-      - status
-      - wifi_strength
 ```
 
 {% configuration %}
@@ -51,7 +40,7 @@ password:
 scan_interval:
     description: How frequently to query for new data. Defaults to 60 seconds.
     required: false
-    type: int
+    type: integer
 binary_sensors:
     description: Binary sensor configuration options.
     required: false
@@ -77,11 +66,32 @@ sensors:
 
 Since the cameras are battery operated, setting the `scan_interval` must be done with care so as to not drain the battery too quickly, or hammer Blink's servers with too many API requests.  The cameras can be manually updated via the `trigger_camera` service which will ignore the throttling caused by `scan_interval`.  As a note, all of the camera-specific sensors are only polled when a new image is requested from the camera. This means that relying on any of these sensors to provide timely and accurate data is not recommended.
 
-**Note:** Each camera reports two different states, one as `sensor.blink_<camera_name>_status` and the other as `binary_sensor.blink_<camera_name>_motion_enabled`.  The `moition_enabld` property reports if the `camera` is ready to detect motion *regardless if the system is actually armed**.  The `status` property is more descriptive, and can be one of the following states:
+**Note:** Each camera reports two different states, one as `sensor.blink_<camera_name>_status` and the other as `binary_sensor.blink_<camera_name>_motion_enabled`.  The `moition_enabled` property reports if the `camera` is ready to detect motion *regardless if the system is actually armed**.  The `status` property is more descriptive, and can be one of the following states:
 
 - `disabled`: System is disabled.
 - `disarmed`: Camera and/or system are disarmed and not ready to detect motion.
 - `armed`: System and camera are armed and detecting motion.
+
+Below is an example showing every possible entry:
+
+```yaml
+# Example configuration.yaml entry
+blink:
+  username: YOUR_USERNAME
+  password: YOUR_PASSWORD
+  scan_interval: 60
+  binary_sensors:
+    monitored_conditions:
+      - motion_enabled
+      - motion_detected
+  sensors:
+    monitored_conditions:
+      - battery
+      - temperature
+      - status
+      - wifi_strength
+```
+
 
 ## {% linkable_title Services %}
 


### PR DESCRIPTION
**Description:**
There were some additional comments from @MartinHjelmare around the same time my last PR #6427  got merged, so I wanted to address them.

- Added simple config example and moved complex example lower in doc
- Fixed typo (motion_enabld instead of motion_enabled)
- Changed int to integer per #6452 

## Checklist:
- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

