### PR TITLE
Added new config entries for lat/long for sensor.geo_rss_events

### DIFF
--- a/source/_components/sensor.geo_rss_events.markdown
+++ b/source/_components/sensor.geo_rss_events.markdown
@@ -21,7 +21,7 @@ This sensor is particularly useful if events occur unexpectedly in the vicinity 
   <img src='{{site_root}}/images/screenshots/geo-rss-incidents-group-screenshot.png' />
 </p>
 
-The reference point for comparing the distance is defined by `latitude` and `longitude` in the basic configuration.
+The reference point for comparing the distance is by default defined by `latitude` and `longitude` in the basic configuration.
 
 Only entries of the feed are considered that define a location as `point` or `polygon` in *georss.org* format or as *WGS84 latitude/longitude*.
 

--- a/source/_components/sensor.geo_rss_events.markdown
+++ b/source/_components/sensor.geo_rss_events.markdown
@@ -54,6 +54,16 @@ name:
   required: false
   type: string
   default: Event Service
+latitude:
+  description: Latitude of the coordinates around which events are considered.
+  required: false
+  type: string
+  default: Latitude entered in homeassistant component
+longitude:
+  description: Longitude of the coordinates around which events are considered.
+  required: false
+  type: string
+  default: Longitude entered in homeassistant component
 radius:
   description: The distance in kilometers around the Home Assistant's coordinates in which events are considered.
   required: false

--- a/source/_components/sensor.geo_rss_events.markdown
+++ b/source/_components/sensor.geo_rss_events.markdown
@@ -58,12 +58,12 @@ latitude:
   description: Latitude of the coordinates around which events are considered.
   required: false
   type: string
-  default: Latitude entered in homeassistant component
+  default: Latitude defined in your `configuration.yaml`
 longitude:
   description: Longitude of the coordinates around which events are considered.
   required: false
   type: string
-  default: Longitude entered in homeassistant component
+  default: Longitude defined in your `configuration.yaml`
 radius:
   description: The distance in kilometers around the Home Assistant's coordinates in which events are considered.
   required: false


### PR DESCRIPTION
**Description:**

This PR adds a couple of entries to the configuration options for sensor.geo_rss_events to reflect newly configurable latitude and longitude.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17340

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
