### PR TITLE
MyTotalConnectComfort.com is supported

### DIFF
--- a/source/_components/climate.honeywell.markdown
+++ b/source/_components/climate.honeywell.markdown
@@ -17,7 +17,7 @@ ha_iot_class: "Cloud Polling"
 The `honeywell` climate platform let you control [Honeywell Connected](http://getconnected.honeywell.com/en/) thermostats from Home Assistant.
 
 <p class='note'>
-This platform does NOT connect to MyTotalConnectComfort.com.  If you have a Honeywell WIFI thermostat that is connected through MyTotalConnectComfort.com, you may might to take a look at the IFTTT component which can bridge the gap between Home Assistant and MyTotalConnectComfort.com WIFI thermostats on a limited basis.
+This platform DOES support MyTotalConnectComfort.com.  If you have a WiFi thermostat connected via MyTotalConnectComfort.com, you must configure the region to us.
 </p>
 
 To set it up, add the following information to your `configuration.yaml` file:
@@ -28,6 +28,7 @@ climate:
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
     scan_interval: 600
+    region: us #required for MyTotalConnectComfort.com thermostats, otherwise optional
 ```
 <p class='note'>
 Scan interval is expressed in seconds. Omitting scan_interval may result in too-frequent polling and cause you to rate-limited by Honeywell.


### PR DESCRIPTION
Simply add the US region to allow connectivity with MyTotalConnectComfort.com.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
