### PR TITLE
Fixed Configuration link

### DIFF
--- a/source/_components/tesla.markdown
+++ b/source/_components/tesla.markdown
@@ -23,7 +23,7 @@ This component provides the following platforms:
  - Climate - HVAC control. Allow you to control (turn on/off, set target temperature) your Tesla's HVAC system.
  - Switch - Charger and max range switch. Allow you to start/stop charging and set max range charging.
 
- ## {% linkable_title Configuration %}
+## {% linkable_title Configuration %}
 
 To use Tesla in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
This was not displaying correctly on the docs site ("##" were showing).

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
