### PR TITLE
Updated scan_interval documentation

### DIFF
--- a/source/_components/tesla.markdown
+++ b/source/_components/tesla.markdown
@@ -44,7 +44,7 @@ password:
   required: true
   type: string
 scan_interval:
-  description: API polling interval. Minimal value can't be less then 300.
+  description: API polling interval in seconds. Minimum value can't be less than 300 (5 minutes). Very frequent polling can use battery.
   required: false
   type: integer
   default: 300


### PR DESCRIPTION
Minor changes to clarity (primary addition was clarifying this was in seconds). I've read on the forums frequent teslafi polling has impacted battery, but I don't have exact statistics to support this.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
