### PR TITLE
Add room-assistant to mqtt discovery support list

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -188,6 +188,7 @@ The following firmware for ESP8266, ESP32 and Sonoff unit has built-in support f
 - [esphomeyaml](https://esphomelib.com/esphomeyaml/index.html)
 - [ESPurna](https://github.com/xoseperez/espurna)
 - [Arilux AL-LC0X LED controllers](https://github.com/mertenats/Arilux_AL-LC0X)
+- [room-assistant](https://github.com/mKeRix/room-assistant) (starting with 1.1.0)
 
 ### {% linkable_title Examples %}
 


### PR DESCRIPTION
**Description:**
Adds room-assistant to the list of supported tools in the MQTT auto discovery docs.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
