### PR TITLE
Add target temperature low high to MQTT climate

### DIFF
--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -123,6 +123,30 @@ temperature_state_template:
   description: A template to render the value received on the `temperature_state_topic` with.
   required: false
   type: template
+temperature_low_command_topic:
+  description: The MQTT topic to publish commands to change the target low temperature.
+  required: false
+  type: string
+temperature_low_state_topic:
+  description: The MQTT topic to subscribe for changes in the target low temperature. If this is not set, the target low temperature works in optimistic mode (see below).
+  required: false
+  type: string
+temperature_low_state_template:
+  description: A template to render the value received on the `temperature_low_state_topic` with.
+  required: false
+  type: template
+temperature_high_command_topic:
+  description: The MQTT topic to publish commands to change the target high temperature.
+  required: false
+  type: string
+temperature_high_state_topic:
+  description: The MQTT topic to subscribe for changes in the target high temperature. If this is not set, the target high temperature works in optimistic mode (see below).
+  required: false
+  type: string
+temperature_high_state_template:
+  description: A template to render the value received on the `temperature_high_state_topic` with.
+  required: false
+  type: template
 fan_mode_command_topic:
   description: The MQTT topic to publish commands to change the fan mode.
   required: false


### PR DESCRIPTION
**Description:**

Add support for target low and high temperature setpoints in MQTT climate.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17391

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
