### PR TITLE
Update required path for panel files

### DIFF
--- a/source/_components/panel_custom.markdown
+++ b/source/_components/panel_custom.markdown
@@ -30,7 +30,7 @@ panel_custom:
 ```
 
 <p class='note'>
-Store your custom panels in `<config>/www` to make them available in the frontend at the path `/local`.
+Store your custom panels in `<config>/panels` to make them available in the frontend at the path `/local`.
 </p>
 
 {% configuration %}


### PR DESCRIPTION
When placing files in www Home Assistant now throws errors:
[homeassistant.components.panel_custom] Unable to find webcomponent for panel_name: /config/panels/panel_name.html

Change the recommended directory to match.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
