### PR TITLE
x10: Add note about Brightness control

### DIFF
--- a/source/_components/light.x10.markdown
+++ b/source/_components/light.x10.markdown
@@ -17,6 +17,8 @@ The `x10` light platform allows you to control your X10 based lights with Home A
 
 Requires [Heyu x10](http://www.heyu.org) and a CM11A or a CM17A "FireCracker" interface.
 
+Note: Brightness Control is currently only supported on the CM11A
+
 To enable those lights, add the following lines to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
The current implementation only supports the cm11a for brightness control

**Description:**
Make a note of the brightness abilities, this should be merged when the cm11a brightness patch is merged into the main repo.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19190

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
