### PR TITLE
"Advanced" example using dynamic destination

### DIFF
--- a/source/_components/sensor.waze_travel_time.markdown
+++ b/source/_components/sensor.waze_travel_time.markdown
@@ -61,3 +61,43 @@ realtime:
   required: false
   type: boolean
 {% endconfiguration %}
+
+
+## {% linkable_title Example using dynamic destination %}
+
+Using the flexible option to set a sensor value to the `destination`, you can setup a single Waze component that will calculate travel time to multiple optional locations on demand. 
+
+In the following example, the `Input Select` is converted into an address which is used to modify the destination for Waze route calculation from `device_tracker.myphone` location (It takes a few minutes for the value to update due to the interval set to fetch Waze data).
+
+{% raw %}
+```yaml
+input_select:
+  destination:
+    name: destination
+    options:
+      - Home
+      - Work
+      - Parents
+      
+sensor:
+  - platform: template
+    sensors:
+       dest_address:
+         value_template: >-
+            {%- if is_state("input_select.destination", "Home")  -%}
+              725 5th Ave, New York, NY 10022, USA
+            {%- elif is_state("input_select.destination", "Work")  -%}
+              767 5th Ave, New York, NY 10153, USA
+            {%- elif is_state("input_select.destination", "Parents")  -%}
+              178 Broadway, Brooklyn, NY 11211, USA
+            {%- else -%}
+              Unknown
+            {%- endif %}
+         
+  - platform: waze_travel_time
+    name: "Me to destination"
+    origin: device_tracker.myphone
+    destination: sensor.dest_address
+    region: 'US'
+```
+{% endraw %}


### PR DESCRIPTION
Some nice code that saved me from setting up and pulling multiple Waze components,
(hope the language is clear - would welcome any tip for improvement if you feel it's not!)

**Description:**

* The input select offers a user friendly text for the destination
* A template is used to convert to address in a format acceptable to the Waze component
* The Waze component is used to calculate the route between a particular device tracked by HA and the selected destination.

## Checklist:

- [x] Branch: `current` 
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
