### PR TITLE
Update TravisCi component configuration variable

### DIFF
--- a/source/_components/sensor.travisci.markdown
+++ b/source/_components/sensor.travisci.markdown
@@ -30,9 +30,9 @@ api_key:
   required: true
   type: string
 branch:
-  description: Determine which default branch should be used by the **state** condition.
+  description: "Determine which default branch should be used by the **state** condition."
   required: false
-  default: "*master*"
+  default: master
   type: string
 scan_interval:
   description: How frequently to query for new data.
@@ -53,9 +53,9 @@ monitored_conditions:
     last_build_started_at:
       description: Return the timestamp of when the last test job started.
     last_build_state:
-      description: Return the state from the latest test job/PR. The conditions can be: 'passed', 'failed' or 'started'.
+      description: "Return the state from the latest test job/PR. The conditions can be: 'passed', 'failed' or 'started'."
     state:
-      description: Return the build test from the branch specified at by **branch** parameter.
+      description: "Return the build test from the branch specified at by **branch** parameter."
 repository:
   description: Name from the GitHub repositories to be monitored. If not specified, all GitHub repositories linked to Travis-CI will be enabled by default.
   required: false

--- a/source/_components/sensor.travisci.markdown
+++ b/source/_components/sensor.travisci.markdown
@@ -24,16 +24,40 @@ sensor:
     api_key: 123456789
 ```
 
-Configuration variables:
-
-- **api_key** (*Required*): GitHub [access token](https://github.com/settings/tokens) with the following scopes: *read:org*, *user:email*, *repo_deployment*, *repo:status*, *write:repo_hook*.
-- **branch** (*Optional*): Determine which default branch should be used by the **state** condition. Defaults to *master*.
-- **scan_interval** (*Optional*): How frequently to query for new data. Defaults to 30 seconds.
-- **monitored_conditions** array (*Optional*): Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
-  - **last_build_id**: Turn the last build job ID.
-  - **last_build_duration**: Return the time elapsed in seconds to run the last test job.
-  - **last_build_finished_at**: Return the timestamp of when the last test job finished.
-  - **last_build_started_at**: Return the timestamp of when the last test job started.
-  - **last_build_state**: Return the state from the latest test job/PR. The conditions can be: 'passed', 'failed' or 'started'.
-  - **state**: Return the build test from the branch specified at by **branch** parameter.
-- **repository:** array (*Optional*): Name from the GitHub repositories to be monitored. If not specified, all GitHub repositories linked to Travis-CI will be enabled by default.
+{% configuration %}
+api_key:
+  description: "GitHub [access token](https://github.com/settings/tokens) with the following scopes: *read:org*, *user:email*, *repo_deployment*, *repo:status*, *write:repo_hook*."
+  required: true
+  type: string
+branch:
+  description: Determine which default branch should be used by the **state** condition.
+  required: false
+  default: "*master*"
+  type: string
+scan_interval:
+  description: How frequently to query for new data.
+  required: false
+  default: 30
+  type: integer
+monitored_conditions:
+  description: Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
+  required: false
+  type: list
+  keys:
+    last_build_id:
+      description: Turn the last build job ID.
+    last_build_duration:
+      description: Return the time elapsed in seconds to run the last test job.
+    last_build_finished_at:
+      description: Return the timestamp of when the last test job finished.
+    last_build_started_at:
+      description: Return the timestamp of when the last test job started.
+    last_build_state:
+      description: Return the state from the latest test job/PR. The conditions can be: 'passed', 'failed' or 'started'.
+    state:
+      description: Return the build test from the branch specified at by **branch** parameter.
+repository:
+  description: Name from the GitHub repositories to be monitored. If not specified, all GitHub repositories linked to Travis-CI will be enabled by default.
+  required: false
+  type: list
+{% endconfiguration %}

--- a/source/_components/sensor.travisci.markdown
+++ b/source/_components/sensor.travisci.markdown
@@ -34,11 +34,6 @@ branch:
   required: false
   default: master
   type: string
-scan_interval:
-  description: How frequently to query for new data.
-  required: false
-  default: 30
-  type: integer
 monitored_conditions:
   description: Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
   required: false


### PR DESCRIPTION
**Description:**
Update style of TravisCi component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
