### PR TITLE
Update Yandextts component configuration variable

### DIFF
--- a/source/_components/tts.yandextts.markdown
+++ b/source/_components/tts.yandextts.markdown
@@ -14,18 +14,20 @@ ha_release: 0.36
 
 The `yandextts` text-to-speech platform uses [Yandex SpeechKit](https://tech.yandex.com/speechkit/) Text-to-Speech engine to read a text with natural sounding voices.
 
+## {% linkable_title Configuration %}
+
 To enable text-to-speech with Yandex SpeechKit, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
 tts:
   - platform: yandextts
-    api_key: 'XXXXXXXX'
+    api_key: THE_API_KEY
 ```
 
 {% configuration %}
 api_key:
-  description: API Key for use this service.
+  description: The API Key for use this service.
   required: true
   type: string
 language:
@@ -34,22 +36,22 @@ language:
   default: "`en-US`"
   type: string
 codec:
-  description: "Audio codec. Supported us `mp3`, `wav`, `opus`."
+  description: "The audio codec. Supported us `mp3`, `wav`, `opus`."
   required: false
   default: "`mp3`"
   type: string
 voice:
-  description: "Speaker voice. Supported female voices are `jane`, `oksana`, `alyss`, `omazh` and male voices are `zahar` and `ermil`."
+  description: "The speaker voice. Supported female voices are `jane`, `oksana`, `alyss`, `omazh` and male voices are `zahar` and `ermil`."
   required: false
   default: "`zahar`"
   type: string
 emotion:
-  description: "Speaker emotional intonation. Also supported are `good` (friendly) and `evil` (angry)"
+  description: "The speaker emotional intonation. Also supported are `good` (friendly) and `evil` (angry)"
   required: false
   default: "`neutral`"
   type: string
 speed:
-  description: Speech speed. Highest speed is `3` and lowest `0,1`
+  description: The speech speed. Highest speed is `3` and lowest `0,1`
   required: false
   default: "`1`"
   type: float
@@ -57,7 +59,9 @@ speed:
 
 Please check the [API documentation](https://tech.yandex.com/speechkit/cloud/doc/guide/concepts/tts-http-request-docpage/) for details. It seems that the English version of documentation is outdated. You could request an API key [by email](https://tech.yandex.com/speechkit/cloud/) or [online](https://developer.tech.yandex.ru/).
 
-A full configuration sample:
+## {% linkable_title Full configuration example %}
+
+The configuration sample below show how a entry can look like:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/tts.yandextts.markdown
+++ b/source/_components/tts.yandextts.markdown
@@ -23,14 +23,37 @@ tts:
     api_key: 'XXXXXXXX'
 ```
 
-Configuration variables:
-
-- **api_key** (*Required*): API Key for use this service. 
-- **language** (*Optional*): The language to use. Defaults to `en-US`. Supported `en-US`, `ru-RU`, `uk-UK`, `tr-TR`.
-- **codec** (*Optional*): Audio codec. Default is `mp3`. Supported us `mp3`, `wav`, `opus`.
-- **voice** (*Optional*): Speaker voice. Default is `zahar`. Supported female voices are `jane`, `oksana`, `alyss`, `omazh` and male voices are `zahar` and `ermil`.
-- **emotion** (*Optional*): Speaker emotional intonation. Default is `neutral`. Also supported are `good` (friendly) and `evil` (angry)
-- **speed** (*Optional*): Speech speed. Default value is `1`. Highest speed is `3` and lowest `0,1`
+{% configuration %}
+api_key:
+  description: API Key for use this service.
+  required: true
+  type: string
+language:
+  description: "The language to use. Supported `en-US`, `ru-RU`, `uk-UK`, `tr-TR`."
+  required: false
+  default: "`en-US`"
+  type: string
+codec:
+  description: "Audio codec. Supported us `mp3`, `wav`, `opus`."
+  required: false
+  default: "`mp3`"
+  type: string
+voice:
+  description: "Speaker voice. Supported female voices are `jane`, `oksana`, `alyss`, `omazh` and male voices are `zahar` and `ermil`."
+  required: false
+  default: "`zahar`"
+  type: string
+emotion:
+  description: "Speaker emotional intonation. Also supported are `good` (friendly) and `evil` (angry)"
+  required: false
+  default: "`neutral`"
+  type: string
+speed:
+  description: Speech speed. Highest speed is `3` and lowest `0,1`
+  required: false
+  default: "`1`"
+  type: float
+{% endconfiguration %}
 
 Please check the [API documentation](https://tech.yandex.com/speechkit/cloud/doc/guide/concepts/tts-http-request-docpage/) for details. It seems that the English version of documentation is outdated. You could request an API key [by email](https://tech.yandex.com/speechkit/cloud/) or [online](https://developer.tech.yandex.ru/).
 


### PR DESCRIPTION
**Description:**
Update style of Yandex tts component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
