### PR TITLE
Added Lutron Homeworks documentation

### DIFF
--- a/source/_components/binary_sensor.homeworks.markdown
+++ b/source/_components/binary_sensor.homeworks.markdown
@@ -1,0 +1,68 @@
+---
+layout: page
+title: "Homeworks Keypads"
+description: "How to use Lutron Homeworks Series 4 & 8 keypads."
+date: 2018-10-05 23:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: lutron.png
+ha_category: Binary Sensor 
+featured: false
+ha_release: 0.01
+ha_iot_class: "Local Polling"
+---
+
+To enable this sensor, you first have to set up [homeworks](/components/homeworks/), and add the following lines to your `configuration.yaml` file"
+
+```yaml
+# Example configuration.yaml` entry
+binary_sensor:
+  - platform: homeworks
+    keypads:
+      - addr: "[02:08:02:03]"
+        name: "First Keypad"
+        buttons:
+            1: "Button1"
+            2: "Button2"
+            6: "Button6"
+      - addr: "[02:08:02:04]"
+        name: "Second Keypad"
+        buttons:
+            1: "Close Something"
+            2: "Open Something"
+```
+
+{% configuration %}
+keypads:
+  description: A list of Homeworks keypads described below.
+  required: true
+  type: list 
+  keys:
+    addr:
+      description: The unique address of the keypad on the controller.  The quotes, brackets, and number formatting must be of the form `"[##:##:##:##]"`.
+      required: true
+      type: string
+    name:
+      description: The components name is the title of the button + "\_" + the name of the keypad.
+      required: true
+      type: string
+    buttons:
+      description: A list of buttons on a keypad.
+      required: true
+      type: list
+      keys:
+        num:
+          description: The number of the button on the keypad (starting at 1).
+          required: true
+          type: int
+        title:
+          description: The title of the button on the keypad.
+          required: true
+          type: string
+{% endconfiguration %}
+
+<p class='note'>
+Homeworks keypad buttons are momentary switches.  The button is pressed and released, meaning that the state is only "on" for a short period.  Buttons generate `button_pressed` events to make it easier to deal with the rapid transitions.  These events contain the "entity_id" of the button that was pressed.
+</p>

--- a/source/_components/homeworks.markdown
+++ b/source/_components/homeworks.markdown
@@ -1,0 +1,45 @@
+---
+layout: page
+title: "Homeworks Hub"
+description: "How to use Lutron Homeworks Series 4 & 8 with Home Assistant."
+date: 2018-10-05 23:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: lutron.png
+ha_category: Hub
+featured: False
+ha_release: 0.01
+ha_iot_class: "Local Polling"
+---
+
+[Lutron](http://www.lutron.com/) is an American lighting control company. The Lutron Homeworks Series 4 & 8 systems are relatively old (~2003), and use RS-232 connections to communicate with home automation systems.  The `homeworks` component in Home Assistant is responsible for communicating with the main controller for these systems.  Communication is through an ethernet to serial convertor (NPort, for example).
+
+Only a subset of the Homeworks system is supported - lights and keypads.
+
+There is another component [lutron](/components/lutron/) which controls the Lutron RadioRA 2 system.
+
+## {% linkable_title Configuration %}
+
+When configured, the `homeworks` component cannot automatically discover any information from the controller.  Unfortunately, the protocol for extracting this information is not documented.  Each device has to be declared in order for it to be controlled.
+
+To use Lutron Homeworks devices in your installation, add the following to your `configuration.yaml` file:
+
+``` yaml
+# Example configuration.yaml entry
+homeworks:
+  host: IP_ADDRESS
+  port: 4001
+```
+
+{% configuration %}
+host:
+  description: The IP address of the ethernet to serial adapter.  It is assumed that the adaptor has been preconfigured.
+  required: true
+  type: string
+port:
+  description: The port of the ethernet to serial adapter.
+  required: true
+  type: port
+{% endconfiguration %}

--- a/source/_components/light.homeworks.markdown
+++ b/source/_components/light.homeworks.markdown
@@ -1,0 +1,52 @@
+---
+layout: page
+title: "Homeworks Light"
+description: "How to use Lutron Homeworks Series 4 & 8 lights."
+date: 2018-10-05 23:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: lutron.png
+ha_category: Light
+featured: false
+ha_release: 0.01
+ha_iot_class: "Local Polling"
+---
+
+To enable this sensor, you first have to set up [homeworks](/components/homeworks/), and add the following lines to your `configuration.yaml` file"
+
+```yaml
+# Example configuration.yaml` entry
+light:
+  - platform: homeworks
+    dimmers:
+      - addr: "[02:08:02:13]"
+        name: "Slow Light"
+        rate: 3.5
+      - addr: "[02:08:02:14]"
+        name: "Fast Light"
+        rate: 0
+      - addr: "[02:08:02:15]"
+        name: "Default Light"
+```
+
+{% configuration %}
+dimmers:
+  description: A list of Homeworks light switches of any kind (simple on/off units or dimmers).
+  required: true
+  type: list 
+  keys:
+    addr:
+      description: The unique address of the dimmer on the controller.  The quotes, brackets, and number formatting must be of the form `"[##:##:##:##]"`.
+      required: true
+      type: string
+    name:
+      description: The name of the sensor will be the title of the button +`"_"` + the name of the keypad/
+      required: true
+      type: string
+    rate:
+      description: The amount of time it takes for the light to transition to a new brightness level.
+      required: false
+      type: float
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Document the components that connect Lutron Homeworks series 4 and 8 lighting systems to Home Assistant.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
