### PR TITLE
Add water_heater support HomeKit

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -278,6 +278,7 @@ The following components are currently supported:
 | sensor | CarbonDioxideSensor | All sensors that have `co2` as part of their `entity_id` or `co2` as their `device_class` |
 | sensor | LightSensor | All sensors that have `lm` or `lx` as their `unit_of_measurement` or `illuminance` as their `device_class` |
 | switch | Switch | Represented as a switch by default but can be changed by using `type` within `entity_config`. |
+| water_heater | WaterHeater | All water_heater devices. |
 
 
 ## {% linkable_title Error reporting %}


### PR DESCRIPTION
**Description:**
Add documentation for `water_heater` support for the HomeKit component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17614

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
