### PR TITLE
Update llamalab_automate notify component configuration

### DIFF
--- a/source/_components/notify.llamalab_automate.markdown
+++ b/source/_components/notify.llamalab_automate.markdown
@@ -12,7 +12,6 @@ ha_category: Notifications
 ha_release: 0.27
 ---
 
-
 The `llamalab_automate` platform uses Googles Cloud Messaging Services to push messages from Home Assistant to your Android device running the LlamaLab [Automate](https://llamalab.com/automate/) app. This can serve as an alternative to Tasker + AutoRemote.
 
 Go to [https://llamalab.com/automate/cloud/](https://llamalab.com/automate/cloud/) and create a new API key/secret.
@@ -28,12 +27,25 @@ notify:
     to: YOUR_EMAIL_ADDRESS
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **api_key** (*Required*): Enter the API key for Automate.
-- **to** (*Required*): E-Mail address the Automate-Fiber is configured for.
-- **device** (*Optional*): Name of the target device to receive the messages.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+api_key:
+  description: Enter the API key for Automate.
+  required: true
+  type: string
+to:
+  description: E-Mail address the Automate-Fiber is configured for.
+  required: true
+  type: string
+device:
+  description: Name of the target device to receive the messages.
+  required: false
+  type: string
+{% endconfiguration %}
 
 Receiving cloud messages in Automate:
 


### PR DESCRIPTION
**Description:**
Update style of llamalab_automate notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
