### PR TITLE
Update Radiotherm climate component configuration variable

### DIFF
--- a/source/_components/climate.radiotherm.markdown
+++ b/source/_components/climate.radiotherm.markdown
@@ -46,9 +46,9 @@ away_temperature_cool:
   default: 85
   type: float
 hold_temp:
-  description: Boolean to control if Home Assistant temperature adjustments hold (`True`) or are temporary (`False`).
+  description: Boolean to control if Home Assistant temperature adjustments hold (`true`) or are temporary (`false`).
   required: false
-  default: "`False`"
+  default: false
   type: boolean
 {% endconfiguration %}
 

--- a/source/_components/climate.radiotherm.markdown
+++ b/source/_components/climate.radiotherm.markdown
@@ -30,12 +30,27 @@ climate:
   - platform: radiotherm
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): List of your Radiotherm thermostats. If not provided the thermostats will be auto-detected.
-- **away_temperature_heat** (*Optional*): Target heating temperature in Fahrenheit for away mode. This is separate from away mode in the app. Defaults to '60'.
-- **away_temperature_cool** (*Optional*): Target cooling temperature in Fahrenheit for away mode. This is separate from away mode in the app. Defaults to '85'.
-- **hold_temp** (*Optional*): Boolean to control if Home Assistant temperature adjustments hold (`True`) or are temporary (`False`). Defaults to `False`.
+{% configuration %}
+host:
+  description: List of your Radiotherm thermostats. If not provided the thermostats will be auto-detected.
+  required: false
+  type: list
+away_temperature_heat:
+  description: Target heating temperature in Fahrenheit for away mode. This is separate from away mode in the app.
+  required: false
+  default: 60
+  type: float
+away_temperature_cool:
+  description: Target cooling temperature in Fahrenheit for away mode. This is separate from away mode in the app.
+  required: false
+  default: 85
+  type: float
+hold_temp:
+  description: Boolean to control if Home Assistant temperature adjustments hold (`True`) or are temporary (`False`).
+  required: false
+  default: "`False`"
+  type: boolean
+{% endconfiguration %}
 
 Set `hold_temp: True` if you want temperature settings from Home Assistant to override a thermostat schedule on the thermostat itself. Otherwise Home Assistant will perform temporary temperature changes.
 


### PR DESCRIPTION
**Description:**
Update style of Radiotherm climate component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
