### PR TITLE
Sensible documentation change

### DIFF
--- a/source/_components/climate.sensibo.markdown
+++ b/source/_components/climate.sensibo.markdown
@@ -21,7 +21,7 @@ To enable this platform, add the following lines to your `configuration.yaml` fi
 # Example configuration.yaml entry
 climate:
   - platform: sensibo
-    api_key: <your_key_here>
+    api_key: YOUR_API_KEY
 ```
 
 {% configuration %}
@@ -45,7 +45,7 @@ done in the app and actions done by Home Assistant.
 ```yaml
 climate:
   - platform: sensibo
-    api_key: paste_your_api_key_here
+    api_key: YOUR_API_KEY
     id:
       - id1
       - id2

--- a/source/_components/climate.sensibo.markdown
+++ b/source/_components/climate.sensibo.markdown
@@ -45,7 +45,7 @@ done in the app and actions done by Home Assistant.
 ```yaml
 climate:
   - platform: sensibo
-    api_key: deadbeaf
+    api_key: paste_your_api_key_here
     id:
       - id1
       - id2


### PR DESCRIPTION
I updated the sample API key in the documentation to something more beginner friendly to understand.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
