### PR TITLE
Update Synology Chat docs

### DIFF
--- a/source/_components/notify.synology_chat.markdown
+++ b/source/_components/notify.synology_chat.markdown
@@ -38,3 +38,13 @@ resource:
 {% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
+
+A full example of a service call:
+
+```json
+{"message": "This is a test message", 
+ "data":{
+     "file_url":"https://example.com/wp-content/uploads/sites/14/2011/01/cat.jpg"
+     }
+ }
+```


### PR DESCRIPTION
**Description:**
We now allow passing through file_url to the Synology Chat API so the Synology Chat bot can upload files


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17801

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
