### PR TITLE
Missing configuration option

### DIFF
--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -66,6 +66,10 @@ state_topic:
   description: The MQTT topic subscribed to receive cover state messages.
   required: false
   type: string
+position_topic:
+  description: The MQTT topic subscribed to receive cover position messages.
+  required: false
+  type: string
 state_open:
   description: The payload that represents the open state.
   required: false


### PR DESCRIPTION
**Description:**

Upgrading from 0.81.4 -> 0.82 I realised a breaking change

MQTT cover used to rely on state_topic to retrieve position. Looking at the code, one now needs to define "position_topic" if cover relies only on position to determine the state of the cover.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
