### PR TITLE
Added theme to gauge card documentation

### DIFF
--- a/source/_lovelace/gauge.markdown
+++ b/source/_lovelace/gauge.markdown
@@ -40,6 +40,10 @@ unit_of_measurement:
   description: Unit of Measurement given to data
   type: string
   default: "Unit Of Measurement given by entity"
+theme:
+  required: false
+  description: "Set to any theme within themes.yaml"
+  type: string
 min:
   required: false
   description: Minimum value for graph

--- a/source/_lovelace/gauge.markdown
+++ b/source/_lovelace/gauge.markdown
@@ -42,7 +42,7 @@ unit_of_measurement:
   default: "Unit Of Measurement given by entity"
 theme:
   required: false
-  description: "Set to any theme within themes.yaml"
+  description: Set to any theme within `themes.yaml`
   type: string
 min:
   required: false


### PR DESCRIPTION
**Description:**
Found out that severity colors could be changed by theme.
So added it to the docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
