### PR TITLE
Update matrix notify component configuration

### DIFF
--- a/source/_components/notify.matrix.markdown
+++ b/source/_components/notify.matrix.markdown
@@ -12,7 +12,6 @@ ha_category: Notifications
 ha_release: 0.32
 ---
 
-
 The `matrix` platform allows you to deliver notifications from Home Assistant to a [Matrix](http://matrix.org) room. Rooms can be both direct as well as group chats.
 
 ## {% linkable_title Configuration %}
@@ -28,10 +27,17 @@ notify:
     default_room: ROOM_ID_OR_ALIAS
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **default_room** (*Required*): The room all messages will be sent to, when no other target is given.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+default_room:
+  description: The room all messages will be sent to, when no other target is given.
+  required: true
+  type: string
+{% endconfiguration %}
 
 The target room has to be precreated, the room id can be obtained from the rooms settings dialog. Rooms by default have a canonical id of the form `"!<randomid>:homeserver.tld"`, but can also be allocated aliases like `"#roomname:homeserver.tld"`. Make sure to use quotes around the room id or alias to escape special characters (`!`, and `#`) in YAML. The notifying account may need to be invited to the room, depending on the individual rooms policies.
 


### PR DESCRIPTION
**Description:**
Update style of matrix notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
