### PR TITLE
Add code optional parameter on iAlarm

### DIFF
--- a/source/_components/alarm_control_panel.ialarm.markdown
+++ b/source/_components/alarm_control_panel.ialarm.markdown
@@ -46,6 +46,10 @@ name:
   description: Name of device in Home Assistant.
   required: false
   type: string
+code:
+  description: Specifies a code to enable or disable the alarm in the frontend.
+  required: false
+  type: integer
 {% endconfiguration %}
 
 This platform has also been confirmed to work with the alarm system brands Meian and Emooluxr.


### PR DESCRIPTION
**Description:**
Add support for the optional `code` value in the alarm system iAlarm.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19124

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
