### PR TITLE
Grammar correction

### DIFF
--- a/source/_components/media_player.bluesound.markdown
+++ b/source/_components/media_player.bluesound.markdown
@@ -49,7 +49,7 @@ media_player:
 
 ### {% linkable_title Service `bluesound_join` %}
 
-Group players together under a single master speaker. That will make a new group or join to exists group.
+Group players together under a single master speaker. That will make a new group or join an existing group.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
