### PR TITLE
Add BlueStacks method for retrieving device token

### DIFF
--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -258,3 +258,10 @@ To fetch the token follow these instructions depending on your mobile phone plat
 12. Copy the returned 32-digit hexadecimal string to your clipboard.
 13. Open `Terminal` and execute this command: `echo '0: <YOUR HEXADECIMAL STRING>' | xxd -r -p | openssl enc -d -aes-128-ecb -nopad -nosalt -K 00000000000000000000000000000000`
 14. Use the resulting string as your token.
+
+#### {% linkable_title Bluestacks %}
+
+1. Configure the robot with the Mi-Home app.
+2. Install [BlueStacks](https://www.bluestacks.com)
+3. Setup Mi-Home app in BlueStacks and login to synchronize devices
+4. Use [BlueStacks Tweaker](https://forum.xda-developers.com/general/general/bluestacks-tweaker-2-tool-modifing-t3622681) to access the filesystem and retrieve the token

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -29,7 +29,7 @@ Currently supported services are:
 Please follow [Retrieving the Access Token](/components/vacuum.xiaomi_miio/#retrieving-the-access-token) to retrieve the API token used in
 `configuration.yaml`.
 
-## {% linkable_title Configuring the Platform %}
+## {% linkable_title Configuration %}
 
 To add a vacuum to your installation, add the following to `configuration.yaml`:
 
@@ -42,7 +42,7 @@ vacuum:
 
 {% configuration %}
   host:
-    description: The IP of your robot.
+    description: The IP address of your robot.
     required: true
     type: string
   token:
@@ -262,6 +262,6 @@ To fetch the token follow these instructions depending on your mobile phone plat
 #### {% linkable_title Bluestacks %}
 
 1. Configure the robot with the Mi-Home app.
-2. Install [BlueStacks](https://www.bluestacks.com)
-3. Setup Mi-Home app in BlueStacks and login to synchronize devices
-4. Use [BlueStacks Tweaker](https://forum.xda-developers.com/general/general/bluestacks-tweaker-2-tool-modifing-t3622681) to access the filesystem and retrieve the token
+2. Install [BlueStacks](https://www.bluestacks.com).
+3. Set up the Mi-Home app in BlueStacks and login to synchronize devices.
+4. Use [BlueStacks Tweaker](https://forum.xda-developers.com/general/general/bluestacks-tweaker-2-tool-modifing-t3622681) to access the filesystem and retrieve the token.


### PR DESCRIPTION
**Description:**

An access token can also retrieved using BlueStacks which doesn't require tempering with the smartphone.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
