### PR TITLE
Fix deluge configuration

### DIFF
--- a/source/_components/sensor.deluge.markdown
+++ b/source/_components/sensor.deluge.markdown
@@ -35,11 +35,12 @@ sensor:
 host:
   required: true
   type: string
-  description: This is the IP address of your Deluge daemon, eg. 192.168.1.32.
+  description: This is the IP address of your Deluge daemon, e.g., 192.168.1.32.
 port:
   required: false
   type: integer
-  description: The port your Deluge daemon uses. Defaults to 58846. Warning, this is not the port of the WebUI.
+  description: The port your Deluge daemon uses. Warning, this is not the port of the WebUI.
+  default: 58846
 name:
   required: false
   type: string

--- a/source/_components/sensor.deluge.markdown
+++ b/source/_components/sensor.deluge.markdown
@@ -31,14 +31,37 @@ sensor:
       - 'upload_speed'
 ```
 
-Configuration variables:
-
-- **host** (*Required*): This is the IP address of your Deluge daemon, eg. 192.168.1.32.
-- **port** (*Optional*): The port your Deluge daemon uses. Defaults to 58846. Warning, this is not the port of the WebUI.
-- **name** (*Optional*): The name to use when displaying this Deluge instance.
-- **username** (*Required*): Your Deluge daemon username.
-- **password** (*Required*): Your Deluge daemon password.
-- **monitored_variables** array (*Required*): Conditions to display in the frontend.
-  - **current_status**: The status of your Deluge daemon.
-  - **download_speed**: The current download speed.
-  - **upload_speed**: The current upload speed.
+{% configuration %}
+host:
+  required: true
+  type: string
+  description: This is the IP address of your Deluge daemon, eg. 192.168.1.32.
+port:
+  required: false
+  type: integer
+  description: The port your Deluge daemon uses. Defaults to 58846. Warning, this is not the port of the WebUI.
+name:
+  required: false
+  type: string
+  default: Deluge
+  description: The name to use when displaying this Deluge instance.
+username:
+  required: false
+  type: string
+  description: Your Deluge daemon username.
+password:
+  required: true
+  type: string
+  description: Your Deluge daemon password.
+monitored_variables:
+  required: true
+  type: list
+  description: Conditions to display in the frontend.
+  keys:
+    current_status:
+      description: The status of your Deluge daemon.
+    download_speed:
+      description: The current download speed.
+    upload_speed:
+      description: The current upload speed.
+  {% endconfiguration %}

--- a/source/_components/sensor.deluge.markdown
+++ b/source/_components/sensor.deluge.markdown
@@ -46,7 +46,7 @@ name:
   default: Deluge
   description: The name to use when displaying this Deluge instance.
 username:
-  required: false
+  required: true
   type: string
   description: Your Deluge daemon username.
 password:

--- a/source/_components/switch.deluge.markdown
+++ b/source/_components/switch.deluge.markdown
@@ -31,7 +31,7 @@ switch:
 host:
   required: true
   type: string
-  description: This is the IP address of your Deluge daemon, eg. 192.168.1.32.
+  description: This is the IP address of your Deluge daemon, eg., 192.168.1.32.
 username:
   required: true
   type: string
@@ -44,7 +44,7 @@ port:
   required: false
   type: integer
   default: 58846
-  description: The port your Deluge daemon uses. (Warning: This is not the port of the WebUI.)
+  description: "The port your Deluge daemon uses. (Warning: This is not the port of the WebUI.)"
 name:
   required: false
   type: string

--- a/source/_components/switch.deluge.markdown
+++ b/source/_components/switch.deluge.markdown
@@ -27,10 +27,27 @@ switch:
   password : PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Required*): This is the IP address of your Deluge daemon, eg. 192.168.1.32.
-- **username** (*Required*): Your Deluge username, if you use authentication.
-- **password** (*Required*): Your Deluge password, if you use authentication.
-- **port** (*Optional*): The port your Deluge daemon uses, defaults to 58846. Warning,this is not the port of the WebUI
-- **name** (*Optional*): The name to use when displaying this Deluge instance.
+{% configuration %}
+host:
+  required: true
+  type: string
+  description: This is the IP address of your Deluge daemon, eg. 192.168.1.32.
+username:
+  required: true
+  type: string
+  description: Your Deluge username, if you use authentication.
+password:
+  required: true
+  type: string
+  description: Your Deluge password, if you use authentication.
+port:
+  required: false
+  type: integer
+  default: 58846
+  description: The port your Deluge daemon uses. (Warning: This is not the port of the WebUI.)
+name:
+  required: false
+  type: string
+  default: Deluge Switch
+  description: The name to use when displaying this Deluge instance.
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Fix deluge configuration.

Related to #6385.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
