### PR TITLE
Update Voicerss tts component configuration variable

### DIFF
--- a/source/_components/tts.voicerss.markdown
+++ b/source/_components/tts.voicerss.markdown
@@ -14,18 +14,20 @@ ha_release: 0.35
 
 The `voicerss` text-to-speech platform uses [VoiceRSS](http://www.voicerss.org/) Text-to-Speech engine to read a text with natural sounding voices.
 
+## {% linkable_title Configuration %}
+
 To enable text-to-speech with VoiceRSS, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
 tts:
   - platform: voicerss
-    api_key: 'XXXXXXXX'
+    api_key: YOUR_API_KEY
 ```
 
 {% configuration %}
 api_key:
-  description: API Key for use this service.
+  description: The API Key for VoiceRSS.
   required: true
   type: string
 language:
@@ -34,20 +36,22 @@ language:
   default: "`en-us`"
   type: string
 codec:
-  description: Audio codec.
+  description: The audio codec.
   required: false
   default: mp3
   type: string
 format:
-  description: Audio sample format.
+  description: The audio sample format.
   required: false
   default: 8khz_8bit_mono
   type: string
 {% endconfiguration %}
 
-See on api [documentation](http://www.voicerss.org/api/documentation.aspx) for allow values.
+Check the [VoiceRSS API documentation](http://www.voicerss.org/api/documentation.aspx) for allow values.
 
-A full configuration sample:
+## {% linkable_title Full configuration example %}
+
+The configuration sample below show how a entry can look like:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/tts.voicerss.markdown
+++ b/source/_components/tts.voicerss.markdown
@@ -23,12 +23,27 @@ tts:
     api_key: 'XXXXXXXX'
 ```
 
-Configuration variables:
-
-- **api_key** (*Required*): API Key for use this service.
-- **language** (*Optional*): The language to use. Defaults to `en-us`.
-- **codec** (*Optional*): Audio codec. Default is 'mp3'.
-- **format** (*Optional*): Audio sample format. Default is '8khz_8bit_mono'
+{% configuration %}
+api_key:
+  description: API Key for use this service.
+  required: true
+  type: string
+language:
+  description: The language to use.
+  required: false
+  default: "`en-us`"
+  type: string
+codec:
+  description: Audio codec.
+  required: false
+  default: mp3
+  type: string
+format:
+  description: Audio sample format.
+  required: false
+  default: 8khz_8bit_mono
+  type: string
+{% endconfiguration %}
 
 See on api [documentation](http://www.voicerss.org/api/documentation.aspx) for allow values.
 


### PR DESCRIPTION
**Description:**
Update style of Voicerss tts component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
