### PR TITLE
Fix logo for 17track

### DIFF
--- a/source/_components/sensor.seventeentrack.markdown
+++ b/source/_components/sensor.seventeentrack.markdown
@@ -7,7 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: 17track.jpg
+logo: 17track.png
 ha_category: Postal Service
 ha_release: 0.83
 ha_iot_class: "Cloud Polling"


### PR DESCRIPTION
**Description:**
A png was uploaded but linked file is 17track.jpg

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
