### PR TITLE
Documentation for home-assistant/home-assistant-polymer#1779

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -90,6 +90,33 @@ service_data:
   type: object
 {% endconfiguration %}
 
+### {% linkable_title Divider %}
+
+{% configuration %}
+type:
+  required: true
+  description: divider
+  type: string
+style:
+  required: false
+  description: Style the element using CSS.
+  type: object
+  default: "height: 1px, background-color: var(--secondary-text-color)"
+{% endconfiguration %}
+
+### {% linkable_title Section %}
+
+{% configuration %}
+type:
+  required: true
+  description: section
+  type: string
+Label:
+  required: false
+  description: Section label
+  type: string
+{% endconfiguration %}
+
 ### {% linkable_title Weblink %}
 
 {% configuration %}
@@ -109,20 +136,6 @@ url:
   required: true
   description: "Website URL (or internal URL e.g. `/hassio/dashboard` or `/panel_custom_name`)"
   type: string
-{% endconfiguration %}
-
-### {% linkable_title Divider %}
-
-{% configuration %}
-type:
-  required: true
-  description: divider
-  type: string
-style:
-  required: false
-  description: Style the element using CSS.
-  type: object
-  default: "height: 1px, background-color: var(--secondary-text-color)"
 {% endconfiguration %}
 
 ## {% linkable_title Example %}


### PR DESCRIPTION
**Description:**
Documentation for the label row in lovelace.
I also changed the order of the special rows. They are now alphabetical.

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer):** home-assistant/home-assistant-polymer#1779

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
