### PR TITLE
Update Tado component configuration variable

### DIFF
--- a/source/_components/device_tracker.tado.markdown
+++ b/source/_components/device_tracker.tado.markdown
@@ -27,11 +27,20 @@ device_tracker:
     home_id: YOUR_HOME_ID
 ```
 
-Configuration variables:
-
-- **username** (*Required*): The username for your Tado account.
-- **password** (*Required*): The password for your Tado account.
-- **home_id** (*Optional*): The id of your home of which you want to track devices. If provided, the Tado device tracker will tack *all* devices known to Tado associated with this home. See below how to find it.
+{% configuration %}
+username:
+  description: The username for your Tado account.
+  required: true
+  type: string
+password:
+  description: The password for your Tado account.
+  required: true
+  type: string
+home_id:
+  description: The id of your home of which you want to track devices. If provided, the Tado device tracker will tack *all* devices known to Tado associated with this home. See below how to find it.
+  required: false
+  type: integer
+{% endconfiguration %}
 
 After configuration, your device has to be at home at least once before showing up as *home* or *away*.
 Polling Tado API for presence information will happen at most once every 30 seconds.

--- a/source/_components/tado.markdown
+++ b/source/_components/tado.markdown
@@ -24,10 +24,16 @@ tado:
   password: YOUR_PASSWORD
 ```
 
-Configuration variables:
-
-- **username** (*Required*): Username for my.tado.com.
-- **password** (*Required*): Password for my.tado.com.
+{% configuration %}
+username:
+  description: Username for my.tado.com.
+  required: true
+  type: string
+password:
+  description: Password for my.tado.com.
+  required: true
+  type: string
+{% endconfiguration %}
 
 The tado thermostats are internet connected thermostats. There exists an unofficial API at [my.tado.com](https://my.tado.com/webapp/#/account/sign-in), which is used by their website and now by this component.
 


### PR DESCRIPTION
Update style of Tado component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
