### PR TITLE
Update Raincloud component configuration

### DIFF
--- a/source/_components/binary_sensor.raincloud.markdown
+++ b/source/_components/binary_sensor.raincloud.markdown
@@ -25,8 +25,15 @@ binary_sensor:
   - platform: raincloud
 ```
 
-Configuration variables:
-
-- **monitored_conditions** array (*Optional*): Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
-  - **is_watering**: Return if is currently watering per zone.
-  - **status**: Return status from the Melnor RainCloud Controller and Melnor RainCloud Faucet.
+{% configuration %}
+monitored_conditions:
+  description: Conditions to display in the frontend. The following conditions can be monitored.
+  required: false
+  type: list
+  default: If not specified,, all conditions below will be enabled
+  keys:
+    is_watering:
+      description: Return if is currently watering per zone.
+    status:
+      description: Return status from the Melnor RainCloud Controller and Melnor RainCloud Faucet.
+{% endconfiguration %}

--- a/source/_components/sensor.raincloud.markdown
+++ b/source/_components/sensor.raincloud.markdown
@@ -25,10 +25,19 @@ sensor:
   - platform: raincloud
 ```
 
-Configuration variables:
-
-- **monitored_conditions** array (*Optional*): Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
-  - **battery**: Return the battery level the Melnor RainCloud faucet.
-  - **next_cycle**: Return the next schedulle watering cycle per zone.
-  - **rain_delay**: Return the number of days the automatic watering will be delayed due to raining per zone.
-  - **watering_time**: Return the watering remaining minutes per zone.
+{% configuration %}
+monitored_conditions:
+  description: Conditions to display in the frontend. The following conditions can be monitored.
+  required: false
+  default: If not specified, all conditions below will be enabled.
+  type: list
+  keys:
+    battery:
+      description: Return the battery level the Melnor RainCloud faucet.
+    next_cycle:
+      description: Return the next schedulle watering cycle per zone.
+    rain_delay:
+      description: Return the number of days the automatic watering will be delayed due to raining per zone.
+    watering_time:
+      description: Return the watering remaining minutes per zone.
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Raincloud component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
