### PR TITLE
Update cover.rflink.markdown

### DIFF
--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -75,7 +75,6 @@ cover:
 
 Configuration variables:
 
-- **automatic_add** (*Optional*): Automatically add new/unconfigured devices to Home Assistant if detected (default: True).
 - **devices**  (*Optional*): A list of devices with their name to use in the frontend.
 - **device_defaults**: (*Optional*)
   - **fire_event** (*Optional*): Set default `fire_event` for Rflink switch devices (see below).


### PR DESCRIPTION
**Description:**
Remove documentation of automatic_add, it is only supported for rflink.light and rflight.sensor

## Checklist:

- [x] Branch: Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
