### PR TITLE
Update Command Line binary sensor component configuration variable

### DIFF
--- a/source/_components/binary_sensor.command_line.markdown
+++ b/source/_components/binary_sensor.command_line.markdown
@@ -27,16 +27,45 @@ binary_sensor:
     command: cat /proc/sys/net/ipv4/ip_forward
 ```
 
-Configuration variables:
-
-- **command** (*Required*): The action to take to get the value.
-- **name** (*Optional*): Let you overwrite the name of the device. By default *name* from the device is used.
-- **device_class** (*Optional*): The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
-- **payload_on** (*Optional*): The payload that represents enabled state. Default is "ON".
-- **payload_off** (*Optional*): The payload that represents disabled state. Default is "OFF".
-- **value_template** (*Optional*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
-- **scan_interval** (*Optional*): Defines number of seconds for polling interval (defaults to 60 seconds).
-- **command_timeout** (*Optional*): Defines number of seconds for command timeout (defaults to 15 seconds).
+{% configuration %}
+command:
+  description: The action to take to get the value.
+  required: true
+  type: string
+name:
+  description: Let you overwrite the name of the device. By default *name* from the device is used.
+  required: false
+  default: name
+  type: string
+device_class:
+  description: The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
+  required: false
+  type: string
+payload_on:
+  description: The payload that represents enabled state.
+  required: false
+  default: ON
+  type: string
+payload_off:
+  description: The payload that represents disabled state.
+  required: false
+  default: OFF
+  type: string
+value_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
+  required: false
+  type: string
+scan_interval:
+  description: Defines number of seconds for polling interval.
+  required: false
+  default: 60
+  type: integer
+command_timeout:
+  description: Defines number of seconds for command timeout.
+  required: false
+  default: 15
+  type: integer
+{% endconfiguration %}
 
 ## {% linkable_title Examples %}
 


### PR DESCRIPTION
Update style of Command Line binary sensor component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
