### PR TITLE
Made clear that the router is not a IOT devices

### DIFF
--- a/source/_components/device_tracker.tplink.markdown
+++ b/source/_components/device_tracker.tplink.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "TP-Link"
+title: "TP-Link (Device Tracking)"
 description: "Instructions on how to integrate TP-Link routers into Home Assistant."
 date: 2015-06-22 10:30
 sidebar: true
@@ -13,7 +13,12 @@ ha_release: pre 0.7
 ---
 
 
-The `tplink` platform allows you to detect presence by looking at connected devices to a [TP-Link](https://www.tp-link.com) device.
+The `tplink` platform allows you to detect presence by looking at connected devices to a [TP-Link](https://www.tp-link.com) router.
+
+This is not for the TP-Link Smart devices:
+
+- For [lights/bulbs](https://www.home-assistant.io/components/light.tplink/) go here.
+- For [switches/sockets](https://www.home-assistant.io/components/switch.tplink/) go here.
 
 Currently supported devices includes the following:
 

--- a/source/_components/device_tracker.tplink.markdown
+++ b/source/_components/device_tracker.tplink.markdown
@@ -15,7 +15,7 @@ ha_release: pre 0.7
 
 The `tplink` platform allows you to detect presence by looking at connected devices to a [TP-Link](https://www.tp-link.com) router.
 
-This is not for the TP-Link Smart devices:
+This is *not* for the TP-Link Smart devices:
 
 - For [lights/bulbs](https://www.home-assistant.io/components/light.tplink/) go here.
 - For [switches/sockets](https://www.home-assistant.io/components/switch.tplink/) go here.

--- a/source/_components/device_tracker.tplink.markdown
+++ b/source/_components/device_tracker.tplink.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "TP-Link (Device Tracking)"
+title: "TP-Link Router (Presence Detection)"
 description: "Instructions on how to integrate TP-Link routers into Home Assistant."
 date: 2015-06-22 10:30
 sidebar: true

--- a/source/_components/device_tracker.tplink.markdown
+++ b/source/_components/device_tracker.tplink.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "TP-Link Router (Presence Detection)"
+title: "TP-Link Router"
 description: "Instructions on how to integrate TP-Link routers into Home Assistant."
 date: 2015-06-22 10:30
 sidebar: true
@@ -14,11 +14,6 @@ ha_release: pre 0.7
 
 
 The `tplink` platform allows you to detect presence by looking at connected devices to a [TP-Link](https://www.tp-link.com) router.
-
-This is *not* for the TP-Link Smart devices:
-
-- For [lights/bulbs](https://www.home-assistant.io/components/light.tplink/) go here.
-- For [switches/sockets](https://www.home-assistant.io/components/switch.tplink/) go here.
 
 Currently supported devices includes the following:
 


### PR DESCRIPTION
Change display title... to include device tracking.
Added section with bullet points indicating where the bulbs and switches are located.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
