### PR TITLE
Remove google+ reference since its shut down.

### DIFF
--- a/source/help/index.markdown
+++ b/source/help/index.markdown
@@ -17,7 +17,6 @@ There are various ways to get in touch with the Home Assistant community. It doe
 - [Discord Chat Server][discord] for general Home Assistant discussions and questions.
 - Follow us on [Twitter][twitter], use [@home_assistant][twitter]
 - Join the [Facebook community][facebook]
-- Join the [Google+ community][google-plus]
 - Join the Reddit in [/r/homeassistant][reddit]
 
 ### {% linkable_title Bugs, Feature requests, and alike %}


### PR DESCRIPTION
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
