### PR TITLE
Add KU6100K Samsung TV to supported models list

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -81,6 +81,7 @@ Currently known supported models:
 - KS8000 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - KS8005 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - KU6020 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- KU6100 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - KU6290 (port must be set to 8001)
 - KU7000 (port must be set to 8001)
 - MU6170UXZG (port must be set to 8001, and `pip3 install websocket-client` must be executed)


### PR DESCRIPTION
**Description:**

This PR add the KU6100K Samsung TV model to the supported models list of the [media_player.samsungtv](https://www.home-assistant.io/components/media_player.samsungtv/) documentation.

**No associated pull request in [home-assistant](https://github.com/home-assistant/home-assistant)**

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
