### PR TITLE
Update Tapsaff binary sensor component configuration

### DIFF
--- a/source/_components/binary_sensor.tapsaff.markdown
+++ b/source/_components/binary_sensor.tapsaff.markdown
@@ -14,7 +14,6 @@ ha_release: 0.47
 ha_iot_class: "Local Polling"
 ---
 
-
 The `tapsaff` binary sensor provides the 'Taps Aff' status for a given location within the UK using [Taps Aff](http://www.taps-aff.co.uk). 
 
 To enable this sensor, add the following lines to your `configuration.yaml`:

--- a/source/_components/binary_sensor.tapsaff.markdown
+++ b/source/_components/binary_sensor.tapsaff.markdown
@@ -26,7 +26,14 @@ binary_sensor:
     location: glasgow
 ```
 
-Configuration variables:
-
-- **location** (*Required*): The location for the Taps Aff. It must be configured with a UK postcode or city to work. 
-- **name** (*Optional*): The name to use when displaying this sensor.
+{% configuration %}
+location:
+  description: The location for the Taps Aff. It must be configured with a UK postcode or city to work.
+  required: true
+  type: string
+name:
+  description: The name to use when displaying this sensor.
+  required: false
+  default: Taps Aff
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Tapsaff binary sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
