### PR TITLE
Update gc100 switch component configuration

### DIFF
--- a/source/_components/switch.gc100.markdown
+++ b/source/_components/switch.gc100.markdown
@@ -25,7 +25,9 @@ switch:
       - '4:2': Sprinkler
 ```
 
-Configuration variables:
-
-- **ports** (*Required*): A list of module-address to name mappings in the format 'x:y': name, where x is module #, y is address.
-
+{% configuration %}
+ports:
+  description: A list of module-address to name mappings in the format 'x:y': name, where x is module #, y is address.
+  required: true
+  type: list
+{% endconfiguration %}

--- a/source/_components/switch.gc100.markdown
+++ b/source/_components/switch.gc100.markdown
@@ -27,7 +27,7 @@ switch:
 
 {% configuration %}
 ports:
-  description: A list of module-address to name mappings in the format 'x:y': name, where x is module #, y is address.
+  description: "A list of module-address to name mappings in the format 'x:y': name, where x is module #, y is address."
   required: true
   type: list
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of gc100 switch component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
