### PR TITLE
Fix remember_the_milk component configuration

### DIFF
--- a/source/_components/remember_the_milk.markdown
+++ b/source/_components/remember_the_milk.markdown
@@ -32,8 +32,6 @@ remember_the_milk:
 
 ```
 
-Configuration variables:
-
 {% configuration %}
   name:
     description: Name of the RTM account, as you can have several accounts in RTM. The name must be unique.
@@ -70,7 +68,7 @@ The task creation supports the "smart syntax", so to create a task with the tag 
 **Note:**
 At the moment, smart syntax is *not* supported when updating tasks. All smart syntax commands are ignored during the update and will end up as normal text in the name of the task.
 
-|Service data attribute	| Optional | Description | Example |
+|Service data attribute | Optional | Description | Example |
 |-----------------------|----------|-------------|---------|
 | name | no  | Name of the new task, you can use the smart syntax here. | "do this ^today #from_hass" |
 | id   | yes | Identifier for the task you're creating, can be used to update or complete the task later on | "myid" |
@@ -79,16 +77,15 @@ At the moment, smart syntax is *not* supported when updating tasks. All smart sy
 
 Complete a tasks that was privously created from Home Assistant. You can not complete tasks that were created outside of Home Assistant.
 
-If you have created your task with an ```id```, calling ```<account>_complete_task``` with the parameter ```id``` will then complete your task. 
+If you have created your task with an ```id```, calling ```<account>_complete_task``` with the parameter ```id``` will then complete your task.
 
-|Service data attribute	| Optional | Description | Example |
+|Service data attribute | Optional | Description | Example |
 |-----------------------|----------|-------------|---------|
 | id | no | Identifier that was defined when creating the task | "myid" |
 
 ## {% linkable_title Automation example %}
 
 Here's an example for an automation that creates a new task whenever ```sensor.mysensor``` is ```on``` and completes it when the sensor reports ```off```. This way it reminds you to switch it off. By using the ```entity_id``` as id for the task, you can use the same rule also for multiple sensors.
-
 
 ```yaml
 - id: mysensor_on
@@ -113,7 +110,6 @@ Here's an example for an automation that creates a new task whenever ```sensor.m
 
 ```
 
-
-
 ## {% linkable_title Disclaimer %}
+
 This product uses the Remember The Milk API but is not endorsed or certified by Remember The Milk.


### PR DESCRIPTION
**Description:**
Fix style of remember_the_milk component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
