### PR TITLE
Typo spelling correction

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -36,7 +36,7 @@ The alternative to a stick is a hub that supports Z-Wave. Home Assistant support
 
 ## {% linkable_title Controller Notes %}
 
-### {% linkable_title Aoetec Stick %}
+### {% linkable_title Aeotec Stick %}
 
 By default this will turn on "disco lights", which you can turn off by following the instructions in the [device specific page](/docs/z-wave/device-specific/#aeon-z-stick)
 


### PR DESCRIPTION
Aoetec to Aeotec

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
