### PR TITLE
iFrame card -> Iframe card

### DIFF
--- a/source/_lovelace/iframe.markdown
+++ b/source/_lovelace/iframe.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "iFrame Card"
-sidebar_label: iFrame
+title: "Iframe Card"
+sidebar_label: Iframe
 description: "Embed data from other webservices in your dashboard."
 date: 2018-07-01 10:28 +00:00
 sidebar: true


### PR DESCRIPTION
**Description:**

The [iframe element](https://www.w3.org/TR/2011/WD-html5-20110525/the-iframe-element.html) is part of the HTML spec, it's not written as "iFrame" which would imply it's an Apple product.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
