### PR TITLE
Update Digitalloggers switch component configuration

### DIFF
--- a/source/_components/switch.digitalloggers.markdown
+++ b/source/_components/switch.digitalloggers.markdown
@@ -27,16 +27,37 @@ switch:
     host: 192.168.1.43
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP address or FQDN of your DIN III relay, eg. `192.168.1.32` or `myrelay.example.com`.
-- **name** (*Optional*): The name to use when controlling this relay.  Default: `DINRelay`.
-- **username** (*Optional*): Credentials for controlling this relay. Default: `admin`.
-- **password** (*Optional*): Credentials for controlling this relay. Default: `admin`.
-- **timeout** (*Optional*): Default timeout as set by the underlying python-dlipower library is `20` seconds.  Override it if you need to.  Valid range is 1 to 600.
-- **cycletime** (*Optional*): This is the delay enforced by the library when you send multiple commands to the same device.  The default relay cycle time is `2` seconds. Override it if you need to.  Valid range is 1 to 600. A delay is a recommendation of Digital Loggers: 
->Many loads draw more power when they are initially switched on. Sequencing prevents circuit overloads when loads devices are attached to a single circuit. 
-
+{% configuration %}
+host:
+  description: The IP address or FQDN of your DIN III relay, e.g., `192.168.1.32` or `myrelay.example.com`.
+  required: true
+  type: string
+name:
+  description: The name to use when controlling this relay.
+  required: false
+  default: DINRelay
+  type: string
+username:
+  description: Username for controlling this relay.
+  required: false
+  default: admin
+  type: string
+password:
+  description: Password for controlling this relay.
+  required: false
+  default: admin
+  type: string
+timeout:
+  description: Override the timeout in seconds if you need to, valid range is 1 to 600.
+  required: false
+  default: 20
+  type: integer
+cycletime:
+  description: "This is the delay enforced by the library when you send multiple commands to the same device. Override it if you need to. Valid range is 1 to 600. A delay is a recommendation of Digital Loggers: Many loads draw more power when they are initially switched on. Sequencing prevents circuit overloads when loads devices are attached to a single circuit."
+  required: false
+  default: 2
+  type: integer
+{% endconfiguration %}
 
 Your relays will be available in the form `switch.fantasticrelaydevice_individualrelayname`
 


### PR DESCRIPTION
**Description:**
Update style of Digitalloggers switch component documentation to follow new configuration variables description.
Related to #6385.

Please check also the description of the `timeout` variable.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
