### PR TITLE
Add note to telegram setup on getting new chat ids

### DIFF
--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -15,6 +15,8 @@ ha_release: 0.7.5
 
 The `telegram` platform uses [Telegram](https://web.telegram.org) to deliver notifications from Home Assistant to your Android device, your Windows phone, or your iOS device.
 
+## {% linkable_title Setup %}
+
 The requirements are:
 
 - You need a [Telegram bot](https://core.telegram.org/bots). Please follow those [instructions](https://core.telegram.org/bots#6-botfather) to create one and get the token for your bot. Keep in mind that bots are not allowed to contact users. You need to make the first contact with your user. Meaning that you need to send a message to the bot from your user.
@@ -65,8 +67,11 @@ $ python3
 123456789
 ```
 
-Note: 
-If you want to add new CHAT IDs, you will need to disable the active configuration to actually see the result with the IDs, otherwise you may only get empty results array in the json.
+<p class='note'>
+If you want to add new chat IDs then you will need to disable the active configuration to actually see the result with the IDs, otherwise you may only get empty results array.
+</p>
+
+## {% linkable_title Configuration %}
 
 To enable Telegram notifications in your installation, add the following to your `configuration.yaml` file:
 
@@ -86,7 +91,6 @@ notify:
     platform: telegram
     chat_id: CHAT_ID_2
 ```
-
 
 {% configuration %}
 name:

--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -65,6 +65,9 @@ $ python3
 123456789
 ```
 
+Note: 
+If you want to add new CHAT IDs, you will need to disable the active configuration to actually see the result with the IDs, otherwise you may only get empty results array in the json.
+
 To enable Telegram notifications in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -83,6 +86,7 @@ notify:
     platform: telegram
     chat_id: CHAT_ID_2
 ```
+
 
 {% configuration %}
 name:


### PR DESCRIPTION
Ran into a constant empty results array when trying to retrieve new chat ids after it was set up in home assitant, added a note before configuration

**Description:**
 Added note to documentation on telegram bot for getting CHAT IDs after it has been setup in Home Assistant

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ x ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ x ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
