### PR TITLE
Update Zoneminder component configuration variable

### DIFF
--- a/source/_components/sensor.zoneminder.markdown
+++ b/source/_components/sensor.zoneminder.markdown
@@ -13,7 +13,6 @@ ha_release: 0.31
 ha_iot_class: "Local Polling"
 ---
 
-
 The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of events and the current state of the cameras.
 
 <p class='note'>
@@ -29,13 +28,25 @@ sensor:
     include_archived: false
 ```
 
-Configuration variables:
-
-- **include_archived** (*Optional*): Whether to include archived ZoneMinder events in event counts. Default is `false`.
-- **monitored_conditions** array (*Optional*): Event count sensors to display in the frontend. Default is 'all'.
-  - **all**: All events.
-  - **month**: Events in the last month.
-  - **week**: Events in the last week.
-  - **day**: Events in the last day.
-  - **hour**: Events in the last hour.
-
+{% configuration %}
+include_archived:
+  description: Whether to include archived ZoneMinder events in event counts.
+  required: false
+  default: false
+  type: boolean
+monitored_conditions:
+  description: Event count sensors to display in the frontend.
+  required: false
+  type: list
+  keys:
+    all:
+      description: All events.
+    month:
+      description: Events in the last month.
+    week:
+      description: Events in the last week.
+    day:
+      description: Events in the last day.
+    hour:
+      description: Events in the last hour.
+{% endconfiguration %}

--- a/source/_components/switch.zoneminder.markdown
+++ b/source/_components/switch.zoneminder.markdown
@@ -13,7 +13,6 @@ ha_release: 0.31
 ha_iot_class: "Local Polling"
 ---
 
-
 The `zoneminder` switch platform allows you to toggle the current function of all cameras attached to your [ZoneMinder](https://www.zoneminder.com) instance.
 
 <p class='note'>
@@ -30,11 +29,16 @@ switch:
     command_off: Monitor
 ```
 
-Configuration variables:
-
-- **command_on** (*Required*): The function you want the camera to run when turned on.
-- **command_off** (*Required*): The function you want the camera to run when turned off.
-
+{% configuration %}
+command_on:
+  description: The function you want the camera to run when turned on.
+  required: true
+  type: string
+command_off:
+  description: The function you want the camera to run when turned off.
+  required: true
+  type: string
+{% endconfiguration %}
 
 <p class='note'>
 The default functions installed by ZoneMinder are: None, Monitor, Modect, Record, Mocord, Nodect.

--- a/source/_components/zoneminder.markdown
+++ b/source/_components/zoneminder.markdown
@@ -22,14 +22,40 @@ zoneminder:
   host: ZM_HOST
 ```
 
-Configuration variables:
-- **host** (*Required*): Your ZoneMinder server's host (and optional port), not including the scheme.
-- **path** (*Optional*): Path to your ZoneMinder install. Defaults to `/zm/`.
-- **path_zms** (*Optional*): Path to the CGI script for streaming. This should match `PATH_ZMS` in ZM's "Paths" settings. Defaults to `/zm/cgi-bin/nph-zms`.
-- **ssl** (*Optional*): Set to `true` if your ZoneMinder installation is using SSL. Default to `false`.
-- **verify_ssl** (*Optional*): Verify the certification of the endpoint. Default to `true`.
-- **username** (*Optional*): Your ZoneMinder username.
-- **password** (*Optional*): Your ZoneMinder password. Required if `OPT_USE_AUTH` is enabled in ZM.
+{% configuration %}
+host:
+  description: Your ZoneMinder server's host (and optional port), not including the scheme.
+  required: true
+  type: string
+path:
+  description: Path to your ZoneMinder install.
+  required: false
+  default: "`/zm/`"
+  type: string
+path_zms:
+  description: Path to the CGI script for streaming. This should match `PATH_ZMS` in ZM's "Paths" settings.
+  required: false
+  default: "`/zm/cgi-bin/nph-zms`"
+  type: string
+ssl:
+  description: Set to `true` if your ZoneMinder installation is using SSL.
+  required: false
+  default: false
+  type: boolean
+verify_ssl:
+  description: Verify the certification of the endpoint.
+  required: false
+  default: true
+  type: boolean
+username:
+  description: Verify the certification of the endpoint.
+  required: false
+  type: string
+password:
+  description: Your ZoneMinder password. Required if `OPT_USE_AUTH` is enabled in ZM.
+  required: false
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title Full configuration %}
 

--- a/source/_components/zoneminder.markdown
+++ b/source/_components/zoneminder.markdown
@@ -48,7 +48,7 @@ verify_ssl:
   default: true
   type: boolean
 username:
-  description: Verify the certification of the endpoint.
+  description: Your ZoneMinder username.
   required: false
   type: string
 password:


### PR DESCRIPTION
**Description:**
Update style of Zoneminder component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
