### PR TITLE
Fixes for media_player.FireTV config language

### DIFF
--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -60,22 +60,22 @@ Configuration variables:
 
 {% configuration %}
 host:
-  description: "The host where `firetv-server` is running"
+  description: "The host where `firetv-server` is running."
   required: false
   type: string
   default: localhost
 port:
-  description: "The port where `firetv-server` is running"
+  description: "The port where `firetv-server` is running."
   required: false
   type: integer
   default: 5556
 device:
-  description: "The device ID. Defaults to `default`"
+  description: The device ID.
   required: false
   type: string
   default: default
 name:
-  description: The friendly name of the device
+  description: The friendly name of the device.
   required: false
   type: string
   default: Amazon Fire TV

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -60,22 +60,22 @@ Configuration variables:
 
 {% configuration %}
 host:
-  description: The host where `firetv-server` is running. Default is localhost
+  description: "The host where `firetv-server` is running"
   required: false
   type: string
   default: localhost
 port:
-  description: The port where `firetv-server` is running. Default is 5556
+  description: "The port where `firetv-server` is running"
   required: false
   type: integer
   default: 5556
 device:
-  description: The device ID. Defaults to `default`
+  description: "The device ID. Defaults to `default`"
   required: false
   type: string
   default: default
 name:
-  description: The friendly name of the device, default is "Amazon Fire TV"
+  description: The friendly name of the device
   required: false
   type: string
   default: Amazon Fire TV

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -56,8 +56,6 @@ media_player:
   - platform: firetv
 ```
 
-Configuration variables:
-
 {% configuration %}
 host:
   description: "The host where `firetv-server` is running."

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -58,11 +58,28 @@ media_player:
 
 Configuration variables:
 
-- **host** (*Optional*): The host where `firetv-server` is running. Default is localhost.
-- **port** (*Optional*): The port where `firetv-server` is running. Default is 5556.
-- **device** (*Optional*): The device ID. Defaults to `default`.
-- **name** (*Optional*): The friendly name of the device, default is 'Amazon Fire TV'.
-
+{% configuration %}
+host:
+  description: The host where `firetv-server` is running. Default is localhost
+  required: false
+  type: string
+  default: localhost
+port:
+  description: The port where `firetv-server` is running. Default is 5556
+  required: false
+  type: integer
+  default: 5556
+device:
+  description: The device ID. Defaults to `default`
+  required: false
+  type: string
+  default: default
+name:
+  description: The friendly name of the device, default is "Amazon Fire TV"
+  required: false
+  type: string
+  default: Amazon Fire TV
+{% endconfiguration %}
 
 <p class='note warning'>
 Note that python-firetv has support for multiple Amazon Fire TV devices. If you have more than one configured, be sure to specify the device ID in `device`. Run `firetv-server -h` and/or view the source for complete capabilities.


### PR DESCRIPTION
**Description:**

Fixes for the config specification as per https://github.com/home-assistant/home-assistant.io/issues/6385

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
