### PR TITLE
Update TP Link Switch markdown to include power readings

### DIFF
--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -67,7 +67,6 @@ In order to get the power consumption readings from the HS110, you'll have to cr
 {% raw %}
 ```yaml
 sensor:
-# TP-Link power readings
   - platform: template
     sensors:
       my_tp_switch_amps:

--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -77,17 +77,17 @@ sensor:
         friendly_name_template: "{{ states.switch.my_tp_switch.name}} Current Consumption"
         value_template: '{{ states.switch.my_tp_switch.attributes["current_power_w"] | float }}'
         unit_of_measurement: 'W'
-      my_tp_switch_total_kw:
+      my_tp_switch_total_kwh:
         friendly_name_template: "{{ states.switch.my_tp_switch.name}} Total Consumption"
         value_template: '{{ states.switch.my_tp_switch.attributes["total_energy_kwh"] | float }}'
-        unit_of_measurement: 'kW'
+        unit_of_measurement: 'kWh'
       my_tp_switch_volts:
         friendly_name_template: "{{ states.switch.my_tp_switch.name}} Voltage"
         value_template: '{{ states.switch.my_tp_switch.attributes["voltage"] | float }}'
         unit_of_measurement: 'V'
-      my_tp_switch_todays_kw:
+      my_tp_switch_today_kwh:
         friendly_name_template: "{{ states.switch.my_tp_switch.name}} Today's Consuption"
         value_template: '{{ states.switch.my_tp_switch.attributes["today_energy_kwh"] | float }}'
-        unit_of_measurement: 'kW'
+        unit_of_measurement: 'kWh'
 ```
 {% endraw %}

--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -22,6 +22,8 @@ Supported units:
 - HS110
 - HS200
 
+## {% linkable_title Configuration %}
+
 To use your TP-Link switch or socket in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -62,7 +64,7 @@ switch:
 
 ## {% linkable_title Configure Energy Sensors %} ##
 
-In order to get the power consumption readings from the HS110, you'll have to create a [template sensor](https://www.home-assistant.io/components/switch.template/). In the example below, change all of the `my_tp_switch`'s to match your switch's entity ID.
+In order to get the power consumption readings from the HS110, you'll have to create a [template sensor](/components/switch.template/). In the example below, change all of the `my_tp_switch`'s to match your switch's entity ID.
 
 {% raw %}
 ```yaml

--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -71,20 +71,24 @@ sensor:
   - platform: template
     sensors:
       my_tp_switch_amps:
-        friendly_name: Current
-        value_template: '{{ states.switch.my_tp_switch.attributes["Current"] | replace(" A", "") | float }}'
+        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Current"
+        value_template: '{{ states.switch.my_tp_switch.attributes["current_a"] | float }}'
         unit_of_measurement: 'A'
       my_tp_switch_watts:
-        friendly_name: Current Consumption
-        value_template: '{{ states.switch.my_tp_switch.attributes["Current consumption"] | replace(" W", "") | float }}'
+        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Current Consumption"
+        value_template: '{{ states.switch.my_tp_switch.attributes["current_power_w"] | float }}'
         unit_of_measurement: 'W'
-      my_tp_switch_kw:
-        friendly_name: Total Consumption 
-        value_template: '{{ states.switch.my_tp_switch.attributes["Total consumption"] | replace(" kW", "") | float }}'
+      my_tp_switch_total_kw:
+        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Total Consumption"
+        value_template: '{{ states.switch.my_tp_switch.attributes["total_energy_kwh"] | float }}'
         unit_of_measurement: 'kW'
       my_tp_switch_volts:
-        friendly_name: Voltage
-        value_template: '{{ states.switch.my_tp_switch.attributes["Voltage"] | replace(" V", "") | float }}'
+        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Voltage"
+        value_template: '{{ states.switch.my_tp_switch.attributes["voltage"] | float }}'
         unit_of_measurement: 'V'
+      my_tp_switch_todays_kw:
+        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Today's Consuption"
+        value_template: '{{ states.switch.my_tp_switch.attributes["today_energy_kwh"] | float }}'
+        unit_of_measurement: 'kW'
 ```
 {% endraw %}

--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -59,3 +59,32 @@ switch:
   - platform: tplink
     host: SECOND_IP_ADDRESS
 ```
+
+## {% linkable_title Configure Energy Sensors %} ##
+
+In order to get the power consumption readings from the HS110, you'll have to create a [template sensor](https://www.home-assistant.io/components/switch.template/). In the example below, change all of the `my_tp_switch`'s to match your switch's entity ID.
+
+{% raw %}
+```yaml
+sensor:
+# TP-Link power readings
+  - platform: template
+    sensors:
+      my_tp_switch_amps:
+        friendly_name: Current
+        value_template: '{{ states.switch.my_tp_switch.attributes["Current"] | replace(" A", "") | float }}'
+        unit_of_measurement: 'A'
+      my_tp_switch_watts:
+        friendly_name: Current Consumption
+        value_template: '{{ states.switch.my_tp_switch.attributes["Current consumption"] | replace(" W", "") | float }}'
+        unit_of_measurement: 'W'
+      my_tp_switch_kw:
+        friendly_name: Total Consumption 
+        value_template: '{{ states.switch.my_tp_switch.attributes["Total consumption"] | replace(" kW", "") | float }}'
+        unit_of_measurement: 'kW'
+      my_tp_switch_volts:
+        friendly_name: Voltage
+        value_template: '{{ states.switch.my_tp_switch.attributes["Voltage"] | replace(" V", "") | float }}'
+        unit_of_measurement: 'V'
+```
+{% endraw %}


### PR DESCRIPTION
Update the markdown to include how to retrieve power readings from a switch that has Energy Monitoring features, such as the HS110 https://www.tp-link.com/us/products/details/cat-5516_HS110.html

Original credit: https://community.home-assistant.io/t/tplink-hs110-switch-use-energy-consumption-as-sensor/5316/2

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
