### PR TITLE
Update device_tracker.fritz.markdown -  Change pip to pip3

### DIFF
--- a/source/_components/device_tracker.fritz.markdown
+++ b/source/_components/device_tracker.fritz.markdown
@@ -19,7 +19,7 @@ The `fritz` platform offers presence detection by looking at connected devices t
 
 <p class='note warning'>
 It might be necessary to install additional packages: <code>$ sudo apt-get install python3-lxml</code>
-If you installed Home Assistant in a virtualenv, run the following commands inside it: <code>$ sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev; pip install lxml</code>; be patient this will take a while.</p>
+If you installed Home Assistant in a virtualenv, run the following commands inside it: <code>$ sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev; pip3 install lxml</code>; be patient this will take a while.</p>
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
**Description:**
The installation of required packages was with 'pip' instead of pip3 (for python 3.x)


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
