### PR TITLE
Adding some documentation for the services

### DIFF
--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -82,4 +82,16 @@ data_template:
   temperature: {% raw %}{{ 22 - distance(states.device_tracker.paulus) }}{% endraw %}
 ```
 
+### {% linkable_title `homeassistant` services %}
+
+There are four `homeassistant` services that aren't tied to any single domain, these are:
+
+* `homeassistant.turn_on` - Turns on an entity (that supports being turned on), for example an `automation`, `switch`, etc
+* `homeassistant.turn_off` - Turns off an entity (that supports being turned off), for example an `automation`, `switch`, etc
+* `homeassistant.toggle` - Turns off an entity that is on, or turns on an entity that is off (that supports being turned on and off)
+* `homeassistant.update_entity` - Request the update of an entity, rather than waiting for the next scheduled update, for example [google travel time] sensor, a [template sensor], or a [light]
+
 [templating]: /topics/templating/
+[google travel time]: /components/sensor.google_travel_time/
+[template sensor]: /components/sensor.template/
+[light]: /components/light/


### PR DESCRIPTION
As nowhere do we document `homeassistant.update_entity`, or the other `homeassistant` services, it seems overdue that we actually document them.
