### PR TITLE
Update Modbus component configuration variable

### DIFF
--- a/source/_components/binary_sensor.modbus.markdown
+++ b/source/_components/binary_sensor.modbus.markdown
@@ -32,13 +32,26 @@ binary_sensor:
         coil: 110
 ```
 
-Configuration variables:
+{% configuration %}
+coils:
+  description: The array contains a list of coils to read from.
+  required: true
+  type: map
+  keys:
+    name:
+      description: Name of the sensor.
+      required: true
+      type: string
+    slave:
+      description: The number of the slave (Optional for TCP and UDP Modbus).
+      required: true
+      type: integer
+    coil:
+      description: Coil number.
+      required: true
+      type: integer
+{% endconfiguration %}
 
-- **coils** array (*Required*): The array contains a list of coils to read from.
-  - **name** (*Required*): Name of the sensor.
-  - **slave** (*Required*): The number of the slave (Optional for TCP and UDP Modbus).
-  - **coil** (*Required*): Coil number.
-  
 It's possible to change the default 30 seconds scan interval for the sensor updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.
 
 ## {% linkable_title Full example %}

--- a/source/_components/binary_sensor.modbus.markdown
+++ b/source/_components/binary_sensor.modbus.markdown
@@ -36,7 +36,7 @@ binary_sensor:
 coils:
   description: The array contains a list of coils to read from.
   required: true
-  type: map
+  type: [map, list]
   keys:
     name:
       description: Name of the sensor.

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -32,18 +32,11 @@ modbus:
 
 {% configuration %}
 type:
-  description: Type of the connection to Modbus. Possible values are `tcp`, `udp` and `rtuovertcp`.
+  description: Type of the connection to Modbus. Possible values are `tcp` (Modbus TCP protocol according to "MODBUS Messaging Implementation Guide version 1.0b" provided by Schneider Automation.), `udp`(Modbus TCP form, but using UDP for transport. It removes the overheads required for TCP.) and `rtuovertcp` (Modbus RTU message transmitted with a TCP/IP wrapper and sent over a network instead of serial lines.).
   required: true
-  type: map
-  keys:
-    tcp:
-      description: Modbus TCP protocol according to "MODBUS Messaging Implementation Guide version 1.0b" provided by Schneider Automation.
-    udp:
-      description: Modbus TCP form, but using UDP for transport (removes the overheads required for TCP).
-    rtuovertcp:
-      description: Modbus RTU message transmitted with a TCP/IP wrapper and sent over a network instead of serial lines.
+  type: string
 host:
-  description: The IP address of your Modbus device, eg. 192.168.1.1.
+  description: The IP address of your Modbus device, e.g., 192.168.1.1.
   required: true
   type: string
 port:

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -30,15 +30,32 @@ modbus:
   port: 2020
 ```
 
-Configuration variables:
-
-- **type** (*Required*): Type of the connection to Modbus. Possible values are:
-  - *tcp*: Modbus TCP protocol according to "MODBUS Messaging Implementation Guide version 1.0b" provided by Schneider Automation, 
-  - *udp*: Modbus TCP form, but using UDP for transport (removes the overheads required for TCP),
-  - *rtuovertcp*: Modbus RTU message transmitted with a TCP/IP wrapper and sent over a network instead of serial lines.
-- **host** (*Required*): The IP address of your Modbus device, eg. 192.168.1.1.
-- **port** (*Required*): The port for the communication.
-- **timeout** (*Optional*): Timeout for slave response in seconds. (default: 3)
+{% configuration %}
+type:
+  description: Type of the connection to Modbus. Possible values are:
+  required: true
+  type: map
+  keys:
+    tcp:
+      description: Modbus TCP protocol according to "MODBUS Messaging Implementation Guide version 1.0b" provided by Schneider Automation.
+    udp:
+      description: Modbus TCP form, but using UDP for transport (removes the overheads required for TCP).
+    rtuovertcp:
+      description: Modbus RTU message transmitted with a TCP/IP wrapper and sent over a network instead of serial lines.
+host:
+  description: The IP address of your Modbus device, eg. 192.168.1.1.
+  required: true
+  type: string
+port:
+  description: The port for the communication.
+  required: true
+  type: integer
+timeout:
+  description: Timeout for slave response in seconds.
+  required: false
+  default: 3
+  type: integer
+{% endconfiguration %}
 
 For a serial connection:
 
@@ -54,16 +71,41 @@ modbus:
   parity: N
 ```
 
-Configuration variables:
-
-- **type** (*Required*): Type of the connection to Modbus.
-- **method** (*Required*): Method of the connection to Modbus.
-- **port** (*Required*): The port where your Modbus device is connected to your Home Assistant host.
-- **baudrate** (*Required*): The speed for the serial connection.
-- **stopbits** (*Required*): The stopbits for the serial connection.
-- **bytesize** (*Required*): The bytesize for the serial connection.
-- **parity** (*Required*): The parity for the serial connection.
-- **timeout** (*Optional*): Timeout for slave response in seconds. (default: 3)
+{% configuration %}
+type:
+  description: Type of the connection to Modbus.
+  required: true
+  type: string
+method:
+  description: Method of the connection to Modbus.
+  required: true
+  type: string
+port:
+  description: The port where your Modbus device is connected to your Home Assistant host.
+  required: true
+  type: string
+baudrate:
+  description: The speed for the serial connection.
+  required: true
+  type: integer
+stopbits:
+  description: The stopbits for the serial connection.
+  required: true
+  type: integer
+bytesize:
+  description: The bytesize for the serial connection.
+  required: true
+  type: integer
+parity:
+  description: The parity for the serial connection.
+  required: true
+  type: string
+timeout:
+  description: Timeout for slave response in seconds.
+  required: false
+  default: 3
+  type: integer
+{% endconfiguration %}
 
 ### {% linkable_title Services %}
 

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -32,7 +32,7 @@ modbus:
 
 {% configuration %}
 type:
-  description: Type of the connection to Modbus. Possible values are:
+  description: Type of the connection to Modbus. Possible values are `tcp`, `udp` and `rtuovertcp`.
   required: true
   type: map
   keys:

--- a/source/_components/sensor.modbus.markdown
+++ b/source/_components/sensor.modbus.markdown
@@ -101,7 +101,7 @@ registers:
       default: int
       type: string
     structure:
-      description: "If data_type is custom specify here a double quoted python struct format string to unpack the value. See python documentation for details. Ex: ">i"."
+      description: "If data_type is custom specify here a double quoted python struct format string to unpack the value. See python documentation for details. Ex: >i."
       required: false
       type: string
 {% endconfiguration %}

--- a/source/_components/sensor.modbus.markdown
+++ b/source/_components/sensor.modbus.markdown
@@ -101,7 +101,7 @@ registers:
       default: int
       type: string
     structure:
-      description: If data_type is custom specify here a double quoted python struct format string to unpack the value. See python documentation for details. Ex: ">i".
+      description: "If data_type is custom specify here a double quoted python struct format string to unpack the value. See python documentation for details. Ex: ">i"."
       required: false
       type: string
 {% endconfiguration %}

--- a/source/_components/sensor.modbus.markdown
+++ b/source/_components/sensor.modbus.markdown
@@ -45,21 +45,66 @@ sensor:
       precision: 2
 ```
 
-Configuration variables:
-
-- **registers** array (*Required*): The array contains a list of relevant registers to read from.
-  - **name** (*Required*): Name of the sensor.
-  - **slave** (*Required*): The number of the slave (Optional for tcp and upd Modbus).
-  - **register** (*Required*): Register number.
-  - **register_type** (*Optional*): Modbus register type (holding, input), default holding.
-  - **unit_of_measurement** (*Optional*): Unit to attach to value.
-  - **count** (*Optional*): Number of registers to read.
-  - **reverse_order** (*Optional*): Reverse the order of registers when count >1, default False.
-  - **scale** (*Optional*): Scale factor (output = scale * value + offset), default 1.
-  - **offset** (*Optional*): Final offset (output = scale * value + offset), default 0.
-  - **precision** (*Optional*): Number of valid decimals, default 0.
-  - **data_type** (*Optional*): Response representation (int, uint, float, custom). If float selected, value will be converted to IEEE 754 floating point format. Default int.
-  - **structure** (*Optional*): If data_type is custom specify here a double quoted python struct format string to unpack the value. See python documentation for details. Ex: ">i".
+{% configuration %}
+registers:
+  description: The array contains a list of relevant registers to read from.
+  required: true
+  type: map
+  keys:
+    name:
+      description: Name of the sensor.
+      required: true
+      type: string
+    slave:
+      description: The number of the slave (Optional for tcp and upd Modbus).
+      required: true
+      type: integer
+    register:
+      description: Register number.
+      required: true
+      type: integer
+    register_type:
+      description: Modbus register type (holding, input), default holding.
+      required: false
+      type: string
+    unit_of_measurement:
+      description: Unit to attach to value.
+      required: false
+      type: integer
+    count:
+      description: Number of registers to read.
+      required: integer
+      type: integer
+    reverse_order:
+      description: Reverse the order of registers when count >1.
+      required: false
+      default: False
+      type: boolean
+    scale:
+      description: Scale factor (output = scale * value + offset).
+      required: false
+      default: 1
+      type: float
+    offset:
+      description: Final offset (output = scale * value + offset).
+      required: false
+      default: 0
+      type: float
+    precision:
+      description: Number of valid decimals.
+      required: false
+      default: 0
+      type: integer
+    data_type:
+      description: Response representation (int, uint, float, custom). If float selected, value will be converted to IEEE 754 floating point format.
+      required: false
+      default: int
+      type: string
+    structure:
+      description: If data_type is custom specify here a double quoted python struct format string to unpack the value. See python documentation for details. Ex: ">i".
+      required: false
+      type: string
+{% endconfiguration %}
 
 It's possible to change the default 30 seconds scan interval for the sensor updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.
 

--- a/source/_components/switch.modbus.markdown
+++ b/source/_components/switch.modbus.markdown
@@ -94,7 +94,7 @@ register:
       default: same as register
       type: string
     register_type:
-      description: Modbus register type: holding or input.
+      description: Modbus register types are holding or input.
       required: false
       default: holding
       type: string

--- a/source/_components/switch.modbus.markdown
+++ b/source/_components/switch.modbus.markdown
@@ -40,20 +40,72 @@ switch:
       command_off: 0
 ```
 
-Configuration variables:
-
-- **coils** (*Optional*): A list of relevant coils to read from/write to.
-  - **slave** (*Required*): The number of the slave (can be omitted for tcp and udp Modbus).
-  - **name** (*Required*): Name of the switch.
-  - **coil** (*Required*): Coil number.
-- **registers** (*Optional*): A list of relevant registers to read from/write to.
-  - **slave** (*Required*): The number of the slave (can be omitted for tcp and udp Modbus).
-  - **name** (*Required*): Name of the switch.
-  - **register** (*Required*): Register number.
-  - **command_on** (*Required*): Value to write to turn on the switch.
-  - **command_off** (*Required*): Value to write to turn off the switch.
-  - **verify_state** (*Optional*): Define if is possible to readback the status of the switch. (default: True)
-  - **verify_register** (*Optional*): Register to readback. (default: same as register)
-  - **register_type** (*Optional*): Modbus register type: holding or input. (default: holding)
-  - **state_on** (*Optional*): Register value when switch is on. (default: same as command_on)
-  - **state_off** (*Optional*): Register value when switch is off. (default: same as command_off)
+{% configuration %}
+coils:
+  description: A list of relevant coils to read from/write to.
+  required: false
+  type: map
+  keys:
+    slave:
+      description: The number of the slave (can be omitted for tcp and udp Modbus).
+      required: true
+      type: integer
+    name:
+      description: Name of the switch.
+      required: true
+      type: string
+    coil:
+      description: Coil number.
+      required: true
+      type: integer
+register:
+  description: A list of relevant registers to read from/write to.
+  required: false
+  type: map
+  keys:
+    slave:
+      description: The number of the slave (can be omitted for tcp and udp Modbus).
+      required: true
+      type: integer
+    name:
+      description: Name of the switch.
+      required: true
+      type: string
+    register:
+      description: Register number.
+      required: true
+      type: integer
+    command_on:
+      description: Value to write to turn on the switch.
+      required: true
+      type: integer
+    command_off:
+      description: Value to write to turn off the switch.
+      required: true
+      type: integer
+    verify_state:
+      description: Define if is possible to readback the status of the switch.
+      required: false
+      default: True
+      type: boolean
+    verify_register:
+      description: Register to readback.
+      required: false
+      default: same as register
+      type: string
+    register_type:
+      description: Modbus register type: holding or input.
+      required: false
+      default: holding
+      type: string
+    state_on:
+      description: Register value when switch is on.
+      required: false
+      default: same as command_on
+      type: integer
+    state_off:
+      description: Register value when switch is off.
+      required: false
+      default: same as command_off
+      type: integer
+{% endconfiguration %}


### PR DESCRIPTION
Update style of Modbus component (all the 4 files) documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
