### PR TITLE
Update Birth_will MQTT component configuration

### DIFF
--- a/source/_docs/mqtt/birth_will.markdown
+++ b/source/_docs/mqtt/birth_will.markdown
@@ -25,15 +25,51 @@ mqtt:
     payload: 'offline'
 ```
 
-Configuration variables:
-
-- **birth_message** (*Optional*):
-  - **topic** (*Required*): The MQTT topic to publish the message.
-  - **payload** (*Required*): The message content.
-  - **qos** (*Optional*): The maximum QoS level of the topic. Default is 0.
-  - **retain** (*Optional*): If the published message should have the retain flag on or not. Defaults to `True`.
-- **will_message** (*Optional*):
-  - **topic** (*Required*): The MQTT topic to publish the message.
-  - **payload** (*Required*): The message content.
-  - **qos** (*Optional*): The maximum QoS level of the topic. Default is 0.
-  - **retain** (*Optional*): If the published message should have the retain flag on or not. Defaults to `True`.
+{% configuration %}
+birth_message:
+  description: Birth Message.
+  required: false
+  type: list
+  keys:
+    topic:
+      description: The MQTT topic to publish the message.
+      required: true
+      type: string
+    payload:
+      description: The message content.
+      required: true
+      type: string
+    qos:
+      description: The maximum QoS level of the topic.
+      required: false
+      default: 0
+      type: integer
+    retain:
+      description: If the published message should have the retain flag on or not.
+      required: false
+      default: true
+      type: boolean
+will_message:
+  description: Will Message
+  required: false
+  type: list
+  keys:
+    topic:
+      description: The MQTT topic to publish the message.
+      required: true
+      type: string
+    payload:
+      description: The message content.
+      required: true
+      type: string
+    qos:
+      description: The maximum QoS level of the topic.
+      required: false
+      default: 0
+      type: integer
+    retain:
+      description: If the published message should have the retain flag on or not.
+      required: false
+      default: true
+      type: boolean
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Birth_will MQTT component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
