### PR TITLE
Update sendgrid notify component configuration

### DIFF
--- a/source/_components/notify.sendgrid.markdown
+++ b/source/_components/notify.sendgrid.markdown
@@ -25,11 +25,24 @@ notify:
     recipient: YOUR_RECIPIENT
 ```
 
-Configuration variables:
-
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-- **api_key** (*Required*): SendGrid API key - https://app.sendgrid.com/settings/api_keys
-- **sender** (*Required*): E-mail address of the sender.
-- **recipient** (*Required*): Recipient of the notification.
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+api_key:
+  description: SendGrid API key - https://app.sendgrid.com/settings/api_keys
+  required: true
+  type: string
+sender:
+  description: E-mail address of the sender.
+  required: true
+  type: string
+recipient:
+  description: Recipient of the notification.
+  required: true
+  type: string
+{% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).


### PR DESCRIPTION
**Description:**
Update style of sendgrid notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
