### PR TITLE
Samba Add-on: Emphasizes security note

### DIFF
--- a/source/_addons/samba.markdown
+++ b/source/_addons/samba.markdown
@@ -40,13 +40,67 @@ Also be careful when setting up port forwarding for remote access. If you don't 
 }
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Set netbios name of Hass.io device. Default is `hassio`.
-- **workgroup** (*Optional*): Set network workgroup name. Default is `WORKGROUP`.
-- **guest** (*Optional*): Allow login without a username or password. Default is `true`.
-- **map** (*Optional*): Control which folders will be exposed. `config` shares the Home Assistant configuration folder. `addons` shares the local custom repository. `share` shares a folder that can be accessed by add-ons and Home Assistant. `backup` shares access to snapshot files. `ssl` shares certificate storage. Be careful with the `ssl` option! Defaults are all set to `true`, except for `ssl`.
-- **username** (*Optional*): Username for logging in if guest login is not used.
-- **password** (*Optional*): Password for `username`. An empty password is not supported.
-- **interface** (*Optional*): Interface that will start the share. Normally this is `eth0` for ethernet wired connection and `wlan0` for wireless connection. If you are running on an Intel NUC this could also be `enp3s0` for ethernet or `wlp5s0` for wireless connection.
-- **allow_hosts** (*Optional*): The hosts that are allowed to connect to your Samba server. By default it is limited to people within the same local network.
+{% configuration %}
+name:
+  description: Set netbios name of Hass.io device.
+  required: false
+  default: "`hassio`"
+  type: string
+workgroup:
+  description: Set network workgroup name.
+  required: false
+  default: "`WORKGROUP`"
+  type: string
+guest:
+  description: Allow login without a username or password.
+  required: false
+  default: true
+  type: boolean
+map:
+  description: Control which folders will be exposed.
+  required: false
+  type: map
+  keys:
+    config:
+      description: The Home Assistant configuration folder
+      required: false
+      default: true
+      type: boolean
+    addons:
+      description: The local custom addons repository
+      required: false
+      default: true
+      type: boolean
+    share:
+      description: The folder that can be accessed by add-ons and Home Assistant
+      required: false
+      default: true
+      type: boolean
+    backup:
+      description: Access to snapshot files
+      required: false
+      default: true
+      type: boolean
+    ssl:
+      description: Certificate storage (Careful! Sharing is set to `false` by default)
+      required: false
+      default: false
+      type: boolean
+username:
+  description: Username for logging in if guest login is not used.
+  required: false
+  type: string
+password:
+  description: Password for `username`. An empty password is not supported.
+  required: false
+  type: string
+interface:
+  description: Interface that will start the share. Normally this is `eth0` for ethernet wired connection and `wlan0` for wireless connection. If you are running on an Intel NUC this could also be `enp3s0` for ethernet or `wlp5s0` for wireless connection.
+  required: false
+  type: string
+allow_hosts:
+  description: The hosts that are allowed to connect to your Samba server. By default it is limited to people within the same local network.
+  required: false
+  default: '`["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]`'
+  type: list
+{% endconfiguration %}

--- a/source/_addons/samba.markdown
+++ b/source/_addons/samba.markdown
@@ -12,6 +12,11 @@ featured: true
 
 This add-on allows you to set up a [Samba](https://samba.org/) server to access Hass.io folders using Windows network shares.
 
+<p class='note warning'>
+It is <strong>strongly recommended to set a username and password</strong>. By using guest mode, you expose your configuration and secrets to every user in local network.<br />
+Also be careful when setting up port forwarding for remote access. If you don't restrict access by setting a username and password, your configuration could be exposed to the entire internet!
+</p>
+
 ```json
 {
   "name": "hassio",
@@ -45,7 +50,3 @@ Configuration variables:
 - **password** (*Optional*): Password for `username`. An empty password is not supported.
 - **interface** (*Optional*): Interface that will start the share. Normally this is `eth0` for ethernet wired connection and `wlan0` for wireless connection. If you are running on an Intel NUC this could also be `enp3s0` for ethernet or `wlp5s0` for wireless connection.
 - **allow_hosts** (*Optional*): The hosts that are allowed to connect to your Samba server. By default it is limited to people within the same local network.
-
-<p class='note warning'>
-Be careful when setting up port forwarding to the remote access. If you don't restrict access by requiring authentication and guest access is enabled, your configuration could be exposed to the internet!
-</p>


### PR DESCRIPTION
**Description:** This emphasizes the security note of the Samba Add-on concerning exposing the configuration and secrets in the local LAN. (Guest mode is enabled by default...)

Also updates the configuration syntax to the new standard.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** n/a

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
