### PR TITLE
Update rainbird sensor's configuration variables style

### DIFF
--- a/source/_components/sensor.rainbird.markdown
+++ b/source/_components/sensor.rainbird.markdown
@@ -27,8 +27,12 @@ sensor:
       - rainsensor
 ```
 
-Configuration variables:
-
-- **monitored_conditions**: Currently only rainsensor is supported. Returns the sensor level.
+{% configuration %}
+monitored_conditions:
+  description: Conditions to be monitored. 
+  keys:
+    rainsensor:
+      description: Returns the sensor level.
+{% endconfiguration %}
 
 Please note that due to the implementation of the API within the LNK Module, there is a concurrency issue. For example, the Rain Bird app will give connection issues (like already a connection active).


### PR DESCRIPTION
**Description:**

Use the new style for configuration variables as described in #6385 for sensor.rainbird.markdown

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
