### PR TITLE
Add documentation for current_temperature_template in climate.mqtt

### DIFF
--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -106,6 +106,11 @@ mode_state_template:
   description: A template to render the value received on the `mode_state_topic` with.
   required: false
   type: template
+modes:
+  description: A list of supported modes.
+  required: false
+  default: ['auto', 'off', 'cool', 'heat', 'dry', 'fan_only']
+  type: list
 temperature_command_topic:
   description: The MQTT topic to publish commands to change the target temperature.
   required: false
@@ -130,6 +135,11 @@ fan_mode_state_template:
   description: A template to render the value received on the `fan_mode_state_topic` with.
   required: false
   type: template
+fan_modes:
+  description: A list of supported fan modes.
+  required: false
+  default: ['auto', 'low', 'medium', 'high']
+  type: list
 swing_mode_command_topic:
   description: The MQTT topic to publish commands to change the swing mode.
   required: false
@@ -142,6 +152,11 @@ swing_mode_state_template:
   description: A template to render the value received on the `swing_mode_state_topic` with.
   required: false
   type: template
+swing_modes:
+  description: A list of supported swing modes.
+  required: false
+  default: ['on', 'off']
+  type: list
 away_mode_command_topic:
   description: The MQTT topic to publish commands to change the away mode.
   required: false

--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -86,6 +86,10 @@ current_temperature_topic:
   description: The MQTT topic on which to listen for the current temperature.
   required: false
   type: string
+current_temperature_template:
+  description: A template with which the value received on `current_temperature_topic` will be rendered.
+  required: false
+  type: template
 power_command_topic:
   description: The MQTT topic to publish commands to change the power state. This is useful if your device has a separate power toggle in addition to mode.
   required: false


### PR DESCRIPTION
**Description:**
An undocumented feature (current_temperature_template) was accidentally discovered in the mqtt climate platform.
This PR adds documentation for this feature.
Fixes #6467 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
