### PR TITLE
Add documentation for google assistant locks

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -124,6 +124,11 @@ project_id:
   description: Project ID from the Actions on Google console (looks like `words-2ab12`)
   required: true
   type: string
+allow_unlock:
+  description: "When True, allows Google Assistant to unlock locks."
+  required: false
+  type: boolean
+  default: False
 api_key:
   description: Your API key.
   required: false
@@ -176,6 +181,7 @@ Currently, the following domains are available to be used with Google Assistant,
 - switch (on/off)
 - fan (on/off)
 - light (on/off/brightness/rgb color/color temp)
+- lock (lock/unlock (to allow assistant to unlock, set the `allow_unlock` key in configuration))
 - cover (on/off/set position (via set brightness))
 - media_player (on/off/set volume (via set brightness))
 - climate (temperature setting)


### PR DESCRIPTION
Adds documentation for un-merged PR: home-assistant/home-assistant#18233

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18233

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
