### PR TITLE
Fix mixed up description

### DIFF
--- a/source/_components/switch.zigbee.markdown
+++ b/source/_components/switch.zigbee.markdown
@@ -36,7 +36,7 @@ pin:
   required: true
   type: integer
 address:
-  description: The long 64-bit address of the remote ZigBee device whose pin you would like to sample. Do not include this variable if you want to sample the local ZigBee device's pins.
+  description: The long 64-bit address of the remote ZigBee device whose digital output pin you would like to switch. Do not include this variable if you want to switch the local ZigBee device's pins.
   required: false
   type: string
 on_state:


### PR DESCRIPTION
**Description:** The original description has been replaced by a wrong one in #6514.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
