### PR TITLE
Add the service `lock.open` to the docs

### DIFF
--- a/source/_components/lock.markdown
+++ b/source/_components/lock.markdown
@@ -12,7 +12,7 @@ footer: true
 Keeps track which locks are in your environment, their state and allows you to control them.
 
  * Maintains a state per lock and a combined state `all_locks`.
- * Registers services `lock.lock` and `lock.unlock` to control locks.
+ * Registers services `lock.lock`, `lock.unlock` and `lock.open` (unlatch) to control locks.
 
 ### {% linkable_title Services %}
 
@@ -54,7 +54,7 @@ action:
 
 ### {% linkable_title Use the services %}
 
-Go to the **Developer Tools**, then to **Call Service** in the frontend, and choose `lock.lock` or `lock.unlock` from the list of available services (**Services:** on the left). Enter something like the sample below into the **Service Data** field and hit **CALL SERVICE**.
+Go to the **Developer Tools**, then to **Call Service** in the frontend, and choose `lock.lock`, `lock.unlock` or `lock.open` from the list of available services (**Services:** on the left). Enter something like the sample below into the **Service Data** field and hit **CALL SERVICE**.
 
 ```json
 {"entity_id":"lock.front_door"}


### PR DESCRIPTION

**Description:**
Document the `lock.open` service.  It is already implemented, so probably it should be documented.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
