### PR TITLE
Add optional ttl configuration for route53 component

### DIFF
--- a/source/_components/route53.markdown
+++ b/source/_components/route53.markdown
@@ -100,4 +100,9 @@ records:
   description: A list of records you want to update.
   required: true
   type: list
+ttl:
+  description: The ttl value for the dns records
+  required: false
+  type: int
+  default: 300
 {% endconfiguration %}

--- a/source/_components/route53.markdown
+++ b/source/_components/route53.markdown
@@ -101,7 +101,7 @@ records:
   required: true
   type: list
 ttl:
-  description: The ttl value for the dns records
+  description: The TTL value for the DNS records.
   required: false
   type: int
   default: 300


### PR DESCRIPTION
**Description:**
Adds an optional ttl configuration for route53 component

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18135

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
