### PR TITLE
Add state of union card for frontend

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -141,10 +141,9 @@ $primary-color: #049cdb;
     }
   }
 
-  .shirt-promo {
+  .picture-promo {
     display: block;
     padding-top: 30%;
-    background-image: url(/images/merchandise/shirt-frontpage.png);
     background-size: cover;
     background-position: center;
     text-decoration: none;

--- a/source/index.html
+++ b/source/index.html
@@ -64,11 +64,30 @@ description: Open source home automation that puts local control and privacy fir
         {% endfor %}
       </div>
 
+      <a
+        class='material-card picture-promo'
+        href='/blog/2018/11/16/state-of-the-union/'
+        style='background-image: url(/images/blog/2018-11-state-of-the-union/share-the-love.jpg)'
+      >
+        <div class='caption'>
+          <div class='title'>
+            Watch the State of the Union 2018
+          </div>
+          <div class='subtitle'>
+            Learn about the origin of Home Assistant and where we're heading.
+          </div>
+        </div>
+      </a>
+
       <a class='material-card highlight-blog-post large' href='/blog/2017/07/25/introducing-hassio/'>
         Learn how Hass.io can turn your Raspberry Pi into the ultimate home automation hub <i class="icon-arrow-right"></i>
       </a>
 
-      <a class='material-card shirt-promo' href='/blog/2017/02/22/home-assistant-tshirts-have-arrived/'>
+      <a
+        class='material-card picture-promo'
+        href='/blog/2017/02/22/home-assistant-tshirts-have-arrived/'
+        style='background-image: url(/images/merchandise/shirt-frontpage.png)'
+      >
         <div class='caption'>
           <div class='title'>
             Join the Home Assistant t-shirt revolution!


### PR DESCRIPTION
**Description:**
This adds a state of the union card to the frontend to promote people to watch it.

![image](https://user-images.githubusercontent.com/1444314/48781426-45a1ec00-ecdc-11e8-936a-063289c34b17.png)

[(best to watch netlify preview)](https://deploy-preview-7591--home-assistant-docs.netlify.com/)

## Checklist:

- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
