### PR TITLE
Remove incorrect truth table

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -139,23 +139,6 @@ condition:
         before: sunrise
 ```
 
-Here is a truth table to clarify the parameters with and without offset:
-
-| command                            |        night | at sunrise  | daytime | at sunset  |
-| ---------------------------------- | ------------ |:-----------:| ------- |:----------:|
-| `after: sunset`                    | True         |      ⇒      | False   |     ⇒      |
-| + `after_offset: "01:00:00"`       | True         |      ⇒      | False   |  **+1h**   |
-| + `after_offset: "-01:00:00"`      | True         |      ⇒      | False   |  **-1h**   |
-| `before: sunset`                   | False        |      ⇒      | True    |     ⇒      |
-| + `before_offset: "01:00:00"`      | False        |      ⇒      | True    |  **+1h**   |
-| + `before_offset: "-01:00:00"`     | False        |      ⇒      | True    |  **-1h**   |
-| `after: sunrise`                   | False        |      ⇒      | True    |     ⇒      |
-| + `after_offset: "01:00:00"`       | False        |   **+1h**   | True    |     ⇒      |
-| + `after_offset: "-01:00:00"`      | False        |   **-1h**   | True    |     ⇒      |
-| `before: sunrise`                  | True         |      ⇒      | False   |     ⇒      |
-| + `before_offset: "01:00:00"`      | True         |   **+1h**   | False   |     ⇒      |
-| + `before_offset: "-01:00:00"`     | True         |   **-1h**   | False   |     ⇒      |
-
 ### {% linkable_title Template condition %}
 
 The template condition will test if the [given template][template] renders a value equal to true. This is achieved by having the template result in a true boolean expression or by having the template render 'true'.


### PR DESCRIPTION
**Description:**
It turns out this truth table wasn't correct for the actual implementation of sun conditions, and was causing confusion. I don't think having columns with a mix of arrows and "+1s" and ambiguous headers like "night/at sunrise" provides additional clarity anyway.