### PR TITLE
Update Rfxtrx component configuration

### DIFF
--- a/source/_components/binary_sensor.rfxtrx.markdown
+++ b/source/_components/binary_sensor.rfxtrx.markdown
@@ -50,11 +50,47 @@ binary_sensor:
       name: device_name
 ```
 
-Configuration variables:
-
-- **automatic_add** (*Optional*): To enable the automatic addition of new binary sensors.
-- **device_class** (*Optional*): The [type or class of the sensor](/components/binary_sensor/) to set the icon in the frontend.
-- **off_delay** (*Optional*): For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
+{% configuration %}
+devices:
+  description: A list of devices.
+  required: false
+  type: list
+  keys:
+    name:
+      description: Override the name to use in the frontend.
+      required: false
+      type: string
+    device_class:
+      description: "The [type or class of the sensor](/components/binary_sensor/) to set the icon in the frontend."
+      required: false
+      type: device_class
+    fire_event:
+      description: Fires an event even if the state is the same as before. Can be used for automations.
+      required: false
+      default: false
+      type: boolean
+    off_delay:
+      description: For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
+      required: false
+      type: integer
+    data_bits:
+      description: Defines how many bits are used for commands inside the data packets sent by the device.
+      required: false
+      type: integer
+    command_on:
+      description: Defines the data bits value that is sent by the device upon an 'On' command.
+      required: false
+      type: string
+    command_off:
+      description: Defines the data bits value that is sent by the device upon an 'Off' command.
+      required: false
+      type: string
+automatic_add:
+  description: To enable the automatic addition of new binary sensors.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
 
 <p class='note warning'>
 This component and the [rfxtrx switch](/components/switch/rfxtrx/) can steal each other's devices when setting the `automatic_add` configuration parameter to `true`.
@@ -104,9 +140,9 @@ and the fields lengths are not included in the data. One device that sends 2
 different commands will be seen as 2 devices on Home Assistant. For such cases,
 the following options are available in order to circumvent the problem:
 
-- **data_bits** (*Optional*): Defines how many bits are used for commands inside the data packets sent by the device.
-- **command_on** (*Optional*): Defines the data bits value that is sent by the device upon an 'On' command.
-- **command_off** (*Optional*): Defines the data bits value that is sent by the device upon an 'Off' command.
+- **data_bits** (*Optional*)
+- **command_on** (*Optional*)
+- **command_off** (*Optional*)
 
 Let's try to add a new PT-2262 sensor using the "automatic_add"
 option and have a look at Home Assistant system log.

--- a/source/_components/cover.rfxtrx.markdown
+++ b/source/_components/cover.rfxtrx.markdown
@@ -61,12 +61,31 @@ cover:
         name: Bathroom Shutter
 ```
 
-Configuration variables:
-
-- **devices** (*Required*): A list of devices with their name to use in the frontend.
-- **automatic_add** (*Optional*): To enable the automatic addition of new covers (Siemens/LightwaveRF only).
-- **signal_repetitions** (*Optional*): Because the rxftrx device sends its actions via radio and from most receivers it's impossible to know if the signal was received or not. Therefore you can configure the roller shutter to try to send each signal repeatedly.
-- **fire_event** (*Optional*): Fires an event even if the state is the same as before. Can be used for automations.
+{% configuration %}
+devices:
+  description: A list of devices.
+  required: false
+  type: list
+  keys:
+    name:
+      description: Override the name to use in the frontend.
+      required: true
+      type: string
+    fire_event:
+      description: Fires an event even if the state is the same as before. Can be used for automations.
+      required: false
+      default: false
+      type: boolean
+automatic_add:
+  description: To enable the automatic addition of new covers (Siemens/LightwaveRF only).
+  required: false
+  default: false
+  type: boolean
+signal_repetitions:
+  description: Because the rxftrx device sends its actions via radio and from most receivers it's impossible to know if the signal was received or not. Therefore you can configure the roller shutter to try to send each signal repeatedly.
+  required: false
+  type: integer
+{% endconfiguration %}
 
 <p class='note warning'>
 If a device ID consists of only numbers, please make sure to surround it with quotes. 

--- a/source/_components/light.rfxtrx.markdown
+++ b/source/_components/light.rfxtrx.markdown
@@ -54,12 +54,31 @@ light:
       name: Light_TV
 ```
 
-Configuration variables:
-
-- **devices** (*Required*): A list of devices with their name to use in the frontend.
-- **automatic_add** (*Optional*): To enable the automatic addition of new lights.
-- **signal_repetitions** (*Optional*): Because the RFXtrx device sends its actions via radio and from most receivers it's impossible to know if the signal was received or not. Therefore you can configure the switch to try to send each signal repeatedly.
-- **fire_event** (*Optional*): Fires an event even if the state is the same as before. Can be used for automations.
+{% configuration %}
+devices:
+  description: A list of devices.
+  required: false
+  type: list
+  keys:
+    name:
+      description: Override the name to use in the frontend.
+      required: true
+      type: string
+    fire_event:
+      description: Fires an event even if the state is the same as before. Can be used for automations.
+      required: false
+      default: false
+      type: boolean
+automatic_add:
+  description: To enable the automatic addition of new lights.
+  required: false
+  default: false
+  type: boolean
+signal_repetitions:
+  description: Because the RFXtrx device sends its actions via radio and from most receivers it's impossible to know if the signal was received or not. Therefore you can configure the switch to try to send each signal repeatedly.
+  required: false
+  type: integer
+{% endconfiguration %}
 
 <p class='note warning'>
 If a device ID consists of only numbers, please make sure to surround it with quotes. 

--- a/source/_components/rfxtrx.markdown
+++ b/source/_components/rfxtrx.markdown
@@ -22,11 +22,22 @@ rfxtrx:
   device: PATH_TO_DEVICE
 ```
 
-Configuration variables:
-
-- **device** (*Required*): The path to your device, e.g., `/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0`
-- **debug** (*Optional*): If you want to receive debug output.
-- **dummy** (*Optional*): Then you have need a connected drive to test your settings. Can be useful for debugging and testing.
+{% configuration %}
+device:
+  description: "The path to your device, e.g., `/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0`."
+  required: true
+  type: string
+debug:
+  description: If you want to receive debug output.
+  required: false
+  default: false
+  type: boolean
+dummy:
+  description: Then you have need a connected drive to test your settings. Can be useful for debugging and testing.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
 
 Supported protocols
 

--- a/source/_components/sensor.rfxtrx.markdown
+++ b/source/_components/sensor.rfxtrx.markdown
@@ -56,7 +56,7 @@ sensor:
        - Temperature
 ```
 
-Only these data_type are valid :
+Only these data_type are valid:
 
 - *Temperature*
 - *Humidity*
@@ -88,12 +88,31 @@ sensor:
        - Temperature
 ```
 
-Configuration variables:
-
-- **devices**  (*Optional*): A list of devices with their name to use in the frontend.
-- **automatic_add** (*Optional*): To enable the automatic addition of new lights.
-- **data_type**  (*Optional*): Which data type the sensor should show
-- **fire_event** (*Optional*): Fires an event even if the state is the same as before. Can be used for automations.
+{% configuration %}
+devices:
+  description: A list of devices.
+  required: false
+  type: list
+  keys:
+    name:
+      description: Override the name to use in the frontend.
+      required: false
+      type: string
+    fire_event:
+      description: Fires an event even if the state is the same as before. Can be used for automations.
+      required: false
+      default: false
+      type: boolean
+    data_type:
+      description: Which data type the sensor should show.
+      required: false
+      type: list
+automatic_add:
+  description: To enable the automatic addition of new lights.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
 
 <p class='note warning'>
 If a device ID consists of only numbers, please make sure to surround it with quotes. 

--- a/source/_components/switch.rfxtrx.markdown
+++ b/source/_components/switch.rfxtrx.markdown
@@ -43,12 +43,31 @@ switch:
       name: device_name
 ```
 
-Configuration variables:
-
-- **devices** (*Required*): A list of devices with their name to use in the frontend.
-- **automatic_add** (*Optional*): To enable the automatic addition of new switches.
-- **signal_repetitions** (*Optional*): Because the RFXtrx device sends its actions via radio and from most receivers it's impossible to know if the signal was received or not. Therefore you can configure the switch to try to send each signal repeatedly.
-- **fire_event** (*Optional*): Fires an event even if the state is the same as before, for example a doorbell switch. Can also be used for automations.
+{% configuration %}
+devices:
+  description: A list of devices.
+  required: false
+  type: list
+  keys:
+    name:
+      description: Override the name to use in the frontend.
+      required: true
+      type: string
+    fire_event:
+      description: Fires an event even if the state is the same as before, for example a doorbell switch. Can also be used for automations.
+      required: false
+      default: false
+      type: boolean
+automatic_add:
+  description: To enable the automatic addition of new switches.
+  required: false
+  default: false
+  type: boolean
+signal_repetitions:
+  description: Because the RFXtrx device sends its actions via radio and from most receivers it's impossible to know if the signal was received or not. Therefore you can configure the switch to try to send each signal repeatedly.
+  required: false
+  type: integer
+{% endconfiguration %}
 
 <p class='note warning'>
 This component and the [rfxtrx binary sensor](/components/binary_sensor.rfxtrx/) can steal each other's devices when setting the `automatic_add` configuration parameter to `true`. Set `automatic_add` only when you have some devices to add to your installation, otherwise leave it to `False`.


### PR DESCRIPTION
**Description:**
Update style of Rfxtrx component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
