### PR TITLE
Fix Discord notify docs

### DIFF
--- a/source/_components/notify.discord.markdown
+++ b/source/_components/notify.discord.markdown
@@ -14,7 +14,9 @@ ha_release: 0.37
 
 The [Discord service](https://discordapp.com/) is a platform for the notify component. This allows components to send messages to the user using Discord.
 
-In order to get a token you need to go to the [Discord My Apps page](https://discordapp.com/developers/applications/me) and create a new application. Once the application is ready, create a [bot](https://discordapp.com/developers/docs/topics/oauth2#bots) user (**Create a Bot User**) and activate **Require OAuth2 Code Grant**. Retrieve the **Client ID** and the (hidden) **Token** of your bot for later.
+In order to get a token you need to go to the [Discord My Apps page](https://discordapp.com/developers/applications/me) and create a new application. Once the application is ready, create a [bot](https://discordapp.com/developers/docs/topics/oauth2#bots) user (**Create a Bot User**).
+
+Retreive the **Client ID** from the information section and the (hidden) **Token** of your bot for later.
 
 When setting up the application you can use this [icon](/demo/favicon-192x192.png).
 


### PR DESCRIPTION
**Description:**

Fixes incorrect setup documentation for `notify.discord`.

Removes `activate Require OAuth2 Code Grant` since this will cause an error on authorisation. Without this enabled, the bot works.

**Issue this fixes**

#7051 

**Docs page**

https://www.home-assistant.io/components/notify.discord

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
