### PR TITLE
Fix MQTT topic and ON/OFF displaying as true/false

### DIFF
--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -24,8 +24,8 @@ It uses a sensor under the hood to obtain the current temperature.
 climate:
   - platform: mqtt
     name: Study
-    current_temperature_topic: /sensors/hvac_study/current_temp
-    temperature_command_topic: /sensors/hvac_study/target_temp
+    current_temperature_topic: sensors/hvac_study/current_temp
+    temperature_command_topic: sensors/hvac_study/target_temp
 ```
 
 {% configuration %}
@@ -58,12 +58,12 @@ payload_on:
   description: The payload that represents enabled state.
   required: false
   type: string
-  default: ON
+  default: "ON"
 payload_off:
   description: The payload that represents disabled state.
   required: false
   type: string
-  default: OFF
+  default: "OFF"
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false
@@ -219,9 +219,9 @@ climate:
   - platform: mqtt
     name: Study
     modes:
-      - off
-      - on
-      - auto
+      - "off"
+      - "on"
+      - "auto"
     mode_command_topic: "study/ac/mode/set"
     mode_state_topic: "study/ac/mode/state"
     mode_state_template: "{{ value_json }}"
@@ -241,16 +241,16 @@ climate:
   - platform: mqtt
     name: Study
     modes:
-      - off
-      - cool
-      - fan_only
+      - "off"
+      - "cool"
+      - "fan_only"
     swing_modes:
-      - on
-      - off
+      - "on"
+      - "off"
     fan_modes:
-      - high
-      - medium
-      - low
+      - "high"
+      - "medium"
+      - "low"
     power_command_topic: "study/ac/power/set"
     mode_command_topic: "study/ac/mode/set"
     temperature_command_topic: "study/ac/temperature/set"

--- a/source/_components/fan.mqtt.markdown
+++ b/source/_components/fan.mqtt.markdown
@@ -50,12 +50,12 @@ payload_on:
   description: The payload that represents the running state.
   required: false
   type: string
-  default: ON
+  default: "ON"
 payload_off:
   description: The payload that represents the stop state.
   required: false
   type: string
-  default: OFF
+  default: "OFF"
 state_value_template:
   description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the state."
   required: false

--- a/source/_components/switch.mqtt.markdown
+++ b/source/_components/switch.mqtt.markdown
@@ -50,12 +50,12 @@ state_on:
   description: The payload that represents the on state.
   required: false
   type: string
-  default: ON
+  default: "ON"
 state_off:
   description: The payload that represents the off state.
   required: false
   type: string
-  default: OFF
+  default: "OFF"
 command_topic:
   description: The MQTT topic to publish commands to change the switch state.
   required: false
@@ -68,12 +68,12 @@ payload_on:
   description: The payload that represents enabled state.
   required: false
   type: string
-  default: ON
+  default: "ON"
 payload_off:
   description: The payload that represents disabled state.
   required: false
   type: string
-  default: OFF
+  default: "OFF"
 payload_available:
   description: The payload that represents the available state.
   required: false


### PR DESCRIPTION
Fix MQTT documentation so ON and OFF are correctly displayed. These currently show as true and false. Also fix MQTT topic that had a leading forward slash.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
