### PR TITLE
Add message template support for alert component

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -44,6 +44,7 @@ alert:
     repeat: 30
     can_acknowledge: True
     skip_first: True
+    include_problem: True
     notifiers:
       - ryans_phone
       - kristens_phone
@@ -84,6 +85,13 @@ skip_first:
   description: >
     Controls whether the notification should be
     sent immediately or after the first delay.
+  required: false
+  type: boolean
+  default: false
+include_problem:
+  description: >
+    Controls whether the notification should contain
+    the problem, if provided by the entity.
   required: false
   type: boolean
   default: false

--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -51,13 +51,13 @@ alert:
 
 {% configuration %}
 name:
-  description: The friendly name of the alert. This can include a [template][template].
+  description: The friendly name of the alert.
   required: true
   type: string
 done_message:
   description: >
     A message sent after an alert transitions from `on` to `off`. Is only sent
-    if an alert notification was sent for transitioning from `off` to `on`. This can include a [template][template].
+    if an alert notification was sent for transitioning from `off` to `on`.
   required: false
   type: string
 entity_id:
@@ -191,5 +191,3 @@ sent 30 minutes after that, and a 60 minute delay will fall between every
 following notification.
 For example, if the garage door opens at 2:00, a notification will be
 sent at 2:15, 2:45, 3:45, 4:45, etc., continuing every 60 minutes.
-
-[template]: /docs/configuration/templating/

--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -44,7 +44,6 @@ alert:
     repeat: 30
     can_acknowledge: True
     skip_first: True
-    include_problem: True
     notifiers:
       - ryans_phone
       - kristens_phone
@@ -85,13 +84,6 @@ skip_first:
   description: >
     Controls whether the notification should be
     sent immediately or after the first delay.
-  required: false
-  type: boolean
-  default: false
-include_problem:
-  description: >
-    Controls whether the notification should contain
-    the problem, if provided by the entity.
   required: false
   type: boolean
   default: false

--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -54,12 +54,6 @@ name:
   description: The friendly name of the alert.
   required: true
   type: string
-done_message:
-  description: >
-    A message sent after an alert transitions from `on` to `off`. Is only sent
-    if an alert notification was sent for transitioning from `off` to `on`.
-  required: false
-  type: string
 entity_id:
   description: The ID of the entity to watch.
   required: true
@@ -87,6 +81,19 @@ skip_first:
   required: false
   type: boolean
   default: false
+message:
+  description: >
+    A message to be sent after an alert transitions from `of` to `on`
+    with [template][template] support.
+  required: false
+  type: template
+done_message:
+  description: >
+    A message sent after an alert transitions from `on` to `off` with 
+    [template][template] support. Is only sent if an alert notification 
+    was sent for transitioning from `off` to `on`.
+  required: false
+  type: template
 notifiers:
   description: "List of `notification` components to use for alerts."
   required: true
@@ -191,3 +198,30 @@ sent 30 minutes after that, and a 60 minute delay will fall between every
 following notification.
 For example, if the garage door opens at 2:00, a notification will be
 sent at 2:15, 2:45, 3:45, 4:45, etc., continuing every 60 minutes.
+
+### {% linkable_title Message Templates %}
+
+It may be desirable to have the alert notifications include information
+about the state of the entity.
+The following will show for a plant how to include the problem `attribute`
+of the entity.
+
+```yaml
+# Example configuration.yaml entry
+  office_plant:
+    name: Plant in office needs help
+    entity_id: plant.plant_office
+    state: 'problem'
+    repeat: 30
+    can_acknowledge: True
+    skip_first: True
+    message: "Plant {{ states.plant.plant_office }} needs help ({{ state_attr('plant.plant_office', 'problem') }})"
+    done_message: Plant in office is fine
+    notifiers:
+      - ryans_phone
+      - kristens_phone
+```
+
+The resulting message could be `Plant Officeplant needs help (moisture low)`.
+
+[template]: /docs/configuration/templating/


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17516

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
