### PR TITLE
Updated configuration style for rflink.markdown

### DIFF
--- a/source/_components/rflink.markdown
+++ b/source/_components/rflink.markdown
@@ -36,13 +36,29 @@ rflink:
   port: /dev/serial/by-id/usb-id01234
 ```
 
-Configuration variables:
-
-- **port** (*Required*): The path to RFLink USB/serial device or TCP port in TCP mode.
-- **host** (*Optional*): Switches to TCP mode, connects to host instead of to USB/serial.
-- **wait_for_ack** (*Optional*): Wait for RFLink to acknowledge commands sent before sending new command (slower but more reliable). Defaults to `True`
-- **ignore_devices** (*Optional*): List of device id's to ignore. Supports wildcards (*) at the end.
-- **reconnect_interval** (*Optional*): Time in seconds between reconnect attempts.
+{% configuration %}
+port:
+  description: The path to RFLink USB/serial device or TCP port in TCP mode.
+  required: true
+  type: string
+host:
+  description: Switches to TCP mode, connects to host instead of to USB/serial.
+  required: false
+  type: string
+wait_for_ack:
+  description: Wait for RFLink to acknowledge commands sent before sending new command (slower but more reliable).
+  required: false
+  type: string
+  default: true
+ignore_devices:
+  description: List of device id's to ignore. Supports wildcards (*) at the end.
+  required: false
+  type: string
+reconnect_interval:
+  description: Time in seconds between reconnect attempts.
+  required: false
+  type: integer
+{% endconfiguration %}
 
 Complete example:
 

--- a/source/_components/rflink.markdown
+++ b/source/_components/rflink.markdown
@@ -28,6 +28,8 @@ This component is tested with the following hardware/software:
 
 - Nodo RFLink Gateway V1.4/RFLink R46
 
+## {% linkable_title Configuration %}
+
 To enable RFLink in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -51,7 +53,7 @@ wait_for_ack:
   type: string
   default: true
 ignore_devices:
-  description: List of device id's to ignore. Supports wildcards (*) at the end.
+  description: List of device id's to ignore. Supports wildcards (`*`) at the end.
   required: false
   type: string
 reconnect_interval:
@@ -60,7 +62,7 @@ reconnect_interval:
   type: integer
 {% endconfiguration %}
 
-Complete example:
+### {% linkable_title Full example %}
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
**Description:**
Change to new style for configuration variables description.

Related to home-assistant.io #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
