### PR TITLE
Fix logo 404 not found

### DIFF
--- a/source/_components/sensor.flunearyou.markdown
+++ b/source/_components/sensor.flunearyou.markdown
@@ -7,7 +7,7 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
-logo: flunearyou.jpg
+logo: flunearyou.png
 ha_category: Health
 ha_release: 0.83
 ha_iot_class: "Cloud Polling"


### PR DESCRIPTION
**Description:**
Docs were added but there doesn't exist a flunearyou.jpg, there is a .png however. (introduced with https://github.com/home-assistant/home-assistant.io/pull/7345)

PS: same issue with w800rf32.png, but I can't seem to find a related logo either.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
