### PR TITLE
Update picture.markdown

### DIFF
--- a/source/_lovelace/picture.markdown
+++ b/source/_lovelace/picture.markdown
@@ -85,7 +85,9 @@ Navigate to another view:
 ```yaml
 - type: picture
   image: /local/home.jpg
-  navigation_path: /lovelace/home
+  tap_action:
+    action: navigate
+    navigation_path: /lovelace/home
 ```
 
 Check the [views](/lovelace/views/) setup on how to setup custom IDs.


### PR DESCRIPTION
Picture card example was not updated to reflect changes from .84 update in regards to tap_action and navigation.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
