### PR TITLE
 Update Raspihats component configuration variable

### DIFF
--- a/source/_components/binary_sensor.raspihats.markdown
+++ b/source/_components/binary_sensor.raspihats.markdown
@@ -35,16 +35,45 @@ binary_sensor:
             name: PIR Bedroom
 ```
 
-Configuration variables:
-
-- **i2c_hats** (*Optional*): Array of used I2C-HATs.
-  - **board** (*Required*): The board name [Di16, Di6Rly6, DI16ac, DI6acDQ6rly].
-  - **address** (*Required*): The board I2C address, hex value.
-    - **channels** (*Required*): Array of used digital input channels.
-      - **index** (*Required*): Digital input channel index.
-      - **name** (*Required*): Friendly name to use for the frontend.
-      - **invert_logic** (*Optional*): Inverts the input logic, default is `false`.
-      - **device_class** (*Optional*): See device classes in [binary_sensor component](/components/binary_sensor/), default is `None`
+{% configuration %}
+i2c_hats:
+  description: Array of used I2C-HATs.
+  required: false
+  type: list
+  keys:
+    board:
+      description: The board name [Di16, Di6Rly6, DI16ac, DI6acDQ6rly].
+      required: true
+      type: string
+    address:
+      description: The board I2C address, hex value.
+      required: true
+      type: string
+      keys:
+        channels:
+          description: Array of used digital input channels.
+          required: true
+          type: list
+          keys:
+            index:
+              description: Digital input channel index.
+              required: true
+              type: integer
+            name:
+              description: Friendly name to use for the frontend.
+              required: true
+              type: string
+            invert_logic:
+              description: Inverts the input logic.
+              required: false
+              default: "`false`"
+              type: boolean
+            device_class:
+              description: See device classes in [binary_sensor component](/components/binary_sensor/).
+              required: false
+              default: "`None`"
+              type: string
+{% endconfiguration %}
 
 ## {% linkable_title Directions for installing smbus support on Raspberry Pi %}
 

--- a/source/_components/binary_sensor.raspihats.markdown
+++ b/source/_components/binary_sensor.raspihats.markdown
@@ -37,16 +37,16 @@ binary_sensor:
 
 {% configuration %}
 i2c_hats:
-  description: Array of used I2C-HATs.
+  description: An array of used I2C-HATs.
   required: false
   type: list
   keys:
     board:
-      description: The board name [Di16, Di6Rly6, DI16ac, DI6acDQ6rly].
+      description: The board name either Di16, Di6Rly6, DI16ac or DI6acDQ6rly.
       required: true
       type: string
     address:
-      description: The board I2C address, hex value.
+      description: The board I2C address as HEX value.
       required: true
       type: string
       keys:
@@ -66,12 +66,12 @@ i2c_hats:
             invert_logic:
               description: Inverts the input logic.
               required: false
-              default: "`false`"
+              default: false
               type: boolean
             device_class:
               description: See device classes in [binary_sensor component](/components/binary_sensor/).
               required: false
-              default: "`None`"
+              default: "None"
               type: string
 {% endconfiguration %}
 

--- a/source/_components/binary_sensor.raspihats.markdown
+++ b/source/_components/binary_sensor.raspihats.markdown
@@ -49,30 +49,29 @@ i2c_hats:
       description: The board I2C address as HEX value.
       required: true
       type: string
+    channels:
+      description: Array of used digital input channels.
+      required: true
+      type: list
       keys:
-        channels:
-          description: Array of used digital input channels.
+        index:
+          description: Digital input channel index.
           required: true
-          type: list
-          keys:
-            index:
-              description: Digital input channel index.
-              required: true
-              type: integer
-            name:
-              description: Friendly name to use for the frontend.
-              required: true
-              type: string
-            invert_logic:
-              description: Inverts the input logic.
-              required: false
-              default: false
-              type: boolean
-            device_class:
-              description: See device classes in [binary_sensor component](/components/binary_sensor/).
-              required: false
-              default: "None"
-              type: string
+          type: integer
+        name:
+          description: Friendly name to use for the frontend.
+          required: true
+          type: string
+        invert_logic:
+          description: Inverts the input logic.
+          required: false
+          default: false
+          type: boolean
+        device_class:
+          description: See device classes in [binary_sensor component](/components/binary_sensor/).
+          required: false
+          default: "None"
+          type: string
 {% endconfiguration %}
 
 ## {% linkable_title Directions for installing smbus support on Raspberry Pi %}

--- a/source/_components/switch.raspihats.markdown
+++ b/source/_components/switch.raspihats.markdown
@@ -50,30 +50,29 @@ i2c_hats:
       description: The board I2C address as HEX value.
       required: true
       type: string
+    channels:
+      description: An array of used digital input channels.
+      required: true
+      type: list
       keys:
-        channels:
-          description: An array of used digital input channels.
+        index:
+          description: The digital input channel index.
           required: true
-          type: list
-          keys:
-            index:
-              description: The digital input channel index.
-              required: true
-              type: integer
-            name:
-              description: The friendly name to use for the frontend.
-              required: true
-              type: string
-            invert_logic:
-              description: Inverts the input logic.
-              required: false
-              default: false
-              type: boolean
-            initial_state:
-              description: "The initial state, can be either `true` or `false`. `none` means no state is forced on the corresponding digital output when this switch is instantiated."
-              required: false
-              default: None
-              type: boolean
+          type: integer
+        name:
+          description: The friendly name to use for the frontend.
+          required: true
+          type: string
+        invert_logic:
+          description: Inverts the input logic.
+          required: false
+          default: false
+          type: boolean
+        initial_state:
+          description: "The initial state, can be either `true` or `false`. `none` means no state is forced on the corresponding digital output when this switch is instantiated."
+          required: false
+          default: None
+          type: boolean
 {% endconfiguration %}
 
 ## {% linkable_title Directions for installing smbus support on Raspberry Pi %}

--- a/source/_components/switch.raspihats.markdown
+++ b/source/_components/switch.raspihats.markdown
@@ -36,17 +36,45 @@ switch:
             name: Light Office
 ```
 
-Configuration variables:
-
-- **i2c_hats** (*Optional*): Array of used I2C-HATs.
-  - **board** (*Required*): The board name.
-  - **address** (*Required*): The board I2C address, hex value.
-    - **channels** (*Required*): Array of used digital output channels.
-      - **index** (*Required*): Digital output channel index.
-      - **name** (*Required*): Friendly name to use for the frontend.
-      - **invert_logic** (*Optional*): Inverts the output logic, default is `False`.
-      - **initial_state** (*Optional*): Initial state, default is `None`, can also be `True` or `False`. `None` means no state is forced on the corresponding digital output when this switch is instantiated.
-
+{% configuration %}
+i2c_hats:
+  description: Array of used I2C-HATs.
+  required: false
+  type: list
+  keys:
+    board:
+      description: The board name.
+      required: true
+      type: string
+    address:
+      description: The board I2C address, hex value.
+      required: true
+      type: string
+      keys:
+        channels:
+          description: Array of used digital input channels.
+          required: true
+          type: list
+          keys:
+            index:
+              description: Digital input channel index.
+              required: true
+              type: integer
+            name:
+              description: Friendly name to use for the frontend.
+              required: true
+              type: string
+            invert_logic:
+              description: Inverts the input logic.
+              required: false
+              default: "`false`"
+              type: boolean
+            initial_state:
+              description: Initial state, can also be `True` or `False`. `None` means no state is forced on the corresponding digital output when this switch is instantiated.
+              required:
+              default: "`None`"
+              type: boolean
+{% endconfiguration %}
 
 ## {% linkable_title Directions for installing smbus support on Raspberry Pi %}
 

--- a/source/_components/switch.raspihats.markdown
+++ b/source/_components/switch.raspihats.markdown
@@ -70,7 +70,7 @@ i2c_hats:
               default: false
               type: boolean
             initial_state:
-              description: Initial state, can also be `true` or `false`. `none` means no state is forced on the corresponding digital output when this switch is instantiated.
+              description: "The initial state, can also be `true` or `false`. `none` means no state is forced on the corresponding digital output when this switch is instantiated."
               required:
               default: "None"
               type: boolean

--- a/source/_components/switch.raspihats.markdown
+++ b/source/_components/switch.raspihats.markdown
@@ -57,22 +57,17 @@ i2c_hats:
           type: list
           keys:
             index:
-              description: Digital input channel index.
+              description: The digital input channel index.
               required: true
               type: integer
             name:
-              description: Friendly name to use for the frontend.
+              description: The friendly name to use for the frontend.
               required: true
               type: string
             invert_logic:
               description: Inverts the input logic.
               required: false
               default: false
-              type: boolean
-            initial_state:
-              description: "The initial state, can also be `true` or `false`. `none` means no state is forced on the corresponding digital output when this switch is instantiated."
-              required:
-              default: "None"
               type: boolean
 {% endconfiguration %}
 

--- a/source/_components/switch.raspihats.markdown
+++ b/source/_components/switch.raspihats.markdown
@@ -69,6 +69,11 @@ i2c_hats:
               required: false
               default: false
               type: boolean
+            initial_state:
+              description: "The initial state, can be either `true` or `false`. `none` means no state is forced on the corresponding digital output when this switch is instantiated."
+              required:
+              default: None
+              type: boolean
 {% endconfiguration %}
 
 ## {% linkable_title Directions for installing smbus support on Raspberry Pi %}

--- a/source/_components/switch.raspihats.markdown
+++ b/source/_components/switch.raspihats.markdown
@@ -38,7 +38,7 @@ switch:
 
 {% configuration %}
 i2c_hats:
-  description: Array of used I2C-HATs.
+  description: An array of used I2C-HATs.
   required: false
   type: list
   keys:
@@ -47,12 +47,12 @@ i2c_hats:
       required: true
       type: string
     address:
-      description: The board I2C address, hex value.
+      description: The board I2C address as HEX value.
       required: true
       type: string
       keys:
         channels:
-          description: Array of used digital input channels.
+          description: An array of used digital input channels.
           required: true
           type: list
           keys:
@@ -67,12 +67,12 @@ i2c_hats:
             invert_logic:
               description: Inverts the input logic.
               required: false
-              default: "`false`"
+              default: false
               type: boolean
             initial_state:
-              description: Initial state, can also be `True` or `False`. `None` means no state is forced on the corresponding digital output when this switch is instantiated.
+              description: Initial state, can also be `true` or `false`. `none` means no state is forced on the corresponding digital output when this switch is instantiated.
               required:
-              default: "`None`"
+              default: "None"
               type: boolean
 {% endconfiguration %}
 

--- a/source/_components/switch.raspihats.markdown
+++ b/source/_components/switch.raspihats.markdown
@@ -71,7 +71,7 @@ i2c_hats:
               type: boolean
             initial_state:
               description: "The initial state, can be either `true` or `false`. `none` means no state is forced on the corresponding digital output when this switch is instantiated."
-              required:
+              required: false
               default: None
               type: boolean
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Raspihats component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
