### PR TITLE
Update notify.html5 example

### DIFF
--- a/source/_components/notify.html5.markdown
+++ b/source/_components/notify.html5.markdown
@@ -166,7 +166,7 @@ if there already exists one with the same tag.
       - platform: state
         entity_id: sensor.sensor
     action:
-      service: notify.html5
+      service: notify.notify
       data_template:
         message: "Last known sensor state is {% raw %}{{ states('sensor.sensor') }}{% endraw %}."
       data:


### PR DESCRIPTION
**Description:**
Update the html5 notification example as the service `notify.html5` does not exist, but `notify.notify`
does.
Logging would show the following when `notify.html5` as the service was used:
```
Unable to find service notify/html5
```

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** Not applicable

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
