### PR TITLE
Update scsgate cover component configuration

### DIFF
--- a/source/_components/cover.scsgate.markdown
+++ b/source/_components/cover.scsgate.markdown
@@ -26,14 +26,27 @@ cover:
         scs_id: XXXXX
 ```
 
-Configuration variables:
-
-- **devices** array (*Required*): A list of devices.
-  - **[slug]** (*Required*): Slug of the device.
-    - **name** (*Required*): Name to use in the frontend.
-    - **scs_id** (*Required*): The ID of your SCSGate device.
+{% configuration %}
+devices:
+  description: A list of devices.
+  required: true
+  type: list
+  keys:
+    slug:
+      description: Slug of the device.
+      required: true
+      type: list
+      keys:
+        name:
+          description: Name to use in the frontend.
+          required: true
+          type: string
+        scs_id:
+          description: The ID of your SCSGate device.
+          required: true
+          type: string
+{% endconfiguration %}
 
 <p class='note'>
 **Known limitation:** It is not possible to know the current state of the cover.
 </p>
-


### PR DESCRIPTION
**Description:**
Update style of scsgate cover component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
