### PR TITLE
Update FFMPEG component configuration variable

### DIFF
--- a/source/_components/binary_sensor.ffmpeg_motion.markdown
+++ b/source/_components/binary_sensor.ffmpeg_motion.markdown
@@ -35,16 +35,45 @@ binary_sensor:
     input: FFMPEG_SUPPORTED_INPUT
 ```
 
-Configuration variables:
-
-- **input** (*Required*): An FFmpeg-compatible input file, stream, or feed.
-- **name** (*Optional*): Override the name of your camera for the frontend.
-- **initial_state** (*Optional*): Start `ffmpeg` with Home Assistant. Defaults to `true`.
-- **changes** (*Optional*): How much needs to change between two frames to detect it as motion (a lower value is more sensitive). Defaults to 10%.
-- **reset** (*Optional*): The time to reset the state after no new motion is detected. Defaults to 20 seconds.
-- **repeat** (*Optional*): How many events need to be detected in *repeat_time* in order to trigger a motion. Defaults to 0 repeats (deactivated).
-- **repeat_time** (*Optional*): The span of time *repeat* events need to occur in before triggering a motion. Defaults to 0 seconds (deactivated).
-- **extra_arguments** (*Optional*): Extra options to pass to `ffmpeg`, e.g., video denoise filtering.
+{% configuration %}
+input:
+  description: An FFmpeg-compatible input file, stream, or feed.
+  required: true
+  type: string
+name:
+  description: Override the name of your camera for the frontend.
+  required: false
+  type: string
+initial_state:
+  description: Start `ffmpeg` with Home Assistant.
+  required: false
+  default: true
+  type: boolean
+changes:
+  description: How much needs to change between two frames to detect it as motion, value in percentage (a lower value is more sensitive).
+  required: false
+  default: 10%
+  type: integer
+reset:
+  description: The time to reset the state after no new motion is detected.
+  required: false
+  default: 20
+  type: integer
+repeat:
+  description: How many events need to be detected in *repeat_time* in order to trigger a motion, 0 repeats means deactivated.
+  required: false
+  default: 0
+  type: integer
+repeat_time:
+  description: The span of time *repeat* events need to occur in before triggering a motion, 0 seconds means deactivated.
+  required: false
+  default: 0
+  type: integer
+extra_arguments:
+  description: Extra options to pass to `ffmpeg`, e.g., video denoise filtering.
+  required: false
+  type: string
+{% endconfiguration %}
 
 To experiment with values (changes/100 is the scene value in `ffmpeg`):
 

--- a/source/_components/binary_sensor.ffmpeg_noise.markdown
+++ b/source/_components/binary_sensor.ffmpeg_noise.markdown
@@ -30,16 +30,44 @@ binary_sensor:
     input: FFMPEG_SUPPORTED_INPUT
 ```
 
-Configuration variables:
-
-- **input** (*Required*): An FFmpeg-compatible input file, stream, or feed.
-- **name** (*Optional*): Override the name of your camera.
-- **initial_state** (*Optional*): Default true. Start ffmpeg with home-assistant.
-- **peak** (*Optional*): Default -30. The threshold of detecting noise, in dB. 0 is very loud and -100 is low.
-- **duration** (*Optional*): Default 1 second. How long the noise needs to be over the peak to trigger the state.
-- **reset** (*Optional*): Default 20 seconds. The time to reset the state after no new noise is over the peak.
-- **extra_arguments** (*Optional*): Extra options to pass to `ffmpeg`, like audio frequency filtering.
-- **output** (*Optional*): Allows you to send the audio output of this sensor to an Icecast server or other FFmpeg-supported output, e.g., to stream with Sonos after a state is triggered.
+{% configuration %}
+input:
+  description: An FFmpeg-compatible input file, stream, or feed.
+  required: true
+  type: string
+name:
+  description: Override the name of your camera.
+  required: false
+  type: string
+initial_state:
+  description: Start ffmpeg with home-assistant.
+  required: false
+  default: true
+  type: boolean
+peak:
+  description: The threshold of detecting noise, in dB. 0 is very loud and -100 is low.
+  required: false
+  default: -30
+  type: integer
+duration:
+  description: How long the noise needs to be over the peak to trigger the state.
+  required: false
+  default: 1
+  type: integer
+reset:
+  description: The time to reset the state after no new noise is over the peak.
+  required: false
+  default: 20
+  type: integer
+extra_arguments:
+  description: Extra options to pass to `ffmpeg`, like audio frequency filtering.
+  required: false
+  type: string
+output:
+  description: Allows you to send the audio output of this sensor to an Icecast server or other FFmpeg-supported output, e.g., to stream with Sonos after a state is triggered.
+  required: false
+  type: string
+{% endconfiguration %}
 
 To experiment with values:
 

--- a/source/_components/camera.ffmpeg.markdown
+++ b/source/_components/camera.ffmpeg.markdown
@@ -25,11 +25,20 @@ camera:
     input: FFMPEG_SUPPORTED_INPUT
 ```
 
-Configuration variables:
-
-- **input** (*Required*): An FFmpeg-compatible input file, stream, or feed.
-- **name** (*Optional*): Override the name of your camera.
-- **extra_arguments** (*Optional*): Extra options to pass to `ffmpeg`, e.g., image quality or video filter options.
+{% configuration %}
+input:
+  description: An FFmpeg-compatible input file, stream, or feed.
+  required: true
+  type: string
+name:
+  description: Override the name of your camera.
+  required: false
+  type: string
+extra_arguments:
+  description: Extra options to pass to `ffmpeg`, e.g., image quality or video filter options.
+  required: false
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title Image quality %}
 

--- a/source/_components/ffmpeg.markdown
+++ b/source/_components/ffmpeg.markdown
@@ -29,10 +29,18 @@ To set it up, add the following information to your `configuration.yaml` file:
 ffmpeg:
 ```
 
-Configuration variables:
-
-- **ffmpeg_bin** (*Optional*): Default `ffmpeg`. The name or path to the `ffmpeg` binary.
-- **run_test** (*Optional*): Default True. Check if `input` is usable by ffmpeg.
+{% configuration %}
+ffmpeg_bin:
+  description: The name or path to the `ffmpeg` binary.
+  required: false
+  default: ffmpeg
+  type: string
+run_test:
+  description: Check if `input` is usable by ffmpeg.
+  required: false
+  default: True
+  type: boolean
+{% endconfiguration %}
 
 ### {% linkable_title Raspbian Debian Jessie Lite Installations %}
 To get the binary on Raspbian Debian Jessie Lite on a RPi you need to perform the following:
@@ -100,4 +108,3 @@ Stream mapping:
 Press [q] to stop, [?] for help
 frame=  223 fps= 40 q=-1.0 Lsize=   16709kB time=00:00:07.40 bitrate=18497.5kbits/s dup=58 drop=0 speed=1.32x
 ```
-


### PR DESCRIPTION
Update style of FFMPEG component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
