### PR TITLE
Note about needed doorbird user's permission

### DIFF
--- a/source/_components/doorbird.markdown
+++ b/source/_components/doorbird.markdown
@@ -53,7 +53,7 @@ devices:
       required: true
       type: string
     username:
-      description: The username of a non-administrator user account on the device.
+      description: The username of a non-administrator user account on the device. This user needs the "API-Operator" permission enabled on doorbird.
       required: true
       type: string
     password:


### PR DESCRIPTION
**Description:**

This adds a note about a user permission which is needed to be enabled on the doorbird before home assistant can use the device. This only applies to 0.82+, everything worked without this permission in older versions.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
