### PR TITLE
Host is required in tomato configuration

### DIFF
--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -41,7 +41,7 @@ device_tracker:
 {% configuration %}
 host:
   description: "The IP address or hostname of your router, e.g., `192.168.1.1` or `rt-ac68u`."
-  required: false
+  required: true
   type: string
 port:
   description: "The port number of your router, e.g., `443`."


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
