### PR TITLE
Update Crime Reports sensor's configuration variables style

### DIFF
--- a/source/_components/sensor.crimereports.markdown
+++ b/source/_components/sensor.crimereports.markdown
@@ -26,14 +26,32 @@ sensor:
     radius: <your radius>
 ```
 
-Configuration options for the Crime Reports Sensor:
-
-- **name** (*Required*): Name the sensor whatever you want.
-- **radius** (*Required*): Radius in meters.
-- **latitude** (*Optional*): Defaults to your home zone latitude.
-- **longitude** (*Optional*): Defaults to your home zone longitude.
-- **include** (*Optional*): List of incident types to include.
-- **exclude** (*Optional*): List of incident types to exclude.
+{% configuration %}
+name:
+  description: Custom name for the sensor.
+  required: true
+  type: string
+radius: 
+  description: Radius in meters
+  required: true
+  type: float
+latitude: 
+  description: Latitude for sensor.
+  required: false
+  default: Your home zone latitude defined in your configuration.
+longitude: 
+  description: Longitude for sensor.
+  required: false
+  default: Your home zone longitude defined in your configuration.
+include: 
+  description: List of incident types to include. See below for a list of valid incidents.
+  required: false
+  type: list
+exclude: 
+  description: List of incident types to exclude. See below for a list of valid incidents.
+  required: false
+  type: list
+{% endconfiguration %}
 
 
 ## {% linkable_title Notes %}


### PR DESCRIPTION
**Description:**

Use the new style for configuration variables as described in #6385 for sensor.crimereports.markdown

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
