### PR TITLE
Adds light switch platform documentation

### DIFF
--- a/source/_components/light.switch.markdown
+++ b/source/_components/light.switch.markdown
@@ -28,8 +28,7 @@ To enable this platform in your installation, add the following to your
 light:
   - platform: switch
     name: Christmas Tree Lights
-    entities:
-      - switch.christmas_tree_lights
+    entity_id: switch.christmas_tree_lights
 ```
 
 {% configuration %}

--- a/source/_components/light.switch.markdown
+++ b/source/_components/light.switch.markdown
@@ -1,0 +1,47 @@
+---
+layout: page
+title: "Light Switch"
+description: "Instructions on how to set up a light switch within Home Assistant."
+date: 2018-11-18 19:59
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Light
+ha_release: 0.83
+ha_iot_class: "Local Push"
+logo: home-assistant.png
+ha_qa_scale: internal
+---
+
+The light switch platform lets you control an existing switch, allowing you
+to use a switch a likes a light in Home Assistant.
+
+In Home Assistant's world, a wall plug is a switch. This platform allows you
+to expose this switch as a light source, allowing you to add, e.g., the wall
+plug controlling your Christmas Tree, to be part of a light group.
+
+To enable this platform in your installation, add the following to your
+`configuration.yaml` file:
+
+```yaml
+light:
+  - platform: switch
+    name: Christmas Tree Lights
+    entities:
+      - switch.christmas_tree_lights
+```
+
+{% configuration %}
+  name:
+    description: The name of the light switch.
+    required: false
+    type: string
+    default: Light Switch
+  entity_id:
+    description: "The `entity_id` of a switch entity to control as a light source."
+    required: true
+    type: string
+{% endconfiguration %}
+
+A light switch only supports turning on/off a light.

--- a/source/_components/light.switch.markdown
+++ b/source/_components/light.switch.markdown
@@ -15,7 +15,7 @@ ha_qa_scale: internal
 ---
 
 The light switch platform lets you control an existing switch, allowing you
-to use a switch a likes a light in Home Assistant.
+to use a switch like a light in Home Assistant.
 
 In Home Assistant's world, a wall plug is a switch. This platform allows you
 to expose this switch as a light source, allowing you to add, e.g., the wall


### PR DESCRIPTION
**Description:**

Add documentation for the Light Switch Platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18562

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
