### PR TITLE
Fix config that could be interpreted as octal

### DIFF
--- a/source/_components/sensor.meteo_france.markdown
+++ b/source/_components/sensor.meteo_france.markdown
@@ -23,7 +23,7 @@ To add Météo-France to your installation, add the following to your `configura
 # Example configuration.yaml entry
 sensor:
   - platform: meteo_france
-    postal_code: 76000
+    postal_code: '76000'
     monitored_conditions:
       - temperature
       - weather


### PR DESCRIPTION
**Description:**
Some postal codes have a leading zero which would be interpreted as an octal int.
Adding quotes on the documentation to avoid confusion with those postal codes.
Fixes https://github.com/home-assistant/home-assistant/issues/18375

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
