### PR TITLE
Update PM Sensor documentation to standards

### DIFF
--- a/source/_components/sensor.serial_pm.markdown
+++ b/source/_components/sensor.serial_pm.markdown
@@ -17,6 +17,8 @@ Particulate matter sensors measure the amount of very small particles in the air
 
 Cheap LED based sensors usually use a GPIO interface that is hard to attach to computers. However, there are a lot of laser LED based sensors on the market that use a serial interface and can be [connected to your Home Assistant system easily with an USB to serial converter](https://www.open-homeautomation.com/2016/07/20/connecting-an-particulate-matter-sensor-to-your-pc-or-mac/).
 
+## {% linkable_title Supported Sensors %}
+
 At this time, the following sensors are supported:
 
 * oneair,s3
@@ -28,7 +30,33 @@ At this time, the following sensors are supported:
 * plantower,pms2003
 * plantower,pms3003
 
+## {% linkable_title Configuration %}
+
 To use your PM sensor in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+sensor:
+  - platform: serial_pm
+    serial_device: /dev/tty.SLAB_USBtoUART
+    brand: oneair,s3
+```
+
+{% configuration %}
+serial_device:
+  description: The serial port to use. On *nix systems, it can often be identified by `$ ls /dev/tty*`
+  required: true
+  type: string
+name:
+  description: The name displayed in the frontend.
+  required: false
+  type: string
+brand:
+  description: Manufacturer and type of the sensor. (Use a value from the supported sensors list.).
+  required: true
+  type: string
+{% endconfiguration %}
+
+### {% linkable_title Named Sensor Configuration Example %}
 
 ```yaml
 sensor:
@@ -37,8 +65,4 @@ sensor:
     name: Nova
     brand: novafitness,sds011
 ```
-
-- **serial_device** (*Required*): The serial port to use. On *nix systems, it can often be identified by `$ ls /dev/tty*`
-- **name** (*Optional*): The name displayed in the frontend.
-- **brand** (*Required*): Manufacturer and type of the sensor.
 


### PR DESCRIPTION
Update configuration variable section and move "complete" configuration example (including the optional value) as a second example. Have the main configuration example only include required variables. Bring more attention to the list of supported sensors. (List of supported sensors is still current with the pmsensor library used by this component.)

Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
