### PR TITLE
Fix then/than typo in climate.generic_thermostat

### DIFF
--- a/source/_components/climate.generic_thermostat.markdown
+++ b/source/_components/climate.generic_thermostat.markdown
@@ -13,7 +13,7 @@ ha_release: pre 0.7
 ha_iot_class: "Local Polling"
 ---
 
-The `generic_thermostat` climate platform is a thermostat implemented in Home Assistant. It uses a sensor and a switch connected to a heater or air conditioning under the hood. When in heater mode, if the measured temperature is cooler then the target temperature, the heater will be turned on and turned off when the required temperature is reached. When in air conditioning mode, if the measured temperature is hotter then the target temperature, the air conditioning will be turned on and turned off when required temperature is reached. One Generic Thermostat entity can only control one switch. If you need to activate two switches, one for a heater and one for an air conditioner, you will need two Generic Thermostat entities.
+The `generic_thermostat` climate platform is a thermostat implemented in Home Assistant. It uses a sensor and a switch connected to a heater or air conditioning under the hood. When in heater mode, if the measured temperature is cooler than the target temperature, the heater will be turned on and turned off when the required temperature is reached. When in air conditioning mode, if the measured temperature is hotter than the target temperature, the air conditioning will be turned on and turned off when required temperature is reached. One Generic Thermostat entity can only control one switch. If you need to activate two switches, one for a heater and one for an air conditioner, you will need two Generic Thermostat entities.
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
**Description:** The documentation of climate.generic_thermostat used `then` to compare temperatures. I replaced both occurrences with the correct term `than`.
Reference for the usage of `then vs. than`: https://writingexplained.org/then-vs-than-difference

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
