### PR TITLE
Removed optional configuration setting

### DIFF
--- a/source/_components/weblink.markdown
+++ b/source/_components/weblink.markdown
@@ -23,7 +23,6 @@ weblink:
   entities:
     - name: Router
       url: http://192.168.1.1/
-      icon: mdi:router-wireless
     - name: Home Assistant
       url: https://www.home-assistant.io
     - name: Grafana


### PR DESCRIPTION
**Description:**
Removed optional icon configuration setting from example

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
