### PR TITLE
Update yeelight configuration

### DIFF
--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -33,13 +33,37 @@ light:
         name: Front Door
 ```
 
-Configuration variables:
-
-- **ip** (*Required*): IP(s) of your Wifi bulbs
-- **name** (*Optional*): A friendly name for the device.
-- **transition** (*Optional*, default 350): Smooth transitions over time (in ms).
-- **use_music_mode** (*Optional*, default False): Enable music mode.
-- **save_on_change** (*Optional*, default False): Saves the bulb state in its nonvolatile memory when changed from Home Assistant.
+{% configuration %}
+devices:
+  required: true
+  description: List of Yeelight devices.
+  type: map
+  keys:
+    ip:
+      description: IP address of the bulb.
+      required: true
+      type: map
+      keys:
+        name:
+          description: A friendly name for the device.
+          required: false
+          type: string
+        transition:
+          description: Smooth transitions over time (in ms).
+          required: false
+          type: integer
+          default: 350
+        use_music_mode:
+          description: Enable music mode.
+          required: false
+          type: boolean
+          default: False
+        save_on_change:
+          description: Saves the bulb state in its nonvolatile memory when changed from Home Assistant.
+          required: false
+          type: boolean
+          default: False
+{% endconfiguration %}
 
 #### {% linkable_title Music mode  %}
 Per default the bulb limits the amount of requests per minute to 60, a limitation which can be bypassed by enabling the music mode. In music mode the bulb is commanded to connect back to a socket provided by the component and it tries to keep the connection open, which may not be wanted in all use-cases.

--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -26,11 +26,6 @@ light:
     devices:
       192.168.1.25:
         name: Living Room
-        transition: 1000
-        use_music_mode: True #(defaults to False)
-        save_on_change: True #(defaults to False)
-      192.168.1.13:
-        name: Front Door
 ```
 
 {% configuration %}
@@ -104,3 +99,37 @@ Set an operation mode.
 |---------------------------|----------|---------------------------------------------------------------------------------------------|
 | `entity_id`               |      yes | Only act on a specific yeelight. Else targets all.                                          |
 | `mode`                    |       no | Operation mode. Valid values are 'last', 'normal', 'rgb', 'hsv', 'color_flow', 'moonlight'. |
+
+## {% linkable_title Examples %}
+
+In this section you find some real-life examples of how to use this light.
+
+### {% linkable_title Full configuration %}
+
+This example shows how you can use the optional configuration options.
+
+```yaml
+# Example configuration.yaml entry
+light:
+  - platform: yeelight
+    devices:
+      192.168.1.25:
+        name: Living Room
+        transition: 1000
+        use_music_mode: True
+        save_on_change: True
+```
+
+### {% linkable_title Multiple bulbs %}
+
+This example shows how you can add multiple bulbs in your configuration.
+
+```yaml
+light:
+  - platform: yeelight
+    devices:
+      192.168.1.25:
+        name: Living Room
+      192.168.1.13:
+        name: Front Door
+```


### PR DESCRIPTION
**Description:**
Updated the configuration format (#6385) and the examples. I've removed the optional items from the main example and added 2 more examples for these optional items.

The name in the main example is also optional, but Home Assistant throws an error if there's an IP without keys:
```yaml
# Example configuration.yaml entry
light:
  - platform: yeelight
    devices:
      192.168.1.25:
```

Error:
```
Testing configuration at /config
Failed config
  light.yeelight: 
    - Invalid config for [light.yeelight]: expected a dictionary for dictionary value @ data['devices']['192.168.1.25']. Got None
expected a dictionary for dictionary value @ data['devices']['192.168.1.25']. Got None. (See ?, line ?). Please check the docs at https://home-assistant.io/components/light.yeelight/
```

Is this the right way to handle this situation?

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/