### PR TITLE
Update aws_sqs notify component configuration

### DIFF
--- a/source/_components/notify.aws_sqs.markdown
+++ b/source/_components/notify.aws_sqs.markdown
@@ -32,13 +32,30 @@ notify:
     region_name: 'us-east-1'
 ```
 
-Configuration variables:
-
-- **aws_access_key_id** (*Required if aws_secret_access_key is provided*): Your AWS Access Key ID. If provided, you must also provide an `aws_secret_access_key` and must **not** provide a `profile_name`.
-- **aws_secret_access_key** (*Required if aws_access_key_id is provided*): Your AWS Secret Access Key. If provided, you must also provide an `aws_access_key_id` and must **not** provide a `profile_name`.
-- **profile_name** (*Optional*): A credentials profile name.
-- **region_name** (*Required*): The region identifier to connect to. The default is `us-east-1`.
-- **name** (*Optional*): Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+{% configuration %}
+aws_access_key_id:
+  description: Your AWS Access Key ID. If provided, you must also provide an `aws_secret_access_key` and must **not** provide a `profile_name`.
+  required: Required if aws_secret_access_key is provided
+  type: string
+aws_secret_access_key:
+  description: Your AWS Secret Access Key. If provided, you must also provide an `aws_access_key_id` and must **not** provide a `profile_name`.
+  required: Required if aws_access_key_id is provided
+  type: string
+profile_name:
+  description: A credentials profile name.
+  required: false
+  type: string
+region_name:
+  description: The region identifier to connect to.
+  required: true
+  default: us-east-1
+  type: string
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+{% endconfiguration %}
 
 ### {% linkable_title Usage %}
 


### PR DESCRIPTION
**Description:**
Update style of aws_sqs notify component documentation to follow new configuration variables description.
Related to #6385.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
