### PR TITLE
Fix configuration formatting of zamg sensor and weather component

### DIFF
--- a/source/_components/sensor.yweather.markdown
+++ b/source/_components/sensor.yweather.markdown
@@ -44,12 +44,15 @@ sensor:
 woeid:
   required: false
   description: See above.
+  type: string
 forecast:
   required: false
   description: Day of forecast. The default is the current day to display conditions.
+  type: integer
 name:
   required: false
   description: "The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option. Defaults to `Yweather`. "
+  type: string
 monitored_conditions:
   required: true
   description: Conditions to display in the frontend.

--- a/source/_components/sensor.yweather.markdown
+++ b/source/_components/sensor.yweather.markdown
@@ -45,11 +45,11 @@ woeid:
   required: false
   description: See above.
   type: string
-  default: 0
 forecast:
   required: false
   description: Day of forecast. The default is the current day to display conditions.
   type: integer
+  default: 0
 name:
   required: false
   description: "The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option."

--- a/source/_components/sensor.yweather.markdown
+++ b/source/_components/sensor.yweather.markdown
@@ -20,7 +20,7 @@ The `yweather` platform uses [Yahoo Weather](https://www.yahoo.com/news/weather/
 Use of the Yahoo Weather API should not exceed reasonable request volume. Access is limited to 2000 signed calls per day.
 </p>
 
-The `woeid` (Where On Earth ID) for your location, as shown in the example below. You can find your WOEID by copying the numeric digits at the end of the URL for your location at [Yahoo Weather](https://www.yahoo.com/news/weather/). If you don't add a WOEID it generate it from Home Assistant's latitude and longitude.
+The `woeid` (Where On Earth ID) for your location, as shown in the example below. You can find your WOEID by copying the numeric digits at the end of the URL for your location at [Yahoo Weather](https://www.yahoo.com/news/weather/). If you don't add a WOEID it is generated from Home Assistant's latitude and longitude.
 
 To add Yahoo Weather to your installation, add the following to your `configuration.yaml` file:
 
@@ -45,6 +45,7 @@ woeid:
   required: false
   description: See above.
   type: string
+  default: "Defaults to a WOEID generated from coordinates defined in your `configuration.yaml` file."
 forecast:
   required: false
   description: Day of forecast. The default is the current day to display conditions.

--- a/source/_components/sensor.yweather.markdown
+++ b/source/_components/sensor.yweather.markdown
@@ -56,6 +56,7 @@ name:
 monitored_conditions:
   required: true
   description: Conditions to display in the frontend.
+  type: list
   keys:
     weather:
       description: A human-readable text summary with picture from yahoo.

--- a/source/_components/sensor.yweather.markdown
+++ b/source/_components/sensor.yweather.markdown
@@ -54,7 +54,7 @@ name:
   required: false
   description: "The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option."
   type: string
-  default: `Yweather`
+  default: "`Yweather`"
 monitored_conditions:
   required: true
   description: Conditions to display in the frontend.

--- a/source/_components/sensor.yweather.markdown
+++ b/source/_components/sensor.yweather.markdown
@@ -40,21 +40,39 @@ sensor:
       - temperature
 ```
 
-Configuration variables:
-
-- **woeid** (*Optional*): See above.
-- **forecast** (*Optional*): Day of forecast. The default is the current day to display conditions.
-- **name** (*Optional*): The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option. Defaults to `Yweather`. 
-- **monitored_conditions** array (*Required*): Conditions to display in the frontend.
-  - **weather**: A human-readable text summary with picture from yahoo.
-  - **weather_current**: A human-readable text summary with picture from yahoo from current condition.
-  - **temperature**: The current temperature.
-  - **temp_min**: The minimal temperature of this day.
-  - **temp_max**: The maximum temperature of this day.
-  - **wind_speed**: The wind speed.
-  - **humidity**: The relative humidity.
-  - **pressure**: The sea-level air pressure in millibars.
-  - **visibility**: The average visibility.
+{% configuration %}
+woeid:
+  required: false
+  description: See above.
+forecast:
+  required: false
+  description: Day of forecast. The default is the current day to display conditions.
+name:
+  required: false
+  description: "The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option. Defaults to `Yweather`. "
+monitored_conditions:
+  required: true
+  description: Conditions to display in the frontend.
+  keys:
+    weather:
+      description: A human-readable text summary with picture from yahoo.
+    weather_current:
+      description: A human-readable text summary with picture from yahoo from current condition.
+    temperature:
+      description: The current temperature.
+    temp_min:
+      description: The minimal temperature of this day.
+    temp_max:
+      description: The maximum temperature of this day.
+    wind_speed:
+      description: The wind speed.
+    humidity:
+      description: The relative humidity.
+    pressure:
+      description: The sea-level air pressure in millibars.
+    visibility:
+      description: The average visibility.
+{% endconfiguration %}
 
 Example of forecast using multiple days. In example, first sensor shows tomorrow's forecast, second sensor shows the next day and so on:
 
@@ -85,4 +103,3 @@ sensor:
 ```
 
 Details about the API are available in the [Yahoo! Developer Network](https://developer.yahoo.com/weather/).
-

--- a/source/_components/sensor.yweather.markdown
+++ b/source/_components/sensor.yweather.markdown
@@ -45,14 +45,16 @@ woeid:
   required: false
   description: See above.
   type: string
+  default: 0
 forecast:
   required: false
   description: Day of forecast. The default is the current day to display conditions.
   type: integer
 name:
   required: false
-  description: "The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option. Defaults to `Yweather`. "
+  description: "The name of the sensor. To easily recognize each sensor when adding more than one Yahoo weather sensor, it is recommended to use the name option."
   type: string
+  default: `Yweather`
 monitored_conditions:
   required: true
   description: Conditions to display in the frontend.

--- a/source/_components/sensor.zamg.markdown
+++ b/source/_components/sensor.zamg.markdown
@@ -45,6 +45,7 @@ longitude:
 monitored_conditions:
   required: false
   description: Conditions to display in the frontend.
+  type: list
   keys:
     pressure:
       description: Pressure at station level

--- a/source/_components/sensor.zamg.markdown
+++ b/source/_components/sensor.zamg.markdown
@@ -29,15 +29,19 @@ sensor:
 station_id:
   required: false
   description: The ID number for a supported ZAMG station.
+  type: string
 name:
   required: false
   description: Additional name for the sensors. Defaults to platform name.
+  type: string
 latitude:
   required: false
   description: "Latitude coordinate to monitor weather of (required if **longitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+  type: string
 longitude:
   required: false
   description: "Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+  type: string
 monitored_conditions:
   required: false
   description: Conditions to display in the frontend.

--- a/source/_components/sensor.zamg.markdown
+++ b/source/_components/sensor.zamg.markdown
@@ -37,11 +37,13 @@ name:
   type: string
 latitude:
   required: false
-  description: "Latitude coordinate to monitor weather of (required if **longitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+  description: "Latitude coordinate to monitor weather of (required if **longitude** is specified)."
+  default: "Defaults to coordinates defined in your `configuration.yaml` file."
   type: string
 longitude:
   required: false
-  description: "Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+  description: "Longitude coordinate to monitor weather of (required if **latitude** is specified)."
+  default: "Defaults to coordinates defined in your `configuration.yaml` file."
   type: string
 monitored_conditions:
   required: false

--- a/source/_components/sensor.zamg.markdown
+++ b/source/_components/sensor.zamg.markdown
@@ -25,24 +25,46 @@ sensor:
   - platform: zamg
 ```
 
-Configuration variables:
-
-- **station_id** (*Optional*): The ID number for a supported ZAMG station.
-- **name** (*Optional*): Additional name for the sensors. Defaults to platform name.
-- **latitude** (*Optional*): Latitude coordinate to monitor weather of (required if **longitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file.
-- **longitude** (*Optional*): Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file.
-- **monitored_conditions** array (*Optional*): Conditions to display in the frontend.
-  - **pressure**: Pressure at station level
-  - **pressure_sealevel**: Pressure at sea Level
-  - **humidity**: Humidity
-  - **wind_speed**: Wind speed
-  - **wind_bearing**: Wind bearing
-  - **wind_max_speed**: Top wind speed
-  - **wind_max_bearing**: Top wind bearing
-  - **sun_last_hour**: Sun last hour percentage
-  - **temperature**: Temperature
-  - **precipitation**: Precipitation
-  - **dewpoint**: Dew point
+{% configuration %}
+station_id:
+  required: false
+  description: The ID number for a supported ZAMG station.
+name:
+  required: false
+  description: Additional name for the sensors. Defaults to platform name.
+latitude:
+  required: false
+  description: "Latitude coordinate to monitor weather of (required if **longitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+longitude:
+  required: false
+  description: "Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+monitored_conditions:
+  required: false
+  description: Conditions to display in the frontend.
+  keys:
+    pressure:
+      description: Pressure at station level
+    pressure_sealevel:
+      description: Pressure at sea Level
+    humidity:
+      description: Humidity
+    wind_speed:
+      description: Wind speed
+    wind_bearing:
+      description: Wind bearing
+    wind_max_speed:
+      description: Top wind speed
+    wind_max_bearing:
+      description: Top wind bearing
+    sun_last_hour:
+      description: Sun last hour percentage
+    temperature:
+      description: Temperature
+    precipitation:
+      description: Precipitation
+    dewpoint:
+      description: Dew point
+{% endconfiguration %}
 
 A full configuration example:
 

--- a/source/_components/sensor.zamg.markdown
+++ b/source/_components/sensor.zamg.markdown
@@ -33,6 +33,7 @@ station_id:
 name:
   required: false
   description: Additional name for the sensors. Defaults to platform name.
+  default: zamg
   type: string
 latitude:
   required: false
@@ -46,6 +47,7 @@ monitored_conditions:
   required: false
   description: Conditions to display in the frontend.
   type: list
+  default: temperature
   keys:
     pressure:
       description: Pressure at station level

--- a/source/_components/sensor.zamg.markdown
+++ b/source/_components/sensor.zamg.markdown
@@ -39,12 +39,12 @@ latitude:
   required: false
   description: "Latitude coordinate to monitor weather of (required if **longitude** is specified)."
   default: "Defaults to coordinates defined in your `configuration.yaml` file."
-  type: string
+  type: float
 longitude:
   required: false
   description: "Longitude coordinate to monitor weather of (required if **latitude** is specified)."
   default: "Defaults to coordinates defined in your `configuration.yaml` file."
-  type: string
+  type: float
 monitored_conditions:
   required: false
   description: Conditions to display in the frontend.

--- a/source/_components/weather.zamg.markdown
+++ b/source/_components/weather.zamg.markdown
@@ -40,12 +40,12 @@ latitude:
   required: false
   description: "Latitude coordinate to monitor weather of (required if **longitude** is specified)."
   default: "Defaults to coordinates defined in your `configuration.yaml` file."
-  type: string
+  type: float
 longitude:
   required: false
   description: "Longitude coordinate to monitor weather of (required if **latitude** is specified)."
   default: "Defaults to coordinates defined in your `configuration.yaml` file."
-  type: string
+  type: float
 {% endconfiguration %}
 
 <p class='note'>

--- a/source/_components/weather.zamg.markdown
+++ b/source/_components/weather.zamg.markdown
@@ -38,11 +38,13 @@ name:
   type: string
 latitude:
   required: false
-  description: "Latitude coordinate to monitor weather of (required if **longitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+  description: "Latitude coordinate to monitor weather of (required if **longitude** is specified)."
+  default: "Defaults to coordinates defined in your `configuration.yaml` file."
   type: string
 longitude:
   required: false
-  description: "Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+  description: "Longitude coordinate to monitor weather of (required if **latitude** is specified)."
+  default: "Defaults to coordinates defined in your `configuration.yaml` file."
   type: string
 {% endconfiguration %}
 

--- a/source/_components/weather.zamg.markdown
+++ b/source/_components/weather.zamg.markdown
@@ -27,12 +27,20 @@ weather:
   - platform: zamg
 ```
 
-Configuration variables:
-
-- **station_id** (*Optional*): The ID number for a supported ZAMG station.
-- **name** (*Optional*): A name for the weather platform.
-- **latitude** (*Optional*): Latitude coordinate to monitor weather of (required if **longitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file.
-- **longitude** (*Optional*): Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file.
+{% configuration %}
+station_id:
+  required: false
+  description: The ID number for a supported ZAMG station.
+name:
+  required: false
+  description: A name for the weather platform.
+latitude:
+  required: false
+  description: "Latitude coordinate to monitor weather of (required if **longitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+longitude:
+  required: false
+  description: "Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+{% endconfiguration %}
 
 <p class='note'>
 This platform is an alternative to the [`zamg`](/components/sensor.zamg/) sensor. The weather platform is easier to configure but less customizable.

--- a/source/_components/weather.zamg.markdown
+++ b/source/_components/weather.zamg.markdown
@@ -31,15 +31,19 @@ weather:
 station_id:
   required: false
   description: The ID number for a supported ZAMG station.
+  type: string
 name:
   required: false
   description: A name for the weather platform.
+  type: string
 latitude:
   required: false
   description: "Latitude coordinate to monitor weather of (required if **longitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+  type: string
 longitude:
   required: false
   description: "Longitude coordinate to monitor weather of (required if **latitude** is specified). Defaults to coordinates defined in your `configuration.yaml` file."
+  type: string
 {% endconfiguration %}
 
 <p class='note'>


### PR DESCRIPTION
**Description:**
Fix configuration formatting of zamg sensor and weather component.
Related to #6385.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
