### PR TITLE
Configuration ezfix

### DIFF
--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -46,7 +46,7 @@ alarmdecoder:
 ```
 {% configuration %}
 type:
-  description: The type of AlarmDecoder device, optional values: `socket`, `serial` or `USB`
+  description: "The type of AlarmDecoder device, optional values: `socket`, `serial` or `USB`"
   required: true
   type: map
 host:
@@ -75,7 +75,7 @@ panel_display:
   default: `off`
   type: boolean
 zones:
-  description: AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.* 
+  description: "AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.*"
   required: false
   type: string
 rfid:
@@ -83,11 +83,11 @@ rfid:
   required: false
   type: string
 relayaddr:
-  description: Address of the relay expander board to associate with the zone. (ex: 12, 13, 14, or 15). Typically used in cases where a panel will not send bypassed zones such as motion during an armed home state, the Vista 20P is an example of this. Alarmdecoder can emulate a zone expander board and the panel can be programmed to push zone events to this virtual expander. This allows the bypassed zone binary sensors to be utilized. One example is using bypassed motion sensors at night for motion-based automated lights while the system is armed with the motion sensor bypassed.
+  description: "Address of the relay expander board to associate with the zone. (ex: 12, 13, 14, or 15). Typically used in cases where a panel will not send bypassed zones such as motion during an armed home state, the Vista 20P is an example of this. Alarmdecoder can emulate a zone expander board and the panel can be programmed to push zone events to this virtual expander. This allows the bypassed zone binary sensors to be utilized. One example is using bypassed motion sensors at night for motion-based automated lights while the system is armed with the motion sensor bypassed."
   required: inclusive
   type: string
 relaychan:
-  description: Channel of the relay expander board to associate with the zone. (ex: 1, 2, 3, or 4)
+  description: "Channel of the relay expander board to associate with the zone. (ex: 1, 2, 3, or 4)"
   required: inclusive
   type: string
 {% endconfiguration %}

--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -50,24 +50,29 @@ type:
   required: true
   type: map
 host:
-  description: The IP address of the AlarmDecoder device on your home network, if using socket type. Default: `localhost`
+  description: The IP address of the AlarmDecoder device on your home network, if using socket type. 
   required: false
+  default: `localhost`
   type: map
 port:
-  description: The port of the AlarmDecoder device on your home network, if using socket type. Default: `10000`
+  description: The port of the AlarmDecoder device on your home network, if using socket type.
   required: false
+  default: `10000`
   type: integer
 path:
-  description: The path of the AlarmDecoder device, if using socket type. Default: `/dev/ttyUSB0`
+  description: The path of the AlarmDecoder device, if using socket type.
   required: false
+  default: `/dev/ttyUSB0`
   type: string
 baudrate:
-  description: The baud rate of the AlarmDecoder device, if using serial type. Default: `115200`
+  description: The baud rate of the AlarmDecoder device, if using serial type.
   required: false
+  default: `115200`
   type: string
 panel_display:
-  description: Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
+  description: Create a sensor called sensor.alarm_display to match the Alarm Keypad display.
   required: false
+  default: `off`
   type: boolean
 zones:
   description: AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.* 

--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -44,16 +44,46 @@ alarmdecoder:
       name: 'Front Door'
       type: 'opening'
 ```
-
-Configuration variables:
-
-- **type** (*Required*): The type of AlarmDecoder device: socket, serial or USB
-- **host** (*Optional*): The IP address of the AlarmDecoder device on your home network, if using socket type. Default: `localhost`
-- **port** (*Optional*): The port of the AlarmDecoder device on your home network, if using socket type. Default: `10000`
-- **path** (*Optional*): The path of the AlarmDecoder device, if using socket type. Default: `/dev/ttyUSB0`
-- **baudrate** (*Optional*): The baud rate of the AlarmDecoder device, if using serial type. Default: `115200`
-- **panel_display** (*Optional*): Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
+{% configuration %}
+type:
+  description: The type of AlarmDecoder device, optional values: `socket`, `serial` or `USB`
+  required: true
+  type: map
+host:
+  description: The IP address of the AlarmDecoder device on your home network, if using socket type. Default: `localhost`
+  required: false
+  type: map
+port:
+  description: The port of the AlarmDecoder device on your home network, if using socket type. Default: `10000`
+  required: false
+  type: int
+path:
+  description: The path of the AlarmDecoder device, if using socket type. Default: `/dev/ttyUSB0`
+  required: false
+  type: string
+baudrate:
+  description: The baud rate of the AlarmDecoder device, if using serial type. Default: `115200`
+  required: false
+  type: string
+panel_display:
+  description: Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
+  required: false
+  type: string
+zones:
+  description: Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
 - **zones** (*Optional*): AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.*
-- **rfid** (*Optional*): The RF serial-number associated with RF zones. Providing this field allows Home Assistant to associate raw sensor data to a given zone, allowing direct monitoring of the state, battery, and supervision status.
-- **relayaddr** (*Optional*): Address of the relay expander board to associate with the zone. (ex: 12, 13, 14, or 15). Typically used in cases where a panel will not send bypassed zones such as motion during an armed home state, the Vista 20P is an example of this. Alarmdecoder can emulate a zone expander board and the panel can be programmed to push zone events to this virtual expander. This allows the bypassed zone binary sensors to be utilized. One example is using bypassed motion sensors at night for motion-based automated lights while the system is armed with the motion sensor bypassed.
-- **relaychan** (*Optional*): Channel of the relay expander board to associate with the zone. (ex: 1, 2, 3, or 4)
+  required: false
+  type: string
+rfid:
+  description: The RF serial-number associated with RF zones. Providing this field allows Home Assistant to associate raw sensor data to a given zone, allowing direct monitoring of the state, battery, and supervision status.
+  required: false
+  type: string
+relayaddr:
+  description: Address of the relay expander board to associate with the zone. (ex: 12, 13, 14, or 15). Typically used in cases where a panel will not send bypassed zones such as motion during an armed home state, the Vista 20P is an example of this. Alarmdecoder can emulate a zone expander board and the panel can be programmed to push zone events to this virtual expander. This allows the bypassed zone binary sensors to be utilized. One example is using bypassed motion sensors at night for motion-based automated lights while the system is armed with the motion sensor bypassed.
+  required: inclusive
+  type: string
+relaychan:
+  description: Channel of the relay expander board to associate with the zone. (ex: 1, 2, 3, or 4)
+  required: inclusive
+  type: string
+{% endconfiguration %}

--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -68,7 +68,7 @@ baudrate:
 panel_display:
   description: Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
   required: false
-  type: string
+  type: boolean
 zones:
   description: Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
 - **zones** (*Optional*): AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.*

--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -52,27 +52,27 @@ type:
 host:
   description: The IP address of the AlarmDecoder device on your home network, if using socket type. 
   required: false
-  default: `localhost`
+  default: "`localhost`"
   type: map
 port:
   description: The port of the AlarmDecoder device on your home network, if using socket type.
   required: false
-  default: `10000`
+  default: "`10000`"
   type: integer
 path:
   description: The path of the AlarmDecoder device, if using socket type.
   required: false
-  default: `/dev/ttyUSB0`
+  default: "`/dev/ttyUSB0`"
   type: string
 baudrate:
   description: The baud rate of the AlarmDecoder device, if using serial type.
   required: false
-  default: `115200`
+  default: "`115200`"
   type: string
 panel_display:
   description: Create a sensor called sensor.alarm_display to match the Alarm Keypad display.
   required: false
-  default: `off`
+  default: "`off`"
   type: boolean
 zones:
   description: "AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.*"

--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -70,8 +70,7 @@ panel_display:
   required: false
   type: boolean
 zones:
-  description: Create a sensor called sensor.alarm_display to match the Alarm Keypad display. Default: `off`
-- **zones** (*Optional*): AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.*
+  description: AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/components/binary_sensor.alarmdecoder/) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor components.* 
   required: false
   type: string
 rfid:

--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -56,7 +56,7 @@ host:
 port:
   description: The port of the AlarmDecoder device on your home network, if using socket type. Default: `10000`
   required: false
-  type: int
+  type: integer
 path:
   description: The path of the AlarmDecoder device, if using socket type. Default: `/dev/ttyUSB0`
   required: false


### PR DESCRIPTION
#6385 related

Hope I got it right - 
* there are types such as Boolean and Byte in the code but the standards does not seem to offer these options (?)
* a couple of "inclusive" parameters according to the code - not sure what that means but I marked them accordingly in required...

**Description:**

## Checklist:

- [x] Branch: `current`
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
