### PR TITLE
dovado sensor configuration variable format

### DIFF
--- a/source/_components/sensor.dovado.markdown
+++ b/source/_components/sensor.dovado.markdown
@@ -13,7 +13,7 @@ ha_release: 0.32
 ha_iot_class: "Local Polling"
 ---
 
-The `dovado` platform let you monitor your router from [Dovado](http://www.dovado.com/)
+The `dovado` platform let you monitor your router from [Dovado](http://www.dovado.com/). If the router provides SMS functionality, a service for sending SMS will also be registered in Home Assistant.
 
 To add a Dovado sensor to your installation, add the following to your `configuration.yaml` file:
 
@@ -47,16 +47,18 @@ port:
   type: integer
   default: 6435
 sensors:
-  description: Conditions to display in the frontend.
+  description: Conditions to display in the frontend. Only accepts the values listed here.
   required: true
   type: list
+  keys:
+      network:
+        description: Creates a sensor for Network State (3G, 4G, etc.)
+      signal:
+        description: Creates a sensor for the signal strength (%).
+      download:
+        description: Creates a sensor for download speed.
+      upload:
+        description: Creates a sensor for download speed.
+      sms:
+        description: Creates a sensor for number of unread text messages.
 {% endconfiguration %}
-
-Allowed values under *sensors*:
-- **network**: Network state (3G, 4G, etc).
-- **signal**: The signal strength (%).
-- **download**: The download speed.
-- **upload**: The upload speed.
-- **sms**: Number of unread text messages
-
-If the router provides SMS functionality, a service for sending SMS will also be registered in Home Assistant.

--- a/source/_components/sensor.dovado.markdown
+++ b/source/_components/sensor.dovado.markdown
@@ -23,23 +23,40 @@ sensor:
   - platform: dovado
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
-    host: IP_ADDRESS
-    port: PORT
     sensors:
       - network
 ```
 
-Configuration variables:
+{% configuration %}
+username:
+  description: Your username.
+  required: true
+  type: string
+password:
+  description: Your password.
+  required: true
+  type: string
+host:
+  description: The IP address of your router, e.g., 192.168.1.1
+  required: false
+  type: string
+  default: Home Assistant's default gateway
+port:
+  description:  The port number of your router, e.g., 999
+  required: false
+  type: integer
+  default: 6435
+sensors:
+  description: Conditions to display in the frontend.
+  required: true
+  type: list
+{% endconfiguration %}
 
-- **username** (*Required*): Your username.
-- **password** (*Required*): Your password.
-- **host** (*Optional*): The IP address of your router, e.g., `192.168.1.1`. If no host is provided, the gateway for the same network as Home Assistant will automatically be used.
-- **port** (*Optional*): The port number of your router, e.g., `999`. If no port is provided, the default API port (6435) will be used.
-- **sensors** array (*Required*): Conditions to display in the frontend.
-  - **network**: Network state (3G, 4G, etc).
-  - **signal**: The signal strength (%).
-  - **download**: The download speed.
-  - **upload**: The upload speed.
-  - **sms**: Number of unread text messages
+Allowed values under *sensors*:
+- **network**: Network state (3G, 4G, etc).
+- **signal**: The signal strength (%).
+- **download**: The download speed.
+- **upload**: The upload speed.
+- **sms**: Number of unread text messages
 
 If the router provides SMS functionality, a service for sending SMS will also be registered in Home Assistant.

--- a/source/_components/sensor.dovado.markdown
+++ b/source/_components/sensor.dovado.markdown
@@ -29,20 +29,20 @@ sensor:
 
 {% configuration %}
 username:
-  description: Your username.
+  description: Your Dovado username.
   required: true
   type: string
 password:
-  description: Your password.
+  description: Your Dovado password.
   required: true
   type: string
 host:
-  description: The IP address of your router, e.g., 192.168.1.1
+  description: The IP address of your router.
   required: false
   type: string
   default: Home Assistant's default gateway
 port:
-  description:  The port number of your router, e.g., 999
+  description:  The port number of your router.
   required: false
   type: integer
   default: 6435
@@ -51,14 +51,14 @@ sensors:
   required: true
   type: list
   keys:
-      network:
-        description: Creates a sensor for Network State (3G, 4G, etc.)
-      signal:
-        description: Creates a sensor for the signal strength (%).
-      download:
-        description: Creates a sensor for download speed.
-      upload:
-        description: Creates a sensor for download speed.
-      sms:
-        description: Creates a sensor for number of unread text messages.
+    network:
+      description: Creates a sensor for Network State (3G, 4G, etc.).
+    signal:
+      description: Creates a sensor for the signal strength.
+    download:
+      description: Creates a sensor for download speed.
+    upload:
+      description: Creates a sensor for download speed.
+    sms:
+      description: Creates a sensor for number of unread text messages.
 {% endconfiguration %}


### PR DESCRIPTION
Update configuration variable format.
Remove two optional configurations from the example configuration.

Section underneath configuration variable has a list of allowed values for the *sensors* array there. I am not sure how to describe this using the configuration block format. Possibly related to home-assistant/developers.home-assistant/issues/107

Related to #6385 

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
