### PR TITLE
Alarmdecoder doc updates for new zone loop parameter

### DIFF
--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -40,6 +40,7 @@ alarmdecoder:
       name: 'Smoke Detector'
       type: 'smoke'
       rfid: '0123456'
+      loop: 1
     02:
       name: 'Front Door'
       type: 'opening'
@@ -99,6 +100,10 @@ zones:
       description: The RF serial-number associated with RF zones. Providing this field allows Home Assistant to associate raw sensor data to a given zone, allowing direct monitoring of the state, battery, and supervision status.
       required: false
       type: string
+    loop:
+      description: The loop number associated with RF zones (1, 2, 3, or 4). Providing this field allows Home Assistant to read open/closed status from the raw sensor data in addition to from the panel display, meaning it can correctly show a bypassed RF zone as open or closed when the alarm is armed. (This is an alternative to relayaddr/relaychan below for RF zones.)
+      required: false
+      type: integer
     relayaddr:
       description: "Address of the relay expander board to associate with the zone. (ex: 12, 13, 14, or 15). Typically used in cases where a panel will not send bypassed zones such as motion during an armed home state, the Vista 20P is an example of this. Alarmdecoder can emulate a zone expander board and the panel can be programmed to push zone events to this virtual expander. This allows the bypassed zone binary sensors to be utilized. One example is using bypassed motion sensors at night for motion-based automated lights while the system is armed with the motion sensor bypassed."
       required: inclusive

--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -40,7 +40,6 @@ alarmdecoder:
       name: 'Smoke Detector'
       type: 'smoke'
       rfid: '0123456'
-      loop: 1
     02:
       name: 'Front Door'
       type: 'opening'


### PR DESCRIPTION
**Description:**
Docs for new config option.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18477

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
