### PR TITLE
Clarity edits

### DIFF
--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -23,6 +23,8 @@ The way these sensors are displayed in the frontend can be modified in the [cust
 - **illuminance**: The current light level in lx or lm.
 - **temperature**: Temperature in °C or °F.
 
+Setting the device class does not set the units.
+
 <p class='img'>
 <img src='/images/screenshots/sensor_device_classes_icons.png' />
 Example of various device class icons for sensors.


### PR DESCRIPTION
The _user_ docs imply that setting the device class sets the unit of measurement. This clearly isn't the case, so doing a set of clarity edits.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
