### PR TITLE
Update Google Wifi configuration to new style

### DIFF
--- a/source/_components/sensor.google_wifi.markdown
+++ b/source/_components/sensor.google_wifi.markdown
@@ -16,7 +16,7 @@ ha_release: "0.50"
 
 The `google_wifi` sensor platform is displaying the exposed status of a [Google Wifi](https://madeby.google.com/wifi/) (or OnHub) router.
 
-The sensor is able to report network status, up-time, current IP address, and firmware versions.
+The sensor is able to report network status, up-time, current IP address and firmware versions.
 
 To enable this sensor, add the following lines to your `configuration.yaml` file:
 
@@ -28,12 +28,12 @@ sensor:
 
 {% configuration %}
 host:
-  description: The address to retrieve status from the router. Defaults to `testwifi.here` (other options include `onhub.here` and your router's IP such as `192.168.86.1`).
+  description: The address to retrieve status from the router. Valid options are `testwifi.here`, in some cases `onhub.here` or the router's IP address such as 192.168.86.1.
   required: false
   default: testwifi.here
   type: string
 name:
-  description: Name to give the Google Wifi sensor. Defaults to `google_wifi`.
+  description: Name to give the Google Wifi sensor.
   required: false
   default: google_wifi
   type: string
@@ -45,8 +45,7 @@ monitored_conditions:
     current_version:
       description: Current firmware version of the router.
     new_version:
-      description: Latest available firmware version. If router is up-to-date, this value defaults to `Latest`.
-      default: Latest
+      description: Latest available firmware version. If router is up-to-date, this value shows to `Latest`.
     uptime:
       description: Days since router has been turned on.
     last_restart:

--- a/source/_components/sensor.google_wifi.markdown
+++ b/source/_components/sensor.google_wifi.markdown
@@ -26,15 +26,33 @@ sensor:
   - platform: google_wifi
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The address to retrieve status from the router. Defaults to `testwifi.here` (other options include `onhub.here` and your router's IP such as `192.168.86.1`).
-- **name** (*Optional*): Name to give the Google Wifi sensor. Defaults to `google_wifi`.
-- **monitored_conditions** array (*Optional*): Defines the data to monitor as sensors. Defaults to all of the listed options below.
-  - **current_version**: Current firmware version of the router.
-  - **new_version**: Latest available firmware version. If router is up-to-date, this value defaults to `Latest`.
-  - **uptime**: Days since router has been turned on.
-  - **last_restart**: Date of last restart. Format is `YYYY-MM-DD HH:mm:SS`.
-  - **local_ip**: Local public IP address.
-  - **status**: Reports whether the router is or is not connected to the internet.
-
+{% configuration %}
+host:
+  description: The address to retrieve status from the router. Defaults to `testwifi.here` (other options include `onhub.here` and your router's IP such as `192.168.86.1`).
+  required: false
+  default: testwifi.here
+  type: string
+name:
+  description: Name to give the Google Wifi sensor. Defaults to `google_wifi`.
+  required: false
+  default: google_wifi
+  type: string
+monitored_conditions:
+  description: Defines the data to monitor as sensors. Defaults to all of the listed options below.
+  required: false
+  type: map
+  keys:
+    current_version:
+      description: Current firmware version of the router.
+    new_version:
+      description: Latest available firmware version. If router is up-to-date, this value defaults to `Latest`.
+      default: Latest
+    uptime:
+      description: Days since router has been turned on.
+    last_restart:
+      description: Date of last restart. Format is `YYYY-MM-DD HH:mm:SS`.
+    local_ip:
+      description: Local public IP address.
+    status:
+      description: Reports whether the router is or is not connected to the internet.
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Updates Google Wifi configuration to new style, as per #6385. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
