### PR TITLE
Fix Yi camera component configuration variable

### DIFF
--- a/source/_components/camera.yi.markdown
+++ b/source/_components/camera.yi.markdown
@@ -65,8 +65,6 @@ camera:
     password: my_password_123
 ```
 
-Configuration variables:
-
 {% configuration %}
 name:
   description: A human-friendly name for the camera.


### PR DESCRIPTION
**Description:**
Fix for Yi camera component documentation to follow new configuration variables description.
Related to #6385.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
