### PR TITLE
Remove piped jq command from command examples

### DIFF
--- a/source/_components/eufy.markdown
+++ b/source/_components/eufy.markdown
@@ -43,15 +43,14 @@ eufy:
 ```bash
 $ curl -H "Content-Type: application/json" \
    -d '{"client_id":"eufyhome-app", "client_Secret":"GQCpr9dSp3uQpsOMgJ4xQ", "email":"USERNAME", "password":"PASSWORD"}' \
-   https://home-api.eufylife.com/v1/user/email/login \
-   | jq
+   https://home-api.eufylife.com/v1/user/email/login
 ```
 
 replacing USERNAME and PASSWORD with the Eufy username and password. This will give an `access_token`. Then run:
 
 ```bash
 $ curl -H token:TOKEN -H category:Home \
-   https://home-api.eufylife.com/v1/device/list/devices-and-groups | jq
+   https://home-api.eufylife.com/v1/device/list/devices-and-groups
 ```
 
 replacing TOKEN with the `access_token` from the previous command. This will provide the local_code for each device.


### PR DESCRIPTION
jq package is not installed by default. It is unnecessary.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
