### PR TITLE
Add docs to sensor.miflora

### DIFF
--- a/source/_components/sensor.miflora.markdown
+++ b/source/_components/sensor.miflora.markdown
@@ -15,6 +15,8 @@ ha_iot_class: "Local Polling"
 
 The `miflora` sensor platform allows one to monitor plant soil and air conditions. The [Mi Flora plant sensor](https://www.huahuacaocao.com/product) is a small Bluetooth Low Energy device that monitors the moisture and conductivity of the soil as well as ambient light and temperature. Since only one BLE device can be polled at a time, the library implements locking to prevent polling more than one device at a time.
 
+Note: there are "Chinese" and "International" versions available and some user [reported](https://community.home-assistant.io/t/miflora-showing-data-unknown/19550/8) that only the International worked for him.
+
 # Install Bluetooth Backend
 Before configuring Home Assistant you need a Bluetooth backend and the MAC address of your sensor. Depending on your operating system, you may have to configure the proper Bluetooth backend for your system:
 


### PR DESCRIPTION
**Description:**
Add information about Chinese vs International versions.

As a potential buyer of MiFlora sensor, I'd like to know whether I should buy "Chinese" or "International" version. Some user on forums indicated, that Chinese version didn't work for him and I believe it's worth putting this information on the docs page.

(https://community.home-assistant.io/t/miflora-showing-data-unknown/19550/8)

**Pull request in home-assistant (if applicable):** N/A

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
