### PR TITLE
Fix default name for version

### DIFF
--- a/source/_components/sensor.version.markdown
+++ b/source/_components/sensor.version.markdown
@@ -31,7 +31,7 @@ name:
   description: Name to use in the frontend.
   required: false
   type: string
-  default: `Current Version` in case of `source: local`, `Latest Version` otherwise
+  default: "`Current Version` in case of `source: local`, `Latest Version` otherwise"
 beta:
   description: Flag to indicate that it will check for beta versions, only supported for the sources `pypi`, `hassio` and `docker`.
   required: false

--- a/source/_components/sensor.version.markdown
+++ b/source/_components/sensor.version.markdown
@@ -31,7 +31,7 @@ name:
   description: Name to use in the frontend.
   required: false
   type: string
-  default: Home Assistant Version
+  default: `Current Version` in case of `source: local`, `Latest Version` otherwise
 beta:
   description: Flag to indicate that it will check for beta versions, only supported for the sources `pypi`, `hassio` and `docker`.
   required: false


### PR DESCRIPTION
**Description:**
Still stated `Home Assistant Version` as default name while it was reversed in a later commit to maintain compatibility in existing configurations.
Also updated to declare the default name when using the new functionality.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/18292

*should be cherry-picked for the beta 0.82 release*

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
