### PR TITLE
Add note about entity_namespace deprecation

### DIFF
--- a/source/_docs/configuration/platform_options.markdown
+++ b/source/_docs/configuration/platform_options.markdown
@@ -23,6 +23,8 @@ light:
     entity_namespace: holiday_house
 ```
 
+_NB: For manual config platforms, such as Sonos and Cast, `entity_namespace` is no longer supported._
+
 ### {% linkable_title Scan Interval %}
 
 Platforms that require polling will be polled in an interval specified by the main component. For example a light will check every 30 seconds for a changed state. It is possible to overwrite this scan interval for any platform that is being polled by specifying a `scan_interval` configuration key. In the example below we set up the `your_lights` platform but tell Home Assistant to poll the devices every 10 seconds instead of the default 30 seconds.

--- a/source/_docs/configuration/platform_options.markdown
+++ b/source/_docs/configuration/platform_options.markdown
@@ -10,6 +10,8 @@ footer: true
 redirect_from: /topics/platform_options/
 ---
 
+<p class='note info'>These options are being phased out and are only available for single platform integrations.</p>
+
 Some components or platforms (those that are based on the [entity](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/helpers/entity.py) class) allows various extra options to be set.
 
 ### {% linkable_title Entity namespace %}
@@ -22,8 +24,6 @@ light:
   - platform: your_lights
     entity_namespace: holiday_house
 ```
-
-_NB: For manual config platforms, such as Sonos and Cast, `entity_namespace` is no longer supported._
 
 ### {% linkable_title Scan Interval %}
 


### PR DESCRIPTION
**Description:**


- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
