### PR TITLE
Update Rflink switch component configuration

### DIFF
--- a/source/_components/switch.rflink.markdown
+++ b/source/_components/switch.rflink.markdown
@@ -41,12 +41,12 @@ switch:
 
 {% configuration %}
 device_defaults:
-  description: Device Defaults.
+  description: The defaults for all listed devices.
   required: false
   type: list
   keys:
     fire_event:
-      description: Set default `fire_event` for Rflink switch devices (see below)
+      description: Set default `fire_event` for Rflink switch devices (see below).
       required: false
       type: boolean
     signal_repetitions:

--- a/source/_components/switch.rflink.markdown
+++ b/source/_components/switch.rflink.markdown
@@ -39,22 +39,68 @@ switch:
 
 ```
 
-Configuration variables:
-
-- **devices** (*Optional*): A list of devices with their name to use in the frontend.
-- **device_defaults**: (*Optional*)
-  - **fire_event** (*Optional*): Set default `fire_event` for RFLink switch devices (see below).
-  - **signal_repetitions** (*Optional*): Set default `signal_repetitions` for RFLink switch devices (see below).
-
-Device configuration variables:
-
-- **name** (*Optional*): Name for the device, defaults to RFLink ID.
-- **aliases** (*Optional*): Alternative RFLink ID's this device is known by.
-- **fire_event** (*Optional*): Fire a `button_pressed` event if this device is turned on or off (default: False).
-- **signal_repetitions** (*Optional*): Repeat every RFLink command this number of times (default: 1)
-- **group** (*Optional*): Allow switch to respond to group commands (ALLON/ALLOFF). (default: yes)
-- **group_aliases** (*Optional*): `aliases` which only respond to group commands.
-- **no_group_aliases** (*Optional*): `aliases` which do not respond to group commands.
+{% configuration %}
+device_defaults:
+  description: Device Defaults.
+  required: false
+  type: list
+  keys:
+    fire_event:
+      description: Set default `fire_event` for Rflink switch devices (see below)
+      required: false
+      type: boolean
+    signal_repetitions:
+      description: Set default `signal_repetitions` for Rflink switch devices (see below).
+      required: false
+      type: integer
+automatic_add:
+  description: Automatically add new/unconfigured devices to HA if detected.
+  required: false
+  default: true
+  type: boolean
+devices:
+  description: A list of devices with their name to use in the frontend.
+  required: false
+  type: list
+  keys:
+    name:
+      description: Name for the device.
+      required: false
+      default: Rflink ID
+      type: string
+    type:
+      description: "Override automatically detected type of the light device, can be: switchable, dimmable, hybrid or toggle. See 'Light Types' below."
+      required: false
+      default: switchable
+      type: string
+    aliases:
+      description: (deprecated) Alternative Rflink ID's this device is known by.
+      required: false
+      type: [list, string]
+    group_aliases:
+      description: "(deprecated) `aliases` which only respond to group commands."
+      required: false
+      type: [list, string]
+    no_group_aliases:
+      description: "(deprecated) `aliases` which do not respond to group commands."
+      required: false
+      type: [list, string]
+    fire_event:
+      description: Fire a `button_pressed` event if this device is turned on or off.
+      required: false
+      default: false
+      type: boolean
+    signal_repetitions:
+      description: Set default `signal_repetitions` for RFLink switch devices (see below).
+      required: false
+      default: 1
+      type: integer
+    group:
+      description: Allow light to respond to group commands (ALLON/ALLOFF).
+      required: false
+      default: true
+      type: boolean
+{% endconfiguration %}
 
 ### {% linkable_title Switch state %}
 
@@ -80,4 +126,3 @@ Any on/off command from any alias ID updates the current state of the switch. Ho
 ### {% linkable_title Device support %}
 
 See [device support](/components/rflink/#device-support)
-

--- a/source/_components/switch.rflink.markdown
+++ b/source/_components/switch.rflink.markdown
@@ -53,11 +53,6 @@ device_defaults:
       description: Set default `signal_repetitions` for Rflink switch devices (see below).
       required: false
       type: integer
-automatic_add:
-  description: Automatically add new/unconfigured devices to HA if detected.
-  required: false
-  default: true
-  type: boolean
 devices:
   description: A list of devices with their name to use in the frontend.
   required: false
@@ -67,11 +62,6 @@ devices:
       description: Name for the device.
       required: false
       default: Rflink ID
-      type: string
-    type:
-      description: "Override automatically detected type of the light device, can be: switchable, dimmable, hybrid or toggle. See 'Light Types' below."
-      required: false
-      default: switchable
       type: string
     aliases:
       description: (deprecated) Alternative Rflink ID's this device is known by.


### PR DESCRIPTION
**Description:**
Update style of Rflink switch component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
