### PR TITLE
fix get_state syntax examples

### DIFF
--- a/source/_docs/ecosystem/appdaemon/api.markdown
+++ b/source/_docs/ecosystem/appdaemon/api.markdown
@@ -317,10 +317,10 @@ state = self.get_state("switch")
 state = self.get_state("light.office_1")
 
 # Return the brightness attribute for light.office_1
-state = self.get_state("light.office_1", "brightness")
+state = self.get_state("light.office_1", attribute = "brightness")
 
 # Return the entire state for light.office_1
-state = self.get_state("light.office_1", "all")
+state = self.get_state("light.office_1", attribute = "all")
 ```
 
 ### {% linkable_title set_state() %}


### PR DESCRIPTION
**Description:**

when called as given, errors with `TypeError: get_state() takes from 1 to 2 positional arguments but 3 were given`

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
