### PR TITLE
Tested with nu7400 model

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -93,6 +93,7 @@ Currently known supported models:
 - UE6199UXZG (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 - Q7F (port must be set to 8001, MAC must be specified for Power On)
 - UE40KU6400U (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- NU7400 (port set to 8001 and `pip3 install websocket-client` executed)
 
 Currently tested but not working models:
 


### PR DESCRIPTION
Just bought the UE50NU7402 and tested with homeassistant and this component. All the functionality that I could try was working. 
Thnx for the great work

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
