### PR TITLE
Added host_entity_id to the configuration options

### DIFF
--- a/source/_components/media_player.gpmdp.markdown
+++ b/source/_components/media_player.gpmdp.markdown
@@ -38,4 +38,8 @@ name:
   required: false
   default: GPM Desktop Player
   type: string
+host_entity_id:
+  description: entity_id representing the device on which Google Play Music Desktop Player is running on
+  required: false
+  type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Documentation PR to go with the changes made in PR #18525

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18525

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
