### PR TITLE
Add documentation for activity state of MQTT climate

### DIFF
--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -206,12 +206,12 @@ temp_step:
   type: number
   required: false
   default: 1
-activity_state_topic:
-  description: The MQTT topic to subscribe for changes of the HVAC activity. When the device is not active, it has `idle` state, except `off` mode. Otherwise state is defined by operation mode. If this is not set, the HVAC is always active.
+state_topic:
+  description: The MQTT topic to subscribe for changes of the HVAC state. If this is not set, the HVAC state is operation mode.
   required: false
   type: string
-activity_state_template:
-  description: A template to render the value received on the `activity_state_topic` with.
+state_template:
+  description: A template to render the value received on the `state_topic` with.
   required: false
   type: template
 {% endconfiguration %}

--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -206,6 +206,14 @@ temp_step:
   type: number
   required: false
   default: 1
+activity_state_topic:
+  description: The MQTT topic to subscribe for changes of the HVAC activity. When the device is not active, it has `idle` state, except `off` mode. Otherwise state is defined by operation mode. If this is not set, the HVAC is always active.
+  required: false
+  type: string
+activity_state_template:
+  description: A template to render the value received on the `activity_state_topic` with.
+  required: false
+  type: template
 {% endconfiguration %}
 
 #### {% linkable_title Optimistic mode %}
@@ -261,4 +269,6 @@ climate:
     temperature_command_topic: "study/ac/temperature/set"
     fan_mode_command_topic: "study/ac/fan/set"
     swing_mode_command_topic: "study/ac/swing/set"
+    activity_state_topic: "study/ac/activity"
+
 ```


### PR DESCRIPTION
**Description:**
Display state of MQTT HVAC depending on payload of state topic.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17414

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
