### PR TITLE
Update Scrape sensor component configuration

### DIFF
--- a/source/_components/sensor.scrape.markdown
+++ b/source/_components/sensor.scrape.markdown
@@ -26,17 +26,45 @@ sensor:
     select: ".current-version h1"
 ```
 
-Configuration variables:
-
-- **resource** (*Required*): The URL to the website that contains the value.
-- **select** (*Required*): Defines the HTML tag to search for. Check Beautifulsoup's [CSS selectors](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors) for details.
-- **attribute** (*optional*): Get value of an attribute on the selected tag.
-- **name** (*Optional*): Name of the sensor.
-- **unit_of_measurement** (*Optional*): Defines the units of measurement of the sensor, if any.
-- **authentication** (*Optional*): Type of the HTTP authentication. Either `basic` or `digest`.
-- **username** (*Optional*): The username for accessing the website.
-- **password** (*Optional*): The password for accessing the website.
-- **headers** (*Optional*): Headers to use for the web request
+{% configuration %}
+resource:
+  description: The URL to the website that contains the value.
+  required: true
+  type: string
+select:
+  description: "Defines the HTML tag to search for. Check Beautifulsoup's [CSS selectors](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors) for details."
+  required: true
+  type: string
+attribute:
+  description: Get value of an attribute on the selected tag.
+  required: false
+  type: string
+name:
+  description: Name of the sensor.
+  required: false
+  default: Web scrape
+  type: string
+unit_of_measurement:
+  description: Defines the units of measurement of the sensor, if any.
+  required: false
+  type: string
+authentication:
+  description: Type of the HTTP authentication. Either `basic` or `digest`.
+  required: false
+  type: string
+username:
+  description: The username for accessing the website.
+  required: false
+  type: string
+password:
+  description: The password for accessing the website.
+  required: false
+  type: string
+headers:
+  description: Headers to use for the web request.
+  required: false
+  type: string
+{% endconfiguration %}
 
 ## {% linkable_title Examples %}
 


### PR DESCRIPTION
**Description:**
Update style of Scrape sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
