### PR TITLE
Update Fritzbox component configuration

### DIFF
--- a/source/_components/sensor.fritzbox_callmonitor.markdown
+++ b/source/_components/sensor.fritzbox_callmonitor.markdown
@@ -13,7 +13,6 @@ ha_release: 0.27
 ha_iot_class: "Local Polling"
 ---
 
-
 The `fritzbox_callmonitor` sensor monitors the call monitor exposed by [AVM Fritz!Box](http://avm.de/produkte/fritzbox/) routers on TCP port 1012. It will assume the values `idle`, `ringing`, `dialing` or `talking` with the phone numbers involved contained in the state attributes.
 It can also access the internal phone book of the router to look up the names corresponding to the phone numbers and store them in the state attributes.
 
@@ -41,14 +40,40 @@ sensor:
   - platform: fritzbox_callmonitor
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The IP address of your router, eg. 192.168.1.1. It is optional since every fritzbox is also reachable by using the IP address 169.254.1.1.
-- **port** (*Optional*): The TCP port of the call monitor. There is usually no reason to change this.
-- **username** (*Optional*): Fritz!Box user's user name. This is required to use the phone book lookup feature. The user needs to have the "voice message, fax message, Fritz!App Fon and call list" permission.
-- **password** (*Optional*): Fritz!Box user's user password. This is required to use the phone book lookup feature.
-- **phonebook** (*Optional*): Numerical ID identifying the phonebook to be used. If there is just one phonebook, this is usually 0.
-- **prefixes** (*Optional*): In case of a local call, the phone number seen by the router might differ from the one stored in the phone book by an area code, similarly for the international prefix. To remedy this, a list of prefixes, that can be appended to the phone number in case it is not found in the phone book, can be given.
+{% configuration %}
+name:
+  description: Give the sensor a friendly name for in the front-end.
+  required: false
+  default: Phone
+  type: string
+host:
+  description: The IP address of your router, e.g., 192.168.1.1. It is optional since every fritzbox is also reachable by using the IP address 169.254.1.1.
+  required: false
+  default: 169.254.1.1
+  type: string
+port:
+  description: The TCP port of the call monitor. There is usually no reason to change this.
+  required: false
+  default: 1012
+  type: integer
+username:
+  description: Fritz!Box user's user name. This is required to use the phone book lookup feature. The user needs to have the "voice message, fax message, Fritz!App Fon and call list" permission.
+  required: false
+  type: string
+password:
+  description: Fritz!Box user's user password. This is required to use the phone book lookup feature.
+  required: false
+  type: string
+phonebook:
+  description: Numerical ID identifying the phonebook to be used. If there is just one phonebook, this is usually 0.
+  required: false
+  default: 0
+  type: integer
+prefixes:
+  description: In case of a local call, the phone number seen by the router might differ from the one stored in the phone book by an area code, similarly for the international prefix. To remedy this, a list of prefixes, that can be appended to the phone number in case it is not found in the phone book, can be given.
+  required: false
+  type: list
+{% endconfiguration %}
 
 ## {% linkable_title Examples %}
 

--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -28,9 +28,18 @@ sensor:
   - platform: fritzbox_netmonitor
 ```
 
-Configuration variables:
-
-- **host** (*Optional*): The IP address of your router, eg. 192.168.1.1. It is optional since every fritzbox is also reachable by using the IP address 169.254.1.1.
+{% configuration %}
+host:
+  description: The IP address of your router, e.g., 192.168.1.1. It is optional since every fritzbox is also reachable by using the IP address 169.254.1.1.
+  required: false
+  default: 169.254.1.1
+  type: string
+name:
+  description: Give the sensor a friendly name for in the front-end.
+  required: false
+  default: fritz_netmonitor
+  type: string
+{% endconfiguration %}
 
 The following statistics will be exposed as attributes.
 


### PR DESCRIPTION
**Description:**
Update style of Fritzbox component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
