### PR TITLE
Update Ciscospark notify component configuration

### DIFF
--- a/source/_components/notify.ciscospark.markdown
+++ b/source/_components/notify.ciscospark.markdown
@@ -32,11 +32,20 @@ notify:
     roomid: CISCO_SPARK_ROOMID
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **token** (*Required*): Your development token.
-- **roomid** (*Required*): The Room ID.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+token:
+  description: Your development token.
+  required: true
+  type: string
+roomid:
+  description: The Room ID.
+  required: true
+  type: string
+{% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
-


### PR DESCRIPTION
**Description:**
Update style of ciscospark notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
