### PR TITLE
Added note about ibeacon support being removed from the android version

### DIFF
--- a/source/_components/device_tracker.owntracks.markdown
+++ b/source/_components/device_tracker.owntracks.markdown
@@ -119,7 +119,6 @@ Sometimes Owntracks will lose connection with an iBeacon for a few seconds. If y
 
 ### {% linkable_title Using Owntracks iBeacons to track devices %}
 
-
 iBeacons don't need to be stationary. You could put one on your key ring, or in your car.
 
 When your phone sees a mobile iBeacon that it knows about, it will tell HA the location of that iBeacon. If your phone moves while you are connected to the iBeacon, HA will update the location of the iBeacon. But when your phone loses the connection, HA will stop updating the iBeacon location.

--- a/source/_components/device_tracker.owntracks.markdown
+++ b/source/_components/device_tracker.owntracks.markdown
@@ -103,6 +103,10 @@ When you exit a zone, Home Assistant will start using location updates to track 
 
 ### {% linkable_title Using Owntracks regions - forcing Owntracks to update using  %}iBeacons
 
+<p class='note'>
+Owntracks v2.0.0 removes support for iBecons on android 
+</p>
+
 When run in the usual *significant changes mode* (which is kind to your phone battery), Owntracks sometimes doesn't update your location as quickly as you'd like when you arrive at a zone. This can be annoying if you want to trigger an automation when you get home. You can improve the situation using iBeacons.
 
 iBeacons are simple Bluetooth devices that send out an "I'm here" message. They are supported by IOS and some Android devices. Owntracks explain more [here](http://owntracks.org/booklet/guide/beacons/).
@@ -114,9 +118,7 @@ When you exit an iBeacon region HA will switch back to using GPS to determine yo
 Sometimes Owntracks will lose connection with an iBeacon for a few seconds. If you name your beacon starting with `-` Owntracks will wait longer before deciding it has exited the beacon zone. HA will ignore the `-` when it matches the Owntracks region with Zones. So if you call your Owntracks region `-home` then HA will recognize it as `home`, but you will have a more stable iBeacon connection.
 
 ### {% linkable_title Using Owntracks iBeacons to track devices %}
-<p class='note'>
-On android, Owntracks support for iBecons has been remove in the `v.2.0.0` release of owntracks
-</p>
+
 
 iBeacons don't need to be stationary. You could put one on your key ring, or in your car.
 

--- a/source/_components/device_tracker.owntracks.markdown
+++ b/source/_components/device_tracker.owntracks.markdown
@@ -101,10 +101,10 @@ Home Assistant will use the enter and leave messages to set your zone location. 
 
 When you exit a zone, Home Assistant will start using location updates to track you again. To make sure that Home Assistant correctly exits a zone (which it calculates based on your GPS coordinates), you may want to set your Zone radius in HA to be slightly smaller that the Owntracks region radius.
 
-### {% linkable_title Using Owntracks regions - forcing Owntracks to update using  %}iBeacons
+### {% linkable_title Using Owntracks regions - forcing Owntracks to update using iBeacons %}
 
 <p class='note'>
-Owntracks v2.0.0 removes support for iBecons on android 
+Owntracks v2.0.0 removes support for iBecons on Android.
 </p>
 
 When run in the usual *significant changes mode* (which is kind to your phone battery), Owntracks sometimes doesn't update your location as quickly as you'd like when you arrive at a zone. This can be annoying if you want to trigger an automation when you get home. You can improve the situation using iBeacons.

--- a/source/_components/device_tracker.owntracks.markdown
+++ b/source/_components/device_tracker.owntracks.markdown
@@ -114,6 +114,9 @@ When you exit an iBeacon region HA will switch back to using GPS to determine yo
 Sometimes Owntracks will lose connection with an iBeacon for a few seconds. If you name your beacon starting with `-` Owntracks will wait longer before deciding it has exited the beacon zone. HA will ignore the `-` when it matches the Owntracks region with Zones. So if you call your Owntracks region `-home` then HA will recognize it as `home`, but you will have a more stable iBeacon connection.
 
 ### {% linkable_title Using Owntracks iBeacons to track devices %}
+<p class='note'>
+On android, Owntracks support for iBecons has been remove in the `v.2.0.0` release of owntracks
+</p>
 
 iBeacons don't need to be stationary. You could put one on your key ring, or in your car.
 


### PR DESCRIPTION
**Description:** In owntracks 2.0.0 on android support for beacons has been removed [due to it causing a high number of crashes on the platform](https://github.com/owntracks/android/releases/tag/Android-v.2.0.0). this release is not in the play store yet, but has been released on their github

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
