### PR TITLE
Adding documentation for Somfy MyLink platform

### DIFF
--- a/source/_components/cover.somfy_mylink.markdown
+++ b/source/_components/cover.somfy_mylink.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: tahoma.png
 ha_category: Cover
-ha_release: 0.XX
+ha_release: 0.81
 ---
 
 The `somfy_mylink` cover platform lets you control covers added to your compatible Somfy MyLink hub in Home Assistant.

--- a/source/_components/cover.somfy_mylink.markdown
+++ b/source/_components/cover.somfy_mylink.markdown
@@ -1,0 +1,17 @@
+---
+layout: page
+title: "Somfy MyLink Cover"
+description: "Instructions on how to integrate Somfy MyLink covers into Home Assistant."
+date: 2018-10-20 12:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: tahoma.png
+ha_category: Cover
+ha_release: 0.XX
+---
+
+The `somfy_mylink` cover platform lets you control covers added to your compatible Somfy MyLink hub in Home Assistant.
+
+Covers will be added automatically. Please refer to the [component](/components/somfy_mylink/) configuration on how to setup Somfy MyLink.

--- a/source/_components/scene.somfy_mylink.markdown
+++ b/source/_components/scene.somfy_mylink.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: tahoma.png
 ha_category: Scene
-ha_release: 0.XX
+ha_release: 0.81
 ---
 
 The `somfy_mylink` scene platform lets you trigger scenes added to your compatible Somfy MyLink hub in Home Assistant.

--- a/source/_components/scene.somfy_mylink.markdown
+++ b/source/_components/scene.somfy_mylink.markdown
@@ -1,0 +1,17 @@
+---
+layout: page
+title: "Somfy MyLink Scene"
+description: "Instructions on how to integrate Somfy MyLink scenes into Home Assistant."
+date: 2018-10-20 12:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: tahoma.png
+ha_category: Scene
+ha_release: 0.XX
+---
+
+The `somfy_mylink` scene platform lets you trigger scenes added to your compatible Somfy MyLink hub in Home Assistant.
+
+Scenes will be added automatically. Please refer to the [component](/components/somfy_mylink/) configuration on how to setup Somfy MyLink.

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -23,6 +23,13 @@ To use your compatible `Somfy MyLink` devices in your installation, add the foll
 somfy_mylink:
   host: 10.1.1.100
   password: mylink_id
+```
+
+```yaml
+# Example configuration.yaml entry setting specific options on a per-cover basis
+somfy_mylink:
+  host: 10.1.1.100
+  password: mylink_id
   cover_options:
     - name: "*"
       reverse: true

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: tahoma.png
 ha_category: Hub
-ha_release: 0.XX
+ha_release: 0.81
 ha_iot_class: "Assumed State"
 ---
 

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -24,20 +24,6 @@ somfy_mylink:
   password: mylink_id
 ```
 
-```yaml
-# Example configuration.yaml entry setting specific options on a per-cover basis
-somfy_mylink:
-  host: 10.1.1.100
-  password: mylink_id
-  cover_options:
-    - name: "*"
-      reverse: true
-    - name: "Bedroom"
-      move_time: 20.5
-    - name: "Living Room"
-      move_time: 22
-```
-
 {% configuration %}
 host:
   description: The IP address of the Somfy MyLink hub device.
@@ -66,3 +52,16 @@ cover_options:
       type: boolean
 {% endconfiguration %}
 
+```yaml
+# Advanced configuration.yaml entry setting specific options on a per-cover basis
+somfy_mylink:
+  host: 10.1.1.100
+  password: mylink_id
+  cover_options:
+    - name: "*"
+      reverse: true
+    - name: "Bedroom"
+      move_time: 20.5
+    - name: "Living Room"
+      move_time: 22
+```

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -13,7 +13,6 @@ ha_release: 0.81
 ha_iot_class: "Assumed State"
 ---
 
-
 The `Somfy MyLink` component platform is used as an interface to a compatible Somfy MyLink hub utilizing the `Synergy` API. It adds covers and scenes from the Somfy MyLink platform.
 
 To use your compatible `Somfy MyLink` devices in your installation, add the following to your `configuration.yaml` file:

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -53,6 +53,10 @@ cover_options:
   required: false
   type: list
   keys:
+    name:
+      description: The name of the device to apply the specified options to. A 'star' symbol (`*`) can be used as a wildcard to apply for all devices.
+      required: true
+      type: string
     move_time:
       description: The time it takes for the cover to open or close in seconds. This value is used to emulate setting and reading the position of the cover. If this value is omitted the ability to set a specific position will be disabled.
       required: false

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -1,0 +1,58 @@
+---
+layout: page
+title: "Somfy MyLink"
+description: "Instructions on how to integrate Somfy MyLink devices with Home Assistant."
+date: 2018-10-20 12:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: tahoma.png
+ha_category: Hub
+ha_release: 0.XX
+ha_iot_class: "Assumed State"
+---
+
+
+The `Somfy MyLink` component platform is used as an interface to a compatible Somfy MyLink hub utilizing the `Synergy` API. It adds covers and scenes from the Somfy MyLink platform.
+
+To use your compatible `Somfy MyLink` devices in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+somfy_mylink:
+  host: 10.1.1.100
+  password: mylink_id
+  cover_options:
+    - name: "*"
+      reverse: true
+    - name: "Bedroom"
+      move_time: 20.5
+    - name: "Living Room"
+      move_time: 22
+```
+
+{% configuration %}
+host:
+  description: The IP address of the Somfy MyLink hub device.
+  required: true
+  type: string
+password:
+  description: The `System ID` of the Somfy MyLink hub. This can be found in the `Integration` menu in the mobile app.
+  required: true
+  type: string
+cover_options:
+  description: Allows setting specific options on a per-cover basis.
+  required: false
+  type: list
+  keys:
+    move_time:
+      description: The time it takes for the cover to open or close in seconds. This value is used to emulate setting and reading the position of the cover. If this value is omitted the ability to set a specific position will be disabled.
+      required: false
+      type: float
+    reverse:
+      description: Reverses the direction of the cover. Possible values are `true` or `false`.
+      required: false
+      type: boolean
+{% endconfiguration %}
+

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -33,23 +33,32 @@ password:
   description: The `System ID` of the Somfy MyLink hub. This can be found in the `Integration` menu in the mobile app.
   required: true
   type: string
-cover_options:
-  description: Allows setting specific options on a per-cover basis.
+default_move_time:
+  description: Sets the default time it takes for covers to open or close in seconds. This value is used to emulate setting and reading the position of the cover. If this value is omitted the ability to set a specific position will be disabled by default. This value can be applied on a per-cover basis (see `entity_config` below)
   required: false
-  type: list
+  type: float
+default_reverse:
+  description: Sets the default reversal status of the cover. Possible values are `true` or `false`. This value can be applied on a per-cover basis (see `entity_config` below)
+  required: false
+  type: boolean
+entity_config:
+  description: Configuration for specific cover entities. All subordinate keys are the corresponding entity ids to the domains, e.g., `cover.bedroom_blinds`.
+  required: false
+  type: map
   keys:
-    name:
-      description: The name of the device to apply the specified options to. A 'star' symbol (`*`) can be used as a wildcard to apply for all devices.
-      required: true
-      type: string
-    move_time:
-      description: The time it takes for the cover to open or close in seconds. This value is used to emulate setting and reading the position of the cover. If this value is omitted the ability to set a specific position will be disabled.
+    '`<ENTITY_ID>`':
+      description: Additional options for specific entities.
       required: false
-      type: float
-    reverse:
-      description: Reverses the direction of the cover. Possible values are `true` or `false`.
-      required: false
-      type: boolean
+      type: map
+      keys:
+        move_time:
+          description: The time it takes for the cover to open or close in seconds. This value is used to emulate setting and reading the position of the cover. If this value is omitted the ability to set a specific position will be disabled.
+          required: false
+          type: float
+        reverse:
+          description: Reverses the direction of the cover. Possible values are `true` or `false`.
+          required: false
+          type: boolean
 {% endconfiguration %}
 
 ```yaml
@@ -57,11 +66,11 @@ cover_options:
 somfy_mylink:
   host: 10.1.1.100
   password: mylink_id
-  cover_options:
-    - name: "*"
-      reverse: true
-    - name: "Bedroom"
-      move_time: 20.5
-    - name: "Living Room"
-      move_time: 22
+  default_move_time: 21.5
+  default_reverse: false
+  entity_config:
+    cover.bedroom:
+        move_time: 20.5
+    cover.outdoor_awning:
+        reverse: true
 ```

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: tahoma.png
 ha_category: Hub
-ha_release: 0.81
+ha_release: 0.85
 ha_iot_class: "Assumed State"
 ---
 

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -21,7 +21,7 @@ To use your compatible `Somfy MyLink` devices in your installation, add the foll
 # Example configuration.yaml entry
 somfy_mylink:
   host: 10.1.1.100
-  password: mylink_id
+  system_id: mylink_id
 ```
 
 {% configuration %}
@@ -29,7 +29,7 @@ host:
   description: The IP address of the Somfy MyLink hub device.
   required: true
   type: string
-password:
+system_id:
   description: The `System ID` of the Somfy MyLink hub. This can be found in the `Integration` menu in the mobile app.
   required: true
   type: string
@@ -65,7 +65,7 @@ entity_config:
 # Advanced configuration.yaml entry setting specific options on a per-cover basis
 somfy_mylink:
   host: 10.1.1.100
-  password: mylink_id
+  system_id: mylink_id
   default_move_time: 21.5
   default_reverse: false
   entity_config:


### PR DESCRIPTION
**Description:**
This adds the documentation required for the Somfy MyLink platform based on the Synergy JsonRPC API.
The following component pages are included:
- compenent/somfy_mylink
  - cover/somfy_mylink
  - scene/somfy_mylink

It might be a good idea to change the name of the current `tahoma.png` logo to `somfy.png` at some point, however in the spirit of introducing as little change at a time, I'm leaving it as `tahoma.png`.

Thanks!

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17654

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
