### PR TITLE
Update Octoprint component configuration

### DIFF
--- a/source/_components/binary_sensor.octoprint.markdown
+++ b/source/_components/binary_sensor.octoprint.markdown
@@ -30,9 +30,19 @@ binary_sensor:
       - Printing Error
 ```
 
-Configuration variables:
-
-- **monitored_conditions** array (*Required*): States to monitor.
-  - **Printing**: State of the printer.
-  - **Printing Error**: Error while printing.
-- **name** (*Optional*): The name of the sensor. Default is 'OctoPrint'.
+{% configuration %}
+monitored_conditions:
+  description: States to monitor.
+  required: true
+  type: list
+  keys:
+    printing:
+      description: State of the printer.
+    printing error:
+      description: Error while printing.
+name:
+  description:
+  required: The name of the sensor.
+  default: OctoPrint
+  type: string
+{% endconfiguration %}

--- a/source/_components/octoprint.markdown
+++ b/source/_components/octoprint.markdown
@@ -42,7 +42,7 @@ bed:
   default: false
   type: boolean
 number_of_tools:
-  description: Number of temperature adjustable tools. i.e. nozzle
+  description: Number of temperature adjustable tools, i.e. nozzle.
   required: false
   default: 0
   type: integer

--- a/source/_components/octoprint.markdown
+++ b/source/_components/octoprint.markdown
@@ -27,12 +27,26 @@ octoprint:
   number_of_tools: 1
 ```
 
-Configuration variables:
-
-- **host** (*Required*): IP address or hostname of Octoprint host.
-- **api_key** (*Required*): The retrieved api key.
-- **bed** (*Optional*): If the printer has a heated bed.
-- **number_of_tools** (*Optional*): Number of temperature adjustable tools. i.e. nozzle.
+{% configuration %}
+host:
+  description: IP address or hostname of Octoprint host.
+  required: true
+  type: string
+api_key:
+  description: The retrieved api key.
+  required: true
+  type: string
+bed:
+  description: If the printer has a heated bed.
+  required: false
+  default: false
+  type: boolean
+number_of_tools:
+  description: Number of temperature adjustable tools. i.e. nozzle
+  required: false
+  default: 0
+  type: integer
+{% endconfiguration %}
 
 If the OctoPrint host is equipped with a web camera it is possible to add this as well.
 

--- a/source/_components/sensor.octoprint.markdown
+++ b/source/_components/sensor.octoprint.markdown
@@ -35,15 +35,28 @@ sensor:
       - Time Remaining
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): The name of the sensor. Default is 'OctoPrint'.
-- **monitored_conditions** array (*Required*): States to monitor.
-  - **Current State**: Text of current state.
-  - **Temperatures**:  Temperatures of all available tools, eg. `print`, `head`, `print bed`, etc. These will be displayed as `tool0`, `tool1`, or `toolN` please refer to your OctoPrint frontend to associate the tool number with an actual device.
-  - **Job Percentage**: Percentage of the job.
-  - **Time Elapsed**: Time elapsed on current print job, in seconds.
-  - **Time Remaining**: Time remaining on current print job, in seconds.
+{% configuration %}
+name:
+  description: The name of the sensor.
+  required: false
+  default: OctoPrint
+  type: string
+monitored_conditions:
+  description: States to monitor.
+  required: true
+  type: list
+  keys:
+    current state:
+      description: Text of current state.
+    temperatures:
+      description: Temperatures of all available tools, e.g., `print`, `head`, `print bed`, etc. These will be displayed as `tool0`, `tool1`, or `toolN` please refer to your OctoPrint frontend to associate the tool number with an actual device.
+    job percentage:
+      description: Percentage of the job.
+    time elapsed:
+      description: Time elapsed on current print job, in seconds.
+    time remaining:
+      description: Time remaining on current print job, in seconds.
+{% endconfiguration %}
 
 <p class='note'>
 If you are tracking temperature it is recommended to set `bed` and/or `number_of_tools` in your octoprint configuration. This will allow the octoprint sensors to load if the printer is offline during Home Assistant startup.


### PR DESCRIPTION
**Description:**
Update style of Octoprint component documentation to follow new configuration variables description.
Related to #6385.

**Note:**
Consideration should be given as to the white spaces in the options list of monitored conditions. It is possible that there is still a "_" in between

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
