### PR TITLE
Update Htu21d sensor component configuration

### DIFF
--- a/source/_components/sensor.htu21d.markdown
+++ b/source/_components/sensor.htu21d.markdown
@@ -13,7 +13,6 @@ ha_release: 0.48
 ha_iot_class: "Local Push"
 ---
 
-
 The `htu21d` sensor platform allows you to read the temperature and humidity from a [HTU21D sensor](http://www.datasheetspdf.com/PDF/HTU21D/779951/1) connected via [I2c](https://en.wikipedia.org/wiki/I²C) bus (SDA, SCL pins).
 
 Tested devices:
@@ -30,11 +29,18 @@ sensor:
   - platform: htu21d
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): The name of the sensor
-- **i2c_bus** (*Optional*): I2c bus where the sensor is. Defaults to 1, for Raspberry Pi 2 and 3.
-
+{% configuration %}
+name:
+  description: The name of the sensor.
+  required: false
+  default: i2c_bus
+  type: string
+i2c_bus:
+  description: I2c bus where the sensor is.
+  required: false
+  default: 1 (for Raspberry Pi 2 and 3)
+  type: integer
+{% endconfiguration %}
 
 ## {% linkable_title Customizing the sensor data %}
 


### PR DESCRIPTION
**Description:**
Update style of Htu21d sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
