### PR TITLE
Adding note for Hipchat component

### DIFF
--- a/source/_components/notify.hipchat.markdown
+++ b/source/_components/notify.hipchat.markdown
@@ -12,6 +12,11 @@ ha_category: Notifications
 ha_release: "0.52"
 ---
 
+<p class='note'>
+This component will be removed from Home Assistant in the future. Slack has taken over Hipchat and Stride and will therefore stop these platforms. For more information: <a href="https://www.atlassian.com/blog/announcements/new-atlassian-slack-partnership">announcement</a>.
+
+Hipchat will be discontinued after February 15th, 2019. This to give customers the opportunity to make a switch.
+</p>
 
 The `hipchat` platform allows you to send notifications from Home Assistant to [HipChat](https://hipchat.com/).
 


### PR DESCRIPTION
**Description:**
Since Hipchat will be discontinued in the future, I added a note to the page.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
