### PR TITLE
Add password caveat to 17track.net docs

### DIFF
--- a/source/_components/sensor.seventeentrack.markdown
+++ b/source/_components/sensor.seventeentrack.markdown
@@ -18,6 +18,14 @@ The 17track.net sensor platform allows users to get package data tied to their
 number of packages in a current state (e.g., "In Transit"), as well as
 individual sensors for each package within the account.
 
+<p class='note warning'>
+Although the 17track.net website states that account passwords cannot be longer
+than 16 characters, users can technically set long-than-16-character passwords.
+These passwords **will not** work with the API utilized by `py17track`.
+Therefore, please ensure that your 17track password does not exceed 16
+characters.
+</p>
+
 ## {% linkable_title Configuration %}
 
 To enable the platform, add the following lines to your `configuration.yaml`


### PR DESCRIPTION
**Description:**

This PR adds a caveat about password length to the 17track.net docs (the necessity of which was discovered in https://github.com/home-assistant/home-assistant/issues/19020#issuecomment-445519669).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
