### PR TITLE
Correct type from picture-status to plant-status in text

### DIFF
--- a/source/_lovelace/plant-status.markdown
+++ b/source/_lovelace/plant-status.markdown
@@ -20,7 +20,7 @@ Screenshot of the plant status card.
 {% configuration %}
 type:
   required: true
-  description: picture-status
+  description: plant-status
   type: string
 entity:
   required: true


### PR DESCRIPTION

**Description:** Correct type from `picture-status` to `plant-status`


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#7499
## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
