### PR TITLE
Updated Link for Flower Care sensor

### DIFF
--- a/source/_components/sensor.miflora.markdown
+++ b/source/_components/sensor.miflora.markdown
@@ -13,7 +13,7 @@ ha_release: 0.29
 ha_iot_class: "Local Polling"
 ---
 
-The `miflora` sensor platform allows one to monitor plant soil and air conditions. The [Mi Flora plant sensor](https://xiaomi-mi.com/sockets-and-sensors/xiaomi-huahuacaocao-flower-care-smart-monitor/) is a small Bluetooth Low Energy device that monitors the moisture and conductivity of the soil as well as ambient light and temperature. Since only one BLE device can be polled at a time, the library implements locking to prevent polling more than one device at a time.
+The `miflora` sensor platform allows one to monitor plant soil and air conditions. The [Mi Flora plant sensor](https://www.huahuacaocao.com/product) is a small Bluetooth Low Energy device that monitors the moisture and conductivity of the soil as well as ambient light and temperature. Since only one BLE device can be polled at a time, the library implements locking to prevent polling more than one device at a time.
 
 # Install Bluetooth Backend
 Before configuring Home Assistant you need a Bluetooth backend and the MAC address of your sensor. Depending on your operating system, you may have to configure the proper Bluetooth backend for your system:


### PR DESCRIPTION
The old link leads to "xiaomi-mi.com", a site that pretends to be an official site of Xiaomi through the domain, favicon and logo, but is only supposed to attract users to the webshop nis-store.com. The new link also leads to the official site of the manufacturer.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
