### PR TITLE
Added UOM and value casts

### DIFF
--- a/source/_components/plant.markdown
+++ b/source/_components/plant.markdown
@@ -146,23 +146,28 @@ sensor:
   - platform: mqtt
     name: my_plant_moisture
     state_topic: my_plant_topic
-    value_template: '{{ value_json.moisture }}'
+    value_template: '{{ value_json.moisture | int }}'
+    unit_of_measurement: '%'
   - platform: mqtt
     name: my_plant_battery
     state_topic: my_plant_topic
-    value_template: '{{ value_json.battery }}'
+    value_template: '{{ value_json.battery | int }}'
+    unit_of_measurement: '%'
   - platform: mqtt
     name: my_plant_temperature
     state_topic: my_plant_topic
-    value_template: '{{ value_json.temperature }}'
+    value_template: '{{ value_json.temperature | float }}'
+    unit_of_measurement: '°C'
   - platform: mqtt
     name: my_plant_conductivity
     state_topic: my_plant_topic
-    value_template: '{{ value_json.conductivity }}'
+    value_template: '{{ value_json.conductivity | int }}'
+    unit_of_measurement: 'µS/cm'
   - platform: mqtt
     name: my_plant_brightness
     state_topic: my_plant_topic
-    value_template: '{{ value_json.brightness }}'
+    value_template: '{{ value_json.brightness | int }}'
+    unit_of_measurement: 'Lux'
 ```
 
 {% endraw %}


### PR DESCRIPTION
Completed the configuration for PlantGateway to make sure everything displays even more beautiful by default

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
