### PR TITLE
Add documentation for new Z-Wave Lock configuration option

### DIFF
--- a/source/_components/lock.zwave.markdown
+++ b/source/_components/lock.zwave.markdown
@@ -27,9 +27,9 @@ If your lock does not update the status properly for all events, but the notific
 `use_notification_state` flag for your lock. For example, with an Entity ID for the lock of `lock.my_lock you would set the following in your
 `configuration.yaml`:
 
-{% configuration %}
+```yaml
 zwave:
   device_config:
     lock.my_lock:
       use_notification_state: true
-{% endconfiguration %}
+```

--- a/source/_components/lock.zwave.markdown
+++ b/source/_components/lock.zwave.markdown
@@ -22,3 +22,14 @@ Z-Wave locks will expose three services under the lock domain to manage usercode
 | clear_usercode | Clears a usercode at code_slot X. Valid code_slots are 1-254, but max is defined by the lock. |
 | get_usercode | Get a usercode from the lock at code_slot. Valid code_slots are 1-254, but max is defined by the lock. |
 | set_usercode | Sets usercode to X at code_slot Y. Valid usercodes are at least 4 digits, and max defined by the lock. |
+
+If your lock does not update the status properly for all events but the notification gets updated to show the state change you may need to set the
+`use_notification_state` flag for your lock. For example, with an Entity ID for the lock of `lock.my_lock you would set the following in your
+`configuration.yaml`:
+
+{% configuration %}
+zwave:
+  device_config:
+    lock.my_lock:
+      use_notification_state: true
+{% endconfiguration %}

--- a/source/_components/lock.zwave.markdown
+++ b/source/_components/lock.zwave.markdown
@@ -23,7 +23,7 @@ Z-Wave locks will expose three services under the lock domain to manage usercode
 | get_usercode | Get a usercode from the lock at code_slot. Valid code_slots are 1-254, but max is defined by the lock. |
 | set_usercode | Sets usercode to X at code_slot Y. Valid usercodes are at least 4 digits, and max defined by the lock. |
 
-If your lock does not update the status properly for all events but the notification gets updated to show the state change you may need to set the
+If your lock does not update the status properly for all events, but the notification gets updated to show the state change you may need to set the
 `use_notification_state` flag for your lock. For example, with an Entity ID for the lock of `lock.my_lock you would set the following in your
 `configuration.yaml`:
 


### PR DESCRIPTION
**Description:**
This commit adds documentation around setting the new
use_notification_state configuration option being added to
home-assistant in home-assistant/home-assistant#17386

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17386
## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
