### PR TITLE
 Update Documentation for 'Soundtouch' Media Player Component Configuration

### DIFF
--- a/source/_components/media_player.soundtouch.markdown
+++ b/source/_components/media_player.soundtouch.markdown
@@ -51,6 +51,7 @@ host:
 name:
   description: The name of the device used in the frontend.
   required: true
+  default: Bose Soundtouch
   type: string
 port:
   description: The port number. 

--- a/source/_components/media_player.soundtouch.markdown
+++ b/source/_components/media_player.soundtouch.markdown
@@ -43,11 +43,21 @@ media_player:
     name: Soundtouch kitchen
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The host name or address of the Soundtouch device.
-- **name** (*Required*): The name of the device used in the frontend.
-- **port** (*Optional*): The port number. Defaults to 8090.
+{% configuration %}
+host:
+  description: The host name or address of the Soundtouch device.
+  required: true
+  type: string
+name:
+  description: The name of the device used in the frontend.
+  required: true
+  type: string
+port:
+  description: The port number. 
+  required: false
+  default: 8090
+  type: integer
+{% endconfiguration %}
 
 You can switch between one of your 6 pre-configured presets using ```media_player.play_media```
 


### PR DESCRIPTION
**Description:**
Related to #6385
Adds default value for 'name' key

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/7032

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
