### PR TITLE
Update pushsafer notify component configuration

### DIFF
--- a/source/_components/notify.pushsafer.markdown
+++ b/source/_components/notify.pushsafer.markdown
@@ -26,15 +26,21 @@ notify:
     private_key: YOUR_KEY
 ```
 
-**Configuration variables:**
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **private_key** (*Required*): Your private or alias key. Private key = send the notification to all devices with standard params, alias key send the notification to the devices stored in the alias with predefined params.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+private_key:
+  description: Your private or alias key. Private key = send the notification to all devices with standard params, alias key send the notification to the devices stored in the alias with predefined params.
+  required: true
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title Examples %}
 
 Message to two devices with formatted text.
-
 
 ```yaml
 action:


### PR DESCRIPTION
**Description:**
Update style of pushsafer notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
