### PR TITLE
Update Updater configuration

### DIFF
--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -14,7 +14,9 @@ ha_qa_scale: internal
 
 The `updater` component will check daily for new releases. It will show a badge in the frontend if a new version is found. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this component on Hass.io.
 
-The updater component will also collect basic information about the running Home Assistant instance and its environment. The information includes the current Home Assistant version, the time zone, Python version and operating system information. No identifiable information (i.e., IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/updater.py#L91). For further information about the Updater's data, please check the [detailed overview](/docs/backend/updater/).
+The updater component will also collect basic information about the running Home Assistant instance and its environment. The information includes the current Home Assistant version, the time zone, Python version and operating system information. No identifiable information (i.e., IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/updater.py#L91).
+
+## {% linkable_title Configuration %}
 
 To integrate this into Home Assistant, add the following section to your `configuration.yaml` file:
 
@@ -22,9 +24,22 @@ To integrate this into Home Assistant, add the following section to your `config
 updater:
 ```
 
-If you choose not to share any information when checking for updates, you can add `reporting: False`.
+{% configuration %}
+reporting:
+  description: Whether or not to share system information when checking for updates.
+  required: false
+  type: boolean
+  default: true
+include_used_components:
+  description: Whether or not to report the components that you are using in Home Assistant.
+  required: false
+  type: boolean
+  default: false
+{% endconfiguration %}
 
-It is possible to report the components that you are using to the Home Assistant developers. This will help them focus on improving the popular ones. To enable this option, you have to add `include_used_components: True`. 
+For further information about the Updater's data, please check the [detailed overview](/docs/backend/updater/). If you choose not to share any information when checking for updates, you can set `reporting: false`.
+
+It is possible to report the components that you are using to the Home Assistant developers. This will help them focus on improving the popular ones. To enable this option, you have to add `include_used_components: true`.
 
 ```json
 "components": [
@@ -41,7 +56,7 @@ It is possible to report the components that you are using to the Home Assistant
 ]
 ```
 
-### {% linkable_title Notification %}
+## {% linkable_title Notification %}
 
 For an added bonus, an automation component can be created to send a message with a notifier when that state of this component's entity changes.
 
@@ -57,4 +72,3 @@ automation:
     data:
       message: 'Update for Home Assistant is available.'
 ```
-


### PR DESCRIPTION
**Description:**
Use new configuration variables
Related to #6385

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
