### PR TITLE
Change discovery component

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -59,8 +59,6 @@ discovery:
     - homekit
 ```
 
-{% linkable_title Configuration variables: %}
-
 {% configuration discovery %}
 ignore:
   description: A list of platforms that never will be automatically configured by `discovery`.


### PR DESCRIPTION
A double line removed

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
