### PR TITLE
Wemo discovery

### DIFF
--- a/source/_components/fan.wemo.markdown
+++ b/source/_components/fan.wemo.markdown
@@ -1,0 +1,46 @@
+---
+layout: page
+title: "Belkin WeMo (Holmes) Smart Humidifier"
+description: "Instructions how to integrate Belkin WeMo humidifiers into Home Assistant."
+date: 2018-10-29 19:58
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: belkin_wemo.png
+ha_category: Fan
+ha_iot_class: "Local Polling"
+ha_release: 0.82
+---
+
+
+The `wemo` platform allows you to control your [Belkin WeMo](http://www.belkin.com/us/p/P-F7C027/) humidifiers from within Home Assistant. This includes support for the [Holmes Smart Humidifier](https://www.holmesproducts.com/wemo-humidifier.html).
+
+They will be automatically discovered if the discovery component is enabled.
+
+For more configuration information, see the [WeMo component](/components/wemo/) documentation.
+
+### {% linkable_title Attributes %}
+
+There are several attributes which can be used for automations and templates.
+
+| Attribute | Description |
+| --------- | ----------- |
+| `current_humidity` | An integer that indicates the current relative humidity percentage of the room, as determined by the device's onboard humidity sensor.
+| `target_humidity` | An integer that indicates the desired relative humidity percentage (this is constrained to the humidity settings of the device, which are 45, 50, 55, 60, and 100).
+| `fan_mode` | String that indicates the current fan speed setting, as reported by the WeMo humidifier.
+| `water level` | String that indicates whether the water level is Good, Low, or Empty.
+| `filter_life` | The used life of the filter (as a percentage).
+| `filter_expired` | A boolean that indicates whether the filter has expired and needs to be replaced.
+
+### {% linkable_title Services %}
+
+There are several services which can be used for automations and control of the humidifier.
+
+| Service | Description |
+| --------- | ----------- |
+| `set_speed` | Calling this service sets the fan speed (entity_id and speed are required parameters, and speed must be one of the following: off, low, medium, or high). When selecting low for the speed, this will map to the WeMo humidifier speed of minimum. When selecting high for the speed, this will map to the WeMo humidifier speed of maximum. The WeMo humidifier speeds of low and high are unused due to constraints on which fan speeds Home Assistant supports.
+| `wemo_set_humidity` | Calling this service will set the desired relative humidity setting on the device (entity_id is an optional list of entities to set humidity on (omitting this list will set humidity on all WeMo Humidifiers), and target_humidity is a required float value between 0 and 100 (this value will be rounded down and mapped to one of the valid desired humidity settings of 45, 50, 55, 60, or 100 that are supported by the WeMo humidifier)).
+| `turn_on` | Calling this service will turn the humidifier on and set the speed to the last used speed (defaults to medium, entity_id is required).
+| `turn_off` | Calling this service will turn the humidifier off (entity_id is required).
+| `toggle` | Calling this service will toggle the humidifier between on and off states.

--- a/source/_components/wemo.markdown
+++ b/source/_components/wemo.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Belkin WeMo"
 description: "Instructions on how to integrate Belkin WeMo devices into Home Assistant."
-date: 2016-02-20 00:41
+date: 2018-11-01 01:53
 sidebar: true
 comments: false
 sharing: true
@@ -17,33 +17,35 @@ The `wemo` component is the main component to integrate various [Belkin WeMo](ht
 
 ## {% linkable_title Configuration %}
 
-Supported devices will be automatically discovered if the discovery component is enabled. Loading the `wemo` component will scan the local network for WeMo devices, even if you are not using the discovery component
+Supported devices will be automatically discovered if the optional `disable_discovery` configuration item is omitted or set to false or if the `discovery` component is enabled. If the `disable_discovery` configuration item is set to true, then automatic discovery of WeMo devices is disabled both for the `wemo` component and for the `discovery` component. Loading the `wemo` component with the `disable_discovery` configuration item omitted or set to false will scan the local network for WeMo devices, even if you are not using the `discovery` component.
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry with automatic discovery enabled
 wemo:
+  disable_disovery: false
 ```
 
 Alternately, WeMo devices that are not discoverable can be statically configured. If you have WeMo devices on subnets other than where Home Assistant is running, or devices in a remote location reachable over a VPN, you will need to configure them manually. This is also useful if you wish to disable discovery for some WeMo's, even if they are local. Example static configuration:
 
 ```yaml
+# Example configuration.yaml entry with automatic discovery disabled, and 2 static entries for WeMo devices to be discovered manually
 wemo:
+  disable_disovery: true
   static:
     - 192.168.1.23
     - 192.168.52.172
 ```
 
-Any WeMo devices that are not statically configured but reachable via discovery will still be added automatically.
+Note that if you use static device entries, you may want to set up your router (or whatever runs your DHCP server) to force your WeMo devices to use a static IP address. Check the DHCP section of your router configuration for this ability.
 
-Note that if you use this, you may want to set up your router (or whatever runs your DHCP server) to force your WeMo devices to use a static IP address. Check the DHCP section of your router configuration for this ability.
-
-If the device doesn't seem to work and all you see is the state "unavailable" on your dashboard, check that your firewall doesn't block incoming request on port 8989 since this is the address to which the WeMo devices send their update.
+If the device doesn't seem to work and all you see is the state "unavailable" on your dashboard, check that your firewall doesn't block incoming requests on port 8989, since this is the port to which the WeMo devices send their updates.
 
 ## {% linkable_title Emulated devices %}
 
-Various software that emulates WeMo devices often uses alternative ports. Static configuration should include the port value:
+Various software that emulate WeMo devices often use alternative ports. Static configuration should include the port value:
 
 ```yaml
+# Example configuration.yaml entry with static device entries that include non-standard port numbers
 wemo:
   static:
     - 192.168.1.23:52001


### PR DESCRIPTION
**Description:**
Update WeMo base platform documentation to include new disable_discovery configuration option.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
