### PR TITLE
Update UK transport sensor component configuration variable

### DIFF
--- a/source/_components/sensor.uk_transport.markdown
+++ b/source/_components/sensor.uk_transport.markdown
@@ -37,14 +37,32 @@ sensor:
         destination: WAT
 ```
 
-Configuration variables:
-
-- **app_id** (*Required*): Your application id
-- **app_key** (*Required*): Your application key
-- **queries** array (*Required*): At least one entry required.
-- **mode** (*Required*): One of `bus` or `train`.
-- **origin** (*Required*): Specify the three character long origin station code.
-- **destination** (*Required*): Specify the three character long destination station code.
+{% configuration %}
+app_id:
+  description: Your application ID
+  required: true
+  type: string
+app_key:
+  description: Your application KEY
+  required: true
+  type: string
+queries:
+  description: At least one entry required.
+  required: true
+  type: list
+mode:
+  description: One of `bus` or `train`.
+  required: true
+  type: list
+origin:
+  description: Specify the three character long origin station code.
+  required: true
+  type: string
+destination:
+  description: Specify the three character long destination station code.
+  required: true
+  type: string
+{% endconfiguration %}
 
 A large amount of information about upcoming departures is available within the attributes of the sensor. The example above creates a sensor with ID `sensor.next_train_to_wat` with the attribute `next_trains` which is a list of the next 25 departing trains.
 

--- a/source/_components/sensor.uk_transport.markdown
+++ b/source/_components/sensor.uk_transport.markdown
@@ -39,11 +39,11 @@ sensor:
 
 {% configuration %}
 app_id:
-  description: Your application ID
+  description: Your application ID.
   required: true
   type: string
 app_key:
-  description: Your application KEY
+  description: Your application Key.
   required: true
   type: string
 queries:

--- a/source/_components/sensor.uk_transport.markdown
+++ b/source/_components/sensor.uk_transport.markdown
@@ -50,18 +50,19 @@ queries:
   description: At least one entry required.
   required: true
   type: list
-mode:
-  description: One of `bus` or `train`.
-  required: true
-  type: list
-origin:
-  description: Specify the three character long origin station code.
-  required: true
-  type: string
-destination:
-  description: Specify the three character long destination station code.
-  required: true
-  type: string
+  keys:
+    mode:
+      description: One of `bus` or `train`.
+      required: true
+      type: list
+    origin:
+      description: Specify the three character long origin station code.
+      required: true
+      type: string
+    destination:
+      description: Specify the three character long destination station code.
+      required: true
+      type: string
 {% endconfiguration %}
 
 A large amount of information about upcoming departures is available within the attributes of the sensor. The example above creates a sensor with ID `sensor.next_train_to_wat` with the attribute `next_trains` which is a list of the next 25 departing trains.


### PR DESCRIPTION
**Description:**
Update style of UK transport sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
