### PR TITLE
Update Picotts component configuration variable

### DIFF
--- a/source/_components/tts.picotts.markdown
+++ b/source/_components/tts.picotts.markdown
@@ -24,10 +24,13 @@ tts:
   - platform: picotts
 ```
 
-Configuration variables:
-
-- **language** (*Optional*): The language to use. Defaults to `en-US`. 
-Supported languages : 'en-US', 'en-GB', 'de-DE', 'es-ES', 'fr-FR', 'it-IT'
+{% configuration %}
+language:
+  description: "The language to use. Supported languages : 'en-US', 'en-GB', 'de-DE', 'es-ES', 'fr-FR', 'it-IT'"
+  required: false
+  default: "`en-US`"
+  type: string
+{% endconfiguration %}
 
 A full configuration sample:
 


### PR DESCRIPTION
**Description:**
Update style of Picotts component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
