### PR TITLE
Update Rainbird switch component configuration variable

### DIFF
--- a/source/_components/switch.rainbird.markdown
+++ b/source/_components/switch.rainbird.markdown
@@ -35,11 +35,23 @@ switch:
         scan_interval: 10
 ```
 
-Configuration variables:
-
-- **zone** (*Required*): Station zone identifier.
-- **friendly_name** (*Optional*): Just a friendly name for the station.
-- **trigger_time** (*Required*): The default duration to sprinkle the zone.
-- **scan_interval** (*Optional*): How fast to refresh the switch.
+{% configuration %}
+zone:
+  description: Station zone identifier.
+  required: true
+  type: string
+friendly_name:
+  description: Just a friendly name for the station.
+  required: false
+  type: string
+trigger_time:
+  description: The default duration to sprinkle the zone.
+  required: true
+  type: integer
+scan_interval:
+  description: How fast to refresh the switch.
+  required: false
+  type: integer
+{% endconfiguration %}
 
 Please note that due to the implementation of the API within the LNK Module, there is a concurrency issue. For example, the Rain Bird app will give connection issues (like already a connection active).


### PR DESCRIPTION
**Description:**
Update style of Rainbird switch component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
