### PR TITLE
Several types for matching allowed

### DIFF
--- a/source/_components/binary_sensor.pilight.markdown
+++ b/source/_components/binary_sensor.pilight.markdown
@@ -49,11 +49,11 @@ name:
 payload_on:
   description: "Variable `on` value. The component will recognize this as logical '1'."
   required: false
-  type: string
+  type: string, float, or int
 payload_off:
   description: "Variable `off` value. The component will recognize this as logical '0'."
   required: false
-  type: string
+  type: string, float, or int
 disarm_after_trigger:
   description: Configure sensor as trigger type.
   required: false

--- a/source/_components/binary_sensor.pilight.markdown
+++ b/source/_components/binary_sensor.pilight.markdown
@@ -49,7 +49,7 @@ name:
 payload_on:
   description: "Variable `on` value. The component will recognize this as logical '1'."
   required: false
-  type: string, float, or int
+  type: [string, float, integer]
 payload_off:
   description: "Variable `off` value. The component will recognize this as logical '0'."
   required: false

--- a/source/_components/binary_sensor.pilight.markdown
+++ b/source/_components/binary_sensor.pilight.markdown
@@ -53,7 +53,7 @@ payload_on:
 payload_off:
   description: "Variable `off` value. The component will recognize this as logical '0'."
   required: false
-  type: string, float, or int
+  type: [string, float, integer]
 disarm_after_trigger:
   description: Configure sensor as trigger type.
   required: false


### PR DESCRIPTION
**Description:**
Just so the docs match the change referenced below...

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17922

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
