### PR TITLE
Missing > in documentation

### DIFF
--- a/source/_components/binary_sensor.workday.markdown
+++ b/source/_components/binary_sensor.workday.markdown
@@ -101,7 +101,7 @@ automation:
     entity_id: switch.heater
 ```
 
-<p class='note'
+<p class='note'>
 Please remember that [as explained here][devices] you can only have a single `automation:` entry. Add the automation to your existing automations.
 </p>
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
