### PR TITLE
Update Apns notify component configuration

### DIFF
--- a/source/_components/notify.apns.markdown
+++ b/source/_components/notify.apns.markdown
@@ -11,7 +11,6 @@ ha_category: Notifications
 ha_release: 0.31
 ---
 
-
 The `apns` platform uses the Apple Push Notification service (APNS) to deliver notifications from Home Assistant.
 
 To use the APNS service you will need an Apple developer account and you will need to create an app to receive push notifications. For more information, see the Apple developer documentation.
@@ -25,12 +24,30 @@ notify:
   topic: topic
 ```
 
-Configuration variables:
-
-- **name** (*Required*): The name of the notifier. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **cert_file** (*Required*): The certificate to use to authenticate with the APNS service.
-- **topic** (*Required*): The app bundle ID specified in the certificate.
-- **sandbox** (*Optional*): If true notifications will be sent to the sandbox (test) notification service. Default false.
+{% configuration %}
+platform:
+  description: Name of the platform.
+  required: true
+  default: apns
+  type: string
+name:
+  description: he name of the notifier. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: true
+  type: string
+cert_file:
+  description: The certificate to use to authenticate with the APNS service.
+  required: true
+  type: string
+topic:
+  description: The app bundle ID specified in the certificate.
+  required: true
+  type: string
+sandbox:
+  description: If true notifications will be sent to the sandbox (test) notification service.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
 
 The APNS platform will register two services, `notify.NOTIFIER_NAME` and `notify.apns_NOTIFIER_NAME`.
 

--- a/source/_components/notify.apns.markdown
+++ b/source/_components/notify.apns.markdown
@@ -19,7 +19,7 @@ To use the APNS service you will need an Apple developer account and you will ne
 
 ## {% linkable_title Configuration %}
 
-To enable the APNS notificationsr, add the following lines to your `configuration.yaml`:
+To enable APNS notifications, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/notify.apns.markdown
+++ b/source/_components/notify.apns.markdown
@@ -13,7 +13,13 @@ ha_release: 0.31
 
 The `apns` platform uses the Apple Push Notification service (APNS) to deliver notifications from Home Assistant.
 
+## {% linkable_title Setup %}
+
 To use the APNS service you will need an Apple developer account and you will need to create an app to receive push notifications. For more information, see the Apple developer documentation.
+
+## {% linkable_title Configuration %}
+
+To enable the APNS notificationsr, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
@@ -25,11 +31,6 @@ notify:
 ```
 
 {% configuration %}
-platform:
-  description: Name of the platform.
-  required: true
-  default: apns
-  type: string
 name:
   description: he name of the notifier. The notifier will bind to the service `notify.NOTIFIER_NAME`.
   required: true
@@ -51,13 +52,13 @@ sandbox:
 
 The APNS platform will register two services, `notify.NOTIFIER_NAME` and `notify.apns_NOTIFIER_NAME`.
 
-### notify.apns_NOTIFIER_NAME
+### {% linkable_title notify.apns_NOTIFIER_NAME %}
 
 This service will register device IDs with Home Assistant. In order to receive a notification a device must be registered. The app on the device can use this service to send an ID to Home Assistant during startup, the ID will be stored in `[NOTIFIER_NAME]_apns.yaml`.
 
 See `didRegisterForRemoteNotificationsWithDeviceToken` in the [Apple developer documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/#//apple_ref/occ/intfm/UIApplicationDelegate/application:didRegisterForRemoteNotificationsWithDeviceToken:) for more information about how to obtain a device ID.
 
-### notify.NOTIFIER_NAME
+### {% linkable_title notify.NOTIFIER_NAME %}
 
 This service will send messages to a registered device. The following parameters can be used:
 


### PR DESCRIPTION
**Description:**
Update style of Apns notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
