### PR TITLE
Update Certificate Expiry sensor

### DIFF
--- a/source/_components/sensor.cert_expiry.markdown
+++ b/source/_components/sensor.cert_expiry.markdown
@@ -13,7 +13,7 @@ ha_release: 0.44
 ha_iot_class: "depends"
 ---
 
-The `cert_expiry` sensor fetches information from a configured URL and displays the certificate expiry in days. 
+The `cert_expiry` sensor fetches information from a configured URL and displays the certificate expiry in days.
 
 ## {% linkable_title Configuration %}
 
@@ -26,13 +26,23 @@ sensor:
     host: home-assistant.io
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The host FQDN (or IP) to retrieve certificate from.
-- **port** (*Optional*): The port number where the server is running. Defaults to `443`.
-- **name** (*Optional*): The friendly name for the certificate.
+{% configuration %}
+host:
+  description: The host FQDN (or IP) to retrieve certificate from.
+  required: true
+  type: string
+port:
+  description: The port number where the server is running.
+  required: false
+  default: 443
+  type: integer
+name:
+  description: The friendly name for the certificate.
+  required: false
+  default: SSL Certificate Expiry
+  type: string
+{% endconfiguration %}
 
 <p class='note warning'>
 Make sure that the URL exactly matches your endpoint or resource.
 </p>
-


### PR DESCRIPTION
**Description:**
Update configuration variables of the Certificate Expiry sensor #6385 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
