### PR TITLE
Update Raincloud switch component configuration variable

### DIFF
--- a/source/_components/switch.raincloud.markdown
+++ b/source/_components/switch.raincloud.markdown
@@ -25,9 +25,23 @@ switch:
   - platform: raincloud
 ```
 
-Configuration variables:
-
-- **watering_minutes** (*Optional*): Value in minutes to watering your garden via frontend. Defaults to 15. The values allowed are: 5, 10, 15, 30, 45, 60.
-- **monitored_conditions** array (*Optional*): Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
-  - **auto_watering**: Toggle the watering scheduled per zone.
-  - **manual_watering**: Toggle manually the watering per zone. It will inherent the value in minutes specified on the RainCloud hub component.
+{% configuration %}
+watering_minutes:
+  description: "Value in minutes to watering your garden via frontend. The values allowed are: 5, 10, 15, 30, 45, 60."
+  required: false
+  default: 15
+  type: integer
+monitored_conditions:
+  description: Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
+  required: false
+  type: list
+  keys:
+    auto_watering:
+      description: Toggle the watering scheduled per zone.
+      required: false
+      type: boolean
+    manual_watering:
+      description: Toggle manually the watering per zone. It will inherent the value in minutes specified on the RainCloud hub component.
+      required: false
+      type: boolean
+{% endconfiguration %}

--- a/source/_components/switch.raincloud.markdown
+++ b/source/_components/switch.raincloud.markdown
@@ -13,11 +13,11 @@ ha_release: "0.55"
 ha_iot_class: "Cloud Polling"
 ---
 
-To get your [Melnor RainCloud](https://wifiaquatimer.com) binary sensors working within Home Assistant, please follow the instructions for the general [Raincloud component](/components/raincloud).
+To get your [Melnor RainCloud](https://wifiaquatimer.com) binary sensors working within Home Assistant, please follow the instructions for the general [Raincloud component](/components/raincloud/).
 
 ## {% linkable_title Configuration %}
 
-Once you have enabled the [Raincloud component](/components/raincloud), add the following to your `configuration.yaml` file:
+Once you have enabled the [Raincloud component](/components/raincloud/), add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -32,7 +32,7 @@ watering_minutes:
   default: 15
   type: integer
 monitored_conditions:
-  description: Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
+  description: Conditions to display in the frontend. If not specified, all conditions below will be enabled by default.
   required: false
   type: list
   keys:


### PR DESCRIPTION
**Description:**
Update style of Raincloud switch component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
