### PR TITLE
Aqara Gateway is not supported

### DIFF
--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -18,7 +18,7 @@ The `xiaomi_aqara` component allows you to integrate [Xiaomi](http://www.mi.com/
 
 #### {% linkable_title Supported Devices %}
 
-- Xiaomi Aqara Gateway (lumi.gateway.v2, lumi.gateway.v3)
+- Xiaomi Mijia Gateway (lumi.gateway.v2, lumi.gateway.v3)
 - Aqara Air Conditioning Companion (lumi.acpartner.v3)
 - Aqara Intelligent Door Lock (lock.aq1)
 - Temperature and Humidity Sensor (1st and 2nd generation)
@@ -45,13 +45,13 @@ The `xiaomi_aqara` component allows you to integrate [Xiaomi](http://www.mi.com/
 
 #### {% linkable_title Unsupported Devices %}
 
+- Xiaomi Aqara Gateway (lumi.gateway.aqhm01), as it is not possible to activate dev mode in the Mi Home App.
 - Gateway Radio
 - Gateway Button
 - Xiaomi Mi Air Conditioning Companion (lumi.acpartner.v2)
 - Aqara Intelligent Air Conditioner Controller Hub (lumi.acpartner.v1)
 - Decoupled mode of the Aqara Wall Switches (Single & Double)
 - Additional alarm events of the Gas and Smoke Detector: Analog alarm, battery fault alarm (smoke detector only), sensitivity fault alarm, I2C communication failure
-- Aqara HomeKit Gateway version(v3), as it is not supported by the Mi Home App, only the Aqara Home App.
 
 ## {% linkable_title Setup %}
 


### PR DESCRIPTION
lumi.gateway.v2 and lumi.gateway.v3 is not Aqara branded, it is Mijia. Real Aqara Gateway is not supported, that why it shouldn't be in the list of supported devices, because it is confusing.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
