### PR TITLE
Fixed example host

### DIFF
--- a/source/_components/switch.dlink.markdown
+++ b/source/_components/switch.dlink.markdown
@@ -34,7 +34,7 @@ switch:
 
 {% configuration %}
 host:
-  description: "The IP address of your D-Link plug, e.g., http://192.168.1.32"
+  description: "The IP address of your D-Link plug, e.g., 192.168.1.32"
   required: true
   type: string
 name:

--- a/source/_components/switch.dlink.markdown
+++ b/source/_components/switch.dlink.markdown
@@ -34,7 +34,7 @@ switch:
 
 {% configuration %}
 host:
-  description: "The IP address of your D-Link plug, e.g., 192.168.1.32"
+  description: "The IP address of your D-Link plug, e.g., 192.168.1.32."
   required: true
   type: string
 name:


### PR DESCRIPTION
"http://" is not needed nor wanted in host, in order for the plugin to work

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
