### PR TITLE
Change for speedtest, day option removed

### DIFF
--- a/source/_components/sensor.speedtest.markdown
+++ b/source/_components/sensor.speedtest.markdown
@@ -20,7 +20,7 @@ web service to measure network bandwidth performance.
 ## {% linkable_title Configuration %}
 
 By default, it will run every hour. The user can change the update frequency in
-the configuration by defining the minute, hour, and day for a speed test to run.
+the configuration by defining the minute and hour for a speed test to run.
 For the `server_id` check the list of
 [available servers](https://www.speedtest.net/speedtest-servers.php).
 
@@ -55,10 +55,6 @@ sensor:
     description: Specify the speed test server to perform the test against.
     required: false
     type: integer
-  day:
-    description: Specify the day(s) of the month to schedule the speed test. Use a list for multiple entries.
-    required: false
-    type: [int, list]
   hour:
     description: Specify the hour(s) of the day to schedule the speed test. Use a list for multiple entries.
     required: false


### PR DESCRIPTION
**Description:**
This will remove the speedtest "day" configuration.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17452

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
