### PR TITLE
Clarification on base_url format

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -41,7 +41,7 @@ server_port:
   type: integer
   default: 8123
 base_url:
-  description: "The URL that Home Assistant is available on the internet. For example: `hass-example.duckdns.org:8123`. The iOS app finds local installations, if you have an outside URL use this so that you can auto-fill when discovered in the app."
+  description: "The URL that Home Assistant is available on the internet. For example: `https://hass-example.duckdns.org:8123`. The iOS app finds local installations, if you have an outside URL use this so that you can auto-fill when discovered in the app."
   required: false
   type: string
   default: Your local IP address


### PR DESCRIPTION
Needs `https://` if you're using HTTPS ;)
