### PR TITLE
Update check_config add-on component configuration

### DIFF
--- a/source/_addons/check_config.markdown
+++ b/source/_addons/check_config.markdown
@@ -17,6 +17,9 @@ You can use this add-on to check whether your configuration files are valid agai
 }
 ```
 
-Configuration variables:
-
-- **version** (*Required*): Version of Home Assistant that you plan to install.
+{% configuration %}
+version:
+  description: Version of Home Assistant that you plan to install.
+  required: true
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of check_config add-on component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
