### PR TITLE
weblink parameters `name` and `icon` optional

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -124,18 +124,20 @@ type:
   required: true
   description: weblink
   type: string
-name:
-  required: true
-  description: Link label.
-  type: string
-icon:
-  required: true
-  description: "Icon to display (e.g., `mdi:home`)"
-  type: string
 url:
   required: true
   description: "Website URL (or internal URL e.g. `/hassio/dashboard` or `/panel_custom_name`)"
   type: string
+name:
+  required: false
+  description: Link label
+  type: string
+  default: url path
+icon:
+  required: false
+  description: "Icon to display (e.g., `mdi:home`)"
+  type: string
+  default: `mdi:link`
 {% endconfiguration %}
 
 ## {% linkable_title Example %}

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -137,7 +137,7 @@ icon:
   required: false
   description: "Icon to display (e.g., `mdi:home`)"
   type: string
-  default: `mdi:link`
+  default: "`mdi:link`"
 {% endconfiguration %}
 
 ## {% linkable_title Example %}


### PR DESCRIPTION
This will coincide with https://github.com/home-assistant/home-assistant-polymer/pull/1898

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
