### PR TITLE
drop unit parameter from waterfurnace docs

### DIFF
--- a/source/_components/waterfurnace.markdown
+++ b/source/_components/waterfurnace.markdown
@@ -42,7 +42,6 @@ To use Waterfurnace in your installation, add the following to your `configurati
 waterfurnace:
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
-  unit: 0123456789AB
 ```
 
 {% configuration %}
@@ -52,10 +51,6 @@ username:
   type: string
 password:
   description: The password for your Symphony WaterFurnace account
-  required: true
-  type: string
-unit:
-  description: The unit serial number for your WaterFurnace
   required: true
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
The unit parameter will no longer be required in the next version of
home assistant, which makes it easier for people to use it.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19040

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
