### PR TITLE
option to provide an additional UNIX socket for local connection

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -89,6 +89,10 @@ ssl_profile:
   required: false
   type: string
   default: modern
+unix_socket:
+  description: Writeable path to create a UNIX socket.
+  required: false
+  type: string
 {% endconfiguration %}
 
 The sample below shows a configuration entry with possible values:
@@ -114,6 +118,7 @@ http:
     - fd00::/8
   ip_ban_enabled: true
   login_attempts_threshold: 5
+  unix_socket: /run/homeassistant/homeassistant.socket
 ```
 
 The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-using-lets-encrypt/)


### PR DESCRIPTION
## Description:
This adds the ability to create a local UNIX socket. Connecting via a UNIX socket creates less overhead than TCP and also gives a little speed boost (maybe barely noticeable in many setups). Originally the idea was to circumvent the docker networking layers by using a UNIX socket which can be mounted into containers as a docker volume. I am using this code since 3-4 days to run my appdaemon apps and everything ran smoothly in this time. I also created the needed PR for appdaemon, see (will be updated in a second).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant): home-assistant/home-assistant#17489
**Pull request in [appdaemon](https://github.com/home-assistant/appdaemon): home-assistant/appdaemon#386


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17489

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
