### PR TITLE
Changed how packages are exposed by the postnl sensor.

### DIFF
--- a/source/_components/sensor.postnl.markdown
+++ b/source/_components/sensor.postnl.markdown
@@ -15,7 +15,7 @@ ha_iot_class: "Cloud Polling"
 
 The `postnl` platform allows one to track deliveries by [PostNL](https://www.postnl.nl) (Dutch Postal Services). To use this sensor, you need a [PostNL Account](https://jouw.postnl.nl). It is possible to add multiple accounts to your Home Assistant configuration.
 
-The sensor value shows the number of packages to be delivered. Each of the packages is available as an attribute.
+The sensor value shows the number of packages to be delivered. The packages are available in the shipments attribute.
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
**Description:**

Changed bit about how packages are exposed by the postnl sensor.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18334

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
