### PR TITLE
Updating unifi documentation to be clearer about the site_id value

### DIFF
--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -88,6 +88,20 @@ The Unifi controller can either be a dedicated hardware device (Unifi's cloud ke
 
 It is recommended that you run the Unifi controller in a dedicated virtual machine to avoid that situation.
 
+### {% linkable_title Correctly specifying the Site ID %}
+For environments where there are multiple sites setup on the controller, or the default site is not being used you can use the site_id parameter to specify which site you would like to target.
+
+Please note that the value that is to be specificed here is not the name of the site as you would see it in controller interface, but a site ID value assigned from the software itself.
+
+To obtain this value for your configuration file, you can take it from the URL of your browser when on the controller webpage.
+
+For example, this is what would be seen in the URL bar when inside the dashboard page of a site:
+
+* https://127.0.0.1:8443/manage/s/ceb1m27d/dashboard
+
+And your site_id value would be ceb1m27d
+
+
 ### {% linkable_title Troubleshooting and Time Synchronization %}
 
 Presence detection depends on accurate time configuration between Home Assistant and the Unifi controller.

--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -89,7 +89,8 @@ The Unifi controller can either be a dedicated hardware device (Unifi's cloud ke
 It is recommended that you run the Unifi controller in a dedicated virtual machine to avoid that situation.
 
 ### {% linkable_title Correctly specifying the Site ID %}
-For environments where there are multiple sites setup on the controller, or the default site is not being used you can use the site_id parameter to specify which site you would like to target.
+
+For environments where there are multiple sites setup on the controller, or the default site is not being used you can use the `site_id` parameter to specify which site you would like to target.
 
 Please note that the value that is to be specificed here is not the name of the site as you would see it in controller interface, but a site ID value assigned from the software itself.
 
@@ -99,7 +100,7 @@ For example, this is what would be seen in the URL bar when inside the dashboard
 
 * https://127.0.0.1:8443/manage/s/ceb1m27d/dashboard
 
-And your site_id value would be ceb1m27d
+And your `site_id` value would be ceb1m27d.
 
 
 ### {% linkable_title Troubleshooting and Time Synchronization %}


### PR DESCRIPTION
**Description:**
I encountered some initial challenges with getting the unifi tracker working for my environment because I was not using the default site.

I'm adding some more information to the documentation to ensure that those who have similar configurations know how to find the value for the site_id parameter as it is not as clear that is not the name of the site, but a controller generated value.


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
