### PR TITLE
RFC: Put default value between code quotes

### DIFF
--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -69,7 +69,7 @@ module Jekyll
         end
         markup << "</p>"
         if attr.key? 'default'
-          markup << "<p class='default'>Default value: #{attr['default']}</p>"
+          markup << "<p class='default'>Default value: `#{attr['default']}`</p>"
         end
         markup << "</dd>"
 

--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -69,7 +69,11 @@ module Jekyll
         end
         markup << "</p>"
         if attr.key? 'default'
-          markup << "<p class='default'>Default value: `#{attr['default']}`</p>"
+          if #{attr['default']} | number_of_words == 1
+            markup << "<p class='default'>Default value: `#{attr['default']}`</p>"
+          else
+            markup << "<p class='default'>Default value: #{attr['default']}</p>"
+          end
         end
         markup << "</dd>"
 


### PR DESCRIPTION
**Description:**

I think it would be better if the default value is shown as code.
This is already done by some people for some docs.
What are other people's opinion on this?

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
