### PR TITLE
Update matrix.markdown

### DIFF
--- a/source/_components/matrix.markdown
+++ b/source/_components/matrix.markdown
@@ -96,6 +96,7 @@ matrix:
     - "#someothertest:matrix.org"
   commands:
     - word: testword
+      name: testword
       rooms:
         - "#someothertest:matrix.org"
     - expression: "My name is (?P<name>.*)"
@@ -126,7 +127,7 @@ automation:
     action:
       service: notify.matrix_notify
       data_template:
-        message: "Hello {{trigger.event.data.name}}"
+        message: "Hello {{trigger.event.data.args['name']}}"
 ```
 
 This configuration will:

--- a/source/_components/matrix.markdown
+++ b/source/_components/matrix.markdown
@@ -85,6 +85,7 @@ If the command is a word command, the `data` field contains a list of the comman
 
 This example also uses the [matrix `notify` platform](/components/notify.matrix/).
 
+{% raw %}
 ```yaml
 # The Matrix component
 matrix:
@@ -129,7 +130,9 @@ automation:
       data_template:
         message: "Hello {{trigger.event.data.args['name']}}"
 ```
+{% endraw %}
 
 This configuration will:
+
 - Listen for "!testword" in the room "#someothertest:matrix.org" (and *only*) there. If such a message is encountered, it will answer with "It looks like you wrote !testword" into the "#hasstest:matrix.org" channel.
 - Listen in both rooms for any message matching "My name is <any string>" and answer with "Hello <the string>" into "#hasstest:matrix.org".


### PR DESCRIPTION
**Description:**

The example is incomplete (or maybe out of date). For it to work (in version 0.83.3) I had to make 2 changes.
Also, for whatever reason (perhaps because of nested layers of markup), the part with the double braces on the last line does not show up on the actual displayed page (it shows when editing the page, but not the normal page). So when copy-pasting the example, a crucial bit is missing. I'm not sure how to fix that aspect of it and since I can't test it either, I haven't proposed a change for this.

Arthur

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
