### PR TITLE
Clarification about the region name

### DIFF
--- a/source/_components/sensor.dwd_weather_warnings.markdown
+++ b/source/_components/sensor.dwd_weather_warnings.markdown
@@ -27,9 +27,14 @@ sensor:
     region_name: Hansestadt Hamburg
 ```
 
-To get the region name:
+<p class='important'>
+As it suggests the region name is not the city or nearest city you want to get the warnings for but the next higher level of the governmental district called "Kreis" in German.
+
+Be aware, to get the region name you need to use the following link by replacing `Hamburg` with your city:
 - Find your region here: `https://www.dwd.de/DE/wetter/warnungen_landkreise/warnWetter_node.html?ort=Hamburg`
-- Verify if you find any warning for your region here: `https://www.dwd.de/DWD/warnungen/warnapp_landkreise/json/warnings.json?jsonp=loadWarnings`
+- On the page that is loaded in your browser you will find the correct region ("Kreis") below the map as a headding.
+- Verify if you find any warning for your region here. Your region ("Kreis") will appear only if warnings exist: `https://www.dwd.de/DWD/warnungen/warnapp_landkreise/json/warnings.json?jsonp=loadWarnings`
+</p>
 
 The warning level is between 0 (no danger) and 4 (extreme weather conditions):
 - Warnungen vor extremem Unwetter (Stufe 4)


### PR DESCRIPTION
Myself and, by searching for a solution to my wrong usage of `region_name`, others have misunderstood - or not read carefully - the documentation. We used the name of our city by prior searching for it on the DWD website. This mistake is definetly on our part but could hopefully avoided by stronger pointing out the existing section in the documentation.

I surrounded the section by an `important` box and rephrased the wording a little.

