### PR TITLE
Update Hipchat notify component configuration

### DIFF
--- a/source/_components/notify.hipchat.markdown
+++ b/source/_components/notify.hipchat.markdown
@@ -24,19 +24,45 @@ To enable the HipChat notification in your installation, add the following to yo
 notify:
   - name: NOTIFIER_NAME
     platform: hipchat
-    token: ABCDEFGHJKLMNOPQRSTUVXYZ
+    token: YOUR_TOKEN
     room: 1234567
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **token** (*Required*): The HipChat API token to use for sending HipChat notifications.
-- **room** (*Required*): The default room to post to if no room is explicitly specified when sending the notification.
-- **color** (*Optional*): Setting color will override the default color for the notification. By default not setting this will post to HipChat using the default color yellow. Valid options are 'yellow', 'green', 'red', 'purple', 'gray', 'random'.
-- **notify** (*Optional*): Setting notify will override the default notify (blink application icon, chime, or otherwise call attention) setting for the notification. By default this is 'false'. Valid options are 'true' and 'false'.
-- **format** (*Optional*): Setting format will override the default message format. Default is 'text'. Valid options are 'text' and 'html'.
-- **host** (*Optional*): Setting the host will override the default HipChat server host. Default is 'https://api.hipchat.com/'.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+token:
+  description: The HipChat API token to use for sending HipChat notifications.
+  required: true
+  type: string
+room:
+  description: The default room to post to if no room is explicitly specified when sending the notification.
+  required: true
+  type: integer
+color:
+  description: Setting color will override the default color for the notification. Valid options are 'yellow', 'green', 'red', 'purple', 'gray', 'random'.
+  required: false
+  default: yellow
+  type: string
+notify:
+  description: Setting notify will override the default notify (blink application icon, chime, or otherwise call attention) setting for the notification. Valid options are 'true' and 'false'.
+  required: false
+  default: false
+  type: boolean
+format:
+  description: Setting format will override the default message format. Default is 'text'. Valid options are 'text' and 'html'.
+  required: false
+  default: text
+  type: string
+host:
+  description: Setting the host will override the default HipChat server host.
+  required: false
+  default: "https://api.hipchat.com/"
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title HipChat service data %}
 
@@ -50,4 +76,3 @@ The following attributes can be placed `data` for extended functionality.
 | `format`             |      yes | (str) Same usage as in configuration.yaml. Overrides any setting set in configuration.yaml.
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
-


### PR DESCRIPTION
**Description:**
Update style of Hipchat notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
