### PR TITLE
Tips for enabling GPIO on Hass.io

### DIFF
--- a/source/_components/sensor.onewire.markdown
+++ b/source/_components/sensor.onewire.markdown
@@ -29,7 +29,8 @@ The 1-Wire bus can be connected directly to the IO pins of Raspberry Pi or using
 
 ## {% linkable_title Raspberry Pi setup %}
 
-In order to setup 1-Wire support on Raspberry Pi, you'll need to edit `/boot/config.txt` following [this documentation](https://www.waveshare.com/wiki/Raspberry_Pi_Tutorial_Series:_1-Wire_DS18B20_Sensor#Enable_1-Wire). Don't use the `mount_dir` option.
+In order to setup 1-Wire support on Raspberry Pi, you'll need to edit `/boot/config.txt` following [this documentation](https://www.waveshare.com/wiki/Raspberry_Pi_Tutorial_Series:_1-Wire_DS18B20_Sensor#Enable_1-Wire).
+To edit `/boot/config.txt` on Hass.io use [this documentation](https://developers.home-assistant.io/docs/en/hassio_debugging.html) to enable SSH and edit `/mnt/boot/config.txt` via `vi`.
 
 ## {% linkable_title Interface adapter setup %}
 


### PR DESCRIPTION
- Removed a hint to `mount_dir`, because it's not mentioned in the linked documentation (anymore?).
- A tip for activating GPIO on Hass.io has been added, as the other documentation only applies to Debian based systems.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
