### PR TITLE
Add documentation for new verisure option

### DIFF
--- a/source/_components/verisure.markdown
+++ b/source/_components/verisure.markdown
@@ -64,6 +64,10 @@ locks:
   required: false
   type: boolean
   default: true
+default_lock_code:
+  description: Code that will be used to lock or unlock, if none is supplied.
+  required: false
+  type: string
 thermometers:
   description: Set to `true` to show thermometers, `false` to disable.
   required: false


### PR DESCRIPTION
**Description:**

Adds documentation for a new Verisure option.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#18873

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
