### PR TITLE
Removed api_password

### DIFF
--- a/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
@@ -38,7 +38,6 @@ Update the `http:` entry in your `configuration.yaml` file and let it point to y
 
 ```yaml
 http:
-  api_password: YOUR_SECRET_PASSWORD
   ssl_certificate: /home/your_user/.homeassistant/certificate.pem
   ssl_key: /home/your_user/.homeassistant/privkey.pem
 ```


### PR DESCRIPTION
**Description:**
Removed api_password from example configuration.
api_password is being discontinued and replaced with users/passwords.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
