### PR TITLE
Fix - Mqqt position topic docs more clear

### DIFF
--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -81,7 +81,7 @@ state_closed:
   type: string
   default: closed
 position_topic:
-  description: The MQTT topic subscribed to receive cover position messages. If position_topic is set state_topic is ignored.
+  description: The MQTT topic subscribed to receive cover position messages. If `position_topic` is set `state_topic` is ignored.
   required: false
   type: integer
 position_open:

--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -67,7 +67,7 @@ payload_stop:
   type: string
   default: STOP
 state_topic:
-  description: The MQTT topic subscribed to receive cover state messages. Use only if not using get_position_topic. State topic can only read open/close state. Cannot read position state.
+  description: The MQTT topic subscribed to receive cover state messages. Use only if not using `position_topic`. State topic can only read open/close state. Cannot read position state. If `position_topic` is set `state_topic` is ignored.
   required: false
   type: string
 state_open:
@@ -81,7 +81,7 @@ state_closed:
   type: string
   default: closed
 position_topic:
-  description: The MQTT topic subscribed to receive cover position messages. Always in favor if used together with state_topic.
+  description: The MQTT topic subscribed to receive cover position messages. If position_topic is set state_topic is ignored.
   required: false
   type: integer
 position_open:


### PR DESCRIPTION
Changes position_topic and state_topic info to be more clear for users (**hopefully**).
Also deleted `get_position_topic` expression as it wasn't clear enough. 
Using only `position_topic` expression from now.

Replaced bad PR: https://github.com/home-assistant/home-assistant.io/pull/7481

Related issue: https://github.com/home-assistant/home-assistant/issues/18383

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
