### PR TITLE
Update sensor.nederlandse_spoorwegen.markdown to fix typo

### DIFF
--- a/source/_components/sensor.nederlandse_spoorwegen.markdown
+++ b/source/_components/sensor.nederlandse_spoorwegen.markdown
@@ -53,7 +53,7 @@ routes:
       description: Name of the route.
       required: true
       type: string
-    frome:
+    from:
       description: The start station.
       required: true
       type: string


### PR DESCRIPTION
Fix typo in route configuration variable

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
