### PR TITLE
Update google_assistant.markdown

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -30,6 +30,8 @@ To use Google Assistant, your Home Assistant configuration has to be externally 
 Since release 0.80, the `Authorization Code` type of `OAuth` account linking is supported. To migrate your configuration, you need:
 
 1. Change your `Account linking` setting in [Actions on Google console](https://console.actions.google.com/), look for the `Advanced Options` in the bottom left of the sidebar.
+    - Under `Create an Action`, under the build section, modify `Add fulfillment URL` to `https://[YOUR HOME ASSISTANT         URL:PORT]/api/google_assistant`, where `[YOUR HOME ASSISTANT URL:PORT]` is the domain / IP address and the port under which your Home Assistant instance is reachable.
+    
     - Change `Linking type` to `OAuth` and `Authorization Code`.
     - In the `Client information` section:
         - Change `Client ID` to `https://oauth-redirect.googleusercontent.com/`, the trailing slash is important.

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -31,7 +31,6 @@ Since release 0.80, the `Authorization Code` type of `OAuth` account linking is 
 
 1. Change your `Account linking` setting in [Actions on Google console](https://console.actions.google.com/), look for the `Advanced Options` in the bottom left of the sidebar.
     - Under `Create an Action`, under the build section, modify `Add fulfillment URL` to `https://[YOUR HOME ASSISTANT         URL:PORT]/api/google_assistant`, where `[YOUR HOME ASSISTANT URL:PORT]` is the domain / IP address and the port under which your Home Assistant instance is reachable.
-    
     - Change `Linking type` to `OAuth` and `Authorization Code`.
     - In the `Client information` section:
         - Change `Client ID` to `https://oauth-redirect.googleusercontent.com/`, the trailing slash is important.


### PR DESCRIPTION
Needed to make this change, as without this change, HA was giving errors pertaining to Bearer tokens, as Legacy Password was removed from my configuration

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
