### PR TITLE
Changed Google Maps to OpenStreetMap in code explanation

### DIFF
--- a/source/_components/binary_sensor.iss.markdown
+++ b/source/_components/binary_sensor.iss.markdown
@@ -53,7 +53,7 @@ The default name of the location attributes is `lat` and `long` to avoid showing
 ### {% linkable_title Show position on map with camera platform %}
 
 The [generic camera platform](/components/camera.mjpeg/) offers
-the possibility to show the location of the ISS on Google Maps.
+the possibility to show the location of the ISS on OpenStreetMap.
 
 {% raw %}
 ```yaml


### PR DESCRIPTION
**Description:**

The code snippet contains an OpenStreetMap URL, but the paragraph above mentioned Google Maps

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
