### PR TITLE
Update Sharp Aquos TV configuration to new style

### DIFF
--- a/source/_components/media_player.aquostv.markdown
+++ b/source/_components/media_player.aquostv.markdown
@@ -27,14 +27,37 @@ media_player:
     host: 192.168.0.10
 ```
 
-Configuration variables:
+{% configuration %}
+host:
+  description: The IP/Hostname of the Sharp Aquos TV, eg. `192.168.0.10`.
+  required: true
+  type: string
+port:
+  description: The port of the Sharp Aquos TV. Defaults to 10002.
+  required: false
+  default: 10002
+  type: int
+username:
+  description: The username of the Sharp Aquos TV. Defaults to admin.
+  required: false
+  default: admin
+  type: string
+password:
+  description: The password of the Sharp Aquos TV. Defaults to password.
+  required: false
+  default: password
+  type: string
+name:
+  description: The name you would like to give to the Sharp Aquos TV.
+  required: false
+  type: string
+power_on_enabled:
+  description: If you want to be able to turn on your TV. Defaults to False.
+  required: false
+  default: false
+  type: string
+{% endconfiguration %}
 
-- **host** (*Required*): The IP/Hostname of the Sharp Aquos TV, eg. `192.168.0.10`.
-- **port** (*Optional*): The port of the Sharp Aquos TV. Defaults to 10002.
-- **username** (*Optional*): The username of the Sharp Aquos TV. Defaults to admin.
-- **password** (*Optional*): The password of the Sharp Aquos TV. Defaults to password.
-- **name** (*Optional*): The name you would like to give to the Sharp Aquos TV.
-- **power_on_enabled** (*Optional*): If you want to be able to turn on your TV. Defaults to False.
 
 <p class='note warning'>
 When you set **power_on_enabled** as True, you have to turn on your TV on the first time with the remote.

--- a/source/_components/media_player.aquostv.markdown
+++ b/source/_components/media_player.aquostv.markdown
@@ -33,17 +33,17 @@ host:
   required: true
   type: string
 port:
-  description: The port of the Sharp Aquos TV. Defaults to 10002.
+  description: The port of the Sharp Aquos TV.
   required: false
   default: 10002
   type: int
 username:
-  description: The username of the Sharp Aquos TV. Defaults to admin.
+  description: The username of the Sharp Aquos TV.
   required: false
   default: admin
   type: string
 password:
-  description: The password of the Sharp Aquos TV. Defaults to password.
+  description: The password of the Sharp Aquos TV.
   required: false
   default: password
   type: string
@@ -52,7 +52,7 @@ name:
   required: false
   type: string
 power_on_enabled:
-  description: If you want to be able to turn on your TV. Defaults to False.
+  description: If you want to be able to turn on your TV.
   required: false
   default: false
   type: string

--- a/source/_components/media_player.aquostv.markdown
+++ b/source/_components/media_player.aquostv.markdown
@@ -55,7 +55,7 @@ power_on_enabled:
   description: If you want to be able to turn on your TV.
   required: false
   default: false
-  type: string
+  type: boolean
 {% endconfiguration %}
 
 


### PR DESCRIPTION
**Description:**
Updates Sharp Aquos TV configuration variables to new style, as per #6385.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
