### PR TITLE
Fix configuration tag binary_sensor template 

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -34,7 +34,7 @@ binary_sensor:
 ```
 {% endraw %}
 
-{% configuration binary_sensor.template %}
+{% configuration %}
   sensors:
     description: List of your sensors.
     required: true


### PR DESCRIPTION


**Description:**
The configuration tag contained some additional text, which I think it shouldn't. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
