### PR TITLE
Added Lovelace info to the dev-tools page

### DIFF
--- a/source/_docs/tools/dev-tools.markdown
+++ b/source/_docs/tools/dev-tools.markdown
@@ -101,3 +101,6 @@ Even though MQTT in general provides deeper functionality, the developer tools s
 {% linkable_title Info %}
 
 The Information tab simply provides information about the current installed version, additional links and credits. The tab also contains a section that shows `syslog` information, and the contents of `home-assistant.log` with an option to clear and refresh the logs.
+
+The Information tab also allows makes it possible to try out the Lovelace User Interface (UI) by clicking "Try out the new Lovelace UI (experimental)" or set Lovelace as the default UI, so that when the "Overview" link in the Sidebar is selected, the Lovelace UI will load by default.
+


### PR DESCRIPTION
I've added a paragraph in the dev-tools page mentioning that it's possible to both try Lovelace and set it as the default UI, as this I not mentioned in the docs. I understand if this PR needs to re-filled under the next branch.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
