### PR TITLE
Added note about persistence of messages with embedded broker

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -39,7 +39,7 @@ Configuration variables:
 - **discovery_prefix** (*Optional*): The prefix for the discovery topic. Defaults  to `homeassistant`.
 
 <p class='note'>
-The [embedded MQTT broker](/docs/mqtt/broker#embedded-broker) does not save any messages between restarts. If you use the embedded MQTT broker you have to send the mqtt discovery messages after every Home Assistant restart for the devices to show up.
+The [embedded MQTT broker](/docs/mqtt/broker#embedded-broker) does not save any messages between restarts. If you use the embedded MQTT broker you have to send the MQTT discovery messages after every Home Assistant restart for the devices to show up.
 </p>
 
 The discovery topic need to follow a specific format:

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -38,6 +38,10 @@ Configuration variables:
 - **discovery** (*Optional*): If the MQTT discovery should be enabled or not. Defaults to `False`.
 - **discovery_prefix** (*Optional*): The prefix for the discovery topic. Defaults  to `homeassistant`.
 
+<p class='note'>
+The [embedded MQTT broker](/docs/mqtt/broker#embedded-broker) does not save any messages between restarts. If you use the embedded MQTT broker you have to send the mqtt discovery messages after every Home Assistant restart for the devices to show up.
+</p>
+
 The discovery topic need to follow a specific format:
 
 ```text


### PR DESCRIPTION
**Description:**

The embedded mqtt broker does not save messages between restarts. Because of this the discovery messages have to be sent after every restart for the devices to show up in HA. I added a note section to make users aware of this.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** Documentation enhancement only.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
