### PR TITLE
Update Entity Button Docs

### DIFF
--- a/source/_lovelace/entity-button.markdown
+++ b/source/_lovelace/entity-button.markdown
@@ -77,6 +77,7 @@ Title and Script Service Example:
 ```yaml
 - type: entity-button
   name: Turn Off Lights
+  tap_action: call-service
   entity: script.turn_off_lights
   service: script.turn_on
 ```


### PR DESCRIPTION
**Description:**
Tap Action was not added to doc example. Needs fixed now

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
