### PR TITLE
Update tellstick add-on component configuration

### DIFF
--- a/source/_addons/tellstick.markdown
+++ b/source/_addons/tellstick.markdown
@@ -17,19 +17,7 @@ After installation you are presented with a default and example configuration, t
 
 After any changes have been made to the configuration, you need to restart the add-on for the changes to take effect.
 
-Configuration variables:
-
-- **id** (*Required*): A number and must be unique for each device.
-- **name** (*Required*): A name for easy identification of the device.
-- **protocol** (*Required*): This is the protocol the device uses. More on the different protocols later down.
-- **model** (*Optional*): The model parameter is only used by some protocols where there exists different types of devices using the same protocol. This can be dimmers versus non-dimmers, codeswitch versus self-learning, etc.
-- **house** (*Optional*): Depending on protocol the values here can vary a lot to identify or group per house or type.
-- **unit** (*Optional*): Unit identifier, in most cases a value between 1 to 16 and often used in combination with the house.
-- **fade** (*Optional*): Fade is either `true` or `false` and tells a dimmer if it should fade smooth or instant between values (only for IKEA protocol as it seems).
-- **code** (*Optional*): A number series based on ones and zeroes often used for dip-switch based devices.
-
 You will need to add internal communication details to `configuration.yaml` to enable the integration from Hass.io and the add-on.
-
 
 ```yaml
 # Example configuration.yaml entry
@@ -69,11 +57,47 @@ Example for adding more devices in the add-on configuration (note the comma sepa
 }
 ```
 
+{% configuration %}
+id:
+  description: A number and must be unique for each device.
+  required: true
+  type: integer
+name:
+  description: A name for easy identification of the device.
+  required: true
+  type: string
+protocol:
+  description: This is the protocol the device uses. More on the different protocols later down.
+  required: true
+  type: string
+model:
+  description: The model parameter is only used by some protocols where there exists different types of devices using the same protocol. This can be dimmers versus non-dimmers, codeswitch versus self-learning, etc.
+  required: false
+  type: string
+house:
+  description: Depending on protocol the values here can vary a lot to identify or group per house or type.
+  required: false
+  type: string
+unit:
+  description: Unit identifier, in most cases a value between 1 to 16 and often used in combination with the house.
+  required: false
+  type: integer
+fade:
+  description: Fade is either `true` or `false` and tells a dimmer if it should fade smooth or instant between values (only for IKEA protocol as it seems).
+  required: false
+  type: boolean
+code:
+  description: A number series based on ones and zeroes often used for dip-switch based devices.
+  required: false
+  type: string
+{% endconfiguration %}
+
 ## {% linkable_title Service calls %}
 
 If you wish to teach a self-learning device in your TellStick configuration:
 
 Go to Home Assistant [service call](http://hassio.local:8123/dev-service) in Developer tools and select.
+
 - Service: `hassio.addon_stdin`
 - Enter service Data:
   `{"addon":"core_tellstick","input":{"function":"learn","device":"1"}}`


### PR DESCRIPTION
**Description:**
Update style of tellstick add-on component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
