### PR TITLE
Re-add truth table for sun conditions

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -149,7 +149,7 @@ condition:
         before: sunrise
 ```
 
-Here is a truth table to clarify the parameters with and without offset:
+Here is a truth table to clarify the conditions with and without offset:
 
 | command                            |after midnight | at sunrise  | daytime | at sunset  | until midnight |
 | ---------------------------------- | ------------ |:-----------:| ------- |:----------:|----------|

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -139,6 +139,23 @@ condition:
         before: sunrise
 ```
 
+Here is a truth table to clarify the parameters with and without offset:
+
+| command                            |after midnight | at sunrise  | daytime | at sunset  | until midnight |
+| ---------------------------------- | ------------ |:-----------:| ------- |:----------:|----------|
+| `after: sunset`                    | False        |      ⇒      | False   |     ⇒      |True     |
+| + `after_offset: "01:00:00"`       | False        |      ⇒      | False   |  **+1h**   |True     |
+| + `after_offset: "-01:00:00"`      | False        |      ⇒      | False   |  **-1h**   |True     |
+| `before: sunset`                   | True         |      ⇒      | True    |     ⇒      |False    |
+| + `before_offset: "01:00:00"`      | True         |      ⇒      | True    |  **+1h**   |False    |
+| + `before_offset: "-01:00:00"`     | True         |      ⇒      | True    |  **-1h**   |False    |
+| `after: sunrise`                   | False        |      ⇒      | True    |     ⇒      |True    |
+| + `after_offset: "01:00:00"`       | False        |   **+1h**   | True    |     ⇒      |True    |
+| + `after_offset: "-01:00:00"`      | False        |   **-1h**   | True    |     ⇒      |True    |
+| `before: sunrise`                  | True         |      ⇒      | False   |     ⇒      |False   |
+| + `before_offset: "01:00:00"`      | True         |   **+1h**   | False   |     ⇒      |False   |
+| + `before_offset: "-01:00:00"`     | True         |   **-1h**   | False   |     ⇒      |False   |
+
 ### {% linkable_title Template condition %}
 
 The template condition will test if the [given template][template] renders a value equal to true. This is achieved by having the template result in a true boolean expression or by having the template render 'true'.

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -139,6 +139,16 @@ condition:
         before: sunrise
 ```
 
+```yaml
+condition:
+    condition: and  # 'when light' condition: before sunset and after sunrise
+    conditions:
+      - condition: sun
+        after: sunset
+      - condition: sun
+        before: sunrise
+```
+
 Here is a truth table to clarify the parameters with and without offset:
 
 | command                            |after midnight | at sunrise  | daytime | at sunset  | until midnight |


### PR DESCRIPTION
**Description:**
Re-add truth table for sun conditions which was removed in 44ec6aeaca2d3c87f168adf344e9d783cde61e96, but align with the implementation

## Checklist:

- [x] Branch: Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
