### PR TITLE
Add configurable title to Lovelace thermostat card

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -143,12 +143,12 @@ social:
 current_major_version: 0
 current_minor_version: 81
 current_patch_version: 2
-date_released: 2018-10-29
+date_released: 2018-11-02
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.
 # Major release:
-patch_version_notes: "#release-0812---october-29"
+patch_version_notes: "#release-0813---november-3"
 # Minor release (Example #release-0431---april-25):
 
 # Date we moved to Discourse for comments

--- a/_config.yml
+++ b/_config.yml
@@ -142,13 +142,13 @@ social:
 # Home Assistant release details
 current_major_version: 0
 current_minor_version: 81
-current_patch_version: 2
+current_patch_version: 4
 date_released: 2018-11-02
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.
 # Major release:
-patch_version_notes: "#release-0813---november-3"
+patch_version_notes: "#release-0814---november-3"
 # Minor release (Example #release-0431---april-25):
 
 # Date we moved to Discourse for comments

--- a/source/_components/bmw_connected_drive.markdown
+++ b/source/_components/bmw_connected_drive.markdown
@@ -22,8 +22,9 @@ This component provides the following platforms:
  - Device tracker: The location of your car.
  - Lock: Control the lock of your car.
  - Sensors: Mileage, remaining range, remaining fuel, charging time remaining (electric cars), charging status (electric cars), remaining range electric (electric cars).
+ - Services: Turn on air condition, sound the horn, flash the lights and update the state. More details can be found [here](https://www.home-assistant.io/components/bmw_connected_drive/#services).
 
- ## {% linkable_title Configuration %}
+## {% linkable_title Configuration %}
 
 To enable this component in your installation, add the following to your
 `configuration.yaml` file:

--- a/source/_components/device_tracker.tplink.markdown
+++ b/source/_components/device_tracker.tplink.markdown
@@ -26,6 +26,9 @@ Currently supported devices includes the following:
 TP-Link devices typically only allow one login at a time to the admin console.  This component will count towards your one allowed login. Depending on how aggressively you configure device_tracker you may not be able to access the admin console of your TP-Link device without first stopping Home Assistant. Home Assistant takes a few seconds to login, collect data, and log out. If you log into the admin console manually, remember to log out so that Home Assistant can log in again.
 </p>
 
+## {% linkable_title Configuration %}
+
+To enable this device tracker, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/keyboard_remote.markdown
+++ b/source/_components/keyboard_remote.markdown
@@ -25,11 +25,20 @@ keyboard_remote:
   type: 'key_up'
 ```
 
-Configuration variables:
-
-- **type** (*Required*): Possible values are `key_up`, `key_down`, and `key_hold`. Be careful, `key_hold` will fire a lot of events.
-- **device_descriptor** (*Optional*): Path to the local event input device file that corresponds to the keyboard.
-- **device_name** (*Optional*): Name of the keyboard device.
+{% configuration %}
+type:
+  description: Possible values are `key_up`, `key_down`, and `key_hold`. Be careful, `key_hold` will fire a lot of events.
+  required: true
+  type: string
+device_description:
+  description: Path to the local event input device file that corresponds to the keyboard.
+  required: false
+  type: string
+device_name:
+  description: Name of the keyboard device.
+  required: false
+  type: string
+{% endconfiguration %}
 
 Either `device_name` or `device_descriptor` must be present in the configuration entry. Indicating a device name is useful in case of repeating disconnections and re-connections of the device (for example, a bluetooth keyboard): the local input device file might change, thus breaking the configuration, while the name remains the same.
 In case of presence of multiple devices of the same model, `device_descriptor` must be used.

--- a/source/_components/light.blinksticklight.markdown
+++ b/source/_components/light.blinksticklight.markdown
@@ -16,9 +16,17 @@ ha_iot_class: "Local Polling"
 
 The `blinkstick` platform lets you control your [Blinkstick](https://www.blinkstick.com/) lights from within Home Assistant.
 
+## {% linkable_title Setup %}
+
+To use your Blinkstick, you need to allow the access to the device for [non-root users](https://github.com/arvydas/blinkstick-python#permission-problems-in-linux-and-mac-os-x).
+
+```bash
+$ sudo blinkstick --add-udev-rule
+```
+
 ## {% linkable_title Configuration %}
 
-To add blinkstick to your installation, add the following to your `configuration.yaml` file:
+To add a Blinkstick to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/media_player.kodi.markdown
+++ b/source/_components/media_player.kodi.markdown
@@ -19,6 +19,8 @@ The `kodi` platform allows you to control a [Kodi](http://kodi.tv/) multimedia s
 
 The preferred way to set up the Kodi platform is by enabling the [discovery component](/components/discovery/) which requires enabled [web interface](https://kodi.wiki/view/Web_interface) on your Kodi installation.
 
+## {% linkable_title Configuration %}
+
 In case the discovery does not work, or you need specific configuration variables, you can add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -80,18 +82,26 @@ timeout:
   default: 5
 {% endconfiguration %}
 
+## {% linkable_title Services %}
+
 ### {% linkable_title Service `kodi_add_to_playlist` %}
 
 Add music to the default playlist (i.e. playlistid=0).
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | Name(s) of the Kodi entities where to add the media.
-| `media_type` | yes | Media type identifier. It must be one of SONG or ALBUM.
-| `media_id` | no | Unique Id of the media entry to add (`songid` or `albumid`). If not defined, `media_name` and `artist_name` are needed to search the Kodi music library.
-| `media_name` | no| Optional media name for filtering media. Can be 'ALL' when `media_type` is 'ALBUM' and `artist_name` is specified, to add all songs from one artist.
-| `artist_name` | no | Optional artist name for filtering media.
+| `entity_id` | no | Name(s) of the Kodi entities where to add the media. |
+| `media_type` | yes | Media type identifier. It must be one of SONG or ALBUM. |
+| `media_id` | no | Unique Id of the media entry to add (`songid` or `albumid`). If not defined, `media_name` and `artist_name` are needed to search the Kodi music library. |
+| `media_name` | no| Optional media name for filtering media. Can be 'ALL' when `media_type` is 'ALBUM' and `artist_name` is specified, to add all songs from one artist. |
+| `artist_name` | no | Optional artist name for filtering media. |
 
+#### {% linkable_title Service `media_player/kodi_set_shuffle` %}
+
+| Service data attribute | Optional | Description |
+|------------------------|----------|-------------|
+| `entity_id`            | yes      | Target a specific media player. It must be of type kodi. |
+| `shuffle_on`           | no       | True/false for shuffle on/off. |
 
 ### {% linkable_title Service `kodi_call_method` %}
 
@@ -99,10 +109,9 @@ Call a [Kodi JSONRPC API](http://kodi.wiki/?title=JSON-RPC_API) method with opti
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | Name(s) of the Kodi entities where to run the API method.
-| `method` | yes | Name of the Kodi JSONRPC API method to be called.
-| any other parameter | no | Optional parameters for the Kodi API call.
-
+| `entity_id` | no | Name(s) of the Kodi entities where to run the API method. |
+| `method` | yes | Name of the Kodi JSONRPC API method to be called. |
+| any other parameter | no | Optional parameters for the Kodi API call. |
 
 ### {% linkable_title Event triggering %}
 
@@ -240,6 +249,7 @@ This example and the following requires to have the [script.json-cec](https://gi
 
 #### Simple script to turn on the PVR in some channel as a time function
 
+{% raw %}
 ```yaml
 script:
   play_kodi_pvr:
@@ -249,14 +259,13 @@ script:
         service: media_player.turn_on
         data:
           entity_id: media_player.kodi
-
       - alias: Play TV channel
         service: media_player.play_media
         data_template:
           entity_id: media_player.kodi
           media_content_type: "CHANNEL"
           media_content_id: >
-            {% raw %}{% if (now().hour < 14) or ((now().hour == 14) and (now().minute < 50)) %}
+            {% if (now().hour < 14) or ((now().hour == 14) and (now().minute < 50)) %}
               10
             {% elif (now().hour < 16) %}
               15
@@ -268,8 +277,9 @@ script:
               15
             {% else %}
               10
-            {% endif %}{% endraw %}
+            {% endif %}
 ```
+{% endraw %}
 
 #### Trigger a Kodi video library update
 

--- a/source/_components/notify.kodi.markdown
+++ b/source/_components/notify.kodi.markdown
@@ -13,7 +13,9 @@ ha_release: 0.29
 ---
 
 
-The `Kodi` platform allows you to send messages to your  [Kodi](https://kodi.tv/) multimedia system from Home Assistant.
+The `kodi` platform allows you to send messages to your [Kodi](https://kodi.tv/) multimedia system from Home Assistant.
+
+## {% linkable_title Configuration %}
 
 To add Kodi to your installation, add the following to your `configuration.yaml` file:
 
@@ -32,7 +34,7 @@ notify:
 - **username** (*Optional*): The XBMC/Kodi HTTP username.
 - **password** (*Optional*): The XBMC/Kodi HTTP password.
 
-### {% linkable_title script.yaml example %}
+### {% linkable_title Script example %}
 
 ```yaml
 kodi_notification:
@@ -55,32 +57,4 @@ kodi_notification:
   - **displaytime** (*Optional*): Length in milliseconds the message stays on screen. *Defaults to `10000` ms*
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
-
-## {% linkable_title Services %}
-
-### {% linkable_title Media control services %}
-Available services: `kodi_add_to_playlist`, `kodi_set_shuffle`
-
-| Service data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            |      yes | Target a specific media player. Defaults to all. |
-
-#### {% linkable_title Service `media_player/kodi_set_shuffle` %}
-
-| Service data attribute | Optional | Description                                              |
-|------------------------|----------|----------------------------------------------------------|
-| `entity_id`            |      yes | Target a specific media player. It must be of type kodi. |
-| `shuffle_on     `      |       no | True/false for shuffle on/off                            |
-
-#### {% linkable_title Service `media_player/kodi_add_to_playlist` %}
-
-Add a song or an entire album to the default playlist (i.e. playlist id 0).
-
-| Service data attribute | Optional | Description                                                                |
-|------------------------|----------|----------------------------------------------------------------------------|
-| `entity_id`            |      yes | Target a specific media player. It must be of type kodi.                   |
-| `media_type     `      |       no | either SONG or ALBUM                                                       |
-|  media_id              |      yes | id of the media as defined in kodi                                         |
-|  media_name            |      yes | name of the media, HA will search for the media with name closer to this. If ALL add all albums, if artist_name is provided adds all albums of that artist.  |
-|  artist_name           |      yes | name of the artist, HA will search for the artist with name closer to this.|
 

--- a/source/_components/notify.smtp.markdown
+++ b/source/_components/notify.smtp.markdown
@@ -26,19 +26,58 @@ notify:
     recipient: YOUR_RECIPIENT
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **sender** (*Required*): E-mail address of the sender.
-- **recipient** (*Required*): E-mail address of the recipient of the notification. This can be a recipient address or a list of addresses for multiple recipients.
-- **server** (*Optional*): SMTP server which is used to end the notifications. Defaults to `localhost`.
-- **port** (*Optional*): The port that the SMTP server is using. Defaults to 587.
-- **timeout** (*Optional*): The timeout in seconds that the SMTP server is using. Defaults to 5.
-- **username** (*Optional*): Username for the SMTP account.
-- **password** (*Optional*): Password for the SMTP server that belongs to the given username. If the password contains a colon it need to be wrapped in apostrophes.
-- **encryption** (*Optional*): Set mode for encryption, `starttls`, `tls` or `none`. Defaults to `starttls`.
-- **sender_name** (*Optional*): Sets a custom 'sender name' in the emails headers (*From*: Custom name <example@mail.com>).
-- **debug** (*Optional*): Enables Debug, eg. True or False. Defaults to False.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  type: string
+  default: notify
+sender:
+  description: E-mail address of the sender.
+  required: true
+  type: string
+recipient:
+  description: E-mail address of the recipient of the notification. This can be a recipient address or a list of addresses for multiple recipients.
+  required: true
+  type: [list, string]
+server:
+  description: SMTP server which is used to end the notifications.
+  required: false
+  type: string
+  default: localhost  
+port:
+  description: The port that the SMTP server is using.  
+  required: false
+  type: integer
+  default: 587
+timeout:
+  description: The timeout in seconds that the SMTP server is using.
+  required: false
+  type: integer
+  default: 5
+username:
+  description: Username for the SMTP account.
+  required: false
+  type: string
+password:
+  description: Password for the SMTP server that belongs to the given username. If the password contains a colon it need to be wrapped in apostrophes.
+  required: false
+  type: string
+encryption:
+  description: Set mode for encryption, `starttls`, `tls` or `none`.
+  required: false
+  type: string
+  default: starttls
+sender_name:
+  description: "Sets a custom 'sender name' in the emails headers (*From*: Custom name <example@mail.com>)."
+  required: false
+  type: string
+debug:  
+  description: Enables Debug, eg. True or False.
+  required: false
+  type: boolean
+  default: false
+{% endconfiguration %}
 
 A sample configuration entry for Google Mail.
 

--- a/source/_components/rflink.markdown
+++ b/source/_components/rflink.markdown
@@ -28,6 +28,8 @@ This component is tested with the following hardware/software:
 
 - Nodo RFLink Gateway V1.4/RFLink R46
 
+## {% linkable_title Configuration %}
+
 To enable RFLink in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -36,15 +38,31 @@ rflink:
   port: /dev/serial/by-id/usb-id01234
 ```
 
-Configuration variables:
+{% configuration %}
+port:
+  description: The path to RFLink USB/serial device or TCP port in TCP mode.
+  required: true
+  type: string
+host:
+  description: Switches to TCP mode, connects to host instead of to USB/serial.
+  required: false
+  type: string
+wait_for_ack:
+  description: Wait for RFLink to acknowledge commands sent before sending new command (slower but more reliable).
+  required: false
+  type: string
+  default: true
+ignore_devices:
+  description: List of device id's to ignore. Supports wildcards (`*`) at the end.
+  required: false
+  type: string
+reconnect_interval:
+  description: Time in seconds between reconnect attempts.
+  required: false
+  type: integer
+{% endconfiguration %}
 
-- **port** (*Required*): The path to RFLink USB/serial device or TCP port in TCP mode.
-- **host** (*Optional*): Switches to TCP mode, connects to host instead of to USB/serial.
-- **wait_for_ack** (*Optional*): Wait for RFLink to acknowledge commands sent before sending new command (slower but more reliable). Defaults to `True`
-- **ignore_devices** (*Optional*): List of device id's to ignore. Supports wildcards (*) at the end.
-- **reconnect_interval** (*Optional*): Time in seconds between reconnect attempts.
-
-Complete example:
+### {% linkable_title Full example %}
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/scsgate.markdown
+++ b/source/_components/scsgate.markdown
@@ -23,9 +23,12 @@ scsgate:
   device: PATH_TO_DEVICE
 ```
 
-Configuration variables:
-
-- **device** (*Required*): The path to your device, e.g., `/dev/ttyACM0`
+{% configuration %}
+device:
+  description: The path to your device, e.g., `/dev/ttyACM0`.
+  required: true
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title How to find the scs_id for your devices %}
 

--- a/source/_components/sensor.fitbit.markdown
+++ b/source/_components/sensor.fitbit.markdown
@@ -32,11 +32,23 @@ Please be aware that Fitbit has very low rate limits, 150 per user per hour. The
 
 The unit system that the sensor will use is based on the country you set in your Fitbit profile.
 
-Configuration variables:
-
-- **monitored_resources** (*Optional*): Resource to monitor. Defaults to `activities/steps`.
-- **clock_format** (*Optional*): Format to use for `sleep/startTime` resource. Accepts `12H` or `24H`. Defaults to `24H`.
-- **unit_system** (*Optional*): Unit system to use for measurements. Accepts `default`, `metric`, `en_US` or `en_GB`. Defaults to `default`.
+{% configuration %}
+monitored_resources:
+  description: Resource to monitor.
+  required: false
+  default: "`activities/steps`"
+  type: list
+clock_format:
+  description: Format to use for `sleep/startTime` resource. Accepts `12H` or `24H`.
+  required: false
+  default: "`24H`"
+  type: string
+unit_system:
+  description: Unit system to use for measurements. Accepts `default`, `metric`, `en_US` or `en_GB`.
+  required: false
+  default: "`default`"
+  type: string
+{% endconfiguration %}
 
 Below is the list of resources that you can add to `monitored_resources`. One sensor is exposed for every resource.
 

--- a/source/_components/sensor.london_air.markdown
+++ b/source/_components/sensor.london_air.markdown
@@ -55,9 +55,13 @@ sensor:
       - Westminster
 ```
 
-Configuration variables:
-
-- **locations** array (*Required*): At least one entry required.
+{% configuration %}
+locations:
+  description: Areas/boroughs in London to monitor.
+  required: false
+  default: All location with data available.
+  type: list
+{% endconfiguration %}
 
 To explore the data available within the `data` attribute of a sensor use the `dev-template` tool on the Home-assistant frontend. `data` contains a list of monitored sites, where the number of monitored sites are given by the `sites` attribute. If a sensor has four sites, access the fourth site by indexing the list of sites using data[3]. Each site is a dictionary with multiple fields, with entries for the `latitude` and `longitude` of that site, a `pollution_status`, `site_code`, `site_name` and `site_type`. The field `number_of_pollutants` states how many pollutants are monitored (of the possible six) and the field `pollutants` returns a list with data for each pollutant. To access the first pollutant in the list for site zero use `attributes.data[0].pollutants[0]`. Each entry in `pollutants` is a dictionary with fields for the pollutant `code`, `description`, `index`, `quality` and a `summary`. [Template sensors](/components/sensor.template/) can then be added to display these attributes, for example:
 

--- a/source/_components/snips.markdown
+++ b/source/_components/snips.markdown
@@ -167,8 +167,6 @@ In the above example, the slots are plain strings. However, Snips has a duration
 
 In this example if we had an intent triggered with 'Set a timer for five minutes', `duration:` would equal 300 and `duration_raw:` would be set to 'five minutes'. The duration can be easily used to trigger Home Assistant events and the `duration_raw:` could be used to send a human readable response or alert. 
 
-In this example if we had an intent triggered with 'Set a timer for five minutes', duration would equal 300 and duration_raw would be set to 'five minutes'. The duration can be easily used to trigger HA events, and the duration_raw could be used to send a human readable response or alert.
-
 {% raw %}
 ```yaml
 SetTimer:

--- a/source/_components/telegram_bot.markdown
+++ b/source/_components/telegram_bot.markdown
@@ -392,9 +392,9 @@ For a more complex usage of the `telegram_bot` capabilities, using [AppDaemon](/
 This is how the previous 4 automations would be through a simple AppDaemon app:
 
 ```python
-import appdaemon.appapi as appapi
+import appdaemon.plugins.hass.hassapi as hass
 
-class TelegramBotEventListener(appapi.AppDaemon):
+class TelegramBotEventListener(hass.Hass):
     """Event listener for Telegram bot events."""
 
     def initialize(self):

--- a/source/_lovelace/thermostat.markdown
+++ b/source/_lovelace/thermostat.markdown
@@ -26,6 +26,11 @@ entity:
   required: true
   description: Entity id of `climate` domain
   type: string
+title:
+  required: false
+  description: Title displayed in the card
+  type: string
+  default: Display name of the entity
 {% endconfiguration %}
 
 ## {% linkable_title Example %}

--- a/source/_posts/2018-10-29-release-81.markdown
+++ b/source/_posts/2018-10-29-release-81.markdown
@@ -94,7 +94,9 @@ Other things to be aware of:
 [cloud docs]: /components/cloud/
 [unifi docs]: /components/unifi/
 
-## {% linkable_title Release 0.81.3 - November 2 %}
+_0.81.3 was skipped because it broke LL._
+
+## {% linkable_title Release 0.81.4 - November 2 %}
 
 - fix naming bug ([@helto4real] - [#17976]) ([weather.smhi docs])
 - Konnected: Pass hass_config to load_platform ([@heythisisnate] - [#18027]) ([konnected docs])

--- a/source/_posts/2018-10-29-release-81.markdown
+++ b/source/_posts/2018-10-29-release-81.markdown
@@ -94,6 +94,32 @@ Other things to be aware of:
 [cloud docs]: /components/cloud/
 [unifi docs]: /components/unifi/
 
+## {% linkable_title Release 0.81.3 - November 2 %}
+
+- fix naming bug ([@helto4real] - [#17976]) ([weather.smhi docs])
+- Konnected: Pass hass_config to load_platform ([@heythisisnate] - [#18027]) ([konnected docs])
+- Change cv.string to [cv.string] ([@awarecan] - [#18050]) ([nest docs])
+- Revert HomeKit update to 2.2.2 ([@cdce8p] - [#18069]) ([homekit docs])
+- Fix time zone for flux switch ([@amelchio] - [#18102]) ([switch.flux docs])
+- Bunch of frontend fixes ([link](https://github.com/home-assistant/home-assistant-polymer/releases/tag/20181026.2))
+- Upgrade pyipma
+
+[#17976]: https://github.com/home-assistant/home-assistant/pull/17976
+[#18027]: https://github.com/home-assistant/home-assistant/pull/18027
+[#18050]: https://github.com/home-assistant/home-assistant/pull/18050
+[#18069]: https://github.com/home-assistant/home-assistant/pull/18069
+[#18102]: https://github.com/home-assistant/home-assistant/pull/18102
+[@amelchio]: https://github.com/amelchio
+[@awarecan]: https://github.com/awarecan
+[@cdce8p]: https://github.com/cdce8p
+[@helto4real]: https://github.com/helto4real
+[@heythisisnate]: https://github.com/heythisisnate
+[homekit docs]: /components/homekit/
+[konnected docs]: /components/konnected/
+[nest docs]: /components/nest/
+[switch.flux docs]: /components/switch.flux/
+[weather.smhi docs]: /components/weather.smhi/
+
 ## {% linkable_title If you need help... %}
 
 ...don't hesitate to use our very active [forums](https://community.home-assistant.io/) or join us for a little [chat](https://discord.gg/c5DvZ4e). The release notes have comments enabled but it's preferred if you use the former communication channels. Thanks.


### PR DESCRIPTION
**Description:**
Add configurable title to Lovelace thermostat card, to match frontend change

**Pull request in ~[home-assistant](https://github.com/home-assistant/home-assistant)~ [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** home-assistant/home-assistant-polymer#1969

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
