### PR TITLE
Update switch Wake on Lan configuration variable

### DIFF
--- a/source/_components/switch.wake_on_lan.markdown
+++ b/source/_components/switch.wake_on_lan.markdown
@@ -50,7 +50,7 @@ turn_off:
   required: false
   type: string
 broadcast_address:
-  description: The IP address of the host to send the magic packet to (default 255.255.255.255).
+  description: The IP address of the host to send the magic packet to.
   required: false
   default: 255.255.255.255
   type: string

--- a/source/_components/switch.wake_on_lan.markdown
+++ b/source/_components/switch.wake_on_lan.markdown
@@ -37,7 +37,7 @@ mac_address:
   required: true
   type: string
 name:
-  description: The name of the switch. Default is 'Wake on LAN'.
+  description: The name of the switch.
   required: false
   default: Wake on LAN
   type: string

--- a/source/_components/switch.wake_on_lan.markdown
+++ b/source/_components/switch.wake_on_lan.markdown
@@ -44,7 +44,7 @@ name:
 host:
   description: The IP address or hostname to check the state of the device (on/off).
   required: false
-  type: [string, int]
+  type: string
 turn_off:
   description: Defines an [action](/getting-started/automation/) to run when the switch is turned off.
   required: false
@@ -53,7 +53,7 @@ broadcast_address:
   description: The IP address of the host to send the magic packet to (default 255.255.255.255).
   required: false
   default: 255.255.255.255
-  type: [string, int]
+  type: string
 {% endconfiguration %}
 
 ## {% linkable_title Examples %}

--- a/source/_components/switch.wake_on_lan.markdown
+++ b/source/_components/switch.wake_on_lan.markdown
@@ -39,6 +39,7 @@ mac_address:
 name:
   description: The name of the switch. Default is 'Wake on LAN'.
   required: false
+  default: Wake on LAN
   type: string
 host:
   description: The IP address or hostname to check the state of the device (on/off).

--- a/source/_components/switch.wake_on_lan.markdown
+++ b/source/_components/switch.wake_on_lan.markdown
@@ -31,13 +31,29 @@ switch:
     mac_address: "00-01-02-03-04-05"
 ```
 
-Configuration variables:
-
-- **mac_address** (*Required*): MAC address to send the wake up command to.
-- **name** (*Optional*): The name of the switch. Default is 'Wake on LAN'.
-- **host** (*Optional*): The IP address or hostname to check the state of the device (on/off).
-- **turn_off** (*Optional*): Defines an [action](/getting-started/automation/) to run when the switch is turned off.
-- **broadcast_address** (*Optional*): The IP address of the host to send the magic packet to (default 255.255.255.255).
+{% configuration %}
+mac_address:
+  description: MAC address to send the wake up command to.
+  required: true
+  type: string
+name:
+  description: The name of the switch. Default is 'Wake on LAN'.
+  required: false
+  type: string
+host:
+  description: The IP address or hostname to check the state of the device (on/off).
+  required: false
+  type: [string, int]
+turn_off:
+  description: Defines an [action](/getting-started/automation/) to run when the switch is turned off.
+  required: false
+  type: string
+broadcast_address:
+  description: The IP address of the host to send the magic packet to (default 255.255.255.255).
+  required: false
+  default: 255.255.255.255
+  type: [string, int]
+{% endconfiguration %}
 
 ## {% linkable_title Examples %}
 


### PR DESCRIPTION
**Description:**
Update style of switch wake on lan documentation to follow new configuration variables description.

Note: the numbered list, I assume that it should remain as the code is now?

Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
