### PR TITLE
Update route53.markdown

### DIFF
--- a/source/_components/route53.markdown
+++ b/source/_components/route53.markdown
@@ -72,7 +72,7 @@ route53:
   aws_access_key_id: ABC123
   aws_secret_access_key: DEF456
   zone: ZONEID678
-  domain: home.yourdomain.com
+  domain: yourdomain.com
   records:
     - vpn
     - hassio


### PR DESCRIPTION
Removing 'home." from the base domain. 
Following this configuration previously would create the following entries: vpn.home.yourdomain.com, hassio.home.yourdomain.com, home.home.yourdomain.com. 
Now it will create vpn.yourdomain.com, hassio.yourdomain.com, home.yourdomain.com.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
