### PR TITLE
Simplification of the supported controllers

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -11,7 +11,15 @@ footer: true
 
 ## {% linkable_title Supported Z-Wave USB Sticks & Hardware Modules %}
 
-You need to have a compatible Z-Wave stick or module installed. This needs to be a *static controller*, which most Z-Wave sticks and modules will be. If yours is a *bridge* device then it won't work with [OpenZWave](http://openzwave.com/), which is what provides Home Assistant's Z-Wave capabilities.
+You need to have a compatible Z-Wave stick or module installed. This needs to be a *static controller*, which most Z-Wave sticks and modules will be. If yours is a *bridge* device then it won't work with [OpenZWave](http://openzwave.com/), which is what provides Home Assistant's Z-Wave capabilities. The following devices have been confirmed to work:
+
+* Aeotec Z-Stick Series 5
+* Everspring USB stick - Gen 5
+* Sigma Designs UZB stick
+* Vision USB stick - Gen5
+* Zooz Z-Wave Plus S2 stick ZST10
+* ZWave.me Razberry Board
+* ZWave.me UZB1 stick
 
 We recommend that you purchase a [Z-Wave Plus](https://z-wavealliance.org/z-wave_plus_certification/) controller, to take advantage of the improvements this provides. As OpenZWave doesn't support S2 or Smart Start, there's no need to buy one just for support of these features.
 

--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -11,22 +11,9 @@ footer: true
 
 ## {% linkable_title Supported Z-Wave USB Sticks & Hardware Modules %}
 
-You need to have a [supported Z-Wave USB stick or module](https://github.com/OpenZWave/open-zwave/wiki/Controller-Compatibility-List) installed.
+You need to have a compatible Z-Wave stick or module installed. This needs to be a *static controller*, which most Z-Wave sticks and modules will be. If yours is a *bridge* device then it won't work with [OpenZWave](http://openzwave.com/), which is what provides Home Assistant's Z-Wave capabilities.
 
-| Device                    | Works on Linux | Works on Windows | Works on OSX |
-|---------------------------|----------------|------------------|--------------|
-| Aeotec Z-Stick            |   &#10003;     |                  |              |
-| Aeotec Z-Stick Series 2   |   &#10003;     |                  |              |
-| Aeotec Z-Stick Series 5   |   &#10003;     |    &#10003;      |   &#10003;   |
-| Pine64 Z-Wave Module      |   &#10003;     |                  |              |
-| Razberry GPIO Module      |   &#10003;     |                  |              |
-| Seluxit ViaSens 100       |                |                  |              |
-| Sigma Designs UZB Stick   |                |                  |              |
-| Tricklestar               |                |                  |              |
-| Vision USB Stick          |                |                  |              |
-| Zooz Z-Wave Plus S2 ZST10 |   &#10003;     |                  |              |
-| ZWave.me Razberry Board   |   &#10003;     |                  |              |
-| ZWave.me UZB1             |   &#10003;     |                  |              |
+We recommend that you purchase a [Z-Wave Plus](https://z-wavealliance.org/z-wave_plus_certification/) controller, to take advantage of the improvements this provides. As OpenZWave doesn't support S2 or Smart Start, there's no need to buy one just for support of these features.
 
 <p class='note'>
   If you're using Hass.io or running HASS in a Docker container, it's recommended to use a USB stick, not a module. Passing a module through Docker is more complicated than passing a USB stick through.


### PR DESCRIPTION
Stripped it down to the key fact - *static controllers* are all that'll work with OZW.

Noted that Z-Wave Plus controllers are recommended, to take advantage of all the features of Z-Wave Plus.

Noted that S2 and Smart Start aren't supported by OZW
