### PR TITLE
Update light.markdown - Clarify that `brigthness` controls the light's brigthness

### DIFF
--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -39,7 +39,7 @@ Most lights do not support all attributes. You can check the platform documentat
 | `color_temp` | yes | An integer in mireds representing the color temperature you want the light to be.
 | `kelvin` | yes | Alternatively, you can specify the color temperature in Kelvin.
 | `color_name` | yes | A human-readable string of a color name, such as `blue` or `goldenrod`. All [CSS3 color names](https://www.w3.org/TR/css-color-3/#svg-color) are supported.
-| `brightness` | yes | Integer between 0 and 255 for how bright the color should be.
+| `brightness` | yes | Integer between 0 and 255 for how bright the light should be.
 | `brightness_pct`| yes | Alternatively, you can specify brightness in percent (a number between 0 and 100).
 | `flash` | yes | Tell light to flash, can be either value `short` or `long`.
 | `effect`| yes | Applies an effect such as `colorloop` or `random`.


### PR DESCRIPTION
**Description:**
Clarify that `brigthness` controls the light's brigthness

## Checklist:

- [x] Branch: Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
