### PR TITLE
Update Alarm.com Alarm Control Panel configuration variable

### DIFF
--- a/source/_components/alarm_control_panel.alarmdotcom.markdown
+++ b/source/_components/alarm_control_panel.alarmdotcom.markdown
@@ -30,7 +30,7 @@ username:
   required: true
   type: string
 password:
-  description: Password for Alarm.com account.
+  description: Password for the Alarm.com account.
   required: true
   type: string
 name:

--- a/source/_components/alarm_control_panel.alarmdotcom.markdown
+++ b/source/_components/alarm_control_panel.alarmdotcom.markdown
@@ -24,9 +24,22 @@ alarm_control_panel:
   password: YOUR_PASSWORD
 ```
 
-Configuration variables:
-
-- **username** (*Required*): Username for the Alarm.com account.
-- **password** (*Required*): Password for Alarm.com account.
-- **name** (*Optional*): The name of the alarm. Default is 'Alarm.com'.
-- **code** (*Optional*): Specifies a code to enable or disable the alarm in the frontend.
+{% configuration %}
+username:
+  description: Username for the Alarm.com account.
+  required: true
+  type: string
+password:
+  description: Password for Alarm.com account.
+  required: true
+  type: string
+name:
+  description: The name of the alarm.
+  required: false
+  default: Alarm.com
+  type:
+code:
+  description: Specifies a code to enable or disable the alarm in the frontend.
+  required: false
+  type: int
+{% endconfiguration %}

--- a/source/_components/alarm_control_panel.alarmdotcom.markdown
+++ b/source/_components/alarm_control_panel.alarmdotcom.markdown
@@ -37,7 +37,7 @@ name:
   description: The name of the alarm.
   required: false
   default: Alarm.com
-  type:
+  type: string
 code:
   description: Specifies a code to enable or disable the alarm in the frontend.
   required: false

--- a/source/_components/alarm_control_panel.concord232.markdown
+++ b/source/_components/alarm_control_panel.concord232.markdown
@@ -24,7 +24,15 @@ alarm_control_panel:
   - platform: concord232
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The host where the concord232 server process is running. Defaults to localhost.
-- **port** (*Optional*): The port where the Alarm panel is listening. Defaults to 5007.
+{% configuration %}
+host:
+  description: The host where the concord232 server process is running.
+  required: false
+  default: localhost
+  type: string
+port:
+  description: The port where the Alarm panel is listening.
+  required: false
+  default: 5007
+  type: int
+{% endconfiguration %}

--- a/source/_components/alarm_control_panel.concord232.markdown
+++ b/source/_components/alarm_control_panel.concord232.markdown
@@ -24,15 +24,7 @@ alarm_control_panel:
   - platform: concord232
 ```
 
-{% configuration %}
-host:
-  description: The host where the concord232 server process is running.
-  required: false
-  default: localhost
-  type: string
-port:
-  description: The port where the Alarm panel is listening.
-  required: false
-  default: 5007
-  type: int
-{% endconfiguration %}
+Configuration variables:
+
+- **host** (*Optional*): The host where the concord232 server process is running. Defaults to localhost.
+- **port** (*Optional*): The port where the Alarm panel is listening. Defaults to 5007.


### PR DESCRIPTION
Update style of Alarm.com Alarm Control Panel documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
