### PR TITLE
Added scan_interval to documentation

### DIFF
--- a/source/_components/sensor.fail2ban.markdown
+++ b/source/_components/sensor.fail2ban.markdown
@@ -28,6 +28,7 @@ To enable this sensor, add the following lines to your `configuration.yaml`:
 # Example configuration.yaml entry
 sensor:
   - platform: fail2ban
+    scan_interval: 60
     jails:
       - ssh
       - hass-iptables
@@ -38,6 +39,10 @@ jails:
   description: List of configured jails you want to display.
   required: true
   type: list
+scan_interval:
+  description: Fail2ban query interval.
+  required: true
+  type: int
 name:
   description: Name of the sensor.
   required: false


### PR DESCRIPTION
If scan_interval is not specified - it causes issues with system. Specifying this parameter seems to fix this.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
