### PR TITLE
Link outdated

### DIFF
--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Polling"
 ---
 
 
-The `firetv` platform allows you to control a [Amazon Fire TV/stick](http://www.amazon.com/Amazon-DV83YW-Fire-TV/dp/B00U3FPN4U).
+The `firetv` platform allows you to control a [Amazon Fire TV/stick](https://www.amazon.com/b/?node=8521791011).
 
 The python-firetv Python 2.x module with its helper script that exposes an HTTP server to fetch state and perform actions is used.
 


### PR DESCRIPTION
Description was linked to an outtaded product page at amazon.com. The new link redirects to the official "Fire TV Family" rather than one specific product.
And it has HTTP**S** 😉

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
