### PR TITLE
Updated harmony configuration to use configuration variables

### DIFF
--- a/source/_components/remote.harmony.markdown
+++ b/source/_components/remote.harmony.markdown
@@ -43,15 +43,31 @@ You can override some default configuration values on a discovered hub (e.g., th
     activity: Watch TV
 ```
 
-Configuration variables:
+{% configuration %}
+name:
+  description: The hub's name to display in the frontend. This name must match the name you have set on the Hub.
+  required: true
+  type: string
+host:
+  description: The Harmony device's IP address. Leave empty for the IP to be discovered automatically.
+  required: false
+  type: string
+port:
+  description: The Harmony device's port.
+  required: false
+  type: integer
+  default: 5222
+activity:
+  description: Activity to use when `turn_on` service is called without any data. Overrides the `activity` setting for this discovered hub.
+  required: false
+  type: string
+delay_secs:
+  description: Default duration in seconds between sending commands to a device.
+  required: false
+  type: float
+{% endconfiguration %}
 
-- **name** (*Required*): The hub's name to display in the frontend. This name must match the name you have set on the Hub.
-- **host** (*Optional*): The Harmony device's IP address. Leave empty for the IP to be discovered automatically.
-- **port** (*Optional*): The Harmony device's port. Defaults to 5222.
-- **activity** (*Optional*): Activity to use when `turn_on` service is called without any data. Overrides the `activity` setting for this discovered hub.
-- **delay_secs** (*Optional*): Default duration in seconds between sending commands to a device.
-
-Configuration file:
+### {% linkable_title Configuration file %}
 
 Upon startup one file will be written to your Home Assistant configuration directory per device in the following format: `harmony_REMOTENAME.conf`. The file will contain:
 


### PR DESCRIPTION
**Description:**
Updated the Harmony Hub documentation to use the new configuration variables (#6385).

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
