### PR TITLE
Update Concord232 binary sensor configuration variable

### DIFF
--- a/source/_components/binary_sensor.concord232.markdown
+++ b/source/_components/binary_sensor.concord232.markdown
@@ -24,7 +24,7 @@ binary_sensor:
 
 {% configuration %}
 host:
-  description: he host where the concord232 server process is running.
+  description: The host where the concord232 server process is running.
   required: false
   default: localhost
   type: string

--- a/source/_components/binary_sensor.concord232.markdown
+++ b/source/_components/binary_sensor.concord232.markdown
@@ -22,8 +22,15 @@ binary_sensor:
   - platform: concord232
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The host where the concord232 server process is running. Defaults to `localhost`.
-- **port** (*Optional*): The port where the Alarm panel is listening. Defaults to 5007.
-
+{% configuration %}
+host:
+  description: he host where the concord232 server process is running.
+  required: false
+  default: localhost
+  type: string
+port:
+  description: The port where the Alarm panel is listening.
+  required: false
+  default: 5007
+  type: integer
+{% endconfiguration %}


### PR DESCRIPTION
Update style of Concord232 binary sensor documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
