### PR TITLE
Update nfandroidtv notify component configuration

### DIFF
--- a/source/_components/notify.nfandroidtv.markdown
+++ b/source/_components/notify.nfandroidtv.markdown
@@ -12,7 +12,6 @@ ha_category: Notifications
 ha_release: 0.32
 ---
 
-
 Notification platform for [Notifications for Android TV](https://play.google.com/store/apps/details?id=de.cyberdream.androidtv.notifications.google) and [Notifications for FireTV](https://play.google.com/store/apps/details?id=de.cyberdream.firenotifications.google). You can use this plarform to send notifications to your Android TV device. An overlay with the message content will appear for a configurable amount of seconds and then disapper again. Sending images (e.g., security cam) is supported too.
 
 The notifications are in the global scope of your Android TV device. They will be displayed regardless of which application is running.
@@ -29,16 +28,52 @@ notify:
     host: 192.168.1.12
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **host** (*Required*): IP address of the Android TV / FireTV device.
-- **duration** (*Optional*): The duration in seconds for which the notification will be displayed. Default is 5 seconds.
-- **fontsize** (*Optional*): Has to be one of: small, medium (default), large, max
-- **position** (*Optional*): Has to be one of: bottom-right (default), bottom-left, top-right, top-left, center
-- **color** (*Optional*): Has to be one of: grey (default), black, indigo, green, red, cyan, teal, amber, pink
-- **transparency** (*Optional*): Has to be one of: 0%, 25% (default), 50%, 75%, 100%
-- **interrupt** (*Optional*): If set to true, 1, on etc., the notification is interactive and can be dismissed or selected to display more details. Depending on the running app (e.g., Netflix), this may stop playback.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+host:
+  description: IP address of the Android TV / FireTV device.
+  required: true
+  type: string
+duration:
+  description: The duration in seconds for which the notification will be displayed.
+  required: false
+  default: 5
+  type: integer
+fontsize:
+  description: "Has to be one of: `small`, `medium`, `large` or `max`."
+  required: false
+  default: medium
+  type: string
+position:
+  description: "Has to be one of: `bottom-right`, `bottom-left`, `top-right`, `top-left` or `center`."
+  required: false
+  default: bottom-right
+  type: string
+color:
+  description: "Has to be one of: `grey`, `black`, `indigo`, `green`, `red`, `cyan`, `teal`, `amber` or `pink`."
+  required: false
+  default: grey
+  type: string
+transparency:
+  description: "Has to be one of: `0%`, `25%`, `50%`, `75%` or `100%`."
+  required: false
+  default: 25%
+  type: string
+timeout:
+  description: The timeout in seconds.
+  required: false
+  default: 5
+  type: integer
+interrupt:
+  description: If set to true, 1, on etc., the notification is interactive and can be dismissed or selected to display more details. Depending on the running app (e.g., Netflix), this may stop playback.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
 
 The configuration will be used to configure the default values for the notification for the host specified by the IP. However, you can override most of the settings by passing them with the data-attribute when calling the service.
 This is a fully customized JSON you can use to test how the final notification will look like:
@@ -65,7 +100,7 @@ The following attributes can be placed inside `data` to send images.
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `file`                 |      yes | Groups the attributes for file upload. If present, either `url` or `path` have to be provided.
-| `path `                |      yes | Local path of an image file. Is placed inside `file`.
+| `path`                |      yes | Local path of an image file. Is placed inside `file`.
 | `url`                  |      yes | URL of an image file. Is placed inside `file`.
 | `username`             |      yes | Username if the url requires authentication. Is placed inside `file`.
 | `password`             |      yes | Password if the url requires authentication. Is placed inside `file`.
@@ -101,4 +136,5 @@ Example for posting file from local path:
   }
 }
 ```
+
 Please note that `path` is validated against the `whitelist_external_dirs` in the `configuration.yaml`.


### PR DESCRIPTION
**Description:**
Update style of nfandroidtv notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
