### PR TITLE
Update Buienradar weather component configuration variable

### DIFF
--- a/source/_components/weather.buienradar.markdown
+++ b/source/_components/weather.buienradar.markdown
@@ -41,7 +41,7 @@ longitude:
   required: false
   type: float
 forecast:
-  description: 'True' to add a temperature forecast, 'False' to suppress it.
+  description: "'True' to add a temperature forecast, 'False' to suppress it."
   required: false
   default: true
   type: boolean

--- a/source/_components/weather.buienradar.markdown
+++ b/source/_components/weather.buienradar.markdown
@@ -27,13 +27,25 @@ weather:
   - platform: buienradar
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): You can specify a name of the component, but do not have to. If you specify a name, the weather component will get an entity name of `weather.[name]`; if no name is specified, it will try to set its name to `weather.BR_[stationname]`. However at the moment in time, the entity is created, no data has been retrieved yet, so the entity will get named `weather.BR_unknown_station`. Later the station name will be known and get updated, but the entity name remains.
-- **latitude** (*Optional*): Latitude to use for selection of data source location. Longitude and latitude will be taken from Home Assistant configuration but can be overridden/changed in this component to select a different location for Buienradar.
-- **longitude**(*Optional*): Longitude to use for selection of data source location. Longitude and latitude will be taken from Home Assistant configuration but can be overridden/changed in this component to select a different location for Buienradar.
-- **forecast** (*Optional*): 'True' to add a temperature forecast, 'False' to suppress it.
-
+{% configuration %}
+name:
+  description: You can specify a name of the component, but do not have to. If you specify a name, the weather component will get an entity name of `weather.[name]`; if no name is specified, it will try to set its name to `weather.BR_[stationname]`. However at the moment in time, the entity is created, no data has been retrieved yet, so the entity will get named `weather.BR_unknown_station`. Later the station name will be known and get updated, but the entity name remains.
+  required: false
+  type: string
+latitude:
+  description: Latitude to use for selection of data source location. Longitude and latitude will be taken from Home Assistant configuration but can be overridden/changed in this component to select a different location for Buienradar.
+  required: false
+  type: float
+longitude:
+  description: Longitude to use for selection of data source location. Longitude and latitude will be taken from Home Assistant configuration but can be overridden/changed in this component to select a different location for Buienradar.
+  required: false
+  type: float
+forecast:
+  description: 'True' to add a temperature forecast, 'False' to suppress it.
+  required: false
+  default: true
+  type: boolean
+{% endconfiguration %}
 
 A full configuration example:
 

--- a/source/_components/weather.buienradar.markdown
+++ b/source/_components/weather.buienradar.markdown
@@ -29,7 +29,7 @@ weather:
 
 {% configuration %}
 name:
-  description: You can specify a name of the component, but do not have to. If you specify a name, the weather component will get an entity name of `weather.[name]`; if no name is specified, it will try to set its name to `weather.BR_[stationname]`. However at the moment in time, the entity is created, no data has been retrieved yet, so the entity will get named `weather.BR_unknown_station`. Later the station name will be known and get updated, but the entity name remains.
+  description: "You can specify a name of the component, but do not have to. If you specify a name, the weather component will get an entity name of `weather.[name]`; if no name is specified, it will try to set its name to `weather.BR_[stationname]`. However at the moment in time, the entity is created, no data has been retrieved yet, so the entity will get named `weather.BR_unknown_station`. Later the station name will be known and get updated, but the entity name remains."
   required: false
   type: string
 latitude:


### PR DESCRIPTION
Update style of Buienradar weather component documentation to follow new configuration variables description.
Related to #6385.
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
