### PR TITLE
Update device_tracker.gpslogger.markdown

### DIFF
--- a/source/_components/device_tracker.gpslogger.markdown
+++ b/source/_components/device_tracker.gpslogger.markdown
@@ -68,10 +68,7 @@ Right after enabling, the app will take you to the **Log to custom URL** setting
 The relevant endpoint is: `/api/gpslogger`
 
 ```text
-https://YOUR.DNS.HOSTNAME:PORT/api/gpslogger?
-   latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC
-   &battery=%BATT&speed=%SPD&direction=%DIR
-   &altitude=%ALT&provider=%PROV&activity=%ACT
+https://YOUR.DNS.HOSTNAME:PORT/api/gpslogger?latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT
 ```
 
 Add the above URL after you modified it with your settings into the **URL** field. Remove the line breaks as they are only there to make the URL readable here.


### PR DESCRIPTION
While it makes it nicer to view, most people are probably going to copy and paste the URL from the site via their Android device and not type it all out. Having the line breaks results in %20 (or spaces) in the URL when sending to Home Assistant which doesn't work. Removing those spaces will make it easier for users to copy/paste.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
