### PR TITLE
Add documentation for the Panasonic Blu-Ray component

### DIFF
--- a/source/_components/media_player.panasonic_bluray.markdown
+++ b/source/_components/media_player.panasonic_bluray.markdown
@@ -1,0 +1,42 @@
+---
+layout: page
+title: "Panasonic Blu-Ray Player"
+description: "Instructions on how to integrate a Panasonic Blu-Ray player into Home Assistant."
+date: 2018-11-13 20:48
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: panasonic.png
+ha_category: Media Player
+ha_iot_class: "Local Polling"
+---
+
+The `panasonic_bluray` platform allows you to control a Panasonic Blu-Ray player. Note that the device must be on the same subnet as Home Assistant; connections from a different subnet will return an error.
+
+Currently known supported models:
+
+- DMP-BDT120
+- DMP-BDT220
+- DMP-BDT221
+- DMP-BDT320
+- DMP-BDT500
+- DMP-BBT01
+
+If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.github.io/blob/next/source/_components/media_player.panasonic_bluray.markdown).
+
+{% configuration %}
+host:
+  description: The IP of the Panasonic Blu-Ray device, e.g., `192.168.0.10`.
+  required: true
+  type: string
+name:
+  description: The name you would like to give to the Panasonic Blu-Ray device.
+  required: false
+  default: Panasonic Blu-Ray
+  type: string
+{% endconfiguration %}
+
+### {% linkable_title Supported operations %}
+
+- These devices support play, pause, stop and power on/off operations. They will also report the current status, title duration and current playing position.

--- a/source/_components/media_player.panasonic_bluray.markdown
+++ b/source/_components/media_player.panasonic_bluray.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: panasonic.png
 ha_category: Media Player
 ha_iot_class: "Local Polling"
+ha_release: 0.83
 ---
 
 The `panasonic_bluray` platform allows you to control a Panasonic Blu-Ray player. Note that the device must be on the same subnet as Home Assistant; connections from a different subnet will return an error.
@@ -23,7 +24,16 @@ Currently known supported models:
 - DMP-BDT500
 - DMP-BBT01
 
-If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.github.io/blob/next/source/_components/media_player.panasonic_bluray.markdown).
+If your model is not on the list, then give it a try, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.github.io/blob/current/source/_components/media_player.panasonic_bluray.markdown).
+
+
+Example configuration:
+
+```yaml
+media_player:
+  - platform: panasonic_bluray
+    host: 192.168.0.10
+```
 
 {% configuration %}
 host:

--- a/source/_components/media_player.panasonic_bluray.markdown
+++ b/source/_components/media_player.panasonic_bluray.markdown
@@ -26,7 +26,6 @@ Currently known supported models:
 
 If your model is not on the list, then give it a try, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.github.io/blob/current/source/_components/media_player.panasonic_bluray.markdown).
 
-
 Example configuration:
 
 ```yaml


### PR DESCRIPTION
**Description:**

This adds the appropriate website documentation for the Panasonic Blu-Ray media_player component, to accompany the corresponding main home-assistant PR (which will be filled after this one)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18541

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
