### PR TITLE
Update NO-IP docs to clarify what it does and doesn't do

### DIFF
--- a/source/_components/no_ip.markdown
+++ b/source/_components/no_ip.markdown
@@ -12,9 +12,9 @@ ha_category: Network
 ha_release: 0.57
 ---
 
-With the `no_ip` component you can keep your [NO-IP.com](https://www.noip.com) record up to date.
+With the `no_ip` component you can keep your current IP address in sync with your [NO-IP.com](https://www.noip.com)  hostname or domain.  
 
-
+Note that it does not confirm your hostname (as is required periodically for free domain names); you will still need to do that manually.
 
 To use the component in your installation, add the following to your `configuration.yaml` file:
 
@@ -28,7 +28,7 @@ no_ip:
 
 {% configuration %}
   domain:
-    description: Your FQDN.
+    description: Your fully qualified domain name (FQDN).
     required: true
     type: string
   username:


### PR DESCRIPTION
**Description:**
When I first installed this component, I hoped it would automatically renew/confirm my free hostname, but it doesn't. I've added that detail to the docs to make it clearer what it does.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
