### PR TITLE
Add documentation for template vacuum component

### DIFF
--- a/source/_components/vacuum.template.markdown
+++ b/source/_components/vacuum.template.markdown
@@ -28,28 +28,8 @@ vacuum:
   - platform: template
     vacuums:
       living_room_vacuum:
-        friendly_name: "Living room vacuum"
-        value_template: "{{ states('input_select.vacuum_state') }}"
-        battery_level_template: "{{ states('input_number.vacuum_battery_level') | int }}"
-        fan_speed_template: "{{ states('input_select.vacuum_fan_speed') }}"
         start:
             service: script.vacuum_start
-        pause:
-            service: script.vacuum_pause
-        stop:
-            service: script.vacuum_stop
-        return_to_base:
-            service: script.vacuum_return_to_base
-        clean_spot:
-            service: script.vacuum_clean_spot
-        locate:
-            service: script.vacuum_locate_vacuum
-        set_fan_speed:
-            service: script.vacuum_set_fan_speed
-        fan_speeds:
-            - Low
-            - Medium
-            - High
 ```
 {% endraw %}
 

--- a/source/_components/vacuum.template.markdown
+++ b/source/_components/vacuum.template.markdown
@@ -21,7 +21,6 @@ return_to_base, clean_spot, locate and set_fan_speed commands of a vacuum.
 To enable Template Vacuums in your installation, add the following to your
 `configuration.yaml` file:
 
-{% raw %}
 ```yaml
 # Example configuration.yaml entry
 vacuum:
@@ -31,7 +30,6 @@ vacuum:
         start:
             service: script.vacuum_start
 ```
-{% endraw %}
 
 {% configuration %}
   vacuums:
@@ -88,3 +86,66 @@ vacuum:
         required: false
         type: string list
 {% endconfiguration %}
+
+## {% linkable_title Examples %}
+
+### {% linkable_title Control vacuum with Harmony Hub %}
+This example shows how you can use a Template Vacuum to control an IR vacuum cleaner using the [Harmony Hub Remote component](/components/remote.harmony/).
+
+```yaml
+vacuum:
+  - platform: template
+    vacuums:
+      living_room_vacuum:
+        start:
+          - service: remote.send_command
+            data:
+              entity_id: remote.harmony_hub
+              command: Clean
+              device: 52840686
+        return_to_base:
+          - service: remote.send_command
+            data:
+              entity_id: remote.harmony_hub
+              command: Home
+              device: 52840686
+        clean_spot:
+          - service: remote.send_command
+            data:
+              entity_id: remote.harmony_hub
+              command: SpotCleaning
+              device: 52840686
+```
+
+### {% linkable_title Vacuum with state %}
+This example shows how to use templates to specify the state of the vacuum.
+
+{% raw %}
+```yaml
+vacuum:
+  - platform: template
+    vacuums:
+      living_room_vacuum:
+        value_template: "{{ states('sensor.vacuum_state') }}"
+        battery_level_template: "{{ states('sensor.vacuum_battery_level')|int }}"
+        fan_speed_template: "{{ states('sensor.vacuum_fan_speed') }}"
+        start:
+            service: script.vacuum_start
+        pause:
+            service: script.vacuum_pause
+        stop:
+            service: script.vacuum_stop
+        return_to_base:
+            service: script.vacuum_return_to_base
+        clean_spot:
+            service: script.vacuum_clean_spot
+        locate:
+            service: script.vacuum_locate_vacuum
+        set_fan_speed:
+            service: script.vacuum_set_fan_speed
+        fan_speeds:
+            - Low
+            - Medium
+            - High
+```
+{% endraw %}

--- a/source/_components/vacuum.template.markdown
+++ b/source/_components/vacuum.template.markdown
@@ -1,0 +1,110 @@
+---
+layout: page
+title: "Template Vacuum"
+description: "Instructions how to setup Template vacuums within Home Assistant."
+date: 2018-10-07 16:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Vacuum
+ha_release: 0.80
+ha_iot_class: "Local Push"
+logo: home-assistant.png
+ha_qa_scale: internal
+---
+
+The `template` platform creates vacuums that combine components and provides the
+ability to run scripts or invoke services for each of the start, pause, stop,
+return_to_base, clean_spot, locate and set_fan_speed commands of a vacuum.
+
+To enable Template Vacuums in your installation, add the following to your
+`configuration.yaml` file:
+
+{% raw %}
+```yaml
+# Example configuration.yaml entry
+vacuum:
+  - platform: template
+    vacuums:
+      living_room_vacuum:
+        friendly_name: "Living room vacuum"
+        value_template: "{{ states('input_select.vacuum_state') }}"
+        battery_level_template: "{{ states('input_number.vacuum_battery_level') | int }}"
+        fan_speed_template: "{{ states('input_select.vacuum_fan_speed') }}"
+        start:
+            service: script.vacuum_start
+        pause:
+            service: script.vacuum_pause
+        stop:
+            service: script.vacuum_stop
+        return_to_base:
+            service: script.vacuum_return_to_base
+        clean_spot:
+            service: script.vacuum_clean_spot
+        locate:
+            service: script.vacuum_locate_vacuum
+        set_fan_speed:
+            service: script.vacuum_set_fan_speed
+        fan_speeds:
+            - Low
+            - Medium
+            - High
+```
+{% endraw %}
+
+{% configuration %}
+  vacuums:
+    description: List of your vacuums.
+    required: true
+    type: map
+    keys:
+      friendly_name:
+        description: Name to use in the frontend.
+        required: false
+        type: string
+      value_template:
+        description: "Defines a template to get the state of the vacuum. Valid value: `docked`/`cleaning`/`idle`/`paused`/`returning`/`error`"
+        required: false
+        type: template
+      battery_level_template:
+        description: "Defines a template to get the battery level of the vacuum. Legal values are numbers between `0` and `100`."
+        required: false
+        type: template
+      fan_speed_template:
+        description: Defines a template to get the fan speed of the vacuum.
+        required: false
+        type: template
+      start:
+        description: Defines an action to run when the vacuum is started.
+        required: true
+        type: action
+      pause:
+        description: Defines an action to run when the vacuum is paused.
+        required: false
+        type: action
+      stop:
+        description: Defines an action to run when the vacuum is stopped.
+        required: false
+        type: action
+      return_to_base:
+        description: Defines an action to run when the vacuum is given a return to base command.
+        required: false
+        type: action
+      clean_spot:
+        description: Defines an action to run when the vacuum is given a clean spot command.
+        required: false
+        type: action
+      locate:
+        description: Defines an action to run when the vacuum is given a locate command.
+        required: false
+        type: action
+      set_fan_speed:
+        description: Defines an action to run when the vacuum is given a command to set the fan speed.
+        required: false
+        type: action
+      fan_speeds:
+        description: List of fan speeds supported by the vacuum.
+        required: false
+        type: string list
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Adds documentation for the Template Vacuum component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17215

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/