### PR TITLE
pin tensorflow version

### DIFF
--- a/source/_components/image_processing.tensorflow.markdown
+++ b/source/_components/image_processing.tensorflow.markdown
@@ -22,7 +22,7 @@ The `tensorflow` image processing platform allows you to detect and recognize ob
 
 ## {% linkable_title Setup %}
 
-You need to install the `tensorflow` Python packages with: `$ pip3 install tensorflow`. The wheel is not available for all platforms. See [the official install guide](https://www.tensorflow.org/install/) for other options. Hass.io has this package pre-installed.
+You need to install the `tensorflow` Python packages with: `$ pip3 install tensorflow==1.11.0`. The wheel is not available for all platforms. See [the official install guide](https://www.tensorflow.org/install/) for other options. Hass.io has this package pre-installed.
 
 This component requires files to be downloaded, compiled on your computer, and added to the Home Assistant configuration directory. These steps can be performed using the sample script at [this gist](https://gist.github.com/hunterjm/6f9332f92b60c3d5e448ad936d7353c3). Alternatively, if you wish to perform the process manually, the process is as follows:
 


### PR DESCRIPTION
**Description:**
TensorFlow 1.12.0 was recently released which includes breaking changes for this component.  This change is to pin the install instructions on the site to 1.11.0.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
