### PR TITLE
Remove comment about weekly portion

### DIFF
--- a/source/_components/sensor.jewish_calendar.markdown
+++ b/source/_components/sensor.jewish_calendar.markdown
@@ -53,7 +53,7 @@ sensors:
     date:
       description: Show the hebrew date for today.
     weekly_portion:
-      description: Show the weekly portion (parshat hashavu'a) - _At the moment only shows up on Saturday's_.
+      description: Show the weekly portion (parshat hashavu'a).
     holiday_name:
       description: If it is a holiday, show the name of the holiday.
     holyness:


### PR DESCRIPTION
This has been fixed in #17447 so this comment is irrelevant

**Description:**
In PR #17447 which has been merged in 0.81 I fixed this so the comment is irrelevant.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17447

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
