### PR TITLE
Attributes 'entity' and 'field' can both be used

### DIFF
--- a/source/_components/deconz.markdown
+++ b/source/_components/deconz.markdown
@@ -59,11 +59,13 @@ Set attribute of device in deCONZ using [Rest API](http://dresden-elektronik.git
 | `entity` | No | String representing a specific Home Assistant entity of a device in deCONZ. |
 | `data` | No | Data is a JSON object with what data you want to alter. |
 
-Field and entity are exclusive, i.e you can only use one in a request.
+Either `entity` or `field` must be provided. If both are present, `field` will be interpreted as a subpath under the device path corresponding to the specified `entity`:
 
 { "field": "/lights/1", "data": {"name": "light2"} }
 
 { "entity": "light.light1", "data": {"name": "light2"} }
+
+{ "entity": "light.light1", "field: "/state", "data": {"on": true} }
 
 { "field": "/config", "data": {"permitjoin": 60} }
 


### PR DESCRIPTION
**Description:**

Attributes `entity` and `field` can both be used. Note that I'm not a native English speaker, so please point out any non-idiomatic issues with the text.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17722

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
