### PR TITLE
Documented mqtt binary switch toggle

### DIFF
--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -58,12 +58,14 @@ state_topic:
   required: true
   type: string
 payload_on:
-  description: The payload that represents the on state.
+  description: The payload that represents the on state. If the value matches
+  payload_off, then the sensor will act as a toggle.
   required: false
   type: string
   default: "ON"
 payload_off:
-  description: The payload that represents the off state.
+  description: The payload that represents the off state. If the value matches
+  payload_on, then the sensor will act as a toggle.
   required: false
   type: string
   default: "OFF"

--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -58,14 +58,16 @@ state_topic:
   required: true
   type: string
 payload_on:
-  description: The payload that represents the on state. If the value matches
-  payload_off, then the sensor will act as a toggle.
+  description: >
+    The payload that represents the on state. If the value matches
+    payload_off, then the sensor will act as a toggle.
   required: false
   type: string
   default: "ON"
 payload_off:
-  description: The payload that represents the off state. If the value matches
-  payload_on, then the sensor will act as a toggle.
+  description: >
+    The payload that represents the off state. If the value matches
+    payload_on, then the sensor will act as a toggle.
   required: false
   type: string
   default: "OFF"


### PR DESCRIPTION
**Description:**
Documented mqtt binary switch acting as a toggle.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18501

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
