### PR TITLE
Documentation for home-assistant/home-assistant-polymer#1732

### DIFF
--- a/source/_lovelace/glance.markdown
+++ b/source/_lovelace/glance.markdown
@@ -45,6 +45,10 @@ column_width:
   description: "Column width as CSS length like `100px` or `calc(100% / 7)`. This controls how many entities appear in a row - at the default 20% you have 5 entities in a row. Use `calc(100% / 7)` for 7 entities in a row, and so on."
   type: string
   default: 20%
+theming:
+  required: false
+  description: "Set to `primary` to style the card with the background and text color of the header bar."
+  type: string
 {% endconfiguration %}
 
 ## {% linkable_title Options For Entities %}


### PR DESCRIPTION
**Description:**
Adds new `theming` option to documentation of lovelace glance card.

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** home-assistant/home-assistant-polymer#1732

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
