### PR TITLE
OVA hide away

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -27,7 +27,7 @@ The following will take you through the steps required to install Hass.io.
    - As a virtual appliance: 
   
      - [VMDK][vmdk]
-     - [OVA (READ MORE: not available at this time)][Virtual Appliance]
+     - [OVA][Virtual Appliance]  (not available at this time!)
     
 2. Install Hass.io:
 

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -26,8 +26,8 @@ The following will take you through the steps required to install Hass.io.
     
    - As a virtual appliance: 
   
-     - [OVA][Virtual Appliance]
      - [VMDK][vmdk]
+     - [OVA (READ MORE: not available at this time)][Virtual Appliance]
     
 2. Install Hass.io:
 

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -27,7 +27,7 @@ The following will take you through the steps required to install Hass.io.
    - As a virtual appliance: 
   
      - [VMDK][vmdk]
-     - [OVA][Virtual Appliance]  (not available at this time!)
+     - [OVA][Virtual Appliance] (not available at this time!)
     
 2. Install Hass.io:
 


### PR DESCRIPTION
Reorder list, so OVA is below VMDK, and state that it is not available and that user can read on.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
