### PR TITLE
Update Zha component configuration variable

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -41,11 +41,25 @@ zha:
   database_path: /home/homeassistant/.homeassistant/zigbee.db
 ```
 
-Configuration variables:
-
- - **radio_type** (*Optional*): One of `ezsp` (default) or `xbee`
- - **usb_path** (*Required*): Path to the serial device for the radio.
- - **baudrate** (*Optional*): Baud rate of the serial device.
- - **database_path** (*Required*): _Full_ path to the database which will keep persistent network data.
+{% configuration %}
+radio_type:
+  description: One of `ezsp` or `xbee`.
+  required: false
+  default: ezsp
+  type: string
+usb_path:
+  description: Path to the serial device for the radio.
+  required: true
+  type: string
+baudrate:
+  description: Baud rate of the serial device.
+  required: false
+  default: 57600
+  type: integer
+database_path:
+  description: _Full_ path to the database which will keep persistent network data.
+  required: true
+  type: string
+{% endconfiguration %}
 
 To add new devices to the network, call the `permit` service on the `zha` domain, and then follow the device instructions for doing a scan or factory reset. In case you want to add Philips Hue bulbs that have previously been added to another bridge, have a look at: [https://github.com/vanviegen/hue-thief/](https://github.com/vanviegen/hue-thief/)


### PR DESCRIPTION
**Description:**
Update style of Zha component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
