### PR TITLE
Added "monitored_conditions"

### DIFF
--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -98,18 +98,20 @@ To configure additional functionality, add configuration options beneath a `bina
 openuv:
   api_key: YOUR_OPENUV_API_KEY
   binary_sensors:
-    - uv_protection_window
+    monitored_conditions:
+      - uv_protection_window
   sensors:
-    - current_ozone_level
-    - current_uv_index
-    - current_uv_level
-    - max_uv_index
-    - safe_exposure_time_type_1
-    - safe_exposure_time_type_2
-    - safe_exposure_time_type_3
-    - safe_exposure_time_type_4
-    - safe_exposure_time_type_5
-    - safe_exposure_time_type_6
+    monitored_conditions:
+      - current_ozone_level
+      - current_uv_index
+      - current_uv_level
+      - max_uv_index
+      - safe_exposure_time_type_1
+      - safe_exposure_time_type_2
+      - safe_exposure_time_type_3
+      - safe_exposure_time_type_4
+      - safe_exposure_time_type_5
+      - safe_exposure_time_type_6
 ```
 
 <p class='note warning'>


### PR DESCRIPTION
Added `monitored_conditions` to configure additional functionality beneath `binary_sensor` and `sensor` key within the `openuv` section of the `configuration.yaml` file. Without it, you'll end up with a `expected a dictionary for dictionary value @ data...`-error

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
