### PR TITLE
Remove "unit:"

### DIFF
--- a/source/_components/waterfurnace.markdown
+++ b/source/_components/waterfurnace.markdown
@@ -42,7 +42,6 @@ To use Waterfurnace in your installation, add the following to your `configurati
 waterfurnace:
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
-  unit: 0123456789AB
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:**
The latest version no longer require the unit: configuration option



**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/commit/8c0b50b5dfd11000edcf0f90fcc70d5641fc65d3

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
