### PR TITLE
Fix sensor.google_travel_time automation update example

### DIFF
--- a/source/_components/sensor.google_travel_time.markdown
+++ b/source/_components/sensor.google_travel_time.markdown
@@ -115,5 +115,6 @@ You can also use the `sensor.google_travel_sensor_update` service to update the 
         - fri
   action:
     - service: sensor.google_travel_sensor_update
-      entity_id: sensor.morning_commute
+      data:
+        entity_id: sensor.morning_commute
 ```


### PR DESCRIPTION
**Description:**
The automation rule example provided in the documentation for this sensor is currently wrong and doesn't work (data block is missing in action). 

Added data block in action, to fix it.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17092

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
