### PR TITLE
WeMo Humidifier - Add wemo_reset_filter_life service

### DIFF
--- a/source/_components/fan.wemo.markdown
+++ b/source/_components/fan.wemo.markdown
@@ -16,8 +16,6 @@ ha_release: 0.82
 
 The `wemo` platform allows you to control your [Belkin WeMo](http://www.belkin.com/us/p/P-F7C027/) humidifiers from within Home Assistant. This includes support for the [Holmes Smart Humidifier](https://www.holmesproducts.com/wemo-humidifier.html).
 
-They will be automatically discovered if the discovery component is enabled.
-
 For more configuration information, see the [WeMo component](/components/wemo/) documentation.
 
 ### {% linkable_title Attributes %}
@@ -29,8 +27,8 @@ There are several attributes which can be used for automations and templates.
 | `current_humidity` | An integer that indicates the current relative humidity percentage of the room, as determined by the device's onboard humidity sensor.
 | `target_humidity` | An integer that indicates the desired relative humidity percentage (this is constrained to the humidity settings of the device, which are 45, 50, 55, 60, and 100).
 | `fan_mode` | String that indicates the current fan speed setting, as reported by the WeMo humidifier.
-| `water level` | String that indicates whether the water level is Good, Low, or Empty.
-| `filter_life` | The used life of the filter (as a percentage).
+| `water_level` | String that indicates whether the water level is Good, Low, or Empty.
+| `filter_life` | A decimal that represents the used life of the filter (as a percentage).
 | `filter_expired` | A boolean that indicates whether the filter has expired and needs to be replaced.
 
 ### {% linkable_title Services %}
@@ -41,6 +39,7 @@ There are several services which can be used for automations and control of the 
 | --------- | ----------- |
 | `set_speed` | Calling this service sets the fan speed (entity_id and speed are required parameters, and speed must be one of the following: off, low, medium, or high). When selecting low for the speed, this will map to the WeMo humidifier speed of minimum. When selecting high for the speed, this will map to the WeMo humidifier speed of maximum. The WeMo humidifier speeds of low and high are unused due to constraints on which fan speeds Home Assistant supports.
 | `wemo_set_humidity` | Calling this service will set the desired relative humidity setting on the device (entity_id is an optional list of entities to set humidity on (omitting this list will set humidity on all WeMo Humidifiers), and target_humidity is a required float value between 0 and 100 (this value will be rounded down and mapped to one of the valid desired humidity settings of 45, 50, 55, 60, or 100 that are supported by the WeMo humidifier)).
+| `wemo_reset_filter_life` | Calling this service will reset the humidifier's filter life back to 100% (use this when you change the filter, entity_id is required)
 | `turn_on` | Calling this service will turn the humidifier on and set the speed to the last used speed (defaults to medium, entity_id is required).
 | `turn_off` | Calling this service will turn the humidifier off (entity_id is required).
 | `toggle` | Calling this service will toggle the humidifier between on and off states.


### PR DESCRIPTION
**Description:**
Adds a service to the WeMo Humidifier to reset filter life back to 100% when replacing the filter.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18388

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
