### PR TITLE
Correcting name in Mi Repeater device tracker

### DIFF
--- a/source/_components/device_tracker.xiaomi_miio.markdown
+++ b/source/_components/device_tracker.xiaomi_miio.markdown
@@ -17,7 +17,7 @@ The `xiaomi_miio` device tracker platform is observing your Xiaomi Mi WiFi Repea
 
 Please follow the instructions on [Retrieving the Access Token](/components/vacuum.xiaomi_miio/#retrieving-the-access-token) to get the API token.
 
-To add a Xiaomi Mi Air Quality Monitor to your installation, add the following to your `configuration.yaml` file:
+To add a Xiaomi Mi WiFi Repeater device tracker to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 device_tracker:


### PR DESCRIPTION
**Description:**
Correction of a wrong reference to the mi air quality monitor in Mi WiFi Repeater device tracker documentation.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
