### PR TITLE
Update Min_max sensor component configuration

### DIFF
--- a/source/_components/sensor.min_max.markdown
+++ b/source/_components/sensor.min_max.markdown
@@ -14,7 +14,6 @@ ha_release: "0.31"
 ha_qa_scale: internal
 ---
 
-
 The `min_max` sensor platform consumes the state from other sensors to determine the minimum, maximum, latest (last) and the mean of the collected states. The sensor will always show you the lowest/highest/latest value which was received from all monitored sensors. If you have spikes in your values, it's recommended to filter/equalize your values with a [statistics sensor](/components/sensor.statistics/) first.
 
 This sensor is an alternative to the [template sensor](/components/sensor.template/)'s `value_template:` to get the average of multiple sensors.
@@ -44,10 +43,22 @@ sensor:
       - sensor.office_temperature
 ```
 
-Configuration variables:
-
-- **entity_ids** (*Required*): At least two entities to monitor. The unit of measurement of the first entry will be the one that's used. All entities must use the same unit of measurement.
-- **type** (*Optional*): The type of sensor: `min`, `max`, `last` or `mean`. Defaults to `max`.
-- **name** (*Optional*): Name of the sensor to use in the frontend.
-- **round_digits** (*Optional*): Round mean value to specified number of digits. Defaults to 2.
-
+{% configuration %}
+entity_ids:
+  description: At least two entities to monitor. The unit of measurement of the first entry will be the one that's used. All entities must use the same unit of measurement.
+  required: true
+  type: [list, string]
+type:
+  description: "The type of sensor: `min`, `max`, `last` or `mean`."
+  required: false
+  default: max
+  type: string
+name:
+  description: Name of the sensor to use in the frontend.
+  required: false
+  type: string
+round_digits:
+  description: Round mean value to specified number of digits.
+  required: false
+  type: integer
+{% endconfiguration %}

--- a/source/_components/sensor.min_max.markdown
+++ b/source/_components/sensor.min_max.markdown
@@ -61,4 +61,5 @@ round_digits:
   description: Round mean value to specified number of digits.
   required: false
   type: integer
+  default: 2
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Min_max sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
