### PR TITLE
Update media_player.yamaha_musiccast.markdown

### DIFF
--- a/source/_components/media_player.yamaha_musiccast.markdown
+++ b/source/_components/media_player.yamaha_musiccast.markdown
@@ -34,6 +34,7 @@ port:
   description: UDP source port. If multiple devices are present, specify a different port per device.
   required: false
   type: integer
+  default: 5005
 interval_seconds:
   description: Polling interval in seconds.
   required: false


### PR DESCRIPTION
**Description:**
Add default network port value for the Yamaha MusicCast Receivers.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
