### PR TITLE
Wording tweak

### DIFF
--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -51,7 +51,7 @@ sensor:
         required: false
         type: template
       entity_id:
-        description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
+        description: The template engine will attempt to work out what entities should trigger an update of the sensor. If this fails to get the correct list (for example if your template loops over the contents of a group) then you can provide a list of entity IDs that will cause the sensor to update.
         required: false
         type: string, list
       unit_of_measurement:

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -288,7 +288,7 @@ sensor:
 
 ### {% linkable_title Working with dates %}
 
-The `template` sensors are not limited to use attributes from other entities but can also work with [Home Assistant's template extensions](/docs/configuration/templating/#home-assistant-template-extensions).
+The `template` sensors are not limited to use attributes from other entities but can also work with [Home Assistant's template extensions](/docs/configuration/templating/#home-assistant-template-extensions). This template contains no entities that will trigger an update, so either we need to use `homeassistant.update_entity` or add an `entity_id:` line for an entity that will force an update - here we're using `sun.sun`.
 
 {% raw %}
 ```yaml
@@ -297,6 +297,7 @@ sensor:
   sensors:
     nonsmoker:
       value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
+      entity_id: sun.sun
       friendly_name: 'Not smoking'
       unit_of_measurement: "Days"
 ```


### PR DESCRIPTION
Based upon feedback after the breaking change, re-wording the description of the `entity_id` line to hopefully be clearer.
