### PR TITLE
Fixing broken image

### DIFF
--- a/source/_components/unifi.markdown
+++ b/source/_components/unifi.markdown
@@ -7,7 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: ubiuiti.png
+logo: ubiquiti.png
 ha_category: Hub
 ha_release: "0.81"
 ha_iot_class: "Local Polling"


### PR DESCRIPTION
**Description:** typo in the image name for the unifi docs

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
