### PR TITLE
Update eddystone_temperature sensor component configuration

### DIFF
--- a/source/_components/sensor.eddystone_temperature.markdown
+++ b/source/_components/sensor.eddystone_temperature.markdown
@@ -16,12 +16,12 @@ ha_iot_class: "Local Polling"
 The `eddystone_temperature` sensor platform reads temperature information from Bluetooth LE advertisements transmitted by [Eddystone](https://en.wikipedia.org/wiki/Eddystone_(Google)) beacons. Your beacons must be configured to transmit UID frames (for identification) and TLM frames (for temperature).
 All beacons that support the Eddystone protocol, have a temperature sensor and can transmit TLM frames are compatible with this platform. For example [Gimbal](https://store.gimbal.com/collections/beacons/), [Estimote](http://estimote.com/) or [kontakt.io](https://kontakt.io/). For more manufacturers see [this overview](https://developers.google.com/beacons/eddystone#beacon_manufacturers) by Google.
 
-## Requirements
+## {% linkable_title Requirements %}
 
 As this platform uses `bluez` to scan for Bluetooth LE devices **a Linux OS with bluez installed** is required. In addition to that, the `libbluetooth` headers need to be installed:
 
 ```bash
-$ sudo apt-get install libbluetooth-dev 
+$ sudo apt-get install libbluetooth-dev
 ```
 
 Scanning for Bluetooth LE devices also requires special permissions. To grant these to the python executable execute the following:
@@ -46,10 +46,33 @@ sensor:
         namespace: "112233445566778899AA"
         instance: "000000000002"
 ```
-Configuration variables:
-- **bt_device_id** (*Optional*): The id of the Bluetooth device that should be used for scanning (hci*X*). You can find the correct one using `hcitool dev` (default: 0). 
-- **beacons** array (*Required*): The beacons that should be monitored.
-  - **[entry]** (*Required*): Name of the beacon.
-    - **namespace** (*Required*): Namespace ID of the beacon in hexadecimal notation. Must be exactly 20 characters (10 bytes) long.
-    - **instance** (*Required*): Instance ID of the beacon in hexadecimal notation. Must be exactly 12 characters (6 bytes) long.
-    - **name** (*Optional*): Friendly name of the beacon.
+
+{% configuration %}
+bt_device_id:
+  description: The id of the Bluetooth device that should be used for scanning (hci*X*). You can find the correct one using `hcitool dev`.
+  required: false
+  default: 0
+  type: integer
+beacons:
+  description: The beacons that should be monitored.
+  required: true
+  type: list
+  keys:
+    entry:
+      description: Name of the beacon.
+      required: true
+      type: list
+      keys:
+        namespace:
+          description: Namespace ID of the beacon in hexadecimal notation. Must be exactly 20 characters (10 bytes) long.
+          required: true
+          type: string
+        instance:
+          description: Instance ID of the beacon in hexadecimal notation. Must be exactly 12 characters (6 bytes) long.
+          required: true
+          type: string
+        name:
+          description: Friendly name of the beacon.
+          required: false
+          type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Update style of eddystone_temperature sensor component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
