### PR TITLE
Added note about entity_id and homeassistant.update_entity

### DIFF
--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -16,6 +16,10 @@ ha_qa_scale: internal
 
 The `template` platform supports sensors which break out `state_attributes` from other entities.
 
+<p class='note'>
+If you do not supply an `entity_id` in the configuration you will need to run the service `homeassistant.update_entity` to update the sensor.
+</p>
+
 ## {% linkable_title Configuration %}
 
 To enable Template Sensors in your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**

Added a note about `entity_id` and `homeassistant.update_entity` that is needed after this change <https://github.com/home-assistant/home-assistant/pull/17276>
The `entity_id` is now only partially optional...


<!-- **Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here> -->

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
