### PR TITLE
Documentation for RFLink Binary Sensor

### DIFF
--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -24,7 +24,6 @@ Once the ID of a binary sensor is known, it can be used to configure it as a bin
 
 Configuring a device as a binary sensor:
 
-{% raw %}
 ```yaml
 # Example configuration.yaml entry
 binary_sensor:
@@ -32,7 +31,6 @@ binary_sensor:
      devices:
        pt2262_00174754_0: {}
 ```
-{% endraw %}
 
 {% configuration binary_sensor.rflink %}
 devices:
@@ -65,7 +63,7 @@ devices:
           description: Sends update events even if the value has not changed. Useful for sensors that only sends `On`.
           required: false
           type: boolean
-          default: "`false`"
+          default: false
 {% endconfiguration %}
 
 ### {% linkable_title Sensor state %}
@@ -76,9 +74,10 @@ Initially, the state of a binary sensor is unknown. When a sensor update is rece
 
 See [device support](/components/rflink/#device-support)
 
-### Additional configuration examples
+### {% linkable_title Additional configuration examples %}
+
 Multiple sensors with custom name and device class and set off_delay
-{% raw %}
+
 ```yaml
 # Example configuration.yaml entry
 binary_sensor:
@@ -93,4 +92,3 @@ binary_sensor:
          device_class: motion
          off_delay: 5
 ```
-{% endraw %}

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -22,7 +22,7 @@ RFLink binary_sensor/switch/light ID's are composed of: protocol, id, switch/cha
 
 Once the ID of a binary sensor is known, it can be used to configure it as a binary sensor type in Home Assistant, for example, to hide it or configure a nice name.
 
-Configuring a device as a motion detector type binary sensor with a nice name:
+Configuring a device as a binary sensor:
 
 {% raw %}
 ```yaml

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -9,6 +9,7 @@ sharing: true
 footer: true
 logo: rflink.png
 ha_category: Binary Sensor
+ha_iot_class: "Local Push"
 ha_release: "0.81"
 ---
 

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -14,7 +14,7 @@ ha_release: "0.80"
 
 The `rflink` cover platform supports devices that use [RFLink gateway firmware](http://www.nemcon.nl/blog2/), for example, the [Nodo RFLink Gateway](https://www.nodo-shop.nl/nl/21-rflink-gateway). RFLink gateway is an Arduino firmware that allows two-way communication with a multitude of RF wireless devices using cheap hardware (Arduino + transceiver).
 
-First, you have to set up your [rflink hub](/components/rflink/).
+First, you have to set up your [RFLink hub](/components/rflink/).
 
 The RFLink component does not know the difference between a `binary_sensor`, a `switch` and a `light`. Therefore all switchable devices are automatically added as `light` by default.
 
@@ -65,7 +65,7 @@ devices:
           description: Sends update events even if the value has not changed. Useful for sensors that only sends `On`.
           required: false
           type: boolean
-          default: `false`
+          default: "`false`"
 {% endconfiguration %}
 
 ### {% linkable_title Sensor state %}

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -24,6 +24,7 @@ Once the ID of a binary sensor is known, it can be used to configure it as a bin
 
 Configuring a device as a motion detector type binary sensor with a nice name:
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 binary_sensor:
@@ -31,40 +32,40 @@ binary_sensor:
      devices:
        pt2262_00174754_0:
 ```
+{% endraw %}
 
-Configuration variables:
-{% configuration %}
+{% configuration binary_sensor.rflink %}
 devices:
-  description: A list of devices with their name to use in the frontend.
+  description: A list of binary sensors.
   required: false
-  type: list
-  
-{% endconfiguration %}
-
-Device configuration variables:
-
-{% configuration %}
-devices:
-  description: Name of the device, defaults to RFLink ID.
-  required: false
-  type: string
-aliases:
-  description: Alternative RFLink ID's this device is known by.
-  required: false
-  type: list
-device_class:
-  description: The [type or class of the sensor](/components/binary_sensor/) to set the icon in the frontend.
-  required: false
-  type: string
-off_delay:
-  description: For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
-  required: false
-  type: int
-force_update:
-  description: Sends update events even if the value has not changed. Useful for sensors that only sends `On`.
-  required: false
-  type: boolean
-  default: `false`
+  type: map
+  keys:
+    rflink_ids:
+      description: RFLink ID of the device
+      required: true
+      type: map
+      keys:
+        name:
+          description: Name of the device, defaults to RFLink ID.
+          required: false
+          type: string
+        aliases:
+          description: Alternative RFLink ID's this device is known by.
+          required: false
+          type: list
+        device_class:
+          description: The [type or class of the sensor](/components/binary_sensor/) to set the icon in the frontend.
+          required: false
+          type: string
+        off_delay:
+          description: For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
+          required: false
+          type: int
+        force_update:
+          description: Sends update events even if the value has not changed. Useful for sensors that only sends `On`.
+          required: false
+          type: boolean
+          default: `false`
 {% endconfiguration %}
 
 ### {% linkable_title Sensor state %}

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -12,7 +12,7 @@ ha_category: Binary Sensor
 ha_release: "0.81"
 ---
 
-The `rflink` cover platform supports devices that use [RFLink gateway firmware](http://www.nemcon.nl/blog2/), for example, the [Nodo RFLink Gateway](https://www.nodo-shop.nl/nl/21-rflink-gateway). RFLink gateway is an Arduino firmware that allows two-way communication with a multitude of RF wireless devices using cheap hardware (Arduino + transceiver).
+The `rflink` component supports devices that use [RFLink gateway firmware](http://www.nemcon.nl/blog2/), for example, the [Nodo RFLink Gateway](https://www.nodo-shop.nl/nl/21-rflink-gateway). RFLink gateway is an Arduino firmware that allows two-way communication with a multitude of RF wireless devices using cheap hardware (Arduino + transceiver).
 
 First, you have to set up your [RFLink hub](/components/rflink/).
 

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -30,7 +30,7 @@ Configuring a device as a motion detector type binary sensor with a nice name:
 binary_sensor:
    - platform: rflink
      devices:
-       pt2262_00174754_0:
+       pt2262_00174754_0: {}
 ```
 {% endraw %}
 

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -77,7 +77,8 @@ Initially, the state of a binary sensor is unknown. When a sensor update is rece
 See [device support](/components/rflink/#device-support)
 
 ### Additional configuration examples
-Sensor with custom name and device class and set off_delay
+Multiple sensors with custom name and device class and set off_delay
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 binary_sensor:
@@ -87,4 +88,9 @@ binary_sensor:
          name: PIR Entrance
          device_class: motion
          off_delay: 5
+       pt2262_00174758_0:
+         name: PIR Living Room
+         device_class: motion
+         off_delay: 5
 ```
+{% endraw %}

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -9,6 +9,7 @@ sharing: true
 footer: true
 logo: rflink.png
 ha_category: Binary Sensor
+ha_release: "0.80"
 ---
 
 The `rflink` cover platform supports devices that use [RFLink gateway firmware](http://www.nemcon.nl/blog2/), for example, the [Nodo RFLink Gateway](https://www.nodo-shop.nl/nl/21-rflink-gateway). RFLink gateway is an Arduino firmware that allows two-way communication with a multitude of RF wireless devices using cheap hardware (Arduino + transceiver).
@@ -29,22 +30,42 @@ binary_sensor:
    - platform: rflink
      devices:
        pt2262_00174754_0:
-         name: PIR Entrance
-         device_class: motion
-         off_delay: 5
 ```
 
 Configuration variables:
-
-- **devices** (*Optional*): A list of devices with their name to use in the frontend.
+{% configuration %}
+devices:
+  description: A list of devices with their name to use in the frontend.
+  required: false
+  type: list
+  
+{% endconfiguration %}
 
 Device configuration variables:
 
-- **name** (*Optional*): Name for the device, defaults to RFLink ID.
-- **aliases** (*Optional*): Alternative RFLink ID's this device is known by.
-- **device_class** (*Optional*): The [type or class of the sensor](/components/binary_sensor/) to set the icon in the frontend.
-- **off_delay** (*Optional*): For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
-- **force_update** (*Optional*): Sends update events even if the value has not changed. Useful for sensors that only sends `On`. Default `false`
+{% configuration %}
+devices:
+  description: Name of the device, defaults to RFLink ID.
+  required: false
+  type: string
+aliases:
+  description: Alternative RFLink ID's this device is known by.
+  required: false
+  type: list
+device_class:
+  description: The [type or class of the sensor](/components/binary_sensor/) to set the icon in the frontend.
+  required: false
+  type: string
+off_delay:
+  description: For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
+  required: false
+  type: int
+force_update:
+  description: Sends update events even if the value has not changed. Useful for sensors that only sends `On`.
+  required: false
+  type: boolean
+  default: `false`
+{% endconfiguration %}
 
 ### {% linkable_title Sensor state %}
 
@@ -53,3 +74,16 @@ Initially, the state of a binary sensor is unknown. When a sensor update is rece
 ### {% linkable_title Device support %}
 
 See [device support](/components/rflink/#device-support)
+
+### Additional configuration examples
+Sensor with custom name and device class and set off_delay
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+   - platform: rflink
+     devices:
+       pt2262_00174754_0:
+         name: PIR Entrance
+         device_class: motion
+         off_delay: 5
+```

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: rflink.png
 ha_category: Binary Sensor
-ha_release: "0.80"
+ha_release: "0.81"
 ---
 
 The `rflink` cover platform supports devices that use [RFLink gateway firmware](http://www.nemcon.nl/blog2/), for example, the [Nodo RFLink Gateway](https://www.nodo-shop.nl/nl/21-rflink-gateway). RFLink gateway is an Arduino firmware that allows two-way communication with a multitude of RF wireless devices using cheap hardware (Arduino + transceiver).

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -32,7 +32,7 @@ binary_sensor:
        pt2262_00174754_0: {}
 ```
 
-{% configuration binary_sensor.rflink %}
+{% configuration %}
 devices:
   description: A list of binary sensors.
   required: false

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -1,0 +1,56 @@
+---
+layout: page
+title: "RFLink Binary Sensor"
+description: "Instructions on how to integrate RFLink binary sensors into Home Assistant."
+date: 2018-10-04
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: rflink.png
+ha_category: Binary Sensor
+---
+
+
+The `rflink` cover platform supports devices that use [RFLink gateway firmware](http://www.nemcon.nl/blog2/), for example, the [Nodo RFLink Gateway](https://www.nodo-shop.nl/nl/21-rflink-gateway). RFLink gateway is an Arduino firmware that allows two-way communication with a multitude of RF wireless devices using cheap hardware (Arduino + transceiver).
+
+First, you have to set up your [rflink hub](/components/rflink/).
+
+The RFLink component does not know the difference between a `binary_sensor`, a `switch` and a `light`. Therefore all switchable devices are automatically added as `light` by default.
+
+RFLink binary_sensor/switch/light ID's are composed of: protocol, id, switch/channel. For example: `newkaku_0000c6c2_1`.
+
+Once the ID of a binary sensor is known it can be used to configure it as a binary sensor type in HA, for example to hide it or configure a nice name.
+
+Configuring a device as motion detector type binary sensor with a nice name:
+
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+   - platform: rflink
+     devices:
+       pt2262_00174754_0:
+         name: PIR Entrance
+         device_class: motion
+         off_delay: 5
+```
+
+Configuration variables:
+
+- **devices** (*Optional*): A list of devices with their name to use in the frontend.
+
+Device configuration variables:
+
+- **name** (*Optional*): Name for the device, defaults to RFLink ID.
+- **aliases** (*Optional*): Alternative RFLink ID's this device is known by.
+- **device_class** (*Optional*): The [type or class of the sensor](/components/binary_sensor/) to set the icon in the frontend.
+- **off_delay** (*Optional*): For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
+- **force_update** (*Optional*): Sends update events even if the value has not changed. Useful for sensors that only sends `On`. Default `false`
+
+### {% linkable_title Sensor state %}
+
+Initially the state of a binary sensor is unknown. When a sensor update is received the state is known and will be shown in the frontend.
+
+### {% linkable_title Device support %}
+
+See [device support](/components/rflink/#device-support)

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -11,7 +11,6 @@ logo: rflink.png
 ha_category: Binary Sensor
 ---
 
-
 The `rflink` cover platform supports devices that use [RFLink gateway firmware](http://www.nemcon.nl/blog2/), for example, the [Nodo RFLink Gateway](https://www.nodo-shop.nl/nl/21-rflink-gateway). RFLink gateway is an Arduino firmware that allows two-way communication with a multitude of RF wireless devices using cheap hardware (Arduino + transceiver).
 
 First, you have to set up your [rflink hub](/components/rflink/).
@@ -20,9 +19,9 @@ The RFLink component does not know the difference between a `binary_sensor`, a `
 
 RFLink binary_sensor/switch/light ID's are composed of: protocol, id, switch/channel. For example: `newkaku_0000c6c2_1`.
 
-Once the ID of a binary sensor is known it can be used to configure it as a binary sensor type in HA, for example to hide it or configure a nice name.
+Once the ID of a binary sensor is known, it can be used to configure it as a binary sensor type in Home Assistant, for example, to hide it or configure a nice name.
 
-Configuring a device as motion detector type binary sensor with a nice name:
+Configuring a device as a motion detector type binary sensor with a nice name:
 
 ```yaml
 # Example configuration.yaml entry
@@ -49,7 +48,7 @@ Device configuration variables:
 
 ### {% linkable_title Sensor state %}
 
-Initially the state of a binary sensor is unknown. When a sensor update is received the state is known and will be shown in the frontend.
+Initially, the state of a binary sensor is unknown. When a sensor update is received, the state is known and will be shown in the frontend.
 
 ### {% linkable_title Device support %}
 


### PR DESCRIPTION
**Description:**
Documentation for RFLink Binary Sensor

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17146

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. 
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
