### PR TITLE
Update switch.tplink.markdown - Typo fix on template

### DIFF
--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -88,7 +88,7 @@ sensor:
         value_template: '{{ states.switch.my_tp_switch.attributes["voltage"] | float }}'
         unit_of_measurement: 'V'
       my_tp_switch_today_kwh:
-        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Today's Consuption"
+        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Today's Consumption"
         value_template: '{{ states.switch.my_tp_switch.attributes["today_energy_kwh"] | float }}'
         unit_of_measurement: 'kWh'
 ```


### PR DESCRIPTION
**Description:**

Fixed typo on word "ConsuMption" inside the template sensor.

## Checklist:

- [ ] Branch: Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
