### PR TITLE
Update Yeelight sunflower Light component configuration

### DIFF
--- a/source/_components/light.yeelightsunflower.markdown
+++ b/source/_components/light.yeelightsunflower.markdown
@@ -28,15 +28,17 @@ light:
     host: 192.168.1.59
 ```
 
-Configuration variables:
-
-- **host** (*Required*): IP address of your Yeelight Sunflower hub.
+{% configuration %}
+host:
+  description: IP address of your Yeelight Sunflower hub.
+  required: true
+  type: string
+{% endconfiguration %}
 
 <p class='note'>
-When the hub is loaded, your lights will appear as devices with their Zigbee IDs as part of the entity name. 
+When the hub is loaded, your lights will appear as devices with their Zigbee IDs as part of the entity name.
 </p>
 
 <p class='note warning'>
 The Yeelight Sunflower hub supports SSDP discovery, but that has not been built into the platform. Let the developer know if that would be helpful to you.
 </p>
-


### PR DESCRIPTION
**Description:**
Update style of Yeelight sunflower Light component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
