### PR TITLE
Remove parameters in lovelace sensor card

### DIFF
--- a/source/_lovelace/sensor.markdown
+++ b/source/_lovelace/sensor.markdown
@@ -42,20 +42,6 @@ unit:
   required: false
   description: The unit of measurement
   type: string
-height:
-  required: false
-  description: Height of the graph
-  type: integer
-  default: 100
-line_width:
-  required: false
-  description: Width of the line stroke
-  type: integer
-  default: 5
-line_color:
-  required: false
-  description: Color of the line stroke
-  type: string
 detail:
   required: false
   description: Detail of the graph `1` or `2`, `1` equals one point/hour, `2` equals six points/hour


### PR DESCRIPTION
**Description:**

Some parameters were removed in the `sensor` card, as said in the **0.84** changelog.

![image](https://user-images.githubusercontent.com/17952318/49920523-c5217600-feaa-11e8-95a5-4226f1d4bbff.png)

I'm removing those parameters from the documentation

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
