### PR TITLE
Add Air Pollutants docs

### DIFF
--- a/source/_components/air_pollutants.markdown
+++ b/source/_components/air_pollutants.markdown
@@ -13,19 +13,15 @@ The `air_pollutants` gather information about the air quality and pollution deta
 
 The platforms cover the following levels (if they are available):
 
+- The particulate matter 0.1 (<= 0.1 μm) level.
 - The particulate matter 2.5 (<= 2.5 μm) level.
 - The particulate matter 10 (<= 10 μm) level.
-- The current temperature in °C or °F.
-- The current humidity in %.
 - The Air Quality Index (AQI).
 - The O3 (ozone) level.
 - The CO (carbon monoxide) level.
 - The CO2 (carbon dioxide) level.
-- The general particulate matter level.
-- The particulate matter 0.1 (<= 0.1 μm) level.
 - The SO2 (sulphur dioxide) level.
 - The N2O (nitrogen oxide) level.
 - The NO (nitrogen monoxide) level.
 - The NO2 (nitrogen dioxide) level.
-- The volatile organic compounds (VOC) level.
 

--- a/source/_components/air_pollutants.markdown
+++ b/source/_components/air_pollutants.markdown
@@ -1,0 +1,31 @@
+---
+layout: page
+title: "Air Pollutants"
+description: "Instructions on how to air pollutants sensors with Home Assistant"
+date: 2018-11-25 08:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+---
+
+The `air_pollutants` gather information about the air quality and pollution details.
+
+The platforms cover the following levels (if they are available):
+
+- The particulate matter 2.5 (<= 2.5 μm) level.
+- The particulate matter 10 (<= 10 μm) level.
+- The current temperature in °C or °F.
+- The current humidity in %.
+- The Air Quality Index (AQI).
+- The O3 (ozone) level.
+- The CO (carbon monoxide) level.
+- The CO2 (carbon dioxide) level.
+- The general particulate matter level.
+- The particulate matter 0.1 (<= 0.1 μm) level.
+- The SO2 (sulphur dioxide) level.
+- The N2O (nitrogen oxide) level.
+- The NO (nitrogen monoxide) level.
+- The NO2 (nitrogen dioxide) level.
+- The volatile organic compounds (VOC) level.
+

--- a/source/_components/demo.markdown
+++ b/source/_components/demo.markdown
@@ -17,6 +17,7 @@ The `demo` platform allows you to use components which are providing a demo of t
 
 Available demo platforms:
 
+- [Air Pollutants]((/components/air_pollutants/) (`air_pollutants`)
 - [Alarm control panel](/components/alarm_control_panel/) (`alarm_control_panel`)
 - [Binary sensor](/components/binary_sensor/) (`binary_sensor`)
 - [Camera](/components/camera/) (`camera`)


### PR DESCRIPTION
**Description:**
Add Air Pollutants docs

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18707

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
