### PR TITLE
Improve accessibility of the home page

### DIFF
--- a/source/_includes/custom/footer.html
+++ b/source/_includes/custom/footer.html
@@ -4,10 +4,10 @@
       <img width="40" src="/demo/favicon-192x192.png" alt="Home Assistant"> Home Assistant
     </div>
     <div class="icons">
-      <a rel="me" href='https://twitter.com/home_assistant'><i class="icon-twitter"></i></a>
-      <a rel="me" href='https://facebook.com/homeassistantio'><i class="icon-facebook"></i></a>
-      <a rel="me" href='https://plus.google.com/110560654828510104551'><i class="icon-google-plus"></i></a>
-      <a rel="me" href='https://github.com/home-assistant/home-assistant'><i class="icon-github"></i></a>
+      <a rel="me" href='https://twitter.com/home_assistant' title="Twitter"><i class="icon-twitter"></i></a>
+      <a rel="me" href='https://facebook.com/homeassistantio' title="Facebook"><i class="icon-facebook"></i></a>
+      <a rel="me" href='https://plus.google.com/110560654828510104551' title="Google Plus"><i class="icon-google-plus"></i></a>
+      <a rel="me" href='https://github.com/home-assistant/home-assistant' title="GitHub"><i class="icon-github"></i></a>
     </div>
   </div>
 

--- a/source/_includes/custom/footer.html
+++ b/source/_includes/custom/footer.html
@@ -1,7 +1,7 @@
 <div class="copyright grid">
   <div class='company grid__item one-third lap-one-half palm-one-whole'>
     <div class="title">
-      <img width="40" src="/demo/favicon-192x192.png"> Home Assistant
+      <img width="40" src="/demo/favicon-192x192.png" alt="Home Assistant"> Home Assistant
     </div>
     <div class="icons">
       <a rel="me" href='https://twitter.com/home_assistant'><i class="icon-twitter"></i></a>

--- a/source/_includes/custom/grid_item_left.html
+++ b/source/_includes/custom/grid_item_left.html
@@ -3,46 +3,46 @@
 <p>Home Assistant will track the state of all the devices in your home, so you don't have to.</p>
 <div class='supported-brands clearfix'>
   <a href='/components/climate.nest/'>
-    <img src='/images/supported_brands/nest.png' />
+    <img src='/images/supported_brands/nest.png' alt="Nest" />
   </a>
   <a href='/components/ifttt/'>
-    <img src='/images/supported_brands/ifttt.png' />
+    <img src='/images/supported_brands/ifttt.png' alt="IFTTT" />
   </a>
   <a href='/components/light.hue/'>
-    <img src='/images/supported_brands/philips_hue.png' />
+    <img src='/images/supported_brands/philips_hue.png' alt="Philips Hue" />
   </a>
   <a href='/components/media_player.cast/'>
-    <img src='/images/supported_brands/google_cast.png' />
+    <img src='/images/supported_brands/google_cast.png' alt="Google Cast" />
   </a>
   <a href='/components/mqtt/'>
-    <img src='/images/supported_brands/mqtt.png' />
+    <img src='/images/supported_brands/mqtt.png' alt="MQTT" />
   </a>
   <a href='/components/switch.wemo/'>
-    <img src='/images/supported_brands/belkin_wemo.png' />
+    <img src='/images/supported_brands/belkin_wemo.png' alt="Belkin WeMo" />
   </a>
   <a href='/components/notify.pushbullet/'>
-    <img src='/images/supported_brands/pushbullet.png' />
+    <img src='/images/supported_brands/pushbullet.png' alt="Pushbullet" />
   </a>
   <a href='/components/media_player.kodi/'>
-    <img src='/images/supported_brands/kodi.png' />
+    <img src='/images/supported_brands/kodi.png' alt="Kodi" />
   </a>
   <a href='/components/media_player.plex/'>
-    <img src='/images/supported_brands/plex.png' />
+    <img src='/images/supported_brands/plex.png' alt="Plex" />
   </a>
   <a href='/components/tradfri/'>
-    <img src='/images/supported_brands/ikea.svg' width='165' />
+    <img src='/images/supported_brands/ikea.svg' width='165' alt="IKEA" />
   </a>
   <a href='/components/vera/'>
-    <img src='/images/supported_brands/vera.png' />
+    <img src='/images/supported_brands/vera.png' alt="Vera" />
   </a>
   <a href='/components/device_tracker.luci/'>
-    <img src='/images/supported_brands/openwrt.png' />
+    <img src='/images/supported_brands/openwrt.png' alt="OpenWRT" />
   </a>
   <a href='/components/arduino/'>
-    <img src='/images/supported_brands/arduino.png' />
+    <img src='/images/supported_brands/arduino.png' alt="Arduino" />
   </a>
   <!-- <a href='/components/wink/'>
-    <img src='/images/supported_brands/wink.png' />
+    <img src='/images/supported_brands/wink.png' alt="Wink" />
   </a> -->
 </div>
 

--- a/source/_includes/custom/header.html
+++ b/source/_includes/custom/header.html
@@ -1,6 +1,6 @@
 <div class="grid__item three-tenths lap-two-sixths palm-one-whole ha-title">
   <a href="{{ root_url }}/" class="site-title">
-    <img width='40' src='{{ root_url }}/demo/favicon-192x192.png'>
+    <img width='40' src='{{ root_url }}/demo/favicon-192x192.png' alt="Home Assistant">
     <span>{{ site.title }}</span>
   </a>
 </div>


### PR DESCRIPTION
**Description:**

I noticed the accessibility score of the home page isn't very high:

![screen shot 2018-10-08 at 9 33 20 pm](https://user-images.githubusercontent.com/1863540/46648051-082c3980-cb48-11e8-9c2b-3484cfa8fd80.png)

Adding alt text to the images (975f7793cf9ace77c8e34b9e7454d3fd42ecb417) helped quite a bit:

![screen shot 2018-10-08 at 10 04 14 pm](https://user-images.githubusercontent.com/1863540/46648089-46295d80-cb48-11e8-8aa9-ca9bf942f1b5.png)

Adding title attributes to the social links (e4fbb548be30257ad61ba1a03e0ee777215eef37) helped even more:

![screen shot 2018-10-08 at 10 12 05 pm](https://user-images.githubusercontent.com/1863540/46648105-59d4c400-cb48-11e8-8497-88ade5d85306.png)

The main remaining issue is about [color contrast](https://dequeuniversity.com/rules/axe/2.2/color-contrast). Unfortunately, this seems to stem from the [`$primary-color` variable](https://github.com/home-assistant/home-assistant.io/blob/6c7d0a244afa626385a4c6d3b0a0a000b4729519/sass/custom/_paulus.scss#L3) which is part of Home Assistant's brand. Given that, I'm not sure what would be the best way to tackle the color contrast issue, so I've left it alone in this PR.