### PR TITLE
additional warning for broken dependency

### DIFF
--- a/source/_components/device_tracker.google_maps.markdown
+++ b/source/_components/device_tracker.google_maps.markdown
@@ -12,6 +12,10 @@ ha_release: 0.67
 ha_category: Presence Detection
 ha_iot_class: "Cloud Polling"
 ---
+<p class='note warning'>
+This component is currently broken (November 2018, v0.81.6) due to an upstream dependency bug, see here: https://github.com/costastf/locationsharinglib/issues/42 and here: https://github.com/home-assistant/home-assistant/issues/17410 
+</p>
+
 
 The `google_maps` platform allows you to detect presence using the unofficial API of [Google Maps Location Sharing](https://myaccount.google.com/locationsharing).
 


### PR DESCRIPTION
**Description:**
The dependency "locationsharinglib" is currently broken and does not pick up shared locations. 

A fix in the works, but not verified or merged yet. This bug has been present for over a month so wiki should be updated to reflect the issue so as not to confuse new users.

Only one file changed: source/_components/device_tracker.google_maps.markdown.

Added in single line: 
This component is currently broken (November 2018, v0.81.6) due to an upstream dependency bug, see here: https://github.com/costastf/locationsharinglib/issues/42 and here: https://github.com/home-assistant/home-assistant/issues/17410 


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].


[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
