### PR TITLE
Reformat the configuration options

### DIFF
--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -106,7 +106,7 @@ monitored_conditions:
     pressure_mb:
       description: Atmospheric air pressure in millibars
     pressure_trend:
-      description: "Atmospheric air pressure trend signal `(+/-)`"
+      description: "Atmospheric air pressure trend signal"
     relative_humidity:
       description: Relative humidity
     station_id:
@@ -136,13 +136,13 @@ monitored_conditions:
     temp_low_avg_f:
       description: Average low for today in Fahrenheit
     temp_high_1d_c:
-      description: "<sup>[1d]</sup>](#1d): Forecasted high temperature in Celsius"
+      description: "[<sup>[1d]</sup>](#1d): Forecasted high temperature in Celsius"
     temp_high_1d_f:
-      description: "<sup>[1d]</sup>](#1d): Forecasted high temperature in Fahrenheit"
+      description: "[<sup>[1d]</sup>](#1d): Forecasted high temperature in Fahrenheit"
     temp_low_1d_c:
-      description: "<sup>[1d]</sup>](#1d): Forecasted low temperature in Celsius"
+      description: "[<sup>[1d]</sup>](#1d): Forecasted low temperature in Celsius"
     temp_low_1d_f:
-      description: "<sup>[1d]</sup>](#1d): Forecasted low temperature in Fahrenheit"
+      description: "[<sup>[1d]</sup>](#1d): Forecasted low temperature in Fahrenheit"
     UV:
       description: Current levels of UV radiation. See [here](https://www.wunderground.com/resources/health/uvindex.asp) for explanation.
     visibility_km:
@@ -152,11 +152,11 @@ monitored_conditions:
     weather:
       description: A human-readable text summary with picture from Wunderground.
     weather_1d:
-      description: "<sup>[12h]</sup>](#12h): A human-readable weather forecast using imperial units."
+      description: "[<sup>[12h]</sup>](#12h): A human-readable weather forecast using imperial units."
     weather_1d_metric:
-      description: "<sup>[12h]</sup>](#12h): A human-readable weather forecast using metric units."
+      description: "[<sup>[12h]</sup>](#12h): A human-readable weather forecast using metric units."
     weather_1h:
-      description: "<sup>[1h]</sup>](#1h): Weather conditions in 1 hour. (e.g., "Thunderstorm" etc.)"
+      description: "[<sup>[1h]</sup>](#1h): Weather conditions in 1 hour. (e.g., "Thunderstorm" etc.)"
     wind_degrees:
       description: Wind degrees
     wind_dir:
@@ -166,17 +166,17 @@ monitored_conditions:
     wind_gust_mph:
       description: Wind gusts speed in mph
     wind_gust_1d_kph:
-      description: "<sup>[1d]</sup>](#1d): Max. forecasted Wind in kph"
+      description: "[<sup>[1d]</sup>](#1d): Max. forecasted Wind in kph"
     wind_gust_1d_mph:
-      description: "<sup>[1d]</sup>](#1d): Max. forecasted Wind in mph"
+      description: "[<sup>[1d]</sup>](#1d): Max. forecasted Wind in mph"
     wind_kph:
       description: Current wind speed in kph
     wind_mph:
       description: Current wind speed in mph
     wind_1d_kph:
-      description: "<sup>[1d]</sup>](#1d): Forecasted wind speed in kph"
+      description: "[<sup>[1d]</sup>](#1d): Forecasted wind speed in kph"
     wind_1d_mph:
-      description: "<sup>[1d]</sup>](#1d): Forecasted wind speed in mph"
+      description: "[<sup>[1d]</sup>](#1d): Forecasted wind speed in mph"
     wind_string:
       description: Text summary of current wind conditions
 {% endconfiguration %}
@@ -277,6 +277,8 @@ Note: While the platform is called “wunderground” the sensors will show up i
 
 Note that the Weather Underground sensor is added to the entity_registry, so second and subsequent Personal Weather Station ID (pws_id) will have their monitored conditions suffixed with an index number e.g.
 
+```yaml
 - sensor.pws_weather_1d_metric_2
+```
 
 Additional details about the API are available [here](https://www.wunderground.com/weather/api/d/docs).

--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -39,7 +39,7 @@ api_key:
   required: true
   type: string
 pws_id:
-  description: You can enter a Personal Weather Station ID. The current list of Wunderground PWS stations is available [here](https://www.wunderground.com/weatherstation/ListStations.asp). If you do not enter a PWS ID, the current location information (latitude and longitude) from your `configuration.yaml` will be used to display weather conditions.
+  description: "You can enter a Personal Weather Station ID. The current list of Wunderground PWS stations is available [here](https://www.wunderground.com/weatherstation/ListStations.asp). If you do not enter a PWS ID, the current location information (latitude and longitude) from your `configuration.yaml` will be used to display weather conditions."
   required: false
   type: string
 lang:
@@ -96,17 +96,17 @@ monitored_conditions:
     precip_today_string:
       description: Text summary of precipitation today
     precip_1d_mm:
-      description: [<sup>[1d]</sup>](#1d): Forecasted precipitation intensity in millimeters
+      description: "[<sup>[1d]</sup>](#1d): Forecasted precipitation intensity in millimeters"
     precip_1d_in:
-      description: [<sup>[1d]</sup>](#1d): Forecasted precipitation intensity in inches
+      description: "[<sup>[1d]</sup>](#1d): Forecasted precipitation intensity in inches"
     precip_1d:
-      description: [<sup>[1d]</sup>](#1d): Forecasted precipitation probability in %
+      description: "[<sup>[1d]</sup>](#1d): Forecasted precipitation probability in %"
     pressure_in:
       description: Atmospheric air pressure in inches
     pressure_mb:
       description: Atmospheric air pressure in millibars
     pressure_trend:
-      description: Atmospheric air pressure trend signal (+/-)
+      description: "Atmospheric air pressure trend signal `(+/-)`"
     relative_humidity:
       description: Relative humidity
     station_id:
@@ -136,13 +136,13 @@ monitored_conditions:
     temp_low_avg_f:
       description: Average low for today in Fahrenheit
     temp_high_1d_c:
-      description: <sup>[1d]</sup>](#1d): Forecasted high temperature in Celsius
+      description: "<sup>[1d]</sup>](#1d): Forecasted high temperature in Celsius"
     temp_high_1d_f:
-      description: <sup>[1d]</sup>](#1d): Forecasted high temperature in Fahrenheit
+      description: "<sup>[1d]</sup>](#1d): Forecasted high temperature in Fahrenheit"
     temp_low_1d_c:
-      description: <sup>[1d]</sup>](#1d): Forecasted low temperature in Celsius
+      description: "<sup>[1d]</sup>](#1d): Forecasted low temperature in Celsius"
     temp_low_1d_f:
-      description: <sup>[1d]</sup>](#1d): Forecasted low temperature in Fahrenheit
+      description: "<sup>[1d]</sup>](#1d): Forecasted low temperature in Fahrenheit"
     UV:
       description: Current levels of UV radiation. See [here](https://www.wunderground.com/resources/health/uvindex.asp) for explanation.
     visibility_km:
@@ -152,11 +152,11 @@ monitored_conditions:
     weather:
       description: A human-readable text summary with picture from Wunderground.
     weather_1d:
-      description: <sup>[12h]</sup>](#12h): A human-readable weather forecast using imperial units.
+      description: "<sup>[12h]</sup>](#12h): A human-readable weather forecast using imperial units."
     weather_1d_metric:
-      description: <sup>[12h]</sup>](#12h): A human-readable weather forecast using metric units.
+      description: "<sup>[12h]</sup>](#12h): A human-readable weather forecast using metric units."
     weather_1h:
-      description: <sup>[1h]</sup>](#1h): Weather conditions in 1 hour. (e.g., "Thunderstorm" etc.)
+      description: "<sup>[1h]</sup>](#1h): Weather conditions in 1 hour. (e.g., "Thunderstorm" etc.)"
     wind_degrees:
       description: Wind degrees
     wind_dir:
@@ -166,17 +166,17 @@ monitored_conditions:
     wind_gust_mph:
       description: Wind gusts speed in mph
     wind_gust_1d_kph:
-      description: <sup>[1d]</sup>](#1d): Max. forecasted Wind in kph
+      description: "<sup>[1d]</sup>](#1d): Max. forecasted Wind in kph"
     wind_gust_1d_mph:
-      description: <sup>[1d]</sup>](#1d): Max. forecasted Wind in mph
+      description: "<sup>[1d]</sup>](#1d): Max. forecasted Wind in mph"
     wind_kph:
       description: Current wind speed in kph
     wind_mph:
       description: Current wind speed in mph
     wind_1d_kph:
-      description: <sup>[1d]</sup>](#1d): Forecasted wind speed in kph
+      description: "<sup>[1d]</sup>](#1d): Forecasted wind speed in kph"
     wind_1d_mph:
-      description: <sup>[1d]</sup>](#1d): Forecasted wind speed in mph
+      description: "<sup>[1d]</sup>](#1d): Forecasted wind speed in mph"
     wind_string:
       description: Text summary of current wind conditions
 {% endconfiguration %}

--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -106,7 +106,7 @@ monitored_conditions:
     pressure_mb:
       description: Atmospheric air pressure in millibars
     pressure_trend:
-      description: "Atmospheric air pressure trend signal"
+      description: "Atmospheric air pressure trend signal `(+/-)`"
     relative_humidity:
       description: Relative humidity
     station_id:
@@ -156,7 +156,7 @@ monitored_conditions:
     weather_1d_metric:
       description: "[<sup>[12h]</sup>](#12h): A human-readable weather forecast using metric units."
     weather_1h:
-      description: "[<sup>[1h]</sup>](#1h): Weather conditions in 1 hour. (e.g., "Thunderstorm" etc.)"
+      description: "[<sup>[1h]</sup>](#1h): Weather conditions in 1 hour. (e.g., \"Thunderstorm\" etc.)"
     wind_degrees:
       description: Wind degrees
     wind_dir:

--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -13,7 +13,7 @@ ha_release: 0.27
 ha_iot_class: "Cloud Polling"
 ---
 
-The `wunderground` platform uses [Weather Underground](http://www.wunderground.com) as a source for current weather information. 
+The `wunderground` platform uses [Weather Underground](http://www.wunderground.com) as a source for current weather information.
 
 <p class='note warning'>
 Obtain a WUnderground API key [here](https://www.wunderground.com/weather/api). They no longer offer free API keys, and all keys must be paid for. At this time existing free keys will continue to work, but will be disabled Dec 31, 2018.  As of Sept 6, 2018 Weather Underground states they are declaring the [End of Service for the Weather Underground API](https://apicommunity.wunderground.com/weatherapi/topics/end-of-service-for-the-weather-underground-api). They say they will develop new plans for non-commercial users.  No timeline for this has been announced.
@@ -33,72 +33,154 @@ sensor:
       - dewpoint_c
 ```
 
-Configuration variables:
+{% configuration %}
+api_key:
+  description: The API key for Weather Underground. See above for details.
+  required: true
+  type: string
+pws_id:
+  description: You can enter a Personal Weather Station ID. The current list of Wunderground PWS stations is available [here](https://www.wunderground.com/weatherstation/ListStations.asp). If you do not enter a PWS ID, the current location information (latitude and longitude) from your `configuration.yaml` will be used to display weather conditions.
+  required: false
+  type: string
+lang:
+  description: Specify the language that the API returns. The current list of all Wunderground language codes is available [here](https://www.wunderground.com/weather/api/d/docs?d=language-support). If not specified, it defaults to English (EN).
+  required: false
+  type: string
+  default: EN
+latitude:
+  description: Latitude coordinate to monitor weather of (required if **longitude** is specified).
+  required: false
+  type: string
+  default: Coordinates defined in your `configuration.yaml`
+longitude:
+  description: Longitude coordinate to monitor weather of (required if **latitude** is specified).
+  required: false
+  type: string
+  default: Coordinates defined in your `configuration.yaml`
+monitored_conditions:
+  description: Conditions to display in the frontend. The following conditions can be monitored.
+  required: true
+  type: list
+  default: symbol
+  keys:
+    alerts:
+      description: Current severe weather advisories
+    dewpoint_c:
+      description: Temperature in Celsius below which water droplets begin to condense and dew can form
+    dewpoint_f:
+      description: Temperature in Fahrenheit below which water droplets begin to condense and dew can form
+    dewpoint_string:
+      description: Text summary of dew point
+    feelslike_c:
+      description: Feels like (or apparent) temperature in Celsius
+    feelslike_f:
+      description: Feels like (or apparent) temperature in Fahrenheit
+    feelslike_string:
+      description: Text summary of how the current temperature feels like
+    heat_index_c:
+      description: Heat index (combined effects of the temperature and humidity of the air) in Celsius
+    heat_index_f:
+      description: Heat index (combined effects of the temperature and humidity of the air) in Fahrenheit
+    heat_index_string:
+      description: Text summary of current heat index
+    elevation:
+      description: Elevation in feet
+    location:
+      description: City and State
+    observation_time:
+      description: Text summary of observation time
+    precip_today_in:
+      description: Total precipitation in inches
+    precip_today_metric:
+      description: Total precipitation in metric units
+    precip_today_string:
+      description: Text summary of precipitation today
+    precip_1d_mm:
+      description: [<sup>[1d]</sup>](#1d): Forecasted precipitation intensity in millimeters
+    precip_1d_in:
+      description: [<sup>[1d]</sup>](#1d): Forecasted precipitation intensity in inches
+    precip_1d:
+      description: [<sup>[1d]</sup>](#1d): Forecasted precipitation probability in %
+    pressure_in:
+      description: Atmospheric air pressure in inches
+    pressure_mb:
+      description: Atmospheric air pressure in millibars
+    pressure_trend:
+      description: Atmospheric air pressure trend signal (+/-)
+    relative_humidity:
+      description: Relative humidity
+    station_id:
+      description: Your personal weather station (PWS) ID
+    solarradiation:
+      description: Current levels of solar radiation
+    temperature_string:
+      description: Temperature text combining Fahrenheit and Celsius
+    temp_c:
+      description: Current temperature in Celsius
+    temp_f:
+      description: Current temperature in Fahrenheit
+    temp_high_record_c:
+      description: Maximum temperature measured in Celsius
+    temp_high_record_f:
+      description: Maximum temperature measured in Fahrenheit
+    temp_low_record_c:
+      description: Minimal temperature measured in Celsius
+    temp_low_record_f:
+      description: Minimal temperature measured in Fahrenheit
+    temp_high_avg_c:
+      description: Average high for today in Celsius
+    temp_high_avg_f:
+      description: Average high for today in Fahrenheit
+    temp_low_avg_c:
+      description: Average low for today in Celsius
+    temp_low_avg_f:
+      description: Average low for today in Fahrenheit
+    temp_high_1d_c:
+      description: <sup>[1d]</sup>](#1d): Forecasted high temperature in Celsius
+    temp_high_1d_f:
+      description: <sup>[1d]</sup>](#1d): Forecasted high temperature in Fahrenheit
+    temp_low_1d_c:
+      description: <sup>[1d]</sup>](#1d): Forecasted low temperature in Celsius
+    temp_low_1d_f:
+      description: <sup>[1d]</sup>](#1d): Forecasted low temperature in Fahrenheit
+    UV:
+      description: Current levels of UV radiation. See [here](https://www.wunderground.com/resources/health/uvindex.asp) for explanation.
+    visibility_km:
+      description: Average visibility in km
+    visibility_mi:
+      description: Average visibility in miles
+    weather:
+      description: A human-readable text summary with picture from Wunderground.
+    weather_1d:
+      description: <sup>[12h]</sup>](#12h): A human-readable weather forecast using imperial units.
+    weather_1d_metric:
+      description: <sup>[12h]</sup>](#12h): A human-readable weather forecast using metric units.
+    weather_1h:
+      description: <sup>[1h]</sup>](#1h): Weather conditions in 1 hour. (e.g., "Thunderstorm" etc.)
+    wind_degrees:
+      description: Wind degrees
+    wind_dir:
+      description: Wind direction
+    wind_gust_kph:
+      description: Wind gusts speed in kph
+    wind_gust_mph:
+      description: Wind gusts speed in mph
+    wind_gust_1d_kph:
+      description: <sup>[1d]</sup>](#1d): Max. forecasted Wind in kph
+    wind_gust_1d_mph:
+      description: <sup>[1d]</sup>](#1d): Max. forecasted Wind in mph
+    wind_kph:
+      description: Current wind speed in kph
+    wind_mph:
+      description: Current wind speed in mph
+    wind_1d_kph:
+      description: <sup>[1d]</sup>](#1d): Forecasted wind speed in kph
+    wind_1d_mph:
+      description: <sup>[1d]</sup>](#1d): Forecasted wind speed in mph
+    wind_string:
+      description: Text summary of current wind conditions
+{% endconfiguration %}
 
-- **api_key** (*Required*): The API key for Weather Underground. See above for details.
-- **pws_id** (*Optional*): You can enter a Personal Weather Station ID. The current list of Wunderground PWS stations is available [here](https://www.wunderground.com/weatherstation/ListStations.asp). If you do not enter a PWS ID, the current location information (latitude and longitude) from your `configuration.yaml` will be used to display weather conditions. 
-- **lang** (*Optional*): Specify the language that the API returns. The current list of all Wunderground language codes is available [here](https://www.wunderground.com/weather/api/d/docs?d=language-support). If not specified, it defaults to English (EN).
-- **latitude** (*Optional*): Latitude coordinate to monitor weather of (required if **longitude** is specified). Defaults to coordinates defined in your `configuration.yaml`.
-- **longitude** (*Optional*): Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml`.
-- **monitored_conditions** array (*Required*): Conditions to display in the frontend. The following conditions can be monitored.
-  - **alerts**: Current severe weather advisories
-  - **dewpoint_c**: Temperature in Celsius below which water droplets begin to condense and dew can form
-  - **dewpoint_f**: Temperature in Fahrenheit below which water droplets begin to condense and dew can form
-  - **dewpoint_string**: Text summary of dew point
-  - **feelslike_c**: Feels like (or apparent) temperature in Celsius
-  - **feelslike_f**: Feels like (or apparent) temperature in Fahrenheit
-  - **feelslike_string**: Text summary of how the current temperature feels like
-  - **heat_index_c**: Heat index (combined effects of the temperature and humidity of the air) in Celsius
-  - **heat_index_f**: Heat index (combined effects of the temperature and humidity of the air) in Fahrenheit
-  - **heat_index_string**: Text summary of current heat index
-  - **elevation**: Elevation in feet
-  - **location**: City and State
-  - **observation_time**: Text summary of observation time
-  - **precip_today_in**: Total precipitation in inches
-  - **precip_today_metric**: Total precipitation in metric units
-  - **precip_today_string**: Text summary of precipitation today
-  - **precip_1d_mm** [<sup>[1d]</sup>](#1d): Forecasted precipitation intensity in millimeters
-  - **precip_1d_in** [<sup>[1d]</sup>](#1d): Forecasted precipitation intensity in inches
-  - **precip_1d** [<sup>[1d]</sup>](#1d): Forecasted precipitation probability in %
-  - **pressure_in**: Atmospheric air pressure in inches
-  - **pressure_mb**: Atmospheric air pressure in millibars
-  - **pressure_trend**: Atmospheric air pressure trend signal (+/-)
-  - **relative_humidity**: Relative humidity
-  - **station_id**: Your personal weather station (PWS) ID
-  - **solarradiation**: Current levels of solar radiation
-  - **temperature_string**: Temperature text combining Fahrenheit and Celsius
-  - **temp_c**: Current temperature in Celsius
-  - **temp_f**: Current temperature in Fahrenheit
-  - **temp_high_record_c**: Maximum temperature measured in Celsius
-  - **temp_high_record_f**: Maximum temperature measured in Fahrenheit
-  - **temp_low_record_c**: Minimal temperature measured in Celsius
-  - **temp_low_record_f**: Minimal temperature measured in Fahrenheit
-  - **temp_high_avg_c**: Average high for today in Celsius
-  - **temp_high_avg_f**: Average high for today in Fahrenheit
-  - **temp_low_avg_c**: Average low for today in Celsius
-  - **temp_low_avg_f**: Average low for today in Fahrenheit
-  - **temp_high_1d_c** [<sup>[1d]</sup>](#1d): Forecasted high temperature in Celsius
-  - **temp_high_1d_f** [<sup>[1d]</sup>](#1d): Forecasted high temperature in Fahrenheit
-  - **temp_low_1d_c** [<sup>[1d]</sup>](#1d): Forecasted low temperature in Celsius
-  - **temp_low_1d_f** [<sup>[1d]</sup>](#1d): Forecasted low temperature in Fahrenheit
-  - **UV**: Current levels of UV radiation. See [here](https://www.wunderground.com/resources/health/uvindex.asp) for explanation.
-  - **visibility_km**: Average visibility in km
-  - **visibility_mi**: Average visibility in miles
-  - **weather**: A human-readable text summary with picture from Wunderground.
-  - **weather_1d** [<sup>[12h]</sup>](#12h): A human-readable weather forecast using imperial units.
-  - **weather_1d_metric** [<sup>[12h]</sup>](#12h): A human-readable weather forecast using metric units.
-  - **weather_1h** [<sup>[1h]</sup>](#1h): Weather conditions in 1 hour. (e.g., "Thunderstorm" etc.)
-  - **wind_degrees**: Wind degrees
-  - **wind_dir**: Wind direction
-  - **wind_gust_kph**: Wind gusts speed in kph
-  - **wind_gust_mph**: Wind gusts speed in mph
-  - **wind_gust_1d_kph** [<sup>[1d]</sup>](#1d): Max. forecasted Wind in kph
-  - **wind_gust_1d_mph** [<sup>[1d]</sup>](#1d): Max. forecasted Wind in mph
-  - **wind_kph**: Current wind speed in kph
-  - **wind_mph**: Current wind speed in mph
-  - **wind_1d_kph** [<sup>[1d]</sup>](#1d): Forecasted wind speed in kph
-  - **wind_1d_mph** [<sup>[1d]</sup>](#1d): Forecasted wind speed in mph
-  - **wind_string**: Text summary of current wind conditions
 
 All the conditions listed above will be updated every 5 minutes.
 


### PR DESCRIPTION
**Description:**
Reformat configuration options of the wunderground sensor.
Related to #6385.

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/