### PR TITLE
Updating documentation to MQTT (See Pull 7455)

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -55,6 +55,22 @@ This add-on is attached to the Home Assistant user system, so mqtt clients can m
 
 To use the Mosquitto as [broker](/docs/mqtt/broker/#run-your-own), go to the integration page and install the configuration with one click. If you have old MQTT settings available, remove this old integration and restart Home Assistant to see the new one.
 
+
+  #### Using Mosquitto with Hass.io
+  Install the [Mosquitto add-on](https://www.home-assistant.io/addons/mosquitto/) with the default configuration via 'Hass.io > ADD-ON STORE'. (Don't forget to start the add-on & verify that 'Start on boot' is enabled.)
+   Next, create a new user for MQTT via the `Configuration > Users (manage users)`. Restart your HA. (Note: This name cannot be "homeassistant" or "addon")
+   Once back on-line, return to `Configuration > Integrations` and select configure next to `MQTT`.
+   ##### Example of MQTT Integration
+  ```
+    Broker: 192.168.XXX.XXX (Hass.io Local Address)
+    Port: 1883 (by default)
+    Username: username
+    Password: password
+  ```
+  Note: .yaml modifications are not required. 
+   Press submit. See [testing your setup](https://www.home-assistant.io/docs/mqtt/testing/) to verify the steps above.
+
+
 ### {% linkable_title Disable listening on insecure (1883) ports %}
 
 Remove the ports from the add-on page network card (set them as blank) to disable them.

--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -55,21 +55,23 @@ This add-on is attached to the Home Assistant user system, so mqtt clients can m
 
 To use the Mosquitto as [broker](/docs/mqtt/broker/#run-your-own), go to the integration page and install the configuration with one click. If you have old MQTT settings available, remove this old integration and restart Home Assistant to see the new one.
 
+#### {% linkable_title Using Mosquitto with Hass.io %}
 
-  #### Using Mosquitto with Hass.io
-  Install the [Mosquitto add-on](https://www.home-assistant.io/addons/mosquitto/) with the default configuration via 'Hass.io > ADD-ON STORE'. (Don't forget to start the add-on & verify that 'Start on boot' is enabled.)
-   Next, create a new user for MQTT via the `Configuration > Users (manage users)`. Restart your HA. (Note: This name cannot be "homeassistant" or "addon")
-   Once back on-line, return to `Configuration > Integrations` and select configure next to `MQTT`.
-   ##### Example of MQTT Integration
-  ```
-    Broker: 192.168.XXX.XXX (Hass.io Local Address)
-    Port: 1883 (by default)
-    Username: username
-    Password: password
-  ```
-  Note: .yaml modifications are not required. 
-   Press submit. See [testing your setup](https://www.home-assistant.io/docs/mqtt/testing/) to verify the steps above.
+1. Install the [Mosquitto add-on](https://www.home-assistant.io/addons/mosquitto/) with the default configuration via 'Hass.io > ADD-ON STORE'. (Don't forget to start the add-on & verify that 'Start on boot' is enabled.)
 
+2. Create a new user for MQTT via the `Configuration > Users (manage users)`. (Note: This name cannot be "homeassistant" or "addon")
+
+3. Once back on-line, return to `Configuration > Integrations` and select configure next to `MQTT`.
+
+```
+  Broker: YOUR_HASSIO_IP_ADDRESS
+  Port: 1883
+  Username: MQTT_USERNAME
+  Password: MQTT_PASSWORD
+```
+
+Note: .yaml modifications are not required. 
+See [testing your setup](https://www.home-assistant.io/docs/mqtt/testing/) to verify the steps above.
 
 ### {% linkable_title Disable listening on insecure (1883) ports %}
 


### PR DESCRIPTION
As a request of user fabaff, moving change notes to Add-on Section instead of MQTT generic

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
