### PR TITLE
Add configurable title to Lovelace thermostat card

### DIFF
--- a/source/_lovelace/thermostat.markdown
+++ b/source/_lovelace/thermostat.markdown
@@ -26,6 +26,11 @@ entity:
   required: true
   description: Entity id of `climate` domain
   type: string
+title:
+  required: false
+  description: Title displayed in the card
+  type: string
+  default: Display name of the entity
 {% endconfiguration %}
 
 ## {% linkable_title Example %}


### PR DESCRIPTION
**Description:**
Add configurable title to Lovelace thermostat card, to match frontend change. Messed up the first merge, this one should have just the one change :)

**Pull request in ~[home-assistant](https://github.com/home-assistant/home-assistant)~ [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** home-assistant/home-assistant-polymer#1969

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
