### PR TITLE
Restore padding around search icon for easier click target

### DIFF
--- a/sass/oscailte/base/_navigation.scss
+++ b/sass/oscailte/base/_navigation.scss
@@ -81,11 +81,6 @@ header .grid {
   font-weight: normal;
   font-size: 14px;
   line-height: 1;
-
-  &.show-search {
-    padding-left: 0;
-    padding-right: 0;
-  }
 }
 
 .menu > li > a:hover, .menu > li > a:focus{


### PR DESCRIPTION
**Description:**
This removes the CSS styles that set the left/right padding to zero for the search icon in the navigation. Without padding the search icon is very narrow and is not an easy "target" to click with a mouse or tap with a finger.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
