### PR TITLE
Spelling correction

### DIFF
--- a/source/_components/media_player.anthemav.markdown
+++ b/source/_components/media_player.anthemav.markdown
@@ -43,7 +43,7 @@ Configuration variables:
 
 ## Notes and Limitations
 
-- The tuner is currently unsupported as are the `media_player` play, pays, prev, and next controls.
+- The tuner is currently unsupported as are the `media_player` play, pause, prev, and next controls.
 - Enabling this platform will set and enforce "Standby IP Control On" in your Anthem device.  You almost certainly want this.  If you disable it on the device, it will just get re-enabled by Home Assistant.
 - Only Zone 1 is currently supported.
 


### PR DESCRIPTION
"pays" should have been "pause"

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
