### PR TITLE
Updated all Zigbee configuration variable

### DIFF
--- a/source/_components/binary_sensor.zigbee.markdown
+++ b/source/_components/binary_sensor.zigbee.markdown
@@ -25,10 +25,22 @@ binary_sensor:
     pin: 0
 ```
 
-Configuration variables:
-
-- **name** (*Required*): The name you would like to give the binary sensor in Home Assistant.
-- **pin** (*Required*): The number identifying which pin to use.
-- **address** (*Optional*): The long 64-bit address of the remote ZigBee device whose digital input pin you'd like to sample. Do not include this variable if you want to sample the local ZigBee device's pins.
-- **on_state** (*Optional*): Either `high` (default) or `low`, depicting whether the binary sensor is considered `on` when the pin is `high` or `low`.
-
+{% configuration %}
+name:
+  description: The name you would like to give the binary sensor in Home Assistant.
+  required: true
+  type: string
+pin:
+  description: The number identifying which pin to use.
+  required: true
+  type: integer
+address:
+  description: The long 64-bit address of the remote ZigBee device whose digital input pin you'd like to sample. Do not include this variable if you want to sample the local ZigBee device's pins.
+  required: false
+  type: string
+on_state:
+  description: Either `high` (default) or `low`, depicting whether the binary sensor is considered `on` when the pin is `high` or `low`.
+  required: false
+  default: `high`
+  type: string
+{% endconfiguration %}

--- a/source/_components/binary_sensor.zigbee.markdown
+++ b/source/_components/binary_sensor.zigbee.markdown
@@ -41,6 +41,6 @@ address:
 on_state:
   description: Either `high` or `low`, depicting whether the binary sensor is considered `on` when the pin is `high` or `low`.
   required: false
-  default: `high`
+  default: high
   type: string
 {% endconfiguration %}

--- a/source/_components/binary_sensor.zigbee.markdown
+++ b/source/_components/binary_sensor.zigbee.markdown
@@ -39,7 +39,7 @@ address:
   required: false
   type: string
 on_state:
-  description: Either `high` (default) or `low`, depicting whether the binary sensor is considered `on` when the pin is `high` or `low`.
+  description: Either `high` or `low`, depicting whether the binary sensor is considered `on` when the pin is `high` or `low`.
   required: false
   default: `high`
   type: string

--- a/source/_components/light.zigbee.markdown
+++ b/source/_components/light.zigbee.markdown
@@ -24,9 +24,22 @@ light:
     pin: 0
 ```
 
-Configuration variables:
-
-- **name** (*Required*): The name you would like to give the light in Home Assistant.
-- **pin** (*Required*): The number identifying which pin to use.
-- **address** (*Optional*): The long 64 bit address of the remote ZigBee device whose digital output pin you would like to switch. Do not include this variable if you want to switch the local ZigBee device's pins.
-- **on_state** (*Optional*): Either `high` (default) or `low`, depicting whether the digital output pin is pulled `high` or `low` when the light is turned on.
+{% configuration %}
+name:
+  description: The name you would like to give the light in Home Assistant.
+  required: true
+  type: string
+pin:
+  description: The number identifying which pin to use.
+  required: true
+  type: integer
+address:
+  description: The long 64-bit address of the remote ZigBee device whose digital output pin you would like to switch. Do not include this variable if you want to switch the local ZigBee device's pins.
+  required: false
+  type: string
+on_state:
+  description: Either `high` or `low`, depicting whether the digital output pin is pulled `high` or `low` when the light is turned on.
+  required: false
+  default: `high`
+  type: string
+{% endconfiguration %}

--- a/source/_components/light.zigbee.markdown
+++ b/source/_components/light.zigbee.markdown
@@ -40,6 +40,6 @@ address:
 on_state:
   description: Either `high` or `low`, depicting whether the digital output pin is pulled `high` or `low` when the light is turned on.
   required: false
-  default: `high`
+  default: high
   type: string
 {% endconfiguration %}

--- a/source/_components/sensor.zigbee.markdown
+++ b/source/_components/sensor.zigbee.markdown
@@ -50,7 +50,7 @@ address:
 max_volts:
   description: The maximum voltage which the input pin is able to read.
   required: false
-  default: `1.2`
+  default: 1.2
   type: float
 {% endconfiguration %}
 

--- a/source/_components/sensor.zigbee.markdown
+++ b/source/_components/sensor.zigbee.markdown
@@ -30,14 +30,29 @@ sensor:
     address: 0013A2004233D138
 ```
 
-Configuration variables:
-
-- **name** (*Required*): The name you would like to give the sensor in Home Assistant.
-- **type** (*Required*): Set to `analog` or `temperature`.
-- **pin** (*Optional*): The number identifying which pin to sample.
-- **address** (*Optional*): The long 64 bit address of the remote ZigBee device whose pin you would like to sample. Do not include this variable if you want to sample the local ZigBee device's pins.
-- **max_volts** (*Optional*): The maximum voltage which the input pin is able to read. Defaults to `1.2`.
-
+{% configuration %}
+name:
+  description: The name you would like to give the sensor in Home Assistant.
+  required: true
+  type: string
+type:
+  description: Set to `analog` or `temperature`.
+  required: true
+  type: string
+pin:
+  description: The number identifying which pin to sample.
+  required: false
+  type: integer
+address:
+  description: The long 64-bit address of the remote ZigBee device whose pin you would like to sample. Do not include this variable if you want to sample the local ZigBee device's pins.
+  required: false
+  type: string
+max_volts:
+  description: The maximum voltage which the input pin is able to read.
+  required: false
+  default: `1.2`
+  type: float
+{% endconfiguration %}
 
 ## {% linkable_title Examples %}
 
@@ -73,4 +88,3 @@ sensor:
     type: temperature
     address: 0013A20050E752C5
 ```
-

--- a/source/_components/switch.zigbee.markdown
+++ b/source/_components/switch.zigbee.markdown
@@ -42,6 +42,6 @@ address:
 on_state:
   description: Either `high` or `low`, depicting whether the digital output pin is pulled `high` or `low` when the switch is turned on.
   required: false
-  default: `high`
+  default: high
   type: string
 {% endconfiguration %}

--- a/source/_components/switch.zigbee.markdown
+++ b/source/_components/switch.zigbee.markdown
@@ -26,9 +26,22 @@ switch:
     on_state: low
 ```
 
-Configuration variables:
-
-- **name** (*Required*): The name you would like to give the switch in Home Assistant.
-- **pin** (*Required*): The number identifying which pin to use.
-- **address**: The long 6 4bit address of the remote ZigBee device whose digital output pin you would like to switch. Do not include this variable if you want to switch the local ZigBee device's pins.
-- **on_state**: Either `high` (default) or `low`, depicting whether the digital output pin is pulled `high` or `low` when the switch is turned on.
+{% configuration %}
+name:
+  description: The name you would like to give the switch in Home Assistant.
+  required: true
+  type: string
+pin:
+  description: The number identifying which pin to use.
+  required: true
+  type: integer
+address:
+  description: The long 64-bit address of the remote ZigBee device whose pin you would like to sample. Do not include this variable if you want to sample the local ZigBee device's pins.
+  required: false
+  type: string
+on_state:
+  description: Either `high` or `low`, depicting whether the digital output pin is pulled `high` or `low` when the switch is turned on.
+  required: false
+  default: `high`
+  type: string
+{% endconfiguration %}

--- a/source/_components/zigbee.markdown
+++ b/source/_components/zigbee.markdown
@@ -35,7 +35,7 @@ zigbee:
 device:
   description: The serial port to which the local ZigBee device is connected.
   required: false
-  default: /dev/ttyUSB0
+  default: "/dev/ttyUSB0"
   type: string
 baud:
   description: The baud rate at which to communicate with the local ZigBee device.

--- a/source/_components/zigbee.markdown
+++ b/source/_components/zigbee.markdown
@@ -35,12 +35,12 @@ zigbee:
 device:
   description: The serial port to which the local ZigBee device is connected.
   required: false
-  default: `/dev/ttyUSB0`
+  default: /dev/ttyUSB0
   type: string
 baud:
   description: The baud rate at which to communicate with the local ZigBee device.
   required: false
-  default: `9600`
+  default: 9600
   type: integer
 {% endconfiguration %}
 

--- a/source/_components/zigbee.markdown
+++ b/source/_components/zigbee.markdown
@@ -31,8 +31,18 @@ A `zigbee` section must be present in the `configuration.yaml` file and contain 
 zigbee:
 ```
 
-- **device** (*Optional*): The serial port to which the local ZigBee device is connected. Defaults to `/dev/ttyUSB0`
-- **baud** (*Optional*): The baud rate at which to communicate with the local ZigBee device. Defaults to `9600`
+{% configuration %}
+device:
+  description: The serial port to which the local ZigBee device is connected.
+  required: false
+  default: `/dev/ttyUSB0`
+  type: string
+baud:
+  description: The baud rate at which to communicate with the local ZigBee device.
+  required: false
+  default: `9600`
+  type: integer
+{% endconfiguration %}
 
 To find the possible serial port names of your device, run:
 


### PR DESCRIPTION
Updated style of all Zigbee documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
