### PR TITLE
Documentation for home-assistant/home-assistant-polymer#2016

### DIFF
--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -58,14 +58,22 @@ show_state:
   default: true
 tap_action:
   required: false
-  description: "Set to `toggle` for turning entity on/off."
+  description: `more-info`, `toggle`, `call-service`
   type: string
   default: more-info
 hold_action:
   required: false
-  description: Action to perform when clicked-and-held (e.g., `more-info`, `toggle`).
+  description: Action to perform when clicked-and-held (e.g., `more-info`, `toggle`, `call-service`).
   type: string
   default: none
+service:
+  required: false
+  description: "Service to call (e.g., `light.turn_on`)"
+  type: string
+service_data:
+  required: false
+  description: The service data to use.
+  type: object
 {% endconfiguration %}
 
 ## {% linkable_title Examples %}

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -58,12 +58,12 @@ show_state:
   default: true
 tap_action:
   required: false
-  description: `more-info`, `toggle`, `call-service`
+  description: Action to perform when clicked (`more-info`, `toggle`, `call-service`)
   type: string
   default: more-info
 hold_action:
   required: false
-  description: Action to perform when clicked-and-held (e.g., `more-info`, `toggle`, `call-service`).
+  description: Action to perform when clicked-and-held (`more-info`, `toggle`, `call-service`).
   type: string
   default: none
 service:


### PR DESCRIPTION
**Description:**
I noticed the formatting is a bit different between different entities and cards that use `tap_action`. I took the opportunity to make this one more like the picture-elements docs.

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** home-assistant/home-assistant-polymer#2016

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
