### PR TITLE
Updated nuki component configuration section

### DIFF
--- a/source/_components/lock.nuki.markdown
+++ b/source/_components/lock.nuki.markdown
@@ -36,7 +36,7 @@ port:
   description: The port on which the Nuki bridge is listening on.
   required: false
   default: 8080
-  type: int
+  type: integer
 token:
   description: The token that was defined when setting up the bridge.
   required: true

--- a/source/_components/lock.nuki.markdown
+++ b/source/_components/lock.nuki.markdown
@@ -27,24 +27,21 @@ lock:
     token: fe2345ef
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP or hostname of the Nuki bridge.
-- **port** (*Optional*): The port on which the Nuki bridge is listening on. Defaults to `8080`.
-- **token** (*Required*): The token that was defined when setting up the bridge.
-
-## {% linkable_title Full configuration %}
-
-Here's a full configuration example for a Nuki bridge:
-
-```yaml
-# Example configuration.yaml entry
-lock:
-  - platform: nuki
-    host: 192.168.1.120
-    port: 8080
-    token: fe2345ef
-```
+{% configuration %}
+host:
+  description: The IP or hostname of the Nuki bridge.
+  required: true
+  type: string
+port:
+  description: The port on which the Nuki bridge is listening on.
+  required: false
+  default: 8080
+  type: int
+token:
+  description: The token that was defined when setting up the bridge.
+  required: true
+  type: string
+{% endconfiguration %}
 
 ## {% linkable_title Services %}
 


### PR DESCRIPTION
Related to #6385.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
