### PR TITLE
Add note for fixing cloudmqtt certificate errors

### DIFF
--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -173,4 +173,7 @@ mqtt:
 <p class='note'>
 Home Assistant will automatically load the correct certificate if you connect to an encrypted channel of CloudMQTT (port range 20000-30000).
 </p>
+<p class='note'>
+If you experience an error message like `Failed to connect due to exception: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed`, then add `certificate: auto` to your broker configuration and restart Home Assistant.
+</p>
 


### PR DESCRIPTION
See https://community.home-assistant.io/t/cloudmqtt-issues-expired-certificate/73030/4

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
