### PR TITLE
Correcting device_class link

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -69,7 +69,7 @@ assumed_state:
 device_class:
   description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
   required: false
-  type: device_class
+  type: [device_class](/docs/configuration/customizing-devices/#device-class)
   default: None
 unit_of_measurement:
   description: Defines the units of measurement, if any. This will also influence the graphical presentation in the history visualisation as continuous value. Sensors with missing `unit_of_measurement` are showing as discrete values.


### PR DESCRIPTION
Yes, I know it isn't a link in the source, but it is in the live docs 🤷‍♂️
