### PR TITLE
Update Anel_pwctrl switch component configuration variable

### DIFF
--- a/source/_components/switch.anel_pwrctrl.markdown
+++ b/source/_components/switch.anel_pwrctrl.markdown
@@ -32,12 +32,27 @@ switch:
   password: PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The IP address or hostname of your PwrCtrl device.
-- **port_recv** (*Required*): The port to receive data from the device.
-- **port_send** (*Required*): The port to send data to the device.
-- **username** (*Required*): The username for your device.
-- **password** (*Required*): The password for your device.
+{% configuration %}
+host:
+  description: The IP address or hostname of your PwrCtrl device.
+  required: false
+  type: string
+port_recv:
+  description: The port to receive data from the device.
+  required: true
+  type: integer
+port_send:
+  description: The port to send data to the device.
+  required: true
+  type: integer
+username:
+  description: The username for your device.
+  required: true
+  type: string
+password:
+  description: The password for your device.
+  required: true
+  type: string
+{% endconfiguration %}
 
 <p class="note">If no **host** is given the platform will try to auto-discover all devices on the network, that are listening on the given **port_recv**.</p>


### PR DESCRIPTION
**Description:**
Update style of Anel_pwctrl switch component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
