### PR TITLE
Update documentation for HomeMatic

### DIFF
--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -67,7 +67,7 @@ port:
 ssl:
   description: Set to `true` if SSL support is enabled on the CCU3.
   required: false
-  type: bool
+  type: boolean
 verify_ssl:
   description: Set to `true` if a valid certificate is being used. The default is `false` as usually a self-signed certificate is configured.
   required: false

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -16,12 +16,12 @@ featured: false
 The [Homematic](http://www.homematic.com/) component provides bi-directional communication with your CCU/Homegear. It uses a XML-RPC connection to set values on devices and subscribes to receive events the devices and the CCU emit.
 If you are using Homegear with paired [Intertechno](http://intertechno.at/) devices, uni-directional communication is possible as well.
 
-Device support is available for most of the wired and wireless devices, as well as a few IP devices. If you have a setup with mixed protocols, you have to configure additional hosts with the appropriate ports. The default is using port 2001, which are wireless devices. Wired devices usually are available through port 2000 and IP devices through port 2010. The virtual thermostatgroups the CCU provides use port 9292 **and** require you to set the `path` setting to `/groups`.
+Device support is available for most of the wired and wireless devices, as well as a lot of IP devices. If you have a setup with mixed protocols, you have to configure additional [interfaces](https://www.home-assistant.io/components/homematic#interfaces) with the appropriate ports. The default is using port 2001, which are wireless devices. Wired devices usually are available through port 2000 and IP devices through port 2010. The virtual thermostatgroups the CCU provides use port 9292 **and** require you to set the `path` setting to `/groups`. When using SSL on a CCU3, by default the same ports as usual with a prepended 4 are available. So 2001 becomes 42001, 2010 becomes 42010 etc..
 
 If you want to see if a specific device you have is supported, head over to the [pyhomematic](https://github.com/danielperna84/pyhomematic/tree/master/pyhomematic/devicetypes) repository and browse through the source code. A dictionary with the device identifiers (e.g., HM-Sec-SC-2) can be found within the relevant modules near the bottom. If your device is not supported, feel free to contribute.
 
 We automatically detect all devices we currently support and try to generate useful names. If you enable name-resolving, we try to fetch names from Metadata (Homegear), via JSON-RPC or the XML-API you may have installed on your CCU. Since this may fail this is disabled by default.
-You can manually rename the created entities by using Home Assistant's [Customizing](/docs/configuration/customizing-devices/) feature. With it you are also able to hide entities you don't want to see in the UI.
+You can manually rename the created entities by using Home Assistant's [Customizing](/docs/configuration/customizing-devices/) feature. With it you are also able to hide entities you don't want to see in the UI. The HomeMatic component is also supported by the [Entity Registry](https://developers.home-assistant.io/docs/en/entity_registry_index.html), which allows you to change the friendly name and the entity ID directly in the Home Assistant UI.
 
 To set up the component, add the following information to your `configuration.yaml` file:
 
@@ -61,9 +61,17 @@ host:
   required: true
   type: string
 port:
-  description: "Port of CCU/Homegear XML-RPC Server. Wireless: 2001, wired: 2000, IP: 2010, thermostatgroups: 9292."
+  description: Port of CCU/Homegear XML-RPC Server. Wireless: 2001, wired: 2000, IP: 2010, thermostatgroups: 9292. With enabled SSL on the CCU3 usually a 4 is prepended to the Port. E.g. 2001 becomes 42001 with enabled SSL.
   required: false
   type: integer
+ssl:
+  description: Set to `true` if SSL support is enabled on the CCU3.
+  required: false
+  type: bool
+verify_ssl:
+  description: Set to `true` if a valid certificate is being used. The default is `false` as usually a self-signed certificate is configured.
+  required: false
+  type: bool
 callback_ip:
   description: Set this, if Home Assistant is reachable under a different IP from the CCU (NAT, Docker etc.).
   required: false
@@ -78,7 +86,7 @@ resolvenames:
   type: string
   default: false
 jsonport:
-  description: Port of CCU JSON-RPC Server. The default is 80, but it may be different when running CCU virtually via Docker.
+  description: Port of CCU JSON-RPC Server. The default is 80, but it may be different when running CCU virtually via Docker or with enabled SSL.
   required: false
   type: integer
 username:

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -70,6 +70,7 @@ ssl:
   required: false
   type: boolean
 verify_ssl:
+  default: false
   description: Set to `true` if a valid certificate is being used. The default is `false` as usually a self-signed certificate is configured.
   required: false
   type: boolean

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -65,6 +65,7 @@ port:
   required: false
   type: integer
 ssl:
+  default: false
   description: Set to `true` if SSL support is enabled on the CCU3.
   required: false
   type: boolean

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -71,7 +71,7 @@ ssl:
 verify_ssl:
   description: Set to `true` if a valid certificate is being used. The default is `false` as usually a self-signed certificate is configured.
   required: false
-  type: bool
+  type: boolean
 callback_ip:
   description: Set this, if Home Assistant is reachable under a different IP from the CCU (NAT, Docker etc.).
   required: false

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -61,7 +61,7 @@ host:
   required: true
   type: string
 port:
-  description: Port of CCU/Homegear XML-RPC Server. Wireless: 2001, wired: 2000, IP: 2010, thermostatgroups: 9292. With enabled SSL on the CCU3 usually a 4 is prepended to the Port. E.g. 2001 becomes 42001 with enabled SSL.
+  description: "Port of CCU/Homegear XML-RPC Server. Wireless: 2001, wired: 2000, IP: 2010, thermostatgroups: 9292. With enabled SSL on the CCU3 usually a 4 is prepended to the Port. e.g., 2001 becomes 42001 with enabled SSL."
   required: false
   type: integer
 ssl:


### PR DESCRIPTION
**Description:**
Added 2 new options (`ssl` and `verify_ssl`) and some other minor changes.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19056

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
