### PR TITLE
Fix category for wink water heater

### DIFF
--- a/source/_components/water_heater.wink.markdown
+++ b/source/_components/water_heater.wink.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: wink.png
-ha_category: water heater
+ha_category: Water heater
 ha_release: 0.32
 ha_iot_class: "Cloud Polling"
 ---


### PR DESCRIPTION
There are two water heater categories listed due to different upper case/lower case spelling.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
