### PR TITLE
Update Gtfs sensor component configuration

### DIFF
--- a/source/_components/sensor.gtfs.markdown
+++ b/source/_components/sensor.gtfs.markdown
@@ -13,7 +13,6 @@ ha_iot_class: "Local Polling"
 ha_release: 0.17
 ---
 
-
 The `gtfs` sensor will give you the next departure time and associated data from your public transit station/stop. The data comes from your chosen public transit authority and is formatted as [General Transit Feed Specification](https://developers.google.com/transit/gtfs/) data, commonly known as GTFS.
 
 You need to find a valid GTFS data set, which you can usually find just by searching the internet. Most public transit authorities have GTFS available somewhere, as Google requires public transit authorities to provide the data if they wish to appear on Google Maps. You may also be able to find data at either [TransitFeeds](http://transitfeeds.com/feeds) or [GTFS Data Exchange](http://www.gtfs-data-exchange.com/).
@@ -49,11 +48,27 @@ sensor:
     data: DATA_SOURCE
 ```
 
-Configuration variables:
-
-- **origin** (*Required*): The stop ID of your origin station.
-- **destination** (*Required*): The stop ID of your destination station.
-- **data** (*Required*): The name of the ZIP file or folder containing the GTFS data. It must be located inside the `gtfs` folder of your configuration directory.
-- **name** (*Optional*): Name to use in the frontend.
-- **offset** (*Optional*): A minimum delay to look for. If a departure is in less time than `offset`, it will be ignored. Defaults to `0`.
-
+{% configuration %}
+origin:
+  description: The stop ID of your origin station.
+  required: true
+  type: string
+destination:
+  description: The stop ID of your destination station.
+  required: true
+  type: string
+data:
+  description: The name of the ZIP file or folder containing the GTFS data. It must be located inside the `gtfs` folder of your configuration directory.
+  required: true
+  type: string
+name:
+  description: Name to use in the frontend.
+  required: false
+  default: GTFS Sensor
+  type: string
+offset:
+  description: A minimum delay to look for. If a departure is in less time than `offset`, it will be ignored.
+  required: false
+  default: 0
+  type: [integer, time]
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Gtfs sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
