### PR TITLE
YAML 1.2 and standarization of booleans

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -42,8 +42,8 @@ alert:
     entity_id: input_boolean.garage_door
     state: 'on'
     repeat: 30
-    can_acknowledge: True
-    skip_first: True
+    can_acknowledge: true
+    skip_first: true
     notifiers:
       - ryans_phone
       - kristens_phone
@@ -103,7 +103,7 @@ notifiers:
 In this example, the garage door status (`input_boolean.garage_door`) is watched
 and this alert will be triggered when its status is equal to `on`.
 This indicates that the door has been opened. Because the `skip_first` option
-was set to `True`, the first notification will not be delivered immediately.
+was set to `true`, the first notification will not be delivered immediately.
 However, every 30 minutes, a notification will be delivered until either
 `input_boolean.garage_door` no longer has a state of `on` or until the alert is
 acknowledged using the Home Assistant frontend.
@@ -186,8 +186,8 @@ alert:
       - 15
       - 30
       - 60
-    can_acknowledge: True  # Optional, default is True
-    skip_first: True  # Optional, false is the default
+    can_acknowledge: true  # Optional, default is True
+    skip_first: true  # Optional, false is the default
     notifiers:
       - ryans_phone
       - kristens_phone
@@ -213,8 +213,8 @@ of the entity.
     entity_id: plant.plant_office
     state: 'problem'
     repeat: 30
-    can_acknowledge: True
-    skip_first: True
+    can_acknowledge: true
+    skip_first: true
     message: "Plant {{ states.plant.plant_office }} needs help ({{ state_attr('plant.plant_office', 'problem') }})"
     done_message: Plant in office is fine
     notifiers:

--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -186,7 +186,7 @@ alert:
       - 15
       - 30
       - 60
-    can_acknowledge: true  # Optional, default is True
+    can_acknowledge: true  # Optional, default is true
     skip_first: true  # Optional, false is the default
     notifiers:
       - ryans_phone

--- a/source/_components/binary_sensor.ihc.markdown
+++ b/source/_components/binary_sensor.ihc.markdown
@@ -39,7 +39,7 @@ binary_sensor:
       - id: 12345
         name: mysensor
         type: opening
-        inverting: True
+        inverting: true
       - id: 12346
            ...
 ```

--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -112,7 +112,7 @@ force_update:
   description: Sends update events even if the value hasn't changed. Useful if you want to have meaningful value graphs in history.
   required: false
   type: boolean
-  default: False
+  default: false
 off_delay:
   description: For sensors that only sends ‘On’ state updates, this variable sets a delay in seconds after which the sensor state will be updated back to ‘Off’.
   required: false

--- a/source/_components/binary_sensor.pilight.markdown
+++ b/source/_components/binary_sensor.pilight.markdown
@@ -80,6 +80,6 @@ binary_sensor:
     payload:
       unitcode: 371399
     payload_on: 'closed'
-    disarm_after_trigger: True
+    disarm_after_trigger: true
     reset_delay_sec: 30
 ```

--- a/source/_components/calendar.caldav.markdown
+++ b/source/_components/calendar.caldav.markdown
@@ -134,7 +134,7 @@ custom_calendars:
 ### {% linkable_title Sensor attributes %}
 
  - **offset_reached**: If set in the event title and parsed out will be on/off once the offset in the title in minutes is reached. So the title Very important meeting !!-10 would trigger this attribute to be on 10 minutes before the event starts.
- - **all_day**: `True/False` if this is an all day event. Will be `False` if there is no event found.
+ - **all_day**: `true`/`false` if this is an all day event. Will be `false` if there is no event found.
  - **message**: The event title with the `search` values extracted. So in the above example for `offset_reached` the message would be set to Very important meeting
  - **description**: The event description.
  - **location**: The event Location.

--- a/source/_components/calendar.todoist.markdown
+++ b/source/_components/calendar.todoist.markdown
@@ -100,7 +100,7 @@ Home Assistant does its best to [determine what task in each project is "most" i
 
  - **offset_reached**: Not used.
 
- - **all_day**: `True` if the reported task doesn't have a due date. `False` if there is a due date set.
+ - **all_day**: `true` if the reported task doesn't have a due date. `false` if there is a due date set.
 
  - **message**: The title of the "most important" task coming up in this project.
 

--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -51,7 +51,7 @@ authentication:
   default: basic
   type: string
 limit_refetch_to_url_change:
-  description: True/false value. Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
+  description: "`true`/`false` value. Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image."
   required: false
   default: false
   type: boolean

--- a/source/_components/camera.synology.markdown
+++ b/source/_components/camera.synology.markdown
@@ -74,7 +74,7 @@ camera:
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
     timeout: 15
-    verify_ssl: False
+    verify_ssl: false
 ```
 
 <p class='note'>

--- a/source/_components/climate.generic_thermostat.markdown
+++ b/source/_components/climate.generic_thermostat.markdown
@@ -99,7 +99,7 @@ climate:
     target_sensor: sensor.study_temperature
     min_temp: 15
     max_temp: 21
-    ac_mode: False
+    ac_mode: false
     target_temp: 17
     cold_tolerance: 0.3
     hot_tolerance: 0

--- a/source/_components/climate.radiotherm.markdown
+++ b/source/_components/climate.radiotherm.markdown
@@ -52,7 +52,7 @@ hold_temp:
   type: boolean
 {% endconfiguration %}
 
-Set `hold_temp: True` if you want temperature settings from Home Assistant to override a thermostat schedule on the thermostat itself. Otherwise Home Assistant will perform temporary temperature changes.
+Set `hold_temp: true` if you want temperature settings from Home Assistant to override a thermostat schedule on the thermostat itself. Otherwise Home Assistant will perform temporary temperature changes.
 
 The away mode functions similarly to the away mode feature of the website and apps, but cannot detect if you set away mode outside of Home Assistant.
 

--- a/source/_components/climate.venstar.markdown
+++ b/source/_components/climate.venstar.markdown
@@ -61,7 +61,7 @@ ssl:
   description: Whether to use SSL or not when communicating.
   required: false
   type: boolean
-  default: False
+  default: false
 timeout:
   description: Number of seconds for API timeout.
   required: false
@@ -81,9 +81,9 @@ humidifier:
 climate:
   - platform: venstar
     host: IP_OR_HOSTNAME_OF_THERMOSTAT
-    ssl: True/False
+    ssl: true
     username: OPTIONAL_AUTH_USER_HERE
     password: OPTIONAL_AUTH_PASS_HERE
     timeout: 5
-    humidifier: False
+    humidifier: false
 ```

--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -45,7 +45,7 @@ counter:
       description: Try to restore the last known value when Home Assistant starts.
       required: false
       type: boolean
-      default: True
+      default: true
     step:
       description: Incremental/step value for the counter.
       required: false
@@ -61,9 +61,9 @@ Pick an icon that you can find on [materialdesignicons.com](https://materialdesi
 
 ### {% linkable_title Restore State %}
 
-This component will automatically restore the state it had prior to Home Assistant stopping as long as you have the `recorder` component enabled and your entity has `restore` set to `True` which is the default. To disable this feature, set `restore` to `False`. Additional information can be found in the [Restore state](/components/recorder/#restore-state) section of the [`recorder`](/components/recorder/) component documentation.
+This component will automatically restore the state it had prior to Home Assistant stopping as long as you have the `recorder` component enabled and your entity has `restore` set to `true` which is the default. To disable this feature, set `restore` to `false`. Additional information can be found in the [Restore state](/components/recorder/#restore-state) section of the [`recorder`](/components/recorder/) component documentation.
 
-If `restore` is set to `False`, the `initial` value will only be used when no previous state is found or when the counter is reset.
+If `restore` is set to `false`, the `initial` value will only be used when no previous state is found or when the counter is reset.
 
 ## {% linkable_title Services %}
 

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -91,7 +91,7 @@ devices:
     fire_event:
       description: Fire a `button_pressed` event if this device is turned on or off.
       required: false
-      default: False
+      default: false
       type: boolean
     signal_repetitions:
       description: The number of times every Rflink command should repeat.
@@ -100,7 +100,7 @@ devices:
     group:
       description: Allow light to respond to group commands (ALLON/ALLOFF).
       required: false
-      default: True
+      default: true
       type: boolean
     group_aliases:
       description: The `aliases` which only respond to group commands.
@@ -118,7 +118,7 @@ device_defaults:
     fire_event:
       description: The default `fire_event` for Rflink cover devices.
       required: false
-      default: False
+      default: false
       type: boolean
     signal_repetitions:
       description: The default `signal_repetitions` for Rflink cover devices.

--- a/source/_components/cover.rfxtrx.markdown
+++ b/source/_components/cover.rfxtrx.markdown
@@ -25,7 +25,7 @@ The easiest way to find your roller shutters is to add this to your `configurati
 ```yaml
 cover:
   - platform: rfxtrx
-    automatic_add: True
+    automatic_add: true
 ```
 
 Launch your homeassistant and go the website (e.g http://localhost:8123). Push your remote and your device should be added.
@@ -52,7 +52,7 @@ Example configuration:
 # Example configuration.yaml entry
 cover:
   - platform: rfxtrx
-    automatic_add: False
+    automatic_add: false
     signal_repetitions: 2
     devices:
       0b1100ce3213c7f210010f70: # Siemens/LightwaveRF

--- a/source/_components/cover.rpi_gpio.markdown
+++ b/source/_components/cover.rpi_gpio.markdown
@@ -44,7 +44,7 @@ relay_time:
 invert_relay:
   description: Invert the relay pin output so that it is active-high (True).
   required: false
-  default: False
+  default: false
   type: boolean
 state_pull_mode:
   description: The direction the State pin is pulling. It can be UP or DOWN.
@@ -54,7 +54,7 @@ state_pull_mode:
 invert_state:
   description: Invert the value of the State pin so that 0 means closed.
   required: false
-  default: False
+  default: false
   type: boolean
 covers:
   description: List of your doors.
@@ -82,9 +82,9 @@ covers:
 cover:
   - platform: rpi_gpio
     relay_time: 0.2
-    invert_relay: False
+    invert_relay: false
     state_pull_mode: 'UP'
-    invert_state: True
+    invert_state: true
     covers:
       - relay_pin: 10
         state_pin: 11

--- a/source/_components/device_tracker.bluetooth_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_tracker.markdown
@@ -28,7 +28,7 @@ request_rssi:
   description: Performs a request for the "Received signal strength indication" (RSSI) of each tracked device
   required: false
   type: boolean
-  default: False
+  default: false
 {% endconfiguration %}
 
 In some cases it can be that your device is not discovered. In that case let your phone scan for Bluetooth devices while you restart Home Assistant. Just hit `Scan` on your phone all the time until Home Assistant is fully restarted and the device should appear in `known_devices.yaml`.

--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -27,8 +27,8 @@ device_tracker:
     username: admin
     password: YOUR_PASSWORD
     new_device_defaults:
-      track_new_devices: True
-      hide_if_away: False
+      track_new_devices: true
+      hide_if_away: false
 ```
 
 The following optional parameters can be used with any platform. However device tracker will only look for global settings under the configuration of the first configured platform:
@@ -37,10 +37,10 @@ The following optional parameters can be used with any platform. However device 
 |----------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `interval_seconds`   | 12      | Seconds between each scan for new devices                                                                                                                                                                                                                                                                                                                                                 |
 | `consider_home`      | 180     | Seconds to wait till marking someone as not home after not being seen. This parameter is most useful for households with Apple iOS devices that go into sleep mode while still at home to conserve battery life. iPhones will occasionally drop off the network and then re-appear. `consider_home` helps prevent false alarms in presence detection when using IP scanners such as Nmap. `consider_home` accepts various time representations, (e.g., the following all represents 3 minutes: `180`, `0:03`, `0:03:00`)  |
-| `new_device_defaults`|         | Default values for new discovered devices. Available options `track_new_devices` (default: `True`), `hide_if_away` (default: `False`)                                                                                                                                                                                                                                                     |
+| `new_device_defaults`|         | Default values for new discovered devices. Available options `track_new_devices` (default: `true`), `hide_if_away` (default: `false`)                                                                                                                                                                                                                                                     |
 
 <p class='note'>
-  Note that setting `track_new_devices: False` will still result in new devices being recorded in `known_devices.yaml`, but they won't be tracked (`track: no`).
+  Note that setting `track_new_devices: false` will still result in new devices being recorded in `known_devices.yaml`, but they won't be tracked (`track: false`).
 </p>
 
 The extended example from above would look like the following sample:
@@ -53,7 +53,7 @@ device_tracker:
     username: admin
     interval_seconds: 10
     consider_home: 180
-    track_new_devices: yes
+    track_new_devices: true
 ```
 
 Multiple device trackers can be used in parallel, such as [Owntracks](/components/device_tracker.owntracks/#using-owntracks-with-other-device-trackers) and [Nmap](/components/device_tracker.nmap_tracker/). The state of the device will be determined by the source that reported last.
@@ -69,8 +69,8 @@ devicename:
   name: Friendly Name
   mac: EA:AA:55:E7:C6:94
   picture: https://www.home-assistant.io/images/favicon-192x192.png
-  track: yes
-  hide_if_away: no
+  track: true
+  hide_if_away: false
 ```
 
 <p class='note warning'>
@@ -84,8 +84,8 @@ devicename:
 | `picture`      | None                          | A picture that you can use to easily identify the person or device. You can also save the image file in a folder "www" in the same location (can be obtained from developer tools) where you have your configuration.yaml file and just use `picture: /local/favicon-192x192.png`.                                      |
 | `icon`         | mdi:account                   | An icon for this device (use as an alternative to `picture`).                           |
 | `gravatar`     | None                          | An email address for the device's owner. If provided, it will override `picture`.                        |
-| `track`        | [uses platform setting]       | If  `yes`/`on`/`true` then the device will be tracked. Otherwise its location and state will not update. |
-| `hide_if_away` | False                         | If `yes`/`on`/`true` then the device will be hidden if it is not at home.                                |
+| `track`        | [uses platform setting]       | If `true` then the device will be tracked. Otherwise its location and state will not update. |
+| `hide_if_away` | False                         | If `true` then the device will be hidden if it is not at home.                                |
 | `consider_home` | [uses platform setting]      | Seconds to wait till marking someone as not home after not being seen. Allows you to override the global `consider_home` setting from the platform configuration on a per device level.                                 |
 
 ## {% linkable_title Using GPS device trackers with local network device trackers %}
@@ -100,8 +100,8 @@ USERNAME_DEVICE_ID:
   mac: EA:AA:55:E7:C6:94
   picture: https://www.home-assistant.io/images/favicon-192x192.png
   gravatar: test@example.com
-  track: yes
-  hide_if_away: no
+  track: true
+  hide_if_away: false
 ```
 
 If you want to track whether either your GPS based tracker or your local network tracker, identify you as being at home, use [a group](/components/group/) instead.

--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -85,7 +85,7 @@ devicename:
 | `icon`         | mdi:account                   | An icon for this device (use as an alternative to `picture`).                           |
 | `gravatar`     | None                          | An email address for the device's owner. If provided, it will override `picture`.                        |
 | `track`        | [uses platform setting]       | If `true` then the device will be tracked. Otherwise its location and state will not update. |
-| `hide_if_away` | False                         | If `true` then the device will be hidden if it is not at home.                                |
+| `hide_if_away` | false                         | If `true` then the device will be hidden if it is not at home.                                |
 | `consider_home` | [uses platform setting]      | Seconds to wait till marking someone as not home after not being seen. Allows you to override the global `consider_home` setting from the platform configuration on a per device level.                                 |
 
 ## {% linkable_title Using GPS device trackers with local network device trackers %}

--- a/source/_components/device_tracker.owntracks.markdown
+++ b/source/_components/device_tracker.owntracks.markdown
@@ -89,8 +89,8 @@ USERNAME_DEVICE_ID:
   mac: EA:AA:55:E7:C6:94
   picture: https://www.home-assistant.io/images/favicon-192x192.png
   gravatar: test@example.com
-  track: yes
-  hide_if_away: no
+  track: true
+  hide_if_away: false
 ```
 
 ### {% linkable_title Using Owntracks regions %}

--- a/source/_components/device_tracker.tomato.markdown
+++ b/source/_components/device_tracker.tomato.markdown
@@ -49,7 +49,7 @@ ssl:
   type: boolean
   default: false
 verify_ssl:
-  description: "If SSL verification for https resources needs to be turned off (for self-signed certs, etc.) this can take on boolean values `False` or `True` or you can pass a location on the device where a certificate can be used for verification e.g., `/mnt/NAS/router_cert.pem`."
+  description: "If SSL verification for https resources needs to be turned off (for self-signed certs, etc.) this can take on boolean values `false` or `true` or you can pass a location on the device where a certificate can be used for verification e.g., `/mnt/NAS/router_cert.pem`."
   required: false
   type: [string, boolean]
   default: true

--- a/source/_components/discoverable.markdown
+++ b/source/_components/discoverable.markdown
@@ -25,7 +25,7 @@ To enable `discovery` in your installation, add the following to your `configura
 ```yaml
 # Example configuration.yaml entry
 discoverable:
-  expose_password: yes
+  expose_password: false
 ```
 
 

--- a/source/_components/ecobee.markdown
+++ b/source/_components/ecobee.markdown
@@ -57,7 +57,7 @@ api_key:
   required: true
   type: string
 hold_temp:
-  description: True/False whether or not to hold changes indefinitely (True) or until the next scheduled event.
+  description: "`true`/`false` whether or not to hold changes indefinitely (True) or until the next scheduled event."
   required: false
   default: "`false`"
   type: boolean

--- a/source/_components/egardia.markdown
+++ b/source/_components/egardia.markdown
@@ -106,7 +106,7 @@ There seem to be multiple versions of software running on GATE-02 devices; we ha
       host: YOUR_HOST
       username: YOUR_USERNAME
       password: YOUR_PASSWORD
-      report_server_enabled: True
+      report_server_enabled: true
       report_server_port: PORT_OF_EGARDIASERVER (optional, defaults to 52010)
       report_server_codes:
         arm: XXXXXXXXXXXXXXXX, XXXXXXXXXXXXXXXX

--- a/source/_components/eight_sleep.markdown
+++ b/source/_components/eight_sleep.markdown
@@ -43,7 +43,7 @@ password:
   description: Defines if you'd like to fetch data for both sides of the bed.
   required: false
   type: string
-  default: False
+  default: false
 {% endconfiguration %}
 
 ### {% linkable_title Supported features %}

--- a/source/_components/fan.template.markdown
+++ b/source/_components/fan.template.markdown
@@ -75,7 +75,7 @@ fan:
         required: false
         type: template
       oscillating_template:
-        description: "Defines a template to get the osc state of the fan. Valid value: True/False"
+        description: "Defines a template to get the osc state of the fan. Valid value: `true`/`false`."
         required: false
         type: template
       direction_template:

--- a/source/_components/ffmpeg.markdown
+++ b/source/_components/ffmpeg.markdown
@@ -38,7 +38,7 @@ ffmpeg_bin:
 run_test:
   description: Check if `input` is usable by ffmpeg.
   required: false
-  default: True
+  default: true
   type: boolean
 {% endconfiguration %}
 

--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -101,7 +101,7 @@ To enable "night mode":
 ```yaml
 automation:
   - alias: 'Set dark theme for the night'
-    initial_state: True
+    initial_state: true
     trigger:
       - platform: time
         at: '21:00'

--- a/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
+++ b/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
@@ -67,7 +67,7 @@ The following state attributes are available for each entity in addition to the 
 | council_area       | Council area in which this incident takes place. |
 | status             | One of 'Under Control', 'Being Controlled', 'Out of Control'. |
 | type               | Incident type, for example 'Bush Fire', 'Grass Fire' or 'Hazard Reduction'. |
-| fire               | `True` if this incident is a fire, `False` otherwise. |
+| fire               | `true` if this incident is a fire, `false` otherwise. |
 | size               | Size in hectare |
 | responsible_agency | Agency responsible for this incident. |
 

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -131,7 +131,7 @@ api_key:
 expose_by_default:
   description: "Expose devices in all supported domains by default. If set to false, you need to add the expose configuration option to each entity in `entity_config` and set it to true. Setting `exposed_domains` values will _not_ expose those domains if `expose_by_default` is false."
   required: false
-  default: True
+  default: true
   type: boolean
 exposed_domains:
   description: List of entity domains to expose to Google Assistant.

--- a/source/_components/group.markdown
+++ b/source/_components/group.markdown
@@ -61,7 +61,7 @@ name:
   required: false
   type: string
 view:
-  description: "If yes then the entry will be shown as a view (tab) at the top. Groups that are set to `view: yes` cannot be used as entities in other views."
+  description: "If `true` then the entry will be shown as a view (tab) at the top. Groups that are set to `view: true` cannot be used as entities in other views."
   required: false
   type: boolean
 icon:

--- a/source/_components/history.markdown
+++ b/source/_components/history.markdown
@@ -129,12 +129,12 @@ history:
 
 If you'd like the order of display of the sensors to follow the way they are
 listed in the included entity list,
-you can set the flag `use_include_order` to true.
+you can set the flag `use_include_order` to `true`.
 
 ```yaml
 # Example configuration.yaml entry using specified entity display order
 history:
-  use_include_order: True
+  use_include_order: true
   include:
     entities:
       - sun.sun

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -170,7 +170,7 @@ A common situation might be if you decide to disable parts of the configuration 
 
 ## {% linkable_title Disable Auto Start %}
 
-Depending on your individual setup, it might be necessary to disable `Auto Start` for all accessories to be available for `HomeKit`. Only those entities that are fully setup when the `HomeKit` component is started, can be added. To start `HomeKit` when `auto_start: False`, you can call the service `homekit.start`.
+Depending on your individual setup, it might be necessary to disable `Auto Start` for all accessories to be available for `HomeKit`. Only those entities that are fully setup when the `HomeKit` component is started, can be added. To start `HomeKit` when `auto_start: false`, you can call the service `homekit.start`.
 
 If you have Z-Wave entities you want exposed to HomeKit then you'll need to disable auto start and then start it after the Z-Wave mesh is ready. This is because the Z-Wave entities won't be fully set up until then. This can be automated using an automation.
 
@@ -182,7 +182,7 @@ Please remember that [as explained here][devices] you can only have a single `au
 ```yaml
 # Example for Z-Wave
 homekit:
-  auto_start: False
+  auto_start: false
 
 automation:
   - alias: 'Start HomeKit'
@@ -204,7 +204,7 @@ For a general delay where your component doesn't generate an event, you can also
 ```yaml
 # Example using a delay after start of Home Assistant
 homekit:
-  auto_start: False
+  auto_start: false
 
 automation:
   - alias: 'Start HomeKit'

--- a/source/_components/input_select.markdown
+++ b/source/_components/input_select.markdown
@@ -60,7 +60,7 @@ input_select:
 {% endconfiguration %}
 
 <p class='note'>
-Because YAML defines [booleans](http://yaml.org/type/bool.html) as equivalent, any variations of 'On', 'Yes', 'Y', 'Off', 'No', or 'N'  (regardless of case) used as option names will be replaced by True and False unless they are defined in quotation marks.
+Because YAML defines [booleans](http://yaml.org/type/bool.html) as equivalent, any variations of 'On', 'Yes', 'Y', 'Off', 'No', or 'N'  (regardless of case) used as option names will be replaced by `true` and `false` unless they are defined in quotation marks.
 </p>
 
 ### {% linkable_title Restore State %}

--- a/source/_components/knx.markdown
+++ b/source/_components/knx.markdown
@@ -93,13 +93,13 @@ local_ip:
 
 ```yaml
 knx:
-  fire_event: True
+  fire_event: true
   fire_event_filter: ["1/0/*", "6/2,3,4-6/*"]
 ```
 
 {% configuration %}
 fire_event:
-  description: If set to True, platform will write all received KNX messages to event bus
+  description: "If set to `true`, platform will write all received KNX messages to event bus."
   required: inclusive
   type: boolean
 fire_event_filter:

--- a/source/_components/lifx.markdown
+++ b/source/_components/lifx.markdown
@@ -35,7 +35,7 @@ Change the light to a new state.
 | `transition` | Duration (in seconds) for the light to fade to the new state.
 | `zones` | List of integers for the zone numbers to affect (each LIFX Z strip has 8 zones, starting at 0).
 | `infrared` | Automatic infrared level (0..255) when light brightness is low (for compatible bulbs).
-| `power` | Turn the light on (`True`) or off (`False`). Leave out to keep the power as it is.
+| `power` | Turn the light on (`true`) or off (`false`). Leave out to keep the power as it is.
 | `...` | Use `color_name`, `brightness` etc. from [`light.turn_on`]({{site_root}}/components/light/#service-lightturn_on) to specify the new state.
 
 ## {% linkable_title Light effects %}

--- a/source/_components/light.flux_led.markdown
+++ b/source/_components/light.flux_led.markdown
@@ -80,7 +80,7 @@ Will automatically search and add all lights on start up:
 # Example configuration.yaml entry
 light:
   - platform: flux_led
-    automatic_add: True
+    automatic_add: true
 ```
 
 Will add two lights with given name and create an automation rule to randomly set color each 45 seconds:

--- a/source/_components/light.ihc.markdown
+++ b/source/_components/light.ihc.markdown
@@ -35,7 +35,7 @@ light:
     lights:
       - id: 12345
         name: tablelight
-        dimmable: True
+        dimmable: true
       - id: 12346
         name: anotherlight
       ...

--- a/source/_components/light.mqtt_json.markdown
+++ b/source/_components/light.mqtt_json.markdown
@@ -241,7 +241,7 @@ light:
     name: mqtt_json_hs_light
     state_topic: "home/light"
     command_topic: "home/light/set"
-    hs: True
+    hs: true
 ```
 
 Home Assistant expects the hue values to be in the range 0 to 360 and the saturation values to be scaled from 0 to 100. For example, the following is a blue color shade:

--- a/source/_components/light.rfxtrx.markdown
+++ b/source/_components/light.rfxtrx.markdown
@@ -22,7 +22,7 @@ The easiest way to find your lights is to add this to your `configuration.yaml`:
 ```yaml
 light:
   - platform: rfxtrx
-    automatic_add: True
+    automatic_add: true
 ```
 
 Launch your Home Assistant and go the website. Push your remote and your device should be added:

--- a/source/_components/light.yeelight.markdown
+++ b/source/_components/light.yeelight.markdown
@@ -52,12 +52,12 @@ devices:
           description: Enable music mode.
           required: false
           type: boolean
-          default: False
+          default: false
         save_on_change:
           description: Saves the bulb state in its nonvolatile memory when changed from Home Assistant.
           required: false
           type: boolean
-          default: False
+          default: false
         model:
           description: "Yeelight model. Possible values are `mono1`, `color1`, `strip1`, `bslamp1`, `ceiling1`, `ceiling2`, `ceiling3`, `ceiling4`. The setting is used to enable model specific features f.e. a particular color temperature range."
           required: false
@@ -126,8 +126,8 @@ light:
       192.168.1.25:
         name: Living Room
         transition: 1000
-        use_music_mode: True
-        save_on_change: True
+        use_music_mode: true
+        save_on_change: true
 ```
 
 ### {% linkable_title Multiple bulbs %}

--- a/source/_components/lutron.markdown
+++ b/source/_components/lutron.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: lutron.png
 ha_category: Hub
-featured: False
+featured: false
 ha_release: 0.37
 ha_iot_class: "Local Polling"
 ---

--- a/source/_components/lutron_caseta.markdown
+++ b/source/_components/lutron_caseta.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: lutron.png
 ha_category: Hub
-featured: False
+featured: false
 ha_release: 0.41
 ha_iot_class: "Local Polling"
 ---

--- a/source/_components/media_player.denonavr.markdown
+++ b/source/_components/media_player.denonavr.markdown
@@ -46,7 +46,7 @@ media_player:
   - platform: denonavr
     host: IP_ADDRESS
     name: NAME
-    show_all_sources: True / False
+    show_all_sources: true
     timeout: POSITIVE INTEGER
     zones:
       - zone: Zone2 / Zone3

--- a/source/_components/media_player.emby.markdown
+++ b/source/_components/media_player.emby.markdown
@@ -37,7 +37,7 @@ api_key:
   required: true
   type: string
 ssl:
-  description: True if you want to connect with HTTPS/WSS. Your SSL certificate must be valid.
+  description: "`true` if you want to connect with HTTPS/WSS. Your SSL certificate must be valid."
   required: false
   default: false
   type: boolean
@@ -47,7 +47,7 @@ port:
   default: 8096 (No SSL),  8920 (SSL)
   type: integer
 auto_hide:
-  description: True if you want to automatically hide devices that are unavailable from the Home Assistant Interface.
+  description: "`true` if you want to automatically hide devices that are unavailable from the Home Assistant Interface."
   required: false
   default: false
   type: boolean

--- a/source/_components/notify.file.markdown
+++ b/source/_components/notify.file.markdown
@@ -29,6 +29,6 @@ Configuration variables:
 
 - **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
 - **filename** (*Required*): Name of the file to use. The file will be created if it doesn't exist and saved in your [configuration](/docs/configuration/) folder.
-- **timestamp** (*Optional*): Setting `timestamp` to `True` adds a timestamp to every entry.
+- **timestamp** (*Optional*): Setting `timestamp` to `true` adds a timestamp to every entry.
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).

--- a/source/_components/notify.homematic.markdown
+++ b/source/_components/notify.homematic.markdown
@@ -102,7 +102,7 @@ alert:
     name: Temperature too high
     done_message: Temperature OK
     entity_id: binary_sensor.temperature_too_high
-    can_acknowledge: True
+    can_acknowledge: true
     notifiers:
       - group_hm
 ```

--- a/source/_components/notify.lametric.markdown
+++ b/source/_components/notify.lametric.markdown
@@ -45,7 +45,7 @@ cycles:
   default: 1
 priority:
   description: Defines the priority of the notification.
-  required: False
+  required: false
   type: string
   default: warning
 {% endconfiguration %}

--- a/source/_components/notify.pushetta.markdown
+++ b/source/_components/notify.pushetta.markdown
@@ -33,7 +33,7 @@ Configuration variables:
 - **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
 - **api_key** (*Required*): Your API key for Pushetta.
 - **channel_name** (*Required*): The name of your channel.
-- **send_test_msg** (*Optional*): Disable/enable the test message send on Home Assistant's startup to test the API key and the existence of the channel. Default to `False`.
+- **send_test_msg** (*Optional*): Disable/enable the test message send on Home Assistant's startup to test the API key and the existence of the channel. Default to `false`.
 
 It's easy to test your Pushetta setup outside of Home Assistant. Assuming you have a channel *home-assistant*, just fire a request and check the channel page in the dashboard for a new message.
 

--- a/source/_components/opentherm_gw.markdown
+++ b/source/_components/opentherm_gw.markdown
@@ -45,7 +45,7 @@ climate:
       type: float
       default: "`0.5` for Celsius and `1.0` for Fahrenheit."
     floor_temperature:
-      description: "Some thermostats round all temperatures down to the lower value according to their precision. Default behavior for Home Assistant is to round temperatures to the nearest value. Set this to `True` to override Home Assistant and round to the lower value according to the configured `precision`."
+      description: "Some thermostats round all temperatures down to the lower value according to their precision. Default behavior for Home Assistant is to round temperatures to the nearest value. Set this to `true` to override Home Assistant and round to the lower value according to the configured `precision`."
       required: false
       type: boolean
       default: false
@@ -392,7 +392,7 @@ opentherm_gw:
   climate:
     name: Thermostat
     precision: 0.5
-    floor_temperature: True
+    floor_temperature: true
   monitored_variables:
     - room_setpoint
     - room_temp

--- a/source/_components/remote.xiaomi_miio.markdown
+++ b/source/_components/remote.xiaomi_miio.markdown
@@ -54,7 +54,7 @@ hidden:
   description: Hide the entity from UI. There is currently no reason to show the entity in UI as turning it off or on does nothing.
   required: false
   type: boolean
-  default: True
+  default: true
 commands:
   required: false
   type: map

--- a/source/_components/rflink.markdown
+++ b/source/_components/rflink.markdown
@@ -68,7 +68,7 @@ reconnect_interval:
 # Example configuration.yaml entry
 rflink:
   port: /dev/serial/by-id/usb-id01234
-  wait_for_ack: False
+  wait_for_ack: false
   ignore_devices:
     - newkaku_000001_01
     - digitech_*
@@ -131,7 +131,7 @@ For example:
 # Example configuration.yaml entry
 rflink:
   port: /dev/serial/by-id/usb-id01234
-  wait_for_ack: False
+  wait_for_ack: false
   ignore_devices:
     - newkaku_000001_01
     - digitech_*

--- a/source/_components/rss_feed_template.markdown
+++ b/source/_components/rss_feed_template.markdown
@@ -23,7 +23,7 @@ rss_feed_template:
   # Accessible on <Home Assistant url>/api/rss_template/garden
   # Example: https://localhost:8123/api/rss_template/garden
   garden:
-    requires_api_password: False
+    requires_api_password: false
     title: "Garden {% raw %}{{ as_timestamp(now())|timestamp_custom('%H:%M', True) }}{% endraw %}"
     items:
     - title: "Outside temperature"

--- a/source/_components/sensor.daikin.markdown
+++ b/source/_components/sensor.daikin.markdown
@@ -3,7 +3,7 @@ layout: page
 title: "Daikin AC Sensor"
 description: "Instructions on how to integrate Daikin AC(s) with Home Assistant."
 date: 2017-12-03 05:00
-sidebar: True
+sidebar: true
 comments: false
 sharing: true
 footer: true

--- a/source/_components/sensor.fail2ban.markdown
+++ b/source/_components/sensor.fail2ban.markdown
@@ -164,7 +164,7 @@ Once that's added to the nginx configuration, we need to modify the Home Assista
 
 ```yaml
 http:
-  use_x_forwarded_for: True
+  use_x_forwarded_for: true
 ```
 
 At this point, once the Let's Encrypt and Home Assistant dockers are restarted, Home Assistant should be correctly logging the originating IP of any failed login attempt.  Once that's done and verified, we can move onto the final step.

--- a/source/_components/sensor.fastdotcom.markdown
+++ b/source/_components/sensor.fastdotcom.markdown
@@ -59,7 +59,7 @@ hour:
   required: false
   type: list
 manual:
-  description: True or False to turn manual mode on or off. Manual mode will disable scheduled speedtests.
+  description: "`true` or `false` to turn manual mode on or off. Manual mode will disable scheduled speedtests."
   required: false
   default: false
   type: boolean

--- a/source/_components/sensor.jewish_calendar.markdown
+++ b/source/_components/sensor.jewish_calendar.markdown
@@ -43,7 +43,7 @@ longitude:
 diaspora:
   required: false
   description: Consider the location as diaspora or not for calculation of the weekly portion and holidays.
-  default: False
+  default: false
   type: string
 sensors:
   required: false

--- a/source/_components/sensor.kwb.markdown
+++ b/source/_components/sensor.kwb.markdown
@@ -27,7 +27,7 @@ Direct connection via serial port:
     name: kwb
     device: "/dev/ttyUSB0"
     type: serial
-    raw: False
+    raw: false
 ```
 
 Telnet terminal server with a serial-ethernet converter:
@@ -39,7 +39,7 @@ Telnet terminal server with a serial-ethernet converter:
     host: <ip>
     port: 23
     type: tcp
-    raw: False
+    raw: false
 ```
 
 Take a good look at which configuration variables are for `TCP` use or for `serial` use.

--- a/source/_components/sensor.luftdaten.markdown
+++ b/source/_components/sensor.luftdaten.markdown
@@ -72,7 +72,7 @@ sensor:
 {% endconfiguration %}
 
 <p class='note warning'>
-If you set `show_on_map` to `True` then the location attributes are named `latitude` and `longitude`. The default name of the location attributes is `lat` and `long` to avoid showing them on the map.
+If you set `show_on_map` to `true` then the location attributes are named `latitude` and `longitude`. The default name of the location attributes is `lat` and `long` to avoid showing them on the map.
 </p>
 
 Not all sensors provide all conditions. Also, it's possible that the sensor values are not available all the time. To check what a sensor is publishing use `curl`:

--- a/source/_components/sensor.modbus.markdown
+++ b/source/_components/sensor.modbus.markdown
@@ -78,7 +78,7 @@ registers:
     reverse_order:
       description: Reverse the order of registers when count >1.
       required: false
-      default: False
+      default: false
       type: boolean
     scale:
       description: Scale factor (output = scale * value + offset).

--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -63,7 +63,7 @@ force_update:
   description: Sends update events even if the value hasn't changed. Useful if you want to have meaningful value graphs in history.
   reqired: false
   type: boolean
-  default: False
+  default: false
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false

--- a/source/_components/sensor.rest.markdown
+++ b/source/_components/sensor.rest.markdown
@@ -64,7 +64,7 @@ verify_ssl:
   description: Verify the certification of the endpoint.
   required: false
   type: boolean
-  default: True
+  default: true
 unit_of_measurement:
   description: Defines the units of measurement of the sensor, if any.
   required: false
@@ -93,7 +93,7 @@ force_update:
   description: Sends update events even if the value hasn't changed. Useful if you want to have meaningful value graphs in history.
   reqired: false
   type: boolean
-  default: False
+  default: false
 {% endconfiguration %}
 
 <p class='note warning'>

--- a/source/_components/sensor.rfxtrx.markdown
+++ b/source/_components/sensor.rfxtrx.markdown
@@ -21,7 +21,7 @@ The easiest way to find your sensors is to add this to your `configuration.yaml`
 # Example configuration.yaml entry
 sensor:
   platform: rfxtrx
-  automatic_add: True
+  automatic_add: true
 ```
 
 Then when the sensor emits a signal it will be automatically added:
@@ -76,11 +76,11 @@ Example configuration:
 # Example configuration.yaml entry
 sensor:
   platform: rfxtrx
-  automatic_add: True
+  automatic_add: true
   devices:
     0a52080705020095220269:
       name: Lving
-      fire_event: True
+      fire_event: true
     0a520802060100ff0e0269:
       name: Bath
       data_type:

--- a/source/_components/sensor.tellstick.markdown
+++ b/source/_components/sensor.tellstick.markdown
@@ -28,7 +28,7 @@ sensor:
   required: false
   type: string
 only_named:
-  description: Only show the named sensors. Set to `True` to hide sensors.
+  description: Only show the named sensors. Set to `true` to hide sensors.
   required: false
   default: false
   type: boolean
@@ -56,7 +56,7 @@ sensor:
   - platform: tellstick
     135: Outside
     21: Inside
-    only_named: True
+    only_named: true
     temperature_scale: "°C"
     datatype_mask: 1
 ```

--- a/source/_components/switch.arest.markdown
+++ b/source/_components/switch.arest.markdown
@@ -29,7 +29,7 @@ switch:
         name: Fan
       13:
         name: Switch
-        invert: True
+        invert: true
 ```
 
 If you want to use custom functions, then add the following to your `configuration.yaml` file:

--- a/source/_components/switch.flux.markdown
+++ b/source/_components/switch.flux.markdown
@@ -108,7 +108,7 @@ switch:
     sunset_colortemp: 3000
     stop_colortemp: 1900
     brightness: 200
-    disable_brightness_adjust: True
+    disable_brightness_adjust: true
     mode: xy
     transition: 30
     interval: 60

--- a/source/_components/switch.ihc.markdown
+++ b/source/_components/switch.ihc.markdown
@@ -29,7 +29,7 @@ To manually configure IHC switches insert this section in your configuration:
 ```yaml
 switch:
     - platform: ihc
-    auto_setup: True
+    auto_setup: true
     switches:
         - id: 12345
           name: myswitch

--- a/source/_components/switch.modbus.markdown
+++ b/source/_components/switch.modbus.markdown
@@ -86,7 +86,7 @@ register:
     verify_state:
       description: Define if is possible to readback the status of the switch.
       required: false
-      default: True
+      default: true
       type: boolean
     verify_register:
       description: Register to readback.

--- a/source/_components/switch.rfxtrx.markdown
+++ b/source/_components/switch.rfxtrx.markdown
@@ -21,7 +21,7 @@ The easiest way to find your switches is to add this to your `configuration.yaml
 # Example configuration.yaml entry
 switch:
   platform: rfxtrx
-  automatic_add: True
+  automatic_add: true
 ```
 
 Launch your Home Assistant and go the website.
@@ -70,7 +70,7 @@ signal_repetitions:
 {% endconfiguration %}
 
 <p class='note warning'>
-This component and the [rfxtrx binary sensor](/components/binary_sensor.rfxtrx/) can steal each other's devices when setting the `automatic_add` configuration parameter to `true`. Set `automatic_add` only when you have some devices to add to your installation, otherwise leave it to `False`.
+This component and the [rfxtrx binary sensor](/components/binary_sensor.rfxtrx/) can steal each other's devices when setting the `automatic_add` configuration parameter to `true`. Set `automatic_add` only when you have some devices to add to your installation, otherwise leave it to `false`.
 </p>
 
 <p class='note warning'>
@@ -102,7 +102,7 @@ Basic configuration with 3 devices:
 # Example configuration.yaml entry
 switch:
   platform: rfxtrx
-  automatic_add: False
+  automatic_add: false
   signal_repetitions: 2
   devices:
     0b1100ce3213c7f210010f70:
@@ -111,7 +111,7 @@ switch:
       name: Movment2
     0b1111e003af16aa10000060:
       name: Door
-      fire_event: True
+      fire_event: true
 ```
 
 Light hallway if doorbell is pressed (when is sun down):
@@ -120,7 +120,7 @@ Light hallway if doorbell is pressed (when is sun down):
 # Example configuration.yaml entry
 switch:
   platform: rfxtrx
-  automatic_add: False
+  automatic_add: false
   devices:
     0710014c440f0160:
       name: Hall
@@ -154,7 +154,7 @@ Use remote to enable scene (using event_data):
 # Example configuration.yaml entry
 switch:
   platform: rfxtrx
-  automatic_add: False
+  automatic_add: false
   devices:
     0b1100ce3213c7f210010f70:
       name: Light1

--- a/source/_components/tts.markdown
+++ b/source/_components/tts.markdown
@@ -33,7 +33,7 @@ cache:
   description: Allow TTS to cache voice file to local storage.
   required: false
   type: boolean
-  default: True
+  default: true
 cache_dir:
   description: Folder name or path to a folder for caching files.
   required: false

--- a/source/_components/weather.buienradar.markdown
+++ b/source/_components/weather.buienradar.markdown
@@ -59,7 +59,7 @@ weather:
     # Force 'Meetstation Volkel' to be used:
     latitude: 51.65
     longitude: 5.70
-    forecast: True
+    forecast: true
 ```
 
 <p class='note'>

--- a/source/_components/wink.markdown
+++ b/source/_components/wink.markdown
@@ -105,7 +105,7 @@ Error sending local control request. Sending request online
 
 The Wink component only obtains the device states from the Wink API once, during startup. All updates after that are pushed via a third party called PubNub. On rare occasions where an update isn't pushed device states can be out of sync.
 
-You can use the service wink/refresh_state_from_wink to pull the most recent state from the Wink API for all devices. If `local_control` is set to `True` states will be pulled from the devices controlling hub, not the online API.
+You can use the service wink/refresh_state_from_wink to pull the most recent state from the Wink API for all devices. If `local_control` is set to `true` states will be pulled from the devices controlling hub, not the online API.
 
 ### {% linkable_title Service `pull_newly_added_devices_from_wink` %}
 
@@ -268,7 +268,7 @@ You can use the service wink/set_siren_strobe_enabled to enable or disable the s
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `enabled` | no | Boolean. True or False.
+| `enabled` | no | Boolean. `true` or `false`.
 | `entity_id` | yes | String or list of strings that point at `entity_id`s of siren/chime.
 
 Example:
@@ -279,7 +279,7 @@ script:
     sequence:
       - service: wink.set_siren_strobe_enabled
         data:
-          enabled: False
+          enabled: false
 ```
 
 ### {% linkable_title Service `set_chime_strobe_enabled` %}
@@ -288,7 +288,7 @@ You can use the service wink/set_chime_strobe_enabled to enable or disable the s
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `enabled` | no | Boolean. True or False.
+| `enabled` | no | Boolean. `true` or `false`.
 | `entity_id` | yes | String or list of strings that point at `entity_id`s of chime/chime.
 
 Example:
@@ -299,7 +299,7 @@ script:
     sequence:
       - service: wink.set_chime_strobe_enabled
         data:
-          enabled: False
+          enabled: false
 ```
 
 ### {% linkable_title Service `set_nimbus_dial_state` %}

--- a/source/_components/zabbix.markdown
+++ b/source/_components/zabbix.markdown
@@ -37,7 +37,7 @@ path:
   type: string
   default: "`/zabbix/`"
 ssl:
-  description: Set to `True` if your Zabbix installation is using SSL.
+  description: Set to `true` if your Zabbix installation is using SSL.
   required: false
   type: boolean
   default: false
@@ -58,7 +58,7 @@ password:
 zabbix:
   host: ZABBIX_HOST
   path: ZABBIX_PATH
-  ssl: False
+  ssl: false
   username: USERNAME
   password: PASSWORD
 ```

--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -54,7 +54,7 @@ You have to set an initial state in your automations in order for Home Assistant
 ```text
 automation:
 - alias: Automation Name
-  initial_state: True
+  initial_state: true
   trigger:
   ...
 ```

--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -42,17 +42,17 @@ hidden:
   description: Set to `true` to hide the entity.
   required: false
   type: boolean
-  default: False
+  default: false
 homebridge_hidden:
   description: Set to `true` to hide the entity from `HomeBridge`.
   required: false
   type: boolean
-  default: False
+  default: false
 emulated_hue_hidden:
   description: Set to `true` to hide the entity from `emulated_hue` (this will be deprecated in the near future and should be configured in [`emulated_hue`](/components/emulated_hue)).
   required: false
   type: boolean
-  default: False
+  default: false
 entity_picture:
   description: URL to use as picture for entity.
   required: false
@@ -65,7 +65,7 @@ assumed_state:
   description: For switches with an assumed state two buttons are shown (turn off, turn on) instead of a switch. By setting `assumed_state` to `false` you will get the default switch icon.
   required: false
   type: boolean
-  default: True
+  default: true
 device_class:
   description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
   required: false

--- a/source/_docs/configuration/group_visibility.markdown
+++ b/source/_docs/configuration/group_visibility.markdown
@@ -20,7 +20,7 @@ To change visibility of a group, use the service `group.set_visibility`, pass th
 service: group.set_visibility
 entity_id: group.basement
 data:
-  visible: False
+  visible: false
 ```
 
 <p class='note'>
@@ -42,7 +42,7 @@ automation:
     service: group.set_visibility
     entity_id: group.basement
     data:
-      visible: False
+      visible: false
 
 automation 2:
   trigger:
@@ -52,7 +52,7 @@ automation 2:
     service: group.set_visibility
     entity_id: group.basement
     data:
-      visible: True
+      visible: true
 ```
 
 ## {% linkable_title Easier automations %}

--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -101,7 +101,7 @@ Let's look at the `device_tracker.yaml` file from our example:
   hosts: 192.168.2.0/24
   home_interval: 3
 
-  track_new_devices: yes
+  track_new_devices: true
   interval_seconds: 40
   consider_home: 120
 ```

--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -37,7 +37,7 @@ Attribute | Description
 `icon` | Icon to use for the entity in the frontend. Example: `mdi:home`.
 `hidden` | Boolean if the entity should not be shown in the frontend. Example: `true`.
 `entity_picture` | URL to a picture that should be used instead of showing the domain icon. Example: `http://example.com/picture.jpg`.
-`assumed_state` | Boolean if the current state is an assumption. [More info](/blog/2016/02/12/classifying-the-internet-of-things/#classifiers) Example: `True`.
+`assumed_state` | Boolean if the current state is an assumption. [More info](/blog/2016/02/12/classifying-the-internet-of-things/#classifiers) Example: `true`.
 `unit_of_measurement` | The unit of measurement the state is expressed in. Used for grouping graphs or understanding the entity. Example: `°C`.
 
 When an attribute contains spaces, you can retrieve it like this: `states.sensor.livingroom.attributes["Battery numeric"]`.

--- a/source/_docs/ecosystem/ios/notifications/actions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/actions.markdown
@@ -58,7 +58,7 @@ When sending a notification:
 - **identifier** (*Required*): A unique identifier for this action. Must be uppercase and have no special characters or spaces. Only needs to be unique to the category, not unique globally.
 - **title** (*Required*): The text to display on the button. Keep it short.
 - **activationMode** (*Optional*): The mode in which to run the app when the action is performed. Setting this to `foreground` will make the app open after selecting. Default value is `background`.
-- **authenticationRequired** (*Optional*): If a truthy value (`true`, `True`, `yes`, etc.) the user must unlock the device before the action is performed.
+- **authenticationRequired** (*Optional*): If `true` the user must unlock the device before the action is performed.
 - **destructive** (*Optional*): When the value of this property is a truthy value, the system displays the corresponding button differently to indicate that the action is destructive (text color is red).
 - **behavior** (*Optional*): When `textInput` the system provides a way for the user to enter a text response to be included with the notification. The entered text will be sent back to Home Assistant. Default value is `default`.
 - **textInputButtonTitle** (*Optional*): The button label. *Required* if `behavior` is `textInput`.
@@ -76,13 +76,13 @@ ios:
           - identifier: 'SOUND_ALARM'
             title: 'Sound Alarm'
             activationMode: 'background'
-            authenticationRequired: yes
-            destructive: yes
+            authenticationRequired: true
+            destructive: true
             behavior: 'default'
           - identifier: 'SILENCE_ALARM'
             title: 'Silence Alarm'
             activationMode: 'background'
-            authenticationRequired: yes
+            authenticationRequired: true
             destructive: no
             behavior: 'textInput'
             textInputButtonTitle: 'Silencio!'

--- a/source/_docs/ecosystem/ios/notifications/content_extensions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/content_extensions.markdown
@@ -93,13 +93,13 @@ ios:
           - identifier: 'OPEN_COVER'
             title: 'Open Cover'
             activationMode: 'background'
-            authenticationRequired: yes
-            destructive: no
+            authenticationRequired: true
+            destructive: false
           - identifier: 'CLOSE_COVER'
             title: 'Close Cover'
             activationMode: 'background'
-            authenticationRequired: yes
-            destructive: yes
+            authenticationRequired: true
+            destructive: true
 ```
 
 # Troubleshooting

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -71,7 +71,7 @@ autoheal:
   description: Allows disabling auto Z-Wave heal at midnight.
   required: false
   type: boolean
-  default: True
+  default: true
 polling_interval:
   description: The time period in milliseconds between polls of a nodes value. Be careful about using polling values below 30000 (30 seconds) as polling can flood the zwave network and cause problems.
   required: false
@@ -81,7 +81,7 @@ debug:
   description: Print verbose z-wave info to log.
   required: false
   type: boolean
-  default: False
+  default: false
 device_config / device_config_domain / device_config_glob:
   description: "This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the following options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format."
   required: false
@@ -91,7 +91,7 @@ device_config / device_config_domain / device_config_glob:
       description: Ignore this entity completely. It won't be shown in the Web Interface and no events are generated for it.
       required: false
       type: boolean
-      default: False
+      default: false
     polling_intensity:
       description: Enables polling of a value and sets the frequency of polling (0=none, 1=every time through the list, 2=every other time, etc). If not specified then your device will not be polled.
       required: false
@@ -101,7 +101,7 @@ device_config / device_config_domain / device_config_glob:
       description: Enable refreshing of the node value. Only the light component uses this.
       required: false
       type: boolean
-      default: False
+      default: false
     delay:
       description: Specify the delay for refreshing of node value. Only the light component uses this.
       required: false
@@ -111,7 +111,7 @@ device_config / device_config_domain / device_config_glob:
       description: Inverts function of the open and close buttons for the cover domain. This will not invert the position and state reporting.
       required: false
       type: boolean
-      default: False
+      default: false
 {% endconfiguration %}
 
 <p class='note'>

--- a/source/_posts/2016-09-29-async-sleepiq-emoncms-stocks.markdown
+++ b/source/_posts/2016-09-29-async-sleepiq-emoncms-stocks.markdown
@@ -30,7 +30,7 @@ As you might have noticed, this release has been delayed by 5 days. This was due
 
 ### {% linkable_title Hide automation rules %}
 
-Since 0.28 [automation rules](/blog/2016/09/10/notify-group-reload-api-pihole/#reload-automation-rules) can be reloaded directly from the frontend. By default all automation rules are shown. If you want to [hide an automation rule](/getting-started/automation-create-first/), use `hide_entity: True`.
+Since 0.28 [automation rules](/blog/2016/09/10/notify-group-reload-api-pihole/#reload-automation-rules) can be reloaded directly from the frontend. By default all automation rules are shown. If you want to [hide an automation rule](/getting-started/automation-create-first/), use `hide_entity: true`.
 
 ### {% linkable_title All changes %}
 

--- a/source/_posts/2017-06-17-release-47.markdown
+++ b/source/_posts/2017-06-17-release-47.markdown
@@ -125,7 +125,7 @@ lutron:
 mailgun:
   domain: !secret mailgun_domain
   api_key: !secret mailgun_api_key
-  sandbox: False
+  sandbox: false
 
 notify:
   - name: mailgun

--- a/source/getting-started/automation-2.markdown
+++ b/source/getting-started/automation-2.markdown
@@ -18,8 +18,8 @@ We are defining a [trigger](/docs/automation/trigger/) to track the sunset and t
 # Example configuration.yaml entry
 automation:
   alias: Turn on the lights when the sun sets
-  initial_state: True
-  hide_entity: False
+  initial_state: true
+  hide_entity: false
   trigger:
     platform: sun
     event: sunset
@@ -27,7 +27,7 @@ automation:
     service: light.turn_on
 ```
 
-Starting with 0.28 automation rules can be reloaded from the [frontend](/components/automation/) and are shown by default. With [`hide_entity:`](/components/automation/) you can control this behavior. It's convenient if you are working on your rules, but when a rule is finished, and you don't want to see that rule in your frontend, you can set `hide_entity:` to `True`. To set an automation to be disabled when Home Assistant starts set `initial_state:` to `False`.
+Starting with 0.28 automation rules can be reloaded from the [frontend](/components/automation/) and are shown by default. With [`hide_entity:`](/components/automation/) you can control this behavior. It's convenient if you are working on your rules, but when a rule is finished, and you don't want to see that rule in your frontend, you can set `hide_entity:` to `true`. To set an automation to be disabled when Home Assistant starts set `initial_state:` to `false`.
 
 After a few days of running this automation rule, you come to realize that this automation rule is not sufficient. It was already dark when the lights went on, and the one day you weren't home, the lights turned on anyway. Time for some tweaking. Let's add an offset to the sunset trigger and a [condition](/docs/automation/condition/) to only turn on the lights if anyone is home.
 
@@ -91,7 +91,7 @@ group:
 
 automation:
   alias: Turn on the lights when the sun sets
-  hide_entity: True
+  hide_entity: true
   trigger:
     platform: sun
     event: sunset


### PR DESCRIPTION
**Description:**

Removes some last "truthy" boolean values from our documentation and also standardizes boolean usage to lower case.

Also: Fixed a couple of broken examples along the way.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
