### PR TITLE
Change category to Sensor for WaterFurnace

### DIFF
--- a/source/_components/waterfurnace.markdown
+++ b/source/_components/waterfurnace.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: waterfurnace.png
-ha_category: Irrigation
+ha_category: Sensor
 ha_release: 0.62
 ha_iot_class: "Cloud Polling"
 ---


### PR DESCRIPTION
**Description:**
Changed the category to "Sensor" since a geothermal system is not related at all with irrigation and, since this component does not support the thermostat function, it should probably not be put in the "Climate" category.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
