### PR TITLE
Duplicated variables declaration at cover.rflink

### DIFF
--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -87,8 +87,6 @@ Device configuration variables:
 - **aliases** (*Optional*): Alternative Rflink ID's this device is known by.
 - **fire_event** (*Optional*): Fire a `button_pressed` event if this device is turned on or off (default: False).
 - **signal_repetitions** (*Optional*): Repeat every Rflink command this number of times (default: 1).
-- **fire_event_** (*Optional*): Set default `fire_event` for RFLink switch devices (see below).
-- **signal_repetitions** (*Optional*): Set default `signal_repetitions` for RFLink switch devices (see below).
 - **group** (*Optional*): Allow light to respond to group commands (ALLON/ALLOFF). (default: yes)
 - **group_aliases** (*Optional*): `aliases` which only respond to group commands.
 - **no_group_aliases** (*Optional*): `aliases` which do not respond to group commands.


### PR DESCRIPTION
Probably from a copy&paste `fire_event` and `signal_repetitions` were duplicated at "Device coonfiguration variables" point

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
