### PR TITLE
Update alert.markdown

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -42,8 +42,8 @@ alert:
     entity_id: input_boolean.garage_door
     state: 'on'
     repeat: 30
-    can_acknowledge: True
-    skip_first: True
+    can_acknowledge: true
+    skip_first: true
     notifiers:
       - ryans_phone
       - kristens_phone
@@ -103,7 +103,7 @@ notifiers:
 In this example, the garage door status (`input_boolean.garage_door`) is watched
 and this alert will be triggered when its status is equal to `on`.
 This indicates that the door has been opened. Because the `skip_first` option
-was set to `True`, the first notification will not be delivered immediately.
+was set to `true`, the first notification will not be delivered immediately.
 However, every 30 minutes, a notification will be delivered until either
 `input_boolean.garage_door` no longer has a state of `on` or until the alert is
 acknowledged using the Home Assistant frontend.
@@ -125,15 +125,16 @@ provided by the `alert` component:
 ```
 
 ```yaml
-freshwater_temp_alert:
-  name: "Warning: I have detected a problem with the freshwater tank temperature"
-  entity_id: binary_sensor.freshwater_temperature_status
-  state: 'on'
-  repeat: 5
-  can_acknowledge: true
-  skip_first: false
-  notifiers:
-    - john_phone_sms
+alert:
+  freshwater_temp_alert:
+    name: "Warning: I have detected a problem with the freshwater tank temperature"
+    entity_id: binary_sensor.freshwater_temperature_status
+    state: 'on'
+    repeat: 5
+    can_acknowledge: true
+    skip_first: false
+    notifiers:
+      - john_phone_sms
 ```
 
 ### {% linkable_title Complex Alert Criteria %}
@@ -146,12 +147,13 @@ disable the alert on certain days. Maybe the alert firing should depend on more
 than one input. For all of these situations, it is best to use the alert in
 conjunction with a `Template Binary Sensor`. The following example does that.
 
+{% raw %}
 ```yaml
 binary_sensor:
   - platform: template
     sensors:
       motion_battery_low:
-        value_template: {% raw %}'{{ states.sensor.motion.attributes.battery < 15 }}'{% endraw %}
+        value_template: '{{ states.sensor.motion.attributes.battery < 15 }}'
         friendly_name: 'Motion battery is low'
 
 alert:
@@ -163,6 +165,7 @@ alert:
       - ryans_phone
       - kristens_phone
 ```
+{% endraw %}
 
 This example will begin firing as soon as the entity `sensor.motion`'s `battery`
 attribute falls below 15. It will continue to fire until the battery attribute
@@ -186,8 +189,8 @@ alert:
       - 15
       - 30
       - 60
-    can_acknowledge: True  # Optional, default is True
-    skip_first: True  # Optional, false is the default
+    can_acknowledge: true  # Optional, default is true
+    skip_first: true  # Optional, false is the default
     notifiers:
       - ryans_phone
       - kristens_phone
@@ -206,21 +209,24 @@ about the state of the entity.
 The following will show for a plant how to include the problem `attribute`
 of the entity.
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
+alert:
   office_plant:
     name: Plant in office needs help
     entity_id: plant.plant_office
     state: 'problem'
     repeat: 30
-    can_acknowledge: True
-    skip_first: True
+    can_acknowledge: true
+    skip_first: true
     message: "Plant {{ states.plant.plant_office }} needs help ({{ state_attr('plant.plant_office', 'problem') }})"
     done_message: Plant in office is fine
     notifiers:
       - ryans_phone
       - kristens_phone
 ```
+{% endraw %}
 
 The resulting message could be `Plant Officeplant needs help (moisture low)`.
 


### PR DESCRIPTION
**Description:**
Adds the missing `{% raw %}`-tags that slipped in in https://github.com/home-assistant/home-assistant.io/pull/6859;
also changed boolean values to lowercase and improved examples.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here> **NA**

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
