### PR TITLE
Adds missing ankuoo_recswitch logo

### DIFF
--- a/source/_components/switch.recswitch.markdown
+++ b/source/_components/switch.recswitch.markdown
@@ -8,6 +8,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: "ankuoo_recswitch.png"
 ha_release: "0.81"
 ha_category: Switch
 ha_iot_class: "Local Polling"


### PR DESCRIPTION
**Description:**
As per comment by @MartinHjelmare:

https://github.com/home-assistant/home-assistant.io/pull/6548#pullrequestreview-162763994

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
