### PR TITLE
Remove duplicate title attribute

### DIFF
--- a/source/_lovelace/gauge.markdown
+++ b/source/_lovelace/gauge.markdown
@@ -90,7 +90,6 @@ Define the severity map:
 ```yaml
 - type: gauge
   title: With Severity
-  title: CPU Usuage
   unit_of_measurement: '%'
   entity: sensor.cpu_usuage
   severity:


### PR DESCRIPTION
**Description:**
Gauge card with severity had 2 title attributes. The second one was overwritting the first one.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
