### PR TITLE
Add warning about hassio incompatibility

### DIFF
--- a/source/_components/usps.markdown
+++ b/source/_components/usps.markdown
@@ -21,7 +21,12 @@ In addition to having a USPS account, you will need to complete the "Opt-In" pro
 This component requires that a headless-capable web browser is installed on your system - either PhantomJS or Google Chrome. Preferably use Chrome if your operating system supports it, since PhantomJS is deprecated.
 
 <p class='note warning'>
-  If you are using a Raspberry Pi, you must use PhantomJS.
+  If you are using a Raspberry Pi, you must use PhantomJS.  
+</p>
+
+<p class='note warning'>
+  Hass.io containers are based on Alpine Linux. PhanthomJS is not available for Alpine Linux.
+Therefore it is currently not possible to use this component on Hassio 
 </p>
 
 ### PhantomJS

--- a/source/_components/usps.markdown
+++ b/source/_components/usps.markdown
@@ -25,8 +25,7 @@ This component requires that a headless-capable web browser is installed on your
 </p>
 
 <p class='note warning'>
-  Hass.io containers are based on Alpine Linux. PhanthomJS is not available for Alpine Linux.
-Therefore it is currently not possible to use this component on Hassio 
+  Hass.io containers are based on Alpine Linux. PhanthomJS is not available for Alpine Linux. Therefore it is currently not possible to use this component on Hass.io. 
 </p>
 
 ### PhantomJS


### PR DESCRIPTION
According to https://github.com/home-assistant/home-assistant/issues/13751#issuecomment-424007898, this component is not compatibile with Hass.io, adding warning in the documentation to help prevent people from running Hass.io from even attempting to get this working.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
