### PR TITLE
Update light.deconz.markdown

### DIFF
--- a/source/_components/light.deconz.markdown
+++ b/source/_components/light.deconz.markdown
@@ -27,3 +27,5 @@ The `entity_id` names will be `light.device_name`, where `device_name` is define
 - OSRAM Gardenpole RGBW
 - Philips Hue White A19
 - Philips Hue White Ambiance A19
+- Philips Hue Hue White ambiance Milliskin (recessed spotlight) LTW013
+- Busch Jaeger ZigBee Light Link univ. relai (6711 U) with ZigBee Light Link control element 6735-84


### PR DESCRIPTION
I am using 3 Milliskin lights and one A19 light from Philips all controlled by Busch Jaeger ZigBee light link equipment. Works fine for me. Thought it could be nice to have this in the docs.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
