### PR TITLE
Add emulated_roku docs

### DIFF
--- a/source/_components/emulated_roku.markdown
+++ b/source/_components/emulated_roku.markdown
@@ -26,13 +26,11 @@ Windows is not supported because Home Assistant uses `ProactorEventLoop` which d
 
 ## {% linkable_title Configuration %}
 
-```yaml
-# Example configuration.yaml entry
-emulated_roku:
-  servers:
-    - name: hass roku
-      listen_port: 8060
-```
+The component is configurable through the frontend. (**Configuration** -> **Integrations** -> **Emulated Roku**)
+
+<p class='note warning'>
+You can only configure the component through the integrations page, not in configuration files.
+</p>
 
 {% configuration %}
 name:

--- a/source/_components/emulated_roku.markdown
+++ b/source/_components/emulated_roku.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: home-assistant.png
 ha_category: Hub
-ha_release: 0.80.0
+ha_release: 0.81.0
 ha_iot_class: "Local Push"
 ha_qa_scale: internal
 ---
@@ -18,7 +18,7 @@ This component integrates an emulated Roku API into Home Assistant,
 so remotes such as Harmony and Android apps can connect to it through WiFi as it were a Roku player.  
 Home Assistant will see key presses and app launches as Events, which you can use as triggers for automations.  
 Multiple Roku servers may be started if you run out of buttons by specifying multiple server entries.  
-When using multiple servers, you can filter the roku USN which is specified via the `name` attribute.
+When using multiple servers, you can filter the Roku USN which is specified via the `name` attribute.
 
 <p class='note'>  
 Windows is not supported because Home Assistant uses `ProactorEventLoop` which does not support UDP sockets.
@@ -26,26 +26,21 @@ Windows is not supported because Home Assistant uses `ProactorEventLoop` which d
 
 ## {% linkable_title Configuration %}
 
-configuration.yaml
 ```yaml
 # Example configuration.yaml entry
 emulated_roku:
   servers:
     - name: hass roku
       listen_port: 8060
-      host_ip: 192.168.1.150
-      advertise_ip: 10.0.0.10
-      advertise_port: 8070
-      upnp_bind_multicast: True
 ```
 
 {% configuration %}
 name:
-  description: Name of the roku that will be displayed as USN in Harmony.
+  description: Name of the Roku that will be displayed as USN in Harmony.
   required: true
   type: string
 listen_port:
-  description: The port the roku API will run on. This can be any free port on your system.
+  description: The port the Roku API will run on. This can be any free port on your system.
   required: true
   type: integer
 host_ip:
@@ -57,7 +52,7 @@ advertise_ip:
   required: false
   type: string
 advertise_port:
-  description: If you need to specifically override the advertised UPnP port.
+  description: If you need to override the advertised UPnP port.
   required: false
   type: integer
 upnp_bind_multicast:
@@ -74,11 +69,11 @@ If you change your advertised IP or ports you will have to re-add your Roku in H
 
 ### {% linkable_title Event `roku_command` %}
 
-All roku commands are sent as `roku_command` events.
+All Roku commands are sent as `roku_command` events.
 
 Field | Description
 ----- | -----------
-`source_name` | Name of the that sent the event roku. Not required for when using one Emulated Roku instance.
+`source_name` | Name of the that sent the event Roku. Not required for when using one Emulated Roku instance.
 `type` | The type of the event that was called on the Roku API.
 `key` | the code of the pressed key when the command `type` is `keypress`, `keyup` or `keydown`.
 `app_id` | the id of the app that was launched when command `type` is `launch`.  
@@ -88,7 +83,7 @@ The available keys are listed here:
 
 ## {% linkable_title Automations %}
 
-automations.yaml
+The following is an example implementation of an automation:
 ```yaml
 # Example automation
 - id: amp_volume_up
@@ -108,7 +103,7 @@ automations.yaml
 ## {% linkable_title Troubleshooting %}
 
 Known limitations:
-* Some Android remotes send keyup / keydown events instead of keypress.
+* Some Android remotes send key up/down events instead of key presses.
 * Functionality other than key presses and app launches are not implemented yet.
 * Harmony cannot launch apps as it uses IR instead of the WiFi API
 * App ids are limited between 1-10. (The Emulated API reports 10 dummy apps)

--- a/source/_components/emulated_roku.markdown
+++ b/source/_components/emulated_roku.markdown
@@ -56,14 +56,14 @@ advertise_port:
   required: false
   type: integer
 upnp_bind_multicast:
-  description: Whether or not to bind the UPnP (SSDP) listener to the multicast address (239.255.255.250) or instead to the (unicast) host_ip address specified above (or automatically determined). The default is true, which will work for most situations.  In special circumstances, like running in a FreeBSD or FreeNAS jail, you may need to disable this.
+  description: Whether or not to bind the UPnP (SSDP) listener to the multicast address (239.255.255.250) or instead to the (unicast) host_ip address specified above (or automatically determined). The default is true, which will work in most situations. In special circumstances, like running in a FreeBSD or FreeNAS jail, you may need to disable this.
   required: false
   type: boolean
   default: true
 {% endconfiguration %}
 
-After starting up, you can check if the Emulated Roku is reachable at the specified ports on your hass instance (eg.: `http://192.168.1.101:8060/`)  
-If you change your advertised IP or ports you will have to re-add your Roku in Harmony.
+After starting up, you can check if the Emulated Roku is reachable at the specified ports on your Home Assistant instance (eg.: `http://192.168.1.101:8060/`).
+If you change your advertised IP or ports, you will have to re-add your Roku in Harmony.
 
 ## {% linkable_title Events %}
 

--- a/source/_components/emulated_roku.markdown
+++ b/source/_components/emulated_roku.markdown
@@ -1,0 +1,114 @@
+---
+layout: page
+title: "Emulated Roku"
+description: "Instructions on how to set up Emulated Roku within Home Assistant."
+date: 2018-10-03 08:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: home-assistant.png
+ha_category: Hub
+ha_release: 0.80.0
+ha_iot_class: "Local Push"
+ha_qa_scale: internal
+---
+
+This component integrates an emulated Roku API into Home Assistant,  
+so remotes such as Harmony and Android apps can connect to it through WiFi as it were a Roku player.  
+Home Assistant will see key presses and app launches as Events, which you can use as triggers for automations.  
+Multiple Roku servers may be started if you run out of buttons by specifying multiple server entries.  
+When using multiple servers, you can filter the roku USN which is specified via the `name` attribute.
+
+<p class='note'>  
+Windows is not supported because Home Assistant uses `ProactorEventLoop` which does not support UDP sockets.
+</p>  
+
+## {% linkable_title Configuration %}
+
+configuration.yaml
+```yaml
+# Example configuration.yaml entry
+emulated_roku:
+  servers:
+    - name: hass roku
+      listen_port: 8060
+      host_ip: 192.168.1.150
+      advertise_ip: 10.0.0.10
+      advertise_port: 8070
+      upnp_bind_multicast: True
+```
+
+{% configuration %}
+name:
+  description: Name of the roku that will be displayed as USN in Harmony.
+  required: true
+  type: string
+listen_port:
+  description: The port the roku API will run on. This can be any free port on your system.
+  required: true
+  type: integer
+host_ip:
+  description: The IP address that your Home Assistant installation is running on. If you do not specify this option, the component will attempt to determine the IP address on its own.
+  required: false
+  type: string
+advertise_ip:
+  description: If you need to override the IP address used for UPnP discovery. (For example, using network isolation in Docker)
+  required: false
+  type: string
+advertise_port:
+  description: If you need to specifically override the advertised UPnP port.
+  required: false
+  type: integer
+upnp_bind_multicast:
+  description: Whether or not to bind the UPnP (SSDP) listener to the multicast address (239.255.255.250) or instead to the (unicast) host_ip address specified above (or automatically determined). The default is true, which will work for most situations.  In special circumstances, like running in a FreeBSD or FreeNAS jail, you may need to disable this.
+  required: false
+  type: boolean
+  default: true
+{% endconfiguration %}
+
+After starting up, you can check if the Emulated Roku is reachable at the specified ports on your hass instance (eg.: `http://192.168.1.101:8060/`)  
+If you change your advertised IP or ports you will have to re-add your Roku in Harmony.
+
+## {% linkable_title Events %}
+
+### {% linkable_title Event `roku_command` %}
+
+All roku commands are sent as `roku_command` events.
+
+Field | Description
+----- | -----------
+`source_name` | Name of the that sent the event roku. Not required for when using one Emulated Roku instance.
+`type` | The type of the event that was called on the Roku API.
+`key` | the code of the pressed key when the command `type` is `keypress`, `keyup` or `keydown`.
+`app_id` | the id of the app that was launched when command `type` is `launch`.  
+
+The available keys are listed here:
+[Roku key codes](https://sdkdocs.roku.com/display/sdkdoc/External+Control+API#ExternalControlAPI-KeypressKeyValues)
+
+## {% linkable_title Automations %}
+
+automations.yaml
+```yaml
+# Example automation
+- id: amp_volume_up
+  alias: Increase amplifier volume
+  trigger:
+  - platform: event
+    event_type: roku_command
+    event_data:
+      source_name: hass roku
+      type: keypress
+      key: Fwd
+  action:
+  - service: media_player.volume_up
+    entity_id: media_player.amplifier
+```
+
+## {% linkable_title Troubleshooting %}
+
+Known limitations:
+* Some Android remotes send keyup / keydown events instead of keypress.
+* Functionality other than key presses and app launches are not implemented yet.
+* Harmony cannot launch apps as it uses IR instead of the WiFi API
+* App ids are limited between 1-10. (The Emulated API reports 10 dummy apps)

--- a/source/_components/emulated_roku.markdown
+++ b/source/_components/emulated_roku.markdown
@@ -2,14 +2,14 @@
 layout: page
 title: "Emulated Roku"
 description: "Instructions on how to set up Emulated Roku within Home Assistant."
-date: 2018-10-03 08:00
+date: 2019-01-10 08:00
 sidebar: true
 comments: false
 sharing: true
 footer: true
 logo: home-assistant.png
 ha_category: Hub
-ha_release: 0.85.0
+ha_release: 0.86.0
 ha_iot_class: "Local Push"
 ha_qa_scale: internal
 ---

--- a/source/_components/emulated_roku.markdown
+++ b/source/_components/emulated_roku.markdown
@@ -11,7 +11,6 @@ logo: home-assistant.png
 ha_category: Hub
 ha_release: 0.86.0
 ha_iot_class: "Local Push"
-ha_qa_scale: internal
 ---
 
 This component integrates an emulated Roku API into Home Assistant,  

--- a/source/_components/emulated_roku.markdown
+++ b/source/_components/emulated_roku.markdown
@@ -118,6 +118,9 @@ Known limitations:
 * Some Android remotes send key up/down events instead of key presses.
 * Functionality other than key presses and app launches are not implemented yet.
 * App ids are limited between 1-10. (The emulated API reports 10 dummy apps)
+* Harmony uses UPnP discovery (UPnP is not needed after pairing), which might not work in Docker. You can:
+  * Change Docker to host networking temporarily, then revert after pairing.
+  * Run the `advertise.py` helper script from the emulated_roku library directly somewhere else and point it to the emulated Roku API.
 * Harmony cannot launch apps as it uses IR instead of the WiFi API and will not display the custom dummy app list. 
 * Home control buttons cannot be assigned to emulated Roku on the Harmony Hub Companion remote as they are limited to Hue (and possibly other APIs) within Harmony.
 * Harmony will not set the name of the added emulated Roku device to the specified `name`.

--- a/source/_components/emulated_roku.markdown
+++ b/source/_components/emulated_roku.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: home-assistant.png
 ha_category: Hub
-ha_release: 0.81.0
+ha_release: 0.85.0
 ha_iot_class: "Local Push"
 ha_qa_scale: internal
 ---
@@ -28,9 +28,15 @@ Windows is not supported because Home Assistant uses `ProactorEventLoop` which d
 
 The component is configurable through the frontend. (**Configuration** -> **Integrations** -> **Emulated Roku**)
 
-<p class='note warning'>
-You can only configure the component through the integrations page, not in configuration files.
-</p>
+If you wish to configure advanced options, you can add the following entry in `configuration.yaml`.
+
+```yaml
+# Example configuration.yaml entry
+emulated_roku:
+  servers:
+    - name: hass roku
+      listen_port: 8060
+```
 
 {% configuration %}
 name:


### PR DESCRIPTION
**Description:**

Adds documentation for the emulated_roku component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17596

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
