### PR TITLE
Fix link to state helper

### DIFF
--- a/source/_components/scene.markdown
+++ b/source/_components/scene.markdown
@@ -50,7 +50,7 @@ As you can see, there are two ways to define the states of each `entity_id`:
 - Define the `state` directly with the entity.
 - Define a complex state with its attributes.
 
-The mapping from states to services is done with the [state helper](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/helpers/state.py#L74). So, please have a look there for available states for your scenes.
+The mapping from states to services is done with the [state helper](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/helpers/state.py#L82). So, please have a look there for available states for your scenes.
 
 Scenes can be activated using the service `scene.turn_on` (there is no 'scene.turn_off' service).
 


### PR DESCRIPTION
It seems the code has changed but the link hasn't been updated.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
