### PR TITLE
Update Thingspeak component configuration variable

### DIFF
--- a/source/_components/thingspeak.markdown
+++ b/source/_components/thingspeak.markdown
@@ -27,9 +27,17 @@ thingspeak:
   whitelist: sensor.yr_temperature
 ```
 
-Configuration variables:
-
-- **api_key** (*Required*): Your ThingSpeak Channel Write API key.
-- **id** (*Required*): The ID of your desired ThingSpeak channel.
-- **whitelist** (*Required*): The name of the entity whose states should be sent to the channel.
-
+{% configuration %}
+api_key:
+  description: Your ThingSpeak Channel Write API key.
+  required: true
+  type: string
+id:
+  description: The ID of your desired ThingSpeak channel.
+  required: true
+  type: integer
+whitelist:
+  description: The name of the entity whose states should be sent to the channel.
+  required: true
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
Update style of Thingspeak component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
