### PR TITLE
Mention Discovery component in Samsung TV docs

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -20,8 +20,7 @@ The `samsungtv` platform allows you to control a
 When the TV is first connected,
 you will need to accept Home Assistant on the TV to allow communication.
 
-To add a TV to your installation,
-add the following to your `configuration.yaml` file:
+To add a TV to your installation without relying on the [discovery component](/components/discovery/), add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
**Description:**

[Samsung Smart TV component](https://www.home-assistant.io/components/media_player.samsungtv/) can be set up via the [Discovery component](https://www.home-assistant.io/components/discovery/), but this isn't mentioned in the docs unlike similar [Philips Hue docs](https://www.home-assistant.io/components/hue/) for example.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
