### PR TITLE
Fixes a typo in duckdns.markdown

### DIFF
--- a/source/_components/duckdns.markdown
+++ b/source/_components/duckdns.markdown
@@ -23,7 +23,7 @@ To use the component in your installation, add the following to your `configurat
 # Example configuration.yaml entry
 duckdns:
   domain: YOUR_SUBDOMAIN
-  access_token: YOUR_ACCSS_TOKEN
+  access_token: YOUR_ACCESS_TOKEN
 ```
 
 {% configuration duckdns %}


### PR DESCRIPTION
**Description:** Just fixes a typo I've noticed, nothing special.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
