### PR TITLE
Fix impropper capitalization

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -111,7 +111,7 @@ type:
   required: true
   description: section
   type: string
-Label:
+label:
   required: false
   description: Section label
   type: string


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
