### PR TITLE
Small formatting fix, missing `

### DIFF
--- a/source/_components/luftdaten.markdown
+++ b/source/_components/luftdaten.markdown
@@ -105,4 +105,4 @@ luftdaten:
     monitored_conditions:
       - temperature
       - humidity
-``
+```


### PR DESCRIPTION
**Description:**
small formatting fix as it was missing a `

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
