### PR TITLE
Update evohome.markdown

### DIFF
--- a/source/_components/evohome.markdown
+++ b/source/_components/evohome.markdown
@@ -29,9 +29,9 @@ To use this component in your installation, add the following to your `configura
 ```yaml
 # Example configuration.yaml entry
 evohome:
-  - username: YOUR_USERNAME
-    password: YOUR_PASSWORD
-    location_idx: 0
+  username: YOUR_USERNAME
+  password: YOUR_PASSWORD
+  location_idx: 0
 ```
 This is a IoT cloud-polling device, and the `scan_interval` is currently fixed at 3 minutes.  Testing has indicated that this is a safe interval that - by itself - shouldn't cause you to be rate-limited by Honeywell.
 


### PR DESCRIPTION
line 32: username has an - which should not be there. There is only one component: Evohome. So username and password and location_idx should be two spaces backwards. As requested. 
This has been tested by me.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
