### PR TITLE
Added TV model UE40ES6800

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -93,6 +93,7 @@ Currently known supported models:
 - U6000 (port must be set to 8001)
 - U6300 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
 - UE40KU6400U (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- UE40ES6800
 - UE46D7000
 - UE6199UXZG (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 - UE65KS8005 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)


### PR DESCRIPTION
**Description:**

Just added my model UE40ES6800 to the working Samsung TV list.