### PR TITLE
Update vacuum.mqtt.markdown with link to repo for Neato retrofitting

### DIFF
--- a/source/_components/vacuum.mqtt.markdown
+++ b/source/_components/vacuum.mqtt.markdown
@@ -229,6 +229,6 @@ MQTT payload:
 }
 ```
 
-### {% linkable_title Retrofitting a non-wifi Roomba with an ESP8266 %}
-
-- [This repo](https://github.com/johnboiles/esp-roomba-mqtt) has MQTT client firmware for retrofitting your old Roomba.
+### {% linkable_title Retrofitting a non-wifi vacuums %}
+- Retrofitting your old Roomba with an ESP8266. [This repo](https://github.com/johnboiles/esp-roomba-mqtt) provides MQTT client firmware.
+- In you own a non-wifi Neato, you can refer to [This repo](https://github.com/jeroenterheerdt/neato-serial) that uses a Raspberry Pi to retrofit an old Neato.

--- a/source/_components/vacuum.mqtt.markdown
+++ b/source/_components/vacuum.mqtt.markdown
@@ -231,4 +231,4 @@ MQTT payload:
 
 ### {% linkable_title Retrofitting a non-wifi vacuums %}
 - Retrofitting your old Roomba with an ESP8266. [This repo](https://github.com/johnboiles/esp-roomba-mqtt) provides MQTT client firmware.
-- In you own a non-wifi Neato, you can refer to [This repo](https://github.com/jeroenterheerdt/neato-serial) that uses a Raspberry Pi to retrofit an old Neato.
+- In you own a non-wifi Neato, you can refer to [this repo](https://github.com/jeroenterheerdt/neato-serial) that uses a Raspberry Pi to retrofit an old Neato.


### PR DESCRIPTION
**Description:**
Update vacuum.mqtt.markdown with link to repo for Neato retrofitting.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
