### PR TITLE
Update counter component docs

### DIFF
--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -24,18 +24,45 @@ counter:
     step: 1
 ```
 
-Configuration variables:
-
-- **[alias]** (*Required*): Alias for the counter. Multiple entries are allowed.
-  - **name** (*Optional*): Friendly name of the counter.
-  - **initial** (*Optional*): Initial value when Home Assistant starts. Defaults to 0.
-  - **restore** (*Optional*): Restore last known value when Home Assistant restarts. Defaults to True.
-  - **step** (*Optional*): Incremental/step value for the counter. Defaults to 1 (increments by 1).
-  - **icon** (*Optional*): Icon for entry.
-
-If `restore` is set to `False` or no last known value is present, the counter will use the `initial` value upon start.
+{% configuration %}
+# 'alias' should be replaced by the user for their actual value.
+"[alias]":
+  description: Alias for the counter. Multiple entries are allowed.
+  required: true
+  type: map
+  keys:
+    name:
+      description: Friendly name of the counter.
+      required: false
+      type: string
+    initial:
+      description: Initial value when Home Assistant starts or the counter is reset.
+      required: false
+      type: integer
+      default: 0
+    restore:
+      description: Try to restore the last known value when Home Assistant starts.
+      required: false
+      type: boolean
+      default: True
+    step:
+      description: Incremental/step value for the counter.
+      required: false
+      type: integer
+      default: 1
+    icon:
+      description: Icon to display for the counter.
+      required: false
+      type: icon
+{% endconfiguration %}
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your input and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance` or `mdi:motorbike`.
+
+### {% linkable_title Restore State %}
+
+This component will automatically restore the state it had prior to Home Assistant stopping as long as you have the `recorder` component enabled and your entity has `restore` set to `True` which is the default. To disable this feature, set `restore` to `False`. Additional information can be found in the [Restore state](/components/recorder/#restore-state) section of the [`recorder`](/components/recorder/) component documentation.
+
+If `restore` is set to `False`, the `initial` value will only be used when no previous state is found or when the counter is reset.
 
 ## {% linkable_title Services %}
 


### PR DESCRIPTION
**Description:**
Add some information about the initial/restore config options (ref. #6479, home-assistant/home-assistant#17101)
Convert counter configuration description to new format (ref. #6385)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
