### PR TITLE
Add timestamp device class docs

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -57,6 +57,10 @@ secondary_info:
   required: false
   description: "Show additional info. Values: `entity-id`, `last-changed`."
   type: string
+format:
+  required: false
+  description: "How the state should be formatted. Currently only used for timestamp sensors. Valid values are: "relative", "total", "date", "time", "datetime".
+  type: string
 {% endconfiguration %}
 
 ## {% linkable_title Special Row Elements %}

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -59,7 +59,7 @@ secondary_info:
   type: string
 format:
   required: false
-  description: "How the state should be formatted. Currently only used for timestamp sensors. Valid values are: "relative", "total", "date", "time", "datetime".
+  description: "How the state should be formatted. Currently only used for timestamp sensors. Valid values are: 'relative', 'total', 'date', 'time', 'datetime'."
   type: string
 {% endconfiguration %}
 

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -59,7 +59,7 @@ secondary_info:
   type: string
 format:
   required: false
-  description: "How the state should be formatted. Currently only used for timestamp sensors. Valid values are: 'relative', 'total', 'date', 'time', 'datetime'."
+  description: "How the state should be formatted. Currently only used for timestamp sensors. Valid values are: `relative`, `total`, `date`, `time` and `datetime`."
   type: string
 {% endconfiguration %}
 


### PR DESCRIPTION
**Description:**
Docs how to format timestamp sensors.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant-polymer/pull/2087

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
