### PR TITLE
Update Datadog component configuration variable

### DIFF
--- a/source/_components/datadog.markdown
+++ b/source/_components/datadog.markdown
@@ -33,9 +33,25 @@ To use the `datadog` component in your installation, add the following to your `
 datadog:
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The IP address or hostname of your Datadog host, e.g., 192.168.1.23. Defaults to `localhost`.
-- **port** (*Optional*): Port to use. Defaults to 8125.
-- **prefix** (*Optional*): Prefix to use. Defaults to `hass`.
-- **rate** (*Optional*): The sample rate of UDP packets sent to Datadog. Defaults to 1.
+{% configuration %}
+host:
+  description: The IP address or hostname of your Datadog host, e.g., 192.168.1.23.
+  required: false
+  default: localhost
+  type: string
+port:
+  description: Port to use.
+  required: false
+  default: 8125
+  type: integer
+prefix:
+  description: Prefix to use.
+  required: false
+  default: hass
+  type: string
+rate:
+  description: The sample rate of UDP packets sent to Datadog.
+  required: false
+  default: 1
+  type: integer
+{% endconfiguration %}


### PR DESCRIPTION
Update style of Datadog component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
