### PR TITLE
Update Kira component configuration variable

### DIFF
--- a/source/_components/kira.markdown
+++ b/source/_components/kira.markdown
@@ -38,16 +38,45 @@ kira:
       port: 65432
 ```
 
-Configuration variables:
-
-- **sensors** (*Optional*): Kira sensors to register
-  - **name** (*Optional*): Name of this sensor.
-  - **host** (*Optional*): Bind address for this sensor. 0.0.0.0 is default.
-  - **port** (*Optional*): UDP port to listen for packets on. 65432 is default.
-- **remotes** (*Optional*): Remote Kira modules to register
-  - **name** (*Optional*): Name of this remote.
-  - **host** (*Required*): IP address of Kira module to send commands to.
-  - **port** (*Optional*): UDP port to send packets to. 65432 is default.
+{% configuration %}
+sensors:
+  description: Kira sensors to register.
+  required: false
+  type: map
+  keys:
+    name:
+      description: Name of this sensor.
+      required: false
+      type: string
+    host:
+      description: Bind address for this sensor.
+      required: false
+      default: 0.0.0.0
+      type: string
+    port:
+      description: UDP port to listen for packets on.
+      required: false
+      default: 65432
+      type: integer
+remotes:
+  description: Remote Kira modules to register.
+  required: false
+  type: map
+  keys:
+    name:
+      description: Name of this remote.
+      required: false
+      type: string
+    host:
+      description: IP address of Kira module to send commands to.
+      required: true
+      type: string
+    port:
+      description: UDP port to send packets to.
+      required: false
+      default: 65432
+      type: integer
+{% endconfiguration %}
 
 If no sensors or remotes are specified, a sensor with default values will be added.
 
@@ -70,13 +99,30 @@ The first time the Kira component is loaded, `kira_codes.yaml` will be created i
   type: nec
 ```
 
-Configuration variables:
-
-- **name** (*Required*): The name of this code.
-- **code** (*Required*): The data for this code (see below).
-- **device** (*Optional*): The device this code is associated with. Default is "unknown".
-- **type** (*Optional*): The type of this code. If this field is omitted, the type will be autodetected if possible.
-- **repeat** (*Optional*): The number of times to repeat this code (on transmit). Default is 1.
+{% configuration %}
+name:
+  description: The name of this code.
+  required: true
+  type: string
+code:
+  description: The data for this code (see below).
+  required: true
+  type: string
+device:
+  description: The device this code is associated with.
+  required: false
+  default: unknown
+  type: string
+type:
+  description: The type of this code. If this field is omitted, the type will be autodetected if possible.
+  required: false
+  type: string
+repeat:
+  description: The number of times to repeat this code (on transmit).
+  required: false
+  default: 1
+  type: integer
+{% endconfiguration %}
 
 Some manufacturers (e.g., Samsung) require an IR code to be sent a number of times in a row in rapid succession (usually 3). This doesn't apply to the vast majority of devices, but it can be helpful if needed.
 


### PR DESCRIPTION
Update style of Kira component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
