### PR TITLE
More various improvements - letter b

### DIFF
--- a/source/_components/binary_sensor.ads.markdown
+++ b/source/_components/binary_sensor.ads.markdown
@@ -26,16 +26,16 @@ binary_sensor:
 ```
 
 {% configuration %}
-  adsvar:
-    required: true
-    description: The name of the variable which you want to access on the ADS device.
-    type: string
-  name: 
-    required: false
-    description: An identifier for the light in the frontend.
-    type: string
-  device_class:
-    required: false
-    description: The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
-    type: string
+adsvar:
+  description: The name of the variable which you want to access on the ADS device.
+  required: true
+  type: string
+name:
+  description: An identifier for the light in the frontend.
+  required: false
+  type: string
+device_class:
+  description: The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
+  required: false
+  type: string
 {% endconfiguration %}

--- a/source/_components/binary_sensor.aurora.markdown
+++ b/source/_components/binary_sensor.aurora.markdown
@@ -32,17 +32,19 @@ binary_sensor:
 forecast_threshold:
   description: Provide your own threshold number above which the sensor will trigger.
   required: false
-  default: 75
   type: integer
+  default: 75
 name:
   description: The name of the sensor.
   required: false
-  default: Aurora Visibility
   type: string
+  default: Aurora Visibility
 {% endconfiguration %}
 
+## {% linkable_title Full example %}
+
 ```yaml
-  binary_sensor:
-    - platform: aurora
-      forecast_threshold: 50
+binary_sensor:
+  - platform: aurora
+    forecast_threshold: 50
 ```

--- a/source/_components/binary_sensor.bbb_gpio.markdown
+++ b/source/_components/binary_sensor.bbb_gpio.markdown
@@ -48,18 +48,18 @@ pins:
         bouncetime:
           description: Debounce time for reading input pin defined in milliseconds [ms].
           required: false
-          default: 50
           type: integer
+          default: 50
         invert_logic:
           description: If `true`, inverts the input logic to ACTIVE LOW
           required: false
-          default: false
           type: boolean
+          default: false
         pull_mode:
           description: Type of internal pull resistor connected to input. Options are `UP` - pull-up resistor and `DOWN` - pull-down resistor.
           required: false
-          default: UP
-          type: string      
+          type: string
+          default: UP  
 {% endconfiguration %}
 
 For more details about the GPIO layout, visit the [article](http://elinux.org/Beagleboard:BeagleBoneBlack) about the BeagleBone Black.

--- a/source/_components/binary_sensor.command_line.markdown
+++ b/source/_components/binary_sensor.command_line.markdown
@@ -35,7 +35,7 @@ name:
   description: Let you overwrite the name of the device.
   required: false
   type: string
-  default: *name* from the device is used
+  default: "*name* from the device"
 device_class:
   description: The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
   required: false

--- a/source/_components/binary_sensor.command_line.markdown
+++ b/source/_components/binary_sensor.command_line.markdown
@@ -13,7 +13,6 @@ ha_release: 0.12
 ha_iot_class: "Local Polling"
 ---
 
-
 The `command_line` binary sensor platform issues specific commands to get data.
 
 ## {% linkable_title Configuration %}
@@ -33,10 +32,10 @@ command:
   required: true
   type: string
 name:
-  description: Let you overwrite the name of the device. By default *name* from the device is used.
+  description: Let you overwrite the name of the device.
   required: false
-  default: name
   type: string
+  default: *name* from the device is used
 device_class:
   description: The [type/class](/components/binary_sensor/) of the sensor to set the icon in the frontend.
   required: false
@@ -44,13 +43,13 @@ device_class:
 payload_on:
   description: The payload that represents enabled state.
   required: false
-  default: ON
   type: string
+  default: ON
 payload_off:
   description: The payload that represents disabled state.
   required: false
-  default: OFF
   type: string
+  default: OFF
 value_template:
   description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
   required: false
@@ -58,13 +57,13 @@ value_template:
 scan_interval:
   description: Defines number of seconds for polling interval.
   required: false
-  default: 60
   type: integer
+  default: 60
 command_timeout:
   description: Defines number of seconds for command timeout.
   required: false
-  default: 15
   type: integer
+  default: 15
 {% endconfiguration %}
 
 ## {% linkable_title Examples %}

--- a/source/_components/binary_sensor.concord232.markdown
+++ b/source/_components/binary_sensor.concord232.markdown
@@ -14,6 +14,8 @@ ha_release: 0.31
 
 The `concord232` platform provides integration with GE, Interlogix (and other brands) alarm panels that support the RS-232 Automation Control Panel interface module (or have it built in). Supported panels include Concord 4.
 
+## {% linkable_title Configuration %}
+
 To enable this, add the following lines to your `configuration.yaml`:
 
 ```yaml
@@ -26,11 +28,11 @@ binary_sensor:
 host:
   description: The host where the concord232 server process is running.
   required: false
-  default: localhost
   type: string
+  default: localhost
 port:
   description: The port where the Alarm panel is listening.
   required: false
-  default: 5007
   type: integer
+  default: 5007
 {% endconfiguration %}

--- a/source/_components/binary_sensor.ffmpeg_motion.markdown
+++ b/source/_components/binary_sensor.ffmpeg_motion.markdown
@@ -13,7 +13,6 @@ ha_release: 0.27
 redirect_from: /components/binary_sensor.ffmpeg/
 ---
 
-
 The `ffmpeg` platform allows you to use any video feed with [FFmpeg](http://www.ffmpeg.org/) for motion sensors in Home Assistant.
 
 <p class='note'>
@@ -47,28 +46,28 @@ name:
 initial_state:
   description: Start `ffmpeg` with Home Assistant.
   required: false
-  default: true
   type: boolean
+  default: true
 changes:
   description: How much needs to change between two frames to detect it as motion, value in percentage (a lower value is more sensitive).
   required: false
-  default: 10%
   type: integer
+  default: 10
 reset:
   description: The time to reset the state after no new motion is detected.
   required: false
-  default: 20
   type: integer
+  default: 20
 repeat:
   description: How many events need to be detected in *repeat_time* in order to trigger a motion, 0 repeats means deactivated.
   required: false
-  default: 0
   type: integer
+  default: 0
 repeat_time:
   description: The span of time *repeat* events need to occur in before triggering a motion, 0 seconds means deactivated.
   required: false
-  default: 0
   type: integer
+  default: 0
 extra_arguments:
   description: Extra options to pass to `ffmpeg`, e.g., video denoise filtering.
   required: false

--- a/source/_components/binary_sensor.ffmpeg_noise.markdown
+++ b/source/_components/binary_sensor.ffmpeg_noise.markdown
@@ -12,7 +12,6 @@ ha_category: Image Processing
 ha_release: 0.27
 ---
 
-
 The `ffmpeg` platform allows you to use any video or audio feed with [FFmpeg](http://www.ffmpeg.org/) for various sensors in Home Assistant.
 
 <p class='note'>
@@ -42,23 +41,23 @@ name:
 initial_state:
   description: Start ffmpeg with home-assistant.
   required: false
-  default: true
   type: boolean
+  default: true
 peak:
   description: The threshold of detecting noise, in dB. 0 is very loud and -100 is low.
   required: false
-  default: -30
   type: integer
+  default: -30
 duration:
   description: How long the noise needs to be over the peak to trigger the state.
   required: false
-  default: 1
   type: integer
+  default: 1
 reset:
   description: The time to reset the state after no new noise is over the peak.
   required: false
-  default: 20
   type: integer
+  default: 20
 extra_arguments:
   description: Extra options to pass to `ffmpeg`, like audio frequency filtering.
   required: false

--- a/source/_components/binary_sensor.knx.markdown
+++ b/source/_components/binary_sensor.knx.markdown
@@ -42,13 +42,15 @@ device_class:
 significant_bit:
   description: Specify which significant bit of the KNX value should be used.
   required: false
-  default: 1
   type: integer
+  default: 1
 reset_after:
   description: Reset back to OFF state after specified milliseconds.
   required: false
   type: integer
 {% endconfiguration %}
+
+### {% linkable_title Automation actions %}
 
 You can also attach actions to binary sensors (e.g., to switch on a light when a switch was pressed). In this example, one light is switched on when the button was pressed once and two others when the button was pressed a second time.
 
@@ -81,13 +83,13 @@ name:
 counter:
   description: Set to 2 if your only want the action to be executed if the button was pressed twice. To 3 for three times button pressed.
   required: false
-  default: 1
   type: integer
+  default: 1
 hook:
   description: Indicates if the automation should be executed on what state of the binary sensor. Values are "on" or "off".
   required: false
-  default: "on"
   type: string
+  default: "on"
 action:
   description: Specify a list of actions analog to the [automation rules](/docs/automation/action/).
   required: false

--- a/source/_components/binary_sensor.linode.markdown
+++ b/source/_components/binary_sensor.linode.markdown
@@ -28,9 +28,8 @@ binary_sensor:
 ```
 
 {% configuration %}
-  nodes:
-    description:  List of VPSs you want to control.
-    required: true
-    type: string
+nodes:
+  description:  List of VPSs you want to control.
+  required: true
+  type: string
 {% endconfiguration %}
-

--- a/source/_components/binary_sensor.nx584.markdown
+++ b/source/_components/binary_sensor.nx584.markdown
@@ -17,6 +17,8 @@ The `nx584` platform provides integration with GE, Caddx, Interlogix (and other 
 
 Enabling this sensor platform exposes all of your zones as binary sensors, which provides visibility through the UI as well as the ability to trigger automation actions instantly when something happens like a door opening, or a motion sensor trigger.
 
+## {% linkable_title Configuration %}
+
 To enable this feature, add the following lines to your `configuration.yaml`:
 
 ```yaml
@@ -29,19 +31,19 @@ binary_sensor:
 host:
   description: This is the host where the nx584 server process is running. If unset, it is assumed to be `localhost`, which will work if the server process is running on the same system as Home Assistant.
   required: false
-  default: localhost
   type: string
+  default: localhost
 port:
   description: The port where the server process is running.
   required: false
-  default: 5007
   type: integer
+  default: 5007
 exclude_zones:
   description: This is a list of zone numbers that should be excluded. Use this to avoid exposing a zone that is of no interest, unconnected, etc.
   required: false
   type: [list, integer]
 zone_types:
-  description: This is a list of zone numbers mapped to zone types. Use this to designate zones as doors, motion sensors, smoke detectors, etc. See the list of available zone types relevant to alarm zones below. 
+  description: This is a list of zone numbers mapped to zone types. Use this to designate zones as doors, motion sensors, smoke detectors, etc. See the list of available zone types relevant to alarm zones below.
   required: false
   type: map
   keys:
@@ -58,6 +60,8 @@ zone_types:
     safety:
       description: Safety
 {% endconfiguration %}
+
+## {% linkable_title Full example %}
 
 An extended configuration entry could look like this:
 

--- a/source/_components/binary_sensor.octoprint.markdown
+++ b/source/_components/binary_sensor.octoprint.markdown
@@ -13,12 +13,13 @@ ha_release: 0.19
 ha_iot_class: "Local Polling"
 ---
 
-
 The `octoprint` binary sensor platform let you monitor if your 3D printer is printing or if there was a printing error.
 
 <p class='note'>
 You must have the [OctoPrint component](/components/octoprint/) configured to use this sensor.
 </p>
+
+## {% linkable_title Configuration %}
 
 To set it up, add the following information to your `configuration.yaml` file:
 
@@ -41,8 +42,8 @@ monitored_conditions:
     printing error:
       description: Error while printing.
 name:
-  description:
-  required: The name of the sensor.
-  default: OctoPrint
+  description: The name of the sensor.
+  required: false
   type: string
+  default: OctoPrint
 {% endconfiguration %}

--- a/source/_components/binary_sensor.rfxtrx.markdown
+++ b/source/_components/binary_sensor.rfxtrx.markdown
@@ -21,7 +21,7 @@ them may be recognized under the X10 protocol but most of them are recognized
 under the *Lighting4* protocol. The rfxtrx binary sensor component provides
 some special options for them, while other rfxtrx protocols should work too.
 
-# Setting up your devices
+## {% linkable_title Setting up your devices %}
 
 Once you have set up your [rfxtrx hub](/components/rfxtrx/), the easiest way
 to find your binary sensors is to add this to your `configuration.yaml`:
@@ -67,8 +67,8 @@ devices:
     fire_event:
       description: Fires an event even if the state is the same as before. Can be used for automations.
       required: false
-      default: false
       type: boolean
+      default: false
     off_delay:
       description: For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
       required: false
@@ -88,8 +88,8 @@ devices:
 automatic_add:
   description: To enable the automatic addition of new binary sensors.
   required: false
-  default: false
   type: boolean
+  default: false
 {% endconfiguration %}
 
 <p class='note warning'>
@@ -131,7 +131,7 @@ binary_sensor:
       seconds: 5
 ```
 
-## Options for PT-2262 devices under the Lighting4 protocol
+### {% linkable_title Options for PT-2262 devices under the Lighting4 protocol %}
 
 When a data packet is transmitted by a PT-2262 device using the Lighting4
 protocol, there is no way to automatically extract the device identifier and the
@@ -201,7 +201,7 @@ This automatic guess should work most of the time but there is
 no guarantee on that. You should activate it only when you
 want to configure your new devices and leave it off otherwise.
 
-## Known working devices
+### {% linkable_title Known working devices %}
 
 The following devices are known to work with the rfxtrx binary sensor component.
 There are too many other to list.

--- a/source/_components/binary_sensor.skybell.markdown
+++ b/source/_components/binary_sensor.skybell.markdown
@@ -30,9 +30,9 @@ binary_sensor:
 
 {% configuration %}
 monitored_conditions:
-  type: list
-  required: true
   description: Conditions to display in the frontend. The following conditions can be monitored.
+  required: true
+  type: list
   keys:
     button:
       description: Returns whether the doorbell button was pressed.

--- a/source/_components/binary_sensor.tcp.markdown
+++ b/source/_components/binary_sensor.tcp.markdown
@@ -14,53 +14,57 @@ ha_release: 0.14
 
 The TCP Binary Sensor is a type of [TCP Sensor](/components/sensor.tcp/) which is either "off" or "on". In order to use this sensor type, in addition to the configuration for the TCP Sensor, you must supply a `value_on` value to represent what is returned when the device is turned on.
 
+## {% linkable_title Configuration %}
+
 To enable this sensor, add the following lines to your `configuration.yaml`:
 
 ```yaml
-binary_sensor:
 # Example configuration.yaml entry
-  platform: tcp
-  name: TCP Binary Sensor
-  host: IP_ADDRESS
-  port: PORT
-  payload: "r State\n"
-  value_on: 1
-  timeout: 5
+binary_sensor:
+  - platform: tcp
+    name: TCP Binary Sensor
+    host: IP_ADDRESS
+    port: PORT
+    payload: "r State\n"
+    value_on: 1
+    timeout: 5
 ```
-
-Configuration options for the a TCP Sensor:
 
 {% configuration %}
 name:
-    required: true
-    description: The name you'd like to give the sensor in Home Assistant.
-    type: string
+  description: The name you'd like to give the sensor in Home Assistant.
+  required: false
+  type: string
+  default: TCP Sensor
 host:
-    required: true
-    description: The hostname/IP address to connect to.
-    type: string
+  description: The hostname/IP address to connect to.
+  required: true
+  type: string
 port:
-    required: true
-    description: The port to connect to the host on.
-    type: integer
+  description: The port to connect to the host on.
+  required: true
+  type: integer
 payload:
-    required: true
-    description: What to send to the host in order to get the response we're interested in.
-    type: string
+  description: What to send to the host in order to get the response we're interested in.
+  required: true
+  type: string
 value_on:
-    required: true
-    description: The value returned when the device is "on".
-    type: string
-timeout:
-    required: false
-    description: How long in seconds to wait for a response from the service before giving up and disconnecting. Defaults to 10.
-    type: integer
+  description: The value returned when the device is "on".
+  required: true
+  type: string
 value_template:
-    required: false
-    description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the value. By default it's assumed that the entire response is the value.
-    type: string
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the value.
+  required: false
+  type: template
+  default: entire response is the value
 buffer_size:
-    required: false
-    description: The size of the receive buffer in bytes. Set this to a larger value if you expect to receive a response larger than the default. Defaults to 1024.
-    type: integer
+  description: The size of the receive buffer in bytes. Set this to a larger value if you expect to receive a response larger than the default.
+  required: false
+  type: integer
+  default: 1024
+timeout:
+  description: How long in seconds to wait for a response from the service before giving up and disconnecting.
+  required: false
+  type: integer
+  default: 10
 {% endconfiguration %}

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -18,6 +18,8 @@ The `template` platform supports sensors which break out the `state` and
 `state_attributes` from other entities. The state of a Template Binary Sensor
 can only be `on` or `off`.
 
+## {% linkable_title Configuration %}
+
 To enable Template Binary Sensors in your installation, add the following to
 your `configuration.yaml` file:
 
@@ -35,49 +37,49 @@ binary_sensor:
 {% endraw %}
 
 {% configuration %}
-sensors:
-  description: List of your sensors.
-  required: true
-  type: map
-  keys:
-    sensor_name:
-      description: The slug of the sensor.
-      required: true
-      type: map
-      keys:
-        friendly_name:
-          description: Name to use in the frontend.
-          required: false
-          type: string
-        entity_id:
-          description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
-          required: false
-          type: string, list
-        device_class:
-          description: The type/class of the sensor to set the icon in the frontend.
-          required: false
-          type: device_class
-          default: None
-        value_template:
-          description: Defines a template to set the state of the sensor.
-          required: true
-          type: template
-        icon_template:
-          description: Defines a template for the icon of the sensor.
-          required: false
-          type: template
-        entity_picture_template:
-          description: Defines a template for the entity picture of the sensor.
-          required: false
-          type: template
-        delay_on:
-          description: The amount of time the template state must be ***met*** before this sensor will switch to `on`.
-          required: false
-          type: time
-        delay_off:
-          description: The amount of time the template state must be ***not met*** before this sensor will switch to `off`.
-          required: false
-          type: time
+  sensors:
+    description: List of your sensors.
+    required: true
+    type: map
+    keys:
+      sensor_name:
+        description: The slug of the sensor.
+        required: true
+        type: map
+        keys:
+          friendly_name:
+            description: Name to use in the frontend.
+            required: false
+            type: string
+          entity_id:
+            description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
+            required: false
+            type: string, list
+          device_class:
+            description: The type/class of the sensor to set the icon in the frontend.
+            required: false
+            type: device_class
+            default: None
+          value_template:
+            description: Defines a template to set the state of the sensor.
+            required: true
+            type: template
+          icon_template:
+            description: Defines a template for the icon of the sensor.
+            required: false
+            type: template
+          entity_picture_template:
+            description: Defines a template for the entity picture of the sensor.
+            required: false
+            type: template
+          delay_on:
+            description: The amount of time the template state must be ***met*** before this sensor will switch to `on`.
+            required: false
+            type: time
+          delay_off:
+            description: The amount of time the template state must be ***not met*** before this sensor will switch to `off`.
+            required: false
+            type: time
 {% endconfiguration %}
 
 ## {% linkable_title Considerations %}

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -37,49 +37,49 @@ binary_sensor:
 {% endraw %}
 
 {% configuration %}
-  sensors:
-    description: List of your sensors.
-    required: true
-    type: map
-    keys:
-      sensor_name:
-        description: The slug of the sensor.
-        required: true
-        type: map
-        keys:
-          friendly_name:
-            description: Name to use in the frontend.
-            required: false
-            type: string
-          entity_id:
-            description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
-            required: false
-            type: string, list
-          device_class:
-            description: The type/class of the sensor to set the icon in the frontend.
-            required: false
-            type: device_class
-            default: None
-          value_template:
-            description: Defines a template to set the state of the sensor.
-            required: true
-            type: template
-          icon_template:
-            description: Defines a template for the icon of the sensor.
-            required: false
-            type: template
-          entity_picture_template:
-            description: Defines a template for the entity picture of the sensor.
-            required: false
-            type: template
-          delay_on:
-            description: The amount of time the template state must be ***met*** before this sensor will switch to `on`.
-            required: false
-            type: time
-          delay_off:
-            description: The amount of time the template state must be ***not met*** before this sensor will switch to `off`.
-            required: false
-            type: time
+sensors:
+  description: List of your sensors.
+  required: true
+  type: map
+  keys:
+    sensor_name:
+      description: The slug of the sensor.
+      required: true
+      type: map
+      keys:
+        friendly_name:
+          description: Name to use in the frontend.
+          required: false
+          type: string
+        entity_id:
+          description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
+          required: false
+          type: string, list
+        device_class:
+          description: The type/class of the sensor to set the icon in the frontend.
+          required: false
+          type: device_class
+          default: None
+        value_template:
+          description: Defines a template to set the state of the sensor.
+          required: true
+          type: template
+        icon_template:
+          description: Defines a template for the icon of the sensor.
+          required: false
+          type: template
+        entity_picture_template:
+          description: Defines a template for the entity picture of the sensor.
+          required: false
+          type: template
+        delay_on:
+          description: The amount of time the template state must be ***met*** before this sensor will switch to `on`.
+          required: false
+          type: time
+        delay_off:
+          description: The amount of time the template state must be ***not met*** before this sensor will switch to `off`.
+          required: false
+          type: time
 {% endconfiguration %}
 
 ## {% linkable_title Considerations %}

--- a/source/_components/binary_sensor.vera.markdown
+++ b/source/_components/binary_sensor.vera.markdown
@@ -14,5 +14,5 @@ ha_release: pre 0.7
 ---
 
 The `vera` platform allows you to get data from your [Vera](http://getvera.com/) binary sensors from within Home Assistant.
-  
+
 They will be automatically discovered if the vera component is loaded.

--- a/source/_components/binary_sensor.verisure.markdown
+++ b/source/_components/binary_sensor.verisure.markdown
@@ -16,4 +16,4 @@ Integrates Verisure binary sensors into Home Assistant. See the [main component]
 
 The following binary sensor types are supported:
 
-Door & Window
+- Door & Window

--- a/source/_components/binary_sensor.vultr.markdown
+++ b/source/_components/binary_sensor.vultr.markdown
@@ -15,6 +15,8 @@ ha_iot_class: "Cloud Polling"
 
 The `vultr` binary sensor platform allows you to monitor your [Vultr](https://www.vultr.com/) subscription to see if it is powered on or not.
 
+## {% linkable_title Configuration %}
+
 To use this binary sensor, you first have to set up your [Vultr hub](/components/vultr/).
 
 <p class='note'>
@@ -42,6 +44,7 @@ name:
   type: string
 {% endconfiguration %}
 
+## {% linkable_title Full example %}
 
 Full `configuration.yaml` (produces `binary_sensor.totally_awesome_server`):
 
@@ -51,4 +54,3 @@ binary_sensor:
     name: totally_awesome_server
     subscription: 12345
 ```
-

--- a/source/_components/binary_sensor.wink.markdown
+++ b/source/_components/binary_sensor.wink.markdown
@@ -13,11 +13,9 @@ ha_release: 0.14
 ha_iot_class: "Cloud Polling"
 ---
 
-
 The Wink binary sensor platform allows you to get data from your [Wink](http://www.wink.com/) binary sensors.
 
 The requirement is that you have setup [Wink](/components/wink/).
-
 
 ### {% linkable_title Supported Binary sensor devices %}
 
@@ -36,4 +34,3 @@ The requirement is that you have setup [Wink](/components/wink/).
 <p class='note'>
 The above devices are confirmed to work, but others may work as well.
 </p>
-

--- a/source/_components/binary_sensor.wirelesstag.markdown
+++ b/source/_components/binary_sensor.wirelesstag.markdown
@@ -56,4 +56,3 @@ monitored_conditions:
     battery:
       description: On means tag battery is low, Off means normal.
 {% endconfiguration %}
-

--- a/source/_components/binary_sensor.workday.markdown
+++ b/source/_components/binary_sensor.workday.markdown
@@ -82,6 +82,8 @@ If you use the sensor for Canada (`CA`) with Ontario (`ON`) as `province:` then 
 Otherwise the value is evaluated as `true` (check the YAML documentation for further details) and the sensor will not work.
 </p>
 
+## {% linkable_title Automation example %}
+
 Example usage for automation:
 
 ```yaml

--- a/source/_components/binary_sensor.xiaomi_aqara.markdown
+++ b/source/_components/binary_sensor.xiaomi_aqara.markdown
@@ -13,11 +13,9 @@ ha_release: "0.50"
 ha_iot_class: "Local Push"
 ---
 
-
 The `xiaomi aqara` binary sensor platform allows you to get data from your [Xiaomi](http://www.mi.com/en/) binary sensors.
 
 The requirement is that you have setup the [`xiaomi aqara` component](/components/xiaomi_aqara/).
-
 
 ### {% linkable_title Type of sensors supported %}
 

--- a/source/_components/binary_sensor.zigbee.markdown
+++ b/source/_components/binary_sensor.zigbee.markdown
@@ -15,6 +15,8 @@ ha_iot_class: "Local Polling"
 
 A `zigbee` binary sensor in this context is a device connected to one of the digital input pins on a [ZigBee](http://www.zigbee.org/) module. The states reported by such a device are limited to `on` or `off`. By default, a binary sensor is considered `on` when the ZigBee device's digital input pin is held 'high' and considered `off` when it is held `low`. This behavior can be inverted by setting the `on_state` configuration variable to `low`.
 
+## {% linkable_title Configuration %}
+
 To enable a digital input pin as binary sensor in your installation, add the following lines to your `configuration.yaml`:
 
 ```yaml

--- a/source/_components/blink.markdown
+++ b/source/_components/blink.markdown
@@ -134,4 +134,4 @@ homeassistant:
 
 ### {% linkable_title Other Services %}
 
-In addition to the services mentioned above, there are generic `camera` and `alarm_control_panel` services available for use as well. The `camera.enable_motion_detection` and `camera.disable_motion_detection` services allow for individual cameras to be enabled and disabled, respectively, within the Blink system. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` services allow for the whole system to be armed and disarmed, respectively. 
+In addition to the services mentioned above, there are generic `camera` and `alarm_control_panel` services available for use as well. The `camera.enable_motion_detection` and `camera.disable_motion_detection` services allow for individual cameras to be enabled and disabled, respectively, within the Blink system. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` services allow for the whole system to be armed and disarmed, respectively.

--- a/source/_components/bmw_connected_drive.markdown
+++ b/source/_components/bmw_connected_drive.markdown
@@ -23,6 +23,8 @@ This component provides the following platforms:
  - Lock: Control the lock of your car.
  - Sensors: Mileage, remaining range, remaining fuel, charging time remaining (electric cars), charging status (electric cars), remaining range electric (electric cars).
 
+ ## {% linkable_title Configuration %}
+
 To enable this component in your installation, add the following to your
 `configuration.yaml` file:
 
@@ -78,13 +80,13 @@ The vehicle can be locked and unlocked via the lock component that is created au
 
 The air condition of the vehicle can be activated with the service `bmw_connected_drive.activate_air_conditioning`.
 
-What exactly is started here depends on the type of vehicle. It might range from just ventilation over auxiliary heating to real air conditioning. If your vehicle is equipped with auxiliary heating, only trigger this service if the vehicle is parked in a location where it is safe to use it (e.g., not in an underground parking or closed garage). 
+What exactly is started here depends on the type of vehicle. It might range from just ventilation over auxiliary heating to real air conditioning. If your vehicle is equipped with auxiliary heating, only trigger this service if the vehicle is parked in a location where it is safe to use it (e.g., not in an underground parking or closed garage).
 
 The vehicle is identified via the parameter `vin`.
 
 ### {% linkable_title Sound the horn %}
 
-The service `bmw_connected_drive.sound_horn` sounds the horn of the vehicle. This option is not available in some countries (among which  the UK). Use this feature responsibly, as it might annoy your neighbors. The vehicle is identified via the parameter `vin`. 
+The service `bmw_connected_drive.sound_horn` sounds the horn of the vehicle. This option is not available in some countries (among which  the UK). Use this feature responsibly, as it might annoy your neighbors. The vehicle is identified via the parameter `vin`.
 
 ### {% linkable_title Flash the lights %}
 
@@ -92,10 +94,10 @@ The service `bmw_connected_drive.light_flash` flashes the lights of the vehicle.
 
 ### {% linkable_title Update the state %}
 
-The service `bmw_connected_drive.update_state` fetches the last state of the vehicles of all your accounts from the BMW server. This does *not* trigger an update from the vehicle; it gets the data from the BMW servers. So this service does *not* interact with your vehicles. 
+The service `bmw_connected_drive.update_state` fetches the last state of the vehicles of all your accounts from the BMW server. This does *not* trigger an update from the vehicle; it gets the data from the BMW servers. So this service does *not* interact with your vehicles.
 
 This service does not require any attributes.
 
 ## {% linkable_title Disclaimer %}
 
-This software is not affiliated with or endorsed by BMW Group. 
+This software is not affiliated with or endorsed by BMW Group.

--- a/source/_components/browser.markdown
+++ b/source/_components/browser.markdown
@@ -12,8 +12,9 @@ ha_category: Utility
 ha_qa_scale: internal
 ---
 
-
 The `browser` component provides a service to open URLs in the default browser on the host machine.
+
+## {% linkable_title Configuration %}
 
 To load this component, add the following lines to your `configuration.yaml`:
 
@@ -22,7 +23,7 @@ To load this component, add the following lines to your `configuration.yaml`:
 browser:
 ```
 
-#### {% linkable_title Service `browser/browse_url` %} 
+#### {% linkable_title Service `browser/browse_url` %}
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION
**Description:**
Some improvements, docs starting with b (part 2)

Adds titles (and make other linkable)
Improved indentation
Reorder configuration keys
Remove empty lines and trailing spaces

Note: I'm aware the order of keys in the configuration section doesn't matter, but:
- I prefer things to be in the order of the documentation
- I prefer the same standard across all Markdown files
- It makes more sense to know the type of variable before defining the default value

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
