### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.7
+
+ENV HUGO_VERSION 0.49
+ENV HUGO_BINARY hugo_${HUGO_VERSION}_linux-64bit
+ENV HUGO_BASE_URL http://localhost:1313
+
+RUN cd /tmp \
+    && wget https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY}.tar.gz \
+    && tar -xf /tmp/${HUGO_BINARY}.tar.gz -C /tmp \
+    && mkdir -p /usr/local/sbin \
+    && mv /tmp/hugo /usr/local/sbin/hugo \
+    && rm -rf /tmp/* \
+    && apk --update add --no-cache git
+
+VOLUME /src
+WORKDIR /src
+
+EXPOSE 1313
+CMD hugo server -b ${HUGO_BASE_URL} --bind=0.0.0.0

--- a/README.markdown
+++ b/README.markdown
@@ -18,3 +18,8 @@ In order to make the preview available on [http://127.0.0.1:1313](http://127.0.0
 ```bash
 hugo serve -w
 ```
+
+Or, using Docker,
+```
+docker build -t ha-hugo . && docker run --rm -it -v $(pwd):/src -p 1313:1313 ha-hugo
+```


### PR DESCRIPTION
**Description:**

Dockerfile and instruction in README to build site using Docker, to avoid install hugo (See #5751).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
