### PR TITLE
Added example identifier usage matching PR 18078

### DIFF
--- a/source/_components/keyboard_remote.markdown
+++ b/source/_components/keyboard_remote.markdown
@@ -93,10 +93,13 @@ automation:
           entity_id: media_player.speaker
           media_content_id: keyboard_connected.wav
           media_content_type: music
-  - alias: Keyboard Disconnected
+
+  - alias: Bluetooth Keyboard Disconnected
     trigger:
       platform: event
       event_type: keyboard_remote_disconnected
+      event_data:
+        device_name: "00:58:56:4C:C0:91"
     action:
       - service: media_player.play_media
         data:


### PR DESCRIPTION
**Description:**

Update example to include bluetooth identifier in event data in Bluetooth Keyboard disconnect example.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18078

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
