### PR TITLE
Update Dublin bus transport sensor component configuration

### DIFF
--- a/source/_components/sensor.dublin_bus_transport.markdown
+++ b/source/_components/sensor.dublin_bus_transport.markdown
@@ -13,10 +13,9 @@ ha_iot_class: "Cloud Polling"
 ha_release: 0.36
 ---
 
-
 The `dublin_bus_transport` sensor will give you the time until the next two departures from a Dublin bus stop using the RTPI information.
 
-The [Dublin Bus](https://www.dublinbus.ie/RTPI/) website can help to determine the id of your bus stop. You can check if this is correct by going to 
+The [Dublin Bus](https://www.dublinbus.ie/RTPI/) website can help to determine the id of your bus stop. You can check if this is correct by going to
 
 https://data.dublinked.ie/cgi-bin/rtpi/realtimebusinformation?stopid=[Stop ID]
 
@@ -29,10 +28,20 @@ sensor:
     stopid: STOP_ID
 ```
 
-Configuration variables:
-
-- **stopid** (*Required*): The ID of the bus stop to get the information for.
-- **route** (*Optional*): Only show a single bus route at the stop. This is the same as the bus number, e.g., `83`.
-- **name** (*Optional*): A friendly name for this sensor.
+{% configuration %}
+stopid:
+  description: The ID of the bus stop to get the information for.
+  required: true
+  type: string
+route:
+  description: Only show a single bus route at the stop. This is the same as the bus number, e.g., `83`.
+  required: false
+  type: string
+name:
+  description: A friendly name for this sensor.
+  required: false
+  default: Next Bus
+  type: string
+{% endconfiguration %}
 
 The public RTPI information is coming from [Dub Linked](https://data.dublinked.ie/).


### PR DESCRIPTION
**Description:**
Update style of Dublin bus transport sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
