### PR TITLE
Update Dlink switch component configuration variable

### DIFF
--- a/source/_components/switch.dlink.markdown
+++ b/source/_components/switch.dlink.markdown
@@ -34,7 +34,7 @@ switch:
 
 {% configuration %}
 host:
-  description: "The IP address of your D-Link plug, e.g. http://192.168.1.32"
+  description: "The IP address of your D-Link plug, e.g., http://192.168.1.32"
   required: true
   type: string
 name:

--- a/source/_components/switch.dlink.markdown
+++ b/source/_components/switch.dlink.markdown
@@ -32,11 +32,29 @@ switch:
   password: YOUR_PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address of your D-Link plug, eg. http://192.168.1.32
-- **name** (*Optional*): The name to use when displaying this switch.
-- **username** (*Required*): The username for your plug. Defaults to `admin`.
-- **password** (*Required*): The password for your plug. Default password is the `PIN` included on the configuration card.
-- **use_legacy_protocol** (*Optional*): Enable limited support for legacy firmware protocols (Tested with v1.24).
-
+{% configuration %}
+host:
+  description: "The IP address of your D-Link plug, e.g. http://192.168.1.32"
+  required: true
+  type: string
+name:
+  description: The name to use when displaying this switch.
+  required: false
+  default: D-link Smart Plug W215
+  type: string
+username:
+  description: The username for your plug.
+  required: true
+  default: admin
+  type: string
+password:
+  description: The password for your plug.
+  required: true
+  default: The default password is the `PIN` included on the configuration card.
+  type: string
+use_legacy_protocol:
+  description: Enable limited support for legacy firmware protocols (Tested with v1.24).
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}


### PR DESCRIPTION
Update style of Dlink switch component documentation to follow new configuration variables description.
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
