### PR TITLE
update documentation to reflect changes

### DIFF
--- a/source/_components/notify.clicksend.markdown
+++ b/source/_components/notify.clicksend.markdown
@@ -62,7 +62,7 @@ sender:
   description: The name or number of the sender.
   required: false
   type: string
-  default: recipient
+  default: 'hass'
 {% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).


### PR DESCRIPTION
Chased the default sender to be 'hass' to remove sending an array of senders bug.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17713

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
