### PR TITLE
Update Roomba Vacuum component configuration variable

### DIFF
--- a/source/_components/vacuum.roomba.markdown
+++ b/source/_components/vacuum.roomba.markdown
@@ -29,14 +29,35 @@ vacuum:
     password: PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Required*): Hostname or IP address of the Roomba.
-- **username** (*Required*): The username (BLID) for your device.
-- **password** (*Required*): The password for your device.
-- **name** (*Optional*): The name of the vacuum.
-- **certificate** (*Optional*): Path to your certificate store. Defaults to `/etc/ssl/certs/ca-certificates.crt`.
-- **continuous** (*Optional*): Whether to operate in continuous mode. Defaults to `True`.
+{% configuration %}
+host:
+  description: Hostname or IP address of the Roomba.
+  required: true
+  type: string
+username:
+  description: The username (BLID) for your device.
+  required: true
+  type: string
+password:
+  description: The password for your device.
+  required: true
+  type: string
+name:
+  description: The name of the vacuum.
+  required: false
+  default: Roomba
+  type: string
+certificate:
+  description: Path to your certificate store.
+  required: false
+  default: /etc/ssl/certs/ca-certificates.crt
+  type: string
+continuous:
+  description: Whether to operate in continuous mode.
+  required: false
+  default: true
+  type: boolean
+{% endconfiguration %}
 
 <p class='note'>
 The Roomba's MQTT server only allows a single connection. Enabling continuous mode will force the App to connect via the cloud to your Roomba. [More info here](https://github.com/NickWaterton/Roomba980-Python#firmware-2xx-notes)


### PR DESCRIPTION
Update style of Roomba vacuum component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
