### PR TITLE
Change Reserve Proxy setup with DSM 6.2.1.

### DIFF
--- a/source/_docs/ecosystem/synology.markdown
+++ b/source/_docs/ecosystem/synology.markdown
@@ -20,11 +20,7 @@ Starting with DSM 6.2.1+, you can create "custom headers" in the Application Por
 * Select "Websocket". This will automaticly add the required headers for websocket to this reverse proxy.
 * Click "OK". Home Assistant should work now with the reverse proxy.
 
----
-**NOTE**
-
 It's not necessary anymore to change the template anymore since Version DSM 6.2.1. Changing the `Portal.mustache` is not recommended! You should use the following part only if you're using a Version before DSM 6.2.1. on your Synology.
----
 
 ### {% linkable_title Template change %}
 

--- a/source/_docs/ecosystem/synology.markdown
+++ b/source/_docs/ecosystem/synology.markdown
@@ -12,6 +12,20 @@ redirect_from: /ecosystem/synology/
 
 Synology NAS are the perfect companion to running Home Assistant. But by default, the DSM Reverse Proxy does not configure its NGINX settings to allow WebSocket, and some extra configuration will be required to get the Home Assistant frontend working with the DSM.
 
+### {% linkable_title Setup headers %}
+
+Starting with DSM 6.2.1+, you can create "custom headers" in the Application Portal:
+* Go to Application Portal and edit your entry
+* Click on "custom headers" tab and click the dropdon on the "Create" button
+* Select "Websocket". This will automaticly add the required headers for websocket to this reverse proxy.
+* Click "OK". Home Assistant should work now with the reverse proxy.
+
+---
+**NOTE**
+
+It's not necessary anymore to change the template anymore since Version DSM 6.2.1. Changing the `Portal.mustache` is not recommended! You should use the following part only if you're using a Version before DSM 6.2.1. on your Synology.
+---
+
 ### {% linkable_title Template change %}
 
 To allow WebSocket by default for all service exposed by NGINX, you can enable it in the template file located in `/usr/syno/share/nginx/Portal.mustache`. Please be really careful in editing this file since you may break access to the DSM UI. Please backup this file before any edition.


### PR DESCRIPTION
**Description:**
Synology made it a lot easier to use a websocket in their reverse proxy. It's not necessary anymore to log in to ssh so it should be much saver and easier to setup.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
