### PR TITLE
Update hangouts.markdown

### DIFF
--- a/source/_components/hangouts.markdown
+++ b/source/_components/hangouts.markdown
@@ -105,6 +105,7 @@ The intent `HangoutsHelp` is part of the component and return a list of all sent
 
 ## {% linkable_title Adding sentences %}
 
+{% raw %}
 ```yaml
 # The Hangouts component
 hangouts:
@@ -123,9 +124,9 @@ hangouts:
 intent_script:
   Ping:
     speech:
-      text: I know {% raw %}{{ states.hangouts.conversations.state }}{% endraw %} conversations
-
+      text: I know {{ states.hangouts.conversations.state }} conversations
 ```
+{% endraw %}
 
 This configuration will:
 - Toggle the light in the given location in a specific conversation.
@@ -144,6 +145,7 @@ The following configuration can handle the following sentences:
  - Change the lights to the color green
  - Change the lights to the color blue
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 hangouts:
@@ -151,7 +153,7 @@ hangouts:
     ColorLight:
       sentences:
         - Change the lights to [the color] {color}
-{% raw %}
+
 intent_script:
   ColorLight:
     speech:
@@ -163,8 +165,8 @@ intent_script:
           - "{% if color == 'red' %}255{% else %}0{% endif %}"
           - "{% if color == 'green' %}255{% else %}0{% endif %}"
           - "{% if color == 'blue' %}255{% else %}0{% endif %}"
-{% endraw %}
 ```
+{% endraw %}
 
 ## {% linkable_title Services %}
 
@@ -201,6 +203,7 @@ Reconnects the hangouts bot.
 
 The hangouts component can't detect if your ip address changes, so it can't automatic reconnect to the Google servers. This is a workaround for this problem.
 
+{% raw %}
 ```yaml
 sensor:
   - platform: rest
@@ -222,3 +225,4 @@ automation:
     action:
       - service: hangouts.reconnect
 ```
+{% endraw %}


### PR DESCRIPTION
**Description:**
Adds the missing {% raw %}-tags that slipped in in https://github.com/home-assistant/home-assistant.io/pull/7347.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here> **NA**

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
