### PR TITLE
Add note about not being on same network as Home Assistant during relink

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -54,7 +54,7 @@ Since release 0.80, the `Authorization Code` type of `OAuth` account linking is 
 <p class='note'>
 If you've added Home Assistant to the home screen, you have to first remove it from home screen, otherwise, this HTML5 app will show up instead of a browser. Using it would prevent Home Assistant to redirect back to the `Google Assistant` app.
     
-If you're still having trouble, make sure that you're not connected to the same network Home Assistant is running on, e.g. use 4G/LTE instead.
+If you're still having trouble, make sure that you're not connected to the same network Home Assistant is running on, e.g., use 4G/LTE instead.
 </p>
 
 ## {% linkable_title First time setup %}

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -53,6 +53,8 @@ Since release 0.80, the `Authorization Code` type of `OAuth` account linking is 
 
 <p class='note'>
 If you've added Home Assistant to the home screen, you have to first remove it from home screen, otherwise, this HTML5 app will show up instead of a browser. Using it would prevent Home Assistant to redirect back to the `Google Assistant` app.
+    
+If you're still having trouble, make sure that you're not connected to the same network Home Assistant is running on, e.g. use 4G/LTE instead.
 </p>
 
 ## {% linkable_title First time setup %}


### PR DESCRIPTION
**Description:**
I had trouble relinking GA to Hass due to being on the same network, I suspect this is down to how I'm overriding DNS locally for my hass instance, but it solved the issue for me when I was having trouble relinking after moving to 0.80+

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
