### PR TITLE
Fix typo in Google Assistant migrate

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -36,7 +36,7 @@ Since release 0.80, the `Authorization Code` type of `OAuth` account linking is 
         - Input any string you like into `Client Secret`, Home Assistant doesn't need this field.
         - Change `Authorization URL` to `https://[YOUR HOME ASSISTANT URL:PORT]/auth/authorize` (replace with your actual URL).
         - Change `Token URL` to `https://[YOUR HOME ASSISTANT URL:PORT]/auth/token` (replace with your actual URL).
-    - In the `Client information` section:
+    - In the `Configure your client` section:
         - Do **NOT** check `Google to transmit clientID and secret via HTTP basic auth header`.
     - Click 'Save' at the top right corner, then click 'Test' to generate a new draft version of the Test App.
 2. Change your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**
Changed second ``Client information`` to ``Configure your client`` like on the Actions on Google site:
![bildschirmfoto 2018-10-11 um 02 20 15](https://user-images.githubusercontent.com/6409465/46773286-de684380-ccfc-11e8-882f-c510c39d8db4.png)


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
