### PR TITLE
Update rest_command.markdown configuration

### DIFF
--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -45,7 +45,7 @@ service_name:
     headers:
       description: The headers for the requests.
       required: false
-      type: string
+      type: list
     payload:
       description: A string/template to send with request.
       required: false

--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -59,10 +59,10 @@ service_name:
       required: false
       type: string
     timeout:
-      description: Timeout for requests. 
+      description: Timeout for requests in seconds. 
       required: false
       type: string
-      defaut: 10 seconds.
+      defaut: 10
     content_type:
       description: Content type for the request.
       required: false

--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -31,7 +31,7 @@ Configuration variables:
 
 {% configuration %}
 name:
-  description: The name used to expose the service. E.g., in the above example, it would be `rest_command.name`.
+  description: The name used to expose the service. E.g., in the above example, it would be 'rest_command.name'.
   required: true 
   type: string
 url:
@@ -39,9 +39,9 @@ url:
   required: true
   type: [string, template]
 method:
-  description: HTTP method to use (`get`, `post`, `put`, or `delete`).
+  description: HTTP method to use (get, post, put, or delete).
   required: false
-  default: `get`
+  default: get
   type: string
 headers:
   description: The headers for the requests.

--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -29,15 +29,46 @@ rest_command:
 
 Configuration variables:
 
-- **[service_name]** (*Required*): The name used to expose the service. E.g., in the above example, it would be `rest_command.example_request`.
-  - **url** (*Required*): The URL (support template) for sending request.
-  - **method** (*Optional*): HTTP method to use (`get`, `post`, `put`, or `delete`). Defaults to `get`.
-  - **headers** (*Optional*): The headers for the requests.
-  - **payload** (*Optional*): A string/template to send with request.
-  - **username** (*Optional*): The username for HTTP authentication.
-  - **password** (*Optional*): The password for HTTP authentication.
-  - **timeout** (*Optional*): Timeout for requests. Defaults to 10 seconds.
-  - **content_type** (*Optional*): Content type for the request.
+{% configuration %}
+name:
+  description: The name used to expose the service. E.g., in the above example, it would be `rest_command.name`.
+  required: true 
+  type: string
+url:
+  description: The URL (supports template) for sending request.
+  required: true
+  type: [string, template]
+method:
+  description: HTTP method to use (`get`, `post`, `put`, or `delete`).
+  required: false
+  default: `get`
+  type: string
+headers:
+  description: The headers for the requests.
+  required: false
+  type: string
+payload:
+  description: A string/template to send with request.
+  required: false
+  type: [string, template]
+username:
+  description: The username for HTTP authentication.
+  required: false
+  type: string
+password:
+  description: The password for HTTP authentication.
+  required: false
+  type: string
+timeout:
+  description: Timeout for requests. 
+  required: false
+  type: string
+  defaut: 10 seconds.
+content_type:
+  description: Content type for the request.
+  required: false
+  type: string
+{% endconfiguration %}
 
 ## {% linkable_title Examples %}
 

--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -28,7 +28,7 @@ rest_command:
 ```
 
 {% configuration %}
-[service_name]:
+service_name:
   description: The name used to expose the service. E.g., in the above example, it would be 'rest_command.service_name'.
   required: true 
   type: map

--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -27,47 +27,46 @@ rest_command:
     url: 'http://example.com/'
 ```
 
-Configuration variables:
-
 {% configuration %}
-name:
-  description: The name used to expose the service. E.g., in the above example, it would be 'rest_command.name'.
+[service_name]:
+  description: The name used to expose the service. E.g., in the above example, it would be 'rest_command.service_name'.
   required: true 
-  type: string
-url:
-  description: The URL (supports template) for sending request.
-  required: true
-  type: [string, template]
-method:
-  description: HTTP method to use (get, post, put, or delete).
-  required: false
-  default: get
-  type: string
-headers:
-  description: The headers for the requests.
-  required: false
-  type: string
-payload:
-  description: A string/template to send with request.
-  required: false
-  type: [string, template]
-username:
-  description: The username for HTTP authentication.
-  required: false
-  type: string
-password:
-  description: The password for HTTP authentication.
-  required: false
-  type: string
-timeout:
-  description: Timeout for requests. 
-  required: false
-  type: string
-  defaut: 10 seconds.
-content_type:
-  description: Content type for the request.
-  required: false
-  type: string
+  type: map
+  keys:
+    url:
+      description: The URL (supports template) for sending request.
+      required: true
+      type: [string, template]
+    method:
+      description: HTTP method to use (get, post, put, or delete).
+      required: false
+      default: get
+      type: string
+    headers:
+      description: The headers for the requests.
+      required: false
+      type: string
+    payload:
+      description: A string/template to send with request.
+      required: false
+      type: [string, template]
+    username:
+      description: The username for HTTP authentication.
+      required: false
+      type: string
+    password:
+      description: The password for HTTP authentication.
+      required: false
+      type: string
+    timeout:
+      description: Timeout for requests. 
+      required: false
+      type: string
+      defaut: 10 seconds.
+    content_type:
+      description: Content type for the request.
+      required: false
+      type: string
 {% endconfiguration %}
 
 ## {% linkable_title Examples %}


### PR DESCRIPTION
**Description:**
Update style of REST Command documentation to follow new configuration variables description.
Related to #6385

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** n/a

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
