### PR TITLE
Fix indentation for advanced configuration

### DIFF
--- a/source/_components/cast.markdown
+++ b/source/_components/cast.markdown
@@ -34,7 +34,7 @@ you want to configure the IP address of the Cast device directly:
 # Example configuration.yaml entry
 cast:
   media_player:
-  - host: 192.168.1.10
+    - host: 192.168.1.10
 ```
 
 {% configuration %}
@@ -62,6 +62,6 @@ those as follows:
 # Example configuration.yaml entry for multiple devices
 cast:
   media_player:
-  - host: IP_ADDRESS_DEVICE_1
-  - host: IP_ADDRESS_DEVICE_2
+    - host: IP_ADDRESS_DEVICE_1
+    - host: IP_ADDRESS_DEVICE_2
 ```

--- a/source/_components/cast.markdown
+++ b/source/_components/cast.markdown
@@ -37,6 +37,10 @@ cast:
     - host: 192.168.1.10
 ```
 
+<p class='note'>
+You may need to enable Multicast DNS (MDNS) on your router if you are on a different subnet or VLAN.
+</p>
+
 {% configuration %}
 media_player:
   description: A list that contains all Cast devices.


### PR DESCRIPTION
Corrected indentation per original PR at https://github.com/home-assistant/home-assistant/pull/15143

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
