### PR TITLE
Update message_bird notify component configuration

### DIFF
--- a/source/_components/notify.message_bird.markdown
+++ b/source/_components/notify.message_bird.markdown
@@ -24,11 +24,22 @@ notify:
     api_key: YOUR_API_KEY
 ```
 
-Configuration variables:
-
-- **api_key** (*Required*): Enter the API key for MessageBird. Go to https://www.messagebird.com/ to retrieve your API key.
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **sender** (*Optional*): Setting the optional parameter `sender`. This will be the sender of the SMS. It may be either a telephone number (e.g., `+4915112345678`) or a text with a maximum length of 11 characters. Defaults to `HA`.
+{% configuration %}
+api_key:
+  description: "Enter the API key for MessageBird. Go to https://www.messagebird.com/ to retrieve your API key."
+  required: true
+  type: string
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+sender:
+  description: Setting the optional parameter `sender`. This will be the sender of the SMS. It may be either a telephone number (e.g., `+4915112345678`) or a text with a maximum length of 11 characters.
+  required: false
+  default: HA
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title Usage %}
 


### PR DESCRIPTION
**Description:**
Update style of message_bird notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
