### PR TITLE
Correct IFFT event trigger syntax

### DIFF
--- a/source/_components/ifttt.markdown
+++ b/source/_components/ifttt.markdown
@@ -34,7 +34,8 @@ You can then consume that information with the following automation:
 ```yaml
 automation:
   trigger:
-    event: ifttt_webhook_received
+    platform: event
+    event_type: ifttt_webhook_received
     event_data:
       action: call_service
   action:


### PR DESCRIPTION
**Description:**
The IFFT event trigger syntax does not work with HomeAssistant 0.80.0 as is. It needs to be changed like this. This makes it line up with [event trigger documentation](https://www.home-assistant.io/docs/automation/trigger/#event-trigger) as well.

```yaml
automation:
  trigger:
    platform: event
    event_type: ifttt_webhook_received
    event_data:
      action: call_service
```

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
