### PR TITLE
Update doorbird events to include URLs on event_data 

### DIFF
--- a/source/_components/doorbird.markdown
+++ b/source/_components/doorbird.markdown
@@ -118,13 +118,12 @@ Each event includes live image and live video URLs for the Doorbird device that 
 
 The following keys are available on `event_data`:
 
-```
-timestamp
-live_video_url
-live_image_url
-rtsp_live_video_url
-html5_viewer_url
-```
+- `timestamp`
+- `live_video_url`
+- `live_image_url`
+- `rtsp_live_video_url`
+- `html5_viewer_url`
+
 <p class="note">
 The URLs on the event will be based on the configuration used to connect to your Doorbird device.  Ability to connect from outside your network will depend on your configuration.
 </p>

--- a/source/_components/doorbird.markdown
+++ b/source/_components/doorbird.markdown
@@ -116,6 +116,15 @@ Please note that clearing device registrations will prevent the device from send
 #### {% linkable_title Event Data %}
 Each event includes live image and live video URLs for the Doorbird device that triggered the event. These URLs can be found on the event data and can be useful in automation actions.  For example, you could use `html5_viewer_url` on a notification to be linked directly to the live view of the device that triggered the automation.
 
+The following keys are available on `event_data`:
+
+```
+timestamp
+live_video_url
+live_image_url
+rtsp_live_video_url
+html5_viewer_url
+```
 <p class="note">
 The URLs on the event will be based on the configuration used to connect to your Doorbird device.  Ability to connect from outside your network will depend on your configuration.
 </p>


### PR DESCRIPTION
**Description:**
Document available keys on event_data.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19262

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
