### PR TITLE
Add setup section (fixes #7318)

### DIFF
--- a/source/_components/light.blinksticklight.markdown
+++ b/source/_components/light.blinksticklight.markdown
@@ -16,9 +16,17 @@ ha_iot_class: "Local Polling"
 
 The `blinkstick` platform lets you control your [Blinkstick](https://www.blinkstick.com/) lights from within Home Assistant.
 
+## {% linkable_title Setup %}
+
+To use your Blinkstick, you need to allow the access to the device for [non-root users](https://github.com/arvydas/blinkstick-python#permission-problems-in-linux-and-mac-os-x).
+
+```bash
+$ sudo blinkstick --add-udev-rule
+```
+
 ## {% linkable_title Configuration %}
 
-To add blinkstick to your installation, add the following to your `configuration.yaml` file:
+To add a Blinkstick to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
**Description:**
Add setup section.

**Related issue (if applicable):** fixes #7318

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
