### PR TITLE
Fixed off typo in alert documentation

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -83,7 +83,7 @@ skip_first:
   default: false
 message:
   description: >
-    A message to be sent after an alert transitions from `of` to `on`
+    A message to be sent after an alert transitions from `off` to `on`
     with [template][template] support.
   required: false
   type: template


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
