### PR TITLE
Formatting fix

### DIFF
--- a/source/_docs/configuration/devices.markdown
+++ b/source/_docs/configuration/devices.markdown
@@ -66,7 +66,8 @@ switch 1:
 
 switch 2:
   platform: tplink
-  host: IP_ADDRESS```
+  host: IP_ADDRESS
+```
 
 ## {% linkable_title Grouping devices %}
 


### PR DESCRIPTION
Code ending block was placed in a wrong place causing documentation to be output wrongly.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
