### PR TITLE
Add 'run_test' configs to skip ffmpeg input test on startup

### DIFF
--- a/source/_components/binary_sensor.ffmpeg_motion.markdown
+++ b/source/_components/binary_sensor.ffmpeg_motion.markdown
@@ -73,7 +73,7 @@ extra_arguments:
   required: false
   type: string
 run_test:
-  description: Check if `input` is usable by ffmpeg.
+  description: Check if `input` is usable by `ffmpeg`.
   required: false
   default: true
   type: boolean

--- a/source/_components/binary_sensor.ffmpeg_motion.markdown
+++ b/source/_components/binary_sensor.ffmpeg_motion.markdown
@@ -75,7 +75,7 @@ extra_arguments:
 run_test:
   description: Check if `input` is usable by ffmpeg.
   required: false
-  default: True
+  default: true
   type: boolean
 {% endconfiguration %}
 

--- a/source/_components/binary_sensor.ffmpeg_motion.markdown
+++ b/source/_components/binary_sensor.ffmpeg_motion.markdown
@@ -72,6 +72,11 @@ extra_arguments:
   description: Extra options to pass to `ffmpeg`, e.g., video denoise filtering.
   required: false
   type: string
+run_test:
+  description: Check if `input` is usable by ffmpeg.
+  required: false
+  default: True
+  type: boolean
 {% endconfiguration %}
 
 To experiment with values (changes/100 is the scene value in `ffmpeg`):

--- a/source/_components/binary_sensor.ffmpeg_noise.markdown
+++ b/source/_components/binary_sensor.ffmpeg_noise.markdown
@@ -67,7 +67,7 @@ output:
   required: false
   type: string
 run_test:
-  description: Check if `input` is usable by ffmpeg.
+  description: Check if `input` is usable by `ffmpeg`.
   required: false
   default: true
   type: boolean

--- a/source/_components/binary_sensor.ffmpeg_noise.markdown
+++ b/source/_components/binary_sensor.ffmpeg_noise.markdown
@@ -69,7 +69,7 @@ output:
 run_test:
   description: Check if `input` is usable by ffmpeg.
   required: false
-  default: True
+  default: true
   type: boolean
 {% endconfiguration %}
 

--- a/source/_components/binary_sensor.ffmpeg_noise.markdown
+++ b/source/_components/binary_sensor.ffmpeg_noise.markdown
@@ -66,6 +66,11 @@ output:
   description: Allows you to send the audio output of this sensor to an Icecast server or other FFmpeg-supported output, e.g., to stream with Sonos after a state is triggered.
   required: false
   type: string
+run_test:
+  description: Check if `input` is usable by ffmpeg.
+  required: false
+  default: True
+  type: boolean
 {% endconfiguration %}
 
 To experiment with values:

--- a/source/_components/camera.ffmpeg.markdown
+++ b/source/_components/camera.ffmpeg.markdown
@@ -42,7 +42,7 @@ extra_arguments:
 run_test:
   description: Check if `input` is usable by ffmpeg.
   required: false
-  default: True
+  default: true
   type: boolean
 {% endconfiguration %}
 

--- a/source/_components/camera.ffmpeg.markdown
+++ b/source/_components/camera.ffmpeg.markdown
@@ -39,6 +39,11 @@ extra_arguments:
   description: Extra options to pass to `ffmpeg`, e.g., image quality or video filter options.
   required: false
   type: string
+run_test:
+  description: Check if `input` is usable by ffmpeg.
+  required: false
+  default: True
+  type: boolean
 {% endconfiguration %}
 
 ### {% linkable_title Image quality %}

--- a/source/_components/camera.ffmpeg.markdown
+++ b/source/_components/camera.ffmpeg.markdown
@@ -40,7 +40,7 @@ extra_arguments:
   required: false
   type: string
 run_test:
-  description: Check if `input` is usable by ffmpeg.
+  description: Check if `input` is usable by `ffmpeg`.
   required: false
   default: true
   type: boolean

--- a/source/_components/ffmpeg.markdown
+++ b/source/_components/ffmpeg.markdown
@@ -35,11 +35,6 @@ ffmpeg_bin:
   required: false
   default: ffmpeg
   type: string
-run_test:
-  description: Check if `input` is usable by ffmpeg.
-  required: false
-  default: True
-  type: boolean
 {% endconfiguration %}
 
 ### {% linkable_title Raspbian Debian Jessie Lite Installations %}


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17769

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html