### PR TITLE
Latitude and longitude configuration options added to geo location platforms

### DIFF
--- a/source/_components/geo_location.geo_json_events.markdown
+++ b/source/_components/geo_location.geo_json_events.markdown
@@ -41,6 +41,16 @@ radius:
   required: false
   type: string
   default: 20km
+latitude:
+  description: Latitude of the coordinates around which events are considered.
+  required: false
+  type: string
+  default: Latitude defined in your `configuration.yaml`
+longitude:
+  description: Longitude of the coordinates around which events are considered.
+  required: false
+  type: string
+  default: Longitude defined in your `configuration.yaml`
 {% endconfiguration %}
 
 ## {% linkable_title Advanced Configuration Example %}

--- a/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
+++ b/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
@@ -50,6 +50,16 @@ categories:
   required: false
   type: list
   default: None. Any incident regardless of its category will be included.
+latitude:
+  description: Latitude of the coordinates around which events are considered.
+  required: false
+  type: string
+  default: Latitude defined in your `configuration.yaml`
+longitude:
+  description: Longitude of the coordinates around which events are considered.
+  required: false
+  type: string
+  default: Longitude defined in your `configuration.yaml`
 {% endconfiguration %}
 
 ## {% linkable_title State Attributes %}


### PR DESCRIPTION
**Description:**
Added the option to configure custom latitude/longitude for `nsw_rural_fire_service_feed` and `geo_json_events` platforms.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18717

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
