### PR TITLE
Change tradfri default allow groups

### DIFF
--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -38,10 +38,10 @@ host:
   required: true
   type: string
 allow_tradfri_groups:
-  description: "Set this to `false` to stop Home Assistant from importing the groups defined on the Trådfri bridge."
+  description: "Set this to `true` to allow Home Assistant to import the groups defined on the Trådfri bridge."
   required: false
   type: boolean
-  default: true
+  default: false
 {% endconfiguration %}
 
 


### PR DESCRIPTION
**Description:**
Set tradfri default allow groups to false.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):**
https://github.com/home-assistant/home-assistant/pull/17310

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
