### PR TITLE
Update Python_component_simple_alarm component configuration

### DIFF
--- a/source/_cookbook/python_component_simple_alarm.markdown
+++ b/source/_cookbook/python_component_simple_alarm.markdown
@@ -23,10 +23,16 @@ simple_alarm:
   unknown_light: group.living_room
 ```
 
-Configuration variables:
-
-- **known_light** (*Optional*): Which light/light group has to flash when a known device comes home.
-- **unknown_light** (*Optional*): Which light/light group has to flash red when light turns on while no one home.
+{% configuration %}
+known_light:
+  description: Which light/light group has to flash when a known device comes home.
+  required: false
+  type: string
+unknown_light:
+  description: Which light/light group has to flash red when light turns on while no one home.
+  required: false
+  type: string
+{% endconfiguration %}
 
 Create the file `<config dir>/custom_components/simple_alarm.py` and copy paste the content below:
 


### PR DESCRIPTION
**Description:**
Update style of Python_component_simple_alarm component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
