### PR TITLE
Rename sensor.launch to sensor.launch_library

### DIFF
--- a/source/_components/sensor.launch_library.markdown
+++ b/source/_components/sensor.launch_library.markdown
@@ -13,16 +13,14 @@ ha_iot_class: "Cloud Polling"
 ha_release: "0.83"
 ---
 
-The `launch` sensor will provide you with information about the next planed space launch.
-
-## {% linkable_title Configuration %}
+The `launch_library` sensor will provide you with information about the next planed space launch.
 
 Add the data to your `configuration.yaml` file as shown in the example:
 
 ```yaml
 # Example configuration.yaml entry
 sensor:
-  - platform: launch
+  - platform: launch_library
 ```
 
 {% configuration %}
@@ -32,6 +30,6 @@ name:
   type: string
 {% endconfiguration %}
 
-The data this platform are presenting are coming from [launchlibrary.net][launchlibrary].
+_The data this platform are presenting are coming from [launchlibrary.net][launchlibrary]._
 
 [launchlibrary]: http://launchlibrary.net/

--- a/source/_components/sensor.launch_library.markdown
+++ b/source/_components/sensor.launch_library.markdown
@@ -15,6 +15,8 @@ ha_release: "0.83"
 
 The `launch_library` sensor will provide you with information about the next planed space launch.
 
+## {% linkable_title Configuration %}
+
 Add the data to your `configuration.yaml` file as shown in the example:
 
 ```yaml
@@ -30,6 +32,6 @@ name:
   type: string
 {% endconfiguration %}
 
-_The data this platform are presenting are coming from [launchlibrary.net][launchlibrary]._
+The data this platform are presenting are coming from [launchlibrary.net][launchlibrary].
 
 [launchlibrary]: http://launchlibrary.net/


### PR DESCRIPTION
**Description:**

Documentation update for the rename of this sensor platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18337

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
