### PR TITLE
Remove status sensor from blink

### DIFF
--- a/source/_components/blink.markdown
+++ b/source/_components/blink.markdown
@@ -62,7 +62,7 @@ sensors:
       description: The conditions to create sensors from.
       required: false
       type: list
-      default: all (`battery`, `temperature`, `status`, `wifi_strength`)
+      default: all (`battery`, `temperature`, `wifi_strength`)
 {% endconfiguration %}
 
 Once Home Assistant starts, the `blink` component will create the following platforms:
@@ -74,11 +74,7 @@ Once Home Assistant starts, the `blink` component will create the following plat
 
 Since the cameras are battery operated, setting the `scan_interval` must be done with care so as to not drain the battery too quickly, or hammer Blink's servers with too many API requests.  The cameras can be manually updated via the `trigger_camera` service which will ignore the throttling caused by `scan_interval`.  As a note, all of the camera-specific sensors are only polled when a new image is requested from the camera. This means that relying on any of these sensors to provide timely and accurate data is not recommended.
 
-Please note that each camera reports two different states: one as `sensor.blink_<camera_name>_status` and the other as `binary_sensor.blink_<camera_name>_motion_enabled`. The `motion_enabled` property reports if the `camera` is ready to detect motion *regardless if the system is actually armed**. The `status` property is more descriptive, and can be one of the following states:
-
-- `disabled`: System is disabled.
-- `disarmed`: Camera and/or system are disarmed and not ready to detect motion.
-- `armed`: System and camera are armed and detecting motion.
+Please note that each camera reports two different states: one as `sensor.blink_<camera_name>_status` and the other as `binary_sensor.blink_<camera_name>_motion_enabled`. The `motion_enabled` property reports if the `camera` is ready to detect motion *regardless if the system is actually armed**.
 
 Below is an example showing every possible entry:
 
@@ -96,7 +92,6 @@ blink:
     monitored_conditions:
       - battery
       - temperature
-      - status
       - wifi_strength
 ```
 


### PR DESCRIPTION
**Description:**
Camera `status` sensor longer supported with version 0.10.0 of the blinkpy api


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17538

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
