### PR TITLE
Documentation update for google assistant 0.80 migration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -155,3 +155,6 @@ patch_version_notes: "#release-0802---october-17"
 # disqus_end_date: 2018-01-26 0:00:00
 # Disqus is adding gross ads, move all comments to discourse.
 disqus_end_date: 2010-01-26 0:00:00
+
+# Support .well-known directory
+include: [".well-known"]

--- a/_config.yml
+++ b/_config.yml
@@ -142,13 +142,13 @@ social:
 # Home Assistant release details
 current_major_version: 0
 current_minor_version: 80
-current_patch_version: 1
-date_released: 2018-10-15
+current_patch_version: 2
+date_released: 2018-10-17
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.
 # Major release:
-patch_version_notes: "#release-0801---october-15"
+patch_version_notes: "#release-0802---october-17"
 # Minor release (Example #release-0431---april-25):
 
 # Date we moved to Discourse for comments

--- a/source/.well-known/apple-app-site-association
+++ b/source/.well-known/apple-app-site-association
@@ -1,0 +1,13 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "UTQFCBPQRF.io.robbie.HomeAssistant",
+        "paths": [
+          "/ios/*"
+        ]
+      }
+    ]
+  }
+}

--- a/source/_components/binary_sensor.octoprint.markdown
+++ b/source/_components/binary_sensor.octoprint.markdown
@@ -30,9 +30,19 @@ binary_sensor:
       - Printing Error
 ```
 
-Configuration variables:
-
-- **monitored_conditions** array (*Required*): States to monitor.
-  - **Printing**: State of the printer.
-  - **Printing Error**: Error while printing.
-- **name** (*Optional*): The name of the sensor. Default is 'OctoPrint'.
+{% configuration %}
+monitored_conditions:
+  description: States to monitor.
+  required: true
+  type: list
+  keys:
+    printing:
+      description: State of the printer.
+    printing error:
+      description: Error while printing.
+name:
+  description:
+  required: The name of the sensor.
+  default: OctoPrint
+  type: string
+{% endconfiguration %}

--- a/source/_components/binary_sensor.raincloud.markdown
+++ b/source/_components/binary_sensor.raincloud.markdown
@@ -25,8 +25,15 @@ binary_sensor:
   - platform: raincloud
 ```
 
-Configuration variables:
-
-- **monitored_conditions** array (*Optional*): Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
-  - **is_watering**: Return if is currently watering per zone.
-  - **status**: Return status from the Melnor RainCloud Controller and Melnor RainCloud Faucet.
+{% configuration %}
+monitored_conditions:
+  description: Conditions to display in the frontend. The following conditions can be monitored.
+  required: false
+  type: list
+  default: If not specified,, all conditions below will be enabled
+  keys:
+    is_watering:
+      description: Return if is currently watering per zone.
+    status:
+      description: Return status from the Melnor RainCloud Controller and Melnor RainCloud Faucet.
+{% endconfiguration %}

--- a/source/_components/device_tracker.fritz.markdown
+++ b/source/_components/device_tracker.fritz.markdown
@@ -19,7 +19,7 @@ The `fritz` platform offers presence detection by looking at connected devices t
 
 <p class='note warning'>
 It might be necessary to install additional packages: <code>$ sudo apt-get install python3-lxml</code>
-If you installed Home Assistant in a virtualenv, run the following commands inside it: <code>$ sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev; pip install lxml</code>; be patient this will take a while.</p>
+If you installed Home Assistant in a virtualenv, run the following commands inside it: <code>$ sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev; pip3 install lxml</code>; be patient this will take a while.</p>
 
 ## {% linkable_title Configuration %}
 

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -40,10 +40,14 @@ Since release 0.80, the `Authorization Code` type of `OAuth` account linking is 
     - In the `Configure your client` section:
         - Do **NOT** check `Google to transmit clientID and secret via HTTP basic auth header`.
     - Click 'Save' at the top right corner, then click 'Test' to generate a new draft version of the Test App.
-2. Change your `configuration.yaml` file:
+2. Generate a new Draft
+    - From the side bar, Click `Simulator` under `TEST`
+    - In the top middle select `CHANGE VERSION` 
+    - Select the version you wish to test and press `DONE`. This will generate a new draft snapshot.
+3. Change your `configuration.yaml` file:
     - Remove `client_id`, `access_token`, `agent_user_id` config from `google_assistant:` since they are no longer needed.
-3. Restart Home Assistant, open the `Google Assistant` app on your mobile phone then go to `Settings > Home Control`, re-link `[test] your app name`.
-4. A browser will be open and asking you to login to your Home Assistant instance, it will redirect back to `Google Assistant` app right afterward.
+4. Restart Home Assistant, open the `Google Assistant` app on your mobile phone then go to `Settings > Home Control`, re-link `[test] your app name`.
+5. A browser will be open and asking you to login to your Home Assistant instance, it will redirect back to `Google Assistant` app right afterward.
 
 <p class='note'>
 If you've added Home Assistant to the home screen, you have to first remove it from home screen, otherwise, this HTML5 app will show up instead of a browser. Using it would prevent Home Assistant to redirect back to the `Google Assistant` app.

--- a/source/_components/group.markdown
+++ b/source/_components/group.markdown
@@ -55,13 +55,28 @@ group:
       - device_tracker.mom_smith
 ```
 
-Configuration variables:
-
-- **view** (*Optional*): If yes then the entry will be shown as a view (tab) at the top. Groups that are set to `view: yes` cannot be used as entities in other views.
-- **name** (*Optional*): Name of the group.
-- **icon** (*Optional*): If the group is a view, this icon will show at the top in the frontend instead of the name. If the group is a view and both name and icon have been specified, the icon will appear at the top of the frontend and the name will be displayed as the mouse-over text.  If it's not a view, then the icon shows when this group is used in another group.
-- **control** (*Optional*): Set value to `hidden`. If hidden then the group switch will be hidden.
-- **entities** (*Required*): array or comma delimited string, list of entities to group.
+{% configuration %}
+name:
+  description: Name of the group.
+  required: false
+  type: string
+view:
+  description: "If yes then the entry will be shown as a view (tab) at the top. Groups that are set to `view: yes` cannot be used as entities in other views."
+  required: false
+  type: boolean
+icon:
+  description: If the group is a view, this icon will show at the top in the frontend instead of the name. If the group is a view and both name and icon have been specified, the icon will appear at the top of the frontend and the name will be displayed as the mouse-over text. If it's not a view, then the icon shows when this group is used in another group.
+  required: false
+  type: string
+control:
+  description: Set value to `hidden`. If hidden then the group switch will be hidden.
+  required: false
+  type: string
+entities:
+  description: Array or comma delimited string, list of entities to group.
+  required: true
+  type: list
+{% endconfiguration %}
 
 <p class='img'>
 <img src='/images/blog/2016-01-release-12/views.png'>

--- a/source/_components/media_player.cmus.markdown
+++ b/source/_components/media_player.cmus.markdown
@@ -33,9 +33,23 @@ media_player:
     password: YOUR_PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): Hostname or IP address of the machine running cmus. Note if a remote cmus is configured that instance must be configured to listen to remote connections, which also requires a password to be set.
-- **password** (*Required if host is set*): Password for your cmus player.
-- **port** (*Optional*): Port of the cmus socket, defaults to 3000.
-- **name** (*Optional*): The name you'd like to give the cmus player in Home Assistant
+{% configuration %}
+host:
+  description: Hostname or IP address of the machine running cmus. Note if a remote cmus is configured that instance must be configured to listen to remote connections, which also requires a password to be set.
+  required: inclusive
+  type: string
+password:
+  description: Password for your cmus player.
+  required: inclusive
+  type: string
+port:
+  description: Port of the cmus socket.
+  required: false
+  default: 3000
+  type: integer
+name:
+  description: The name you'd like to give the cmus player in Home Assistant.
+  required: false
+  default: cmus
+  type: string
+{% endconfiguration %}

--- a/source/_components/media_player.directv.markdown
+++ b/source/_components/media_player.directv.markdown
@@ -22,13 +22,27 @@ To ensure that your DirecTV boxes are always found and configured, they should b
 media_player:
   - platform: directv
 ```
-Configuration variables:
 
-- **host** (*Optional*): Use only if you don't want to scan for devices.
-- **port** (*Optional*): The port your receiver is using. Defaults to `8080`.
-- **name** (*Optional*): Use to give a specific name to the device.
-- **device** (*Optional*): Use to specify a particular receiver in a Genie setup.
-
+{% configuration %}
+host:
+  description: The IP address or the hostname of the device. Use only if you don't want to scan for devices.
+  required: false
+  type: string
+port:
+  description: The port your receiver is using.
+  required: false
+  default: 8080
+  type: integer
+name:
+  description: Use to give a specific name to the device.
+  required: false
+  default: DirecTV Receiver
+  type: string
+device:
+  description: Use to specify a particular receiver in a Genie setup.
+  required: false
+  type: string
+{% endconfiguration %}
 
 To find valid device IDs, open `http://<IP Address of Genie Server>:8080/info/getLocations` in a web browser. For each Genie slave, you will find a variable `clientAddr` in the response, and this should be used for `device` in `configuration.yaml`
 

--- a/source/_components/media_player.dunehd.markdown
+++ b/source/_components/media_player.dunehd.markdown
@@ -14,7 +14,7 @@ ha_release: 0.34
 ---
 
 
-The `dunehd` platform allows you to control a [Dune HD media player](http://dune-hd.com/eng/products/full_hd_media_players) from Home Assistant. Support is based on the official [IP protocol](http://dune-hd.com/support/ip_control/dune_ip_control_overview.txt) published by Dune.
+The `dunehd` media player platform allows you to control a [Dune HD media player](http://dune-hd.com/eng/products/full_hd_media_players) from Home Assistant. Support is based on the official [IP protocol](http://dune-hd.com/support/ip_control/dune_ip_control_overview.txt) published by Dune.
 
 Devices with firmware 110127_2105_beta or above are supported. Some functions may depend on the version of the protocol (volume / mute control is only available with version 2 onwards).
 
@@ -26,8 +26,19 @@ media_player:
   - platform: dunehd
     host: IP_ADDRESS
 ```
-Configuration variables:
 
-- **host** (*Required*): IP address or hostname of the device. Example: 192.168.1.32
-- **name** (*Optional*): Name of the device.
-- **sources** (*Optional*): A name-value dictionary of sources that HA component can request to play.
+{% configuration %}
+host:
+  description: IP address or hostname of the device, e.g., 192.168.1.32.
+  required: true
+  type: string
+name:
+  description: Name of the device.
+  required: false
+  default: DuneHD
+  type: string
+sources:
+  description: A name-value dictionary of sources than can be requested to play.
+  required: false
+  type: string
+{% endconfiguration %}

--- a/source/_components/media_player.emby.markdown
+++ b/source/_components/media_player.emby.markdown
@@ -26,10 +26,29 @@ media_player:
     api_key: "emby_api_key"
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The host name or address of the device that is running Emby. Defaults to ```localhost```.
-- **api_key** (*Required*): The api-key you would like home-assistant to use to authenticate.
-- **ssl** (*Optional*): True if you want to connect with https/wss. Your SSL certificate must be valid. Default is False.
-- **port** (*Optional*): The port number. Defaults to 8096 with SSL set to False and 8920 with SSL set to True.
-- **auto_hide** (*Optional*): True if you want to automatically hide devices that are unavailable from the Home Assistant Interface. Defaults to False.
+{% configuration %}
+host:
+  description: The host name or IP address of the device that is running Emby.
+  required: false
+  default: localhost
+  type: string
+api_key:
+  description: The API key to use to authenticate.
+  required: true
+  type: string
+ssl:
+  description: True if you want to connect with HTTPS/WSS. Your SSL certificate must be valid.
+  required: false
+  default: false
+  type: boolean
+port:
+  description: The port number of the device that is running Emby.
+  required: false
+  default: 8096 (No SSL),  8920 (SSL)
+  type: integer
+auto_hide:
+  description: True if you want to automatically hide devices that are unavailable from the Home Assistant Interface.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}

--- a/source/_components/media_player.frontier_silicon.markdown
+++ b/source/_components/media_player.frontier_silicon.markdown
@@ -37,11 +37,23 @@ media_player:
     host: IP_ADDRESS
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The host name or the IP address of the device. Defaults to 192.168.1.11.
-- **port** (*Optional*): The port number. Defaults to 80.
-- **password** (*Optional*): PIN code of the Internet Radio. Defaults to 1234.
+{% configuration %}
+host:
+  description: The host name or the IP address of the device.
+  required: true
+  default: 192.168.1.11
+  type: string
+port:
+  description: The port number of the device.
+  required: false
+  default: 80
+  type: integer
+password:
+  description: PIN code of the Internet Radio.
+  required: false
+  default: 1234
+  type: string
+{% endconfiguration %}
 
 Some models use a separate port (2244) for API access, this can be verified by visiting http://[host]:[port]/device.
 
@@ -80,7 +92,7 @@ is based on [tiwillam]'s fsapi project. Special thanks to both developers, this 
 ## Notes and Limitations
 
 <p class='note warning'>
-The Frontier Silicon API does not provide a multi-user environment. There is always a single user (session) controlling a device, which means that once Home Assistant connects to a device all other sessions will be invalidated. This renders the usage of [UNDOK] almost impossible, as the Home Assistant component polls the device state every 30 seconds or issues a command by creating a new session. 
+The Frontier Silicon API does not provide a multi-user environment. There is always a single user (session) controlling a device, which means that once Home Assistant connects to a device all other sessions will be invalidated. This renders the usage of [UNDOK] almost impossible, as the Home Assistant component polls the device state every 30 seconds or issues a command by creating a new session.
 *If you want to prevent Home Assistant to auto connect to your device, simply change the PIN code of the device to something else than: 1234*
 </p>
 
@@ -94,4 +106,3 @@ The Frontier Silicon API does not provide a multi-user environment. There is alw
 [UNDOK]: http://www.frontier-silicon.com/undok
 [flammy]: https://github.com/flammy/fsapi/
 [tiwillam]: https://github.com/tiwilliam/fsapi
-

--- a/source/_components/media_player.gpmdp.markdown
+++ b/source/_components/media_player.gpmdp.markdown
@@ -28,8 +28,14 @@ media_player:
     host: IP_ADDRESS
 ```
 
-Configuration variables:
-
-- **host** (*Required*): IP address of the computer running GPMDP.
-- **name** (*Optional*): Name of the player.
-
+{% configuration %}
+host:
+  description: The IP address of the computer running GPMDP.
+  required: true
+  type: string
+name:
+  description: Name of the player.
+  required: false
+  default: GPM Desktop Player
+  type: string
+{% endconfiguration %}

--- a/source/_components/media_player.lg_netcast.markdown
+++ b/source/_components/media_player.lg_netcast.markdown
@@ -25,11 +25,21 @@ media_player:
     host: 192.168.0.20
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address of the LG Smart TV, eg. 192.168.0.20
-- **access_token** (*Optional*): The access token needed to connect.
-- **name** (*Optional*): The name you would like to give to the LG Smart TV. The default is "LG TV Remote".
+{% configuration %}
+host:
+  description: The IP address of the LG Smart TV, e.g., 192.168.0.20.
+  required: true
+  type: string
+access_token:
+  description: The access token needed to connect.
+  required: false
+  type: string
+name:
+  description: The name you would like to give to the LG Smart TV.
+  required: false
+  default: LG TV Remote
+  type: string
+{% endconfiguration %}
 
 To get the access token for your TV configure the `lg_netcast` platform in Home Assistant without the `access_token`.
 After starting Home Assistant the TV will display the access token on screen.
@@ -38,4 +48,3 @@ Just add the token to your configuration and restart Home Assistant and the medi
 <p class='note'>
 The access token will not change until you factory reset your TV.
 </p>
-

--- a/source/_components/media_player.mpchc.markdown
+++ b/source/_components/media_player.mpchc.markdown
@@ -38,8 +38,19 @@ media_player:
     host: http://192.168.0.123
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The host name or address of the device that is running MPC-HC.
-- **port** (*Optional*): The port number. Defaults to 13579.
-- **name** (*Optional*): The name of the device used in the frontend.
+{% configuration %}
+host:
+  description: The host name or IP address of the device that is running MPC-HC.
+  required: true
+  type: string
+port:
+  description: The port number of the device.
+  required: false
+  default: 13579
+  type: integer
+name:
+  description: The name of the device used in the frontend.
+  required: false
+  default: MPC-HC
+  type: string
+{% endconfiguration %}

--- a/source/_components/media_player.roku.markdown
+++ b/source/_components/media_player.roku.markdown
@@ -23,6 +23,9 @@ media_player:
   - platform: roku
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): Use only if you don't want to scan for devices.
+{% configuration %}
+host:
+  description: The IP address or the hostname of the device. Use only if you don't want to scan for devices.
+  required: false
+  type: string
+{% endconfiguration %}

--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -98,6 +98,7 @@ Currently tested but not working models:
 
 - J5200 - Unable to see state and unable to control
 - J5500 - State is always "on" and unable to control (but port 8001 *is* open)
+- J6300 - State is always "on" and unable to control (but port 8001 *is* open)
 - JU7000 - Unable to see state and unable to control (but port 8001 *is* open)
 - JU7500 - Unable to see state and unable to control
 - JS8005 - State tracking working but unable to control (but port 8001 *is* open)

--- a/source/_components/media_player.yamaha_musiccast.markdown
+++ b/source/_components/media_player.yamaha_musiccast.markdown
@@ -34,6 +34,7 @@ port:
   description: UDP source port. If multiple devices are present, specify a different port per device.
   required: false
   type: integer
+  default: 5005
 interval_seconds:
   description: Polling interval in seconds.
   required: false

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -14,13 +14,16 @@ ha_iot_class: "Local Push"
 ---
 
 
-[Modbus](http://www.modbus.org/) is a serial communication protocol to control PLCs (Programmable logic controller). It currently supports sensors and switches which can be controlled over serial, TCP, and UDP connections.
+[Modbus](http://www.modbus.org/) is a serial communication protocol to control PLCs (Programmable logic controller).
+It currently supports sensors and switches which can be controlled over serial, TCP, and UDP connections.
 
 ## {% linkable_title Configuration %}
 
-To add modbus to your installation, add the following to your `configuration.yaml` file:
+The configuration for adding modbus to your installation depends on the connection type, either a network or serial connection.
 
-For a network connection:
+### {% linkable_title Network connection %}
+
+For a network connection, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry for a TCP connection
@@ -40,7 +43,7 @@ host:
   required: true
   type: string
 port:
-  description: The port for the communication.
+  description: The network port for the communication.
   required: true
   type: integer
 timeout:
@@ -50,7 +53,9 @@ timeout:
   type: integer
 {% endconfiguration %}
 
-For a serial connection:
+### {% linkable_title Serial connection %}
+
+For a serial connection, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry for a serial connection
@@ -66,11 +71,11 @@ modbus:
 
 {% configuration %}
 type:
-  description: Type of the connection to Modbus.
+  description: "Type of the connection to Modbus, needs to be `serial` for this setup."
   required: true
   type: string
 method:
-  description: Method of the connection to Modbus.
+  description: "Method of the connection to Modbus, either `rtu` or `ascii`."
   required: true
   type: string
 port:
@@ -82,15 +87,15 @@ baudrate:
   required: true
   type: integer
 stopbits:
-  description: The stopbits for the serial connection.
+  description: "The stopbits for the serial connection, either `1` or `2`."
   required: true
   type: integer
 bytesize:
-  description: The bytesize for the serial connection.
+  description: "The bytesize for the serial connection; can be `5`, `6`, `7` or `8`."
   required: true
   type: integer
 parity:
-  description: The parity for the serial connection.
+  description: "The parity for the serial connection; can be `E`, `O` or `N`."
   required: true
   type: string
 timeout:

--- a/source/_components/notify.hangouts.markdown
+++ b/source/_components/notify.hangouts.markdown
@@ -48,7 +48,7 @@ default_conversations:
 
 ### {% linkable_title Finding the conversation ID %}
 
-The conversations has to be precreated, the conversation id can be obtained from the `hangouts.conversations` entity, this can be found in with the states developer tool that is shown as this icon <img src='/images/screenshots/developer-tool-states-icon.png' class='no-shadow' height='38' /> in the side bar. Using your web browsers search tool to find the `hangouts.conversations` entity. You will find something like bellow 
+The conversations has to be precreated, the conversation id can be obtained from the `hangouts.conversations` entity, this can be found in with the states developer tool that is shown as this icon <img src='/images/screenshots/developer-tool-states-icon.png' class='no-shadow' height='38' /> in the side bar. Using your web browsers search tool to find the `hangouts.conversations` entity. You will find something like below.
 
 ```
 0: {

--- a/source/_components/notify.twitter.markdown
+++ b/source/_components/notify.twitter.markdown
@@ -13,9 +13,13 @@ ha_release: 0.12
 ---
 
 
-The `twitter` platform uses [Twitter](https://twitter.com) to deliver notifications from Home Assistant.
+The `twitter` notification platform uses [Twitter](https://twitter.com) to deliver notifications from Home Assistant.
 
-Go to [Twitter Apps](https://apps.twitter.com/app/new) and create an application. Visit "Keys and Access Tokens" of the application to get the details ("Consumer Key", "Consumer Secret", "Access Token" and "Access Token Secret" which needs to be generated).
+## {% linkable_title Setup %}
+
+Go to [Twitter Apps](https://apps.twitter.com/app/new) and create an application. Visit "Keys and Access Tokens" of the application to get the details (Consumer Key, Consumer Secret, Access Token and Access Token Secret which needs to be generated).
+
+## {% linkable_title Configuration %}
 
 To add Twitter to your installation, add the following to your `configuration.yaml` file:
 
@@ -30,13 +34,32 @@ notify:
     access_token_secret: ABCDEFGHJKLMNOPQRSTUVXYZ
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **consumer_key** (*Required*): Your "Consumer Key" (API Key) for the application.
-- **consumer_secret** (*Required*): Your "Consumer Secret" (API Secret) for the application.
-- **access_token** (*Required*): Your "Access Token" for the application.
-- **access_token_secret** (*Required*): Your "Access Token Secret" for the application.
-- **username** (*Optional*): Twitter handle without `@` or with `@` and quoting for direct messaging.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: "`notify`"
+  type: string
+consumer_key:
+  description: Your Consumer Key (API Key) for the application.
+  required: true
+  type: string
+consumer_secret:
+  description: Your Consumer Secret (API Secret) for the application.
+  required: true
+  type: string
+access_token:
+  description: Your Access Token for the application.
+  required: true
+  type: string
+access_token_secret:
+  description: Your Access Token Secret for the application.
+  required: true
+  type: string
+username:
+  description: "Twitter handle without `@` or with `@` and quoting for direct messaging."
+  required: false
+  type: string
+{% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).

--- a/source/_components/octoprint.markdown
+++ b/source/_components/octoprint.markdown
@@ -27,12 +27,26 @@ octoprint:
   number_of_tools: 1
 ```
 
-Configuration variables:
-
-- **host** (*Required*): IP address or hostname of Octoprint host.
-- **api_key** (*Required*): The retrieved api key.
-- **bed** (*Optional*): If the printer has a heated bed.
-- **number_of_tools** (*Optional*): Number of temperature adjustable tools. i.e. nozzle.
+{% configuration %}
+host:
+  description: IP address or hostname of Octoprint host.
+  required: true
+  type: string
+api_key:
+  description: The retrieved api key.
+  required: true
+  type: string
+bed:
+  description: If the printer has a heated bed.
+  required: false
+  default: false
+  type: boolean
+number_of_tools:
+  description: Number of temperature adjustable tools, i.e. nozzle.
+  required: false
+  default: 0
+  type: integer
+{% endconfiguration %}
 
 If the OctoPrint host is equipped with a web camera it is possible to add this as well.
 

--- a/source/_components/sensor.bom.markdown
+++ b/source/_components/sensor.bom.markdown
@@ -116,7 +116,7 @@ monitored_conditions:
     swell_dir_worded: 
       description: Swell direction.
     swell_height: 
-      description: Swell hight in m.
+      description: Swell height in m.
     swell_period:
       description: Swell period.
     vis_km:

--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -17,7 +17,7 @@ The `fritzbox_netmonitor` sensor monitors the network statistics exposed by [AVM
 
 <p class='note warning'>
 It might be necessary to install additional packages: <code>$ sudo apt-get install libxslt-dev libxml2-dev python3-lxml</code>
-If you are working with the All-in-One installation, you may also need to execute also within your virtual environment the command <code> pip install lxml</code>; be patient this will take a while.
+If you are working with the All-in-One installation, you may also need to execute also within your virtual environment the command <code> pip3 install lxml</code>; be patient this will take a while.
 </p>
 
 To use the Fritz!Box network monitor in your installation, add the following to your `configuration.yaml` file:

--- a/source/_components/sensor.octoprint.markdown
+++ b/source/_components/sensor.octoprint.markdown
@@ -35,15 +35,28 @@ sensor:
       - Time Remaining
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): The name of the sensor. Default is 'OctoPrint'.
-- **monitored_conditions** array (*Required*): States to monitor.
-  - **Current State**: Text of current state.
-  - **Temperatures**:  Temperatures of all available tools, eg. `print`, `head`, `print bed`, etc. These will be displayed as `tool0`, `tool1`, or `toolN` please refer to your OctoPrint frontend to associate the tool number with an actual device.
-  - **Job Percentage**: Percentage of the job.
-  - **Time Elapsed**: Time elapsed on current print job, in seconds.
-  - **Time Remaining**: Time remaining on current print job, in seconds.
+{% configuration %}
+name:
+  description: The name of the sensor.
+  required: false
+  default: OctoPrint
+  type: string
+monitored_conditions:
+  description: States to monitor.
+  required: true
+  type: list
+  keys:
+    current state:
+      description: Text of current state.
+    temperatures:
+      description: Temperatures of all available tools, e.g., `print`, `head`, `print bed`, etc. These will be displayed as `tool0`, `tool1`, or `toolN` please refer to your OctoPrint frontend to associate the tool number with an actual device.
+    job percentage:
+      description: Percentage of the job.
+    time elapsed:
+      description: Time elapsed on current print job, in seconds.
+    time remaining:
+      description: Time remaining on current print job, in seconds.
+{% endconfiguration %}
 
 <p class='note'>
 If you are tracking temperature it is recommended to set `bed` and/or `number_of_tools` in your octoprint configuration. This will allow the octoprint sensors to load if the printer is offline during Home Assistant startup.

--- a/source/_components/sensor.raincloud.markdown
+++ b/source/_components/sensor.raincloud.markdown
@@ -25,10 +25,19 @@ sensor:
   - platform: raincloud
 ```
 
-Configuration variables:
-
-- **monitored_conditions** array (*Optional*): Conditions to display in the frontend. If not specified, all conditions below will be enabled by default. The following conditions can be monitored.
-  - **battery**: Return the battery level the Melnor RainCloud faucet.
-  - **next_cycle**: Return the next schedulle watering cycle per zone.
-  - **rain_delay**: Return the number of days the automatic watering will be delayed due to raining per zone.
-  - **watering_time**: Return the watering remaining minutes per zone.
+{% configuration %}
+monitored_conditions:
+  description: Conditions to display in the frontend. The following conditions can be monitored.
+  required: false
+  default: If not specified, all conditions below will be enabled.
+  type: list
+  keys:
+    battery:
+      description: Return the battery level the Melnor RainCloud faucet.
+    next_cycle:
+      description: Return the next schedulle watering cycle per zone.
+    rain_delay:
+      description: Return the number of days the automatic watering will be delayed due to raining per zone.
+    watering_time:
+      description: Return the watering remaining minutes per zone.
+{% endconfiguration %}

--- a/source/_components/sensor.supervisord.markdown
+++ b/source/_components/sensor.supervisord.markdown
@@ -37,7 +37,10 @@ sensor:
   - platform: supervisord
 ```
 
-Configuration variables:
-
-- **url** (*Optional*): The URL to track. Default to `http://localhost:9001/RPC2`.
-
+{% configuration %}
+url:
+  description: The URL to track.
+  required: false
+  default: "http://localhost:9001/RPC2"
+  type: string
+{% endconfiguration %}

--- a/source/_components/sensor.sytadin.markdown
+++ b/source/_components/sensor.sytadin.markdown
@@ -25,12 +25,24 @@ sensor:
   - platform: sytadin
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Additional name for the sensors. Default to platform name.
-- **monitored_conditions** array (*Optional*): Conditions to display in the frontend. Defaults to `traffic_jam`.
-  - **traffic_jam**: Amount of kilometers in traffic jam (km).  
-  - **mean_velocity**: Mean velocity (km/h).
-  - **congestion**: Index of congestion (n/a).
+{% configuration %}
+name:
+  description: Additional name for the sensors.
+  required: false
+  default: Sytadin
+  type: string
+monitored_conditions:
+  description: Conditions to display in the frontend.
+  required: false
+  default: traffic_jam
+  type: list
+  keys:
+    traffic_jam:
+      description: Amount of kilometers in traffic jam (km).
+    mean_velocity:
+      description: Mean velocity (km/h).
+    congestion:
+      description: Index of congestion (n/a).
+{% endconfiguration %}
 
 The data is coming from the [Direction des routes Île-de-France (DiRIF)](http://www.sytadin.fr).

--- a/source/_components/sensor.torque.markdown
+++ b/source/_components/sensor.torque.markdown
@@ -46,7 +46,14 @@ sensor:
     email: your_configured@email.com
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Vehicle name (your choice).
-- **email**  (*Required*): Email address configured in Torque application.
+{% configuration %}
+name:
+  description: Vehicle name (your choice).
+  required: false
+  default: vehicle
+  type: string
+email:
+  description: Email address configured in Torque application.
+  required: true
+  type: string
+{% endconfiguration %}

--- a/source/_components/sensor.uk_transport.markdown
+++ b/source/_components/sensor.uk_transport.markdown
@@ -37,14 +37,33 @@ sensor:
         destination: WAT
 ```
 
-Configuration variables:
-
-- **app_id** (*Required*): Your application id
-- **app_key** (*Required*): Your application key
-- **queries** array (*Required*): At least one entry required.
-- **mode** (*Required*): One of `bus` or `train`.
-- **origin** (*Required*): Specify the three character long origin station code.
-- **destination** (*Required*): Specify the three character long destination station code.
+{% configuration %}
+app_id:
+  description: Your application ID.
+  required: true
+  type: string
+app_key:
+  description: Your application Key.
+  required: true
+  type: string
+queries:
+  description: At least one entry required.
+  required: true
+  type: list
+  keys:
+    mode:
+      description: One of `bus` or `train`.
+      required: true
+      type: list
+    origin:
+      description: Specify the three character long origin station code.
+      required: true
+      type: string
+    destination:
+      description: Specify the three character long destination station code.
+      required: true
+      type: string
+{% endconfiguration %}
 
 A large amount of information about upcoming departures is available within the attributes of the sensor. The example above creates a sensor with ID `sensor.next_train_to_wat` with the attribute `next_trains` which is a list of the next 25 departing trains.
 

--- a/source/_components/statsd.markdown
+++ b/source/_components/statsd.markdown
@@ -21,14 +21,37 @@ To use the `statsd` component in your installation, add the following to your `c
 statsd:
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): IP address of your StatsD host, eg. 192.168.1.10. Defaults to `localhost`.
-- **port** (*Optional*): Port to use. Defaults to 8125.
-- **prefix** (*Optional*): Prefix to use. Defaults to `hass`.
-- **rate** (*Optional*): The sample rate. Defaults to 1.
-- **log_attributes** (*Optional*): Log state and attribute changes. This changes the default stats path.
-- **value_mapping** (*Optional*): Map non-numerical values to numerical ones.
+{% configuration %}
+host:
+  description: "IP address of your StatsD host, e.g., 192.168.1.10."
+  required: true
+  default: localhost
+  type: string
+port:
+  description: Port to use.
+  required: false
+  default: 8125
+  type: integer
+prefix:
+  description: Prefix to use.
+  required: false
+  default: hass
+  type: string
+rate:
+  description: The sample rate.
+  required: false
+  default: 1
+  type: integer
+log_attributes:
+  description: Log state and attribute changes. This changes the default stats path.
+  required: false
+  default: false
+  type: boolean
+value_mapping:
+  description: Map non-numerical values to numerical ones.
+  required: false
+  type: list
+{% endconfiguration %}
 
 Full example:
 

--- a/source/_components/switch.anel_pwrctrl.markdown
+++ b/source/_components/switch.anel_pwrctrl.markdown
@@ -32,12 +32,27 @@ switch:
   password: PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The IP address or hostname of your PwrCtrl device.
-- **port_recv** (*Required*): The port to receive data from the device.
-- **port_send** (*Required*): The port to send data to the device.
-- **username** (*Required*): The username for your device.
-- **password** (*Required*): The password for your device.
+{% configuration %}
+host:
+  description: The IP address or hostname of your PwrCtrl device.
+  required: false
+  type: string
+port_recv:
+  description: The port to receive data from the device.
+  required: true
+  type: integer
+port_send:
+  description: The port to send data to the device.
+  required: true
+  type: integer
+username:
+  description: The username for your device.
+  required: true
+  type: string
+password:
+  description: The password for your device.
+  required: true
+  type: string
+{% endconfiguration %}
 
 <p class="note">If no **host** is given the platform will try to auto-discover all devices on the network, that are listening on the given **port_recv**.</p>

--- a/source/_components/switch.edimax.markdown
+++ b/source/_components/switch.edimax.markdown
@@ -24,10 +24,24 @@ switch:
     host: 192.168.1.32
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address of your Edimax switch, eg. `192.168.1.32`.
-- **username** (*Optional*): Your username for the Edimax switch. Defaults to `admin`.
-- **password** (*Optional*): Your password for the Edimax switch. Defaults to `1234`.
-- **name** (*Optional*): The name to use when displaying this switch.
-
+{% configuration %}
+host:
+  description: "The IP address of your Edimax switch, e.g., `192.168.1.32`."
+  required: true
+  type: string
+username:
+  description: Your username for the Edimax switch.
+  required: false
+  default: admin
+  type: string
+password:
+  description: Your password for the Edimax switch.
+  required: false
+  default: 1234
+  type: string
+name:
+  description: The name to use when displaying this switch.
+  required: false
+  default: Edimax Smart Plug
+  type: string
+{% endconfiguration %}

--- a/source/_components/switch.knx.markdown
+++ b/source/_components/switch.knx.markdown
@@ -29,11 +29,21 @@ switch:
     address: '1/1/6'
 ```
 
-Configuration variables:
-
-* **address** (*Required*): KNX group address for switching the switch on/off.
-* **name** (*Optional*): A name for this device used within Home Assistant.
-* **state_address** (*Optional*): separate KNX group address for retrieving the switch state.
+{% configuration %}
+address:
+  description: KNX group address for switching the switch on/off.
+  required: true
+  type: string
+name:
+  description: A name for this device used within Home Assistant.
+  required: false
+  default: KNX Switch
+  type: string
+state_address:
+  description: Separate KNX group address for retrieving the switch state.
+  required: false
+  type: string
+{% endconfiguration %}
 
 Some KNX devices can change their state internally without any messages on the KNX bus, e.g., if you configure a timer on a channel. The optional `state_address` can be used to inform Home Assistant about these state changes. If a KNX message is seen on the bus addressed to the given state address, this will overwrite the state of the switch object.
 For switching actuators that are only controlled by a single group address and can't change their state internally, you don't have to configure the state address.

--- a/source/_components/switch.mfi.markdown
+++ b/source/_components/switch.mfi.markdown
@@ -28,11 +28,32 @@ switch:
     password: YOUR_PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address or hostname of your mFi controller.
-- **port** (*Optional*): The port of your mFi controller. Defaults to 6443.
-- **username** (*Required*): The mFi admin username.
-- **password** (*Required*): The mFi admin user's password.
-- **ssl** (*Optional*): If `True`, use SSL/TLS to contact the mFi controller. Defaults to `True`.
-- **verify_ssl** (*Optional*): Set this to `False` if your mFi controller has a self-signed certificate. Defaults to `True`.
+{% configuration %}
+host:
+  description: The IP address or hostname of your mFi controller.
+  required: true
+  type: string
+port:
+  description: The port of your mFi controller.
+  required: false
+  default: 6443
+  type: integer
+username:
+  description: The mFi admin username.
+  required: true
+  type: string
+password:
+  description: The mFi admin password.
+  required: true
+  type: string
+ssl:
+  description: If `true`, use SSL/TLS to contact the mFi controller.
+  required: false
+  default: true
+  type: boolean
+verify_ssl:
+  description: Set this to `false` if your mFi controller has a self-signed certificate.
+  required: false
+  default: true
+  type: boolean
+{% endconfiguration %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -107,6 +107,18 @@ If your template uses an `entity_id` that begins with a number (example: `states
 Rendering templates with time (`now()`) is dangerous as updates only trigger templates in sensors based on entity state changes.
 </p>
 
+## {% linkable_title Priority of operators %}
+
+The default priority of operators is that the filter (`|`) has priority over everything except brackets. This means that:
+
+{% raw %}
+```yaml
+{{ states('sensor.temperature') | float / 10 | round(2) }}
+```
+{% endraw %}
+
+Would round `10` to 2 decimal places, then divide `states('sensor.temperature')` by that.
+
 ## {% linkable_title Home Assistant template extensions %}
 
 In templates, besides the normal [state object methods and properties](/topics/state_object/), there are also some extra things available:
@@ -114,6 +126,8 @@ In templates, besides the normal [state object methods and properties](/topics/s
 - `states.sensor.temperature.state_with_unit` will print the state of the entity and, if available, the unit.
 
 ## {% linkable_title Examples %}
+
+To test a template, go to the <img src='/images/screenshots/developer-tool-templates-icon.png' alt='template developer tool icon' class="no-shadow" height="38" /> template developer tools, create your template in the _Template editor_ and check the results on the right.
 
 ### {% linkable_title States %}
 
@@ -133,7 +147,7 @@ Print an attribute if state is defined. Both will return the same thing but the 
 {% raw %}
 ```text
 {% if states.device_tracker.paulus %}
-  {{ states.device_tracker.paulus.attributes.battery }}
+  {{ state_attr('device_tracker.paulus', 'battery') }}
 {% else %}
   ??
 {% endif %}
@@ -170,9 +184,9 @@ Print out a list of all the sensor states.
   Paulus is at {{ states('device_tracker.paulus') }}.
 {% endif %}
 
-{{ states.sensor.temperature | float + 1 }}
+{{ states('sensor.temperature') | float + 1 }}
 
-{{ (states.sensor.temperature | float * 10) | round(2) }}
+{{ (states('sensor.temperature') | float * 10) | round(2) }}
 
 {% if states('sensor.temperature') | float > 20 %}
   It is warm!

--- a/source/_posts/2018-10-12-release-80.markdown
+++ b/source/_posts/2018-10-12-release-80.markdown
@@ -63,6 +63,27 @@ On the devices side, we got basic support for the new IKEA TRÅDFRI switches, Ho
 [hangouts docs]: /components/hangouts/
 [websocket_api docs]: /components/websocket_api/
 
+## {% linkable_title Release 0.80.2 - October 17 %}
+
+- Lovelace: Fix glance icon not updating
+- Fix: Connection pool of Request object is smaller than optimal value (8) ([@Anonym-tsk] - [#17483]) ([telegram_bot docs])
+- Blink update - fixes #17316 ([@fronzbot] - [#17538]) ([blink docs]) ([alarm_control_panel.blink docs]) ([binary_sensor.blink docs]) ([camera.blink docs]) ([sensor.blink docs])
+- Home Assistant Cloud: Add another 3 days leeway to give time for payment processing times ([@balloob] - [#17542]) ([cloud docs])
+
+[#17483]: https://github.com/home-assistant/home-assistant/pull/17483
+[#17538]: https://github.com/home-assistant/home-assistant/pull/17538
+[#17542]: https://github.com/home-assistant/home-assistant/pull/17542
+[@Anonym-tsk]: https://github.com/Anonym-tsk
+[@balloob]: https://github.com/balloob
+[@fronzbot]: https://github.com/fronzbot
+[alarm_control_panel.blink docs]: /components/alarm_control_panel.blink/
+[binary_sensor.blink docs]: /components/binary_sensor.blink/
+[blink docs]: /components/blink/
+[camera.blink docs]: /components/camera.blink/
+[cloud docs]: /components/cloud/
+[sensor.blink docs]: /components/sensor.blink/
+[telegram_bot docs]: /components/telegram_bot/
+
 ## {% linkable_title New Features %}
 
 - Add faucet, shower, sprinkler, valve to HomeKit ([@cdce8p] - [#17145]) ([homekit docs]) (new-feature)


### PR DESCRIPTION
**Description:**
Added a step to regenerate draft after changing OAuth to authorization url. Without this step you will get a 404 when trying to relink your account in Google Home app. This is only necessary when migrating.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
