### PR TITLE
Update Slack Notify configuration variables style

### DIFF
--- a/source/_components/notify.slack.markdown
+++ b/source/_components/notify.slack.markdown
@@ -52,14 +52,14 @@ api_key:
   required: true
   type: string
 default_channel:
-  description: The default channel to post to if no channel is explicitly specified when sending the notification message.  A channel can be specified adding a target attribute to the json at the same level as "message"
+  description: The default channel to post to if no channel is explicitly specified when sending the notification message.  A channel can be specified adding a target attribute to the JSON at the same level as "message".
   required: true
   type: string
 username:
   description: Home Assistant will post to Slack using the username specified.
   required: false
   type: string
-  default: The user account or botname that you generated the api_key as.
+  default: The user account or botname that you generated the API key as.
 icon:
   description: Use one of the Slack emojis as an Icon for the supplied username.  Slack uses the standard emoji sets used [here](http://www.webpagefx.com/tools/emoji-cheat-sheet/).
   required: false

--- a/source/_components/notify.slack.markdown
+++ b/source/_components/notify.slack.markdown
@@ -50,7 +50,7 @@ name:
 api_key:
   description: The Slack API token to use for sending Slack messages.
   required: true
-  type: 
+  type: string
 default_channel:
   description: The default channel to post to if no channel is explicitly specified when sending the notification message.  A channel can be specified adding a target attribute to the json at the same level as "message"
   required: true

--- a/source/_components/notify.slack.markdown
+++ b/source/_components/notify.slack.markdown
@@ -42,13 +42,28 @@ notify:
     default_channel: '#general'
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **api_key** (*Required*): The Slack API token to use for sending Slack messages.
-- **default_channel** (*Required*): The default channel to post to if no channel is explicitly specified when sending the notification message.  A channel can be specified adding a target attribute to the json at the same level as "message"
-- **username** (*Optional*): Setting username will allow Home Assistant to post to Slack using the username specified. By default not setting this will post to Slack using the user account or botname that you generated the api_key as.
-- **icon** (*Optional*): Use one of the Slack emojis as an Icon for the supplied username.  Slack uses the standard emoji sets used [here](http://www.webpagefx.com/tools/emoji-cheat-sheet/).
+{% configuration %}
+name: 
+  description: Setting this parameter allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: "notify"
+api_key:
+  description: The Slack API token to use for sending Slack messages.
+  required: true
+  type: 
+default_channel:
+  description: The default channel to post to if no channel is explicitly specified when sending the notification message.  A channel can be specified adding a target attribute to the json at the same level as "message"
+  required: true
+  type: string
+username:
+  description: Home Assistant will post to Slack using the username specified.
+  required: false
+  type: string
+  default: The user account or botname that you generated the api_key as.
+icon:
+  description: Use one of the Slack emojis as an Icon for the supplied username.  Slack uses the standard emoji sets used [here](http://www.webpagefx.com/tools/emoji-cheat-sheet/).
+  required: false
+{% endconfiguration %}
 
 ### {% linkable_title Slack service data %}
 


### PR DESCRIPTION
**Description:**
Use the new style for configuration variables as described in #6385 for notify.slack.markdown

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
