### PR TITLE
Update vacuum.mqtt.markdown to reflect changes in component related to error messages

### DIFF
--- a/source/_components/vacuum.mqtt.markdown
+++ b/source/_components/vacuum.mqtt.markdown
@@ -42,6 +42,8 @@ vacuum:
     cleaning_template: "{{ value_json.cleaning }}"
     docked_topic: "vacuum/state"
     docked_template: "{{ value_json.docked }}"
+    error_topic: "vacuum/state"
+    error_template: "{{ value_json.error }}"
     fan_speed_topic: "vacuum/state"
     fan_speed_template: "{{ value_json.fan_speed }}"
     set_fan_speed_topic: "vacuum/set_fan_speed"
@@ -145,6 +147,14 @@ docked_template:
   description: "Defines a [template](/topics/templating/) to define the docked state of the vacuum."
   required: false
   type: string
+error_topic:
+  description: The MQTT topic subscribed to receive error messages from the vacuum.
+  required: false
+  type: string
+error_template:
+  description: "Defines a [template](/topics/templating/) to define potential error messages emitted by the vacuum."
+  required: false
+  type: string
 fan_speed_topic:
   description: The MQTT topic subscribed to receive fan speed values from the vacuum.
   required: false
@@ -225,7 +235,8 @@ MQTT payload:
     "docked": true,
     "cleaning": false,
     "charging": true,
-    "fan_speed": "off"
+    "fan_speed": "off",
+    "error": "Error message"
 }
 ```
 


### PR DESCRIPTION
**Description:**
I made a PR to also surface error messages from a MQTT based vacuum. Updating documentation to reflect this extra functionality.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17685

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
