### PR TITLE
Remove FFmpeg run_test config

### DIFF
--- a/source/_components/ffmpeg.markdown
+++ b/source/_components/ffmpeg.markdown
@@ -35,11 +35,6 @@ ffmpeg_bin:
   required: false
   default: ffmpeg
   type: string
-run_test:
-  description: Check if `input` is usable by ffmpeg.
-  required: false
-  default: True
-  type: boolean
 {% endconfiguration %}
 
 ### {% linkable_title Raspbian Debian Jessie Lite Installations %}


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18153

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html