### PR TITLE
Fix relative link, fixes #7550

### DIFF
--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -92,7 +92,7 @@ See the documentation about [splitting the configuration](/docs/configuration/sp
 
 ### {% linkable_title Customizing entities with packages %}
 
-It is possible to [customize entities](docs/configuration/customizing-devices/) within packages. Just create your customization entries under:
+It is possible to [customize entities](/docs/configuration/customizing-devices/) within packages. Just create your customization entries under:
 
 ```yaml
 homeassistant:


### PR DESCRIPTION
Link for "customize entities" missing leading slash

**Description:**
Fixes issue #7550

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
