### PR TITLE
Change aspect ratio in example

### DIFF
--- a/source/_lovelace/map.markdown
+++ b/source/_lovelace/map.markdown
@@ -55,7 +55,7 @@ default_zoom:
 
 ```yaml
 - type: map
-  aspect_ratio: 100%
+  aspect_ratio: 16:9
   default_zoom: 8
   entities:
     - device_tracker.demo_paulus


### PR DESCRIPTION
Changes aspect ratio in example to match config variable given in description

**Description:**
Example uses wrong aspect ratio configuration. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [*] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [*] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
