### PR TITLE
Discord configuration variable format

### DIFF
--- a/source/_components/notify.discord.markdown
+++ b/source/_components/notify.discord.markdown
@@ -29,7 +29,7 @@ notify:
 
 {% configuration %}
 name:
-  description: The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  description: The notifier will bind to the service `notify.NAME`.
   required: false
   type: string
   default: notify

--- a/source/_components/notify.discord.markdown
+++ b/source/_components/notify.discord.markdown
@@ -23,15 +23,21 @@ To use Discord notifications, add the following to your `configuration.yaml` fil
 ```yaml
 # Example configuration.yaml entry
 notify:
-  - name: NOTIFIER_NAME
-    platform: discord
-    token: A1aB2b.C3cD4d-E5eF6f
+  - platform: discord
+    token: YOUR_DISCORD_BOT_TOKEN
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **token** (*Required*): Your bot's token.
+{% configuration %}
+name:
+  description: The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  type: string
+  default: notify
+token:
+  description: Your bot's token.
+  required: true
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title Setting up the bot %}
 


### PR DESCRIPTION
Fix configuration variable format.
Modify example configuration.yaml snippet to be generic.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
