### PR TITLE
Clarify cache path variable

### DIFF
--- a/source/_components/media_player.spotify.markdown
+++ b/source/_components/media_player.spotify.markdown
@@ -72,9 +72,10 @@ client_secret:
   required: true
   type: string
 cache_path:
-  description: Path to cache authentication token (defaults to configuration directory).
+  description: Path to cache authentication token.
   required: false
   type: string
+  default: .spotify-token-cache
 aliases:
   description: "Dictionary of device ids to be aliased, handy for devices that Spotify cannot properly determine the device name of. New devices will be logged to the `info` channel for ease of aliasing."
   required: false


### PR DESCRIPTION
Removes ambiguous statement about cache directory. The cache_path is for an authentication token, and it is a file.

Addresses #7330

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
