### PR TITLE
Fixed dead link

### DIFF
--- a/source/_components/device_tracker.openwrt.markdown
+++ b/source/_components/device_tracker.openwrt.markdown
@@ -25,7 +25,7 @@ There are _multiple_ ways of integrating an OpenWRT router for presence detectio
     * [ubus](/components/device_tracker.ubus/)
     * [luci](/components/device_tracker.luci/)
 * __passive/event-based__  
-  External services which notify Home Assistant of devices via the [REST API endpoint](/developers/rest_api.markdown). 
+  External services which notify Home Assistant of devices via the [REST API endpoint](/developers/rest_api). 
   * Advantages: 
     * devices typically registered in under one second when they connect
     * very few network requests

--- a/source/_components/device_tracker.openwrt.markdown
+++ b/source/_components/device_tracker.openwrt.markdown
@@ -25,7 +25,7 @@ There are _multiple_ ways of integrating an OpenWRT router for presence detectio
     * [ubus](/components/device_tracker.ubus/)
     * [luci](/components/device_tracker.luci/)
 * __passive/event-based__  
-  External services which notify Home Assistant of devices via the [REST API endpoint](/developers/rest_api). 
+  External services which notify Home Assistant of devices via the [REST API endpoint](https://developers.home-assistant.io/docs/en/external_api_rest.html). 
   * Advantages: 
     * devices typically registered in under one second when they connect
     * very few network requests


### PR DESCRIPTION
**Description:**
Small fix for typo in link in documentation

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
