### PR TITLE
deCONZ is now fully IQS Platinum

### DIFF
--- a/source/_components/deconz.markdown
+++ b/source/_components/deconz.markdown
@@ -11,6 +11,7 @@ logo: deconz.jpeg
 ha_category: Hub
 ha_release: "0.61"
 ha_iot_class: "Local Push"
+ha_qa_scale: platinum
 ---
 
 [deCONZ](https://www.dresden-elektronik.de/funktechnik/products/software/pc/deconz/) by [Dresden Elektronik](https://www.dresden-elektronik.de) is a software that communicates with Conbee/Raspbee Zigbee gateways and exposes Zigbee devices that are connected to the gateway.


### PR DESCRIPTION
When PRs home-assistant/home-assistant#18106 and home-assistant/home-assistant#18106 are integrated deCONZ is fully IQS Platinum compliant.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html