### PR TITLE
Corrects ha_release 0.83 on Velbus climate component

### DIFF
--- a/source/_components/climate.velbus.markdown
+++ b/source/_components/climate.velbus.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: velbus.png
 ha_category: Climate
 ha_iot_class: "Local Push"
-ha_release: 0.82
+ha_release: 0.83
 ---
 
 The `velbus` climate devices allow you to control [Velbus](http://www.velbus.eu) connected thermostats.


### PR DESCRIPTION
**Description:**

PR #7489 was merged with an incorrect version number in `ha_release`.
This PR corrects it.

As per [comment](https://github.com/home-assistant/home-assistant.io/pull/7489#pullrequestreview-174941364) by @MartinHjelmare.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
