### PR TITLE
Update file notify component configuration

### DIFF
--- a/source/_components/notify.file.markdown
+++ b/source/_components/notify.file.markdown
@@ -12,7 +12,6 @@ ha_category: Notifications
 ha_release: pre 0.7
 ---
 
-
 The `file` platform allows you to store notifications from Home Assistant as a file.
 
 To enable file notifications in your installation, add the following to your `configuration.yaml` file:
@@ -25,10 +24,21 @@ notify:
     filename: FILENAME
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **filename** (*Required*): Name of the file to use. The file will be created if it doesn't exist and saved in your [configuration](/docs/configuration/) folder.
-- **timestamp** (*Optional*): Setting `timestamp` to `True` adds a timestamp to every entry.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+filename:
+  description: Name of the file to use. The file will be created if it doesn't exist and saved in your [configuration](/docs/configuration/) folder.
+  required: true
+  type: string
+timestamp:
+  description: Setting `timestamp` to `True` adds a timestamp to every entry.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).


### PR DESCRIPTION
**Description:**
Update style of file notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
