### PR TITLE
Converting HASS Configurator to the new configuration template format.

### DIFF
--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -94,7 +94,7 @@ banned_ips:
 banlimit:
   description: Ban access from IPs after `banlimit` failed login attempts, setting the value to 0 disables this feature. Restart the add-on to clear the list of banned IP addresses.
   required: true
-  type: int
+  type: integer
   default: 0
 ignore_pattern:
   description: Regex of files and folders to ignore in the UI.

--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -76,11 +76,11 @@ ssl:
   required: true
   type: string
 certfile:
-  description: Set the path the your SSL certificate if the ssl-option is set to true.
+  description: Set the path the your SSL certificate if the ssl-option is set to `true`.
   required: true
   type: string
 keyfile:
-  description: Set the path the your SSL private key if the ssl-option is set to true.
+  description: Set the path the your SSL private key if the ssl-option is set to `true`.
   required: true
   type: string
 allowed_networks:
@@ -92,7 +92,7 @@ banned_ips:
   required: true
   type: string
 banlimit:
-  description: Ban access from IPs after banlimit failed login attempts. The default value 0 disables this feature. Restart the add-on to clear the list of banned IP addresses.
+  description: Ban access from IPs after `banlimit` failed login attempts. The default value 0 disables this feature. Restart the add-on to clear the list of banned IP addresses.
   required: true
   type: int
 ignore_pattern:
@@ -104,7 +104,7 @@ dirsfirst:
   required: true
   type: string
 enforce_basepath:
-  description: If set to true, access is limited to files within the /config directory.
+  description: If set to `true`, access is limited to files within the `/config` directory.
   required: true
   type: string
 notify_service:
@@ -116,15 +116,15 @@ ignore_ssl:
   required: true
   type: string
 loglevel:
-  description: You can change the logging level from the default value info if you want to. Valid values are debug, info, warning, error, critical.
+  description: You can change the logging level from the default value info if you want to. Valid values are `debug`, `info`, `warning`, `error`, `critical`.
   required: false
   type: string
 sesame:
-  description: Secret token to dynamically allow access from the IP the request originates from. Open your bookmark https://hassio.yourdomain.com:8123/somesecretnobodycanguess while allowed_networks is set to [] and your IP will get whitelisted. You can use the Network status menu to revoke IP addresses for which access has been granted. Regular authentication is still required.
+  description: Secret token to dynamically allow access from the IP the request originates from. Open your bookmark https://hassio.yourdomain.com:8123/somesecretnobodycanguess while `allowed_networks` is set to [] and your IP will get whitelisted. You can use the Network status menu to revoke IP addresses for which access has been granted. Regular authentication is still required.
   required: false
   type: string
 sesame_totp_secret:
-  description: Like the sesame option, but instead as Base32 encoded secret string must be provided. This string then can be added to a TOTP App like Google Authenticator. This way you get a 6-digit sesame that changes every 30 seconds.
+  description: Like the `sesame` option, but instead as Base32 encoded secret string must be provided. This string then can be added to a TOTP App like Google Authenticator. This way you get a 6-digit `sesame` that changes every 30 seconds.
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -119,6 +119,14 @@ loglevel:
   description: You can change the logging level from the default value info if you want to. Valid values are debug, info, warning, error, critical.
   required: false
   type: string
+sesame:
+  description: Secret token to dynamically allow access from the IP the request originates from. Open your bookmark https://hassio.yourdomain.com:8123/somesecretnobodycanguess while allowed_networks is set to [] and your IP will get whitelisted. You can use the Network status menu to revoke IP addresses for which access has been granted. Regular authentication is still required.
+  required: false
+  type: string
+sesame_totp_secret:
+  description: Like the sesame option, but instead as Base32 encoded secret string must be provided. This string then can be added to a TOTP App like Google Authenticator. This way you get a 6-digit sesame that changes every 30 seconds.
+  required: false
+  type: string
 {% endconfiguration %}
 
 <p class='note warning'>

--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -62,22 +62,64 @@ Screenshot of the HASS Configurator.
 }
 ```
 
-- **username** (*Required*): Set a username to access your configuration is protected.
-- **password** (*Required*): Set a password for access.
-- **ssl** (*Required*): Enable or Disable SSL/TLS for the editor.
-- **certfile** (*Required*): Set the path the your SSL certificate if the ssl-option is set to `true`.
-- **keyfile** (*Required*): Set the path the your SSL private key if the ssl-option is set to `true`.
-- **allowed_networks** (*Required*): Limit access to the configurator by adding allowed IP addresses/networks to the list.
-- **banned_ips** (*Required*): List of statically banned IP addresses.
-- **banlimit** (*Required*): Ban access from IPs after `banlimit` failed login attempts. The default value `0` disables this feature. Restart the add-on to clear the list of banned IP addresses.
-- **ignore_pattern** (*Required*): Files and folders to ignore in the UI.
-- **dirsfirst** (*Required*): List directories before files in the file browser.
-- **enforce_basepath** (*Required*): If set to `true`, access is limited to files within the `/config` directory.
-- **notify_service** (*Required*): Specify a custom notify-service to be used to push notifications.
-- **ignore_ssl** (*Required*): Ignore SSL errors when accessing the Home Assistant API.
-- **sesame** (*Optional*): Secret token to dynamically allow access from the IP the request originates from. Open your bookmark https://hassio.yourdomain.com:8123/somesecretnobodycanguess while `allowed_networks` is set to `[]` and your IP will get whitelisted. You can use the _Network status_ menu to revoke IP addresses for which access has been granted. Regular authentication is still required.
-- **sesame_totp_secret** (*Optional*): Like the `sesame` option, but instead as Base32 encoded secret string must be provided. This string then can be added to a TOTP App like Google Authenticator. This way you get a 6-digit `sesame` that changes every 30 seconds.
-- **loglevel** (*Optional*): You can change the logging level from the default value `info` if you want to. Valid values are: `debug`, `info`, `warning`, `error`, `critical`.
+{% configuration %}
+username:
+  description: Set a username so that access your configuration is protected.
+  required: true
+  type: string
+password:
+  description: Set a password for access.
+  required: true
+  type: string
+ssl:
+  description: Enable or Disable SSL/TLS for the editor.
+  required: true
+  type: string
+certfile:
+  description: Set the path the your SSL certificate if the ssl-option is set to true.
+  required: true
+  type: string
+keyfile:
+  description: Set the path the your SSL private key if the ssl-option is set to true.
+  required: true
+  type: string
+allowed_networks:
+  description: Limit access to the configurator by adding allowed IP addresses/networks to the list.
+  required: true
+  type: string
+banned_ips:
+  description: List of statically banned IP addresses.
+  required: true
+  type: string
+banlimit:
+  description: Ban access from IPs after banlimit failed login attempts. The default value 0 disables this feature. Restart the add-on to clear the list of banned IP addresses.
+  required: true
+  type: int
+ignore_pattern:
+  description: Regex of files and folders to ignore in the UI
+  required: true
+  type: string
+dirsfirst:
+  description: List directories before files in the file browser.
+  required: true
+  type: string
+enforce_basepath:
+  description: If set to true, access is limited to files within the /config directory.
+  required: true
+  type: string
+notify_service:
+  description: Specify a custom notify-service to be used to push notifications.
+  required: true
+  type: string
+ignore_ssl:
+  description: Ignore SSL errors when accessing the Home Assistant API.
+  required: true
+  type: string
+loglevel:
+  description: You can change the logging level from the default value info if you want to. Valid values are debug, info, warning, error, critical.
+  required: false
+  type: string
+{% endconfiguration %}
 
 <p class='note warning'>
 Be careful when setting up port forwarding to the configurator while embedding into Home Assistant. If you don't restrict access by requiring authentication and/or blocking based on client IP addresses, your configuration will be exposed to the internet!

--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -57,8 +57,7 @@ Screenshot of the HASS Configurator.
   ],
   "dirsfirst": false,
   "enforce_basepath": false,
-  "notify_service": "persistent_notification.create",
-  "ignore_ssl": false
+  "notify_service": "persistent_notification.create"
 }
 ```
 
@@ -74,7 +73,8 @@ password:
 ssl:
   description: Enable or Disable SSL/TLS for the editor.
   required: true
-  type: string
+  type: boolean
+  default: false
 certfile:
   description: Set the path the your SSL certificate if the ssl-option is set to `true`.
   required: true
@@ -92,7 +92,7 @@ banned_ips:
   required: true
   type: string
 banlimit:
-  description: Ban access from IPs after `banlimit` failed login attempts. This feature is disabled by default. Restart the add-on to clear the list of banned IP addresses.
+  description: Ban access from IPs after `banlimit` failed login attempts, setting the value to 0 disables this feature. Restart the add-on to clear the list of banned IP addresses.
   required: true
   type: int
   default: 0
@@ -103,25 +103,24 @@ ignore_pattern:
 dirsfirst:
   description: List directories before files in the file browser.
   required: true
-  type: string
+  type: boolean
+  default: false
 enforce_basepath:
   description: If set to `true`, access is limited to files within the `/config` directory.
   required: true
-  type: string
+  type: boolean
+  default: false
 notify_service:
   description: Specify a custom notify-service to be used to push notifications.
   required: true
   type: string
-ignore_ssl:
-  description: Ignore SSL errors when accessing the Home Assistant API.
-  required: true
-  type: string
 loglevel:
-  description: You can change the logging level from the default value info if you want to. Valid values are `debug`, `info`, `warning`, `error`, `critical`.
+  description: The log level the configurator should run with. Valid values are `debug`, `info`, `warning`, `error`, `critical`.
   required: false
   type: string
+  default: info
 sesame:
-  description: Secret token to dynamically allow access from the IP the request originates from. Open your bookmark https://hassio.yourdomain.com:8123/somesecretnobodycanguess while `allowed_networks` is set to [] and your IP will get whitelisted. You can use the Network status menu to revoke IP addresses for which access has been granted. Regular authentication is still required.
+  description: Secret token to dynamically allow access from the IP the request originates from. Open your bookmark https://hassio.yourdomain.com:8123/somesecretnobodycanguess while `allowed_networks` is set to `[]` and your IP will get whitelisted. You can use the Network status menu to revoke IP addresses for which access has been granted. Regular authentication is still required.
   required: false
   type: string
 sesame_totp_secret:

--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -97,7 +97,7 @@ banlimit:
   type: int
   default: 0
 ignore_pattern:
-  description: Regex of files and folders to ignore in the UI
+  description: Regex of files and folders to ignore in the UI.
   required: true
   type: string
 dirsfirst:

--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -92,9 +92,10 @@ banned_ips:
   required: true
   type: string
 banlimit:
-  description: Ban access from IPs after `banlimit` failed login attempts. The default value 0 disables this feature. Restart the add-on to clear the list of banned IP addresses.
+  description: Ban access from IPs after `banlimit` failed login attempts. This feature is disabled by default. Restart the add-on to clear the list of banned IP addresses.
   required: true
   type: int
+  default: 0
 ignore_pattern:
   description: Regex of files and folders to ignore in the UI
   required: true


### PR DESCRIPTION
**Description:**

Converted the hass.io configurator page to the new config format. As per this request:

https://github.com/home-assistant/home-assistant.io/issues/6385

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
