### PR TITLE
Update device_tracker.bluetooth_le_tracker.markdown

### DIFF
--- a/source/_components/device_tracker.bluetooth_le_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_le_tracker.markdown
@@ -54,11 +54,12 @@ Some BTLE devices (e.g., fitness trackers) are only visible to the devices that 
 
 ## {% linkable_title Rootless Setup %}
 
-Normally accessing the Bluetooth stack is reserved for root, but running programs that are networked as root is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](http://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
+Normally accessing the Bluetooth stack is reserved for root, but running programs that are networked as root is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 and hcitool the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](http://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
 
 ```bash
 $ sudo apt-get install libcap2-bin
 $ sudo setcap 'cap_net_raw,cap_net_admin+eip' `readlink -f \`which python3\``
+$ sudo setcap 'cap_net_raw+ep' `readlink -f \`which hcitool\``
 ```
 
 A restart of Home Assistant is required.


### PR DESCRIPTION
hcitool generates permission denied unless you perform a similar setcap option as you need to with python3

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
