### PR TITLE
Update device_tracker.googlehome.markdown

### DIFF
--- a/source/_components/device_tracker.googlehome.markdown
+++ b/source/_components/device_tracker.googlehome.markdown
@@ -40,9 +40,9 @@ rssi_threshold:
 
 ## {% linkable_title Usage %}
 
-Devices will appear in the format `devicetracker.<home hub ip>_<device mac address>`.  Note that dots are removed from the ip and BT mac addresses.
+Devices will appear in the format `devicetracker.<home hub ip>_<device mac address>`. Note that dots are removed from the IP and BT MAC addresses.
 
-After running this compnent for a little while,. you will likely see many devices appear.  It is advisable to set the configuration to not discover new devices once the device you want to track have appeared.  (see [device tracker configuration][devicetrackerconfig] for details.)
+After running this component for a little while, you will likely see many devices appear. It's advisable to set the configuration to not discover new devices once the device you want to track have appeared (see [device tracker configuration][devicetrackerconfig] for details).
 
 [googlehomeapi]: https://rithvikvibhu.github.io/GHLocalApi/
 [devicetrackerconfig]: https://www.home-assistant.io/components/device_tracker/#configuring-a-device_tracker-platform

--- a/source/_components/device_tracker.googlehome.markdown
+++ b/source/_components/device_tracker.googlehome.markdown
@@ -38,4 +38,11 @@ rssi_threshold:
   type: integer
 {% endconfiguration %}
 
+## {% linkable_title Usage %}
+
+Devices will appear in the format `devicetracker.<home hub ip>_<device mac address>`.  Note that dots are removed from the ip and BT mac addresses.
+
+After running this compnent for a little while,. you will likely see many devices appear.  It is advisable to set the configuration to not discover new devices once the device you want to track have appeared.  (see [device tracker configuration][devicetrackerconfig] for details.)
+
 [googlehomeapi]: https://rithvikvibhu.github.io/GHLocalApi/
+[devicetrackerconfig]: https://www.home-assistant.io/components/device_tracker/#configuring-a-device_tracker-platform


### PR DESCRIPTION
Added notes on tracked device name format, and advice to turn off discovery after tracked device appears.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
