### PR TITLE
Add documentation for Twilio webhook changes

### DIFF
--- a/source/_components/twilio.markdown
+++ b/source/_components/twilio.markdown
@@ -41,3 +41,26 @@ auth_token:
 
 ### {% linkable_title Usage %}
 After configuring the base Twilio component, add and configure either or both of the [twilio SMS](/components/notify.twilio_sms/) and [twilio Phone](/components/notify.twilio_call) components to utilize the notification functionality.
+
+To be able to receive events from Twilio, your Home Assistant instance needs to be accessible from the web ([Hass.io instructions](/addons/duckdns/)) and you need to have the `base_url` configured for the HTTP component ([docs](https://www.home-assistant.io/components/http/#base_url)).
+
+To set it up, go to the integrations page in the configuration screen and find Mailgun. Click on configure. Follow the instructions on the screen to configure Mailgun.
+
+You will get a URL of the following format: `https://<home-assistant-domain>/api/webhook/9940e99a26fae4dcf6fe0a478124b6b58b578ea4c55c9a584beb1c9f5057bb91`. To generate inbound events, you have to configure your webhooks with [Twilio](https://www.twilio.com/docs/glossary/what-is-a-webhook)
+
+Events coming in from Twilio will be available as events in Home Assistant and are fired as `twilio_data_received`. The data specified by Twilio will be available as the event data. You can use this event to trigger automations.
+
+You can then consume that information with the following automation:
+
+```yaml
+automation:
+  trigger:
+    platform: event
+    event_type: twilio_data_received
+    event_data:
+      action: call_service
+  action:
+    service: light.turn_on
+    entity_id: light.office
+```
+


### PR DESCRIPTION
**Description:**
Twilio webhooks were changed to use the webhook component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17715

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
