### PR TITLE
Update x10 light component configuration

### DIFF
--- a/source/_components/light.x10.markdown
+++ b/source/_components/light.x10.markdown
@@ -30,7 +30,18 @@ light:
         name: Bedroom Lamp
 ```
 
-Configuration variables:
-
-- **id** (*Required*): Device identifier. Composed of house code and unit id.
-- **name** (*Required*): A friendly name for the device.
+{% configuration %}
+devices:
+  description: A list of devices.
+  required: true
+  type: list
+  keys:
+    id:
+      description: Device identifier. Composed of house code and unit id.
+      required: true
+      type: string
+    name:
+      description: A friendly name for the device.
+      required: true
+      type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of x10 light component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
