### PR TITLE
Firefox 63+ supports custom elements and shadow DOM by default

### DIFF
--- a/source/lovelace/index.markdown
+++ b/source/lovelace/index.markdown
@@ -28,7 +28,7 @@ The Lovelace UI is:
 </div>
 
 <p class='note warning'>
-If you're not using Chrome, please be sure to [read the FAQ](/lovelace/#faq) below.
+If you're not using Firefox 63+ or Chrome, please be sure to [read the FAQ](/lovelace/#faq) below.
 </p>
 
 ## {% linkable_title How it works %}
@@ -133,7 +133,7 @@ This is the very very early version aimed at gathering feedback. Discussion and 
 
 ### {% linkable_title I am running Firefox but, custom cards like gauge-card look bad or don't load at all. How do I fix this? %}
 
-This is probably because your version of Firefox doesn't have custom components supported or enabled. Please set to `true` in your `about:config` the following settings: `dom.webcomponents.customelements.enabled` and `dom.webcomponents.shadowdom.enabled`
+This is probably because your version of Firefox doesn't have custom components supported or enabled. Please upgrade to version 63 or higher, otherwise set `dom.webcomponents.customelements.enabled` and `dom.webcomponents.shadowdom.enabled` to `true` in `about:config`.
 
 ### {% linkable_title Custom cards don't load on my iOS device? %}
 


### PR DESCRIPTION
**Description:**
Firefox no longer needs preferences flipped


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
