### PR TITLE
Align example with documentation by using dark sky in both locations

### DIFF
--- a/source/_lovelace/weather-forecast.markdown
+++ b/source/_lovelace/weather-forecast.markdown
@@ -37,7 +37,7 @@ name:
 
 ```yaml
 - type: weather-forecast
-  entity: weather.demo_weather_north
+  entity: weather.dark_sky
 ```
 
 <p class="note">


### PR DESCRIPTION
The note talks about dark sky, so people will be nudged to set up dark sky.  Make it easy for them by matching the example to that choice.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
