### PR TITLE
Update docs for new state restore without recorder

### DIFF
--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -61,7 +61,7 @@ Pick an icon that you can find on [materialdesignicons.com](https://materialdesi
 
 ### {% linkable_title Restore State %}
 
-This component will automatically restore the state it had prior to Home Assistant stopping as long as you have the `recorder` component enabled and your entity has `restore` set to `True` which is the default. To disable this feature, set `restore` to `False`. Additional information can be found in the [Restore state](/components/recorder/#restore-state) section of the [`recorder`](/components/recorder/) component documentation.
+This component will automatically restore the state it had prior to Home Assistant stopping as long as you your entity has `restore` set to `True` which is the default. To disable this feature, set `restore` to `False`.
 
 If `restore` is set to `False`, the `initial` value will only be used when no previous state is found or when the counter is reset.
 

--- a/source/_components/input_boolean.markdown
+++ b/source/_components/input_boolean.markdown
@@ -48,7 +48,7 @@ input_boolean:
 
 ### {% linkable_title Restore State %}
 
-This component will automatically restore the state it had prior to Home Assistant stopping as long as you have the `recorder` component enabled and your entity does **not** have a set value for `initial`. To disable this feature, set a valid value for `initial`. Additional information can be found in the [Restore state](/components/recorder/#restore-state) section of the [`recorder`](/components/recorder/) component documentation.
+This component will automatically restore the state it had prior to Home Assistant stopping as long as your entity does **not** have a set value for `initial`. To disable this feature, set a valid value for `initial`.
 
 ## {% linkable_title Automation Examples %}
 

--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -81,11 +81,8 @@ automations and templates.
 ### {% linkable_title Restore State %}
 
 This component will automatically restore the state it had prior to Home
-Assistant stopping as long as you have the `recorder` component enabled and your
-entity does **not** have a set value for `initial`. To disable this feature, set
-a valid value for `initial`. Additional information can be found in the
-[Restore state](/components/recorder/#restore-state) section of the
-[`recorder`](/components/recorder/) component documentation.
+Assistant stopping as long as your entity does **not** have a set value for
+`initial`.  To disable this feature, set a valid value for `initial`.
 
 ### {% linkable_title Services %}
 

--- a/source/_components/input_number.markdown
+++ b/source/_components/input_number.markdown
@@ -85,7 +85,7 @@ input_number:
 
 ### {% linkable_title Restore State %}
 
-This component will automatically restore the state it had prior to Home Assistant stopping as long as you have the `recorder` component enabled and your entity does **not** have a set value for `initial`. To disable this feature, set a valid value for `initial`. Additional information can be found in the [Restore state](/components/recorder/#restore-state) section of the [`recorder`](/components/recorder/) component documentation.
+This component will automatically restore the state it had prior to Home Assistant stopping as long as your entity does **not** have a set value for `initial`. To disable this feature, set a valid value for `initial`.
 
 ## {% linkable_title Automation Examples %}
 

--- a/source/_components/input_select.markdown
+++ b/source/_components/input_select.markdown
@@ -65,7 +65,7 @@ Because YAML defines [booleans](http://yaml.org/type/bool.html) as equivalent, a
 
 ### {% linkable_title Restore State %}
 
-This component will automatically restore the state it had prior to Home Assistant stopping as long as you have the `recorder` component enabled and your entity does **not** have a set value for `initial`. To disable this feature, set a valid value for `initial`. Additional information can be found in the [Restore state](/components/recorder/#restore-state) section of the [`recorder`](/components/recorder/) component documentation.
+This component will automatically restore the state it had prior to Home Assistant stopping as long as your entity does **not** have a set value for `initial`. To disable this feature, set a valid value for `initial`.
 
 ### {% linkable_title Services %}
 

--- a/source/_components/input_text.markdown
+++ b/source/_components/input_text.markdown
@@ -72,4 +72,4 @@ input_text:
 
 ### {% linkable_title Restore State %}
 
-This component will automatically restore the state it had prior to Home Assistant stopping as long as you have the `recorder` component enabled and your entity does **not** have a set value for `initial`. To disable this feature, set a valid value for `initial`. Additional information can be found in the [Restore state](/components/recorder/#restore-state) section of the [`recorder`](/components/recorder/) component documentation.
+This component will automatically restore the state it had prior to Home Assistant stopping as long as your entity does **not** have a set value for `initial`. To disable this feature, set a valid value for `initial`.

--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -131,17 +131,6 @@ Call the service `recorder.purge` to start a purge task which deletes events and
 | `keep_days`            |      yes | The number of history days to keep in recorder database (defaults to the component `purge_keep_days` configuration)
 | `repack`               |      yes | Rewrite the entire database, possibly saving some disk space. Only supported for SQLite and requires at least as much disk space free as the database currently uses.
 
-### {% linkable_title Restore State %}
-
-If the `recorder` component is activated then some components support `restore_state`, which will restore the state of the entity after Home Assistant is started to the state before Home Assistant was stopped. Please make sure that you do not exclude the entities for which you want the state to be restored from your recordings. An incomplete list of components that currently support `restore_state`:
-
-* [`input_boolean`](/components/input_boolean/#restore-state)
-* [`input_number`](/components/input_number/#restore-state)
-* [`input_select`](/components/input_select/#restore-state)
-* [`input_datetime`](/components/input_datetime/#restore-state)
-* [`input_text`](/components/input_text/#restore-state)
-
-
 ## {% linkable_title Custom database engines %}
 
 | Database engine | `db_url`                                                 |


### PR DESCRIPTION
**Description:**
This PR updates the documentation to reflect that the recorder is no longer necessary for restoring states.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17270

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
