### PR TITLE
Update Documentation for 'Snapcast' Media Player Component Configuration

### DIFF
--- a/source/_components/media_player.snapcast.markdown
+++ b/source/_components/media_player.snapcast.markdown
@@ -22,12 +22,12 @@ To add Snapcast to your installation, add the following to your `configuration.y
 # Example configuration.yaml entry
 media_player:
   - platform: snapcast
-    host: xxx.xxx.xxx.xxx
+    host: YOUR_IP_ADDRESS
 ```
 
 {% configuration %}
 host:
-  description: The IP address of the device, eg. `192.168.0.10`.
+  description: The IP address of the device, e.g., `192.168.0.10`.
   required: true
   type: string
 port:

--- a/source/_components/media_player.snapcast.markdown
+++ b/source/_components/media_player.snapcast.markdown
@@ -30,4 +30,8 @@ host:
   description: The IP of the device, eg. `192.168.0.10`.
   required: true
   type: string
+port:
+  description: The port number.
+  required: false
+  type: integer
 {% endconfiguration %}

--- a/source/_components/media_player.snapcast.markdown
+++ b/source/_components/media_player.snapcast.markdown
@@ -27,7 +27,7 @@ media_player:
 
 {% configuration %}
 host:
-  description: The IP of the device, eg. `192.168.0.10`.
+  description: The IP address of the device, eg. `192.168.0.10`.
   required: true
   type: string
 port:

--- a/source/_components/media_player.snapcast.markdown
+++ b/source/_components/media_player.snapcast.markdown
@@ -33,5 +33,6 @@ host:
 port:
   description: The port number.
   required: false
+  default: 1705
   type: integer
 {% endconfiguration %}

--- a/source/_components/media_player.snapcast.markdown
+++ b/source/_components/media_player.snapcast.markdown
@@ -25,6 +25,9 @@ media_player:
     host: xxx.xxx.xxx.xxx
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP of the device, eg. `192.168.0.10`.
+{% configuration %}
+host:
+  description: The IP of the device, eg. `192.168.0.10`.
+  required: true
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Related to #6385
Adds config for 'port' key and its default value

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** https://github.com/home-assistant/home-assistant.io/pull/7033

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
