### PR TITLE
New configuration section for MQTT Manual Alarm Control Panel

### DIFF
--- a/source/_components/alarm_control_panel.manual_mqtt.markdown
+++ b/source/_components/alarm_control_panel.manual_mqtt.markdown
@@ -32,6 +32,8 @@ When the state of the manual alarm changes, Home Assistant will publish one of t
 - 'pending'
 - 'triggered'
 
+## {% linkable_title Configuration %}
+
 To use your panel in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -42,39 +44,113 @@ alarm_control_panel:
     command_topic: home/alarm/set
 ```
 
-Configuration variables:
-
 The following configuration variables from the base manual alarm platform are available:
 
-- **name** (*Optional*): The name of the alarm. Default is "HA Alarm".
-- **code** (*Optional*): If defined, specifies a code to enable or disable the alarm in the frontend. This code is not required for MQTT interactions.
-- **code_template** (*Optional*): If defined, returns a code to enable or disable the alarm in the frontend; an empty string disables checking the code.  Inside the template, the variables **from_state** and **to_state** identify the current and desired state.  Only one of **code** and **code_template** can be specified.
-- **delay_time** (*Optional*): The time in seconds of the pending time before triggering the alarm. Default is 0 seconds.
-- **pending_time** (*Optional*): The time in seconds of the pending time before effecting a state change. Default is 60 seconds.
-- **trigger_time** (*Optional*): The time in seconds of the trigger time in which the alarm is firing. Default is 120 seconds.
-- **disarm_after_trigger** (*Optional*): If true, the alarm will automatically disarm after it has been triggered instead of returning to the previous state.
-- **armed_home/armed_away/armed_night/disarmed/triggered** (*Optional*): State specific settings
-  - **delay_time** (*Optional*): State specific setting for **delay_time** (all states except **triggered**)
-  - **pending_time** (*Optional*): State specific setting for **pending_time** (all states except **disarmed**)
-  - **trigger_time** (*Optional*): State specific setting for **trigger_time** (all states except **triggered**)
+{% configuration %}
+name:
+  description: The name of the alarm.
+  required: false
+  type: string
+  default: HA Alarm
+code:
+  description: >
+    If defined, specifies a code to enable or disable the alarm in the frontend.
+    This code is not required for MQTT interactions.
+    Only one of **code** and **code_template** can be specified.
+  required: exclusive
+  type: string
+code_template:
+  description: >
+    If defined, returns a code to enable or disable the alarm in the frontend; an empty string disables checking the code.
+    Inside the template, the variables **from_state** and **to_state** identify the current and desired state.
+    Only one of **code** and **code_template** can be specified.
+  required: exclusive
+  type: string
+delay_time:
+  description: The time in seconds of the pending time before triggering the alarm.
+  required: false
+  type: integer
+  default: 0
+pending_time:
+  description: The time in seconds of the pending time before effecting a state change.
+  required: false
+  type: integer
+  default: 60
+trigger_time:
+  description: The time in seconds of the trigger time in which the alarm is firing.
+  required: false
+  type: integer
+  default: 120
+disarm_after_trigger:
+  description: If true, the alarm will automatically disarm after it has been triggered instead of returning to the previous state.
+  required: false
+  type: boolean
+armed_home/armed_away/armed_night/disarmed/triggered:
+  description: State specific settings
+  required: false
+  type: list
+  keys:
+    delay_time:
+      description: State specific setting for **delay_time** (all states except **triggered**)
+      required: false
+      type: integer
+    pending_time:
+      description: State specific setting for **pending_time** (all states except **disarmed**)
+      required: false
+      type: integer
+    trigger_time:
+      description: State specific setting for **trigger_time** (all states except **triggered**)
+      required: false
+      type: integer
+{% endconfiguration %}
 
 See the documentation for the [manual alarm platform](/components/alarm_control_panel.manual/) for a description.
 
-Additionally, the following MQTT configuration variables are also available:
+Additionally, the following MQTT configuration variables are also available.
 
-- **state_topic** (*Required*): The MQTT topic HA will publish state updates to.
-- **command_topic** (*Required*): The MQTT topic HA will subscribe to, to receive commands from a remote device to change the alarm state.
-- **qos** (*Optional*): The maximum QoS level for subscribing and publishing to MQTT messages. Default is 0.
-- **payload_disarm** (*Optional*): The payload to disarm this Alarm Panel. Default is "DISARM".
-- **payload_arm_home** (*Optional*): The payload to set armed-home mode on this Alarm Panel. Default is "ARM_HOME".
-- **payload_arm_away** (*Optional*): The payload to set armed-away mode on this Alarm Panel. Default is "ARM_AWAY".
-- **payload_arm_night** (*Optional*): The payload to set armed-night mode on this Alarm Panel. Default is "ARM_NIGHT".
+{% configuration %}
+state_topic:
+  description: The MQTT topic HA will publish state updates to.
+  required: true
+  type: string
+command_topic:
+  description: The MQTT topic HA will subscribe to, to receive commands from a remote device to change the alarm state.
+  required: true
+  type: string
+qos:
+  description: The maximum QoS level for subscribing and publishing to MQTT messages.
+  required: false
+  type: int
+  default: 0
+payload_disarm:
+  description: The payload to disarm this Alarm Panel.
+  required: false
+  type: string
+  default: DISARM
+payload_arm_home:
+  description: The payload to set armed-home mode on this Alarm Panel.
+  required: false
+  type: string
+  default: ARM_HOME
+payload_arm_away:
+  description: The payload to set armed-away mode on this Alarm Panel.
+  required: false
+  type: string
+  default: ARM_AWAY
+payload_arm_night:
+  description: The payload to set armed-night mode on this Alarm Panel.
+  required: false
+  type: string
+  default: ARM_NIGHT
+{% endconfiguration %}
+
+## {% linkable_title Examples %}
 
 In the configuration example below:
 
-- The disarmed state never triggers the alarm.
-- The armed_home state will leave no time to leave the building or disarm the alarm.
-- While other states state will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back.
+- the disarmed state never triggers the alarm;
+- the armed_home state will leave no time to leave the building or disarm the alarm;
+- while other states state will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back.
 
 ```yaml
 # Example configuration.yaml entry
@@ -92,9 +168,7 @@ alarm_control_panel:
       delay_time: 0
 ```
 
-## {% linkable_title Examples %}
-
-Refer to the [Manual Alarm Control page](/components/alarm_control_panel.manual/#examples) for some real-life examples of how to use this panel.
+Refer to the [Manual Alarm Control page](/components/alarm_control_panel.manual/#examples) for more real-life examples on how to use this panel.
 
 ## {% linkable_title MQTT Control %}
 


### PR DESCRIPTION
**Description:**
Updates the MQTT Manual Alarm Control Panel configuration section
Related to https://github.com/home-assistant/home-assistant.io/issues/6385

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
