### PR TITLE
Use list instead of array in configuration block types

### DIFF
--- a/source/_components/daikin.markdown
+++ b/source/_components/daikin.markdown
@@ -43,7 +43,7 @@ hosts:
   description: List of IP addresses or hostnames.
   required: false
   default: All discovered hosts
-  type: array
+  type: list
 monitored_conditions:
   description: List of items you want to monitor for each device.
   required: false

--- a/source/_components/device_tracker.ping.markdown
+++ b/source/_components/device_tracker.ping.markdown
@@ -36,7 +36,7 @@ device_tracker:
 hosts:
   description: List of device names and their corresponding IP address or hostname.
   required: true
-  type: array
+  type: list
 count:
   description: Number of packet used for each device (avoid false detection).
   required: false


### PR DESCRIPTION
**Description:**

For consistency and per https://developers.home-assistant.io/docs/en/documentation_standards.html#component-and-platform-pages

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
