### PR TITLE
Add device registry for MQTT sensors

### DIFF
--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -101,7 +101,7 @@ device:
       required: false
       type: list, string
     connections:
-      description: 'A list of connections of the device to the outside world in the JSON format `{connection_type: connection_identifier}`. For example the MAC address of the network interface.'
+      description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `[["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false
       type: list, tuple
     manufacturer:

--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -91,6 +91,35 @@ device_class:
   required: false
   type: device_class
   default: None
+device:
+  description: 'Information about the device this sensor is a part of to tie it into the [device registry](https://developers.home-assistant.io/docs/en/device_registry_index.html). Only works through [MQTT discovery](/docs/mqtt/discovery/) and when [`unique_id`](#unique_id) is set.'
+  required: false
+  type: map
+  keys:
+    identifiers:
+      description: 'A list of IDs that uniquely identify the device. For example a serial number.'
+      required: false
+      type: list, string
+    connections:
+      description: 'A list of connections of the device to the outside world in the JSON format `{connection_type: connection_identifier}`. For example the MAC address of the network interface.'
+      required: false
+      type: list, tuple
+    manufacturer:
+      description: 'The manufacturer of the device.'
+      required: false
+      type: string
+    model:
+      description: 'The model of the device.'
+      required: false
+      type: string
+    name:
+      description: 'The name of the device.'
+      required: false
+      type: string
+    sw_version:
+      description: 'The firmware version of the device.'
+      required: false
+      type: string
 {% endconfiguration %}
 
 ## {% linkable_title Examples %}

--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -101,9 +101,9 @@ device:
       required: false
       type: list, string
     connections:
-      description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `[["mac", "02:5b:26:a8:dc:12"]]`.'
+      description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false
-      type: list, tuple
+      type: list
     manufacturer:
       description: 'The manufacturer of the device.'
       required: false


### PR DESCRIPTION
**Description:**

Add device registry integration to MQTT sensors. The plan is to expand it to other platforms too.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#16943

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
