### PR TITLE
Update Spc component configuration variable

### DIFF
--- a/source/_components/spc.markdown
+++ b/source/_components/spc.markdown
@@ -25,10 +25,15 @@ spc:
   ws_url: WS_URL
 ```
 
-Configuration variables:
-
-- **api_url** (*Required*): URL of the SPC Web Gateway command REST API, e.g., `http://<ip>:8088`.
-- **ws_url** (*Required*): URL of the SPC Web Gateway websocket, e.g., `ws://<ip>:8088`.
+{% configuration %}
+api_url:
+  description: URL of the SPC Web Gateway command REST API, e.g., `http://<ip>:8088`.
+  required: true
+  type: string
+ws_url:
+  description: URL of the SPC Web Gateway websocket, e.g., `ws://<ip>:8088`.
+  required: true
+  type: string
+{% endconfiguration %}
 
 Supported sensors will be automatically discovered and added, however they will be hidden by default.
-


### PR DESCRIPTION
Update style of Spc component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
