### PR TITLE
New configuration section for Honeywell TotalConnect Alarm Control Panel

### DIFF
--- a/source/_components/alarm_control_panel.totalconnect.markdown
+++ b/source/_components/alarm_control_panel.totalconnect.markdown
@@ -18,6 +18,8 @@ This platform supports the following services: `alarm_arm_away`, `alarm_arm_home
 
 If you have issues running this component, you may require `libxml2-dev` and `libxmlsec1-dev` packages. To install these on Hassbian, run the command `apt install libxml2-dev libxmlsec1-dev` with sudo.
 
+## {% linkable_title Configuration %}
+
 To enable this, add the following lines to your `configuration.yaml`:
 
 ```yaml
@@ -28,13 +30,22 @@ alarm_control_panel:
     password: YOUR_PASSWORD
 ```
 
-Configuration variables:
+{% configuration %}
+name:
+  description: Name of device in Home Assistant.
+  required: false
+  type: string
+username:
+  description: Username used to sign into the TotalConnect app/web client.
+  required: true
+  type: string
+password:
+  description: Password used to sign into the TotalConnect app/web client.
+  required: true
+  type: string
+{% endconfiguration %}
 
-- **name** (*Optional*): Name of device in Home Assistant.
-- **username** (*Required*): Username used to sign into the TotalConnect app/web client.
-- **password** (*Required*): Password used to sign into the TotalConnect app/web client.
-
-Automation example:
+## {% linkable_title Automation example %}
 
 ```yaml
 automation:
@@ -56,5 +67,5 @@ automation:
       to: 'armed_away'
     action:
       service: scene.turn_on
-      entity_id: scene.OnArmedAway 
+      entity_id: scene.OnArmedAway
 ```


### PR DESCRIPTION
**Description:**
Updates the Honeywell TotalConnect Alarm Control Panel configuration section
Related to https://github.com/home-assistant/home-assistant.io/issues/6385

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
