### PR TITLE
Update Ruter docs

### DIFF
--- a/source/_components/sensor.ruter.markdown
+++ b/source/_components/sensor.ruter.markdown
@@ -41,12 +41,13 @@ destination:
 offset:
   description: An offset for the next departure time.
   required: false
-  default: 0
   type: integer
+  default: 1
 name:
   description: Name of the sensor.
   required: false
   type: string
+  default: Ruter
 {% endconfiguration %}
 
 [ruter]: https://ruter.no/reiseplanlegger/Stoppested

--- a/source/_components/sensor.ruter.markdown
+++ b/source/_components/sensor.ruter.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: ruter.png
 ha_category: Transport
 ha_iot_class: "Cloud Polling"
-ha_release: "0.83"
+ha_release: 0.83
 ---
 
 The `ruter` sensor will provide you departure information for the larger Oslo area in Norway from the [Ruter][ruter] public transportation service.
@@ -39,10 +39,10 @@ destination:
   required: false
   type: string
 offset:
-  description: An offset for the next departure time.
+  description: An offset for the next departure, 0 will give the first one.
   required: false
   type: integer
-  default: 1
+  default: 0
 name:
   description: Name of the sensor.
   required: false


### PR DESCRIPTION
**Description:**
Default name was missing and offset is 1 by default.

Since this was introduced in 0.83 (currently beta) I believe this PR should get milestone 0.83 as docs for a new component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/18678

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
