### PR TITLE
Update Clicksend_tts notify component configuration

### DIFF
--- a/source/_components/notify.clicksend_tts.markdown
+++ b/source/_components/notify.clicksend_tts.markdown
@@ -13,7 +13,6 @@ ha_release: 0.55
 redirect_from: /components/notify.clicksendaudio/
 ---
 
-
 The `clicksend_tts` platform uses [ClickSend](https://clicksend.com) to deliver text-to-speech (TTS) notifications from Home Assistant.
 
 Go to your [ClickSend Dashboard](https://dashboard.clicksend.com) section and create your new project. After creating your project, you should now be able to obtain your `username` and `api_key`.
@@ -29,14 +28,34 @@ notify:
     recipient: PHONE_NO
 ```
 
-Configuration variables:
-
-* **name** (Optional): Setting the optional parameter name allows multiple notifiers to be created. The default value is `ClickSend`. The notifier will bind to the service notify.NOTIFIER_NAME.
-* **username** (Required): Your username.
-* **api_key** (Required): Your API Key.
-* **recipient** (Required): Your phone number. This is where you want to send your notification SMS messages (e.g., `09171234567`)
-* **language** (Optional): The language you want to use to convert the message to audio. Accepted values are found in the [ClickSend Documentation](http://docs.clicksend.apiary.io/#reference/voice/voice-languages). Default value is `en-us`.
-* **voice** (Optional): The voice that needs to be used to play the message to the recipient. Allowed values are `female` or `male`. Default value is `female`.
+{% configuration %}
+name:
+  description: Setting the optional parameter name allows multiple notifiers to be created. The notifier will bind to the service notify.NOTIFIER_NAME.
+  required: false
+  default: ClickSend
+  type: string
+username:
+  description: Your username.
+  required: true
+  type: string
+api_key:
+  description: Your API Key.
+  required: true
+  type: string
+recipient:
+  description: Your phone number. This is where you want to send your notification SMS messages (e.g., `09171234567`).
+  required: true
+  type: string
+language:
+  description: The language you want to use to convert the message to audio. Accepted values are found in the [ClickSend Documentation](http://docs.clicksend.apiary.io/#reference/voice/voice-languages).
+  required: false
+  default: en-us
+  type: string
+voice:
+  description: The voice that needs to be used to play the message to the recipient. Allowed values are `female` or `male`.
+  required: false
+  default: female
+  type: string
+{% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
-


### PR DESCRIPTION
**Description:**
Update style of Clicksend_tts notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
