### PR TITLE
Added supported Netatmo devices

### DIFF
--- a/source/_components/sensor.netatmo.markdown
+++ b/source/_components/sensor.netatmo.markdown
@@ -14,7 +14,8 @@ ha_iot_class: "Cloud Polling"
 
 ### {% linkable_title Basic Configuration %}
 
-The `netatmo` sensor platform is consuming the information provided by a [Netatmo](https://www.netatmo.com) device.
+The `netatmo` sensor platform is consuming the information provided by a [Netatmo Weather Station](https://www.netatmo.com/en-us/weather/weatherstation) or a 
+[Netatmo Home Coach](https://www.netatmo.com/en-us/aircare/homecoach) [Netatmo](https://www.netatmo.com) devices.
 
 To enable the Netatmo sensor, you have to set up [netatmo](/components/netatmo/), this will use discovery to add your sensor.
 


### PR DESCRIPTION
**Description:**

This PR in the code repo enables a new device as a sensor of netatmo: https://github.com/home-assistant/home-assistant/pull/18308

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18308

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
