### PR TITLE
Update ifttt.markdown

### DIFF
--- a/source/_components/ifttt.markdown
+++ b/source/_components/ifttt.markdown
@@ -34,7 +34,8 @@ You can then consume that information with the following automation:
 ```yaml
 automation:
   trigger:
-    event: ifttt_webhook_received
+    platform: event
+    event_type: ifttt_webhook_received
     event_data:
       action: call_service
   action:


### PR DESCRIPTION
automation needs trigger platform, right?  Someone check this, but as written before it would not pass config check.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
