### PR TITLE
Update 0.84 release notes

### DIFF
--- a/source/_posts/2018-12-12-release-84.markdown
+++ b/source/_posts/2018-12-12-release-84.markdown
@@ -39,7 +39,7 @@ So if you were using Lovelace before 0.84, you now have two options. Option one 
 
 If you want to continue managing a YAML file, [check here how to enable the YAML mode](/lovelace/yaml-mode/). The file `ui-lovelace.yaml` will now follow the same options as `configuration.yaml`. This means that the Lovelace YAML config is now parsed with YAML 1.1 instead of YAML 1.2. Major change is that you need to make sure that you wrap `on` and `off` with quotes in your configs!
 
-We have also aligned the configuration of all the cards, causing breaking changes. Changes are especially focused around how we define actions for short and long presses. See [the docs][/lovelace/] for more info.
+We have also aligned the configuration of all the cards, causing breaking changes. Changes are especially focused around how we define actions for short and long presses. See [the docs](/lovelace/changelog/) for more info.
 
 Editor UI is now further processed. You can manage your Lovelace UI without leaving your browser! It is possible to add, edit and delete views. It is possible to add, edit, move and delete cards, including custom cards!
 


### PR DESCRIPTION
Fix link to the docs for existing lovelace users

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
