### PR TITLE
Various small fixes - a

### DIFF
--- a/source/_components/ads.markdown
+++ b/source/_components/ads.markdown
@@ -15,6 +15,8 @@ ha_iot_class: "Local Push"
 
 The ADS (automation device specification) describes a device-independent and fieldbus independent interface for communication between [Beckhoff](https://www.beckhoff.com/) automation devices running [TwinCAT](http://www.beckhoff.hu/english.asp?twincat/default.htm) and other devices implementing this interface.
 
+## {% linkable_title Configuration %}
+
 To enable ADS, add the following lines to your `configuration.yaml` file:
 
 ```yaml
@@ -25,18 +27,18 @@ ads:
 ```
 
 {% configuration %}
-  device:
-    required: true
-    description: The AMS NetId that identifies the device.
-    type: string
-  port:
-    required: true
-    description: The port that runs the AMS server on the device, typically this would be 801 or 851.
-    type: integer
-  ip_address:
-    required: false
-    description: The IP address of the ADS device, if not set the first 4 bytes of the device id will be used.
-    type: string
+device:
+  description: The AMS NetId that identifies the device.
+  required: true
+  type: string
+port:
+  description: The port that runs the AMS server on the device, typically this would be 801 or 851.  
+  required: true
+  type: integer
+ip_address:
+  description: The IP address of the ADS device, if not set the first 4 bytes of the device id will be used.
+  required: false
+  type: string
 {% endconfiguration %}
 
 ## {% linkable_title Service %}

--- a/source/_components/alarm_control_panel.alarmdotcom.markdown
+++ b/source/_components/alarm_control_panel.alarmdotcom.markdown
@@ -14,6 +14,8 @@ ha_release: 0.11
 
 The `alarmdotcom` platform is consuming the information provided by [Alarm.com](https://www.alarm.com/).
 
+## {% linkable_title Configuration %}
+
 To enable this, add the following lines to your `configuration.yaml`:
 
 ```yaml
@@ -41,5 +43,5 @@ name:
 code:
   description: Specifies a code to enable or disable the alarm in the frontend.
   required: false
-  type: int
+  type: integer
 {% endconfiguration %}

--- a/source/_components/alarm_control_panel.arlo.markdown
+++ b/source/_components/alarm_control_panel.arlo.markdown
@@ -15,6 +15,8 @@ ha_iot_class: "Cloud Polling"
 
 The `arlo` alarm control panel allows you to control your [Arlo](https://arlo.netgear.com/) base stations. You can use it to switch modes and trigger alarms from Home Assistant.
 
+## {% linkable_title Configuration %}
+
 To get your [Arlo](https://arlo.netgear.com/) base stations working within Home Assistant, please follow the instructions for the general [Arlo component](/components/arlo).
 
 Once you have enabled the [Arlo component](/components/arlo), add the following to your `configuration.yaml` file:

--- a/source/_components/alarm_control_panel.concord232.markdown
+++ b/source/_components/alarm_control_panel.concord232.markdown
@@ -14,7 +14,12 @@ ha_release: 0.31
 
 The `concord232` platform provides integration with GE, Interlogix (and other brands) alarm panels that support the RS-232 Automation Control Panel interface module (or have it built in). Supported panels include Concord 4.
 
-To use this platform, you will need to have the external concord232 client and server installed. The server must be running on the device which is connected to the automation module's serial port. The client must be installed on the machine running Home Assistant. These may often be the same machine, but do not have to be. For additional details in setting up and testing the client and server, see <https://github.com/JasonCarter80/concord232>
+To use this platform, you will need to have the external concord232 client and server installed.
+The server must be running on the device which is connected to the automation module's serial port.
+The client must be installed on the machine running Home Assistant. These may often be the same machine, but do not have to be.
+For additional details in setting up and testing the client and server, see <https://github.com/JasonCarter80/concord232>.
+
+## {% linkable_title Configuration %}
 
 To enable this platform in Home Assistant, add the following lines to your `configuration.yaml`:
 
@@ -28,11 +33,11 @@ alarm_control_panel:
 host:
   description: The host where the concord232 server process is running.
   required: false
-  default: localhost
   type: string
+  default: localhost
 port:
   description: The port where the Alarm panel is listening.
   required: false
-  default: 5007
   type: integer
+  default: 5007
 {% endconfiguration %}

--- a/source/_components/alarm_control_panel.envisalink.markdown
+++ b/source/_components/alarm_control_panel.envisalink.markdown
@@ -13,8 +13,6 @@ ha_release: 0.23
 ha_iot_class: "Local Push"
 ---
 
-
 The `envisalink` alarm control panel platform allows you to control your [Envisalink](http://www.eyezon.com) alarms.
 
 The requirement is that you have setup your [Envisalink hub](/components/envisalink/).
-

--- a/source/_components/alarm_control_panel.ialarm.markdown
+++ b/source/_components/alarm_control_panel.ialarm.markdown
@@ -16,6 +16,8 @@ The `ialarm` platform provides connectivity with the [Antifurto365](https://www.
 
 This platform supports the following services: `alarm_arm_away`, `alarm_arm_home` and `alarm_disarm`.
 
+## {% linkable_title Configuration %}
+
 To enable this, add the following lines to your `configuration.yaml` file:
 
 ```yaml
@@ -28,22 +30,22 @@ alarm_control_panel:
 ```
 
 {% configuration %}
-  host:
-    description: The IP address of the iAlarm device on your home network.
-    required: true
-    type: string
-  username:
-    description: Username used to sign into the iAlarm web client (should be admin by default).
-    required: true
-    type: string
-  password:
-    description: Password used to sign into the iAlarm web client. If it has a leading zero you need to put the password within quotes.
-    required: true
-    type: string
-  name:
-    description: Name of device in Home Assistant.
-    required: false
-    type: string
+host:
+  description: The IP address of the iAlarm device on your home network.
+  required: true
+  type: string
+username:
+  description: Username used to sign into the iAlarm web client (should be admin by default).
+  required: true
+  type: string
+password:
+  description: Password used to sign into the iAlarm web client. If it has a leading zero you need to put the password within quotes.
+  required: true
+  type: string
+name:
+  description: Name of device in Home Assistant.
+  required: false
+  type: string
 {% endconfiguration %}
 
 This platform has also been confirmed to work with the alarm system brands Meian and Emooluxr.

--- a/source/_components/alarm_control_panel.markdown
+++ b/source/_components/alarm_control_panel.markdown
@@ -9,11 +9,9 @@ sharing: true
 footer: true
 ---
 
-
 Home Assistant can give you an interface with is similar to a classic alarm system. There are several panels supported:
 
 - [Alarm.com](/components/alarm_control_panel.alarmdotcom/)
 - [Manual](/components/alarm_control_panel.manual/)
 - [MQTT](/components/alarm_control_panel.mqtt/)
 - [Verisure](/components/verisure/)
-

--- a/source/_components/alarm_control_panel.mqtt.markdown
+++ b/source/_components/alarm_control_panel.mqtt.markdown
@@ -25,6 +25,8 @@ The component will accept the following states from your Alarm Panel (in lower c
 
 The component can control your Alarm Panel by publishing to the `command_topic` when a user interacts with the Home Assistant frontend.
 
+## {% linkable_title Configuration %}
+
 To enable this platform, add the following lines to your `configuration.yaml`:
 
 ```yaml

--- a/source/_components/alarm_control_panel.nx584.markdown
+++ b/source/_components/alarm_control_panel.nx584.markdown
@@ -14,6 +14,8 @@ ha_release: 0.13
 
 The `nx584` platform provides integration with GE, Caddx, Interlogix (and other brands) alarm panels that support the NX584 interface module (or have it built in). Supported panels include NX4/6/8/8E. Actual integration is done through [pynx584](http://github.com/kk7ds/pynx584) which is required for this to work.
 
+## {% linkable_title Configuration %}
+
 To enable this, add the following lines to your `configuration.yaml`:
 
 ```yaml
@@ -26,16 +28,16 @@ alarm_control_panel:
 host:
   description: The host where the nx584 server process is running.
   required: false
-  default: localhost
   type: string
+  default: localhost
 name:
   description: This parameter allows you to override the name.
   required: false
-  default: NX584
   type: string
+  default: NX584
 port:
   description: The port where the Alarm panel is listening.
   required: false
-  default: 5007
   type: integer
+  default: 5007
 {% endconfiguration %}

--- a/source/_components/alarm_control_panel.satel_integra.markdown
+++ b/source/_components/alarm_control_panel.satel_integra.markdown
@@ -13,8 +13,6 @@ ha_release: 0.54
 ha_iot_class: "Local Push"
 ---
 
-
 The `satel_integra` alarm control panel platform allows you to control your [SatelIntegra](http://www.satel.pl/en/) alarms.
 
 The requirement is that you have setup your [SatelIntegra hub](/components/satel_integra/).
-

--- a/source/_components/alarm_control_panel.simplisafe.markdown
+++ b/source/_components/alarm_control_panel.simplisafe.markdown
@@ -14,6 +14,8 @@ ha_category: Alarm
 
 The `simplisafe` platform enables the ability to control a [SimpliSafe](http://simplisafe.com/) control panel.
 
+## {% linkable_title Configuration %}
+
 To enable this, add the following lines to your `configuration.yaml`:
 
 ```yaml

--- a/source/_components/alarm_control_panel.spc.markdown
+++ b/source/_components/alarm_control_panel.spc.markdown
@@ -13,7 +13,6 @@ ha_release: 0.47
 ha_iot_class: "Local Push"
 ---
 
-
 The `spc` alarm control panel platform allows you to control your [Vanderbilt SPC](https://www.spcsupportinfo.com/) alarms.
 
 The requirement is that you have setup your [SPC hub](/components/spc/).

--- a/source/_components/alarm_control_panel.verisure.markdown
+++ b/source/_components/alarm_control_panel.verisure.markdown
@@ -13,7 +13,6 @@ ha_release: 0.7.3
 ha_iot_class: "Cloud Polling"
 ---
 
-
 The Verisure alarm control panel platform allows you to control your [Verisure](https://www.verisure.com/) Alarms.
 
 The requirement is that you have setup your [Verisure hub](/components/verisure/).

--- a/source/_components/alarm_control_panel.wink.markdown
+++ b/source/_components/alarm_control_panel.wink.markdown
@@ -14,18 +14,14 @@ ha_release: 0.37
 
 No Wink hub is required to support these devices.
 
-
 The Wink alarm platform allows you to control your [Wink](http://www.wink.com/) Canary all-in-one security camera.
 
 The requirement is that you have setup [Wink](/components/wink/).
-
 
 ### {% linkable_title Supported devices %}
 
 - Canary all-in-one security camera
 
-
 <p class='note'>
 The above devices are confirmed to work, but others may work as well.
 </p>
-

--- a/source/_components/apcupsd.markdown
+++ b/source/_components/apcupsd.markdown
@@ -35,4 +35,3 @@ port:
   type: integer
   default: 3551
 {% endconfiguration %}
-

--- a/source/_components/api.markdown
+++ b/source/_components/api.markdown
@@ -23,4 +23,4 @@ It is HIGHLY recommended that you set the `api_password`, especially if you are 
 api:
 ```
 
-For details to use the API, please refer to the [REST API](/developers/rest_api/) or the [Python REST API documentation](/developers/python_api/) in the "Developer" section. 
+For details to use the API, please refer to the [REST API](/developers/rest_api/) or the [Python REST API documentation](/developers/python_api/) in the "Developer" section.

--- a/source/_components/apple_tv.markdown
+++ b/source/_components/apple_tv.markdown
@@ -19,6 +19,8 @@ The `apple_tv` platform allows you to control an Apple TV (3rd and 4th generatio
 Currently, you must have Home Sharing enabled for this to work. Support for pairing Home Assistant with your device will be supported in a later release.
 </p>
 
+## {% linkable_title Configuration %}
+
 To use this component, you must first install some system libraries and a compiler. For Debian or a similar system, this should be enough:
 
 ```shell

--- a/source/_components/arduino.markdown
+++ b/source/_components/arduino.markdown
@@ -14,11 +14,14 @@ ha_release: pre 0.7
 ha_iot_class: "Local Polling"
 ---
 
-The [Arduino](https://www.arduino.cc/) device family are microcontroller boards that are often based on the ATmega328 chip. They come with digital input/output pins (some can be used as PWM outputs), analog inputs, and a USB connection. The equipment depends on the [type](https://www.arduino.cc/en/Main/Products) of the board. The most common ones are the Arduino Uno and the Arduino Leonardo with 14 digital input/output pins and 6 analog input pins.
+The [Arduino](https://www.arduino.cc/) device family are microcontroller boards that are often based on the ATmega328 chip. They come with digital input/output pins (some can be used as PWM outputs), analog inputs, and a USB connection.
+The equipment depends on the [type](https://www.arduino.cc/en/Main/Products) of the board. The most common ones are the Arduino Uno and the Arduino Leonardo with 14 digital input/output pins and 6 analog input pins.
 
-There are a lot of extensions (so-called [shields](https://www.arduino.cc/en/Main/ArduinoShields)) available. Those shields can be plugged-in into the existing connectors and stacked on top of each other. This makes it possible to expand the capabilities of the Arduino boards. 
+There are a lot of extensions (so-called [shields](https://www.arduino.cc/en/Main/ArduinoShields)) available. Those shields can be plugged-in into the existing connectors and stacked on top of each other. This makes it possible to expand the capabilities of the Arduino boards.
 
 The `arduino` component is designed to let you use a directly attached board to your Home Assistant host over USB.
+
+## {% linkable_title Configuration %}
 
 You need to have the [Firmata firmware](https://github.com/firmata/) on your board. Please upload the `StandardFirmata` sketch to your board; please refer to the [Arduino documentation](https://www.arduino.cc/en/Main/Howto) for further information.
 
@@ -54,4 +57,3 @@ Add the user who is used to run Home Assistant to the groups to allow access to 
 ```bash
 $ sudo usermod -a -G dialout,lock $USER
 ```
-

--- a/source/_components/auth.markdown
+++ b/source/_components/auth.markdown
@@ -13,4 +13,5 @@ ha_release: 0.73
 ha_qa_scale: internal
 ---
 
-This component creates the endpoints for the [authentication system](/docs/authentication/) that is built into Home Assistant. There are no configuration options for this component directly as it relies on the auth system in the core.
+This component creates the endpoints for the [authentication system](/docs/authentication/) that is built into Home Assistant.
+There are no configuration options for this component directly as it relies on the auth system in the core.

--- a/source/_components/axis.markdown
+++ b/source/_components/axis.markdown
@@ -42,27 +42,26 @@ host:
 username:
   description: The username to your Axis device.
   required: false
-  default: root
   type: string
+  default: root
 password:
   description: The password to your Axis device.
   required: false
-  default: pass
   type: string
+  default: pass
 trigger_time:
   description: Minimum time (in seconds) a sensor should keep its positive value.
   required: false
-  default: 0
   type: integer
+  default: 0
 port:
   description: Configure port web server of device is accessible from.
   required: false
-  default: 80
   type: integer
+  default: 80
 location:
   description: Physical location of your Axis device.
   required: false
-  default: not set
   type: string
 include:
   description: This cannot be empty else there would be no use adding the device at all.

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -57,6 +57,7 @@ sensors:
           description: The type/class of the sensor to set the icon in the frontend.
           required: false
           type: device_class
+          default: None
         value_template:
           description: Defines a template to set the state of the sensor.
           required: true

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -35,49 +35,48 @@ binary_sensor:
 {% endraw %}
 
 {% configuration %}
-  sensors:
-    description: List of your sensors.
-    required: true
-    type: map
-    keys:
-      sensor_name:
-        description: The slug of the sensor.
-        required: true
-        type: map
-        keys:
-          friendly_name:
-            description: Name to use in the frontend.
-            required: false
-            type: string
-          entity_id:
-            description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
-            required: false
-            type: string, list
-          device_class:
-            description: The type/class of the sensor to set the icon in the frontend.
-            required: false
-            type: device_class
-            default: None
-          value_template:
-            description: Defines a template to set the state of the sensor.
-            required: true
-            type: template
-          icon_template:
-            description: Defines a template for the icon of the sensor.
-            required: false
-            type: template
-          entity_picture_template:
-            description: Defines a template for the entity picture of the sensor.
-            required: false
-            type: template
-          delay_on:
-            description: The amount of time the template state must be ***met*** before this sensor will switch to `on`.
-            required: false
-            type: time
-          delay_off:
-            description: The amount of time the template state must be ***not met*** before this sensor will switch to `off`.
-            required: false
-            type: time
+sensors:
+  description: List of your sensors.
+  required: true
+  type: map
+  keys:
+    sensor_name:
+      description: The slug of the sensor.
+      required: true
+      type: map
+      keys:
+        friendly_name:
+          description: Name to use in the frontend.
+          required: false
+          type: string
+        entity_id:
+          description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
+          required: false
+          type: string, list
+        device_class:
+          description: The type/class of the sensor to set the icon in the frontend.
+          required: false
+          type: device_class
+        value_template:
+          description: Defines a template to set the state of the sensor.
+          required: true
+          type: template
+        icon_template:
+          description: Defines a template for the icon of the sensor.
+          required: false
+          type: template
+        entity_picture_template:
+          description: Defines a template for the entity picture of the sensor.
+          required: false
+          type: template
+        delay_on:
+          description: The amount of time the template state must be ***met*** before this sensor will switch to `on`.
+          required: false
+          type: time
+        delay_off:
+          description: The amount of time the template state must be ***not met*** before this sensor will switch to `off`.
+          required: false
+          type: time
 {% endconfiguration %}
 
 ## {% linkable_title Considerations %}

--- a/source/_components/sensor.upnp.markdown
+++ b/source/_components/sensor.upnp.markdown
@@ -13,8 +13,6 @@ ha_release: 0.48
 ha_iot_class: "Local Polling"
 ---
 
-
 The `upnp` sensor platform allows one to get the network statistics from your router such as bytes in/out and packets in/out.
 
 To use your UPNP sensor in your installation, you need to set up the [`upnp`](/components/upnp/) component.
-


### PR DESCRIPTION
**Description:**
This is part one, only components starting with a.
Add configuration and other titles
Remove empty lines
Fix indentation for configuration block
Reorder key list to be in line with the rest
Delete empty default value and fixed value type

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
