### PR TITLE
Add note for FB6490Cable with FritzOS6.87

### DIFF
--- a/source/_components/sensor.fritzbox_netmonitor.markdown
+++ b/source/_components/sensor.fritzbox_netmonitor.markdown
@@ -58,3 +58,7 @@ The following statistics will be exposed as attributes.
 |max_byte_rate_down     |Maximum downstream-rate in bytes/s                           |
 
 The sensor's state corresponds to the `is_linked` attribute and is either `online`, `offline`, or `unavailable` (in case connection to the router is lost).
+
+<p class='note info'>
+This component does not support "Fritz!Box 6490 Cable" with FritzOS 6.87 installed.
+</p>


### PR DESCRIPTION
See [#18609](https://github.com/home-assistant/home-assistant/issues/18609) for details

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
