### PR TITLE
Update Russound_rio media_player component configuration

### DIFF
--- a/source/_components/media_player.russound_rio.markdown
+++ b/source/_components/media_player.russound_rio.markdown
@@ -27,8 +27,18 @@ media_player:
     name: Russound
 ```
 
-Configuration variables:
-
-- **host** (*Required*): The IP of the TCP gateway
-- **port** (*Optional*): The port of the TCP gateway (default: 9621)
-- **name** (*Required*): The name of the device
+{% configuration %}
+host:
+  description: The IP of the TCP gateway.
+  required: true
+  type: string
+port:
+  description: The port of the TCP gateway.
+  required: false
+  default: 9621
+  type: integer
+name:
+  description: The name of the device.
+  required: true
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of Russound_rio media_player component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
