### PR TITLE
Add documentation for SSL and authentication

### DIFF
--- a/source/_components/sensor.glances.markdown
+++ b/source/_components/sensor.glances.markdown
@@ -66,6 +66,24 @@ name:
   required: false
   type: string
   default: Glances
+username:
+  description: Your username for the HTTP connection to Glances.
+  required: true
+  type: string
+password:
+  description: Your password for the HTTP connection to Glances.
+  required: true
+  type: string
+ssl:
+  description: "If `true`, use SSL/TLS to connect to the Glances system."
+  required: false
+  type: boolean
+  default: false
+verify_ssl:
+  description: Verify the certification of the system.
+  required: false
+  type: boolean
+  default: true
 version:
   description: "The version of the Glances API. Supported version: `2` and `3`."
   required: false

--- a/source/_components/sensor.glances.markdown
+++ b/source/_components/sensor.glances.markdown
@@ -68,11 +68,11 @@ name:
   default: Glances
 username:
   description: Your username for the HTTP connection to Glances.
-  required: true
+  required: false
   type: string
 password:
   description: Your password for the HTTP connection to Glances.
-  required: true
+  required: false
   type: string
 ssl:
   description: "If `true`, use SSL/TLS to connect to the Glances system."


### PR DESCRIPTION
**Description:**

Adds documentation for the new SSL and authentication options in `sensor.glances`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18608

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
