### PR TITLE
Add deconz entry manually

### DIFF
--- a/source/_components/deconz.markdown
+++ b/source/_components/deconz.markdown
@@ -34,6 +34,15 @@ If you don't have the API key, you can generate an API key for deCONZ by using t
 
 You can manually add deCONZ by going to the integrations page.
 
+You can also generate the API key manually and then add the deconz entry manually to the configuration.yaml. Generating the API key manually is described in the [Deconz REST Wiki](http://dresden-elektronik.github.io/deconz-rest-doc/getting_started/).
+The IP address is usually the same as your raspberry pi's and the default port is 80. In the configuration.yaml add the deconz component, after that you should see the deconz in the frontend and all the devices added in deconz should appear automatically in Home-Assistant:
+```yaml
+deconz:
+  api_key: [yourAPIkey]
+  host: [yourDeconzIP]
+  port: 80
+```
+
 ## {% linkable_title Debugging component %}
 
 If you have problems with deCONZ or the component you can add debug prints to the log.


### PR DESCRIPTION
A few days ago I tried for a few hours to get deconz to work with the auto discovery and didn't succeed.
I found a ticket for a bug in the deconz github, that the discovery request always returns an empty array. Which will probably be resolved in the future and is most likely the cause of it not working for me.
But I think there would be no harm in adding the manual way of including the deconz component in the configuration.yaml

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
