### PR TITLE
Update London underground sensor component configuration

### DIFF
--- a/source/_components/sensor.london_underground.markdown
+++ b/source/_components/sensor.london_underground.markdown
@@ -38,8 +38,11 @@ sensor:
       - Waterloo & City
 ```
 
-Configuration variables:
-
-- **line** (*Required*): Enter the name of at least one line.
+{% configuration %}
+line:
+  description: Enter the name of at least one line.
+  required: true
+  type: list
+{% endconfiguration %}
 
 Powered by TfL Open Data [TFL](https://api.tfl.gov.uk/).


### PR DESCRIPTION
**Description:**
Update style of London underground sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
