### PR TITLE
Fix link to /components/insteon

### DIFF
--- a/source/_components/insteon_local.markdown
+++ b/source/_components/insteon_local.markdown
@@ -15,4 +15,4 @@ ha_version: 0.36
 
 The `insteon_local` component is depreciated and has been replaced by the [insteon] component.
 
-[insteon]: /component/insteon
+[insteon]: /components/insteon


### PR DESCRIPTION
It was missing an 's'

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
