### PR TITLE
Update coinbase.markdown with new docs

### DIFF
--- a/source/_components/coinbase.markdown
+++ b/source/_components/coinbase.markdown
@@ -49,3 +49,21 @@ exchange_rate_currencies:
 {% endconfiguration %}
 
 Possible currencies are codes that conform to the ISO 4217 standard where possible. Currencies which have or had no representation in ISO 4217 may use a custom code (e.g. BTC). A list of values can be obtained via https://api.coinbase.com/v2/currencies, for more information visit [the Coinbase API documentation](https://developers.coinbase.com/api/v2#get-currencies).
+
+## {% linkable_title Full configuration example %}
+
+A full configuration sample including optional variables:
+
+```yaml
+# Example configuration.yaml entry
+coinbase:
+  api_key: YOUR_API_KEY
+  api_secret: YOUR_API_SECRET
+  account_balance_currencies:
+    - EUR
+    - BTC
+  exchange_rate_currencies:
+    - BTC
+    - ETH
+    - LTC
+```

--- a/source/_components/coinbase.markdown
+++ b/source/_components/coinbase.markdown
@@ -13,7 +13,6 @@ ha_release: 0.61
 ha_iot_class: "Cloud Polling"
 ---
 
-
 The `coinbase` component lets you access account balances and exchange rates from [coinbase](https://coinbase.com).
 
 You will need to obtain an API key from coinbase's [developer site](https://www.coinbase.com/settings/api) to use this component. You need to give read access to `wallet:accounts` in order for the component to access relevant data. 
@@ -25,12 +24,8 @@ To set it up, add the following information to your `configuration.yaml` file:
 ```yaml
 # Example configuration.yaml entry
 coinbase:
-  api_key: YOUR_API_KEY 
-  api_secret: YOUR_API_SECRET 
-  exchange_rate_currencies:
-    - BTC
-    - ETH
-    - LTC
+  api_key: YOUR_API_KEY
+  api_secret: YOUR_API_SECRET
 ```
 
 {% configuration %}
@@ -42,8 +37,15 @@ api_secret:
   description: Your API secret to access coinbase.
   required: true
   type: string
+account_balance_currencies:
+  description: List of currencies to create account wallet sensors for.
+  required: false
+  type: list
+  default: all account wallets
 exchange_rate_currencies:
   description: List of currencies to create exchange rate sensors for.
   required: false
   type: list
 {% endconfiguration %}
+
+Possible currencies are codes that conform to the ISO 4217 standard where possible. Currencies which have or had no representation in ISO 4217 may use a custom code (e.g. BTC). A list of values can be obtained via https://api.coinbase.com/v2/currencies, for more information visit [the Coinbase API documentation](https://developers.coinbase.com/api/v2#get-currencies).


### PR DESCRIPTION
**Description:**
Add documentation for the new `account_balance_currencies` option.
Also makes the example configuration minimal and deletes trailing spaces.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/18167

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
