### PR TITLE
Update device_tracker.fritz - Change pip to pip3

### DIFF
--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -17,7 +17,7 @@ The `fritzbox_netmonitor` sensor monitors the network statistics exposed by [AVM
 
 <p class='note warning'>
 It might be necessary to install additional packages: <code>$ sudo apt-get install libxslt-dev libxml2-dev python3-lxml</code>
-If you are working with the All-in-One installation, you may also need to execute also within your virtual environment the command <code> pip install lxml</code>; be patient this will take a while.
+If you are working with the All-in-One installation, you may also need to execute also within your virtual environment the command <code> pip3 install lxml</code>; be patient this will take a while.
 </p>
 
 To use the Fritz!Box network monitor in your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**
The installation of required packages was with 'pip' instead of pip3 (for python 3.x)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
