### PR TITLE
Standardize example configuration blocks

### DIFF
--- a/source/_components/cloudflare.markdown
+++ b/source/_components/cloudflare.markdown
@@ -28,7 +28,7 @@ To use the component in your installation, add the following to your `configurat
 ```yaml
 # Example configuration.yaml entry
 cloudflare:
-  email: USER@EXAMPLE.COM
+  email: YOUR_EMAIL_ADDRESS
   api_key: YOUR_GLOBAL_API_KEY
   zone: EXAMPLE.COM
   records:

--- a/source/_components/cloudflare.markdown
+++ b/source/_components/cloudflare.markdown
@@ -28,9 +28,9 @@ To use the component in your installation, add the following to your `configurat
 ```yaml
 # Example configuration.yaml entry
 cloudflare:
-  email: user@example.com
-  api_key: c2547eb745079dac9320b638f5e225cf483cc5cfdda41
-  zone: example.com
+  email: USER@EXAMPLE.COM
+  api_key: YOUR_API_KEY
+  zone: EXAMPLE.COM
   records:
     - bin
     - www

--- a/source/_components/cloudflare.markdown
+++ b/source/_components/cloudflare.markdown
@@ -29,7 +29,7 @@ To use the component in your installation, add the following to your `configurat
 # Example configuration.yaml entry
 cloudflare:
   email: USER@EXAMPLE.COM
-  api_key: YOUR_API_KEY
+  api_key: YOUR_GLOBAL_API_KEY
   zone: EXAMPLE.COM
   records:
     - bin

--- a/source/_components/coinbase.markdown
+++ b/source/_components/coinbase.markdown
@@ -25,8 +25,8 @@ To set it up, add the following information to your `configuration.yaml` file:
 ```yaml
 # Example configuration.yaml entry
 coinbase:
-  api_key: asdfghjklqwertyuiopzxcvbnm 
-  api_secret: nkjnewncfghjklqwertyuiopzxcvbnm 
+  api_key: YOUR_API_KEY 
+  api_secret: YOUR_API_SECRET 
   exchange_rate_currencies:
     - BTC
     - ETH

--- a/source/_components/ecobee.markdown
+++ b/source/_components/ecobee.markdown
@@ -48,7 +48,7 @@ To set it up, add the following information to your `configuration.yaml` file:
 ```yaml
 # Example configuration.yaml entry
 ecobee:
-  api_key: asdfghjklqwertyuiopzxcvbnm 
+  api_key: YOUR_API_KEY 
 ```
 
 {% configuration %}

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -98,21 +98,21 @@ Now add the following lines to your `configuration.yaml` file:
 ```yaml
 # Example configuration.yaml entry
 google_assistant:
-  project_id: someproject-2d0b8
-  api_key: [a Homegraph API Key generated for the Google Actions project]
+  project_id: YOUR_PROJECT_ID
+  api_key: YOUR_API_KEY
   exposed_domains:
-    - switch
-    - light
-    - group
+    - SWITCH
+    - LIGHT
+    - GROUP
   entity_config:
     switch.kitchen:
-      name: Custom Name for Google Assistant
+      name: CUSTOM_NAME_FOR_GOOGLE_ASSISTANT
       aliases:
-        - bright lights
-        - entry lights
+        - BRIGHT_LIGHTS
+        - ENTRY_LIGHTS
     light.living_room:
       expose: false
-      room: living room
+      room: LIVING_ROOM
 ```
 
 {% configuration %}

--- a/source/_components/habitica.markdown
+++ b/source/_components/habitica.markdown
@@ -20,8 +20,8 @@ To use the component you should use this example configuration:
 ```yaml
 # Minimum viable configuration.yaml entry
 habitica:
-  - api_user: 'REPLACE_ME_WITH_YOUR_USER_ID'
-    api_key: 'REPLACE_ME_WITH_YOUR_API_KEY'
+  - api_user: YOUR_USER_ID
+    api_key: YOUR_API_KEY
 ```
 
 You can specify several users, providing `api_user` and `api_key` for each.

--- a/source/_components/ifttt.markdown
+++ b/source/_components/ifttt.markdown
@@ -49,7 +49,7 @@ automation:
 ```yaml
 # Example configuration.yaml entry
 ifttt:
-  key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  key: YOUR_API_KEY
 ```
 
 `key` is your API key which can be obtained by viewing the **Settings** of the [Webhooks applet](https://ifttt.com/services/maker_webhooks/settings). It's the last part of the URL (e.g., https://maker.ifttt.com/use/MYAPIKEY) you will find under **My Applets** > **Webhooks** > **Settings**.

--- a/source/_components/image_processing.openalpr_cloud.markdown
+++ b/source/_components/image_processing.openalpr_cloud.markdown
@@ -26,10 +26,10 @@ take a look at the [component](/components/image_processing/) page.
 # Example configuration.yaml entry
 image_processing:
  - platform: openalpr_cloud
-   api_key: 'sk_abcxyz123456'
+   api_key: YOUR_API_KEY
    region: eu
    source:
-    - entity_id: camera.garage
+    - entity_id: CAMERA.GARAGE
 ```
 
 {% configuration %}

--- a/source/_components/joaoapps_join.markdown
+++ b/source/_components/joaoapps_join.markdown
@@ -28,15 +28,15 @@ To set it up, add the following information to your `configuration.yaml` file:
 # Example configuration.yaml entry
 notify:
   - platform: joaoapps_join
-    api_key: asd97823jb628a34fwsdfwefd5384345tf2d
-    device_id: d5asdfasdf54645h45h368761dfe5gt8a
-    device_ids: d5asdfasdf54645h45h368761dfe5gt8a, a4asdfasdf54645h45h368761dfe5gt3b
-    device_names: Pixel, iPhone
-    name: Phones
+    api_key: YOUR_API_KEY
+    device_id: DEVICE_ID
+    device_ids: DEVICE_ID_1, DEVICE_ID_2
+    device_names: DEVICE_1_NAME, DEVICE_2_NAME
+    name: NAME
 joaoapps_join:
-  - name: android
-    device_id: group.android
-    api_key: asd97823jb628a34fwsdfwefd5384345tf2d
+  - name: NAME_OF_GROUP
+    device_id: GROUP.GROUP_NAME
+    api_key: YOUR_API_KEY
 ```
 
 {% configuration %}

--- a/source/_components/light.avion.markdown
+++ b/source/_components/light.avion.markdown
@@ -43,8 +43,8 @@ light:
     devices:
       00:21:4D:00:00:01:
         name: Light 1
-        api_key: Gr35a/rt3RgaRenl9ag8Ba==
+        api_key: YOUR_API_KEY
       00:21:3D:20:00:a1:
         name: Light 2
-        api_key: Gr35a/rt3RgaRenl9ag8Ba==
+        api_key: YOUR_API_KEY
 ```

--- a/source/_components/light.decora.markdown
+++ b/source/_components/light.decora.markdown
@@ -25,7 +25,7 @@ light:
   - platform: decora
     devices:
       00:21:4D:00:00:01:
-        api_key: 0x12345678
+        api_key: YOUR_API_KEY
 ```
 
 {% configuration %}

--- a/source/_components/mailgun.markdown
+++ b/source/_components/mailgun.markdown
@@ -23,8 +23,8 @@ To send messages, use the [Mailgun notify platform][notify].
 ```yaml
 # Example configuration.yaml entry
 mailgun:
-  domain: mg.example.com
-  api_key: XXXXXXXXXXXXX
+  domain: EXAMPLE.COM
+  api_key: YOUR_API_KEY
 ```
 
 Configuration variables:

--- a/source/_components/media_player.emby.markdown
+++ b/source/_components/media_player.emby.markdown
@@ -22,7 +22,7 @@ To add Emby to your installation, add the following to your `configuration.yaml`
 # Example configuration.yaml entry
 media_player:
   - platform: emby
-    host: 192.168.0.0
+    host: YOUR_IP_ADDRESS
     api_key: YOUR_API_KEY
 ```
 

--- a/source/_components/media_player.emby.markdown
+++ b/source/_components/media_player.emby.markdown
@@ -22,8 +22,8 @@ To add Emby to your installation, add the following to your `configuration.yaml`
 # Example configuration.yaml entry
 media_player:
   - platform: emby
-    host: 192.168.11.5
-    api_key: "emby_api_key"
+    host: 192.168.0.0
+    api_key: YOUR_API_KEY
 ```
 
 {% configuration %}

--- a/source/_components/notify.html5.markdown
+++ b/source/_components/notify.html5.markdown
@@ -29,8 +29,8 @@ add the following lines to your `configuration.yaml` file:
 notify:
   - platform: html5
     name: NOTIFIER_NAME
-    gcm_api_key: 'gcm-server-key'
-    gcm_sender_id: 'gcm-sender-id'
+    gcm_api_key: YOUR_API_KEY
+    gcm_sender_id: YOUR_SENDER_ID
 ```
 
 {% configuration %}

--- a/source/_components/notify.instapush.markdown
+++ b/source/_components/notify.instapush.markdown
@@ -24,10 +24,10 @@ To add Instapush to your installation, add the following to your `configuration.
 notify:
   - name: NOTIFIER_NAME
     platform: instapush
-    api_key: ABCDEFGHJKLMNOPQRSTUVXYZ
-    app_secret: ABCDEFGHJKLMNOPQRSTUVXYZ
-    event: ABCDEFGHJKLMNOPQRSTUVXYZ
-    tracker: ABCDEFGHJKLMNOPQRSTUVXYZ
+    api_key: YOUR_API_KEY
+    app_secret: YOUR_APP_SECRET
+    event: PUSH_TO_EVENT
+    tracker: TRACKER_NAME
 ```
 
 Configuration variables:

--- a/source/_components/notify.llamalab_automate.markdown
+++ b/source/_components/notify.llamalab_automate.markdown
@@ -25,7 +25,7 @@ notify:
   - name: NOTIFIER_NAME
     platform: llamalab_automate
     api_key: YOUR_API_KEY
-    to: EXAMPLE@EXAMPLE.COM
+    to: YOUR_EMAIL_ADDRESS
 ```
 
 Configuration variables:

--- a/source/_components/notify.llamalab_automate.markdown
+++ b/source/_components/notify.llamalab_automate.markdown
@@ -24,8 +24,8 @@ To add Automate to your installation, add the following to your `configuration.y
 notify:
   - name: NOTIFIER_NAME
     platform: llamalab_automate
-    api_key: ABCDEFGHJKLMNOPQRSTUVXYZ
-    to: example@gmail.com
+    api_key: YOUR_API_KEY
+    to: EXAMPLE@EXAMPLE.COM
 ```
 
 Configuration variables:

--- a/source/_components/notify.mailgun.markdown
+++ b/source/_components/notify.mailgun.markdown
@@ -21,13 +21,13 @@ The Mailgun notification service allows you to send emails via Mailgun's REST AP
 ```yaml
 # Example configuration.yaml entry
 mailgun:
-  domain: mg.example.com
-  api_key: XXXXXXXXXXXXXX
+  domain: EXAMPLE.COM
+  api_key: YOUR_API_KEY
 
 notify:
   - name: mailgun
     platform: mailgun
-    recipient: me@example.com
+    recipient: CHANGE@EXAMPLE.COM
 ```
 
 Configuration variables:

--- a/source/_components/notify.markdown
+++ b/source/_components/notify.markdown
@@ -17,8 +17,8 @@ The `notify` component makes it possible to send notifications to a wide variety
 # Example configuration.yaml entry
 notify:
   - platform: pushbullet
-    name: paulus
-    api_key: ABCDEFG
+    name: NOTIFY_NAME
+    api_key: YOUR_API_KEY
 ```
 
 The **name** parameter is optional but needed if you want to use multiple platforms. The platform will be exposed as service `notify.<name>`. The name will default to `notify` if not supplied.

--- a/source/_components/notify.prowl.markdown
+++ b/source/_components/notify.prowl.markdown
@@ -24,7 +24,7 @@ To add Prowl notifications to your installation, add the following to your `conf
 notify:
   - name: NOTIFIER_NAME
     platform: prowl
-    api_key: ABCDEFGHJKLMNOPQRSTUVXYZ
+    api_key: YOUR_API_KEY
 ```
 
 Configuration variables:

--- a/source/_components/notify.pushover.markdown
+++ b/source/_components/notify.pushover.markdown
@@ -26,8 +26,8 @@ To use Pushover notifications, add the following to your `configuration.yaml` fi
 notify:
   - name: NOTIFIER_NAME
     platform: pushover
-    api_key: ABCDEFGHJKLMNOPQRSTUVXYZ
-    user_key: ABCDEFGHJKLMNOPQRSTUVXYZ
+    api_key: YOUR_API_KEY
+    user_key: YOUR_USER_KEY
 ```
 
 Configuration variables:

--- a/source/_components/notify.pushsafer.markdown
+++ b/source/_components/notify.pushsafer.markdown
@@ -23,7 +23,7 @@ To use Pushsafer notifications, add the following to your `configuration.yaml` f
 notify:
   - name: NOTIFIER_NAME
     platform: pushsafer
-    private_key: ABCDEFGHJKLMNOPQRSTUVXYZ
+    private_key: YOUR_KEY
 ```
 
 **Configuration variables:**

--- a/source/_components/notify.sendgrid.markdown
+++ b/source/_components/notify.sendgrid.markdown
@@ -20,7 +20,7 @@ To enable notification emails via SendGrid in your installation, add the followi
 notify:
   - name: NOTIFIER_NAME
     platform: sendgrid
-    api_key: API_KEY
+    api_key: YOUR_API_KEY
     sender: SENDER_EMAIL_ADDRESS
     recipient: YOUR_RECIPIENT
 ```

--- a/source/_components/notify.slack.markdown
+++ b/source/_components/notify.slack.markdown
@@ -38,7 +38,7 @@ To enable the Slack notification in your installation, add the following to your
 notify:
   - name: NOTIFIER_NAME
     platform: slack
-    api_key: ABCDEFGHJKLMNOPQRSTUVXYZ
+    api_key: YOUR_API_KEY
     default_channel: '#general'
 ```
 

--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -79,7 +79,7 @@ To enable Telegram notifications in your installation, add the following to your
 # Example configuration.yaml entry for the Telegram Bot
 telegram_bot:
   - platform: polling
-    api_key: ABCDEFGHJKLMNOPQRSTUVXYZ
+    api_key: YOUR_API_KEY
     allowed_chat_ids:
       - CHAT_ID_1
       - CHAT_ID_2

--- a/source/_components/notify.twitter.markdown
+++ b/source/_components/notify.twitter.markdown
@@ -28,10 +28,10 @@ To add Twitter to your installation, add the following to your `configuration.ya
 notify:
   - name: NOTIFIER_NAME
     platform: twitter
-    consumer_key: ABCDEFGHJKLMNOPQRSTUVXYZ
-    consumer_secret: ABCDEFGHJKLMNOPQRSTUVXYZ
-    access_token: ABCDEFGHJKLMNOPQRSTUVXYZ
-    access_token_secret: ABCDEFGHJKLMNOPQRSTUVXYZ
+    consumer_key: YOUR_API_KEY
+    consumer_secret: YOUR_API_SECRET
+    access_token: YOUR_ACCESS_TOKEN
+    access_token_secret: YOUR_ACCESS_SECRET
 ```
 
 {% configuration %}

--- a/source/_components/remember_the_milk.markdown
+++ b/source/_components/remember_the_milk.markdown
@@ -27,8 +27,8 @@ To be able to use this component, you need a Remember The Milk account and you n
 
 remember_the_milk:
   - name: your_rtm_account
-    api_key: <your secret api key goes here>
-    shared_secret: <your secret shared secret goes here>
+    api_key: YOUR_API_KEY
+    shared_secret: YOUR_SHARED_SECRET
 
 ```
 

--- a/source/_components/sensor.spotcrime.markdown
+++ b/source/_components/sensor.spotcrime.markdown
@@ -25,9 +25,9 @@ To enable this sensor, add the following lines to your `configuration.yaml`. You
 ```yaml
 sensor:
   - platform: spotcrime
-    name: <any name>
-    radius: <your radius>
-    api_key: <"your_api_key_here">
+    name: NAME
+    radius: SEARCH_RADIUS
+    api_key: YOUR_API_KEY
 ```
 
 {% configuration %}

--- a/source/_components/sensor.trafikverket_weatherstation.markdown
+++ b/source/_components/sensor.trafikverket_weatherstation.markdown
@@ -29,7 +29,7 @@ To enable this sensor, add the following lines to your `configuration.yaml`.
 sensor:
   - platform: trafikverket_weatherstation
     name: Trafikverket Kungälv
-    api_key: eXXcbXXXacXXXXc39XX3aXXX4aXX46XX
+    api_key: YOUR_API_KEY
     station: Kungälv
     monitored_conditions:
         - air_temp
@@ -93,7 +93,7 @@ Click [here](https://www.trafikverket.se/trafikinformation/vag/?TrafficType=pers
 sensor:
   - platform: trafikverket_weatherstation
     name: Trafikverket Kungälv
-    api_key: eXXcbXXXacXXXXc39XX3aXXX4aXX46XX
+    api_key: YOUR_API_KEY
     station: Kungälv
     monitored_conditions:
         - air_temp
@@ -105,7 +105,7 @@ sensor:
         - wind_speed
   - platform: trafikverket_weatherstation
     name: Trafikverket Lanna
-    api_key: eXXcbXXXacXXXXc39XX3aXXX4aXX46XX
+    api_key: YOUR_API_KEY
     station: Lanna
     monitored_conditions:
         - air_temp
@@ -113,7 +113,7 @@ sensor:
         - humidity
   - platform: trafikverket_weatherstation
     name: Trafikverket Nöbbele
-    api_key: eXXcbXXXacXXXXc39XX3aXXX4aXX46XX
+    api_key: YOUR_API_KEY
     station: Nöbbele
     monitored_conditions:
         - air_temp

--- a/source/_components/sensor.uk_transport.markdown
+++ b/source/_components/sensor.uk_transport.markdown
@@ -29,8 +29,8 @@ To add a single train departure sensor add the following to your `configuration.
 # Example configuration.yaml entry for a single sensor
 sensor:
   - platform: uk_transport
-    app_id: abc123
-    app_key: efg456
+    app_id: YOUR_APP_ID
+    app_key: YOUR_APP_KEY
     queries:
       - mode: train
         origin: MAL
@@ -116,8 +116,8 @@ The `destination` must be a valid location in the "direction" field returned by 
 # Example configuration.yaml entry for multiple sensors
 sensor:
   - platform: uk_transport
-    app_id: abc123
-    app_key: efg456
+    app_id: YOUR_APP_ID
+    app_key: YOUR_APP_KEY
     queries:
       - mode: bus
         origin: 340000368SHE

--- a/source/_components/sensor.wsdot.markdown
+++ b/source/_components/sensor.wsdot.markdown
@@ -23,7 +23,7 @@ Once you have the code, create `wsdot` sensors by editing your `configuration.ya
 # Example configuration.yaml entry
 sensor:
   - platform: wsdot
-    api_key: XXXXXXXXXXXXXXXXXXXXXXX
+    api_key: YOUR_API_KEY
     travel_time:
      - id: 95
        name: I-90 Eastbound HOV

--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -27,7 +27,7 @@ To add Wunderground to your installation, add the following to your `configurati
 # Example configuration.yaml entry
 sensor:
   - platform: wunderground
-    api_key: your_api_key
+    api_key: YOUR_API_KEY
     monitored_conditions:
       - alerts
       - dewpoint_c
@@ -207,7 +207,7 @@ in the `_1h_` part of the sensor name with `1` to `36`. e.g., `weather_24h` will
 ```yaml
 sensor:
   - platform: wunderground
-    api_key: your_api_key
+    api_key: YOUR_API_KEY
     monitored_conditions:
       - weather_1d_metric
       - weather_1n_metric
@@ -239,7 +239,7 @@ group:
 ```yaml
 sensor:
   - platform: wunderground
-    api_key: your_api_key
+    api_key: YOUR_API_KEY
     monitored_conditions:
       - temp_high_record_c
       - temp_high_1d_c

--- a/source/_components/telegram_bot.broadcast.markdown
+++ b/source/_components/telegram_bot.broadcast.markdown
@@ -21,7 +21,7 @@ To integrate this into Home Assistant, add the following section to your `config
 
 telegram_bot:
   - platform: broadcast
-    api_key: <telegram api key>
+    api_key: YOUR_API_KEY
     allowed_chat_ids:
       - 12345
       - 67890

--- a/source/_components/telegram_bot.polling.markdown
+++ b/source/_components/telegram_bot.polling.markdown
@@ -23,7 +23,7 @@ To integrate this into Home Assistant, add the following section to your `config
 
 telegram_bot:
   - platform: polling
-    api_key: <telegram api key>
+    api_key: YOUR_API_KEY
     allowed_chat_ids:
       - 12345
       - 67890

--- a/source/_components/telegram_bot.webhooks.markdown
+++ b/source/_components/telegram_bot.webhooks.markdown
@@ -27,7 +27,7 @@ http:
 
 telegram_bot:
   - platform: webhooks
-    api_key: telegram api key
+    api_key: YOUR_API_KEY
     parse_mode: html
     allowed_chat_ids:
       - 12345
@@ -78,7 +78,7 @@ http:
 
 telegram_bot:
   - platform: webhooks
-    api_key: ABCDEFGHJKLMNOPQRSTUVXYZ
+    api_key: YOUR_API_KEY
     trusted_networks:
       - 149.154.167.197/32
       - 149.154.167.198/31

--- a/source/_components/tts.microsoft.markdown
+++ b/source/_components/tts.microsoft.markdown
@@ -21,7 +21,7 @@ To enable text-to-speech with Microsoft, add the following lines to your `config
 # Example configuration.yaml entry
 tts:
   - platform: microsoft
-    api_key: [YourAPIKey]
+    api_key: YOUR_API_KEY
 ```
 
 Configuration variables:
@@ -41,7 +41,7 @@ A full configuration sample including optional configuration variables:
 # Example configuration.yaml entry
 tts:
   - platform: microsoft
-    api_key: XXXXXXXXX
+    api_key: YOUR_API_KEY
     language: en-gb
     gender: Male
     type: George, Apollo

--- a/source/_components/tts.voicerss.markdown
+++ b/source/_components/tts.voicerss.markdown
@@ -57,7 +57,7 @@ The configuration sample below show how a entry can look like:
 # Example configuration.yaml entry
 tts:
   - platform: voicerss
-    api_key: 'XXXXX'
+    api_key: YOUR_API_KEY
     language: 'de-de'
     codec: mp3
     format: '8khz_8bit_mono'

--- a/source/_components/tts.yandextts.markdown
+++ b/source/_components/tts.yandextts.markdown
@@ -67,7 +67,7 @@ The configuration sample below show how a entry can look like:
 # Example configuration.yaml entry
 tts:
   - platform: yandextts
-    api_key: 'XXXXX'
+    api_key: YOUR_API_KEY
     language: 'ru-RU'
     codec: mp3
     voice: oksana

--- a/source/_components/vultr.markdown
+++ b/source/_components/vultr.markdown
@@ -28,7 +28,7 @@ To integrate your Vultr subscriptions with Home Assistant, add the following sec
 ```yaml
 # Example configuration.yaml entry
 vultr:
-  api_key: ABCDEFG12345
+  api_key: YOUR_API_KEY
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:**

Standardized values in the example configuration.yaml blocks in many files, as described in the [developer docs](https://developers.home-assistant.io/docs/en/documentation_standards.html#component-and-platform-pages)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
