### PR TITLE
Update rpi_gpio_pwm light component configuration

### DIFF
--- a/source/_components/light.rpi_gpio_pwm.markdown
+++ b/source/_components/light.rpi_gpio_pwm.markdown
@@ -33,15 +33,39 @@ light:
         type: simple
 ```
 
-Configuration variables:
-
-- **leds** array (*Required*): Can contain multiple LEDs.
-  - **name** (*Required*): The name of the LED.
-  - **driver** (*Required*): The driver which controls the LED. Choose either `gpio` or `pca9685`.
-  - **pins** (*Required*): The pins connected to the LED as a list.. The order of pins is determined by the specified type.
-  - **type** (*Required*): The type of LED. Choose either `rgb`, `rgbw` or `simple`.
-  - **freq** (*Optional*): The PWM frequency. (Default: `200`)
-  - **address** (*Optional*): The address of the PCA9685 driver. (Default: `0x40`)
+{% configuration %}
+leds:
+  description: Can contain multiple LEDs.
+  required: true
+  type: list
+  keys:
+    name:
+      description: The name of the LED.
+      required: true
+      type: string
+    driver:
+      description: The driver which controls the LED. Choose either `gpio` or `pca9685`.
+      required: true
+      type: string
+    pins:
+      description: The pins connected to the LED as a list.. The order of pins is determined by the specified type.
+      required: true
+      type: [list, integer]
+    type:
+      description: The type of LED. Choose either `rgb`, `rgbw` or `simple`.
+      required: true
+      type: string
+    freq:
+      description: The PWM frequency.
+      required: false
+      default: 200
+      type: integer
+    address:
+      description: The address of the PCA9685 driver.
+      required: false
+      default: 0x40
+      type: string
+{% endconfiguration %}
 
 ## {% linkable_title Examples %}
 

--- a/source/_components/light.rpi_gpio_pwm.markdown
+++ b/source/_components/light.rpi_gpio_pwm.markdown
@@ -48,7 +48,7 @@ leds:
       required: true
       type: string
     pins:
-      description: The pins connected to the LED as a list.. The order of pins is determined by the specified type.
+      description: The pins connected to the LED as a list. The order of pins is determined by the specified type.
       required: true
       type: [list, integer]
     type:


### PR DESCRIPTION
**Description:**
Update style of rpi_gpio_pwm light component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
