### PR TITLE
Update Pulseaudio switch component configuration

### DIFF
--- a/source/_components/switch.pulseaudio_loopback.markdown
+++ b/source/_components/switch.pulseaudio_loopback.markdown
@@ -13,7 +13,6 @@ ha_release: 0.16
 ha_iot_class: "Local Polling"
 ---
 
-
 The goal behind this switch is to allow a very flexible whole home audio system based upon [PulseAudio](https://www.freedesktop.org/wiki/Software/PulseAudio/).
 
 For example, for a system with a 7.1 surround sound card, and 3 instances of [MPD](https://www.musicpd.org/) running, it is possible to quickly route the output of any MPD instance to any of the 8 possible (4 stereo) channels on the sound card, by loading/unloading a loopback module. This loading/unloading functionality is provided by this component. When the switch is `on`, the loopback module is loaded.  When the switch is `off`, the module is not loaded.
@@ -30,17 +29,42 @@ switch:
   - platform: pulseaudio_loopback
 ```
 
-Configuration variables:
-
-- **sink_name** (*Required*): The name of the Pulseaudio sink that will receive the audio.
-- **source_name** (*Required*): The name of the Pulseaudio source that will supply the audio.
-- **name** (*Optional*): Name of the switch.
-- **host** (*Optional*): The IP address or host name of the PulseAudio server.  If not specified, 127.0.0.1 is used.
-- **port** (*Optional*): The port that Pulseaudio is listening on.  Defaults to 4712.
-- **buffer_size** (*Optional*): How much data to load from Pulseaudio at once. Default is 1KB.
-- **tcp_timeout** (*Optional*): How long to wait for a response from Pulseaudio before giving up. Default is 3 seconds.
+{% configuration %}
+sink_name:
+  description: The name of the Pulseaudio sink that will receive the audio.
+  required: true
+  type: string
+source_name:
+  description: The name of the Pulseaudio source that will supply the audio.
+  required: true
+  type: string
+name:
+  description: Name of the switch.
+  required: false
+  default: paloopback
+  type: string
+host:
+  description: The IP address or host name of the PulseAudio server.
+  required: false
+  default: localhost
+  type: string
+port:
+  description: The port that Pulseaudio is listening on.
+  required: false
+  default: 4712
+  type: integer
+buffer_size:
+  description: How much data to load from Pulseaudio at once.
+  required: false
+  default: 1024
+  type: integer
+tcp_timeout:
+  description: How long to wait for a response from Pulseaudio before giving up.
+  required: false
+  default: 3
+  type: integer
+{% endconfiguration %}
 
 <p class='note warning'>
 This component relies on raw TCP commands to PulseAudio. In order for PulseAudio to accept commands with this component, `module-cli-protocol` must be loaded on the PulseAudio server.
 </p>
-


### PR DESCRIPTION
**Description:**
Update style of Pulseaudio switch component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
