### PR TITLE
Mention botvac availability

### DIFF
--- a/source/_components/vacuum.neato.markdown
+++ b/source/_components/vacuum.neato.markdown
@@ -18,7 +18,7 @@ The `neato` vacuum platform allows you to control your [Neato Botvac Connected](
 The status will contain attributes on the robots last clean session.
 
 <p class='note'>
-If you notice the robot stops responding to commands check the status attribute to see if the robot is offline. If you see "Robot Offline" check the Neato app and make sure your robot is connected and working. If it is not then follow the steps in the app to reset your robot and give it the same name as before then restart Home Assistant.
+If you notice the robot stops responding to commands check the state to see if the robot is "unavailable". If you see "unavailable" first try to restart the vacuum and wait about 5 minutes to see if it is no longer "unavailable". If you are still having issues check the Neato app and make sure your robot is connected and working. If it is not then follow the steps in the app to reset your robot and give it the same name as before then restart Home Assistant.
 </p>
 
 To add `neato` vacuum to your installation, please follow instructions in [Neato component](/components/neato/).


### PR DESCRIPTION
**Description:**

Clarify to the user to check the state and add an additional step to restart before resetting.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17350

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
