### PR TITLE
Update OpenTherm Gateway docs to reflect the rewrite to a component.

### DIFF
--- a/source/_components/climate.opentherm_gw.markdown
+++ b/source/_components/climate.opentherm_gw.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "OpenTherm Gateway Climate"
 description: "Control your OpenTherm Gateway from Home Assistant."
-date: 2018-10-09 11:23
+date: 2018-08-29 16:23
 sidebar: true
 comments: false
 sharing: true

--- a/source/_components/climate.opentherm_gw.markdown
+++ b/source/_components/climate.opentherm_gw.markdown
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: "OpenTherm Gateway"
+title: "OpenTherm Gateway Climate"
 description: "Control your OpenTherm Gateway from Home Assistant."
-date: 2018-08-29 16:23
+date: 2018-10-09 11:23
 sidebar: true
 comments: false
 sharing: true
@@ -18,48 +18,8 @@ The `opentherm_gw` climate platform is used to control the [OpenTherm Gateway](h
 
 # {% linkable_title Configuration %}
 
-```yaml
-# Example configuration.yaml entry
-climate:
-  - platform: opentherm_gw
-    device: /dev/ttyUSB0
-```
-
-{% configuration %}
-device:
-  description: "Path to OpenTherm Gateway device as supported by [PySerial](https://pythonhosted.org/pyserial/url_handlers.html)."
-  required: true
-  type: string
-name:
-  description: The name for the device within Home Assistant.
-  required: false
-  type: string
-  default: OpenTherm Gateway
-precision:
-  description: "The desired precision for this device. Can be used to match your actual thermostat's precision. Supported values are `0.1`, `0.5` and `1.0`."
-  required: false
-  type: float
-  default: "`0.5` for Celsius and `1.0` for Fahrenheit."
-floor_temperature:
-  description: Some thermostats round all temperatures down to the lower value according to their precision. Default behaviour for Home Assistant is to round temperatures to the nearest value. Set this to `True` to override Home Assistant and round to the lower value according to the configured `precision`.
-  required: false
-  type: boolean
-{% endconfiguration %}
+Configuration of this platform is achieved through the [OpenTherm Gateway Hub](/components/opentherm_gw/) configuration.
 
 <p class='note'>
 The OpenTherm protocol is based on polling. The thermostat sends requests to the boiler at specific intervals. As a result, it may take some time for changes to propagate between Home Assistant and the thermostat.
 </p>
-
-# {% linkable_title Example %}
-
-A full configuration example with the OpenTherm Gateway connected to a remote host running `ser2net` looks like the one below.
-
-```yaml
-# Full example configuration.yaml entry
-climate:
-  - platform: opentherm_gw
-    device: socket://otgw.example.org:2345
-    name: Thermostat
-    precision: 0.5
-    floor_temperature: True
-```

--- a/source/_components/opentherm_gw.markdown
+++ b/source/_components/opentherm_gw.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: opentherm.png
 ha_category: Hub
-ha_release: "0.80"
+ha_release: 0.81
 ha_iot_class: "Local Push"
 ---
 
@@ -45,9 +45,10 @@ climate:
       type: float
       default: "`0.5` for Celsius and `1.0` for Fahrenheit."
     floor_temperature:
-      description: "Some thermostats round all temperatures down to the lower value according to their precision. Default behaviour for Home Assistant is to round temperatures to the nearest value. Set this to `True` to override Home Assistant and round to the lower value according to the configured `precision`."
+      description: "Some thermostats round all temperatures down to the lower value according to their precision. Default behavior for Home Assistant is to round temperatures to the nearest value. Set this to `True` to override Home Assistant and round to the lower value according to the configured `precision`."
       required: false
       type: boolean
+      default: false
 {% endconfiguration %}
 
 <p class='note'>

--- a/source/_components/opentherm_gw.markdown
+++ b/source/_components/opentherm_gw.markdown
@@ -1,0 +1,69 @@
+---
+layout: page
+title: "OpenTherm Gateway Hub"
+description: "Control your OpenTherm Gateway from Home Assistant."
+date: 2018-10-07 16:23
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: opentherm.png
+ha_category: Hub
+ha_release: "0.80"
+ha_iot_class: "Local Push"
+---
+
+The `opentherm_gw` component is used to control the [OpenTherm Gateway](http://otgw.tclcode.com/) from Home Assistant.
+When enabled, this component will automatically add it's [`climate` entity](/components/climate.opentherm_gw) to Home Assistant.
+
+# {% linkable_title Configuration %}
+
+```yaml
+# Example configuration.yaml entry
+opentherm_gw:
+  device: /dev/ttyUSB0
+```
+
+{% configuration %}
+device:
+  description: "Path to OpenTherm Gateway device as supported by [PySerial](https://pythonhosted.org/pyserial/url_handlers.html)."
+  required: true
+  type: string
+climate:
+  description: "Settings for the `opentherm_gw` climate entity."
+  required: false
+  type: map
+  keys:
+    name:
+      description: "The name for the device within Home Assistant."
+      required: false
+      type: string
+      default: "OpenTherm Gateway"
+    precision:
+      description: "The desired precision for this device. Can be used to match your actual thermostat's precision. Supported values are `0.1`, `0.5` and `1.0`."
+      required: false
+      type: float
+      default: "`0.5` for Celsius and `1.0` for Fahrenheit."
+    floor_temperature:
+      description: "Some thermostats round all temperatures down to the lower value according to their precision. Default behaviour for Home Assistant is to round temperatures to the nearest value. Set this to `True` to override Home Assistant and round to the lower value according to the configured `precision`."
+      required: false
+      type: boolean
+{% endconfiguration %}
+
+<p class='note'>
+The OpenTherm protocol is based on polling. The thermostat sends requests to the boiler at specific intervals. As a result, it may take some time for changes to propagate between Home Assistant and the thermostat.
+</p>
+
+# {% linkable_title Example %}
+
+A full configuration example with the OpenTherm Gateway connected to a remote host running `ser2net` looks like the one below.
+
+```yaml
+# Full example configuration.yaml entry
+opentherm_gw:
+  device: socket://otgw.example.org:2345
+  climate:
+    name: Thermostat
+    precision: 0.5
+    floor_temperature: True
+```


### PR DESCRIPTION
**Description:**
OpenTherm Gateway has been rewritten to a component. This PR updates the docs accordingly

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17133

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
