### PR TITLE
Update Gstreamer media_player component configuration

### DIFF
--- a/source/_components/media_player.gstreamer.markdown
+++ b/source/_components/media_player.gstreamer.markdown
@@ -23,10 +23,16 @@ media_player:
   - platform: gstreamer
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Name the player.
-- **pipeline** (*Optional*): `gst` pipeline description.
+{% configuration %}
+name:
+  description: Name of the media player.
+  required: false
+  type: string
+pipeline:
+  description: A `gst` pipeline description.
+  required: false
+  type: string
+{% endconfiguration %}
 
 Only the `music` media type is supported.
 
@@ -56,7 +62,7 @@ If you're running Home Assistant in a virtual environment, you'll need to symlin
 
 ```bash
 ln -s /path/to/your/installation/of/gi /path/to/your/venv/lib/python3.4/site-packages
-``` 
+```
 
 On a Raspberry Pi, you may need to add the Home Assistant user to the `audio` group:
 
@@ -65,7 +71,7 @@ sudo usermod -a -G audio <ha_user>
 ```
 
 ## {% linkable_title Example Usage %}
- 
+
 ### {% linkable_title Using with TTS %}
 
 To play TTS on your local computer (for example, if you have speakers attached to your Raspberry Pi:


### PR DESCRIPTION
**Description:**
Update style of Gstreamer media_player component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
