### PR TITLE
Change generic camera icon to HA

### DIFF
--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 ha_category: Camera
-logo: camcorder.png
+logo: home-assistant.png
 ha_release: pre 0.7
 ha_iot_class: "depends"
 ---


### PR DESCRIPTION
**Description:**
Most core/internal components like Universal MediaPlayer, Bayesian Sensor, Template Sensor have the Home Assistant logo. Generic Camera should follow this for easy identification.

## Checklist:
- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
