### PR TITLE
Add config entry note for Z-Wave

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -110,6 +110,11 @@ device_config / device_config_domain / device_config_glob:
       default: False
 {% endconfiguration %}
 
+<p class='note'>
+As of 0.81, the Z-Wave usb_path and network_key options are configured through the Integrations page in Home Assistant. Specifying a zwave: section in configuration.yaml is no longer required unless you need to customize other settings, such as device_config, polling_interval, etc.
+</p>
+
+
 ### {% linkable_title Finding the controller path on Linux %}
 
 <p class='note'>

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -111,7 +111,7 @@ device_config / device_config_domain / device_config_glob:
 {% endconfiguration %}
 
 <p class='note'>
-As of 0.81, the Z-Wave usb_path and network_key options are configured through the Integrations page in Home Assistant. Specifying a zwave: section in configuration.yaml is no longer required unless you need to customize other settings, such as device_config, polling_interval, etc.
+As of Home Assistant 0.81, the Z-Wave `usb_path` and `network_key` options are configured through the Integrations page in Home Assistant. Specifying a `zwave:` section in configuration.yaml is no longer required unless you need to customize other settings, such as `device_config`, `polling_interval`, etc.
 </p>
 
 


### PR DESCRIPTION
**Description:**
Adds a note to Z-Wave config docs about setting it up through the Integrations page after 0.81.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17119

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].