### PR TITLE
`is_state` needs quotes all the way

### DIFF
--- a/source/_docs/z-wave/entities.markdown
+++ b/source/_docs/z-wave/entities.markdown
@@ -161,7 +161,7 @@ binary_sensor:
       YOUR_SENSOR:
         friendly_name: "Friendly name here"
         device_class: door
-        value_template: "{{ is_state('sensor.YOUR_ORIGINAL_SENSOR_access_control', 22) }}"
+        value_template: "{{ is_state('sensor.YOUR_ORIGINAL_SENSOR_access_control', '22') }}"
 ```
 {% endraw %}
 
@@ -187,7 +187,7 @@ binary_sensor:
       YOUR_SENSOR:
         friendly_name: "Friendly name here"
         device_class: motion
-        value_template: "{{ is_state('sensor.YOUR_SENSOR_burglar', 8) }}"
+        value_template: "{{ is_state('sensor.YOUR_SENSOR_burglar', '8') }}"
 ```
 {% endraw %}
 


### PR DESCRIPTION
Apparently `is_state` treats the value as a string
