### PR TITLE
Add night arm mode to MQTT alarm control panel

### DIFF
--- a/source/_components/alarm_control_panel.mqtt.markdown
+++ b/source/_components/alarm_control_panel.mqtt.markdown
@@ -20,6 +20,7 @@ The component will accept the following states from your Alarm Panel (in lower c
 - 'disarmed'
 - 'armed_home'
 - 'armed_away'
+- 'armed_night'
 - 'pending'
 - 'triggered'
 
@@ -69,6 +70,11 @@ payload_arm_away:
   required: false
   type: string
   default: ARM_AWAY
+payload_arm_night:
+  description: The payload to set armed-night mode on your Alarm Panel.
+  required: false
+  type: string
+  default: ARM_NIGHT
 code:
   description: If defined, specifies a code to enable or disable the alarm in the frontend.
   required: false


### PR DESCRIPTION
**Description:**

Add support for night arming mode to MQTT alarm control panel.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17390

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
