### PR TITLE
Updated http base_url sample

### DIFF
--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -55,7 +55,7 @@ Use the following configuration in Home Assistant to use the generated certifica
 
 ```yaml
 http:
-  base_url: https://my-domain.duckdns.org:8123
+  base_url: http://my-domain.duckdns.org:8123
   ssl_certificate: /ssl/fullchain.pem
   ssl_key: /ssl/privkey.pem
 ```

--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -55,7 +55,7 @@ Use the following configuration in Home Assistant to use the generated certifica
 
 ```yaml
 http:
-  base_url: http://my-domain.duckdns.org:8123
+  base_url: my-domain.duckdns.org:8123
   ssl_certificate: /ssl/fullchain.pem
   ssl_key: /ssl/privkey.pem
 ```


### PR DESCRIPTION
The base_url example incorrectly referenced a duck dns link with https instead of http which may be confusing for some users.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
