### PR TITLE
Some service-row fields are now optional

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -85,7 +85,7 @@ service:
   description: "Service like `media_player.media_play_pause`"
   type: string
 service_data:
-  required: true
+  required: false
   description: The service data to use.
   type: object
 {% endconfiguration %}

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -72,18 +72,20 @@ name:
   required: true
   description: Main Label.
   type: string
-icon:
-  required: true
-  description: "Icon to display (e.g., `mdi:home`)"
-  type: string
-action_name:
-  required: true
-  description: Button label.
-  type: string
 service:
   required: true
   description: "Service like `media_player.media_play_pause`"
   type: string
+icon:
+  required: false
+  description: "Icon to display (e.g., `mdi:home`)"
+  type: string
+  default: `mdi:remote`
+action_name:
+  required: false
+  description: Button label.
+  type: string
+  default: `Run`
 service_data:
   required: false
   description: The service data to use.

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -80,12 +80,12 @@ icon:
   required: false
   description: "Icon to display (e.g., `mdi:home`)"
   type: string
-  default: `mdi:remote`
+  default: "`mdi:remote`"
 action_name:
   required: false
   description: Button label.
   type: string
-  default: `Run`
+  default: "`Run`"
 service_data:
   required: false
   description: The service data to use.


### PR DESCRIPTION
https://github.com/home-assistant/home-assistant-polymer/pull/1894

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
