### PR TITLE
Added the Microsoft Bluetooth LE Explorer app as scanner

### DIFF
--- a/source/_components/sensor.miflora.markdown
+++ b/source/_components/sensor.miflora.markdown
@@ -46,7 +46,7 @@ $ bluetoothctl
 [NEW] C4:D3:8C:12:4C:57 Flower mate
 ```
 
-If you can't use `hcitool` or `bluetoothctl` but have access to an Android phone you can try `BLE Scanner` or similar scanner applications from the Play Store to easily find your sensor MAC address.
+If you can't use `hcitool` or `bluetoothctl` but have access to an Android phone you can try `BLE Scanner` or similar scanner applications from the Play Store to easily find your sensor MAC address. If you are using Windows 10, try the `Microsoft Bluetooth LE Explorer` app from the Windows Store.
 
 # Configure
 To use your Mi Flora plant sensor in your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**
The Microsoft Bluetooth LE Explorer app from the Windows Store works fine for me to find the MAC address of the Mi Flora Plant Sensor

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
