### PR TITLE
Update Facebook notify component configuration

### DIFF
--- a/source/_components/notify.facebook.markdown
+++ b/source/_components/notify.facebook.markdown
@@ -24,10 +24,17 @@ notify:
     page_access_token: FACEBOOK_PAGE_ACCESS_TOKEN
 ```
 
-Configuration variables:
-
-- **page_access_token** (*Required*): Access token for your Facebook page. Checkout [Facebook Messenger Platform](https://developers.facebook.com/docs/messenger-platform/guides/setup) for more information.
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+{% configuration %}
+page_access_token:
+  description: "Access token for your Facebook page. Checkout [Facebook Messenger Platform](https://developers.facebook.com/docs/messenger-platform/guides/setup) for more information."
+  required: true
+  type: string
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: "`notify`"
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title Usage %}
 

--- a/source/_components/notify.facebook.markdown
+++ b/source/_components/notify.facebook.markdown
@@ -141,4 +141,3 @@ To enable broadcast just use the keyword "BROADCAST" as your target. Only put ON
       target:
         - BROADCAST
 ```
-


### PR DESCRIPTION
**Description:**
Update style of Facebook notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
