### PR TITLE
Fix broken Broadlink Homepage Link

### DIFF
--- a/source/_components/switch.broadlink.markdown
+++ b/source/_components/switch.broadlink.markdown
@@ -13,7 +13,7 @@ ha_release: 0.35
 ha_iot_class: "Local Polling"
 ---
 
-This `Broadlink` switch platform allow to you control Broadlink [devices](http://www.ibroadlink.com/rm/).
+This `Broadlink` switch platform allow to you control Broadlink [devices](http://www.ibroadlink.com/).
 
 To enable it, add the following lines to your `configuration.yaml`:
 


### PR DESCRIPTION


**Description:**
So it does not point to a `403 Forbidden` page

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
