### PR TITLE
note about `!include` and `!secret` for storage

### DIFF
--- a/source/_posts/2018-12-12-release-84.markdown
+++ b/source/_posts/2018-12-12-release-84.markdown
@@ -41,7 +41,7 @@ We have improved how we call services with better validation checks. This means 
 
 If you are currently testing Lovelace, please read the notes thoroughly as a lot has changed. First, we now have now three different Lovelace modes: auto-generated, storage, and yaml (the old way of doing Lovelace). The UI editor will be limited to the storage mode, in which we control how the config is stored.
 
-So if you were using Lovelace before 0.84, you now have two options. Option one is to use the new storage mode and import your existing file. You can do this by opening the Lovelace UI and click on Configure UI, this will prompt you to change to storage mode. This will unlock a new option in the menu called "raw config editor". Open this and paste the content of your `ui-lovelace.yaml` file into it and click save. Note that YAML comments are not persisted.
+So if you were using Lovelace before 0.84, you now have two options. Option one is to use the new storage mode and import your existing file. You can do this by opening the Lovelace UI and click on Configure UI, this will prompt you to change to storage mode. This will unlock a new option in the menu called "raw config editor". Open this and paste the content of your `ui-lovelace.yaml` file into it and click save. Note that YAML comments are not persisted and `!include`/`!secret` are not supported if in storage mode.
 
 If you want to continue managing a YAML file, [check here how to enable the YAML mode](/lovelace/yaml-mode/). The file `ui-lovelace.yaml` will now follow the same options as `configuration.yaml`. This means that the Lovelace YAML config is now parsed with YAML 1.1 instead of YAML 1.2. Major change is that you need to make sure that you wrap `on` and `off` with quotes in your configs!
 


### PR DESCRIPTION
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
