### PR TITLE
Update Gntp notify component configuration

### DIFF
--- a/source/_components/notify.gntp.markdown
+++ b/source/_components/notify.gntp.markdown
@@ -12,7 +12,6 @@ ha_category: Notifications
 ha_release: 0.16
 ---
 
-
 [GNTP](http://www.growlforwindows.com/gfw/help/gntp.aspx) is a specification for sending and receiving notifications between computers. The most well known server implementations are [Growl](http://growl.info) for Mac and [Growl for Windows](http://www.growlforwindows.com/gfw/).
 
 To use GNTP notifications, add the following to your `configuration.yaml` file:
@@ -26,13 +25,35 @@ notify:
 
 GNTP will attempt to connect to a local server running on port 23053 if no `hostname` is provided.
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **app_name** (*Optional*): The application name that will be displayed on every notification and will be registered with the server.
-- **app_icon** (*Optional*): The icon that will be displayed on every notification. You can provide an HTTP URL or a `file://` URL. File URLs only work if Home Assistant and the GNTP server are running on the same machine. If no `app_icon` is set a local copy of the Home Assistant logo will be used. If you choose to use an HTTP URL please make the maximum image size 150 px by 150 px as Growl for Mac will sometimes timeout when registering.
-- **hostname** (*Optional*): The hostname or IP address of the GNTP server to contact.
-- **password** (*Optional*): The password to authenticate to the GNTP server with.
-- **port** (*Optional*): The port that the GNTP server runs on. The specification states that servers should not allow users to use any port other than 23053 but `port` is provided here just in case.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+app_name:
+  description: The application name that will be displayed on every notification and will be registered with the server.
+  required: false
+  default: HomeAssistant
+  type: string
+app_icon:
+  description: "The icon that will be displayed on every notification. You can provide an HTTP URL or a `file://` URL. File URLs only work if Home Assistant and the GNTP server are running on the same machine. If no `app_icon` is set a local copy of the Home Assistant logo will be used. If you choose to use an HTTP URL please make the maximum image size 150 px by 150 px as Growl for Mac will sometimes timeout when registering."
+  required: false
+  type: string
+hostname:
+  description: The hostname or IP address of the GNTP server to contact.
+  required: false
+  default: localhost
+  type: string
+password:
+  description: The password to authenticate to the GNTP server with.
+  required: false
+  type: string
+port:
+  description: The port that the GNTP server runs on. The specification states that servers should not allow users to use any port other than 23053 but `port` is provided here just in case.
+  required: false
+  default: 23053
+  type: integer
+{% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).


### PR DESCRIPTION
**Description:**
Update style of Gntp notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
