### PR TITLE
Update Huawei lte sensor component configuration

### DIFF
--- a/source/_components/sensor.huawei_lte.markdown
+++ b/source/_components/sensor.huawei_lte.markdown
@@ -15,12 +15,15 @@ ha_release: 0.79
 
 The `huawei_lte` sensor platform allows you to monitor Huawei LTE routers.
 
-This requires you to have set up the [Huawei LTE component](/components/huawei_lte/).
+## {% linkable_title Configuration %}
+
+This platform requires you to have set up the [Huawei LTE component](/components/huawei_lte/).
+
+The names for the item you want to monitor are dot separated paths to information returned by the router. The data set varies by router model. To see what your router provides, set logging level to debug and watch `homeassistant.components.huawei_lte` debug entries. The configuration variable description contains a few example paths just to illustrate the syntax. These may not be available on all routers or their semantics may differ, and there are quite likely many more that are not listed here.
 
 ## {% linkable_title Configuration %}
 
-To enable the sensor, add the following lines to your
-`configuration.yaml` file:
+To enable the sensor, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -35,7 +38,7 @@ sensor:
 
 {% configuration %}
 monitored_conditions:
-  description: Defines the data to monitor as sensors. Defaults to a few generally available data items expected to be available on most boxes. The names here are dot separated paths to information returned by the router. The data set varies by router model; to see what your router provides, set logging level to debug and watch homeassistant.components.huawei_lte debug entries. The following list contains a few example paths just to illustrate the syntax; these may not be available on all routers or their semantics may differ, and there are quite likely many more that are not listed here.
+  description: Defines the data to monitor as sensors. Defaults to a few generally available data items expected to be available on most boxes.
   required: false
   default: Below is indicated which conditions are the default.
   type: list

--- a/source/_components/sensor.huawei_lte.markdown
+++ b/source/_components/sensor.huawei_lte.markdown
@@ -33,19 +33,40 @@ sensor:
       - traffic_statistics.TotalConnectTime
 ```
 
-Configuration variables:
-
-**monitored_conditions** array (*Optional*): Defines the data to monitor as sensors. Defaults to a few generally available data items expected to be available on most boxes. The names here are dot separated paths to information returned by the router. The data set varies by router model; to see what your router provides, set logging level to debug and watch homeassistant.components.huawei_lte debug entries. The following list contains a few example paths just to illustrate the syntax; these may not be available on all routers or their semantics may differ, and there are quite likely many more that are not listed here.
-
-  - **device_information.SoftwareVersion**: Software version.
-  - **device_information.WanIPAddress**: WAN interface IP address.
-  - **device_information.WanIPv6Address**: WAN interface IP address.
-  - **device_signal.rsrq**: The signal RSRQ value.
-  - **device_signal.rsrp**: The signal RSRP value.
-  - **device_signal.rssi**: The signal RSSI value.
-  - **device_signal.sinr**: The signal SINR value.
-  - **traffic_statistics.CurrentDownloadRate**: Current download rate, bytes/sec.
-  - **traffic_statistics.CurrentUploadRate**: Current upload rate, bytes/sec.
-  - **traffic_statistics.TotalUpload**: Total bytes uploaded since last reset.
-  - **traffic_statistics.TotalDownload**: Total bytes downloaded since last reset.
-  - **traffic_statistics.TotalConnectTime**: Total time connected since last reset.
+{% configuration %}
+monitored_conditions:
+  description: Defines the data to monitor as sensors. Defaults to a few generally available data items expected to be available on most boxes. The names here are dot separated paths to information returned by the router. The data set varies by router model; to see what your router provides, set logging level to debug and watch homeassistant.components.huawei_lte debug entries. The following list contains a few example paths just to illustrate the syntax; these may not be available on all routers or their semantics may differ, and there are quite likely many more that are not listed here.
+  required: false
+  default: Below is indicated which conditions are the default.
+  type: list
+  keys:
+    device_information.SoftwareVersion:
+      description: Software version.
+    device_information.WanIPAddress:
+      description: WAN interface IPv4 address.
+      default: default
+    device_information.WanIPv6Address:
+      description: WAN interface IPv6 address.
+    device_signal.rsrq:
+      description: The signal RSRQ value.
+      default: default
+    device_signal.rsrp:
+      description: The signal RSRP value.
+      default: default
+    device_signal.rssi:
+      description: The signal RSSI value.
+      default: default
+    device_signal.sinr:
+      description: The signal SINR value.
+      default: default
+    traffic_statistics.CurrentDownloadRate:
+      description: Current download rate, bytes/sec.
+    traffic_statistics.CurrentUploadRate:
+      description: Current upload rate, bytes/sec.
+    traffic_statistics.TotalUpload:
+      description: Total bytes uploaded since last reset.
+    traffic_statistics.TotalDownload:
+      description: Total bytes downloaded since last reset.
+    traffic_statistics.TotalConnectTime:
+      description: Total time connected since last reset.
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Huawei lte sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
