### PR TITLE
Update pushetta notify component configuration

### DIFF
--- a/source/_components/notify.pushetta.markdown
+++ b/source/_components/notify.pushetta.markdown
@@ -12,7 +12,6 @@ ha_category: Notifications
 ha_release: pre 0.7
 ---
 
-
 The `pushetta` notify platform uses [Pushetta](http://www.pushetta.com) to delivery notifications from Home Assistant to your devices.
 
 To retrieve the API token, log into your account at [http://www.pushetta.com](http://www.pushetta.com) and go to your **Dashboard**. Create a new  channel by clicking on **Channels** and then **Add a Channel**.
@@ -28,21 +27,35 @@ notify:
     channel_name: YOUR_CHANNEL_NAME
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **api_key** (*Required*): Your API key for Pushetta.
-- **channel_name** (*Required*): The name of your channel.
-- **send_test_msg** (*Optional*): Disable/enable the test message send on Home Assistant's startup to test the API key and the existence of the channel. Default to `False`.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+api_key:
+  description: Your API key for Pushetta.
+  required: true
+  type: string
+channel_name:
+  description: The name of your channel.
+  required: true
+  type: string
+send_test_msg:
+  description: Disable/enable the test message send on Home Assistant's startup to test the API key and the existence of the channel.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
 
 It's easy to test your Pushetta setup outside of Home Assistant. Assuming you have a channel *home-assistant*, just fire a request and check the channel page in the dashboard for a new message.
 
 ```bash
 curl -X POST \
-    -H "Authorization: Token YOUR_API_KEY" \
-    -H "Content-Type: application/json" \
-    -d "{ \"body\" : \"Hello World\", \"message_type\" : \"text/plain\" }" \
-    http://api.pushetta.com/api/pushes/home-assistant/
+  -H "Authorization: Token YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{ \"body\" : \"Hello World\", \"message_type\" : \"text/plain\" }" \
+  http://api.pushetta.com/api/pushes/home-assistant/
 ```
 
 For further details, please check the [API](http://pushetta.com/pushetta-api/).


### PR DESCRIPTION
**Description:**
Update style of pushetta notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
