### PR TITLE
Update Zabbix component configuration variable

### DIFF
--- a/source/_components/zabbix.markdown
+++ b/source/_components/zabbix.markdown
@@ -26,13 +26,30 @@ zabbix:
   host: 192.168.0.100
 ```
 
-Configuration variables:
-
-- **host** (*Required*): Your Zabbix server.
-- **path** (*Optional*): Path to your Zabbix install. Defaults to `/zabbix/`.
-- **ssl** (*Optional*): Set to `True` if your Zabbix installation is using SSL. Default to `False`.
-- **username** (*Optional*): Your Zabbix username.
-- **password** (*Optional*): Your Zabbix password.
+{% configuration %}
+host:
+  description: Your Zabbix server.
+  required: true
+  type: string
+path:
+  description: Path to your Zabbix install.
+  required: false
+  default: "`/zabbix/`"
+  type: string
+ssl:
+  description: Set to `True` if your Zabbix installation is using SSL.
+  required: false
+  default: false
+  type: boolean
+username:
+  description: Your Zabbix username.
+  required: false
+  type: string
+password:
+  description: Your Zabbix password.
+  required: false
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title Full configuration %}
 


### PR DESCRIPTION
**Description:**
Update style of Zabbix component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
