### PR TITLE
Update media_player.russound_rnet_markdown

### DIFF
--- a/source/_components/media_player.russound_rnet.markdown
+++ b/source/_components/media_player.russound_rnet.markdown
@@ -15,7 +15,7 @@ ha_iot_class: "Local Polling"
 
 The `russound_rnet` platform allows you to control Russound devices that make use of the RNET protocol.
 
-This has initially been tested against a Russound CAV6.6 unit with six zones and six sources.
+This has initially been tested against a Russound CAV6.6 unit with six zones and six sources. It will also work with a Russound CAA66, but be sure to use a null-modem cable.
 
 Connecting to the Russound device is only possible by TCP, you can make use of a TCP to Serial gateway such as [tcp_serial_redirect](https://github.com/pyserial/pyserial/blob/master/examples/tcp_serial_redirect.py)
 


### PR DESCRIPTION
I have a Russound CAA66. This component also works to control it. Important note: While the CAV6.6 uses a straight through cable, the CAA66 uses a null-modem cable!

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
