### PR TITLE
Update homematic add-on component configuration

### DIFF
--- a/source/_addons/homematic.markdown
+++ b/source/_addons/homematic.markdown
@@ -45,26 +45,63 @@ Follow devices will be supported and tested:
 }
 ```
 
-Configuration variables:
-
-- **rf_enable** (*Required*): Boolean. Enable or disable BidCoS-RF.
-- **wired_enable** (*Required*): Boolean. Enable or disable BidCoS-Wired.
-
-For RF devices:
-
-- **type** (*Required*): Device type for RFD service. Look into the manual of your device.
-- **device** (*Required*): Device on the host.
-
-For wired devices:
-
-- **serial** (*Required*): Serial number of the device.
-- **key** (*Required*): Encrypted key.
-- **ip** (*Required*): IP address of LAN gateway.
-
-For HmIP devices:
-
-- **type** (*Required*): Device type for RFD service. Look into the manual of your device.
-- **device** (*Required*): Device on the host.
+{% configuration %}
+rf_enable:
+  description: Enable or disable BidCoS-RF.
+  required: true
+  type: boolean
+rf:
+  description: RF devices.
+  required: true
+  type: list
+  keys:
+    type:
+      description: Device type for RFD service. Look into the manual of your device.
+      required: true
+      type: string
+    device:
+      description: Device on the host.
+      required: true
+      type: string
+wired_enable:
+  description: Enable or disable BidCoS-Wired.
+  required: true
+  type: boolean
+wired:
+  description: Wired devices.
+  required: true
+  type: list
+  keys:
+    serial:
+      description: Serial number of the device.
+      required: true
+      type: string
+    key:
+      description: Encrypted key.
+      required: true
+      type: string
+    ip:
+      description: IP address of LAN gateway.
+      required: true
+      type: string
+hmip_enable:
+  description: Enable or disable hmip.
+  required: true
+  type: boolean
+hmip:
+  description: HMIP devices.
+  required: true
+  type: list
+  keys:
+    type:
+      description: Device type for RFD service. Look into the manual of your device.
+      required: true
+      type: string
+    device:
+      description: Device on the host.
+      required: true
+      type: string
+{% endconfiguration %}
 
 ## {% linkable_title Home Assistant configuration %}
 


### PR DESCRIPTION
**Description:**
Update style of homematic add-on component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
