### PR TITLE
Fix service call documentation

### DIFF
--- a/source/_components/water_heater.markdown
+++ b/source/_components/water_heater.markdown
@@ -77,13 +77,14 @@ automation:
         operation_mode: eco
 ```
 
-### {% linkable_title Service `water_heater.turn_away_mode_on` %}
+### {% linkable_title Service `water_heater.set_away_mode` %}
 
-Turn away mode on for water heater device
+Turn away mode on or off for water heater device
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Else targets all.
+| `away_mode` | no | New value of away mode. 'on'/'off' or True/False
 
 #### {% linkable_title Automation example  %}
 
@@ -93,28 +94,8 @@ automation:
     platform: time
     at: "07:15:00"
   action:
-    - service: water_heater.turn_away_mode_on
+    - service: water_heater.set_away_mode
       data:
         entity_id: water_heater.demo
-```
-
-### {% linkable_title Service `water_heater.turn_away_mode_off` %}
-
-Trun away mode off for water heater device
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Else targets all.
-
-#### {% linkable_title Automation example  %}
-
-```yaml
-automation:
-  trigger:
-    platform: time
-    at: "07:15:00"
-  action:
-    - service: water_heater.turn_away_mode_off
-      data:
-        entity_id: water_heater.demo
+        away_mode: True
 ```


### PR DESCRIPTION
**Description:**
See #7368 
The component doesn't seem to register "turn_away_mode_off" and "turn_away_mode_on" as services and instead uses "set_away_mode".
Fix the Water Heater documentation to reflect the registered services.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
