### PR TITLE
Image processing scan_interval doc updates

### DIFF
--- a/source/_components/image_processing.facebox.markdown
+++ b/source/_components/image_processing.facebox.markdown
@@ -98,7 +98,7 @@ Use the `image_processing.detect_face` events to trigger automations, and breako
 
 ## {% linkable_title Service `facebox_teach_face` %}
 
-The service `facebox_teach_face` can be used to teach Facebox faces.  
+The service `facebox_teach_face` can be used to teach Facebox faces.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -133,7 +133,7 @@ You can use an automation to receive a notification when you train a face:
   action:
   - service: notify.pushbullet
     data_template:
-      message: '{{ trigger.event.data.service_data.name }} taught 
+      message: '{{ trigger.event.data.service_data.name }} taught
       with file {{ trigger.event.data.service_data.file_path }}'
       title: Face taught notification
 ```
@@ -166,6 +166,3 @@ you can create an automation to receive notifications on Facebox errors:
 ```
 {% endraw %}
 
-## {% linkable_title Optimising resources %}
-
-[Image processing components](https://www.home-assistant.io/components/image_processing/) process the image from a camera at a fixed period given by the `scan_interval`. This leads to excessive processing if the image on the camera hasn't changed, as the default `scan_interval` is 10 seconds. You can override this by adding to your config `scan_interval: 10000` (setting the interval to 10,000 seconds), and then call the `image_processing.scan` service when you actually want to perform processing.

--- a/source/_components/image_processing.facebox.markdown
+++ b/source/_components/image_processing.facebox.markdown
@@ -24,7 +24,7 @@ MB_KEY="INSERT-YOUR-KEY-HERE"
 
 sudo docker run --name=facebox --restart=always -p 8080:8080 -e "MB_KEY=$MB_KEY"  machinebox/facebox
 ```
-You can run Facebox with a username and password by adding `-e "MB_BASICAUTH_USER=my_username" -e "MB_BASICAUTH_PASS=my_password"` but bare in mind that the component does not encrypt these credentials and this approach does not guarantee security on an unsecured network. 
+You can run Facebox with a username and password by adding `-e "MB_BASICAUTH_USER=my_username" -e "MB_BASICAUTH_PASS=my_password"` but bear in mind that the component does not encrypt these credentials and this approach does not guarantee security on an unsecured network.
 
 If you only require face detection (number of faces) you can disable face recognition by adding `-e "MB_FACEBOX_DISABLE_RECOGNITION=true"` to the `docker run` command.
 

--- a/source/_components/image_processing.markdown
+++ b/source/_components/image_processing.markdown
@@ -12,8 +12,6 @@ ha_release: 0.36
 
 Image processing enables Home Assistant to process images from [cameras](/components/#camera). Only camera entities are supported as sources.
 
-For interval control, use `scan_interval` in platform.
-
 <p class='note'>
 If you are running Home Assistant over SSL or from within a container, you will have to setup a base URL (`base_url`) inside the [http component](/components/http/).
 </p>
@@ -59,3 +57,21 @@ automation:
 ```
 
 The following event attributes will be present (platform-dependent): `entity_id`, `name`, `confidence`, `age`, `gender`, `motion`, `glasses`
+
+## {% linkable_title scan_interval and Optimising Resources %}
+
+Image processing components process the image from a camera at a fixed period given by the `scan_interval`. This leads to excessive processing if the image on the camera hasn't changed, as the default `scan_interval` is 10 seconds. You can override this by adding to your config `scan_interval: 10000` (setting the interval to 10,000 seconds), and then call the `image_processing.scan` service when you actually want to perform processing.
+
+```yaml
+# Example configuration.yaml automation entry
+automation:
+- alias: Scan for faces when motion detected
+  trigger:
+    - platform: state
+      entity_id: sensor.door_motion_sensor
+      to: 'on'
+  action:
+    - service: image_processing.scan
+      data:
+        entity_id: image_processing.door
+```

--- a/source/_components/image_processing.markdown
+++ b/source/_components/image_processing.markdown
@@ -63,7 +63,11 @@ The following event attributes will be present (platform-dependent): `entity_id`
 Image processing components process the image from a camera at a fixed period given by the `scan_interval`. This leads to excessive processing if the image on the camera hasn't changed, as the default `scan_interval` is 10 seconds. You can override this by adding to your config `scan_interval: 10000` (setting the interval to 10,000 seconds), and then call the `image_processing.scan` service when you actually want to perform processing.
 
 ```yaml
-# Example configuration.yaml automation entry
+# Example configuration.yaml
+sensor:
+- platform: _AN_IMAGE_PROCESSING_PLATFORM_
+  scan_interval: 10000
+...
 automation:
 - alias: Scan for faces when motion detected
   trigger:
@@ -74,4 +78,5 @@ automation:
     - service: image_processing.scan
       data:
         entity_id: image_processing.door
+...
 ```

--- a/source/_components/image_processing.microsoft_face_detect.markdown
+++ b/source/_components/image_processing.microsoft_face_detect.markdown
@@ -18,11 +18,11 @@ The `microsoft_face_detect` image processing platform allows you to use the
 API through Home Assistant. This platform enables you do detect face on camera
 and fire an event with attributes.
 
-Please refer to the [component](/components/microsoft_face/) configuration on
+Please refer to the [Microsoft Face component](/components/microsoft_face/) configuration on
 how to setup the API key.
 
 For using the result inside an automation rule,
-take a look at the [component](/components/image_processing/) page.
+take a look at the [Image Processing component](/components/image_processing/) page.
 
 ### {% linkable_title Configuration %}
 

--- a/source/_components/image_processing.microsoft_face_detect.markdown
+++ b/source/_components/image_processing.microsoft_face_detect.markdown
@@ -24,6 +24,10 @@ how to setup the API key.
 For using the result inside an automation rule,
 take a look at the [Image Processing component](/components/image_processing/) page.
 
+<p class='note'>
+The free version of the Microsoft Face identify API limits the number of requests possible per month. Therefore, it is strongly recommended that you limit the `scan_interval` when setting up an instance of this entity as detailed on the main [Image Processing component](/components/image_processing/) page.
+</p>
+
 ### {% linkable_title Configuration %}
 
 ```yaml

--- a/source/_components/image_processing.microsoft_face_identify.markdown
+++ b/source/_components/image_processing.microsoft_face_identify.markdown
@@ -24,6 +24,10 @@ how to setup the API key.
 For using the result inside an automation rule,
 take a look at the [Image Processing component](/components/image_processing/) page.
 
+<p class='note'>
+The free version of the Microsoft Face identify API limits the number of requests possible per month. Therefore, it is strongly recommended that you limit the `scan_interval` when setting up an instance of this entity as detailed on the main [Image Processing component](/components/image_processing/) page.
+</p>
+
 ### {% linkable_title Configuration %}
 
 ```yaml

--- a/source/_components/image_processing.microsoft_face_identify.markdown
+++ b/source/_components/image_processing.microsoft_face_identify.markdown
@@ -18,11 +18,11 @@ The `microsoft_face_identify` image processing platform lets you use
 API through Home Assistant. This platform allow you do identify persons on
 camera and fire an event with attributes.
 
-Please refer to the [component](/components/microsoft_face/) configuration on
+Please refer to the [Microsoft Face component](/components/microsoft_face/) configuration on
 how to setup the API key.
 
 For using the result inside an automation rule,
-take a look at the [component](/components/image_processing/) page.
+take a look at the [Image Processing component](/components/image_processing/) page.
 
 ### {% linkable_title Configuration %}
 


### PR DESCRIPTION
**Description:**

Brings the generic information about `scan_interval` from the Facebox doc page up to the generic Image Processing component page. Adds a note about `scan_interval` to the two MS component pages, as with the default setup it is very easy to burn through a month's worth of requests in hours.

Tweaked wording in a couple of places to be clearer.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
