### PR TITLE
Update Flexit climate component configuration variable

### DIFF
--- a/source/_components/climate.flexit.markdown
+++ b/source/_components/climate.flexit.markdown
@@ -26,10 +26,16 @@ climate:
     slave: 21
 ```
 
-Configuration variables:
-
-- **slave** (*Required*): The slave ID of the modbus adapter, set using DIP-switches.
-- **name** (*Optional*): Displayed name of the A/C unit
+{% configuration %}
+slave:
+  description: The slave ID of the modbus adapter, set using DIP-switches.
+  required: true
+  type: integer
+name:
+  description: Displayed name of the A/C unit.
+  required: false
+  type: string
+{% endconfiguration %}
 
 <p class='note'>
 This component requires the [Modbus](/components/modbus/) component to be set up to work


### PR DESCRIPTION
**Description:**
Update style of Flexit climate component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
