### PR TITLE
Fixed a link on z-wave entities

### DIFF
--- a/source/_docs/z-wave/entities.markdown
+++ b/source/_docs/z-wave/entities.markdown
@@ -177,7 +177,7 @@ binary_sensor:
    - **254**: Deep sleep
    - **255**: Case open
 
-If your device has a `burglar` entity, but not a `binary_sensor` equivalent, you can use a [template binary sensor](/components/binary_sensor.template/) to create one (here we've defined it as a motion sensor, but you can use [any relevant device class](/components/binary_sensor/#device-class:
+If your device has a `burglar` entity, but not a `binary_sensor` equivalent, you can use a [template binary sensor](/components/binary_sensor.template/) to create one (here we've defined it as a motion sensor, but you can use [any relevant device class](/components/binary_sensor/#device-class):
 
 {% raw %}
 ```yaml


### PR DESCRIPTION
**Description:**

A link missing was missing an ending parenthesis. 

## Checklist:

- [x] Branch: current
- [x] The documentation follows the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
