### PR TITLE
Fix example config

### DIFF
--- a/source/_lovelace/gauge.markdown
+++ b/source/_lovelace/gauge.markdown
@@ -80,7 +80,7 @@ Title and Unit of Measurement Example:
 
 ```yaml
 - type: gauge
-  title: CPU Usuage
+  name: CPU Usuage
   unit: '%'
   entity: sensor.cpu_usage
 ```
@@ -94,7 +94,7 @@ Define the severity map:
 
 ```yaml
 - type: gauge
-  title: With Severity
+  name: With Severity
   unit: '%'
   entity: sensor.cpu_usage
   severity:


### PR DESCRIPTION


**Description:**
Example configs were using `title` instead of `name`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
