### PR TITLE
Added verify_ssl to notify.synology_chat documentation

### DIFF
--- a/source/_components/notify.synology_chat.markdown
+++ b/source/_components/notify.synology_chat.markdown
@@ -23,6 +23,7 @@ To enable the Synology Chat notification in your installation, add the following
 notify:
   - platform: synology_chat
     name: hass_synchat
+    verify_ssl: True
     resource: https://example.your.synology.com/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=1&token=ABCDEFG
 ```
 
@@ -31,6 +32,11 @@ name:
   description: "Setting the  parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`."
   required: true
   type: string
+verify_ssl:
+  description: If SSL/TLS verification for HTTPS resources needs to be turned off (for self-signed certs, etc.)
+  required: false
+  type: boolean
+  default: true
 resource:
   description: The incoming webhook URL.
   required: true

--- a/source/_components/notify.synology_chat.markdown
+++ b/source/_components/notify.synology_chat.markdown
@@ -23,7 +23,6 @@ To enable the Synology Chat notification in your installation, add the following
 notify:
   - platform: synology_chat
     name: hass_synchat
-    verify_ssl: True
     resource: https://example.your.synology.com/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=1&token=ABCDEFG
 ```
 
@@ -33,7 +32,7 @@ name:
   required: true
   type: string
 verify_ssl:
-  description: If SSL/TLS verification for HTTPS resources needs to be turned off (for self-signed certs, etc.)
+  description: If SSL/TLS verification for HTTPS resources needs to be turned off (for self-signed certs, etc.).
   required: false
   type: boolean
   default: true


### PR DESCRIPTION
**Description:**
Added verify_ssl option into documentation to match pull request to allow users to disable ssl verification for self signed certs or direct IP address in the url.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19276

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
