### PR TITLE
Update Mochad light and switch component configuration variable

### DIFF
--- a/source/_components/light.mochad.markdown
+++ b/source/_components/light.mochad.markdown
@@ -26,10 +26,25 @@ light:
       - address: a5
 ```
 
-Configuration variables:
-
-- **address** (*Required*): The X10 address of the light.
-- **name** (*Optional*): The name of the light. Default is: x10_light_dev_*address*.
-- **comm_type** (*Optional*): pl (powerline) or rf (radio frequency). Default is pl.
-- **brightness_levels** (*Optional*): The number of brightness levels the X10 light device supports. This can either be 32, 64, or 256 (note that the max
-value sent to the device will be n-1 because it starts at 0)
+{% configuration %}
+address:
+  description: The X10 address of the light.
+  required: true
+  type: string
+name:
+  description: The name of the light.
+  required: false
+  default: x10_light_dev_*address*
+  type: string
+comm_type:
+  description: pl (powerline) or rf (radio frequency).
+  required: false
+  default: pl
+  type: string
+brightness_levels:
+  description: The number of brightness levels the X10 light device supports. This can either be 32, 64, or 256 (note that the max
+  value sent to the device will be n-1 because it starts at 0)
+  required: false
+  default: 32
+  type: integer
+{% endconfiguration %}

--- a/source/_components/light.mochad.markdown
+++ b/source/_components/light.mochad.markdown
@@ -15,7 +15,7 @@ The `mochad` light platform lets you control an X10 enabled dimmer/light device.
 
 
 
-To enable this sensor, you first have to set up the [mochad component](/components/mochad/) and then add the following to your `configuration.yaml` file:
+To enable this sensor, you first have to set up the [mochad component](/components/mochad/) and then add the following to your `configuration.yaml` file.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/light.mochad.markdown
+++ b/source/_components/light.mochad.markdown
@@ -34,7 +34,7 @@ address:
 name:
   description: The name of the light.
   required: false
-  default: x10_light_dev_*address*
+  default: x10_light_dev_address
   type: string
 comm_type:
   description: pl (powerline) or rf (radio frequency).

--- a/source/_components/light.mochad.markdown
+++ b/source/_components/light.mochad.markdown
@@ -15,7 +15,7 @@ The `mochad` light platform lets you control an X10 enabled dimmer/light device.
 
 
 
-To enable this sensor, you first have to set up the [mochad component](/components/mochad/) and then add the following to your `configuration.yaml` file.
+To enable this sensor, you first have to set up the [mochad component](/components/mochad/) and then add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/light.mochad.markdown
+++ b/source/_components/light.mochad.markdown
@@ -42,8 +42,7 @@ comm_type:
   default: pl
   type: string
 brightness_levels:
-  description: The number of brightness levels the X10 light device supports. This can either be 32, 64, or 256 (note that the max
-  value sent to the device will be n-1 because it starts at 0)
+  description: The number of brightness levels the X10 light device supports. This can either be 32, 64, or 256 (note that the max value sent to the device will be n-1 because it starts at 0).
   required: false
   default: 32
   type: integer

--- a/source/_components/switch.mochad.markdown
+++ b/source/_components/switch.mochad.markdown
@@ -27,11 +27,19 @@ switch:
       - address: a5
 ```
 
-Configuration variables:
-
-- **address** (*Required*): The X10 address of the switch.
-- **name** (*Optional*): The name of the switch. Default is: x10_switch_dev_*address*.
-- **comm_type** (*Optional*): pl (powerline) or rf (radio frequency). Default is pl.
-
-
-
+{% configuration %}
+address:
+  description: The X10 address of the switch.
+  required: true
+  type: string
+name:
+  description: The name of the switch.
+  required: false
+  default: x10_switch_dev_*address*
+  type: string
+comm_type:
+  description: pl (powerline) or rf (radio frequency).
+  required: false
+  default: pl
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
Update style of Mochad light and switch component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
