### PR TITLE
Refined documentation on how the delay time works

### DIFF
--- a/source/_components/alarm_control_panel.manual_mqtt.markdown
+++ b/source/_components/alarm_control_panel.manual_mqtt.markdown
@@ -150,7 +150,7 @@ In the configuration example below:
 
 - The disarmed state never triggers the alarm;
 - The armed_home state will leave no time to leave the building or disarm the alarm;
-- While other states state will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back.
+- While other states state will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back;
 - Setting pending_time to 0 for triggered state allows the alarm to trigger after previous state's delay time only. If not set, the alarm will be pending for previous state's delay_time plus the default pending_time before triggering.
 
 ```yaml

--- a/source/_components/alarm_control_panel.manual_mqtt.markdown
+++ b/source/_components/alarm_control_panel.manual_mqtt.markdown
@@ -67,7 +67,7 @@ code_template:
   required: exclusive
   type: string
 delay_time:
-  description: The time in seconds of the pending time before triggering the alarm.
+  description: The time in seconds of delay added to the triggered state's **pending_time** before triggering the alarm.
   required: false
   type: integer
   default: 0
@@ -151,6 +151,7 @@ In the configuration example below:
 - the disarmed state never triggers the alarm;
 - the armed_home state will leave no time to leave the building or disarm the alarm;
 - while other states state will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back.
+- Setting pending_time to 0 for triggered state allows alarm to trigger after previous state's delay time only. If not set, the alarm will be pending for previous state's delay_time plus the default pending_time before triggering.
 
 ```yaml
 # Example configuration.yaml entry
@@ -166,6 +167,8 @@ alarm_control_panel:
     armed_home:
       pending_time: 0
       delay_time: 0
+    triggered:
+      pending_time: 0
 ```
 
 Refer to the [Manual Alarm Control page](/components/alarm_control_panel.manual/#examples) for more real-life examples on how to use this panel.

--- a/source/_components/alarm_control_panel.manual_mqtt.markdown
+++ b/source/_components/alarm_control_panel.manual_mqtt.markdown
@@ -148,10 +148,10 @@ payload_arm_night:
 
 In the configuration example below:
 
-- the disarmed state never triggers the alarm;
-- the armed_home state will leave no time to leave the building or disarm the alarm;
-- while other states state will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back.
-- Setting pending_time to 0 for triggered state allows alarm to trigger after previous state's delay time only. If not set, the alarm will be pending for previous state's delay_time plus the default pending_time before triggering.
+- The disarmed state never triggers the alarm;
+- The armed_home state will leave no time to leave the building or disarm the alarm;
+- While other states state will give 30 seconds to leave the building before triggering the alarm, and 20 seconds to disarm the alarm when coming back.
+- Setting pending_time to 0 for triggered state allows the alarm to trigger after previous state's delay time only. If not set, the alarm will be pending for previous state's delay_time plus the default pending_time before triggering.
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
Refined documentation based on issue #14268 (https://github.com/home-assistant/home-assistant/issues/14268) on how the delay time works. Also updated the example config.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
