### PR TITLE
Remove "height" and "line_color" from example

### DIFF
--- a/source/_lovelace/sensor.markdown
+++ b/source/_lovelace/sensor.markdown
@@ -64,6 +64,4 @@ theme:
 - type: sensor
   entity: sensor.illumination
   name: Illumination
-  height: 75
-  line_color: "#3498db"
 ```


### PR DESCRIPTION

**Description:**
Updated config example to match revised config options as of version 0.84.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
