### PR TITLE
Amend the .gitignore to not block README.md files

### DIFF
--- a/source/_docs/ecosystem/backup/backup_github.markdown
+++ b/source/_docs/ecosystem/backup/backup_github.markdown
@@ -61,6 +61,7 @@ Here is an example that will ignore everything but your YAML configuration.
 *
 !*.yaml
 !.gitignore
+!*.md
 *.conf
 *.txt
 *.log


### PR DESCRIPTION
Currently, if you use the .gitignore suggestion you will get a 404 error when trying to add a README.md file in gitea. This is naturally confusing for users and README.md files are a common component of git. suggest allowing this.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
