### PR TITLE
monitored_variables required now?

### DIFF
--- a/source/_components/device_tracker.tile.markdown
+++ b/source/_components/device_tracker.tile.markdown
@@ -25,6 +25,10 @@ device_tracker:
   - platform: tile
     username: email@address.com
     password: MY_PASSWORD_123
+    monitored_variables:
+      - TILE
+      - PHONE
+  
 ```
 
 {% configuration %}
@@ -37,7 +41,7 @@ device_tracker:
     required: true
     type: string
   monitored_variables:
-    description: the Tile types to monitor; valid values are `TILE` and `PHONE` (default is for all types to be included)
+    description: the Tile types to monitor; valid values are `TILE` and `PHONE` (default is for only 'PHONE' to be monitored)
     required: false
     type: list
   show_inactive:


### PR DESCRIPTION
When I did my install, the TILEs weren't tracked until I added the monitored_variables with Phone and Tile specified.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
