### PR TITLE
Updated to new style configuration for keyboard_remote.markdown

### DIFF
--- a/source/_components/keyboard_remote.markdown
+++ b/source/_components/keyboard_remote.markdown
@@ -25,11 +25,20 @@ keyboard_remote:
   type: 'key_up'
 ```
 
-Configuration variables:
-
-- **type** (*Required*): Possible values are `key_up`, `key_down`, and `key_hold`. Be careful, `key_hold` will fire a lot of events.
-- **device_descriptor** (*Optional*): Path to the local event input device file that corresponds to the keyboard.
-- **device_name** (*Optional*): Name of the keyboard device.
+{% configuration %}
+type:
+  description: Possible values are `key_up`, `key_down`, and `key_hold`. Be careful, `key_hold` will fire a lot of events.
+  required: true
+  type: string
+device_description:
+  description: Path to the local event input device file that corresponds to the keyboard.
+  required: false
+  type: string
+device_name:
+  description: Name of the keyboard device.
+  required: false
+  type: string
+{% endconfiguration %}
 
 Either `device_name` or `device_descriptor` must be present in the configuration entry. Indicating a device name is useful in case of repeating disconnections and re-connections of the device (for example, a bluetooth keyboard): the local input device file might change, thus breaking the configuration, while the name remains the same.
 In case of presence of multiple devices of the same model, `device_descriptor` must be used.


### PR DESCRIPTION
**Description:**
Change to new style for configuration variables description.

Related to home-assistant.io #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
