### PR TITLE
add note for hassOS boot folder

### DIFF
--- a/source/_addons/homematic.markdown
+++ b/source/_addons/homematic.markdown
@@ -72,3 +72,4 @@ With HM-MOD-RPI-PCB you need to add follow into your `config.txt` on boot partit
 ```text
 dtoverlay=pi3-miniuart-bt
 ```
+(In hassOS (non resin based version) you can edit the `config.txt` directly in `/mnt/boot`.)


### PR DESCRIPTION
**Description:**
add note where to find boot/config file in hassOS, because it is pretty confusing... 
