### PR TITLE
Adds battery_percent to sensor.netatmo.markdown

### DIFF
--- a/source/_components/sensor.netatmo.markdown
+++ b/source/_components/sensor.netatmo.markdown
@@ -89,6 +89,8 @@ modules:
           description: Wifi status per Base station
         battery_vp:
           description: Current battery status per module.
+        battery_percent:
+          description: Percentage of battery remaining per module.
 {% endconfiguration %}
 
 ### {% linkable_title Find your modules name %}


### PR DESCRIPTION
**Description:**

Adds battery_percent to sensor.netatmo.markdown

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant# TBD

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
