### PR TITLE
Fix small typo in `sensor.cpu_usage`

### DIFF
--- a/source/_lovelace/gauge.markdown
+++ b/source/_lovelace/gauge.markdown
@@ -19,7 +19,7 @@ Screenshot of the gauge card.
 
 ```yaml
 - type: gauge
-  entity: sensor.cpu_usuage
+  entity: sensor.cpu_usage
 ```
 
 {% configuration %}
@@ -77,7 +77,7 @@ Title and Unit of Measurement Example:
 - type: gauge
   title: CPU Usuage
   unit_of_measurement: '%'
-  entity: sensor.cpu_usuage
+  entity: sensor.cpu_usage
 ```
 
 <p class='img'>
@@ -91,7 +91,7 @@ Define the severity map:
 - type: gauge
   title: With Severity
   unit_of_measurement: '%'
-  entity: sensor.cpu_usuage
+  entity: sensor.cpu_usage
   severity:
     green: 0
     yellow: 45


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
