### PR TITLE
Fixed SNMP Documentation

### DIFF
--- a/source/_components/sensor.snmp.markdown
+++ b/source/_components/sensor.snmp.markdown
@@ -28,7 +28,7 @@ sensor:
 {% configuration %}
 host:
   description: The IP address of your host, eg. `192.168.1.32`.
-  required: true
+  required: false
   type: string
   default: 'localhost'
 baseoid:
@@ -37,7 +37,7 @@ baseoid:
   type: string
 port:
   description: The SNMP port of your host.
-  required: Option
+  required: false
   type: string
   default: '161'
 community:


### PR DESCRIPTION
Fixed a typo for the required value and corrected the value for the host attribute, which is not required according to the module: https://github.com/home-assistant/home-assistant/blob/27d50d388fe61e38f5623d0e63c4bdc28764ebe2/homeassistant/components/sensor/snmp.py#L73

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
