### PR TITLE
Update Yweather component configuration variable

### DIFF
--- a/source/_components/weather.yweather.markdown
+++ b/source/_components/weather.yweather.markdown
@@ -31,15 +31,20 @@ weather:
   - platform: yweather
 ```
 
-Configuration variables:
-
-- **woeid** (*Optional*): See above.
-- **name** (*Optional*): The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option. Defaults to `Yweather`. 
-
+{% configuration %}
+woeid:
+  description: Your Where On Earth ID, see above for all the info.
+  required: false
+  type: integer
+name:
+  description: The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option.
+  required: false
+  default: yweather
+  type: string
+{% endconfiguration %}
 
 <p class='note'>
-This platform is an alternative to the [`yweather`](/components/sensor.yweather/) sensor. 
+This platform is an alternative to the [`yweather`](/components/sensor.yweather/) sensor.
 </p>
 
 Details about the API are available in the [Yahoo! Developer Network](https://developer.yahoo.com/weather/).
-


### PR DESCRIPTION
Update style of Yweather component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
