### PR TITLE
influxdb component config var formatting

### DIFF
--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -40,17 +40,15 @@ username:
   type: string
   description: The username of the database user. The user needs read/write privileges on the database
   required: false
-  default: home-assistant
 password:
   type: string
   description: The password for the database user account.
   required: false
-  default: password
 database:
   type: string
   description: Name of the database to use. The database must already exist.
   required: false
-  default: home_assistant
+  default: will use the default database of your influxdb instance
 ssl:
   type: boolean
   description: Use https instead of http to connect.
@@ -60,7 +58,7 @@ verify_ssl:
   type: boolean
   description: Verify SSL certificate for https request.
   required: false
-  default: false
+  default: true
 max_retries:
   type: int
   description: Set this to allow the component to retry if there was a network error when transmitting data.

--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -109,6 +109,36 @@ tags_attributes:
   description: The list of attribute names which should be reported as tags and not fields to InfluxDB. For example, if set to `friendly_name`, it will be possible to group by entities' friendly names as well, in addition to their ids.
   required: false
   default: 0
+component_config:
+  type: string
+  required: false
+  description: These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
+  keys:
+    override_measurement:
+      type: boolean
+      description: Measurement name to use for this component, takes precedence over the global ‘override_measurement’ and component-specific ‘unit_of_measurement’ attribute.
+      required: false
+      default: false
+component_config_domain:
+  type: string
+  required: false
+  description: These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
+  keys:
+    override_measurement:
+      type: boolean
+      description: Measurement name to use for this component, takes precedence over the global ‘override_measurement’ and component-specific ‘unit_of_measurement’ attribute.
+      required: false
+      default: false
+component_config_glob: 
+  type: string
+  required: false
+  description: These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
+  keys:
+    override_measurement:
+      type: boolean
+      description: Measurement name to use for this component, takes precedence over the global ‘override_measurement’ and component-specific ‘unit_of_measurement’ attribute.
+      required: false
+      default: false
 {% endconfiguration %}
 
 ## {% linkable_title Helper scripts %}

--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -32,7 +32,7 @@ host:
   required: false
   default: localhost
 port:
-  type: int
+  type: integer
   description: Port to use
   required: false
   default: 8086
@@ -48,7 +48,7 @@ database:
   type: string
   description: Name of the database to use. The database must already exist.
   required: false
-  default: will use the default database of your influxdb instance
+  default: home_assistant
 ssl:
   type: boolean
   description: Use https instead of http to connect.
@@ -60,7 +60,7 @@ verify_ssl:
   required: false
   default: true
 max_retries:
-  type: int
+  type: integer
   description: Set this to allow the component to retry if there was a network error when transmitting data.
   required: false
   default: 0

--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -70,10 +70,9 @@ default_measurement:
   required: false
   default: uses the entity id of the entity
 override_measurement:
-  type: boolean
+  type: string
   description:  Measurement name to use instead of unit or default measurement. This will store all data points in a single measurement.
   required: false
-  default: false
 exclude:
   type: list
   description:  Configure which components should be excluded from recording to InfluxDB.
@@ -115,30 +114,27 @@ component_config:
   description: These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
   keys:
     override_measurement:
-      type: boolean
-      description: Measurement name to use for this component, takes precedence over the global ‘override_measurement’ and component-specific ‘unit_of_measurement’ attribute.
+      type: string
+      description:  Measurement name to use instead of unit or default measurement. This will store all data points in a single measurement.
       required: false
-      default: false
 component_config_domain:
   type: string
   required: false
   description: These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
   keys:
     override_measurement:
-      type: boolean
-      description: Measurement name to use for this component, takes precedence over the global ‘override_measurement’ and component-specific ‘unit_of_measurement’ attribute.
+      type: string
+      description:  Measurement name to use instead of unit or default measurement. This will store all data points in a single measurement.
       required: false
-      default: false
 component_config_glob: 
   type: string
   required: false
   description: These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
   keys:
     override_measurement:
-      type: boolean
-      description: Measurement name to use for this component, takes precedence over the global ‘override_measurement’ and component-specific ‘unit_of_measurement’ attribute.
+      type: string
+      description:  Measurement name to use instead of unit or default measurement. This will store all data points in a single measurement.
       required: false
-      default: false
 {% endconfiguration %}
 
 ## {% linkable_title Helper scripts %}

--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -111,7 +111,7 @@ tags_attributes:
 component_config:
   type: string
   required: false
-  description: These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
+  description: This attribute contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
   keys:
     override_measurement:
       type: string
@@ -120,7 +120,7 @@ component_config:
 component_config_domain:
   type: string
   required: false
-  description: These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
+  description: This attribute contains domain-specific component override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
   keys:
     override_measurement:
       type: string
@@ -129,7 +129,7 @@ component_config_domain:
 component_config_glob: 
   type: string
   required: false
-  description: These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
+  description: This attribute contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
   keys:
     override_measurement:
       type: string

--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -25,28 +25,93 @@ influxdb:
 
 You will still need to create a database named `home_assistant` via InfluxDB's command line interface. For instructions on how to create a database check the [InfluxDB documentation](https://docs.influxdata.com/influxdb/latest/introduction/getting_started/#creating-a-database) relevant to the version you have installed.
 
-Configuration variables:
-
-- **host** (*Optional*): IP address of your database host, e.g., 192.168.1.10. Defaults to `localhost`.
-- **port** (*Optional*): Port to use. Defaults to 8086.
-- **username** (*Optional*): The username of the database user. The user needs read/write privileges on the database.
-- **password** (*Optional*): The password for the database user account.
-- **database** (*Optional*): Name of the database to use. Defaults to `home_assistant`. The database must already exist.
-- **ssl** (*Optional*): Use https instead of http to connect. Defaults to false.
-- **verify_ssl** (*Optional*): Verify SSL certificate for https request. Defaults to false.
-- **max_retries** (*Optional*): Allow the component to retry if there was a network error when transmitting data
-- **default_measurement** (*Optional*): Measurement name to use when an entity doesn't have a unit. Defaults to entity id.
-- **override_measurement** (*Optional*): Measurement name to use instead of unit or default measurement. This will store all data points in a single measurement.
-- **component_config**, **component_config_domain**, **component_config_glob** (*Optional*): These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
-  - **override_measurement** (*Optional*): Measurement name to use for this component, takes precedence over the global 'override_measurement' and component-specific 'unit_of_measurement' attribute.
-- **exclude** (*Optional*): Configure which components should be excluded from recording to InfluxDB.
-  - **entities** (*Optional*): The list of entity ids to be excluded from recording to InfluxDB.
-  - **domains** (*Optional*): The list of domains to be excluded from recording to InfluxDB.
-- **include** (*Optional*): Configure which components should be included in recordings to InfluxDB. If set, all other entities will not be recorded to InfluxDB. Values set by the **blacklist** option will prevail.
-  - **entities** (*Optional*): The list of entity ids to be included from recordings to InfluxDB.
-  - **domains** (*Optional*): The list of domains to be included from recordings to InfluxDB.
-- **tags** (*Optional*): Tags to mark the data.
-- **tags_attributes** (*Optional*): The list of attribute names which should be reported as tags and not fields to InfluxDB. For example, if set to `friendly_name`, it will be possible to group by entities' friendly names as well, in addition to their ids.
+{% configuration %}
+host:
+  type: string
+  description: IP address of your database host, e.g., 192.168.1.10
+  required: false
+  default: localhost
+port:
+  type: int
+  description: Port to use
+  required: false
+  default: 8086
+username:
+  type: string
+  description: The username of the database user. The user needs read/write privileges on the database
+  required: false
+  default: home-assistant
+password:
+  type: string
+  description: The password for the database user account.
+  required: false
+  default: password
+database:
+  type: string
+  description: Name of the database to use. The database must already exist.
+  required: false
+  default: home_assistant
+ssl:
+  type: boolean
+  description: Use https instead of http to connect.
+  required: false
+  default: false
+verify_ssl:
+  type: boolean
+  description: Verify SSL certificate for https request.
+  required: false
+  default: false
+max_retries:
+  type: int
+  description: Set this to allow the component to retry if there was a network error when transmitting data.
+  required: false
+  default: 0
+default_measurement:
+  type: string
+  description: Measurement name to use when an entity doesn't have a unit. 
+  required: false
+  default: uses the entity id of the entity
+override_measurement:
+  type: boolean
+  description:  Measurement name to use instead of unit or default measurement. This will store all data points in a single measurement.
+  required: false
+  default: false
+exclude:
+  type: list
+  description:  Configure which components should be excluded from recording to InfluxDB.
+  required: false
+  keys:
+    entities:
+      type: list
+      description:  The list of entity ids to be excluded from recording to InfluxDB.
+      required: false    
+    domains:
+      type: list
+      description:  The list of domains to be excluded from recording to InfluxDB.
+      required: false
+include:
+  type: list
+  description:  Configure which components should be included in recordings to InfluxDB. If set, all other entities will not be recorded to InfluxDB. Values set by the **exclude** lists will take precedence.
+  required: false
+  keys:
+    entities:
+      type: string, list
+      description:  The list of entity ids to be included in recording to InfluxDB.
+      required: false    
+    domains:
+      type: string, list
+      description:  The list of domains to be included in recording to InfluxDB.
+      required: false
+tags:
+  type: string, list
+  description: Tags to mark the data.
+  default: 0
+tags_attributes:
+  type: string, list
+  description: The list of attribute names which should be reported as tags and not fields to InfluxDB. For example, if set to `friendly_name`, it will be possible to group by entities' friendly names as well, in addition to their ids.
+  required: false
+  default: 0
+{% endconfiguration %}
 
 ## {% linkable_title Helper scripts %}
 


### PR DESCRIPTION
Updating the configuration variable section.

I wasn't sure that the customize variables should be included, since they apply to all components from my understanding.
```
- **component_config**, **component_config_domain**, **component_config_glob** (*Optional*): These attributes contains component-specific override values. See [Customizing devices and services](/getting-started/customizing-devices/) for format.
  - **override_measurement** (*Optional*): Measurement name to use for this component, takes precedence over the global 'override_measurement' and component-specific 'unit_of_measurement' attribute.
```

Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
