### PR TITLE
Update support controllers

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -24,6 +24,7 @@ You need to have a [supported Z-Wave USB stick or module](https://github.com/Ope
 | Sigma Designs UZB Stick |                |                  |              |
 | Tricklestar             |                |                  |              |
 | Vision USB Stick        |                |                  |              |
+| Zooz Z-Wave ZST10       |   &#10003;     |                  |              |
 | ZWave.me Razberry Board |   &#10003;     |                  |              |
 | ZWave.me UZB1           |   &#10003;     |                  |              |
 


### PR DESCRIPTION
**Description:**

Tested the Zooz z-wave Plus S2 Stick ZST10 with Home-Assistant. Zwave worked, nodes included and communicating using a Raspberriy Pi3 with the latest Hass.io.

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
