### PR TITLE
Add option to manually specify device detection method

### DIFF
--- a/source/_components/device_tracker.mikrotik.markdown
+++ b/source/_components/device_tracker.mikrotik.markdown
@@ -59,6 +59,10 @@ port:
   required: false
   default: 8728
   type: integer
+method:
+  description: Override autodetection of device scanning method. Can be *wireless* to use local wireless registration, *capsman* for capsman wireless registration, or *ip* for DHCP leases.
+  required: false
+  type: string
 {% endconfiguration %}
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.mikrotik.markdown
+++ b/source/_components/device_tracker.mikrotik.markdown
@@ -60,7 +60,7 @@ port:
   default: 8728
   type: integer
 method:
-  description: Override autodetection of device scanning method. Can be *wireless* to use local wireless registration, *capsman* for capsman wireless registration, or *ip* for DHCP leases.
+  description: Override autodetection of device scanning method. Can be `wireless` to use local wireless registration, `capsman` for capsman wireless registration, or `ip` for DHCP leases.
   required: false
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**

Add new option to mikrotik device detection which allows the user to specify how to scan router for devices.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17852

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
