### PR TITLE
Update sensor london air

### DIFF
--- a/source/_components/sensor.london_air.markdown
+++ b/source/_components/sensor.london_air.markdown
@@ -55,9 +55,13 @@ sensor:
       - Westminster
 ```
 
-Configuration variables:
-
-- **locations** array (*Required*): At least one entry required.
+{% configuration %}
+locations:
+  description: Areas/boroughs in London to monitor.
+  required: false
+  default: All location with data available.
+  type: list
+{% endconfiguration %}
 
 To explore the data available within the `data` attribute of a sensor use the `dev-template` tool on the Home-assistant frontend. `data` contains a list of monitored sites, where the number of monitored sites are given by the `sites` attribute. If a sensor has four sites, access the fourth site by indexing the list of sites using data[3]. Each site is a dictionary with multiple fields, with entries for the `latitude` and `longitude` of that site, a `pollution_status`, `site_code`, `site_name` and `site_type`. The field `number_of_pollutants` states how many pollutants are monitored (of the possible six) and the field `pollutants` returns a list with data for each pollutant. To access the first pollutant in the list for site zero use `attributes.data[0].pollutants[0]`. Each entry in `pollutants` is a dictionary with fields for the pollutant `code`, `description`, `index`, `quality` and a `summary`. [Template sensors](/components/sensor.template/) can then be added to display these attributes, for example:
 


### PR DESCRIPTION
**Description:**

Update configuration variables for london air sensor #6385

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
