### PR TITLE
Change link removing domain.

### DIFF
--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -29,7 +29,7 @@ We will need a few things to get started with installing Home Assistant. For bes
 
 ### {% linkable_title Software requirements %}
 
-- Download the Hass.io image for [your device](https://www.home-assistant.io/hassio/installation/)
+- Download the Hass.io image for [your device](/hassio/installation/)
 - Download [Etcher] to write the image to an SD card
 - Text Editor like [Visual Studio Code](https://code.visualstudio.com/)
 


### PR DESCRIPTION
Changed link so it is less annoying for dev, through removing the home assistant domain from 'your device' link.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
