### PR TITLE
Update Aurora binary sensor component configuration variable

### DIFF
--- a/source/_components/binary_sensor.aurora.markdown
+++ b/source/_components/binary_sensor.aurora.markdown
@@ -28,10 +28,18 @@ binary_sensor:
   - platform: aurora
 ```
 
-Configuration variables:
-
-- **forecast_threshold** (*Optional*): Provide your own threshold number above which the sensor will trigger. Defaults to 75.
-- **name** (*Optional*): The name of the sensor. Default is 'Aurora Visibility'. 
+{% configuration %}
+forecast_threshold:
+  description: Provide your own threshold number above which the sensor will trigger.
+  required: false
+  default: 75
+  type: integer
+name:
+  description: The name of the sensor.
+  required: false
+  default: Aurora Visibility
+  type: string
+{% endconfiguration %}
 
 ```yaml
   binary_sensor:


### PR DESCRIPTION
Update style of Aurora binary sensor component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
