### PR TITLE
Update Heatmiser climate component configuration variable

### DIFF
--- a/source/_components/climate.heatmiser.markdown
+++ b/source/_components/climate.heatmiser.markdown
@@ -22,7 +22,7 @@ To set it up, add the following information to your `configuration.yaml` file:
 ```yaml
 climate:
   - platform: heatmiser
-    ipaddress: YOUR_IPADDRESS
+    ipaddress: YOUR_IP_ADDRESS
     port: YOUR_PORT
     tstats:
       - 1:
@@ -34,7 +34,7 @@ A single interface can handle up to 32 connected devices.
 
 {% configuration %}
 ipaddress:
-  description: The ip address of your interface.
+  description: The IP address of your interface.
   required: true
   type: string
 port:
@@ -47,7 +47,7 @@ tstats:
   type: list
   keys:
     id:
-      description: The id of the thermostat as configured on the device itself.
+      description: The ID of the thermostat as configured on the device itself.
       required: true
       type: string
     name:

--- a/source/_components/climate.heatmiser.markdown
+++ b/source/_components/climate.heatmiser.markdown
@@ -13,7 +13,6 @@ ha_release: "0.10"
 ha_iot_class: "Local Polling"
 ---
 
-
 The `heatmiser` climate platform let you control [Heatmiser DT/DT-E/PRT/PRT-E](http://www.heatmisershop.co.uk/heatmiser-slimline-programmable-room-thermostat/) thermostats from Heatmiser. The module itself is currently setup to work over a RS232 -> RS485 converter, therefore it connects over IP.
 
 Further work would be required to get this setup to connect over Wifi, but the HeatmiserV3 python module being used is a full implementation of the V3 protocol.

--- a/source/_components/climate.heatmiser.markdown
+++ b/source/_components/climate.heatmiser.markdown
@@ -33,10 +33,26 @@ climate:
 
 A single interface can handle up to 32 connected devices.
 
-Configuration variables:
-
-- **ipaddress** (*Required*): The ip address of your interface.
-- **port** (*Required*): The port that the interface is listening on.
-- **tstats** (*Required*): A list of thermostats activated on the gateway.
-- **id** (*Required*): The id of the thermostat as configured on the device itself
-- **name** (*Required*): A friendly name for the thermostat
+{% configuration %}
+ipaddress:
+  description: The ip address of your interface.
+  required: true
+  type: string
+port:
+  description: The port that the interface is listening on.
+  required: true
+  type: integer
+tstats:
+  description: A list of thermostats activated on the gateway.
+  required: true
+  type: list
+  keys:
+    id:
+      description: The id of the thermostat as configured on the device itself.
+      required: true
+      type: string
+    name:
+      description: A friendly name for the thermostat.
+      required: true
+      type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Heatmiser climate component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
