### PR TITLE
Update device_tracker.markdown

### DIFF
--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -31,7 +31,11 @@ device_tracker:
       hide_if_away: false
 ```
 
-The following optional parameters can be used with any platform. However device tracker will only look for global settings under the configuration of the first configured platform:
+The following optional parameters can be used with any platform:
+
+<p class='note'>
+  Device tracker will only look for global settings under the configuration of the first configured platform.
+</p>
 
 | Parameter           | Default | Description                                                                                                                                                                                                                                                                                                                                                                               |
 |----------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
**Description:**
Uses a note to emphasize this excerpt:

"Device tracker will only look for global settings under the configuration of the first configured platform."

This might help other users to not make a mistake in their configuration, like I did. See https://github.com/home-assistant/home-assistant/issues/19156

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
