### PR TITLE
Fix typo in "Ping (ICMP) Binary sensor" docs

### DIFF
--- a/source/_components/binary_sensor.ping.markdown
+++ b/source/_components/binary_sensor.ping.markdown
@@ -13,7 +13,7 @@ ha_release: 0.43
 ha_qa_scale: internal
 ---
 
-The `ping` binary sensor platform allows you to using `ping` to send ICMP echo requests. This way you can check if a given host is online and determine the round trip times from your Home Assistant instance to that system.
+The `ping` binary sensor platform allows you to use `ping` to send ICMP echo requests. This way you can check if a given host is online and determine the round trip times from your Home Assistant instance to that system.
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
**Description:**

Fixes typo in the first sentence of "Ping (ICMP) Binary sensor" docs:

https://www.home-assistant.io/components/binary_sensor.ping/

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
