### PR TITLE
0.82.0 changelog

### DIFF
--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -8,6 +8,14 @@ comments: false
 sharing: true
 footer: true
 ---
+## {% linkable_title Changes in 0.82.0 %}
+- 📣 New card type: `light` ❤️
+- 📣 Alpha release of UI Editor
+- 📣 [entities card]: can be themed
+- 📣 [gauge card]: can be themed
+- 📣 [light card]: can be themed
+- 📣 [thermostat card]: can be themed
+
 ## {% linkable_title Changes in 0.81.0 %}
 - 📣 New card type: `alarm-panel` ❤️
 - 📣 New card type: `thermostat` ❤️

--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -15,6 +15,7 @@ footer: true
 - 📣 [gauge card]: can be themed
 - 📣 [light card]: can be themed
 - 📣 [thermostat card]: can be themed
+- `!secret` and `!include` usage restored for manual editing, but are not supported with the UI editor
 
 ## {% linkable_title Changes in 0.81.0 %}
 - 📣 New card type: `alarm-panel` ❤️


### PR DESCRIPTION
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
