### PR TITLE
Updated all Telegram component files configuration variable

### DIFF
--- a/source/_components/telegram_bot.broadcast.markdown
+++ b/source/_components/telegram_bot.broadcast.markdown
@@ -37,7 +37,7 @@ api_key:
   required: true
   type: string
 parse_mode:
-  description: Default parser for messages if not explicit in message data: 'html' or 'markdown'.
+  description: "Default parser for messages if not explicit in message data: 'html' or 'markdown'."
   required: false
   default: markdown
   type: string

--- a/source/_components/telegram_bot.broadcast.markdown
+++ b/source/_components/telegram_bot.broadcast.markdown
@@ -27,13 +27,28 @@ telegram_bot:
       - 67890
 ```
 
-Configuration variables:
-
-- **allowed_chat_ids** (*Required*): A list of user in the `user_id` Telegram format enabled to interact to webhook
-- **api_key** (*Required*): The API token of your bot.
-- **parse_mode** (*Optional*): Default parser for messages if not explicit in message data: 'html' or 'markdown'. Default is 'markdown'.
-- **proxy_url** (*Optional*): Proxy url if working behind one (`socks5://proxy_ip:proxy_port`)
-- **proxy_params** (*Optional*): Proxy configuration parameters, as dict, if working behind a proxy (`username`, `password`, etc.)
+{% configuration %}
+allowed_chat_ids:
+  description: A list of user in the `user_id` Telegram format enabled to interact to webhook
+  required: true
+  type: list
+api_key:
+  description: The API token of your bot.
+  required: true
+  type: string
+parse_mode:
+  description: Default parser for messages if not explicit in message data: 'html' or 'markdown'.
+  required: false
+  default: markdown
+  type: string
+proxy_url:
+  description: Proxy url if working behind one (`socks5://proxy_ip:proxy_port`)
+  required: false
+  type: string
+proxy_params:
+  description: Proxy configuration parameters, as dict, if working behind a proxy (`username`, `password`, etc.)
+  required: false
+  type: string
+{% endconfiguration %}
 
 To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram/).
-

--- a/source/_components/telegram_bot.polling.markdown
+++ b/source/_components/telegram_bot.polling.markdown
@@ -29,13 +29,28 @@ telegram_bot:
       - 67890
 ```
 
-Configuration variables:
-
-- **allowed_chat_ids** (*Required*): A list of user in the `user_id` Telegram format enabled to interact to webhook
-- **api_key** (*Required*): The API token of your bot.
-- **parse_mode** (*Optional*): Default parser for messages if not explicit in message data: 'html' or 'markdown'. Default is 'markdown'.
-- **proxy_url** (*Optional*): Proxy url if working behind one (`socks5://proxy_ip:proxy_port`)
-- **proxy_params** (*Optional*): Proxy configuration parameters, as dict, if working behind a proxy (`username`, `password`, etc.)
+{% configuration %}
+allowed_chat_ids:
+  description: A list of user in the `user_id` Telegram format enabled to interact to webhook
+  required: true
+  type: list
+api_key:
+  description: The API token of your bot.
+  required: true
+  type: string
+parse_mode:
+  description: Default parser for messages if not explicit in message data: 'html' or 'markdown'.
+  required: false
+  default: markdown
+  type: string
+proxy_url:
+  description: Proxy url if working behind one (`socks5://proxy_ip:proxy_port`)
+  required: false
+  type: string
+proxy_params:
+  description: Proxy configuration parameters, as dict, if working behind a proxy (`username`, `password`, etc.)
+  required: false
+  type: string
+{% endconfiguration %}
 
 To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram/).
-

--- a/source/_components/telegram_bot.polling.markdown
+++ b/source/_components/telegram_bot.polling.markdown
@@ -39,7 +39,7 @@ api_key:
   required: true
   type: string
 parse_mode:
-  description: Default parser for messages if not explicit in message data: 'html' or 'markdown'.
+  description: "Default parser for messages if not explicit in message data: 'html' or 'markdown'."
   required: false
   default: markdown
   type: string

--- a/source/_components/telegram_bot.webhooks.markdown
+++ b/source/_components/telegram_bot.webhooks.markdown
@@ -49,7 +49,7 @@ trusted_networks:
   default: 149.154.167.197-233
   type: string
 parse_mode:
-  description: Default parser for messages if not explicit in message data: 'html' or 'markdown'.
+  description: "Default parser for messages if not explicit in message data: 'html' or 'markdown'."
   required: false
   default: markdown
   type: string

--- a/source/_components/telegram_bot.webhooks.markdown
+++ b/source/_components/telegram_bot.webhooks.markdown
@@ -34,15 +34,38 @@ telegram_bot:
       - 67890
 ```
 
-Configuration variables:
-
-- **allowed_chat_ids** (*Required*): A list of ids representing the users and group chats that are authorized to interact with the webhook.
-- **api_key** (*Required*): The API token of your bot.
-- **trusted_networks** (*Optional*): Telegram server access ACL as list. Defaults to `149.154.167.197-233`.
-- **parse_mode** (*Optional*): Default parser for messages if not explicit in message data: 'html' or 'markdown'. Default is 'markdown'.
-- **proxy_url** (*Optional*): Proxy url if working behind one (`socks5://proxy_ip:proxy_port`)
-- **proxy_params** (*Optional*): Proxy configuration parameters, as dict, if working behind a proxy (`username`, `password`, etc.)
-- **url** (*Optional*): Allow to overwrite the `base_url` from the [`http`](/components/http/) component for different configurations (`https://<public_url>:<port>`).
+{% configuration %}
+allowed_chat_ids:
+  description: A list of ids representing the users and group chats that are authorized to interact with the webhook.
+  required: true
+  type: list
+api_key:
+  description: The API token of your bot.
+  required: true
+  type: string
+trusted_networks:
+  description: Telegram server access ACL as list.
+  required: false
+  default: 149.154.167.197-233
+  type: string
+parse_mode:
+  description: Default parser for messages if not explicit in message data: 'html' or 'markdown'.
+  required: false
+  default: markdown
+  type: string
+proxy_url:
+  description: Proxy url if working behind one (`socks5://proxy_ip:proxy_port`)
+  required: false
+  type: string
+proxy_params:
+  description: Proxy configuration parameters, as dict, if working behind a proxy (`username`, `password`, etc.)
+  required: false
+  type: string
+url:
+  description: Allow to overwrite the `base_url` from the [`http`](/components/http/) component for different configurations (`https://<public_url>:<port>`).
+  required: false
+  type: string
+{% endconfiguration %}
 
 To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram). As well as authorizing the chat, if you have added your bot to a group you will also need to authorize any user that will be interacting with the webhook. When an unauthorized user tries to interact with the webhook Home Assistant will raise an error ("Incoming message is not allowed"), you can easily obtain the users id by looking in the "from" section of this error message.
 


### PR DESCRIPTION
Updated style of all Telegram documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
