### PR TITLE
Update group notify component configuration

### DIFF
--- a/source/_components/notify.group.markdown
+++ b/source/_components/notify.group.markdown
@@ -40,11 +40,11 @@ services:
   type: list
   keys:
     service:
-      description: The service part of an entity ID, i.e. if you use `notify.html5` normally, just put `html5`. Note that you must put everything in lower case here. Although you might have capitals written in the actual notification services!
+      description: The service part of an entity ID, e.g. if you use `notify.html5` normally, just put `html5`. Note that you must put everything in lower case here. Although you might have capitals written in the actual notification services!
       required: true
       type: string
     data:
-      description: A dictionary containing parameters to add to all notify payloads. This can be anything that is valid to use in a payload, such as `data`, `message`, `target`, `title`.
+      description: A dictionary containing parameters to add to all notify payloads. This can be anything that is valid to use in a payload, such as `data`, `message`, `target` or `title`.
       required: false
       type: string
 {% endconfiguration %}

--- a/source/_components/notify.group.markdown
+++ b/source/_components/notify.group.markdown
@@ -29,9 +29,22 @@ notify:
       - service: html5_nexus
 ```
 
-Configuration variables:
-
-- **name** (*Required*): Setting the parameter `name` sets the name of the group.
-- **services** (*Required*): A list of all the services to be included in the group.
-  - **service** (*Required*): The service part of an entity ID, i.e. if you use `notify.html5` normally, just put `html5`. Note that you must put everything in lower case here. Although you might have capitals written in the actual notification services!
-  - **data** (*Optional*): A dictionary containing parameters to add to all notify payloads. This can be anything that is valid to use in a payload, such as `data`, `message`, `target`, `title`.
+{% configuration %}
+name:
+  description: Setting the parameter `name` sets the name of the group.
+  required: true
+  type: string
+services:
+  description: A list of all the services to be included in the group.
+  required: true
+  type: list
+  keys:
+    service:
+      description: The service part of an entity ID, i.e. if you use `notify.html5` normally, just put `html5`. Note that you must put everything in lower case here. Although you might have capitals written in the actual notification services!
+      required: true
+      type: string
+    data:
+      description: A dictionary containing parameters to add to all notify payloads. This can be anything that is valid to use in a payload, such as `data`, `message`, `target`, `title`.
+      required: false
+      type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of group notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
