### PR TITLE
Update sensor.sigfox.markdown

### DIFF
--- a/source/_components/sensor.sigfox.markdown
+++ b/source/_components/sensor.sigfox.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: sigfox.png
 ha_category: Sensor
-ha_iot_class: "Local Polling"
+ha_iot_class: "Cloud Polling"
 ha_release: 0.68
 ---
 


### PR DESCRIPTION
Change IoT Class to Cloud Polling as it is using the Sigfox API.
**Description:**
Previous IoT Class was Local Polling which is incorrect. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: current
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
