### PR TITLE
Update some h-a.io/developers links directly to developers.h-a.io

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,6 @@
 ## Checklist:
 
 - [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
-- [ ] The documentation follow the [standards][standards].
+- [ ] The documentation follows the [standards][standards].
 
-[standards]: https://home-assistant.io/developers/documentation/standards/
+[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ This is the source for the [Home-Assistant.io website](https://home-assistant.io
 
 ## Setup
 
-Setting up to contribute to documentation and the process for submitting pull requests is [explained here](https://home-assistant.io/developers/documentation/).
+Setting up to contribute to documentation and the process for submitting pull requests is explained in the [developer documentation](https://developers.home-assistant.io/docs/documentation_index.html).
 
 ## Site preview
 


### PR DESCRIPTION
While at it, sneak in a minor rephrase and a grammar fix.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
