### PR TITLE
Update Velux component configuration variable

### DIFF
--- a/source/_components/velux.markdown
+++ b/source/_components/velux.markdown
@@ -13,7 +13,7 @@ ha_release: 0.49
 ha_iot_class: "Local Polling"
 ---
 
-[Velux](http://www.velux.com) integration for Home Assistant allows you to connect to a Velux KLF 200 interface, to control [io-homecontrol](http://www.io-homecontrol.com)  devices like windows and blinds. The module allows you to start scenes configured within KLF 200. 
+[Velux](http://www.velux.com) integration for Home Assistant allows you to connect to a Velux KLF 200 interface, to control [io-homecontrol](http://www.io-homecontrol.com)  devices like windows and blinds. The module allows you to start scenes configured within KLF 200.
 
 A `velux` section must be present in the `configuration.yaml` file and contain the following options as required:
 
@@ -24,7 +24,13 @@ velux:
   password: "velux123"
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address or hostname of the KLF 200 to use.
-- **password** (*Required*): The password of the KLF 200 interface. 
+{% configuration %}
+host:
+  description: The IP address or hostname of the KLF 200 to use.
+  required: true
+  type: string
+password:
+  description: The password of the KLF 200 interface.
+  required: true
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
Update style of velux component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
