### PR TITLE
Update Dyson component configuration variable

### DIFF
--- a/source/_components/dyson.markdown
+++ b/source/_components/dyson.markdown
@@ -32,15 +32,34 @@ dyson:
       device_ip: DEVICE_IP_2
 ```
 
-Configuration variables:
+{% configuration %}
+username:
+  description: Dyson account username (email address).
+  required: true
+  type: string
+password:
+  description: Dyson account password.
+  required: true
+  type: string
+language:
+  description: Dyson account language country code. Known working codes: `FR`, `NL`, `GB`, `AU`. Other codes should be supported.
+  required: true
+  type: string
+devices:
+  description: List of devices.
+  required:  false
+  type: map
+  keys:
+    device_id:
+      description: Device ID. The Serial Number of the device. Found in the smart phone app device settings page.
+      required: true
+      type: string
+    device_ip:
+      description: Device IP address.
+      required: true
+      type: string
 
-- **username** (*Required*): Dyson account username (email address).
-- **password** (*Required*): Dyson account password.
-- **language** (*Required*): Dyson account language country code. Known working codes: `FR`, `NL`, `GB`, `AU`. Other codes should be supported.
-- **devices** (*Optional*): List of devices.
-  - **device_id** (*Required*): Device ID. The Serial Number of the device. Found in the smart phone app device settings page.
-  - **device_ip** (*Required*): Device IP address.
-
+{% endconfiguration %}
 
 The `devices` list is optional, but you'll have to provide them if discovery is not working (warnings in the logs and the devices are not available in Home Assistant web interface).
 

--- a/source/_components/dyson.markdown
+++ b/source/_components/dyson.markdown
@@ -42,7 +42,7 @@ password:
   required: true
   type: string
 language:
-  description: Dyson account language country code. Known working codes: `FR`, `NL`, `GB`, `AU`. Other codes should be supported.
+  description: "Dyson account language country code. Known working codes: `FR`, `NL`, `GB`, `AU`. Other codes should be supported."
   required: true
   type: string
 devices:
@@ -58,7 +58,6 @@ devices:
       description: Device IP address.
       required: true
       type: string
-
 {% endconfiguration %}
 
 The `devices` list is optional, but you'll have to provide them if discovery is not working (warnings in the logs and the devices are not available in Home Assistant web interface).


### PR DESCRIPTION
Update style of Dyson component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
