### PR TITLE
Adds warning about lovelace in 'panel_iframe' documentation.

### DIFF
--- a/source/_components/panel_iframe.markdown
+++ b/source/_components/panel_iframe.markdown
@@ -18,8 +18,6 @@ The `panel_iframe` support allows you to add additional panels to your Home Assi
 
 <p class='note warning'>If you are accessing Home Assistant over HTTPS using SSL, you cannot access HTTP sites through an iframe panel.</p>
 
-<p class='note warning'>Do **not** create one that are named `lovelace` it will overwrite lovelace causing it to never load.</p>
-
 To enable Panel iFrames in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -62,3 +60,4 @@ panel_iframe:
             type: icon
 {% endconfiguration %}
 
+<p class='note warning'>Do **not** create one that are named `lovelace` it will overwrite lovelace causing it to never load.</p>

--- a/source/_components/panel_iframe.markdown
+++ b/source/_components/panel_iframe.markdown
@@ -18,6 +18,8 @@ The `panel_iframe` support allows you to add additional panels to your Home Assi
 
 <p class='note warning'>If you are accessing Home Assistant over HTTPS using SSL, you cannot access HTTP sites through an iframe panel.</p>
 
+<p class='note warning'>Do **not** create one that are named `lovelace` it will overwrite lovelace causing it to never load.</p>
+
 To enable Panel iFrames in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
**Description:**

This adds a warning about `lovelace` if that is used it will result in this error:
```text
overwriting component lovelace
```

I'm unsure if this should be in it's own warning box, or if I should make a list in the existing one?

<!-- **Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here> -->

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
