### PR TITLE
Update Leviton Decora configuration to new style

### DIFF
--- a/source/_components/light.decora.markdown
+++ b/source/_components/light.decora.markdown
@@ -34,12 +34,12 @@ devices:
   required: true
   type: map
   keys:
-    [mac address]:
+    mac_address:
       required: true
       description: The bluetooth address of the switch.
       type: string
       name:
-        description: The custom name to use in the frontend.
+        description: The name to use in the frontend.
         required: false
         type: string
       api_key:

--- a/source/_components/light.decora.markdown
+++ b/source/_components/light.decora.markdown
@@ -28,12 +28,25 @@ light:
         api_key: 0x12345678
 ```
 
-Configuration variables:
-
-- **devices** array (*Required*): A list of lights to use.
-  - **[mac address]** (*Required*): The bluetooth address of the switch.
-    - **name** (*Optional*): The custom name to use in the frontend.
-    - **api_key** (*Required*): The API key to access the device.
+{% configuration %}
+devices:
+  description: A list of lights to use.
+  required: true
+  type: map
+  keys:
+    [mac address]:
+      required: true
+      description: The bluetooth address of the switch.
+      type: string
+      name:
+        description: The custom name to use in the frontend.
+        required: false
+        type: string
+      api_key:
+        description: The API key to access the device.
+        required: true
+        type: string
+{% endconfiguration %}
 
 <p class='note'>
 If you get an error looking like this:


### PR DESCRIPTION
**Description:**
Updates Leviton Decora configuration to new style, as per #6385.  

I'm unfamiliar with configuration variable type 'map', so I will need some extra review of the keys listed.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
