### PR TITLE
Update Rpi_gpio/pfio/rf switch component configuration

### DIFF
--- a/source/_components/switch.rpi_gpio.markdown
+++ b/source/_components/switch.rpi_gpio.markdown
@@ -29,11 +29,22 @@ switch:
       12: Light Desk
 ```
 
-Configuration variables:
-
-- **ports** array (*Required*): Array of used ports.
-  - **port: name** (*Required*): Port numbers and corresponding names (GPIO #).
-- **invert_logic** (*Optional*): If true, inverts the output logic to ACTIVE LOW. Default is false (ACTIVE HIGH).
+{% configuration %}
+ports:
+  description: Array of used ports.
+  required: true
+  type: list
+  keys:
+    port:
+      description:  Port numbers and corresponding names (GPIO #).
+      required: true
+      type: [integer, string]
+invert_logic:
+  description: If true, inverts the output logic to ACTIVE LOW.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
 
 For more details about the GPIO layout, visit the Wikipedia [article](https://en.wikipedia.org/wiki/Raspberry_Pi#GPIO_connector) about the Raspberry Pi.
 
@@ -51,5 +62,3 @@ switch:
     ports:
       17: Speaker Relay
 ```
-
-

--- a/source/_components/switch.rpi_pfio.markdown
+++ b/source/_components/switch.rpi_pfio.markdown
@@ -31,10 +31,24 @@ switch:
         name: Light Desk
 ```
 
-Configuration variables:
-
-- **ports** array (*Required*): Array of used ports.
-  - **num** (*Required*): Port number.
-    - **name** (*Required*): Port name.
-    - **invert_logic** (*Optional*): If true, inverts the output logic to ACTIVE LOW. Default is false (ACTIVE HIGH).
-
+{% configuration %}
+ports:
+  description: Array of used ports.
+  required: true
+  type: list
+  keys:
+    num:
+      description: Port number.
+      required: true
+      type: list
+      keys:
+        name:
+          description: Port name.
+          required: true
+          type: string
+        invert_logic:
+          description: If true, inverts the output logic to ACTIVE LOW.
+          required: false
+          default: false
+          type: boolean
+{% endconfiguration %}

--- a/source/_components/switch.rpi_rf.markdown
+++ b/source/_components/switch.rpi_rf.markdown
@@ -43,13 +43,41 @@ switch:
         signal_repetitions: 15
 ```
 
-Configuration variables:
-
-- **gpio** (*Required*): GPIO to which the data line of the TX module is connected.
-- **switches:** (*Required*): The array that contains all switches.
-  - **[entry]** (*Required*): Name of the switch. Multiple entries are possible.
-    - **code_on** (*Required*): Decimal code(s) to switch the device on. To run multiple codes in a sequence, separate the individual codes with commas ','.
-    - **code_off** (*Required*): Decimal code(s) to switch the device off. To run multiple codes in a sequence, separate the individual codes with commas ','.
-    - **protocol** (*Optional*): RF Protocol (Default is `1`).
-    - **pulselength** (*Optional*): Pulselength (Default is the protocol default).
-    - **signal_repetitions** (*Optional*): Number of times to repeat transmission (default is 10, can increase to try to improve reliability).
+{% configuration %}
+gpio:
+  description: GPIO to which the data line of the TX module is connected.
+  required: true
+  type: integer
+switches:
+  description: The array that contains all switches.
+  required: true
+  type: list
+  keys:
+    entry:
+      description: Name of the switch. Multiple entries are possible.
+      required: true
+      type: list
+      keys:
+        code_on:
+          description: Decimal code(s) to switch the device on. To run multiple codes in a sequence, separate the individual codes with commas ','.
+          required: true
+          type: list
+        code_off:
+          description: Decimal code(s) to switch the device off. To run multiple codes in a sequence, separate the individual codes with commas ','.
+          required: true
+          type: list
+        protocol:
+          description: RF Protocol.
+          required: false
+          default: 1
+          type: integer
+        pulselength:
+          description: Pulselength
+          required: false
+          type: integer
+        signal_repetitions:
+          description: Number of times to repeat transmission
+          required: false
+          default: 10
+          type: integer
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Rpi_gpio/pfio/rf switch component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
