### PR TITLE
Update Proliphix climate component configuration

### DIFF
--- a/source/_components/climate.proliphix.markdown
+++ b/source/_components/climate.proliphix.markdown
@@ -30,12 +30,20 @@ climate:
     password: YOUR_PASSWORD
 ```
 
-Configuration variables:
-
-- **host** (*Required*): Address of your thermostat, eg. 192.168.1.32.
-- **username** (*Required*): Username for the thermostat.
-- **password** (*Required*): Password for the thermostat.
+{% configuration %}
+host:
+  description: Address of your thermostat, e.g., 192.168.1.32.
+  required: true
+  type: string
+username:
+  description: Username for the thermostat.
+  required: true
+  type: string
+password:
+  description: Password for the thermostat.
+  required: true
+  type: string
+{% endconfiguration %}
 
 The Proliphix NT Thermostat series are Ethernet connected thermostats. They have a local HTTP interface that is based on get/set
 of OID values. A complete collection of the API is available in this [API documentation](https://github.com/sdague/thermostat.rb/blob/master/docs/PDP_API_R1_11.pdf).
-


### PR DESCRIPTION
**Description:**
Update style of Proliphix climate component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
