### PR TITLE
Add 'device_class' section

### DIFF
--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -15,12 +15,22 @@ The display style of each entity can be modified in the [customize section](/get
  
 | Attribute | Default | Description |
 | --------- | ------- | ----------- |
-| `device_class` | | `none` Generic cover device<br>`damper` Ventilation damper controller<br>`garage` Garage door controller<br>`window` Window controller
+| `device_class` | | see below
 | `assumed_state` | `false` | If set to `true`, cover buttons will always be enabled
+
+### {% linkable_title Device Class %}
+
+The way these sensors are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for covers:
+
+- **None**: Generic cover. This is the default and doesn't need to be set.
+- **damper**: Ventilation damper controller.
+- **garage**: Garage door controller.
+- **window**: Window controller.
 
 ## {% linkable_title Services %}
 
 ### {% linkable_title Cover control services %}
+
 Available services: `cover.open_cover`, `cover.close_cover`, `cover.stop_cover`, `cover.open_cover_tilt`, `cover.close_cover_tilt`, `cover.stop_cover_tilt`
 
 | Service data attribute | Optional | Description |


### PR DESCRIPTION
**Description:**
Add 'device_class' section to be able to link to it from the platforms.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
