### PR TITLE
Changelog for 0.83

### DIFF
--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -8,6 +8,20 @@ comments: false
 sharing: true
 footer: true
 ---
+## {% linkable_title Changes in 0.83.0 %}
+
+### Breaking changes
+- 📣 [sensor card]: Removed configs `height`, `line_color` and `line_width`
+- 📣 [gauge card]: Renamed config `title` to `name`
+- 📣 [alarm-panel card]: Renamed config `title` to `name`
+
+### All changes
+- 📣 New card type: `shopping-list` ❤️
+- 📣 [weather card]: New config `name`
+- 📣 [thermostat card]: New config `name`
+- 📣 [plant card]: New config `name`
+- Ability to generate a new Lovelace config using available entities if one does not yet exist from the UI Editor
+
 ## {% linkable_title Changes in 0.82.0 %}
 - 📣 New card type: `light` ❤️
 - 📣 Alpha release of UI Editor
@@ -36,7 +50,7 @@ footer: true
 
 ## {% linkable_title Changes in 0.75.0 %}
 
-### Breaking changes 
+### Breaking changes
 - 📣 [glance card]: `turn-on` replaced with `call-service`
 
 ### All changes
@@ -157,7 +171,7 @@ footer: true
 - [picture elements card] combined `service.domain` and `service.server` into `service`
 - 📣 [entities card] allow custom title just like `glance`
 - 📣 [entity filter card] allow auto-hide if empty using `show_empty: false`
-- 🔧 Fix card size calculation `horizontal-stack`/`vertical-stack` 
+- 🔧 Fix card size calculation `horizontal-stack`/`vertical-stack`
 
 ## {% linkable_title Changes in 0.73.0b0 %}
 

--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -9,18 +9,7 @@ sharing: true
 footer: true
 ---
 ## {% linkable_title Changes in 0.83.0 %}
-
-### Breaking changes
-- 📣 [sensor card]: Removed configs `height`, `line_color` and `line_width`
-- 📣 [gauge card]: Renamed config `title` to `name`
-- 📣 [alarm-panel card]: Renamed config `title` to `name`
-
-### All changes
 - 📣 New card type: `shopping-list` ❤️
-- 📣 [weather card]: New config `name`
-- 📣 [thermostat card]: New config `name`
-- 📣 [plant card]: New config `name`
-- Ability to generate a new Lovelace config using available entities if one does not yet exist from the UI Editor
 
 ## {% linkable_title Changes in 0.82.0 %}
 - 📣 New card type: `light` ❤️


### PR DESCRIPTION
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
