### PR TITLE
Update sensor.template.markdown

### DIFF
--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -322,7 +322,7 @@ sensor:
 Note: If a template uses more than one sensor they can be listed
 
 
-The alternative to this is to create an `Automation`using the new (81.0) service `home_assistant.update_entity` and list all entity's requiring updates and setting the interval based on time.
+The alternative to this is to create an `Automation`using the new (81.0) service `homeassistant.update_entity` and list all entity's requiring updates and setting the interval based on time.
 
 {% raw %}
 ```yaml

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -301,3 +301,38 @@ sensor:
       unit_of_measurement: "Days"
 ```
 {% endraw %}
+
+### {% linkable_title Template tracking %}
+
+This example shows how to add `entity_id` to a template to allow tracking of updates. Fixing an error caused in (81.0) 
+
+{% raw %}
+```yaml
+sensor:
+- platform: template
+  sensors:
+    nonsmoker:
+      entity_id: now.strptime
+      value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
+      friendly_name: 'Not smoking'
+      unit_of_measurement: "Days"
+```
+{% endraw %}
+
+Note: If a template uses more than one sensor they can be listed
+
+
+The alternative to this is to create an `Automation`using the new (81.0) service `home_assistant.update_entity` and list all entity's requiring updates and setting the interval based on time.
+
+{% raw %}
+```yaml
+automation:
+  - alias: 'nonsmoker_update'
+    trigger:
+      - platform: time
+        minutes: '/1'
+    action:
+      - service: homeassistant.update_entity
+        entity_id: sensor.nonsmoker
+```
+{% endraw %}


### PR DESCRIPTION

**Description:**
Update documents to cover how to fix errors arising from the 81.0 update around templates.

Shows both methods (adding entity_id and using the new service `update_entity`

[homeassistant.components.sensor.template] Template sensor today has no entity ids configured to track nor were we able to extract the entities to track from the value template(s). This entity will only be able to be updated manually.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html