### PR TITLE
Improve huawei_lte debug logging instructions

### DIFF
--- a/source/_components/sensor.huawei_lte.markdown
+++ b/source/_components/sensor.huawei_lte.markdown
@@ -35,7 +35,7 @@ sensor:
 
 {% configuration %}
 monitored_conditions:
-  description: Defines the data to monitor as sensors. The names here are dot-separated paths to information returned by the router. The dataset varies by router model; to see what your router provides, set logging level to debug and watch `homeassistant.components.huawei_lte` debug entries. The following list of values contains a few example paths just to illustrate the syntax; these may not be available on all routers, or their semantics may differ, and there are quite likely many more that are not listed here.
+  description: Defines the data to monitor as sensors. The names here are dot-separated paths to information returned by the router. The dataset varies by router model; to see what your router provides, [set logging level](/components/logger/) of the `homeassistant.components.huawei_lte` component to debug and watch its log entries. The following list of values contains a few example paths just to illustrate the syntax; these may not be available on all routers, or their semantics may differ, and there are quite likely many more that are not listed here.
   type: list
   required: false
   default:


### PR DESCRIPTION
**Description:**

Some huawei_lte debug logging instruction improvements. Branch is next because this is on top of stuff that's not yet in current.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
