### PR TITLE
Add documentation for the ZoneMinder runstate sensor and service

### DIFF
--- a/source/_components/sensor.zoneminder.markdown
+++ b/source/_components/sensor.zoneminder.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Polling"
 ---
 
 
-The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of event, the current state of the cameras and ZoneMinder's current run state.
+The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of events, the current state of the cameras and ZoneMinder's current run state.
 
 <p class='note'>
 You must have the [ZoneMinder component](/components/zoneminder/) configured to use this sensor.

--- a/source/_components/sensor.zoneminder.markdown
+++ b/source/_components/sensor.zoneminder.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Polling"
 ---
 
 
-The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of events and the current state of the cameras.
+The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of event, the current state of the cameras and ZoneMinder's current run state.
 
 <p class='note'>
 You must have the [ZoneMinder component](/components/zoneminder/) configured to use this sensor.

--- a/source/_components/zoneminder.markdown
+++ b/source/_components/zoneminder.markdown
@@ -44,3 +44,19 @@ zoneminder:
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
 ```
+
+### {% linkable_title Service %}
+
+Once loaded, the `zoneminder` platform will expose a service (`set_run_state`) that can be used to change the current run state of ZoneMinder.
+
+| Service data attribute | Optional | Description                       |
+|:-----------------------|:---------|:----------------------------------|
+| `name`                 | no       | Name of the new run state to set. |
+
+For example, if your ZoneMinder instance was configured with a run state called "Home", you could write an [automation](/getting-started/automation/) that changes ZoneMinder to the "Home" run state by including the following [action](/getting-started/automation-action/):
+ ```yaml
+action:
+  service: zoneminder.set_run_state
+  data:
+    name: Home
+```


### PR DESCRIPTION
**Description:**
This is a re-implementation of @jantman's PR in #5655 to go with a re-implementation of ZoneMinder run states in home-assistant.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17198

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
