### PR TITLE
Add more documentation to modbus services

### DIFF
--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -111,6 +111,10 @@ timeout:
 | Service | Description |
 | ------- | ----------- |
 | write_register | Write register. Requires `unit`, `address` and `value` fields. `value` can be either single value or an array |
+| unit | Slave address (255 if not used) |
+| address | Address of the Register (e. g. 138) |
+| value | an array of 16 bit values. Might need reverse ordering. E. g. to set 0x0004 you might need to set [4,0] |
+
 
 
 ## {% linkable_title Building on top of Modbus %}

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -116,9 +116,9 @@ timeout:
 
 | Attribute | Description |
 | --------- | ----------- |
-| unit      | Slave address (set to 255 you talk to modbus via TCP) |
-| address   | Address of the Register (e. g. 138) |
-| value     | An array of 16 bit values. Might need reverse ordering. E. g. to set 0x0004 you might need to set [4,0] |
+| unit      | Slave address (set to 255 you talk to Modbus via TCP) |
+| address   | Address of the Register (e.g., 138) |
+| value     | An array of 16-bit values. Might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |
 
 ## {% linkable_title Building on top of Modbus %}
 

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -111,11 +111,14 @@ timeout:
 | Service | Description |
 | ------- | ----------- |
 | write_register | Write register. Requires `unit`, `address` and `value` fields. `value` can be either single value or an array |
-| unit | Slave address (255 if not used) |
-| address | Address of the Register (e. g. 138) |
-| value | an array of 16 bit values. Might need reverse ordering. E. g. to set 0x0004 you might need to set [4,0] |
 
+#### {% linkable_title Service Data Attributes %}
 
+| Attribute | Description |
+| --------- | ----------- |
+| unit      | Slave address (set to 255 you talk to modbus via TCP) |
+| address   | Address of the Register (e. g. 138) |
+| value     | An array of 16 bit values. Might need reverse ordering. E. g. to set 0x0004 you might need to set [4,0] |
 
 ## {% linkable_title Building on top of Modbus %}
 


### PR DESCRIPTION
Useful for people not so familiar with modbus terminology. I had to use Wikipedia to understand the paramters, this should clarify things.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
