### PR TITLE
Add Repetier-Server platform documentation

### DIFF
--- a/source/_components/sensor.repetier.markdown
+++ b/source/_components/sensor.repetier.markdown
@@ -15,21 +15,35 @@ ha_iot_class: "Local Polling"
 This component creates one sensor for each devices in your Repetier-Server installation.
 Each sensor contains information about the current state of the device, including job name, start time and percentage done.
 
-To enable this sensor, add the following lines to your `configuration.yaml`:
+Tested against Repetier-Server 0.90.7 with multiple printers attached.
 
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: repetier
-    url: http://IP_ADDRESS
-    port: PORT
-    api_key: YOUR_API_KEY
-```
+{% configuration %}
+url:
+  description: The URL to connect to, without the port part.
+  required: true
+  type: string
+port:
+  description: The port to connect to the hos at (default Repetier-Server port is 3344)
+  required: true
+  type: integer
+api_key:
+  description: API-key for the user used to connect to Repetier-Server
+  required: true
+  type: string
+state_percent:
+  description: Use percent as sensor state, otherwise On, Idle and Off are the states.
+  required: false
+  type: boolean
+  default: false
+decimals:
+  description: How many decimals to show in state percent. Only used if state_percent is true.
+  required: false
+  type: integer
+  default: 1
+{% endconfiguration %}
 
-Configuration options for the Repetier-Server Sensor:
+### {% retrieve_api_key Retrieve API-key %}
 
-- **url** (*Required*): The URL to connect to without the port part.
-- **port** (*Required*): The port to connect to the host on (default Repetier-Server port is 3344).
-- **api_key** (*Required*): API-Key for the Repetier-Server user to login as.
-- **state_percent** (*Optional*): Show percent done as state of sensor. Defaults to `false` (On/Idle/Off)
-- **decimals** (*Optional*): How many decimals to show in state if state_percent is true. Defaults to `1`.
+To generate the needed API-key, go into your Repetier Server web-console, push the settings icon (the gear icon) and select User Profiles.
+Create a new user, deselect all options and click Create User.
+Edit the newly created user and take note of the API-key for this user, that's the one to use in the Home Assistant Settings

--- a/source/_components/sensor.repetier.markdown
+++ b/source/_components/sensor.repetier.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: Repetier-Server Sensor
 description: "Instructions how to add Repetier-Server sensors to Home Assistant."
-date: 2018-12-02 22:03
+date: 2018-12-02 22:12
 sidebar: true
 comments: false
 sharing: true

--- a/source/_components/sensor.repetier.markdown
+++ b/source/_components/sensor.repetier.markdown
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Repetier-Server Sensor
+description: "Instructions how to add Repetier-Server sensors to Home Assistant."
+date: 2018-12-02 22:03
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Sensor
+ha_release: 0.84
+ha_iot_class: "Local Polling"
+---
+
+This component creates one sensor for each devices in your Repetier-Server installation.
+Each sensor contains information about the current state of the device, including job name, start time and percentage done.
+
+To enable this sensor, add the following lines to your `configuration.yaml`:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: repetier
+    url: http://IP_ADDRESS
+    port: PORT
+    api_key: YOUR_API_KEY
+```
+
+Configuration options for the Repetier-Server Sensor:
+
+- **url** (*Required*): The URL to connect to without the port part.
+- **port** (*Required*): The port to connect to the host on (default Repetier-Server port is 3344).
+- **api_key** (*Required*): API-Key for the Repetier-Server user to login as.
+- **state_percent** (*Optional*): Show percent done as state of sensor. Defaults to `false` (On/Idle/Off)
+- **decimals** (*Optional*): How many decimals to show in state if state_percent is true. Defaults to `1`.

--- a/source/_components/sensor.repetier.markdown
+++ b/source/_components/sensor.repetier.markdown
@@ -42,7 +42,7 @@ decimals:
   default: 1
 {% endconfiguration %}
 
-### {% retrieve_api_key Retrieve API-key %}
+### {% linkable_title Retrieve API-key %}
 
 To generate the needed API-key, go into your Repetier Server web-console, push the settings icon (the gear icon) and select User Profiles.
 Create a new user, deselect all options and click Create User.


### PR DESCRIPTION
**Description:**
Documentation for Repetier-Server platform

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19930
git 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].
