### PR TITLE
update BMW docs to allow unit_system config

### DIFF
--- a/source/_components/bmw_connected_drive.markdown
+++ b/source/_components/bmw_connected_drive.markdown
@@ -33,6 +33,7 @@ bmw_connected_drive:
     username: USERNAME_BMW_CONNECTED_DRIVE
     password: PASSWORD_BMW_CONNECTED_DRIVE
     region: one of "north_america", "china", "rest_of_world"
+    unit_system: imperial
 ```
 
 {% configuration %}
@@ -62,6 +63,11 @@ bmw_connected_drive:
       required: false
       type: boolean
       default: false
+    unit_system:
+      description: One of `imperial` or `metric`.  If this is not configured the default Home Assistant unit_system is used.
+      required: false
+      type: string
+      
 {% endconfiguration %}
 
 ## {% linkable_title Services %}


### PR DESCRIPTION
**Description:**
This PR adds documentation for an optional `unit_system` configuration for the BMW Connected Drive component

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17197

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].
