### PR TITLE
LimitlessLed port number and version formatting correction

### DIFF
--- a/source/_components/light.limitlessled.markdown
+++ b/source/_components/light.limitlessled.markdown
@@ -61,7 +61,7 @@ Configuration variables:
 - **bridges** array (*Required*):
   - **host** (*Required*): IP address of the device, eg. `192.168.1.32`
   - **version** (*Optional*): Bridge version (default is `6`).
-  - **port** (*Optional*): Bridge port. Defaults to 5987. For older bridges than v6 choose `8899`.
+  - **port** (*Optional*): Bridge port. Defaults to `5987`. For older bridges than `v6` choose `8899`.
   - **groups** array (*Required*): The list of available groups.
     - **number** (*Required*): Group number (`1`-`4`). Corresponds to the group number on the remote. These numbers may overlap only if the type is different.
     - **name** (*Required*): Any name you'd like. Must be unique among all configured groups.


### PR DESCRIPTION
**Description:**
Correction of the port number and version formatting to match with the rest of the limitlessled documentation and follow the documentation standard.

## Checklist:

- [X ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
