### PR TITLE
Add `white_value` as a possible variable in `command_on_template`

### DIFF
--- a/source/_components/light.mqtt_template.markdown
+++ b/source/_components/light.mqtt_template.markdown
@@ -52,7 +52,7 @@ state_topic:
   required: false
   type: string
 command_on_template:
-  description: "The [template](/docs/configuration/templating/#processing-incoming-data) for *on* state changes. Available variables: `state`, `brightness`, `red`, `green`, `blue`, `white_value` `flash`, `transition` and `effect`."
+  description: "The [template](/docs/configuration/templating/#processing-incoming-data) for *on* state changes. Available variables: `state`, `brightness`, `red`, `green`, `blue`, `white_value`, `flash`, `transition` and `effect`."
   required: true
   type: string
 command_off_template:

--- a/source/_components/light.mqtt_template.markdown
+++ b/source/_components/light.mqtt_template.markdown
@@ -52,7 +52,7 @@ state_topic:
   required: false
   type: string
 command_on_template:
-  description: "The [template](/docs/configuration/templating/#processing-incoming-data) for *on* state changes. Available variables: `state`, `brightness`, `red`, `green`, `blue`, `flash`, `transition` and `effect`."
+  description: "The [template](/docs/configuration/templating/#processing-incoming-data) for *on* state changes. Available variables: `state`, `brightness`, `red`, `green`, `blue`, `white_value` `flash`, `transition` and `effect`."
   required: true
   type: string
 command_off_template:


### PR DESCRIPTION
**Description:**
`white_value` is a missing allowed parameter in the documentation for the `command_on_template` for the light.mqtt_template component. I discovered this while investigating https://github.com/home-assistant/home-assistant/issues/12533.

This closes https://github.com/home-assistant/home-assistant/issues/12533

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
