### PR TITLE
Update Discovery component configuration

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -33,10 +33,19 @@ mqtt:
   discovery: true
   discovery_prefix: homeassistant
 ```
-Configuration variables:
 
-- **discovery** (*Optional*): If the MQTT discovery should be enabled or not. Defaults to `False`.
-- **discovery_prefix** (*Optional*): The prefix for the discovery topic. Defaults  to `homeassistant`.
+{% configuration %}
+discovery:
+  description: If the MQTT discovery should be enabled or not.
+  required: false
+  default: false
+  type: boolean
+discovery_prefix:
+  description: The prefix for the discovery topic.
+  required: false
+  default: homeassistant
+  type: string
+{% endconfiguration %}
 
 <p class='note'>
 The [embedded MQTT broker](/docs/mqtt/broker#embedded-broker) does not save any messages between restarts. If you use the embedded MQTT broker you have to send the MQTT discovery messages after every Home Assistant restart for the devices to show up.


### PR DESCRIPTION
**Description:**
Update style of Discovery component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
