### PR TITLE
Install guide tweaks

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -13,26 +13,26 @@ The following will take you through the steps required to install Hass.io.
 
 1. Download the appropriate install option:
 
-  - As an image for your device:
+   - As an image for your device:
   
-    - [Raspberry Pi Zero][pi1]
-    - [Raspberry Pi Zero W][pi0-w]
-    - [Raspberry Pi 1 Model B][pi1]
-    - [Raspberry Pi 2 Model B][pi2]
-    - [Raspberry Pi 3 Model B and B+ 32bit][pi3-32] (recommended)
-    - [Raspberry Pi 3 Model B and B+ 64bit][pi3-64]
-    - [Tinkerboard (Beta)][tinker]
-    - [Odroid-C2 (Beta)][odroid-c2]
+     - [Raspberry Pi Zero][pi1]
+     - [Raspberry Pi Zero W][pi0-w]
+     - [Raspberry Pi 1 Model B][pi1]
+     - [Raspberry Pi 2 Model B][pi2]
+     - [Raspberry Pi 3 Model B and B+ 32bit][pi3-32]
+     - [Raspberry Pi 3 Model B and B+ 64bit][pi3-64] (beta)
+     - [Tinkerboard (Beta)][tinker]
+     - [Odroid-C2 (Beta)][odroid-c2]
     
-  - As a virtual appliance: 
+   - As a virtual appliance: 
   
-    - [OVA][Virtual Appliance]
-    - [VMDK][vmdk]
+     - [OVA][Virtual Appliance]
+     - [VMDK][vmdk]
     
 2. Install Hass.io:
 
-  - Flash the downloaded image to an SD card using [Etcher][etcher]. We recommend at least a 32 GB SD card to avoid running out of space.
-  - Load the appliance image into your virtual machine software.
+   - Flash the downloaded image to an SD card using [Etcher][etcher]. We recommend at least a 32 GB SD card to avoid running out of space.
+   - Load the appliance image into your virtual machine software.
 
 3. Optional - set up the WiFi or static IP: On a USB stick, create the `network/my-network` file and follow the [HassOS howto][hassos-network].
 
@@ -53,6 +53,8 @@ If your router doesn't support mDNS, then you'll have to use the IP address of y
 <p class='note warning'>
 If you are using a Raspberry Pi please remember to ensure you're using an [appropriate power supply][pi-power] with your Pi. Mobile chargers may not be suitable since some were only designed to provide just enough power to the device it was designed for by the manufacturer. **Do not** try to power the Pi from the USB port on a TV, computer, or similar.
 </p>
+
+Now you can [configure][configure] your install.
 
 ### {% linkable_title Migrating from a non-Hass.io install %}
 
@@ -104,3 +106,4 @@ A detailed guide about running Hass.io as a virtual machine is available in the 
 [ssh]: /addons/ssh/
 [pi-power]: https://www.raspberrypi.org/help/faqs/#powerReqs
 [hassio-vm]: /blog/2017/11/29/hassio-virtual-machine/
+[configuration]: /getting-started/configuration/

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -40,7 +40,7 @@ The following will take you through the steps required to install Hass.io.
 
 5. Turn on your device or virtual appliance. On first boot, it downloads the latest version of Home Assistant which takes around 20 minutes (slower/faster depending on the platform and your Internet connection).
 
-<img src='/images/hassio/screenshots/first-start.png' style='clear: right; border:none; box-shadow: none; float: right; margin-bottom: 12px;' width='150' />
+   <img src='/images/hassio/screenshots/first-start.png' style='clear: right; border:none; box-shadow: none; float: right; margin-bottom: 12px;' width='150' />
 
 6. You will be able to reach your installation at [http://hassio.local:8123][local] (if your router supports mDNS, otherwise see below).
 

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -9,36 +9,49 @@ sharing: true
 footer: true
 ---
 
-Hass.io images are available for:
+The following will take you through the steps required to install Hass.io.
 
-- Download the appropriate image for your device:
-  - [Raspberry Pi Zero][pi1]
-  - [Raspberry Pi Zero W][pi0-w]
-  - [Raspberry Pi 1 Model B][pi1]
-  - [Raspberry Pi 2 Model B][pi2]
-  - [Raspberry Pi 3 Model B and B+ 32bit][pi3-32] (recommended)
-  - [Raspberry Pi 3 Model B and B+ 64bit][pi3-64]
-  - [Tinkerboard (Beta)][tinker]
-  - [Odroid-C2 (Beta)][odroid-c2]
-- As [Virtual Appliance]:
-  - [VMDK][vmdk]
+1. Download the appropriate install option:
 
-<p class='note warning'>
-Please remember to ensure you're using an [appropriate power supply](https://www.raspberrypi.org/help/faqs/#powerReqs) with your Pi. Mobile chargers may not be suitable since some were only designed to provide just enough power to the device it was designed for by the manufacturer. **Do not** try to power the Pi from the USB port on a TV, computer, or similar.
-</p>
+  - As an image for your device:
+  
+    - [Raspberry Pi Zero][pi1]
+    - [Raspberry Pi Zero W][pi0-w]
+    - [Raspberry Pi 1 Model B][pi1]
+    - [Raspberry Pi 2 Model B][pi2]
+    - [Raspberry Pi 3 Model B and B+ 32bit][pi3-32] (recommended)
+    - [Raspberry Pi 3 Model B and B+ 64bit][pi3-64]
+    - [Tinkerboard (Beta)][tinker]
+    - [Odroid-C2 (Beta)][odroid-c2]
+    
+  - As a virtual appliance: 
+  
+    - [OVA][Virtual Appliance]
+    - [VMDK][vmdk]
+    
+2. Install Hass.io:
 
-- Flash the downloaded image to an SD card using [Etcher][etcher]. We recommend at least a 32 GB SD card to avoid running out of space.
+  - Flash the downloaded image to an SD card using [Etcher][etcher]. We recommend at least a 32 GB SD card to avoid running out of space.
+  - Load the appliance image into your virtual machine software.
 
-- Optional - Setup the WiFi or static IP: On a USB stick, create the `network/my-network` file and follow the [HassOS howto][hassos-network].
-- Insert the SD card (and optional USB stick) into the Raspberry Pi and turn it on. On first boot, it downloads the latest version of Home Assistant which takes ~20 minutes (slower/faster depending on the platform).
+3. Optional - set up the WiFi or static IP: On a USB stick, create the `network/my-network` file and follow the [HassOS howto][hassos-network].
+
+4. For image based installs insert the SD card (and optional USB stick) into the device.
+
+5. Turn on your device or virtual appliance. On first boot, it downloads the latest version of Home Assistant which takes around 20 minutes (slower/faster depending on the platform and your Internet connection).
 
 <img src='/images/hassio/screenshots/first-start.png' style='clear: right; border:none; box-shadow: none; float: right; margin-bottom: 12px;' width='150' />
 
-- You will be able to reach your installation at [http://hassio.local:8123][local].
-- Enable either the [Samba add-on][samba] or the [SSH add-on][ssh] to manage your configuration in `/config/` (From the UI choose **Hass.io** which is located in the sidebar).
+6. You will be able to reach your installation at [http://hassio.local:8123][local] (if your router supports mDNS, otherwise see below).
+
+7. Enable either the [Samba add-on][samba] or the [SSH add-on][ssh] to manage your configuration in `/config/` (From the UI choose **Hass.io** which is located in the sidebar).
 
 <p class='note'>
 If your router doesn't support mDNS, then you'll have to use the IP address of your Pi instead of `hassio.local`. For example, `http://192.168.0.9:8123`. You should be able to find the IP address of your Pi from the admin interface of your router.
+</p>
+
+<p class='note warning'>
+If you are using a Raspberry Pi please remember to ensure you're using an [appropriate power supply][pi-power] with your Pi. Mobile chargers may not be suitable since some were only designed to provide just enough power to the device it was designed for by the manufacturer. **Do not** try to power the Pi from the USB port on a TV, computer, or similar.
 </p>
 
 ### {% linkable_title Migrating from a non-Hass.io install %}
@@ -72,7 +85,7 @@ $ curl -sL https://raw.githubusercontent.com/home-assistant/hassio-build/master/
 When you use this installation method, the core SSH add-on may not function correctly. If that happens, use the community SSH add-on. Some of the documentation might not work for your installation either.
 </p>
 
-A detailed guide about running Hass.io as a virtual machine is available in the [blog](/blog/2017/11/29/hassio-virtual-machine/).
+A detailed guide about running Hass.io as a virtual machine is available in the [blog][hassio-vm].
 
 [etcher]: https://etcher.io/
 [Virtual Appliance]: https://github.com/home-assistant/hassos/blob/dev/Documentation/boards/ova.md
@@ -89,3 +102,5 @@ A detailed guide about running Hass.io as a virtual machine is available in the 
 [local]: http://hassio.local:8123
 [samba]: /addons/samba/
 [ssh]: /addons/ssh/
+[pi-power]: https://www.raspberrypi.org/help/faqs/#powerReqs
+[hassio-vm]: /blog/2017/11/29/hassio-virtual-machine/

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -106,4 +106,4 @@ A detailed guide about running Hass.io as a virtual machine is available in the 
 [ssh]: /addons/ssh/
 [pi-power]: https://www.raspberrypi.org/help/faqs/#powerReqs
 [hassio-vm]: /blog/2017/11/29/hassio-virtual-machine/
-[configuration]: /getting-started/configuration/
+[configure]: /getting-started/configuration/


### PR DESCRIPTION
- Moved the guide to a numbered list so it's more clearly step by step
- Moved the power supply warning out, so it doesn't break the list
- Highlighted and broken out the parts that only apply to the image based installs
- Standardised some of the links so none are inline
- HIghlighted that `hassio.local` requires working mDNS
- A few minor wording tweaks
