### PR TITLE
Clarity update

### DIFF
--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -58,6 +58,7 @@ sensor:
         description: "Defines the units of measurement of the sensor, if any. This will also influence the graphical presentation in the history visualisation as continuous value. Sensors with missing `unit_of_measurement` are showing as discrete values."
         required: false
         type: string
+        default: None
       value_template:
         description: Defines a template to get the state of the sensor.
         required: true
@@ -71,7 +72,7 @@ sensor:
         required: false
         type: template
       device_class:
-        description: The type/class of the sensor to set the icon in the frontend.
+        description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
         required: false
         type: device_class
         default: None


### PR DESCRIPTION
The _user_ docs imply that setting the device class sets the unit of measurement. This clearly isn't the case, so doing a set of clarity edits.
