### PR TITLE
Make configuration.yaml more generic

### DIFF
--- a/source/_components/sensor.onewire.markdown
+++ b/source/_components/sensor.onewire.markdown
@@ -66,8 +66,6 @@ To enable One wire sensors in your installation, add the following to your `conf
 # Example configuration.yaml entry
 sensor:
   - platform: onewire
-    names:
-      some_id: your name
 ```
 
 {% configuration %}
@@ -80,4 +78,16 @@ mount_dir:
   required: false
   type: string
 {% endconfiguration %}
+
+### Configuration Example
+
+When `onewire` is added to Home Assistant, it will generate an ID for the sensor. You can specify a friendly name for the sensor with the name configuration option.
+
+```yaml
+# Named sensor configuration.yaml entry
+sensor:
+  - platform: onewire
+    names:
+      GENERATED_ID: FRIENDLY_NAME
+```
 


### PR DESCRIPTION
Example configuration should not include optional configuration.
To make the names configuration clearer, add a second example.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
