### PR TITLE
Update securing.markdown to give a hint to SSH server add-on

### DIFF
--- a/source/_docs/configuration/securing.markdown
+++ b/source/_docs/configuration/securing.markdown
@@ -12,6 +12,10 @@ redirect_from: /getting-started/securing/
 
 One major advantage of Home Assistant is that it's not dependent on cloud services. Even if you're only using Home Assistant on a local network, you should take steps to secure your instance.
 
+<p class='note'>
+In order to follow these steps you should have ssh access to your Home Assistant instance. When you have installed [Hass.io](/hassio/) via the [Getting Started](/getting-started/) guide you need to activate the [SSH server add-on](/addons/ssh/) (or alternatives) to get ssh access.
+</p>
+
 ## {% linkable_title Checklist %}
 
 Here's the summary of what you *must* do to secure your Home Assistant system:


### PR DESCRIPTION
People coming to this page from the [Getting Started](https://www.home-assistant.io/getting-started/) > "secure your installation" link (and working their way through the documentation) will most likely find a note helpful with a link to the ssh addon.

At least it took me a while and some googling to find this answer, so I place it in the docs. Don't worry to edit my lines, I am not a native speaker :)