### PR TITLE
Update insteon.markdown

### DIFF
--- a/source/_components/insteon.markdown
+++ b/source/_components/insteon.markdown
@@ -51,7 +51,6 @@ To set up an INSTEON Hub model [2242], use the following configuration:
 # Hub 2242 configuration variables
 insteon:
   host: HOST
-  ip_port: IP_PORT
   hub_version: 1
 ```
 


### PR DESCRIPTION
Remove ip port configuration variable for hub model 2242 since it uses the socket connection method.

https://github.com/home-assistant/home-assistant/issues/16657

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
