### PR TITLE
Update Z-Wave device 'delay' default

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -106,7 +106,7 @@ device_config / device_config_domain / device_config_glob:
       description: Specify the delay for refreshing of node value. Only the light component uses this.
       required: false
       type: integer
-      default: 2
+      default: 5
     invert_openclose_buttons:
       description: Inverts function of the open and close buttons for the cover domain. This will not invert the position and state reporting.
       required: false


### PR DESCRIPTION
**Description:**

The Z-Wave component code sets a default of 5, not 2.

See https://github.com/home-assistant/home-assistant/blob/0.82.1/homeassistant/components/zwave/__init__.py

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
