### PR TITLE
Enhance motion sensor lighting cookbook example

### DIFF
--- a/source/_cookbook/turn_on_light_for_10_minutes_when_motion_detected.markdown
+++ b/source/_cookbook/turn_on_light_for_10_minutes_when_motion_detected.markdown
@@ -73,3 +73,36 @@ timer:
   hallway:
     duration: '00:10:00'
 ```
+
+You can also restrict lights from turning on based on time of day and implement transitions for fading lights on and off.
+
+```yaml
+- alias: Motion Sensor Lights On
+  trigger:
+    platform: state
+    entity_id: binary_sensor.ecolink_pir_motion_sensor_sensor
+    to: 'on'
+  condition: 
+    condition: time
+    after: '07:30'
+    before: '23:30'
+  action:
+    service: homeassistant.turn_on
+    entity_id: group.office_lights
+    data: 
+      transition: 15
+
+
+- alias: Motion Sensor Lights Off
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.ecolink_pir_motion_sensor_sensor
+      to: 'off'
+      for:
+        minutes: 15
+  action:
+    - service: homeassistant.turn_off
+      entity_id: group.office_lights
+      data: 
+        transition: 160
+```


### PR DESCRIPTION
**Description:**

Add an example for the [motion sensor cookbook](https://www.home-assistant.io/cookbook/turn_on_light_for_10_minutes_when_motion_detected/). 

* Adds `yaml` example for adding `time` based conditions to only turn on lights when motion is detected between certain hours.
* Adds `transition` configuration example to fade lights on and off.



**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** 

`N/A`

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
