### PR TITLE
Correct netgear example on known_devices.yaml

### DIFF
--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -53,7 +53,8 @@ device_tracker:
     username: admin
     interval_seconds: 10
     consider_home: 180
-    track_new_devices: yes
+    new_device_defaults:
+      track_new_devices: true
 ```
 
 Multiple device trackers can be used in parallel, such as [Owntracks](/components/device_tracker.owntracks/#using-owntracks-with-other-device-trackers) and [Nmap](/components/device_tracker.nmap_tracker/). The state of the device will be determined by the source that reported last.


### PR DESCRIPTION
The netgear example on known_devices.yaml uses the old config mechanism which does not place "track_new_devices" nested in new_device_defaults.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
