### PR TITLE
change plex activity monitor category from media_player to sensor

### DIFF
--- a/source/_components/sensor.plex.markdown
+++ b/source/_components/sensor.plex.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: plex.png
-ha_category: Media Player
+ha_category: Sensor
 ha_release: 0.22
 ha_iot_class: "Local Polling"
 ---


### PR DESCRIPTION
**Description:**
Changes "Plex activity monitor" to Sensor category because it is a sensor.
