### PR TITLE
Update Notify Telegram configuration variable

### DIFF
--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -86,8 +86,9 @@ notify:
 
 {% configuration %}
 name:
-  description: Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
   required: false
+  default: notify
   type: string
 chat_id:
   description: The chat ID of your user.

--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -92,7 +92,7 @@ name:
 chat_id:
   description: The chat ID of your user.
   required: true
-  type: string
+  type: integer
 {% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
@@ -169,8 +169,9 @@ password:
   required: false
   type: string
 authentication:
-  description: Set to 'digest' to use HTTP digest authentication, defaults to 'basic'.
+  description: Set to 'digest' to use HTTP digest authentication.
   required: false
+  default: basic
   type: string
 keyboard:
   description: List of rows of commands, comma-separated, to make a custom keyboard.
@@ -233,8 +234,9 @@ password:
   required: false
   type: string
 authentication:
-  description: Set to 'digest' to use HTTP digest authentication, defaults to 'basic'.
+  description: Set to 'digest' to use HTTP digest authentication.
   required: false
+  default: basic
   type: string
 keyboard:
   description: List of rows of commands, comma-separated, to make a custom keyboard.
@@ -282,8 +284,9 @@ password:
   required: false
   type: string
 authentication:
-  description: Set to 'digest' to use HTTP digest authentication, defaults to 'basic'.
+  description: Set to 'digest' to use HTTP digest authentication.
   required: false
+  default: basic
   type: string
 keyboard:
   description: List of rows of commands, comma-separated, to make a custom keyboard.

--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -153,8 +153,8 @@ action:
 ```
 
 {% configuration %}
-url or file:
-  description: For local or remote path to an image.
+url:
+  description: For local or remote path to an image (file).
   required: true
   type: string
 caption:
@@ -319,11 +319,11 @@ action:
 latitude:
   description: The latitude to send.
   required: true
-  type: [string, int]
+  type: float
 longitude:
   description: The longitude to send.
   required: true
-  type: [string, int]
+  type: float
 keyboard:
   description: List of rows of commands, comma-separated, to make a custom keyboard.
   required: false

--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -84,10 +84,16 @@ notify:
     chat_id: CHAT_ID_2
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **chat_id** (*Required*): The chat ID of your user.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  type: string
+chat_id:
+  description: The chat ID of your user.
+  required: true
+  type: string
+{% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
 
@@ -106,12 +112,24 @@ action:
         - 'Task 3:/command3, Task 4:/command4'
 ```
 
-Configuration variables:
-
-- **message** (*Required*): Message text.
-- **title** (*Optional*): Will be composed as '%title\n%message'.
-- **keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom keyboard.
-- **inline_keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+{% configuration %}
+title:
+  description: Will be composed as '%title\n%message'.
+  required: false
+  type: string
+message:
+  description: Message text.
+  required: true
+  type: string
+keyboard:
+  description: List of rows of commands, comma-separated, to make a custom keyboard.
+  required: false
+  type: list
+inline_keyboard:
+  description: List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+  required: false
+  type: list
+{% endconfiguration %}
 
 ### {% linkable_title Photo support %}
 
@@ -133,15 +151,36 @@ action:
           caption: I.e. for a Title
 ```
 
-Configuration variables:
-
-- **url** or **file** (*Required*): For local or remote path to an image.
-- **caption** (*Optional*): The title of the image.
-- **username** (*Optional*): Username for a URL which require HTTP authentication.
-- **password** (*Optional*): Username for a URL which require HTTP authentication.
-- **authentication** (*Optional*): Set to 'digest' to use HTTP digest authentication, defaults to 'basic'.
-- **keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom keyboard.
-- **inline_keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+{% configuration %}
+url or file:
+  description: For local or remote path to an image.
+  required: true
+  type: string
+caption:
+  description: The title of the image.
+  required: false
+  type: string
+username:
+  description: Username for a URL which require HTTP authentication.
+  required: false
+  type: string
+password:
+  description: Password for a URL which require HTTP authentication.
+  required: false
+  type: string
+authentication:
+  description: Set to 'digest' to use HTTP digest authentication, defaults to 'basic'.
+  required: false
+  type: string
+keyboard:
+  description: List of rows of commands, comma-separated, to make a custom keyboard.
+  required: false
+  type: list
+inline_keyboard:
+  description: List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+  required: false
+  type: list
+{% endconfiguration %}
 
 <p class='note'>
 Since Home Assistant version 0.48 you have to [whitelist the source folder](/docs/configuration/basic/) of the file you want to include in the notification.
@@ -176,15 +215,36 @@ action:
           caption: I.e. for a Title
 ```
 
-Configuration variables:
-
-- **url** or **file** (*Required*): For local or remote path to a video.
-- **caption** (*Optional*): The title of the video.
-- **username** (*Optional*): Username for a URL which require HTTP authentication.
-- **password** (*Optional*): Username for a URL which require HTTP authentication.
-- **authentication** (*Optional*): Set to 'digest' to use HTTP digest authentication, defaults to 'basic'.
-- **keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom keyboard.
-- **inline_keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+{% configuration %}
+url or file:
+  description: For local or remote path to an image.
+  required: true
+  type: string
+caption:
+  description: The title of the image.
+  required: false
+  type: string
+username:
+  description: Username for a URL which require HTTP authentication.
+  required: false
+  type: string
+password:
+  description: Password for a URL which require HTTP authentication.
+  required: false
+  type: string
+authentication:
+  description: Set to 'digest' to use HTTP digest authentication, defaults to 'basic'.
+  required: false
+  type: string
+keyboard:
+  description: List of rows of commands, comma-separated, to make a custom keyboard.
+  required: false
+  type: list
+inline_keyboard:
+  description: List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+  required: false
+  type: list
+{% endconfiguration %}
 
 ### {% linkable_title Document support %}
 
@@ -204,15 +264,36 @@ action:
       - '/command3, /command4'
 ```
 
-Configuration variables:
-
-- **url** or **file** (*Required*): For local or remote path to a document.
-- **caption** (*Optional*): The title of the document.
-- **username** (*Optional*): Username for a URL which require HTTP authentication.
-- **password** (*Optional*): Username for a URL which require HTTP authentication.
-- **authentication** (*Optional*): Set to 'digest' to use HTTP digest authentication, defaults to 'basic'.
-- **keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom keyboard.
-- **inline_keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+{% configuration %}
+url or file:
+  description: For local or remote path to an image.
+  required: true
+  type: string
+caption:
+  description: The title of the image.
+  required: false
+  type: string
+username:
+  description: Username for a URL which require HTTP authentication.
+  required: false
+  type: string
+password:
+  description: Password for a URL which require HTTP authentication.
+  required: false
+  type: string
+authentication:
+  description: Set to 'digest' to use HTTP digest authentication, defaults to 'basic'.
+  required: false
+  type: string
+keyboard:
+  description: List of rows of commands, comma-separated, to make a custom keyboard.
+  required: false
+  type: list
+inline_keyboard:
+  description: List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+  required: false
+  type: list
+{% endconfiguration %}
 
 ### {% linkable_title Location support %}
 
@@ -230,9 +311,21 @@ action:
         longitude: 117.22743
 ```
 
-Configuration variables:
-
-- **latitude** (*Required*): The latitude to send.
-- **longitude** (*Required*): The longitude to send.
-- **keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom keyboard.
-- **inline_keyboard** (*Optional*): List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+{% configuration %}
+latitude:
+  description: The latitude to send.
+  required: true
+  type: [string, int]
+longitude:
+  description: The longitude to send.
+  required: true
+  type: [string, int]
+keyboard:
+  description: List of rows of commands, comma-separated, to make a custom keyboard.
+  required: false
+  type: list
+inline_keyboard:
+  description: List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+  required: false
+  type: list
+{% endconfiguration %}

--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -154,11 +154,11 @@ action:
 
 {% configuration %}
 url:
-  description: A remote path to an image.
+  description: A remote path to an image. Either this or the `file` configuration option is required.
   required: true
   type: string
 file:
-  description: A local path to an image.
+  description: A local path to an image. Either this or the `url` configuration option is required.
   required: true
   type: string
 caption:
@@ -223,11 +223,11 @@ action:
 
 {% configuration %}
 url:
-  description: A remote path to an video.
+  description: A remote path to an video. Either this or the `file` configuration option is required.
   required: true
   type: string
 file:
-  description: A local path to an video.
+  description: A local path to an video. Either this or the `url` configuration option is required.
   required: true
   type: string
 caption:
@@ -277,11 +277,11 @@ action:
 
 {% configuration %}
 url:
-  description: A remote path to an document.
+  description: A remote path to an document. Either this or the `file` configuration option is required.
   required: true
   type: string
 file:
-  description: A local path to an document.
+  description: A local path to an document. Either this or the `url` configuration option is required.
   required: true
   type: string
 caption:

--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -154,7 +154,11 @@ action:
 
 {% configuration %}
 url:
-  description: For local or remote path to an image (file).
+  description: A remote path to an image.
+  required: true
+  type: string
+file:
+  description: A local path to an image.
   required: true
   type: string
 caption:
@@ -218,12 +222,16 @@ action:
 ```
 
 {% configuration %}
-url or file:
-  description: For local or remote path to an image.
+url:
+  description: A remote path to an video.
+  required: true
+  type: string
+file:
+  description: A local path to an video.
   required: true
   type: string
 caption:
-  description: The title of the image.
+  description: The title of the video.
   required: false
   type: string
 username:
@@ -268,12 +276,16 @@ action:
 ```
 
 {% configuration %}
-url or file:
-  description: For local or remote path to an image.
+url:
+  description: A remote path to an document.
+  required: true
+  type: string
+file:
+  description: A local path to an document.
   required: true
   type: string
 caption:
-  description: The title of the image.
+  description: The title of the document.
   required: false
   type: string
 username:


### PR DESCRIPTION
A new PR since my old one went to the wrong branch 😢 

Update style of notify telegram documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
