### PR TITLE
Change generic thermostat icon to HA

### DIFF
--- a/source/_components/climate.generic_thermostat.markdown
+++ b/source/_components/climate.generic_thermostat.markdown
@@ -7,7 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: heat-control.png
+logo: home-assistant.png
 ha_category: Climate
 ha_release: pre 0.7
 ha_iot_class: "Local Polling"


### PR DESCRIPTION
**Description:**
Most core/internal components like Universal MediaPlayer, Bayesian Sensor, Template Sensor have the Home Assistant logo. Generic Thermostat should follow this for easy identification.

## Checklist:
- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
