### PR TITLE
Update Mfi switch component configuration variable

### DIFF
--- a/source/_components/switch.mfi.markdown
+++ b/source/_components/switch.mfi.markdown
@@ -47,12 +47,12 @@ password:
   required: true
   type: string
 ssl:
-  description: If `True`, use SSL/TLS to contact the mFi controller.
+  description: If `true`, use SSL/TLS to contact the mFi controller.
   required: false
   default: true
   type: boolean
 verify_ssl:
-  description: Set this to `False` if your mFi controller has a self-signed certificate.
+  description: Set this to `false` if your mFi controller has a self-signed certificate.
   required: false
   default: true
   type: boolean

--- a/source/_components/switch.mfi.markdown
+++ b/source/_components/switch.mfi.markdown
@@ -28,11 +28,32 @@ switch:
     password: YOUR_PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address or hostname of your mFi controller.
-- **port** (*Optional*): The port of your mFi controller. Defaults to 6443.
-- **username** (*Required*): The mFi admin username.
-- **password** (*Required*): The mFi admin user's password.
-- **ssl** (*Optional*): If `True`, use SSL/TLS to contact the mFi controller. Defaults to `True`.
-- **verify_ssl** (*Optional*): Set this to `False` if your mFi controller has a self-signed certificate. Defaults to `True`.
+{% configuration %}
+host:
+  description: The IP address or hostname of your mFi controller.
+  required: true
+  type: string
+port:
+  description: The port of your mFi controller.
+  required: false
+  default: 6443
+  type: integer
+username:
+  description: The mFi admin username.
+  required: true
+  type: string
+password:
+  description: The mFi admin password.
+  required: true
+  type: string
+ssl:
+  description: If `True`, use SSL/TLS to contact the mFi controller.
+  required: false
+  default: true
+  type: boolean
+verify_ssl:
+  description: Set this to `False` if your mFi controller has a self-signed certificate.
+  required: false
+  default: true
+  type: boolean
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Mfi switch component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
