### PR TITLE
Update spotify component to clarify base_url and improve wording

### DIFF
--- a/source/_components/media_player.spotify.markdown
+++ b/source/_components/media_player.spotify.markdown
@@ -19,30 +19,32 @@ The `spotify` media player platform allows you to control
 
 ## {% linkable_title Prerequisites %}
 
-- Spotify account.
-- Spotify Application, properly configured
+- Spotify account
+- Spotify application, properly configured (see below)
 
 <p class='note'>
-Controlling the Spotify component (pause, play, next, etc) requires a Premium account. If you do not have a Premium account, the component in the frontend will not show the controls.
+Controlling the Spotify component (pause, play, next, etc.) requires a Premium account. If you do not have a Premium account, the component in the frontend will not show the controls.
 </p>
 
-To create the required Spotify Application:
+To create the required Spotify application:
 
 - Login to [Spotify Developer](https://developer.spotify.com)
 - Visit the [My Applications](https://developer.spotify.com/my-applications/#!/applications) page
 - Select **Create An App**. Enter any name and description. Once your application is created, view it and copy your **Client ID** and **Client Secret**, which are used in the Home Assistant configuration file.
-- Add a **Redirect URI** in the following forms:
+- Add a **Redirect URI** in one of the following forms:
 
- No SSL:
+ If you are not using SSL:
   `http://<your_home_assistant_url_or_local_ip>:<port>/api/spotify`
 
- If using SSL:
+ If you are using SSL:
   `https://<your_home_assistant_url_or_local_ip>:<port>/api/spotify`
 
  The URL is whatever you use to access Home Assistant from outside your network
  (including port if applicable).
 
-- Click **Save** after adding the URI. You may also need to set the `base_url` attribute of the [HTTP Component](/components/http/).
+- Click **Save** after adding the URI.
+
+You will likely also need to set the `base_url` attribute of the [HTTP Component](/components/http/). This should be set using the same base URL as the redirect URI, e.g., if you used a domain name (not local IP) in the redirect, then use the same domain name in your `base_url`.
 
 ## {% linkable_title Configuration %}
 
@@ -62,11 +64,11 @@ media_player:
 
 {% configuration %}
 client_id:
-  description: Client ID from your Spotify Application.
+  description: Client ID from your Spotify application.
   required: true
   type: string
 client_secret:
-  description: Client Secret from your Spotify Application.
+  description: Client Secret from your Spotify application.
   required: true
   type: string
 cache_path:
@@ -84,29 +86,27 @@ aliases:
 After the prerequisites and configuration are complete, restart Home Assistant.
 A **Spotify** configurator element will be available. Follow the instructions to
 authorize Home Assistant to access your Spotify account. A Spotify media player
-will then appear. If Spotify prompts you to download a file after completing
+will then appear. If you are prompted to download a file after completing
 authorization, discard the download. It is not needed.
 
 ## {% linkable_title Sources %}
 The sources are based on if you have streamed to these devices before in
 Spotify. If you don't have any sources, then simply stream from your phone to
-another device in your house, Bluetooth, echo, etc. Once you do the sources will
-show up in the developer console as a device to cast/stream to. Also know that
-the devices won't show up in the dev-console as sources unless they are powered
-on as well.
+another device in your house: Bluetooth, echo, etc. Once you do, the sources will
+show up in the developer console as a device to cast/stream to. The devices won't show up in the dev-console as sources unless they are powered on as well.
 
-## {% linkable_title URI Links For Playlists/Etc %}
-You can send playlists to spotify via the "media_content_type": "playlist" and
-"media_content_id": "spotify:user:spotify:playlist:37i9dQZF1DWSkkUxEhrBdF"
-which are a part of the
+## {% linkable_title URI Links For Playlists/Etc. %}
+You can send playlists to spotify via the `"media_content_type": "playlist"` and something like (depending on your content ID)
+`"media_content_id": "spotify:user:spotify:playlist:37i9dQZF1DWSkkUxEhrBdF"`
+which are part of the
 [media_player.play_media](/components/media_player/#service-media_playerplay_media)
-service, you can test this from the services
+service. You can test this from the services
 control panel in the Home Assistant frontend.
 
-In this example this is a URI link to the Reggae Infusions playlist,
-[this support document from Spotify](https://support.spotify.com/us/article/sharing-music/)
+The above playlist example is a URI link to the "Reggae Infusions" playlist.
+[This support document from Spotify](https://support.spotify.com/us/article/sharing-music/)
 explains how to get this URI value to use for playlists in the Spotify component.
 
-## {% linkable_title Unsupported devices %}
+## {% linkable_title Unsupported Devices %}
 
-- **Sonos**: Although its a Spotify Connect device, it is not supported by the official Spotify API.
+- **Sonos**: Although Sonos is a Spotify Connect device, it is not supported by the official Spotify API.


### PR DESCRIPTION
**Description:**
This adds some more detail about `base_url` in the Spotify component (since that was an issue for me when setting up Spotify). Improved/fixed wording while editing it.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
