### PR TITLE
Added ssl and verify_ssl parameters in ddwrt device tracker component

### DIFF
--- a/source/_components/device_tracker.ddwrt.markdown
+++ b/source/_components/device_tracker.ddwrt.markdown
@@ -38,6 +38,16 @@ password:
   description: The password for your given admin account.
   required: true
   type: string
+ssl:
+  description: Whether to connect via https.
+  required: false
+  type: boolean
+  default: false
+verify_ssl:
+  description: If SSL verification for https resources needs to be turned off (for self-signed certs, etc.)
+  required: false
+  type: boolean
+  default: true
 {% endconfiguration %}
 
 By default Home Assistant pulls information about connected devices from DD-WRT every 5 seconds.

--- a/source/_components/device_tracker.ddwrt.markdown
+++ b/source/_components/device_tracker.ddwrt.markdown
@@ -39,12 +39,12 @@ password:
   required: true
   type: string
 ssl:
-  description: Whether to connect via https.
+  description: Whether to connect via HTTPS.
   required: false
   type: boolean
   default: false
 verify_ssl:
-  description: If SSL verification for https resources needs to be turned off (for self-signed certs, etc.)
+  description: If SSL/TLS verification for HTTPS resources needs to be turned off (for self-signed certs, etc.)
   required: false
   type: boolean
   default: true


### PR DESCRIPTION
**Description:**
Added support for HTTPS connection (DDWRT component).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17406

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
