### PR TITLE
Update google_assistant add-on component configuration

### DIFF
--- a/source/_addons/google_assistant.markdown
+++ b/source/_addons/google_assistant.markdown
@@ -68,10 +68,14 @@ Configuration example that uses the USB microphone and the built-in headset audi
 }
 ```
 
-Configuration variables:
-
-- **mic**: This is the hardware address of your microphone. Look at the add-on output
-- **speaker**: This is the hardware address of your speakers. Look at the add-on output
+{% configuration %}
+mic:
+  description: This is the hardware address of your microphone. Look at the add-on output.
+  type: float
+speaker:
+  description: This is the hardware address of your speakers. Look at the add-on output.
+  type: float
+{% endconfiguration %}
 
 ### {% linkable_title Home Assistant configuration %}
 


### PR DESCRIPTION
**Description:**
Update style of google_assistant add-on component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
