### PR TITLE
The current text assumes your user is always "homeassistant"

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -21,8 +21,8 @@ If the preceding command returns the string `systemd`, continue with the instruc
 A service file is needed to control Home Assistant with `systemd`. The template below should be created using a text editor. Note, root permissions via `sudo` will likely be needed. The following should be noted to modify the template:
 
 - `ExecStart` contains the path to `hass` and this may vary. Check with `whereis hass` for the location.
-- For most systems, the file is `/etc/systemd/system/home-assistant@[your user].service` with [your user] replaced by the user account that Home Assistant will run as (normally `homeassistant`).  In particular, this is the case for Ubuntu 16.04.
-- If unfamiliar with command-line text editors, `sudo nano -w [filename]` can be used with `[filename]` replaced with the full path to the file.  Ex. `sudo nano -w /etc/systemd/system/home-assistant@[your user].service`.  After text entered, press CTRL-X then press Y to save and exit.
+- For most systems, the file is `/etc/systemd/system/home-assistant@YOUR_USER.service` with YOUR_USER replaced by the user account that Home Assistant will run as (normally `homeassistant`).  In particular, this is the case for Ubuntu 16.04.
+- If unfamiliar with command-line text editors, `sudo nano -w [filename]` can be used with `[filename]` replaced with the full path to the file.  Ex. `sudo nano -w /etc/systemd/system/home-assistant@YOUR_USER.service`.  After text entered, press CTRL-X then press Y to save and exit.
 - If you're running Home Assistant in a Python virtual environment or a Docker container, please skip to the appropriate template listed below.
 
 ```
@@ -41,7 +41,7 @@ WantedBy=multi-user.target
 
 ### {% linkable_title Python virtual environment %}
 
-If you've setup Home Assistant in `virtualenv` following our [Python installation guide](/getting-started/installation-virtualenv/) or [manual installation guide for Raspberry Pi](/getting-started/installation-raspberry-pi/), the following template should work for you. If Home Assistant install is not located at `/srv/homeassistant`, please modify the `ExecStart=` line appropriately. [your user] should replaced by the user account that Home Assistant will run as (e.g `homeassistant`).
+If you've setup Home Assistant in `virtualenv` following our [Python installation guide](/getting-started/installation-virtualenv/) or [manual installation guide for Raspberry Pi](/getting-started/installation-raspberry-pi/), the following template should work for you. If Home Assistant install is not located at `/srv/homeassistant`, please modify the `ExecStart=` line appropriately. YOUR_USER should replaced by the user account that Home Assistant will run as (e.g `homeassistant`).
 
 ```
 [Unit]
@@ -51,7 +51,7 @@ After=network-online.target
 [Service]
 Type=simple
 User=%i
-ExecStart=/srv/homeassistant/bin/hass -c "/home/[your user]/.homeassistant"
+ExecStart=/srv/homeassistant/bin/hass -c "/home/YOUR_USER/.homeassistant"
 
 [Install]
 WantedBy=multi-user.target

--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -41,7 +41,7 @@ WantedBy=multi-user.target
 
 ### {% linkable_title Python virtual environment %}
 
-If you've setup Home Assistant in `virtualenv` following our [Python installation guide](/getting-started/installation-virtualenv/) or [manual installation guide for Raspberry Pi](/getting-started/installation-raspberry-pi/), the following template should work for you. If Home Assistant install is not located at `/srv/homeassistant`, please modify the `ExecStart=` line appropriately. YOUR_USER should replaced by the user account that Home Assistant will run as (e.g `homeassistant`).
+If you've setup Home Assistant in `virtualenv` following our [Python installation guide](/getting-started/installation-virtualenv/) or [manual installation guide for Raspberry Pi](/getting-started/installation-raspberry-pi/), the following template should work for you. If Home Assistant install is not located at `/srv/homeassistant`, please modify the `ExecStart=` line appropriately. `YOUR_USER` should be replaced by the user account that Home Assistant will run as (e.g `homeassistant`).
 
 ```
 [Unit]

--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -41,7 +41,7 @@ WantedBy=multi-user.target
 
 ### {% linkable_title Python virtual environment %}
 
-If you've setup Home Assistant in `virtualenv` following our [Python installation guide](/getting-started/installation-virtualenv/) or [manual installation guide for Raspberry Pi](/getting-started/installation-raspberry-pi/), the following template should work for you. If Home Assistant install is not located at `/srv/homeassistant`, please modify the `ExecStart=` line appropriately.
+If you've setup Home Assistant in `virtualenv` following our [Python installation guide](/getting-started/installation-virtualenv/) or [manual installation guide for Raspberry Pi](/getting-started/installation-raspberry-pi/), the following template should work for you. If Home Assistant install is not located at `/srv/homeassistant`, please modify the `ExecStart=` line appropriately. [your user] should replaced by the user account that Home Assistant will run as (e.g `homeassistant`).
 
 ```
 [Unit]
@@ -51,7 +51,7 @@ After=network-online.target
 [Service]
 Type=simple
 User=%i
-ExecStart=/srv/homeassistant/bin/hass -c "/home/homeassistant/.homeassistant"
+ExecStart=/srv/homeassistant/bin/hass -c "/home/[your user]/.homeassistant"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If you follow the advanced guide to setup a virtual environment a user named "homeassistant" or whatever you want will be created. See:
https://www.home-assistant.io/docs/installation/raspberry-pi/
If you follow this guide the "homeassistant" user won't be created:
https://www.home-assistant.io/docs/installation/virtualenv
This page actually refers to the Autostart page on which is assumed that you created a user named "homeassistant". It's better to refer to the user which runs HA in general.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
