### PR TITLE
Wrong filename given for wifi setup.

### DIFF
--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -39,7 +39,7 @@ We will need a few things to get started with installing Home Assistant. For bes
 
 1. Put the SD card in your SD card reader.
 1. Open Etcher, select the Hass.io image and flash it to the SD card.
-1. WiFi and Static IP setup only: Format a USB-Stick with name `CONFIG`, create a folder named `network` and within that folder a file named `my-network`. Copy one of [the examples] to the `my-network` file.
+1. WiFi and Static IP setup only: Format a USB-Stick with name `CONFIG`, create a folder named `network` and within that folder a file named `system-connections`. Copy one of [the examples] to the `system-connections` file.
 1. Unmount the SD card and remove it from your SD card reader.
 1. Insert the SD card into your Raspberry Pi 3. If you are going to use an Ethernet cable, connect that too.
 1. Connect your Raspberry Pi to the power supply, so it turns on.


### PR DESCRIPTION
I tried for about an hour to try to get the wifi network working. It turns out the file shouldn't be `my-network`, but install `system-connections`. I'm running 0.83.2.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
