### PR TITLE
Added some .gitignore example lines

### DIFF
--- a/source/_docs/ecosystem/backup/backup_github.markdown
+++ b/source/_docs/ecosystem/backup/backup_github.markdown
@@ -63,6 +63,7 @@ Here is an example that will ignore everything but your YAML configuration.
 !.gitignore
 *.conf
 *.txt
+*.log
 .storage
 .cloud
 .google.token

--- a/source/_docs/ecosystem/backup/backup_github.markdown
+++ b/source/_docs/ecosystem/backup/backup_github.markdown
@@ -57,10 +57,16 @@ Creating a `.gitignore` file in your repository will tell Git which files NOT to
 Here is an example that will ignore everything but your YAML configuration.
 
 ```bash
-# Example .gitignore file for your config dir
+# Example .gitignore file for your config dir. Lines with ! will not be ignored.
 *
 !*.yaml
 !.gitignore
+*.conf
+*.txt
+.storage
+.cloud
+.google.token
+ip_bans.yaml
 secrets.yaml
 known_devices.yaml
 ```


### PR DESCRIPTION
**Description:**
Added some extra files/folders and file extensions to the .gitignore example. This is to prevent people from unknowingly accidentally pushing sensitive data to github.
Related to #6994 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
