### PR TITLE
Additional attributes and hint to manual bug fix

### DIFF
--- a/source/_components/device_tracker.luci.markdown
+++ b/source/_components/device_tracker.luci.markdown
@@ -59,6 +59,9 @@ ssl:
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.
 
+This device tracker provides a number of additional attributes for each tracked device (if it is at home): `flags`, `ip`, `device`, and `host`. The first three attributes are taken from the ARP table returned by the luci RPC. The `host` attribute is taken from the platform configuration and can be used to distinguish in which router a device is logged in, if you are using multiple OpenWRT routers.
+
 <p class='note warning'>
-Some installations have [a small bug](https://github.com/openwrt/luci/issues/576). The timeout for luci RPC calls is not set and this makes the call fail.
+Some installations have [a small bug](https://github.com/openwrt/luci/issues/576). The timeout for luci RPC calls is not set and this makes the call fail. 
+If you want to locally fix your OpenWRT installation, you can apply the change manually to `/usr/lib/lua/luci/controller/rpc.lua`, or simply set a fixed timeout. The default is 3600.
 </p>


### PR DESCRIPTION
**Description:**
Highlihts the additional attributes and explains a (my) use case for the `host`attribute. Also hints to how to apply the bug fix manually, in case a user does not want to update their OpenWRT firmware.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17987

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
