### PR TITLE
Fixed a grammar mistake in the database docs

### DIFF
--- a/source/_docs/backend/database.markdown
+++ b/source/_docs/backend/database.markdown
@@ -116,7 +116,7 @@ If you don't want to keep certain entities, you can delete them permanently:
 sqlite> DELETE FROM states WHERE entity_id="sensor.cpu";
 ```
 
-The `VACUUM` command cleans the your database.
+The `VACUUM` command cleans your database.
 
 ```bash
 sqlite> VACUUM;


### PR DESCRIPTION
"The `VACUUM` command cleans the your database."

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
