### PR TITLE
Split out geofency into a new component and device_tracker platform

### DIFF
--- a/source/_components/device_tracker.geofency.markdown
+++ b/source/_components/device_tracker.geofency.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Geofency"
+title: "Geofency Device Tracker"
 description: "Instructions for how to use Geofency to track devices in Home Assistant."
 date: 2017-08-22 19:00
 sidebar: true
@@ -10,37 +10,14 @@ footer: true
 logo: geofency.png
 ha_category: Presence Detection
 ha_release: 0.53
+ha_iot_class: "Cloud Push"
 ---
 
-This platform allows you to detect presence using [Geofency](http://www.geofency.com/). Geofency is a [paid app](https://itunes.apple.com/app/id615538630) for iOS that lets users to configure a request that will be sent when a geofence or iBeacon region is entered or exited. This can be configured with Home Assistant to update your location.
+This platform allows you to detect presence using [Geofency](http://www.geofency.com/).
 
-To integrate Geofency in Home Assistant, add the following section to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-device_tracker:
-  - platform: geofency
-```
-
-{% configuration %}
-mobile_beacons:
-  description: List of beacon names that are to be treated as *mobile*. The name must match the name you configure in Geofency. By default, beacons will be treated as *stationary*.
-  required: false
-  type: list
-{% endconfiguration %}
-
-A full sample configuration for the `geofency` platform is shown below:
-
-```yaml
-# Example configuration.yaml entry
-device_tracker:
-  - platform: geofency
-    mobile_beacons:
-      - car
-      - keys
-```
-
-To configure Geofency, you must configure (via the Webhook feature) to send a POST request to your Home Assistant server at `http://<ha_server>/api/geofency`. Use the default POST format, and make sure to include the API password if you have configured a password in Home Assistant (add `?api_password=<password>` to the end of the URL). Make sure to enable the 'Update Geo-Position' functionality for mobile beacons.
+<p class='note'>
+You must have the [Geofency component](/components/geofency/) configured to use this device tracker.
+</p>
 
 Geofency will automatically generate the device tracker name used for geofences, and you will find it in `known_devices.yaml` after the first request. For beacons, the device name will be `beacon_<name from Geofency>`, e.g., `device_tracker.beacon_car`.
 

--- a/source/_components/geofency.md
+++ b/source/_components/geofency.md
@@ -1,0 +1,44 @@
+---
+layout: page
+title: "Geofency"
+description: "Instructions for how to use Geofency to track devices in Home Assistant."
+date: 2017-08-22 19:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: geofency.png
+ha_category: Hub
+ha_release: 0.82
+ha_iot_class: "Cloud Push"
+---
+
+This component sets up integration with [Geofency](http://www.geofency.com/). Geofency is a [paid app](https://itunes.apple.com/app/id615538630) for iOS that lets users to configure a request that will be sent when a geofence or iBeacon region is entered or exited. This can be configured with Home Assistant to update your location.
+
+Enabling this component will automatically enable the [Geofency Device Tracker](/components/device_tracker.geofency/).
+
+To integrate Geofency in Home Assistant, add the following section to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+geofency:
+```
+
+{% configuration %}
+mobile_beacons:
+  description: List of beacon names that are to be treated as *mobile*. The name must match the name you configure in Geofency. By default, beacons will be treated as *stationary*.
+  required: false
+  type: list
+{% endconfiguration %}
+
+A full sample configuration for the `geofency` component is shown below:
+
+```yaml
+# Example configuration.yaml entry
+geofency:
+  mobile_beacons:
+    - car
+    - keys
+```
+
+To configure Geofency, you must configure (via the Webhook feature) to send a POST request to your Home Assistant server at `http://<ha_server>/api/geofency`. Use the default POST format, and make sure to include the API password if you have configured a password in Home Assistant (add `?api_password=<password>` to the end of the URL). Make sure to enable the 'Update Geo-Position' functionality for mobile beacons.

--- a/source/_components/geofency.md
+++ b/source/_components/geofency.md
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: geofency.png
 ha_category: Presence Detection
-ha_release: 0.82
+ha_release: 0.83
 ha_iot_class: "Cloud Push"
 ---
 

--- a/source/_components/geofency.md
+++ b/source/_components/geofency.md
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: geofency.png
-ha_category: Hub
+ha_category: Presence Detection
 ha_release: 0.82
 ha_iot_class: "Cloud Push"
 ---


### PR DESCRIPTION
**Description:**
Splitting out the geofency device tracker platform to a separate component/platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17933

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
