### PR TITLE
Fixed case of exposed domains

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -105,9 +105,9 @@ google_assistant:
   project_id: YOUR_PROJECT_ID
   api_key: YOUR_API_KEY
   exposed_domains:
-    - SWITCH
-    - LIGHT
-    - GROUP
+    - switch
+    - light
+    - group
   entity_config:
     switch.kitchen:
       name: CUSTOM_NAME_FOR_GOOGLE_ASSISTANT


### PR DESCRIPTION
Exposed domains must be lowercase, otherwise Google Home will link accounts but will not find any device to setup.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
