### PR TITLE
Removed the venv link from the sidebar

### DIFF
--- a/source/_includes/asides/docs_navigation.html
+++ b/source/_includes/asides/docs_navigation.html
@@ -10,7 +10,6 @@
         <b>{% active_link /docs/installation/ Installation %}</b>
         <ul>
           <li>{% active_link /hassio/ Hass.io %}</li>
-          <li>{% active_link /docs/installation/virtualenv/ Python Virtual Env %}</li>
           <li>{% active_link /docs/installation/hassbian/ Hassbian %}</li>
           <li>{% active_link /docs/installation/updating/ Updating %}</li>
           <li>{% active_link /docs/installation/troubleshooting/ Troubleshooting %}</li>


### PR DESCRIPTION
Removed the venv link, since that gets people the worst of all options, and helps them break their system when they install another Python program. Obviously the link (and others) are still available if they click _Installation_.
