### PR TITLE
Update NX584 component configuration variable

### DIFF
--- a/source/_components/alarm_control_panel.nx584.markdown
+++ b/source/_components/alarm_control_panel.nx584.markdown
@@ -22,8 +22,20 @@ alarm_control_panel:
   - platform: nx584
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The host where the nx584 server process is running. Defaults to `localhost`.
-- **port** (*Optional*): The port where the Alarm panel is listening. Defaults to `5007`.
-
+{% configuration %}
+host:
+  description: The host where the nx584 server process is running.
+  required: false
+  default: localhost
+  type: string
+name:
+  description: This parameter allows you to override the name.
+  required: false
+  default: NX584
+  type: string
+port:
+  description: The port where the Alarm panel is listening.
+  required: false
+  default: 5007
+  type: integer
+{% endconfiguration %}

--- a/source/_components/binary_sensor.nx584.markdown
+++ b/source/_components/binary_sensor.nx584.markdown
@@ -25,12 +25,26 @@ binary_sensor:
   platform: nx584
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): This is the host where the nx584 server process is running. If unset, it is assumed to be `localhost`, which will work if the server process is running on the same system as Home Assistant.
-- **port** (*Optional*): The port where the server process is running. Defaults to `5007`. 
-- **exclude_zones** (*Optional*): This is a list of zone numbers that should be excluded. Use this to avoid exposing a zone that is of no interest, unconnected, etc.
-- **zone_types** (*Optional*): This is a list of zone numbers mapped to zone types. Use this to designate zones as doors, motion sensors, smoke detectors, etc. The list of available zone types relevant to alarm zones are: `opening`, `motion`, `gas`, `smoke`, `moisture`, `safety`.
+{% configuration %}
+host:
+  description: This is the host where the nx584 server process is running. If unset, it is assumed to be `localhost`, which will work if the server process is running on the same system as Home Assistant.
+  required: false
+  default: localhost
+  type: string
+port:
+  description: The port where the server process is running.
+  required: false
+  default: 5007
+  type: integer
+exclude_zones:
+  description: This is a list of zone numbers that should be excluded. Use this to avoid exposing a zone that is of no interest, unconnected, etc.
+  required: false
+  type: [list, integer]
+zone_types:
+  description: "This is a list of zone numbers mapped to zone types. Use this to designate zones as doors, motion sensors, smoke detectors, etc. The list of available zone types relevant to alarm zones are: `opening`, `motion`, `gas`, `smoke`, `moisture`, `safety`."
+  required: false
+  type: [string, integer]
+{% endconfiguration %}
 
 An extended configuration entry could look like this:
 

--- a/source/_components/binary_sensor.nx584.markdown
+++ b/source/_components/binary_sensor.nx584.markdown
@@ -41,7 +41,7 @@ exclude_zones:
   required: false
   type: [list, integer]
 zone_types:
-  description: This is a list of zone numbers mapped to zone types. Use this to designate zones as doors, motion sensors, smoke detectors, etc. See the list of available zone types relevant to alarm zones belowe. 
+  description: This is a list of zone numbers mapped to zone types. Use this to designate zones as doors, motion sensors, smoke detectors, etc. See the list of available zone types relevant to alarm zones below. 
   required: false
   type: map
   keys:

--- a/source/_components/binary_sensor.nx584.markdown
+++ b/source/_components/binary_sensor.nx584.markdown
@@ -41,9 +41,22 @@ exclude_zones:
   required: false
   type: [list, integer]
 zone_types:
-  description: "This is a list of zone numbers mapped to zone types. Use this to designate zones as doors, motion sensors, smoke detectors, etc. The list of available zone types relevant to alarm zones are: `opening`, `motion`, `gas`, `smoke`, `moisture`, `safety`."
+  description: This is a list of zone numbers mapped to zone types. Use this to designate zones as doors, motion sensors, smoke detectors, etc. See the list of available zone types relevant to alarm zones belowe. 
   required: false
-  type: [string, integer]
+  type: map
+  keys:
+    opening:
+      description: Opening
+    motion:
+      description: Motion
+    gas:
+      description: Gas
+    smoke:
+      description: Smoke
+    moisture:
+      description: Moisture
+    safety:
+      description: Safety
 {% endconfiguration %}
 
 An extended configuration entry could look like this:


### PR DESCRIPTION
Update style of NX584 component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
