### PR TITLE
Add certfile and keyfile to default configuration

### DIFF
--- a/source/_addons/lets_encrypt.markdown
+++ b/source/_addons/lets_encrypt.markdown
@@ -19,7 +19,9 @@ Setup and manage a [Let's Encrypt](https://letsencrypt.org/) certificate. This a
 ```json
 {
   "email": "example@example.com",
-  "domains": ["example.com", "mqtt.example.com", "hass.example.com"]
+  "domains": ["example.com", "mqtt.example.com", "hass.example.com"],
+  "certfile": "fullchain.pem",
+  "keyfile": "privkey.pem"
 }
 ```
 
@@ -32,6 +34,16 @@ domains:
   description: A list of domains to create/renew the certificate.
   required: true
   type: list
+certfile:
+  description: Name of the certfile that is created.  Leave as default value.
+  required: true
+  type: string
+  default: fullchain.pem
+keyfile:
+  description: Name of the keyfile that is created.  Leave as default value.
+  required: true
+  type: string
+  default: privkey.pem
 {% endconfiguration %}
 
 ## {% linkable_title Home Assistant configuration %}


### PR DESCRIPTION
**Description:**
The default configuration in hassio has certfile and keyfile but it was missing in documentation.  It was confusing for me if the configuration was asking for the path to where the files are stored or if it was the file name to be created.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
