### PR TITLE
Update prowl notify component configuration

### DIFF
--- a/source/_components/notify.prowl.markdown
+++ b/source/_components/notify.prowl.markdown
@@ -12,7 +12,6 @@ ha_category: Notifications
 ha_release: 0.52
 ---
 
-
 The `prowl` platform uses [Prowl](https://www.prowlapp.com/) to deliver push notifications from Home Assistant to your iOS device.
 
 Go to the [Prowl website](https://www.prowlapp.com/) and create a new API key.
@@ -27,10 +26,17 @@ notify:
     api_key: YOUR_API_KEY
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **api_key** (*Required*): The Prowl API key to use.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+api_key:
+  description: The Prowl API key to use.
+  required: true
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title Prowl service data %}
 


### PR DESCRIPTION
**Description:**
Update style of prowl notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
