### PR TITLE
Add Device Tracker to Mercedes me page

### DIFF
--- a/source/_components/device_tracker.mercedesme.markdown
+++ b/source/_components/device_tracker.mercedesme.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Mercedes me"
+title: "Mercedes me Device Tracker"
 description: "Instructions on for how to integrate Mercedes me into Home Assistant."
 date: 2018-01-27 10:00
 sidebar: true


### PR DESCRIPTION
**Description:**
Add Device Tracker to page name so it's clear in the list which component it is.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
