### PR TITLE
New guide for installing new Home Assistent on Synology

### DIFF
--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -479,7 +479,7 @@ esac
 /volume1/homeassistant/hass-daemon restart
 ```
 
-### {% linkable_title Starting Home Assistant on bootup %}
+### {% linkable_title Starting Home Assistant 0.64.3 on bootup %}
 
 To have Home Assistant start on bootup of your Synology NAS, do as follows:
 1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -112,7 +112,7 @@ $ cd ~/Module-Packages
 $ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz; gzip -df /tmp/package.tgz
 $ for file in cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl curve25519_donna-1.3-cp35-none-any.whl ed25519-1.4-cp35-none-any.whl; do tar -x -f /tmp/package.tar share/wheelhouse/$file --strip=2; done
 ```
-Inside some of the `.whl` archives you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is required for ARM based Synology's.  
+Inside some of the `.whl` files (These are zip archives) you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is required for ARM based Synology's.  
 Run this command to all patch `.whl` files found in the current directory:
 ```bash
 $ rand=$RANDOM; for module in *.whl; do unzip "$module" -d "temp$rand" && find "temp$rand" -name "*x86_64-linux-gnu*" -type f | while read -r file; do mv "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done && rm "$module" && (cd "temp$rand" && zip -r0 "../$module" ./) && rm -r "temp$rand"; done

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -70,9 +70,9 @@ These edits also enable you to use the "[Cloud](/components/cloud/)" and [Homeki
 Edit "*~/spksrc/spk/python3/src/requirements.txt*", add at the end of the file this text:
 ```
 ## It may happen you want to add a component to Home Assistant, but it fails to install a package.
-## In the logs you see "Unable to install package *Module_Name*", if you install that
-# package with pip, some of its required packages fail with "Failed building wheel for *module_name*"
-## Add the Python modules/packages that error with that "building wheel" error in to the list below.
+## In the logs you see a error "Unable to install package *Module_Name*", if you install that
+# package with pip, some of its required packages fail with error "Failed building wheel for *module_name*"
+## Add these Python modules/packages that error with that "building wheel" error in to the list below.
 
 # Example format of module:
 #pythonmodule==version

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -106,17 +106,6 @@ sudo docker run -it --rm -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bas
 After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
 
-#### {% linkable_title Extracting cross compiled packages %}
-Now you need to extract the Python module packages which you added earlier to "*requirements.txt*".
-Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "*python3_**XXXX**.spk*" points to the package file you made earlier:
-```bash
-$ mkdir -p ~/Module-Packages && cd ~/Module-Packages
-$ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz && gzip -df /tmp/package.tgz && tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2
-```
-Inside some of the `.whl` files (These are zip archives) you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is only required for ARM based Synology NAS.  
-Run this command to patch all `.whl` files found in the current directory:
-```bash
-$ rand=$RANDOM; for module in *.whl; do unzip "$module" -d "temp$rand" && find "temp$rand" -name "*x86_64-linux-gnu*" -type f | while read -r file; do mv "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done && rm "$module" && (cd "temp$rand" && zip -r0 "../$module" ./) && rm -r "temp$rand"; done
 ```
 ## {% linkable_title Using the Synology webadmin %}
 Install the Python 3 package as follows:
@@ -176,10 +165,8 @@ Replace "*user*" with your Synology user and "x.x.x.x" with the its IP address:
 ```bash
 $ ssh user@x.x.x.x
 ```
-Install the `.whl` module package files you made earlier and Home Assistant.  
-This command expects you have copied the "*~/Module-Packages*" directory from "[Extracting cross compiled packages](#-linkable_title-extracting-cross-compiled-packages-)" to your "*homeassistant*" "[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)":
+Install Home Assistant.
 ```bash
-# sudo /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install homeassistant
 ```
 Create a file named "**hass-daemon**" in your "*homeassistant*" Shared-Folder with the script below as its content.
@@ -307,7 +294,7 @@ $ /volume1/homeassistant/hass-daemon restart
 $ /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
-If you need to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory, redo the steps from "[Preparing compiling environment](#-linkable_title-preparing-compiling-environment-)", add the failed python modules to "*requirements.txt*" file, extract and install the new `.whl` module package files to your Synology.
+If you need to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory and redo the steps from "[Preparing compiling environment](#-linkable_title-preparing-compiling-environment-)", add the failed python modules to "*requirements.txt*" file, compile and reinstall the Python 3 package on your Synology.
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -298,7 +298,7 @@ esac
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
-If you need to update Python 3 or added a component which fails caused by a Python module not installing on your on your Synology NAS with error code "*Failed building wheel for *Module_Name**", delete the "*~/spksrc*" directory and redo the guide, but add the failed python modules to "*requirements.txt*" from "[Preparing compiling environment](#title-preparing-compiling-environment)".
+If you need to update Python 3 or added a component which fails caused by a Python module not installing on your on your Synology NAS with error code "*Failed building wheel for *Module_Name**", delete the "*~/spksrc*" directory and redo the guide, but add the failed python modules to "*requirements.txt*" from "[Preparing compiling environment](#preparing-compiling-environment)".
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}
@@ -340,7 +340,7 @@ Install Python 3 as follows:
 1. Go to "*All Packages*"
 1. Scroll all the way down until you find "*Python3*" and click on "*Install*"
 
-Follow the other instructions at "[Using the Synology webadmin](#title-using-the-synology-webadmin)", ignore the  "Python 3 package" part.
+Follow the other instructions at "[Using the Synology webadmin](#using-the-synology-webadmin)", ignore the  "Python 3 package" part.
 
 ### {% linkable_title Installing Home Assistant 0.64.3 %}
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -128,11 +128,7 @@ $ make setup
 $ cd spk/python3
 ```
 
-You need to change "arch-**XXXX**" to the architecture of your Synology (e.g., DS115j = arch-armada370)
-For information about the Arch of your Synology look at the <a href="https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model">list of architectures on spkrc</a>
-Depending on your device, compilation may take a hour or more (significantly less if you have a SSD and a good CPU).
-
-Compile Python 3 for your Synology model
+Compile Python 3 for your Synology model, please replace "arch-**XXXX**" by the apporiate architecture of your Synology. For a list of architectures, look at the [list on architectures spkrc](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model). Depending on your device, compilation may take a hour or more (significantly less if you have a SSD and a good CPU).
 ```bash
 $ make arch-XXXX
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -14,7 +14,7 @@ redirect_from: /getting-started/installation-synology/
 Synology only provide Python 3.5.1, which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python3 -m pip install homeassistant==0.64.3`
 </p>
 <p class='note'>
-Update: You can install a more recent home assistent (Tested to work at Home Assistant 0.84) by manually compiling a python3 package using the spksrc compilation framework. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “Discovery”, “Cloud” and “Xiaomi_Aqara”. Thread for more info: [Python >=3.5.3 on Synology](https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27)
+Update: You can install a more recent home assistent (Tested to work on Home Assistant 0.84.2) by manually compiling a python3 package using the spksrc compilation framework. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “Discovery”, “Cloud” and “Xiaomi_Aqara”. Thread for more info: [Python >=3.5.3 on Synology](https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27)
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -90,7 +90,7 @@ Install Git
 ```
 Fork and clone spksrc, this will make a directory named "spksrc".
 ```bash
-$ git clone https://You@github.com/You/spksrc.git ~/spksrc
+$ git clone https://github.com/SynoCommunity/spksrc.git
 ```
 Download the spksrc Docker container:
 ```bash

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -63,15 +63,16 @@ Fork and clone spksrc, this will make a directory named "spksrc".
 $ git clone https://github.com/SynoCommunity/spksrc.git
 ```
 
-Now you need to edit 2 files.
-Doing this will cross compile python modules, which are needed for Home Assistant to able to install.
-These edits also enable you to use the "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)" components and fix the OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.
+Edit the following 2 files.
 
-Edit "*~/spksrc/spk/python3/src/requirements.txt*", add at the end of the file this text:
+These edits will make cross compiled Python module packages, which Home Assistant needs to install. These edits also enable use of the "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)" components.
+Most components will setup just fine, but certain components need a python package that compiles on installation, which will fail as Synology did not provide a compiler, causing said need for cross compilation.
+
+Edit "*~/spksrc/spk/python3/src/requirements.txt*" and add the following text to the end of the file:
 ```
 ## It may happen you want to add a component to Home Assistant, but it fails to install a package.
 ## In the logs you see a error "Unable to install package *Module_Name*", if you install that
-# package with pip, some of its required packages fail with error "Failed building wheel for *module_name*"
+# package with pip, some of its required packages fail with error "Failed building wheel for *Module_Name*"
 ## Add these Python modules/packages that error with that "building wheel" error in to the list below.
 
 # Example format of module:
@@ -89,9 +90,11 @@ pycryptodome==3.7.2
 curve25519-donna==1.3
 ed25519==1.4
 ```
-Edit "*~/spksrc/spk/python3/Makefile*", above the line that says "**include ../../mk/spksrc.spk.mk**" add this text:
+
+Add these edits to fix OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.  
+Edit "*~/spksrc/spk/python3/Makefile*" and add the following text above the text "**include ../../mk/spksrc.spk.mk**":
 ```makefile
-## Fix needed to stop "_openssl.so: undefined symbol: pthread_atfork" error (Needed to use SSL and the "xiaomi_aqara" component)
+## Fix needed to fix "_openssl.so: undefined symbol: pthread_atfork" error when using "xiaomi_aqara" component.
 export CFLAGS=-pthread
 ```
 #### {% linkable_title Compiling the Python 3 package %}
@@ -107,8 +110,8 @@ After the compilation is done, you can find the Python 3 package at "*~/spksrc/p
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
 
 #### {% linkable_title Extracting cross compiled packages %}
-Now you need to extract the `.whl` module packages files which you added earlier to "*requirements.txt*".
-Run these commands to extract the `.whl` files to a directory named "**Module-Packages**", please modify `pyspk` command so the "**XXXX**" in `python3_XXXX.spk` points to the package file you made earlier.
+Now you need to extract the Python module packages which you added earlier to "*requirements.txt*".
+Run these commands to extract the `.whl` files to a directory the "**~/Module-Packages**", please modify `pyspk` command so the "**XXXX**" in `python3_XXXX.spk` points to the package file you made earlier.
 ```bash
 $ mkdir ~/Module-Packages
 $ cd ~/Module-Packages
@@ -140,7 +143,7 @@ Now while it's installing, you may setup the Shared-Folder for Home Assistant:
 * Click on "*Next*" again
 * Click on "*Apply*"
 
-As the "*homeassistant*" Shared-Folder has been made, copy the (previously created) "*Module-Packages*" directory there.
+As the "*homeassistant*" Shared-Folder has been made, copy the (previously created) "*~/Module-Packages*" directory there.
 
 Next setup the user:
 * Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
@@ -180,7 +183,7 @@ Replace "*user*" with your Synology user and "x.x.x.x" with the its IP address:
 $ ssh user@x.x.x.x
 ```
 Install the `.whl` module package files you made earlier and Home Assistant.  
-This command expects you have copied the "*Module-Packages*" directory from "[Extracting cross compiled packages](#-linkable_title-extracting-cross-compiled-packages-)" to your "*homeassistant*" "[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)".
+This command expects you have copied the "*~/Module-Packages*" directory from "[Extracting cross compiled packages](#-linkable_title-extracting-cross-compiled-packages-)" to your "*homeassistant*" "[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)".
 ```bash
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install homeassistant

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -91,7 +91,7 @@ ed25519==1.4
 ```
 Edit "*~/spksrc/spk/python3/Makefile*", above the line that says "**include ../../mk/spksrc.spk.mk**" add this text:
 ```makefile
-# Needed to fix "_openssl.so: undefined symbol: pthread_atfork" error caused by lack of libpthread linkage on Synology (Needed for SSL and "xiaomi_aqara" component)
+## Fix needed to stop "_openssl.so: undefined symbol: pthread_atfork" error (Needed to use SSL and the "xiaomi_aqara" component)
 export CFLAGS=-pthread
 ```
 #### {% linkable_title Compiling the Python 3 package %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -180,8 +180,7 @@ Replace "*user*" with your Synology user and "x.x.x.x" with the its IP address:
 $ ssh user@x.x.x.x
 ```
 Install the `.whl` module package files you made earlier and Home Assistant.  
-This command expects you have copied the "*Module-Packages*" directory from "[Extracting cross compiled packages]({https://github.com/home-assistant/home-assistant.io/blob/c41d2091e00ec4e93211331fdef910587dfceb22/source/_docs/installation/synology.markdown#-linkable_title-controlling-home-assistant-)" to your "*homeassistant*" Shared-Folder.
-[Extracting cross compiled packages](#-linkable_title-controlling-home-assistant-)
+This command expects you have copied the "*Module-Packages*" directory from "[Extracting cross compiled packages](#-linkable_title-controlling-home-assistant-)" to your "*homeassistant*" Shared-Folder.
 
 ```bash
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
@@ -312,7 +311,7 @@ $ /volume1/homeassistant/hass-daemon restart
 $ /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
-If you need to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, extract and install the new `.whl` module package files to your Synology.
+If you need to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory, redo the steps from "[Preparing compiling environment](#-linkable_title-preparing-compiling-environment-)", add the failed python modules to "*requirements.txt*" file, extract and install the new `.whl` module package files to your Synology.
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -201,35 +201,55 @@ Extract the .whl (these are zip archives), rename all files as described above, 
 
 ## {% linkable_title Using the Synology webadmin: %}
 
-Open Synology Package Center and press the “*Manual Install*” button.
-Click “*Browse*” and select the Python package we created, then press “*Next*”.
-You will get a unverified package popup, press yes and next screen press “*Apply*”.
+* Open [Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
+* Press the “*Manual Install*” button on the top right of the window
+* Click on “*Browse*” and select the Python3 spk package we created
+* Click on “*Next*”
+* You will most likely get a unverified signature warning, click on “*Yes*”
+* Click on “*Apply*”
 
-Now while it's installing, you may setup the user and Shared-Folder for Home Assistent.
+Now while it's installing, you may setup the Shared-Folder for Home Assistent:
+* Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
+* Go to “[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)” settings
+* Click on “*Create*”
+* In “*Name*” write “**homeassistant**”
+* in "*Description*” write “**Home Assistent**”
+* Click on “*Next*”
+* Click on “*Next*” again
+* Click on “*Apply*”
 
-Open “*Control Panel*”, go to “*Shared-Folder*” settings and click on “*Create*”.
-In “*Name*” write “**homeassistant**”, in "Description” write “**Home Assistent**”
-Click “*Next*”, same for second screen, the third screen click “*Apply*”.
+Now the “*homeassistent*” Shared-Folder has been made, you need to copy the (previously created) “*Module-Packages*” directory there.
 
-Next go to “*User*” settings and click on “*Create*”.
-In "*Name*" write “**homeassistant**”, in "*Description*” write “**Home Assistent**”, "*Password*" is up to your choice.
-Click “*Next*”, next screen leave only “*users*” group checked and click “*Next*”.
-In this screen, set permission “*No access*” for all Shared-Folders and only “*homeassistent*” Shared-Folder to “*Read/Write*”.
-Click “*Next*” on this screen and the next, on the last screen click “*Apply*”.
-
-Now the “*homeassistent*” Shared-Folder has been made, you need to copy the “*Module-Packages*” directory there.
+Next setup the user:
+* Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
+* Go to “[*User*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_user_desc)” settings
+* Click on “*Create*”
+* In "*Name*" write “**homeassistant**”
+* In "*Description*” write “**Home Assistent**”
+* The "*Password*" up to your choice
+* Click on “*Next*”
+* Make sure only “*users*” group is checked and click “*Next*”
+* Set the permission “*Read/Write*” for “*homeassistent*” and the all the other Shared-Folders to “*No access*”
+* Click on “*Next*”
+* Click on “*Next*” again
+* Click on “*Apply*”.
 
 Incase you turned on the firewall on your Synology device, please update it as follows to allow connections for Home Assistent:
+* Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
+* Go to “[*Security*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_desc)” settings
+* Go to “[*Firewall*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_firewall)” settings
+* Go to “*Edit Rules*”
+* Click on “*Create*”
+* Select Custom: Destination port “TCP”
+* Type “8123” in port (eg, setting in [*server_port*](https://www.home-assistant.io/components/http/#server_port))
+* Click on “*OK*”
+* Click on “*OK*” again
 
-* Go to your Synology control panel
-* Go to security
-* Go to firewall
-* Go to Edit Rules
-* Click Create
-* Select Custom: Destination port "TCP"
-* Type "8123" in port (eg, setting in [server_port](https://www.home-assistant.io/components/http/#server_port)
-* Click on OK
-* Click on OK again
+
+Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM):
+* Install compiled Python3 package using the [Synology Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
+
+
 
 
 ## {% linkable_title Installing Home Assistent %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -15,7 +15,7 @@ Synology only provide <a href="https://www.synology.com/nl-nl/dsm/packages/py3k"
 </p>
 
 <p class="note">
-Update: You can install a more recent home assistant (eg, 0.84.2) by manually compiling a python3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “<a href="https://www.home-assistant.io/components/discovery">Discovery</a>”, “<a href="https://www.home-assistant.io/components/cloud">Cloud</a>” and “<a href="https://www.home-assistant.io/components/Xiaomi_Aqara">Xiaomi_Aqara</a>”. Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27">Python >=3.5.3 on Synology</a>.
+Update: You can install a more recent home assistant (eg, 0.84.2) by manually compiling a python3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “<a href="/components/discovery/">Discovery</a>”, “<a href="/components/cloud/">Cloud</a>” and “<a href="/components/Xiaomi_Aqara/">Xiaomi_Aqara</a>”. Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27">Python >=3.5.3 on Synology</a>.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -126,7 +126,7 @@ docker pull synocommunity/spksrc
 
 Now you need to edit 2 files.
 You need to do this to get “cross compiled module package” files, which you require for Home Assistant to able to be installed.
-These edits also enable you to use the “[Cloud](https://www.home-assistant.io/components/cloud)” component and fix the OpenSSL errors when using the “[Xiaomi_Aqara](https://www.home-assistant.io/components/Xiaomi_Aqara)” component.
+These edits also enable you to use the “[Cloud](/components/cloud/)” component and fix the OpenSSL errors when using the “[Xiaomi_Aqara](/components/Xiaomi_Aqara/)” component.
 
 
 Edit “*~/spksrc/spksrc/spk/python3/src/requirements.txt*”, add at the end of the file:
@@ -241,7 +241,7 @@ In the case you turned on the firewall on your Synology device, please config it
 * Go to “*Edit Rules*”
 * Click on “*Create*”
 * Select Custom: Destination port “TCP”
-* Type “8123” in port (eg, setting in [*server_port*](https://www.home-assistant.io/components/http/#server_port))
+* Type “8123” in port (eg, setting in [*server_port*](/components/http/#server_port))
 * Click on “*OK*”
 * Click on “*OK*” again
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -50,10 +50,6 @@ Start Docker and enable start on system bootup:
 # sudo systemctl start docker
 # sudo systemctl enable docker
 ```
-Download the [spksrc Docker container](https://github.com/SynoCommunity/spksrc#docker):
-```bash
-# sudo docker pull synocommunity/spksrc
-```
 
 #### {% linkable_title Preparing compiling environment %}
 
@@ -61,7 +57,7 @@ Install Git:
 ```bash
 # sudo apt-get install git
 ```
-Fork and clone spksrc, this will make a directory "~/spksrc":
+Fork and clone [spksrc](https://github.com/SynoCommunity/spksrc), this will make a directory "~/spksrc":
 ```bash
 $ git clone https://github.com/SynoCommunity/spksrc.git ~/spksrc
 ```
@@ -103,14 +99,14 @@ export CFLAGS=-pthread
 
 #### {% linkable_title Compiling the Python 3 package %}
 
-Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
+Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by [spksrc](https://github.com/SynoCommunity/spksrc). Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
 ```bash
-sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
+$ sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
 ```
 After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
 
-If you want to remove the spksrc Docker container to save space, run the following command:
+If you want to remove the Docker container downloaded by `docker run` to save drive space, run the following command:
 ```bash
 sudo docker rmi synocommunity/spksrc
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -182,8 +182,8 @@ $ ssh user@x.x.x.x
 Install the cross compiled module `.whl` package files we compiled earlier and Home Assistant.
 This command expects you have copied the "*Module-Packages*" directory to your "*homeassistant*" Shared-Folder.
 ```bash
-$ /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
-$ /volume1/@appstore/python3/bin/python3 -m pip install homeassistant
+# sudo /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
+# sudo /volume1/@appstore/python3/bin/python3 -m pip install homeassistant
 ```
 Create a file named "hass-daemon" in the "homeassistant" Shared-Folder with the script below as its content.
 You can use it to easily start, stop and restart Home Assistant like a service/daemon.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -59,7 +59,7 @@ Install Git
 ```bash
 # sudo apt-get install git
 ```
-Fork and clone spksrc, this will make a directory named "spksrc".
+Fork and clone spksrc, this will make a directory "~/spksrc".
 ```bash
 $ git clone https://github.com/SynoCommunity/spksrc.git ~/spksrc
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `/volume1/@appstore/py3k/usr/local/bin/python3 -m pip install homeassistant==0.64.3`
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can follow the instructions "[Using older Python 3 provided by Synology](#-linkable_title-using-older-python-3-provided-by-synology-)" way below of the document.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -318,9 +318,9 @@ To have Home Assistant start on bootup of your Synology NAS, do as follows:
 
 ## {% linkable_title Using older Python 3 provided by Synology %}
 
-
-Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. The instructions above describes how to install newer Home Assistant on your Synology NAS. If you want to proceed with a older version of Home Assistant, follow the instructions below. Please note that you may not be able to use certain components, such as "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)".
-
+<p class="note warning">
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. The instructions above describes how to install newer Home Assistant on your Synology NAS. If you want to proceed with a older version of Home Assistant, follow the instructions below. Please note that you may not be able to use certain components, such as "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)"
+</p>
 
 Running these commands will:
 * Install Home Assistant 0.64.3

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -99,7 +99,7 @@ Edit "*~/spksrc/spk/python3/Makefile*" and add the following text above the text
 export CFLAGS=-pthread
 ```
 #### {% linkable_title Compiling the Python 3 package %}
-Make the Python 3 package for your Synology model, please replace "arch-**XXXX**" by the apporiate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU).
+Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "arch-**XXXX**" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU).
 ```bash
 sudo docker run -it --rm -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -116,11 +116,11 @@ Install Git
 ```
 Fork and clone spksrc, this will make a directory named "spksrc".
 ```bash
-git clone https://You@github.com/You/spksrc.git ~/spksrc
+$ git clone https://You@github.com/You/spksrc.git ~/spksrc
 ```
 Download the spksrc Docker container:
 ```bash
-docker pull synocommunity/spksrc
+$ docker pull synocommunity/spksrc
 ```
 
 Now you need to edit 2 files.
@@ -148,10 +148,10 @@ export CFLAGS=-pthread
 ## {% linkable_title Compiling the Python 3 package %}
 Run the container, this will make your terminal run inside the Docker container:
 ```bash
-# docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
-# cd spksrc/
-# make setup
-# cd spk/python3
+$ docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
+$ cd spksrc/
+$ make setup
+$ cd spk/python3
 ```
 
 You need to change "arch-**XXXX**" to the architecture of your Synology (e.g., DS115j = arch-armada370)
@@ -160,7 +160,7 @@ Depending on your device, compilation may take a hour or more (significantly les
 
 Compile Python 3 for your Synology model
 ```bash
-# make arch-XXXX
+$ make arch-XXXX
 ```
 After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different arch and version.
@@ -168,11 +168,11 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 Now you need to extract your "cross compiled module package" files which you added earlier.
 Run these commands to extract the packages, please replace "python3_**XXXX**.spk" by the apporiate package filename:
 ```bash
-pyspk=python3_armada370-6.1_3.5.5-7.spk
-mkdir ~/Module-Packages
-cd ~/Module-Packages
-tar -x -f ~/spksrc/spksrc/packages/$pyspk -C /tmp package.tgz; gzip -df /tmp/package.tgz
-for file in cffi-1.11.5 bcrypt-3.1.4 cryptography-2.3.1 pycryptodome-3.7.2; do tar -x -f /tmp/package.tar share/wheelhouse/$file-cp35-none-any.whl --strip=2; done
+$ pyspk=python3_armada370-6.1_3.5.5-7.spk
+$ mkdir ~/Module-Packages
+$ cd ~/Module-Packages
+$ tar -x -f ~/spksrc/spksrc/packages/$pyspk -C /tmp package.tgz; gzip -df /tmp/package.tgz
+$ for file in cffi-1.11.5 bcrypt-3.1.4 cryptography-2.3.1 pycryptodome-3.7.2; do tar -x -f /tmp/package.tar share/wheelhouse/$file-cp35-none-any.whl --strip=2; done
 ```
 
 This should give you a directory named "**Module-Packages**" with four .whl files, which you need to install later.
@@ -190,7 +190,7 @@ For ease of use this guide will use p7zip for renaming the files in the archive.
 ```
 Run this command to rename all files containing "x86_64-linux-gnu" to "arm-linux-gnueabihf" inside all `.whl` files found in the current directory:
 ```bash
-for archive in *.whl; do 7z l "$archive" | grep "x86_64-linux-gnu" | cut -c54- | while read -r file; do 7z rn "$archive" "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done; done
+$ for archive in *.whl; do 7z l "$archive" | grep "x86_64-linux-gnu" | cut -c54- | while read -r file; do 7z rn "$archive" "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done; done
 ```
 <p class="note">
 The 7z <b>rn</b> (e.g., rename) parameter was included from 7-Zip 9.30, in the case your distribution only has a older version available, do as follows.
@@ -249,32 +249,32 @@ In the case you turned on the firewall on your Synology device, please config it
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
 Replace "<i>user</i>" with your Synology user and "x.x.x.x" with the its IP-Adress.
 ```bash
-# ssh user@x.x.x.x
+$ ssh user@x.x.x.x
 ```
 Create a virtual Python environment where we will install Home Assistant into.
 This will leave the Python package untouched, makes Home Assistant work better and installable/updateable without sudo.
 Note: After you made a virtual Python envoriment, you cant relocate the folder, else it will break. 
 Make a new one if you need to change it's name, the path or Shared-Folder.
 ```bash
-# /volume1/@appstore/python3/bin/python3 -m venv /volume1/homeassistant/venv-hass
+$ /volume1/@appstore/python3/bin/python3 -m venv /volume1/homeassistant/venv-hass
 ```
 Activate the virtual Python environment
 ```bash
-# source /volume1/homeassistant/venv-hass/bin/activate
+$ source /volume1/homeassistant/venv-hass/bin/activate
 ```
 Install the "cross compiled module package" files we compiled earlier.
 This command expects you have copied the "*Module-Packages*" directory to your "*homeassistant*" Shared-Folder.
 ```bash
-# cd /volume1/homeassistant/Module-Packages
-# pip3 install cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl
+$ cd /volume1/homeassistant/Module-Packages
+$ pip3 install cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl
 ```
 Install Home Assistant
 ```bash
-# pip3 install homeassistant
+$ pip3 install homeassistant
 ```
 Leave the virtual Python environment
 ```bash
-# deactivate
+$ deactivate
 ```
 
 Create a file named "hass-daemon" in the "homeassistant" Shared-Folder with the script below as it's content.
@@ -387,19 +387,19 @@ esac
 
 * Start Home Assistant:
 ```bash
-# /volume1/homeassistant/hass-daemon start
+$ /volume1/homeassistant/hass-daemon start
 ```
 * Stop Home Assistant:
 ```bash
-# /volume1/homeassistant/hass-daemon stop
+$ /volume1/homeassistant/hass-daemon stop
 ```
 * Restart Home Assistant:
 ```bash
-# /volume1/homeassistant/hass-daemon restart
+$ /volume1/homeassistant/hass-daemon restart
 ```
 * Upgrade Home Assistant:
 ```bash
-# source /volume1/homeassistant/venv-hass/bin/activate
-# pip3 install --upgrade homeassistant
-# deactivate
+$ source /volume1/homeassistant/venv-hass/bin/activate
+$ pip3 install --upgrade homeassistant
+$ deactivate
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -35,7 +35,7 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 * Enable [SSH](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal) service
 * Optionally start Home Assistant on bootup of your Synology NAS
 
-## {% linkable_title Getting prerequisites) %}
+## {% linkable_title Making new Python 3 package %}
 
 #### {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -43,7 +43,7 @@ Install Docker
 # sudo apt-get update
 # sudo apt install docker.io
 ```
-Start Docker and enable start on system boot
+Start Docker and enable start on system bootup
 ```bash
 # sudo systemctl start docker
 # sudo systemctl enable docker

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -228,7 +228,7 @@ In the case you turned on the firewall on your Synology device, please config it
 ## {% linkable_title Installing Home Assistant %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
-Replace "<i>user</i>" with your Synology user and "x.x.x.x" with the its IP adress.
+Replace "<i>user</i>" with your Synology user and "x.x.x.x" with the its IP adress:
 ```bash
 $ ssh user@x.x.x.x
 ```
@@ -248,18 +248,17 @@ This command expects you have copied the "*Module-Packages*" directory to your "
 ```bash
 $ pip3 install /volume1/homeassistant/Module-Packages/*.whl
 ```
-Install Home Assistant
+Install Home Assistant:
 ```bash
 $ pip3 install homeassistant
 ```
-Leave the virtual Python environment
+Leave the virtual Python environment:
 ```bash
 $ deactivate
 ```
 
 Create a file named "hass-daemon" in the "homeassistant" Shared-Folder with the script below as its content.
 You can use it to easily start, stop and restart Home Assistant like a service/daemon.
-
 ```sh
 #!/bin/sh
 
@@ -384,7 +383,7 @@ $ pip3 install --upgrade homeassistant
 $ deactivate
 ```
 <p class="note">
-If ever you need to update Python 3 or added a component of which the python modules requirements fail to install/compile on your Synology, delete the "spksrc" directory, redo the steps from [Preparing compiling environment](#Preparing compiling environment), add the failed python modules to "*requirements.txt*" file, compile and add the new "cross compiled module package" names to the extracting commands.
+If ever you need to update Python 3 or added a component of which the python modules requirements fail to install/compile on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, compile and add the new "cross compiled module package" names to the extracting commands.
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -104,7 +104,7 @@ After the compilation is done, you can find the Python 3 package at "*~/spksrc/p
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
 
 #### {% linkable_title Extracting cross compiled packages %}
-Now you need to extract the cross compiled module `.whl` packages which you added earlier to "*requirements.txt*".
+Now you need to extract the `.whl` module packages which you added earlier to "*requirements.txt*".
 Run these commands to extract the `.whl` files to a directory named "**Module-Packages**", please replace "python3_**XXXX**.spk" with the appropriate package filename:
 ```bash
 $ mkdir ~/Module-Packages
@@ -118,7 +118,7 @@ Run this command to patch all `.whl` files found in the current directory:
 $ rand=$RANDOM; for module in *.whl; do unzip "$module" -d "temp$rand" && find "temp$rand" -name "*x86_64-linux-gnu*" -type f | while read -r file; do mv "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done && rm "$module" && (cd "temp$rand" && zip -r0 "../$module" ./) && rm -r "temp$rand"; done
 ```
 <p class="note">
-If you added any modules to "*requirements.txt*", you can find the module `.whl` package files using a archive program in "**~/spksrc/packages/python3_XXXX.spk*" > "*package.tgz*" > "*share/wheelhouse/XXXX.whl*".d
+If you added any modules to "*requirements.txt*", you can find the `.whl` module package files using a archive program and browsing to: "**~/spksrc/packages/python3_XXXX.spk*" > "*package.tgz*" > "*share/wheelhouse/XXXX.whl*".d
 </p>
 
 ## {% linkable_title Using the Synology webadmin %}
@@ -309,7 +309,7 @@ $ /volume1/homeassistant/hass-daemon restart
 $ /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
-If you need to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, extract and install the new cross compiled module `.whl` package files to your Synology.
+If you need to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, extract and install the new `.whl` module package files to your Synology.
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -101,7 +101,7 @@ Start the docker service:
 ---
 To enable your user account to manage Docker without superuser privileges, add your “USER” account to the “docker” group:
 ```bash
-sudo gpasswd -a USER docker
+# sudo gpasswd -a USER docker
 ```
 
 You will now need to get the [spksrc Docker container](https://github.com/SynoCommunity/spksrc#docker) for the compiling environment.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -102,7 +102,7 @@ You need to do this to get "cross compiled module package" files, which you requ
 These edits also enable you to use the "[Cloud](/components/cloud/)" component and fix the OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.
 
 
-Edit "*~/spksrc/spksrc/spk/python3/src/requirements.txt*", add at the end of the file:
+Edit "*~/spksrc/spk/python3/src/requirements.txt*", add at the end of the file:
 ```
 ##Cross compilation requirements for installing Home Assistant (Tested to work on 83.3).
 ##In the future, the requirements may change (e.g., need newer version to work), modify as needed.
@@ -113,7 +113,7 @@ cryptography==2.3.1
 pycryptodome==3.7.2
 ```
 
-Edit "*~/spksrc/spksrc/spk/python3/src/Makefile*", add above the line that says "<b>include ../../mk/spksrc.spk.mk</b>":
+Edit "*~/spksrc/spk/python3/src/Makefile*", add above the line that says "<b>include ../../mk/spksrc.spk.mk</b>":
 ```makefile
 # Needed to fix "_openssl.so: undefined symbol: pthread_atfork" error caused by lack of libpthread linkage on Synology (Needed for SSL and "xiaomi_aqara" component)
 export CFLAGS=-pthread
@@ -141,7 +141,7 @@ Run these commands to extract the packages, please replace "python3_**XXXX**.spk
 $ pyspk=python3_XXXX.spk
 $ mkdir ~/Module-Packages
 $ cd ~/Module-Packages
-$ tar -x -f ~/spksrc/spksrc/packages/$pyspk -C /tmp package.tgz; gzip -df /tmp/package.tgz
+$ tar -x -f ~/spksrc/packages/$pyspk -C /tmp package.tgz; gzip -df /tmp/package.tgz
 $ for file in cffi-1.11.5 bcrypt-3.1.4 cryptography-2.3.1 pycryptodome-3.7.2; do tar -x -f /tmp/package.tar share/wheelhouse/$file-cp35-none-any.whl --strip=2; done
 ```
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -316,6 +316,8 @@ To have Home Assistant start on bootup of your Synology NAS, do as follows:
 * in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
 * Click on "*OK*".
 
+---
+
 ## {% linkable_title Using older Python 3 provided by Synology %}
 
 <p class="note warning">

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -42,7 +42,11 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 Like you might have read above, at this time of writing, Synology has not provided a recent [Python 3](https://www.synology.com/nl-nl/dsm/packages/py3k) package, so we have to create a recent Python 3 package ourself.
 Do not worry though, were gonna try keep this as painless as possible.
 
-## {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
+Small summary: In this guide you will install [Docker](https://opensource.com/resources/what-docker) and run the [spksrc framework and Docker container](https://github.com/SynoCommunity/spksrc#docker) for the compiling environment. You will be using that to compile the new Python 3 package. Through the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM/help), you will install the package, configure settings and enable SSH, which you need to install Home Assistant on your Synology. Lastly you can autostart Home Assistant.
+
+## {% linkable_title Installing prerequisites) %}
+
+#### {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
 
 Refresh package lists:
 ```bash

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -32,22 +32,17 @@ Running these commands will:
 * Install Home Assistant
 * Enable Home Assistant to be launched on http://*Synology_IP*:8123
 
-Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM):
+Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM/help):
 * Install compiled Python 3 package using the [Synology Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
-* Create "homeassistant" user and add to the "users" group
-* Create "homeassistant" "Shared-Folder"
-* Optionally Start Home Assistant on Bootup of Synology
+* Create "homeassistant" user
+* Create "homeassistant" [Shared-Folder](https://www.synology.com/en-us/knowledgebase/DSM/help/DSM/AdminCenter/file_share_desc)
+* Optionally start Home Assistant on bootup of your Synology
 
 
 Like you might have read above, at this time of writing, Synology has not provided a recent [Python 3](https://www.synology.com/nl-nl/dsm/packages/py3k) package, so we have to create a recent Python 3 package ourself.
 Do not worry though, were gonna try keep this as painless as possible.
 
-## {% linkable_title Preparing prerequisites %}
-
-In this guide we are going to use a Linux based Operating System such as [Ubuntu](https://www.ubuntu.com/), [Mint](https://linuxmint.com/) or [Solus](https://getsol.us) to minimize difficulty. You will also need [Docker](https://docs.docker.com/install/).
-
-
-### {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
+## {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
 
 Refresh package lists:
 ```bash
@@ -78,26 +73,6 @@ Install Docker:
 ```bash
 # sudo apt-get install docker-ce
 ```
----
-### {% linkable_title Installing Docker on [Solus](https://getsol.us) %}
-
-Update package lists:
-```bash
-# sudo eopkg update-repo
-```
-Install Docker:
-```bash
-# sudo eopkg install docker
-```
-Enable the docker service at system boot:
-```bash
-# sudo systemctl enable docker
-```
-Start the docker service:
-```bash
-# sudo systemctl start docker
-```
----
 To enable your user account to manage Docker without superuser privileges, add your user account to the "docker" group:
 ```bash
 # sudo gpasswd -a YOUR_USER_ACCOUNT docker
@@ -106,13 +81,8 @@ To enable your user account to manage Docker without superuser privileges, add y
 You will now need to get the [spksrc framework and Docker container](https://github.com/SynoCommunity/spksrc#docker) for the compiling environment.
 
 Install Git
-#### Ubuntu/Mint
 ```bash
 # sudo apt-get install git
-```
-#### Solus
-```bash
-# sudo eopkg install git
 ```
 Fork and clone spksrc, this will make a directory named "spksrc".
 ```bash
@@ -180,13 +150,8 @@ Inside some of the .whl archives you need to rename all files containing the tex
 If you do not, these will be ignored by Python 3 on ARM based Synology's, causing Home Assistant to not function.
 
 For ease of use this guide will use p7zip for renaming the files in the archive.
-#### Ubuntu/Mint
 ```bash
 # sudo apt-get install p7zip
-```
-#### Solus
-```bash
-# sudo eopkg install p7zip
 ```
 Run this command to rename all files containing "x86_64-linux-gnu" to "arm-linux-gnueabihf" inside all `.whl` files found in the current directory:
 ```bash
@@ -197,7 +162,7 @@ The 7z <b>rn</b> (e.g., rename) parameter was included from 7-Zip 9.30, in the c
 Extract the .whl (these are zip archives), rename all files as described above, then rearchive as zip (use the same full name with `.whl` as extension and not `.zip`).
 </p>
 
-## {% linkable_title Using the Synology webadmin: %}
+## {% linkable_title Using the Synology webadmin %}
 
 * Open [Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
 * Press the "*Manual Install*" button on the top right of the window
@@ -253,7 +218,7 @@ $ ssh user@x.x.x.x
 ```
 Create a virtual Python environment where we will install Home Assistant into.
 This will leave the Python package untouched, makes Home Assistant work better and installable/updateable without sudo.
-Note: After you made a virtual Python envoriment, you cant relocate the folder, else it will break. 
+Note: After you made a virtual Python environment, you can't relocate the folder, else it will break. 
 Make a new one if you need to change it's name, the path or Shared-Folder.
 ```bash
 $ /volume1/@appstore/python3/bin/python3 -m venv /volume1/homeassistant/venv-hass
@@ -383,7 +348,7 @@ case $1 in
 esac
 ```
 
-## {% linkable_title Controlling Home Assistent %}
+## {% linkable_title Controlling Home Assistant %}
 
 * Start Home Assistant:
 ```bash
@@ -403,3 +368,5 @@ $ source /volume1/homeassistant/venv-hass/bin/activate
 $ pip3 install --upgrade homeassistant
 $ deactivate
 ```
+
+## {% linkable_title Controlling Home Assistant %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -144,7 +144,7 @@ Now while it's installing, you may setup the Shared-Folder for Home Assistant:
 * Click on "*Next*" again
 * Click on "*Apply*"
 
-As the "*homeassistant*" Shared-Folder has been made, copy the (previously created) "*~/Module-Packages*" directory there.
+As the "*homeassistant*" Shared-Folder has been made, copy the previously created "*~/Module-Packages*" directory there.
 
 Next setup the user:
 * Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -101,14 +101,14 @@ export CFLAGS=-pthread
 
 Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by [spksrc](https://github.com/SynoCommunity/spksrc). Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
 ```bash
-$ sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
+# sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make clean && make setup && make -C spk/python3 arch-XXXX'
 ```
 After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
 
 If you want to remove the Docker container downloaded by `docker run` to save drive space, run the following command:
 ```bash
-sudo docker rmi synocommunity/spksrc
+# sudo docker rmi synocommunity/spksrc
 ```
 
 ## {% linkable_title Using the Synology webadmin %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/nl-nl/dsm/packages/py3k), which is not which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed on their Python version. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
+Synology only provides [Python 3.5.1](https://www.synology.com/nl-nl/dsm/packages/py3k), which is not which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -112,8 +112,8 @@ $ cd ~/Module-Packages
 $ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz; gzip -df /tmp/package.tgz
 $ for file in cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl curve25519_donna-1.3-cp35-none-any.whl ed25519-1.4-cp35-none-any.whl; do tar -x -f /tmp/package.tar share/wheelhouse/$file --strip=2; done
 ```
-Inside some of the `.whl` archives you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is required for ARM based Synology's.
-Run this command to patch `.whl` files found in the current directory:
+Inside some of the `.whl` archives you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is required for ARM based Synology's.  
+Run this command to all patch `.whl` files found in the current directory:
 ```bash
 $ rand=$RANDOM; for module in *.whl; do unzip "$module" -d "temp$rand" && find "temp$rand" -name "*x86_64-linux-gnu*" -type f | while read -r file; do mv "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done && rm "$module" && (cd "temp$rand" && zip -r0 "../$module" ./) && rm -r "temp$rand"; done
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -19,6 +19,7 @@ There are 2 alternatives, when using Home Assistant on Synology NAS:
 2. Directly running on DSM
 
 Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.
+
 Our recommendation is you run Home Assistant on a Raspberri Pi, as this setup might be a bit more involved than you will like.
 
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -19,7 +19,7 @@ There are 2 alternatives, when using Home Assistant on Synology NAS:
 2. Directly running on DSM
 
 Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.  
-Our recommendation is to run Home Assistant on Docker or a Raspberri Pi, as the instructions written below are a bit involved.
+Our recommendation is to run Home Assistant on Docker (If available) or a Raspberri Pi, as the instructions written below are a bit involved.
 
 
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -110,7 +110,7 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 Now you need to extract the Python module packages which you added earlier to "*requirements.txt*".
 Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "*python3_**XXXX**.spk*" points to the package file you made earlier:
 ```bash
-$ mkdir ~/Module-Packages && cd ~/Module-Packages
+$ mkdir -p ~/Module-Packages && cd ~/Module-Packages
 $ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz && gzip -df /tmp/package.tgz && tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2
 ```
 Inside some of the `.whl` files (These are zip archives) you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is only required for ARM based Synology NAS.  

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -142,7 +142,7 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 Now you need to extract your "cross compiled module package" files which you added earlier.
 Run these commands to extract the packages, please replace "python3_**XXXX**.spk" by the apporiate package filename:
 ```bash
-$ pyspk=python3_armada370-6.1_3.5.5-7.spk
+$ pyspk=python3_XXXX.spk
 $ mkdir ~/Module-Packages
 $ cd ~/Module-Packages
 $ tar -x -f ~/spksrc/spksrc/packages/$pyspk -C /tmp package.tgz; gzip -df /tmp/package.tgz

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -110,6 +110,11 @@ sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 
 After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
 
+If you want to remove the spksrc Docker container to save space, run the following command:
+```bash
+sudo docker rmi synocommunity/spksrc
+```
+
 ## {% linkable_title Using the Synology webadmin %}
 
 Install the Python 3 package as follows:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -105,7 +105,7 @@ export CFLAGS=-pthread
 
 Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
 ```bash
-sudo docker run -it --rm -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
+sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
 ```
 After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Installation on a Synology NAS"
 description: "Instructions to install Home Assistant on a Synology NAS."
-date: 2016-04-16 11:36
+date: 2018-12-05 10:36
 sidebar: true
 comments: false
 sharing: true
@@ -13,6 +13,9 @@ redirect_from: /getting-started/installation-synology/
 <p class='note warning'>
 Synology only provide Python 3.5.1, which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python3 -m pip install homeassistant==0.64.3`
 </p>
+<p class='note'>
+Update: You can install a more recent home assistent (Tested to work at Home Assistant 0.84) by manually compiling a python3 package using the spksrc compilation framework. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “Discovery”, “Cloud” and “Xiaomi_Aqara”. Thread for more info: [Python >=3.5.3 on Synology](https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27)
+</p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
 1. using Docker
@@ -21,59 +24,233 @@ There are 2 alternatives, when using Home Assistant on Synology NAS:
 Option 1 is described on the [Docker installation page](/docs/installation/docker/), whereas Option 2 is described below.
 
 
-The following configuration has been tested on Synology 413j running DSM 6.0-7321 Update 1.
+The following configuration has been tested on Synology 115j running DSM 6.2.1-23824 Update 1.
 
 Running these commands will:
-
- - Install Home Assistant
- - Enable Home Assistant to be launched on [http://localhost:8123](http://localhost:8123)
+* Compile the required new python3 package
+* Install Home Assistant
+* Enable Home Assistant to be launched on http://localhost:8123
 
 Using the Synology webadmin:
+* Install compiled python3 package using the Synology Package Center
+* Create “homeassistant” user and add to the “users” group
+* Create “homeassistant” “Shared-Folder”
+* Optionally Start Home Assistant on Bootup of Synology
 
- - Install python3 using the Synology Package Center
- - Create homeassistant user and add to the "users" group
 
-SSH onto your synology & login as admin or root
 
- - Log in with your own administrator account
- - Switch to root using:
+Like you might have read above, at this time of writing, Synology has not provided a recent Python3 package, so we will have to compile Python3 ourself.
+Do not worry though, were gonna try keep this as painless as possible.
+
+## preparing prerequisites
+
+We are going to use a Linux based Operating System such as [Ubuntu](https://www.ubuntu.com/), [Mint](https://linuxmint.com/) or [Solus](https://getsol.us) to minimize difficulty. In this guide we will need [Docker](https://docs.docker.com/install/).
+You can think of Docker as a way more powerful Chroot and containers as ready made mini operating systems.
+
+---
+### Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+
+Refresh package lists:
+```bash
+# sudo apt-get update
+```
+Install prerequisite packages which lets APT get packages over HTTPS:
+```bash
+# sudo apt-get install apt-transport-https ca-certificates curl software-properties-common
+```
+Add GPG key for the official Docker repository to your system:
+```bash
+# curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+```
+<p class='note'>
+Note: The “lsb_release -cs” sub-command below returns the name of your Ubuntu distribution, such as xenial.
+Sometimes, in a distribution like Linux Mint, you might need to change “lsb_release -cs” to your parent Ubuntu distribution.
+For example, if you are using Linux Mint <b>Tara</b>“=19”, you could use <b>Bionic</b>“=18.04”.
+</p>
 
 ```bash
-$ sudo -i
+# sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+```
+Refresh package lists for newly added Docker repository:
+```bash
+# sudo apt-get update
+```
+Install Docker:
+```bash
+# sudo apt-get install docker-ce
+```
+---
+### Installing Docker on Solus
+
+Update package lists:
+```bash
+# sudo eopkg update-repo
+```
+Install Docker:
+```bash
+# sudo eopkg install docker
+```
+Enable the Docker service at system boot:
+```bash
+# sudo systemctl enable docker
+```
+Start the docker service:
+```bash
+# sudo systemctl start docker
+```
+---
+To enable your user account to manage Docker without superuser privileges, add your “USER” account to the “docker” group:
+```bash
+sudo gpasswd -a USER docker
+```
+
+You will now need to get the [spksrc Docker container](https://github.com/SynoCommunity/spksrc#docker) for the compiling environment.
+
+Pull/Download the spksrc Docker container, this will make a directory named “spksrc”.
+```bash
+# docker pull synocommunity/spksrc
+```
+Now run the container, this will make your terminal run inside the Docker container:
+```bash
+# docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
+```
+While inside the container, clone/download the spkrc repository.
+```bash
+# git clone https://github.com/SynoCommunity/spksrc.git
+```
+
+## Preparing to compile Python
+
+Before you continue in the container, you need to edit 2 files.
+You need to do this to get “cross compiled module package” files, which you require for Home Assistent to able to be installed.
+These edits also enable you to use the “Cloud” component and fix the OpenSSL errors when using the “Xiaomi_Aqara” component.
+
+Edit “~/spksrc/spksrc/spk/python3/src/requirements.txt”, add at the end of the file:
+```
+##Cross compilation requirements for installing Home Assistent (Tested to work on 83.3).
+##In the future, the requirements may change (need newer version to work, eg), modify as needed.
+cffi==1.11.5
+bcrypt==3.1.4
+cryptography==2.3.1
+#Cross compilation requirement for installing “Warrent” module (Needed by “Cloud” Component)
+pycryptodome==3.7.2
+```
+Edit “~/spksrc/spksrc/spk/python3/src/Makefile”, add above the line that says “<b>include ../../mk/spksrc.spk.mk</b>”:
+```makefile
+# Needed to fix “_openssl.so: undefined symbol: pthread_atfork” error caused by lack of libpthread linkage on Synology (Needed for SSL and “xiaomi_aqara” component)
+export CFLAGS=-pthread
 ```
 
 
-Check the path to python3 (assumed to be /volume1/@appstore/py3k/usr/local/bin)
-
+While still in the docker container, create the Python3 package:
 ```bash
-# cd /volume1/@appstore/py3k/usr/local/bin
+# cd spksrc/
+# make setup
+# cd spk/python3
+```
+<p class='note'>
+    you have to change the arch-XXXX to the architecture of your Synology (eg, DS115j = arch-armada370)
+For information about the Arch of your Synology look at the {architecture List spkrc}[https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model]
+Depending on your device, compilation may take a hour or more (significantly less if you have a SSD and a good CPU).
+</p>
+
+Compile Python3 for your Synology model
+```bash
+# make arch-XXXX
+```
+After the compilation is done, you can find the Python package at “~/spksrc/spksrc/packages/python3_XXXX.spk”.
+It should be named something like “python3_armada370-6.1_3.5.5-7.spk”, of course with a possibly different arch and version.
+
+Now you need to extract your “cross compiled module package” files which you added earlier.
+For ease of use this guide will use p7zip for extracting from these archives.
+#### Ubuntu/Mint
+```bash
+# sudo apt-get install p7zip
+```
+#### Solus
+```bash
+# sudo eopkg install p7zip
+```
+Run these commands to extract the packages
+```bash
+# 7z e python3_XXXX.spk package.tgz
+# 7z e package.tgz package.tar
+# 7z e package.tar -o"Module-Packages" "share/wheelhouse/cffi-1.11.5-cp35-none-any.whl"
+# 7z e package.tar -o"Module-Packages" "share/wheelhouse/bcrypt-3.1.4-cp35-none-any.whl"
+# 7z e package.tar -o"Module-Packages" "share/wheelhouse/cryptography-2.3.1-cp35-none-any.whl"
+# 7z e package.tar -o"Module-Packages" "share/wheelhouse/pycryptodome-3.7.2-cp35-none-any.whl"
+```
+This should give you a directory “Module-Packages” with four .whl files, which you need to install later.
+Inside some of the .whl archives we need to rename files with “<b>x86_64-linux-gnu</b>” to “<b>arm-linux-gnueabihf</b>”.
+If we dont, these will be ignored by Python on ARM based Synology's, causing Home Assistent to not function.
+```bash
+# 7z rn "Module-Packages/cffi-1.11.5-cp35-none-any.whl" "_cffi_backend.cpython-35m-x86_64-linux-gnu.so" "_cffi_backend.cpython-35m-arm-linux-gnueabihf.so"
+# 7z l "Module-Packages/pycryptodome-3.7.2-cp35-none-any.whl" | grep "x86_64-linux-gnu" | cut -c54- | while read -r file; do 7z rn "Module-Packages/pycryptodome-3.7.2-cp35-none-any.whl" "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done
+```
+<p class='note'>
+The 7z <b>rn</b> (eg, rename) parameter was included from 7-Zip 9.30, in the case you are pitifully stuck on a older version, do as follows.
+Extract the .whl (these are zip archives), rename all files as described above, then rearchive as zip (ofcourse the same full name with .whl and without .zip).
+If that is not possible, then upgrade your base or switch to a recent distribution so you can.
+</p>
+
+
+## Using the Synology webadmin:
+
+Open Synology Package Center and press the “Manual Install” button.
+Click “Browse” and select the Python package we created, then press “Next”.
+You will get a unverified package popup, press yes and next screen press Apply.
+
+Now while it's installing, you can setup the user and Shared-Folder for Home Assistent.
+
+Open “Control Panel”, go to “Shared-Folder” settings and click on “Create”.
+In “Name” write “<b>homeassistant</b>”, in "Description” write “<b>Home Assistent</b>”
+Click “Next”, same for second screen, the third screen click “Apply”.
+
+Next go to “User” settings and click on “Create”.
+In "Name" write “<b>homeassistant</b>”, in "Description” write “<b>Home Assistent</b>”, "Password" is up to you.
+Click “Next”, next screen leave only “users” group checked and click “Next”.
+In this screen, set permission “No access” for all Shared-Folders and only “homeassistent” Shared-Folder to “Read/Write.”
+Click “Next” on this screen and the next, on the last screen click “Apply”.
+
+Now the “homeassistent” Shared-Folder has been made, you need to copy the “Module-Packages” directory there.
+
+## Preparing to install Home Assistent
+
+After the Python package has been installed, open terminal and open SSH to the synology.
+Replace “user” with your Synology user and “x.x.x.x” with the its IP-Adress.
+```bash
+# ssh user@x.x.x.x
+```
+Create a virtual Python environment where we will install Home Assistent into.
+This will leave the Python package untouched, makes Home Assistent work better and installable/updateable without sudo.
+Note: After you made a virtual Python envoriment, you cant relocate the folder, else it will break. 
+Make a new one if you need to change it's name, the path or Shared-Folder.
+```bash
+# /volume1/@appstore/python3/bin/python3 -m venv /volume1/homeassistant/venv-hass
+```
+Activate the virtual Python environment
+```bash
+# source ./venv-hass/bin/activate
+```
+Install the “cross compiled module package” files we compiled earlier.
+This command expects you have copied the “Module-Packages” directory to your “homeassistent” Shared-Folder.
+```bash
+# cd /volume1/homeassistant/Module-Packages
+# pip3 install cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl
+```
+Install Home Assistent
+```bash
+# pip3 install homeassistant
+```
+Leave the virtual Python environment
+```bash
+# deactivate
 ```
 
-Install PIP (Python's package management system)
+Create a file named “hass-daemon” in the “homeassistent” Shared-Folder with the script below as it's content.
+You can use it to easily start, stop and restart Home Assistent like a service/daemon.
 
-```bash
-# ./python3 -m ensurepip
-```
-
-Use PIP to install Homeassistant package 0.64.3
-
-```bash
-# ./python3 -m pip install homeassistant==0.64.3
-```
-
-Create homeassistant config directory & switch to it
-
-```bash
-# mkdir /volume1/homeassistant
-# chown homeassistant /volume1/homeassistant 
-# chmod 755 /volume1/homeassistant
-# cd /volume1/homeassistant
-```
-Hint: alternatively you can also create a "Shared Folder" via Synology WebUI (e.g., via "File Station") - this has the advantage that the folder is visible via "File Station".
-
-Create hass-daemon file using the following code (edit the variables in uppercase if necessary)
-
-```bash
+```sh
 #!/bin/sh
 
 # Package
@@ -82,29 +259,28 @@ DNAME="Home Assistant"
 
 # Others
 USER="homeassistant"
-PYTHON_DIR="/volume1/@appstore/py3k/usr/local/bin"
-PYTHON="$PYTHON_DIR/python3"
-HASS="$PYTHON_DIR/hass"
 INSTALL_DIR="/volume1/homeassistant"
+VIRTENV_DIR="$INSTALL_DIR/venv-hass"
 PID_FILE="$INSTALL_DIR/home-assistant.pid"
 FLAGS="-v --config $INSTALL_DIR --pid-file $PID_FILE --daemon"
 REDIRECT="> $INSTALL_DIR/home-assistant.log 2>&1"
 
 start_daemon ()
 {
-    sudo -u ${USER} /bin/sh -c "$PYTHON $HASS $FLAGS $REDIRECT;"
+   source "$VIRTENV_DIR/bin/activate"
+   sudo -u ${USER} /bin/sh -c "hass $FLAGS $REDIRECT;"
 }
 
 stop_daemon ()
 {
-    kill `cat ${PID_FILE}`
-    wait_for_status 1 20 || kill -9 `cat ${PID_FILE}`
+    sudo kill `cat ${PID_FILE}`
+    wait_for_status 1 20 || sudo kill -9 `cat ${PID_FILE}`
     rm -f ${PID_FILE}
 }
 
 daemon_status ()
 {
-    if [ -f ${PID_FILE} ] && kill -0 `cat ${PID_FILE}` > /dev/null 2>&1; then
+    if [ -f ${PID_FILE} ] && sudo kill -0 `cat ${PID_FILE}` > /dev/null 2>&1; then
         return
     fi
     rm -f ${PID_FILE}
@@ -175,68 +351,40 @@ case $1 in
         exit 1
         ;;
 esac
-
-```
-
-Create links to python folders to make things easier in the future:
-
-```bash
-# ln -s /volume1/@appstore/py3k/usr/local/bin/python3 python3
-# ln -s /volume1/@appstore/py3k/usr/local/lib/python3.5/site-packages/homeassistant homeassistant
-```
-
-Set the owner and permissions on your config folder
-
-```bash
-# chown -R homeassistant:users /volume1/homeassistant
-# chmod -R 664 /volume1/homeassistant
-```
-
-Make the daemon file executable:
-
-```bash
-# chmod 755 /volume1/homeassistant/hass-daemon
 ```
 
 Update your firewall (if it is turned on the Synology device):
 
- - Go to your Synology control panel
- - Go to security 
- - Go to firewall
- - Go to Edit Rules
- - Click Create
- - Select Custom: Destination port "TCP"
- - Type "8123" in port
- - Click on OK
- - Click on OK again
+* Go to your Synology control panel
+* Go to security
+* Go to firewall
+* Go to Edit Rules
+* Click Create
+* Select Custom: Destination port "TCP"
+* Type "8123" in port
+* Click on OK
+* Click on OK again
 
 
-Copy your configuration.yaml file into the config folder
-That's it... you're all set to go
+Copy your configuration.yaml file into the config folder That's it... you're all set to go
 
 Here are some useful commands:
 
-- Start Home Assistant:
-
+* Start Home Assistant:
 ```bash
-$ sudo /volume1/homeassistant/hass-daemon start
+# /volume1/homeassistant/hass-daemon start
 ```
-
-- Stop Home Assistant:
-
+* Stop Home Assistant:
 ```bash
-$ sudo /volume1/homeassistant/hass-daemon stop
+# /volume1/homeassistant/hass-daemon stop
 ```
-
-- Restart Home Assistant:
-
+* Restart Home Assistant:
 ```bash
-$ sudo /volume1/homeassistant/hass-daemon restart
+# /volume1/homeassistant/hass-daemon restart
 ```
-
-- Upgrade Home Assistant::
-
+* Upgrade Home Assistant:
 ```bash
-$  /volume1/@appstore/py3k/usr/local/bin/python3 -m pip install --upgrade homeassistant
+# source ./venv-hass/bin/activate
+# pip3 install --upgrade homeassistant
+# deactivate
 ```
-

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,11 +11,11 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provide <a href="https://www.synology.com/nl-nl/dsm/packages/py3k">Python 3.5.1</a>, which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python3 -m pip install homeassistant==0.64.3`
+Synology only provide <a href="https://www.synology.com/nl-nl/dsm/packages/py3k">Python 3.5.1</a>, which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./Python 3 -m pip install homeassistant==0.64.3`
 </p>
 
 <p class="note">
-Update: You can install a more recent home assistant (eg, 0.84.2) by manually compiling a python3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “<a href="/components/discovery/">Discovery</a>”, “<a href="/components/cloud/">Cloud</a>” and “<a href="/components/Xiaomi_Aqara/">Xiaomi_Aqara</a>”. Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27">Python >=3.5.3 on Synology</a>.
+Update: You can install a more recent Home Assistant (e.g, 0.84.2) by manually compiling a Python 3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as "<a href="/components/discovery/">Discovery</a>", "<a href="/components/cloud/">Cloud</a>" and "<a href="/components/Xiaomi_Aqara/">Xiaomi_Aqara</a>". Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27">Python >=3.5.3 on Synology</a>.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -28,18 +28,18 @@ Option 1 is described on the [Docker installation page](/docs/installation/docke
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.
 
 Running these commands will:
-* Compile the required new Python3 package
+* Compile the required new Python 3 package
 * Install Home Assistant
 * Enable Home Assistant to be launched on http://*Synology_IP*:8123
 
 Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM):
-* Install compiled Python3 package using the [Synology Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
-* Create “homeassistant” user and add to the “users” group
-* Create “homeassistant” “Shared-Folder”
+* Install compiled Python 3 package using the [Synology Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
+* Create "homeassistant" user and add to the "users" group
+* Create "homeassistant" "Shared-Folder"
 * Optionally Start Home Assistant on Bootup of Synology
 
 
-Like you might have read above, at this time of writing, Synology has not provided a recent [Python3](https://www.synology.com/nl-nl/dsm/packages/py3k) package, so we have to create a recent Python3 package ourself.
+Like you might have read above, at this time of writing, Synology has not provided a recent [Python 3](https://www.synology.com/nl-nl/dsm/packages/py3k) package, so we have to create a recent Python 3 package ourself.
 Do not worry though, were gonna try keep this as painless as possible.
 
 ## {% linkable_title Preparing prerequisites %}
@@ -47,7 +47,7 @@ Do not worry though, were gonna try keep this as painless as possible.
 In this guide we are going to use a Linux based Operating System such as [Ubuntu](https://www.ubuntu.com/), [Mint](https://linuxmint.com/) or [Solus](https://getsol.us) to minimize difficulty. You will also need [Docker](https://docs.docker.com/install/).
 You can think of [Docker](https://docs.docker.com/install/) as a way more powerful [Chroot](https://help.ubuntu.com/community/BasicChroot) and containers as ready made mini operating systems.
 
----
+
 ### {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
 
 Refresh package lists:
@@ -63,9 +63,9 @@ Add GPG key for the official Docker repository to your system:
 # curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 ```
 <p class="note">
-The “lsb_release -cs” sub-command below returns the name of your Ubuntu distribution, such as xenial.
-Sometimes, in a distribution like Linux Mint, you might need to change “lsb_release -cs” to your parent Ubuntu distribution.
-For example, if you are using Linux Mint <b>Tara</b> (eg, 19), you could use <b>Bionic</b> (eg, 18.04).
+The "lsb_release -cs" sub-command below returns the name of your Ubuntu distribution, such as xenial.
+Sometimes, in a distribution like Linux Mint, you might need to change "lsb_release -cs" to your parent Ubuntu distribution.
+For example, if you are using Linux Mint <b>Tara</b> (e.g., 19), you could use <b>Bionic</b> (e.g., 18.04).
 </p>
 
 ```bash
@@ -99,7 +99,7 @@ Start the docker service:
 # sudo systemctl start docker
 ```
 ---
-To enable your user account to manage Docker without superuser privileges, add your user account to the “docker” group:
+To enable your user account to manage Docker without superuser privileges, add your user account to the "docker" group:
 ```bash
 # sudo gpasswd -a YOUR_USER_ACCOUNT docker
 ```
@@ -115,7 +115,7 @@ Install Git
 ```bash
 # sudo eopkg install git
 ```
-Fork and clone spksrc, this will make a directory named “spksrc”.
+Fork and clone spksrc, this will make a directory named "spksrc".
 ```bash
 git clone https://You@github.com/You/spksrc.git ~/spksrc
 ```
@@ -125,28 +125,28 @@ docker pull synocommunity/spksrc
 ```
 
 Now you need to edit 2 files.
-You need to do this to get “cross compiled module package” files, which you require for Home Assistant to able to be installed.
-These edits also enable you to use the “[Cloud](/components/cloud/)” component and fix the OpenSSL errors when using the “[Xiaomi_Aqara](/components/Xiaomi_Aqara/)” component.
+You need to do this to get "cross compiled module package" files, which you require for Home Assistant to able to be installed.
+These edits also enable you to use the "[Cloud](/components/cloud/)" component and fix the OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.
 
 
-Edit “*~/spksrc/spksrc/spk/python3/src/requirements.txt*”, add at the end of the file:
+Edit "*~/spksrc/spksrc/spk/python3/src/requirements.txt*", add at the end of the file:
 ```
 ##Cross compilation requirements for installing Home Assistant (Tested to work on 83.3).
-##In the future, the requirements may change (need newer version to work, eg), modify as needed.
+##In the future, the requirements may change (e.g., need newer version to work), modify as needed.
 cffi==1.11.5
 bcrypt==3.1.4
 cryptography==2.3.1
-#Cross compilation requirement for installing “Warrent” module (Needed by “Cloud” Component)
+#Cross compilation requirement for installing "Warrent" module (Needed by "Cloud" Component)
 pycryptodome==3.7.2
 ```
 
-Edit “*~/spksrc/spksrc/spk/python3/src/Makefile*”, add above the line that says “<b>include ../../mk/spksrc.spk.mk</b>”:
+Edit "*~/spksrc/spksrc/spk/python3/src/Makefile*", add above the line that says "<b>include ../../mk/spksrc.spk.mk</b>":
 ```makefile
-# Needed to fix “_openssl.so: undefined symbol: pthread_atfork” error caused by lack of libpthread linkage on Synology (Needed for SSL and “xiaomi_aqara” component)
+# Needed to fix "_openssl.so: undefined symbol: pthread_atfork" error caused by lack of libpthread linkage on Synology (Needed for SSL and "xiaomi_aqara" component)
 export CFLAGS=-pthread
 ```
 
-## {% linkable_title Compiling the Python3 package %}
+## {% linkable_title Compiling the Python 3 package %}
 Run the container, this will make your terminal run inside the Docker container:
 ```bash
 # docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
@@ -155,19 +155,19 @@ Run the container, this will make your terminal run inside the Docker container:
 # cd spk/python3
 ```
 <p class='note'>
-You need to change the arch-XXXX to the architecture of your Synology (eg, DS115j = arch-armada370)
+You need to change the arch-XXXX to the architecture of your Synology (e.g., DS115j = arch-armada370)
 For information about the Arch of your Synology look at the <a href="https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model">list of architectures on spkrc</a>
 Depending on your device, compilation may take a hour or more (significantly less if you have a SSD and a good CPU).
 </p>
 
-Compile Python3 for your Synology model
+Compile Python 3 for your Synology model
 ```bash
 # make arch-XXXX
 ```
-After the compilation is done, you can find the Python package at “*~/spksrc/spksrc/packages/python3_XXXX.spk*”.
-It should be named something like “python3_armada370-6.1_3.5.5-7.spk”, of course with a possibly different arch and version.
+After the compilation is done, you can find the Python package at "*~/spksrc/spksrc/packages/python3_XXXX.spk*".
+It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different arch and version.
 
-Now you need to extract your “cross compiled module package” files which you added earlier.
+Now you need to extract your "cross compiled module package" files which you added earlier.
 For ease of use this guide will use p7zip for extracting from these archives.
 #### Ubuntu/Mint
 ```bash
@@ -186,15 +186,15 @@ Run these commands to extract the packages
 # 7z e package.tar -o"Module-Packages" "share/wheelhouse/cryptography-2.3.1-cp35-none-any.whl"
 # 7z e package.tar -o"Module-Packages" "share/wheelhouse/pycryptodome-3.7.2-cp35-none-any.whl"
 ```
-This should give you a directory named “**Module-Packages**” with four .whl files, which you need to install later.
-Inside some of the .whl archives you need to rename all files containing the text “**x86_64-linux-gnu**” to “**arm-linux-gnueabihf**”.
-If you do not, these will be ignored by Python on ARM based Synology's, causing Home Assistant to not function.
+This should give you a directory named "**Module-Packages**" with four .whl files, which you need to install later.
+Inside some of the .whl archives you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**".
+If you do not, these will be ignored by Python 3 on ARM based Synology's, causing Home Assistant to not function.
 ```bash
 # 7z rn "Module-Packages/cffi-1.11.5-cp35-none-any.whl" "_cffi_backend.cpython-35m-x86_64-linux-gnu.so" "_cffi_backend.cpython-35m-arm-linux-gnueabihf.so"
 # 7z l "Module-Packages/pycryptodome-3.7.2-cp35-none-any.whl" | grep "x86_64-linux-gnu" | cut -c54- | while read -r file; do 7z rn "Module-Packages/pycryptodome-3.7.2-cp35-none-any.whl" "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done
 ```
 <p class='note'>
-The 7z <b>rn</b> (eg, rename) parameter was included from 7-Zip 9.30, in the case you are pitifully stuck on a older version, do as follows.
+The 7z <b>rn</b> (e.g., rename) parameter was included from 7-Zip 9.30, in the case you are pitifully stuck on a older version, do as follows.
 Extract the .whl (these are zip archives), rename all files as described above, then rearchive as zip (ofcourse the same full name with .whl and without .zip).
 </p>
 
@@ -202,54 +202,54 @@ Extract the .whl (these are zip archives), rename all files as described above, 
 ## {% linkable_title Using the Synology webadmin: %}
 
 * Open [Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
-* Press the “*Manual Install*” button on the top right of the window
-* Click on “*Browse*” and select the Python3 spk package you created earlier
-* Click on “*Next*”
-* You will most likely get a unverified signature warning, click on “*Yes*”
-* Click on “*Apply*”
+* Press the "*Manual Install*" button on the top right of the window
+* Click on "*Browse*" and select the Python 3 spk package you created earlier
+* Click on "*Next*"
+* You will most likely get a unverified signature warning, click on "*Yes*"
+* Click on "*Apply*"
 
 Now while it's installing, you may setup the Shared-Folder for Home Assistant:
-* Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
-* Go to “[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)” settings
-* Click on “*Create*”
-* In “*Name*” write “**homeassistant**”
-* in "*Description*” write “**Home Assistant**”
-* Click on “*Next*”
-* Click on “*Next*” again
-* Click on “*Apply*”
+* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+* Go to "[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)" settings
+* Click on "*Create*"
+* In "*Name*" write "**homeassistant**"
+* in "*Description*" write "**Home Assistant**"
+* Click on "*Next*"
+* Click on "*Next*" again
+* Click on "*Apply*"
 
-As the “*homeassistant*” Shared-Folder has been made, copy the (previously created) “*Module-Packages*” directory there.
+As the "*homeassistant*" Shared-Folder has been made, copy the (previously created) "*Module-Packages*" directory there.
 
 Next setup the user:
-* Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
-* Go to “[*User*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_user_desc)” settings
-* Click on “*Create*”
-* In "*Name*" write “**homeassistant**”
-* In "*Description*” write “**Home Assistant**”
+* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+* Go to "[*User*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_user_desc)" settings
+* Click on "*Create*"
+* In "*Name*" write "**homeassistant**"
+* In "*Description*" write "**Home Assistant**"
 * The "*Password*" up to your choice
-* Click on “*Next*”
-* Make sure only “*users*” group is checked and click “*Next*”
-* Set the permission “*Read/Write*” for “*homeassistant*” and the all the other Shared-Folders to “*No access*”
-* Click on “*Next*”
-* Click on “*Next*” again
-* Click on “*Apply*”.
+* Click on "*Next*"
+* Make sure only "*users*" group is checked and click "*Next*"
+* Set the permission "*Read/Write*" for "*homeassistant*" and the all the other Shared-Folders to "*No access*"
+* Click on "*Next*"
+* Click on "*Next*" again
+* Click on "*Apply*".
 
 In the case you turned on the firewall on your Synology device, please config it to allow connections for Home Assistant:
-* Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
-* Go to “[*Security*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_desc)” settings
-* Go to “[*Firewall*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_firewall)” settings
-* Go to “*Edit Rules*”
-* Click on “*Create*”
-* Select Custom: Destination port “TCP”
-* Type “8123” in port (eg, setting in [*server_port*](/components/http/#server_port))
-* Click on “*OK*”
-* Click on “*OK*” again
+* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+* Go to "[*Security*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_desc)" settings
+* Go to "[*Firewall*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_firewall)" settings
+* Go to "*Edit Rules*"
+* Click on "*Create*"
+* Select Custom: Destination port "TCP"
+* Type "8123" in port (e.g., setting in [*server_port*](/components/http/#server_port))
+* Click on "*OK*"
+* Click on "*OK*" again
 
 
 ## {% linkable_title Installing Home Assistant %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
-Replace “<i>user</i>” with your Synology user and “x.x.x.x” with the its IP-Adress.
+Replace "<i>user</i>" with your Synology user and "x.x.x.x" with the its IP-Adress.
 ```bash
 # ssh user@x.x.x.x
 ```
@@ -264,8 +264,8 @@ Activate the virtual Python environment
 ```bash
 # source /volume1/homeassistant/venv-hass/bin/activate
 ```
-Install the “cross compiled module package” files we compiled earlier.
-This command expects you have copied the “*Module-Packages*” directory to your “*homeassistant*” Shared-Folder.
+Install the "cross compiled module package" files we compiled earlier.
+This command expects you have copied the "*Module-Packages*" directory to your "*homeassistant*" Shared-Folder.
 ```bash
 # cd /volume1/homeassistant/Module-Packages
 # pip3 install cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl
@@ -279,7 +279,7 @@ Leave the virtual Python environment
 # deactivate
 ```
 
-Create a file named “hass-daemon” in the “homeassistant” Shared-Folder with the script below as it's content.
+Create a file named "hass-daemon" in the "homeassistant" Shared-Folder with the script below as it's content.
 You can use it to easily start, stop and restart Home Assistant like a service/daemon.
 
 ```sh

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -246,12 +246,6 @@ In the case you turned on the firewall on your Synology device, please config it
 * Click on “*OK*” again
 
 
-Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM):
-* Install compiled Python3 package using the [Synology Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
-
-
-
-
 ## {% linkable_title Installing Home Assistant %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -185,7 +185,7 @@ This command expects you have copied the "*Module-Packages*" directory from "[Ex
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install homeassistant
 ```
-Create a file named "hass-daemon" in the "homeassistant" Shared-Folder with the script below as its content.
+Create a file named "**hass-daemon**" in your "*homeassistant*" Shared-Folder with the script below as its content.
 You can use it to easily start, stop and restart Home Assistant like a service/daemon.
 ```sh
 #!/bin/sh

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `/volume1/@appstore/python3/bin/python3 -m pip install homeassistant==0.64.3`
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -157,7 +157,7 @@ $ tar -x -f ~/spksrc/packages/$pyspk -C /tmp package.tgz; gzip -df /tmp/package.
 $ for file in $pyreq; do tar -x -f /tmp/package.tar share/wheelhouse/$file --strip=2; done
 ```
 <p class="note">
-If you added any other modules to "*requirements.txt*", you can modify the "*pyreq*" command and add these modules filenames.
+If you added any other modules to "*requirements.txt*", you can modify the "*pyreq*" command and add those modules filenames.
 You can find the modules inside "*python3_XXXX.spk*" > "*package.tgz*" > "*share/wheelhouse/XXXX.whl*".
 </p>
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -70,10 +70,10 @@ Most components will setup just fine, but certain components need a python packa
 
 Edit "*~/spksrc/spk/python3/src/requirements.txt*" and add the following text to the end of the file:
 ```
-## It may happen you want to add a component to Home Assistant, but it fails to install a package.
+## It may happen you want to add a component to Home Assistant, but it fails to install a Python package.
 ## In the logs you see a error "Unable to install package *Module_Name*", if you install that
 # package with pip, some of its required packages fail with error "Failed building wheel for *Module_Name*"
-## Add these Python modules/packages that error with that "building wheel" error in to the list below.
+## Add these Python modules/packages that fail with that "building wheel" error in to the list below.
 
 # Example format of module:
 #pythonmodule==version

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -99,7 +99,7 @@ Edit "*~/spksrc/spk/python3/Makefile*" and add the following text above the text
 export CFLAGS=-pthread
 ```
 #### {% linkable_title Compiling the Python 3 package %}
-Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "_arch-_**XXXX**" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
+Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
 ```bash
 sudo docker run -it --rm -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
 ```
@@ -108,7 +108,7 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 
 #### {% linkable_title Extracting cross compiled packages %}
 Now you need to extract the Python module packages which you added earlier to "*requirements.txt*".
-Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "*python3_*__XXXX__*.spk*" points to the package file you made earlier:
+Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "*python3_**XXXX**.spk*" points to the package file you made earlier:
 ```bash
 $ mkdir ~/Module-Packages && cd ~/Module-Packages
 $ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz && gzip -df /tmp/package.tgz && tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -304,9 +304,7 @@ $ /volume1/homeassistant/hass-daemon restart
 ```
 * Upgrade Home Assistant:
 ```bash
-$ source /volume1/homeassistant/venv-hass/bin/activate
-$ pip3 install --upgrade homeassistant
-$ deactivate
+$ /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
 If you need a to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, compile, extract and install the new cross compiled module `.whl` package files to your Synology.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -126,7 +126,8 @@ docker pull synocommunity/spksrc
 
 Now you need to edit 2 files.
 You need to do this to get “cross compiled module package” files, which you require for Home Assistent to able to be installed.
-These edits also enable you to use the “Cloud” component and fix the OpenSSL errors when using the “Xiaomi_Aqara” component.
+These edits also enable you to use the “[Cloud](https://www.home-assistant.io/components/cloud)” component and fix the OpenSSL errors when using the “[Xiaomi_Aqara](https://www.home-assistant.io/components/Xiaomi_Aqara)” component.
+
 
 Edit “~/spksrc/spksrc/spk/python3/src/requirements.txt”, add at the end of the file:
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -392,6 +392,8 @@ $ deactivate
 ```
 <p class="note">
 If ever you need to update Python 3 or added a component of which the python modules requirements fail to install/compile on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, compile and add the new "cross compiled module package" names to the extracting commands.
+   
+You might also have to reinstall Home Assiatant, which can be done by deleting the '*venv-hass*' directory through SSH and redoing "[*Installing Home Assistant*](#Installing Home Assistant)".
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provide <a href="https://www.synology.com/nl-nl/dsm/packages/py3k">Python 3.5.1</a>, which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./Python 3 -m pip install homeassistant==0.64.3`
+Synology only provide <a href="https://www.synology.com/nl-nl/dsm/packages/py3k">Python 3.5.1</a>, which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
 </p>
 
 <p class="note">

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,8 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can follow the instructions "[Using older Python 3 provided by Synology](#using-older-python-3-provided-by-synology)" at the bottom of this page.
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later.<br/>
+If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide, otherwise you can follow the instructions "[Using older Python 3 provided by Synology](#using-older-python-3-provided-by-synology)" at the bottom of this page.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -97,14 +98,15 @@ export CFLAGS=-pthread
 
 #### {% linkable_title Compiling the Python 3 package %}
 
-Make the Python 3 package for your Synology NAS model, please modify `docker run` command so the "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology NAS. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by [spksrc](https://github.com/SynoCommunity/spksrc). Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
+Modify the `docker run` command so "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology NAS. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by [spksrc](https://github.com/SynoCommunity/spksrc).<br/>
+Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
 ```bash
 # sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make clean && make setup && make -C spk/python3 arch-XXXX'
 ```
-After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
-It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
+After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".<br/>
+It should be named something like "python3_armada370-6.1_3.5.5-7.spk" with a possibly different architecture and version.
 
-If you want to remove the Docker container downloaded by `docker run` to save drive space, run the following command:
+To remove the Docker container downloaded by `docker run` to save drive space, run the following command:
 ```bash
 # sudo docker rmi synocommunity/spksrc
 ```
@@ -114,7 +116,7 @@ If you want to remove the Docker container downloaded by `docker run` to save dr
 Install the Python 3 package as follows:
 1. Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
 1. Press the "*Manual Install*" button on the top right of the window
-1. Click on "*Browse*" and select the Python 3 package you made earlier (e.g., "*~/spksrc/packages/python3_XXXX.spk*")
+1. Click on "*Browse*" and select the Python 3 package you made at "[Compiling the Python 3 package](#compiling-the-python-3-package)"
 1. Click on "*Next*"
 1. You will most likely get a unverified signature warning, click on "*Yes*"
 1. Click on "*Apply*"
@@ -129,8 +131,6 @@ Now while it's installing, you may setup the Shared-Folder for Home Assistant:
 1. Click on "*Next*" again
 1. Click on "*Apply*"
 
-As the "*homeassistant*" Shared-Folder has been made, copy the previously created "*~/Module-Packages*" directory there.
-
 Next setup the user:
 1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
 1. Go to "[*User*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_user_desc)" settings
@@ -140,7 +140,7 @@ Next setup the user:
 1. The "*Password*" is up to your choice
 1. Click on "*Next*"
 1. Make sure only "*users*" group is checked and click "*Next*"
-1. Set the permission "*Read/Write*" for "*homeassistant*" and the all the other Shared-Folders to "*No access*"
+1. Set the permission "*Read/Write*" for "*homeassistant*" and all other Shared-Folders to "*No access*"
 1. Click on "*Next*"
 1. Click on "*Next*" again
 1. Click on "*Apply*"
@@ -151,7 +151,7 @@ Next you need to enable SSH:
 1. Click on the checkbox next to "*Enable SSH service*"
 1. Click on "*Apply*"
 
-In the case you turned on the firewall on your Synology NAS, please config it to allow connections for Home Assistant:
+If you turned on the firewall on your Synology NAS, please config it to allow connections for Home Assistant:
 1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
 1. Go to "[*Security*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_desc)" settings
 1. Go to "[*Firewall*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_firewall)" settings
@@ -164,16 +164,16 @@ In the case you turned on the firewall on your Synology NAS, please config it to
 
 ## {% linkable_title Installing Home Assistant %}
 
-After the Python 3 package has been installed, open terminal and open SSH to the synology.
+After the Python 3 package has been installed, open terminal and open SSH to the synology.<br/>
 Replace "*user*" with your Synology NAS user and "x.x.x.x" with the its IP address:
 ```bash
 ssh user@x.x.x.x
 ```
-Use `pip` to install Home Assistant.
+Use `pip` to install Home Assistant:
 ```bash
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install homeassistant
 ```
-Create a file named "**hass-daemon**" in your "*homeassistant*" Shared-Folder with the script below as its content.
+Create a file named "**hass-daemon**" in your "*homeassistant*" Shared-Folder with the script below as its content.<br/>
 You can use it to easily start, stop and restart Home Assistant like a service/daemon.
 ```sh
 #!/bin/sh
@@ -298,7 +298,7 @@ esac
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
-If you need to update Python 3 or added a component which fails caused by a Python module not installing on your on your Synology NAS with error code "*Failed building wheel for *Module_Name**", delete the "*~/spksrc*" directory and redo the guide, but add the failed python modules to "*requirements.txt*" from "[Preparing compiling environment](#preparing-compiling-environment)".
+If you need a update for Python 3 or added a component which failed because of a Python module not installing on your Synology NAS with error code "_Failed building wheel for *Module_Name*_", delete the "*~/spksrc*" directory and redo the guide, but add the failed python module to "*requirements.txt*" from "[Preparing compiling environment](#preparing-compiling-environment)".
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}
@@ -319,7 +319,9 @@ To have Home Assistant start on bootup of your Synology NAS, do as follows:
 ## {% linkable_title Using older Python 3 provided by Synology %}
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. The instructions above describes how to install newer Home Assistant on your Synology NAS. If you want to proceed with a older version of Home Assistant, follow the instructions below. Please note that you may not be able to use certain components, such as "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)"
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later.<br/>
+The instructions above describes how to install newer Home Assistant on your Synology NAS.<br/>
+If you want to proceed with a older version of Home Assistant, follow the instructions below. Please note that you may not be able to use certain components, such as "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)"
 </p>
 
 Running these commands will:
@@ -344,16 +346,16 @@ Follow the other instructions at "[Using the Synology webadmin](#using-the-synol
 
 ### {% linkable_title Installing Home Assistant 0.64.3 %}
 
-After the Python 3 package has been installed, open terminal and open SSH to the synology.
+After the Python 3 package has been installed, open terminal and open SSH to the synology.<br/>
 Replace "*user*" with your Synology NAS user and "x.x.x.x" with the its IP address:
 ```bash
 $ ssh user@x.x.x.x
 ```
-Install `pip` (Python’s package management system)
+Install `pip` (Python’s package management system):
 ```bash
 # sudo /volume1/@appstore/py3k/usr/local/bin/python3 -m ensurepip
 ```
-Use `pip` to install Homeassistant package 0.64.3
+Use `pip` to install Homeassistant 0.64.3:
 ```bash
 # sudo /volume1/@appstore/py3k/usr/local/bin/python3 -m pip install homeassistant==0.64.3
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -203,7 +203,7 @@ Extract the .whl (these are zip archives), rename all files as described above, 
 
 * Open [Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
 * Press the “*Manual Install*” button on the top right of the window
-* Click on “*Browse*” and select the Python3 spk package we created
+* Click on “*Browse*” and select the Python3 spk package you created earlier
 * Click on “*Next*”
 * You will most likely get a unverified signature warning, click on “*Yes*”
 * Click on “*Apply*”

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can follow the instructions "[Using older Python 3 provided by Synology](#using-older-python-3-provided-by-synology)" way below of the document.
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can follow the instructions "[Using older Python 3 provided by Synology](#using-older-python-3-provided-by-synology)" at the bottom of this page.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/nl-nl/dsm/packages/py3k), which is not which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
+Synology only provides [Python 3.5.1](https://www.synology.com/nl-nl/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -15,7 +15,7 @@ Synology only provide <a href="https://www.synology.com/nl-nl/dsm/packages/py3k"
 </p>
 
 <p class="note">
-Update: You can install a more recent home assistent (eg, 0.84.2) by manually compiling a python3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “<a href="https://www.home-assistant.io/components/discovery">Discovery</a>”, “<a href="https://www.home-assistant.io/components/cloud">Cloud</a>” and “<a href="https://www.home-assistant.io/components/Xiaomi_Aqara">Xiaomi_Aqara</a>”. Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27">Python >=3.5.3 on Synology</a>.
+Update: You can install a more recent home assistant (eg, 0.84.2) by manually compiling a python3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “<a href="https://www.home-assistant.io/components/discovery">Discovery</a>”, “<a href="https://www.home-assistant.io/components/cloud">Cloud</a>” and “<a href="https://www.home-assistant.io/components/Xiaomi_Aqara">Xiaomi_Aqara</a>”. Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27">Python >=3.5.3 on Synology</a>.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -125,13 +125,13 @@ docker pull synocommunity/spksrc
 ```
 
 Now you need to edit 2 files.
-You need to do this to get “cross compiled module package” files, which you require for Home Assistent to able to be installed.
+You need to do this to get “cross compiled module package” files, which you require for Home Assistant to able to be installed.
 These edits also enable you to use the “[Cloud](https://www.home-assistant.io/components/cloud)” component and fix the OpenSSL errors when using the “[Xiaomi_Aqara](https://www.home-assistant.io/components/Xiaomi_Aqara)” component.
 
 
 Edit “*~/spksrc/spksrc/spk/python3/src/requirements.txt*”, add at the end of the file:
 ```
-##Cross compilation requirements for installing Home Assistent (Tested to work on 83.3).
+##Cross compilation requirements for installing Home Assistant (Tested to work on 83.3).
 ##In the future, the requirements may change (need newer version to work, eg), modify as needed.
 cffi==1.11.5
 bcrypt==3.1.4
@@ -188,7 +188,7 @@ Run these commands to extract the packages
 ```
 This should give you a directory named “**Module-Packages**” with four .whl files, which you need to install later.
 Inside some of the .whl archives you need to rename all files containing the text “**x86_64-linux-gnu**” to “**arm-linux-gnueabihf**”.
-If you do not, these will be ignored by Python on ARM based Synology's, causing Home Assistent to not function.
+If you do not, these will be ignored by Python on ARM based Synology's, causing Home Assistant to not function.
 ```bash
 # 7z rn "Module-Packages/cffi-1.11.5-cp35-none-any.whl" "_cffi_backend.cpython-35m-x86_64-linux-gnu.so" "_cffi_backend.cpython-35m-arm-linux-gnueabihf.so"
 # 7z l "Module-Packages/pycryptodome-3.7.2-cp35-none-any.whl" | grep "x86_64-linux-gnu" | cut -c54- | while read -r file; do 7z rn "Module-Packages/pycryptodome-3.7.2-cp35-none-any.whl" "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done
@@ -208,33 +208,33 @@ Extract the .whl (these are zip archives), rename all files as described above, 
 * You will most likely get a unverified signature warning, click on “*Yes*”
 * Click on “*Apply*”
 
-Now while it's installing, you may setup the Shared-Folder for Home Assistent:
+Now while it's installing, you may setup the Shared-Folder for Home Assistant:
 * Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
 * Go to “[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)” settings
 * Click on “*Create*”
 * In “*Name*” write “**homeassistant**”
-* in "*Description*” write “**Home Assistent**”
+* in "*Description*” write “**Home Assistant**”
 * Click on “*Next*”
 * Click on “*Next*” again
 * Click on “*Apply*”
 
-As the “*homeassistent*” Shared-Folder has been made, copy the (previously created) “*Module-Packages*” directory there.
+As the “*homeassistant*” Shared-Folder has been made, copy the (previously created) “*Module-Packages*” directory there.
 
 Next setup the user:
 * Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
 * Go to “[*User*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_user_desc)” settings
 * Click on “*Create*”
 * In "*Name*" write “**homeassistant**”
-* In "*Description*” write “**Home Assistent**”
+* In "*Description*” write “**Home Assistant**”
 * The "*Password*" up to your choice
 * Click on “*Next*”
 * Make sure only “*users*” group is checked and click “*Next*”
-* Set the permission “*Read/Write*” for “*homeassistent*” and the all the other Shared-Folders to “*No access*”
+* Set the permission “*Read/Write*” for “*homeassistant*” and the all the other Shared-Folders to “*No access*”
 * Click on “*Next*”
 * Click on “*Next*” again
 * Click on “*Apply*”.
 
-In the case you turned on the firewall on your Synology device, please config it to allow connections for Home Assistent:
+In the case you turned on the firewall on your Synology device, please config it to allow connections for Home Assistant:
 * Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
 * Go to “[*Security*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_desc)” settings
 * Go to “[*Firewall*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_firewall)” settings
@@ -252,15 +252,15 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 
 
 
-## {% linkable_title Installing Home Assistent %}
+## {% linkable_title Installing Home Assistant %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
 Replace “<i>user</i>” with your Synology user and “x.x.x.x” with the its IP-Adress.
 ```bash
 # ssh user@x.x.x.x
 ```
-Create a virtual Python environment where we will install Home Assistent into.
-This will leave the Python package untouched, makes Home Assistent work better and installable/updateable without sudo.
+Create a virtual Python environment where we will install Home Assistant into.
+This will leave the Python package untouched, makes Home Assistant work better and installable/updateable without sudo.
 Note: After you made a virtual Python envoriment, you cant relocate the folder, else it will break. 
 Make a new one if you need to change it's name, the path or Shared-Folder.
 ```bash
@@ -271,12 +271,12 @@ Activate the virtual Python environment
 # source /volume1/homeassistant/venv-hass/bin/activate
 ```
 Install the “cross compiled module package” files we compiled earlier.
-This command expects you have copied the “*Module-Packages*” directory to your “*homeassistent*” Shared-Folder.
+This command expects you have copied the “*Module-Packages*” directory to your “*homeassistant*” Shared-Folder.
 ```bash
 # cd /volume1/homeassistant/Module-Packages
 # pip3 install cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl
 ```
-Install Home Assistent
+Install Home Assistant
 ```bash
 # pip3 install homeassistant
 ```
@@ -285,8 +285,8 @@ Leave the virtual Python environment
 # deactivate
 ```
 
-Create a file named “hass-daemon” in the “homeassistent” Shared-Folder with the script below as it's content.
-You can use it to easily start, stop and restart Home Assistent like a service/daemon.
+Create a file named “hass-daemon” in the “homeassistant” Shared-Folder with the script below as it's content.
+You can use it to easily start, stop and restart Home Assistant like a service/daemon.
 
 ```sh
 #!/bin/sh

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -22,7 +22,7 @@ There are 2 alternatives, when using Home Assistant on Synology NAS:
 1. Using Docker
 2. Directly running on DSM
 
-Option 1 is described on the [Docker installation page](/docs/installation/docker/), whereas Option 2 is described below.
+Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.
 
 
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -34,7 +34,7 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 * Create "homeassistant" [Shared-Folder](https://www.synology.com/en-us/knowledgebase/DSM/help/DSM/AdminCenter/file_share_desc)
 * Optionally start Home Assistant on bootup of your Synology
 
-## {% linkable_title Installing prerequisites) %}
+## {% linkable_title Getting prerequisites) %}
 
 #### {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -177,16 +177,12 @@ Replace "*user*" with your Synology user and "x.x.x.x" with the its IP adress:
 ```bash
 $ ssh user@x.x.x.x
 ```
-Install the cross compiled module `.whl` package files we compiled earlier.
+Install the cross compiled module `.whl` package files we compiled earlier and Home Assistant.
 This command expects you have copied the "*Module-Packages*" directory to your "*homeassistant*" Shared-Folder.
 ```bash
 $ /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
+$ /volume1/@appstore/python3/bin/python3 -m pip install homeassistant
 ```
-Install Home Assistant:
-```bash
- /volume1/@appstore/python3/bin/python3 -m pip install homeassistant
-```
-
 Create a file named "hass-daemon" in the "homeassistant" Shared-Folder with the script below as its content.
 You can use it to easily start, stop and restart Home Assistant like a service/daemon.
 ```sh

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -172,7 +172,7 @@ Run these commands to extract the packages, please replace "python3_**XXXX**.spk
 pyspk=python3_armada370-6.1_3.5.5-7.spk
 mkdir ~/Module-Packages
 cd ~/Module-Packages
-tar -x -f ~/spksrc/spksrc/packages/$pyspk -C /tmp package.tgz; gunzip /tmp/package.tgz
+tar -x -f ~/spksrc/spksrc/packages/$pyspk -C /tmp package.tgz; gzip -df /tmp/package.tgz
 for file in cffi-1.11.5 bcrypt-3.1.4 cryptography-2.3.1 pycryptodome-3.7.2; do tar -x -f /tmp/package.tar share/wheelhouse/$file-cp35-none-any.whl --strip=2; done
 ```
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -127,11 +127,9 @@ export CFLAGS=-pthread
 Run the container, this will make your terminal run inside the Docker container:
 ```bash
 $ docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
-$ cd spksrc/
 $ make setup
 $ cd spk/python3
 ```
-
 Compile Python 3 for your Synology model, please replace "arch-**XXXX**" by the apporiate architecture of your Synology. For a list of architectures, look at the [list on architectures spkrc](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model). Depending on your device, compilation may take a hour or more (significantly less if you have a SSD and a good CPU).
 ```bash
 $ make arch-XXXX

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -321,7 +321,7 @@ To have Home Assistant start on bootup of your Synology NAS, do as follows:
 <p class="note warning">
 Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later.<br/>
 The instructions above describes how to install newer Home Assistant on your Synology NAS.<br/>
-If you want to proceed with a older version of Home Assistant, follow the instructions below. Please note that you may not be able to use certain components, such as "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)"
+If you want to proceed with a older version of Home Assistant, follow the instructions below. Please note that you may not be able to use certain components, such as "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)".
 </p>
 
 Running these commands will:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -107,12 +107,13 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 Now you need to extract the cross compiled module packages which you added earlier to "*requirements.txt*".
 Run these commands to extract the `.whl` files to a directory named "**Module-Packages**", please replace "python3_**XXXX**.spk" with the appropriate package filename:
 ```bash
-$ pyspk="$HOME/spksrc/packages/python3_XXXX.spk"
-$ pyreq="cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl"
 $ mkdir ~/Module-Packages
 $ cd ~/Module-Packages
-$ tar -x -f $pyspk -C /tmp package.tgz; gzip -df /tmp/package.tgz
-$ for file in $pyreq; do tar -x -f /tmp/package.tar share/wheelhouse/$file --strip=2; done
+$ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz; gzip -df /tmp/package.tgz
+$ for file in cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl curve25519_donna-1.3-cp35-none-any.whl ed25519-1.4-cp35-none-any.whl; do tar -x -f /tmp/package.tar share/wheelhouse/$file --strip=2; done
+```
+Inside some of the .whl archives you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is required for ARM based Synology's.
+```bash
 $ rand=$RANDOM; for module in *.whl; do unzip "$module" -d "temp$rand" && find "temp$rand" -name "*x86_64-linux-gnu*" -type f | while read -r file; do mv "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done && rm "$module" && (cd "temp$rand" && zip -r0 "../$module" ./) && rm -r "temp$rand"; done
 ```
 <p class="note">
@@ -307,7 +308,7 @@ $ /volume1/homeassistant/hass-daemon restart
 $ /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
-If you need a to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, compile, extract and install the new cross compiled module `.whl` package files to your Synology.
+If you need to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, extract and install the new cross compiled module `.whl` package files to your Synology.
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -42,7 +42,7 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 Install Docker:
 ```bash
 # sudo apt-get update
-# sudo apt install docker.io
+# sudo apt-get install docker.io
 ```
 Start Docker and enable start on system bootup:
 ```bash
@@ -308,8 +308,8 @@ To have Home Assistant start on bootup of your Synology NAS, do as follows:
 1. Click on the checkbox next to "*Enabled*"
 1. Make sure "*root*" is selected in "*User*"
 1. Go to "*Task Settings* settings
-1. in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
-1. Click on "*OK*".
+1. In "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
+1. Click on "*OK*"
 
 ---
 
@@ -487,5 +487,5 @@ To have Home Assistant start on bootup of your Synology NAS, do as follows:
 1. Click on the checkbox next to "*Enabled*"
 1. Make sure "*root*" is selected in "*User*"
 1. Go to "*Task Settings* settings
-1. in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
-1. Click on "*OK*".
+1. In "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
+1. Click on "*OK*"

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -15,7 +15,7 @@ Synology only provide <a href="https://www.synology.com/nl-nl/dsm/packages/py3k"
 </p>
 
 <p class="note">
-Update: You can install a more recent Home Assistant (e.g, 0.84.2) by manually compiling a Python 3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as "<a href="/components/discovery/">Discovery</a>", "<a href="/components/cloud/">Cloud</a>" and "<a href="/components/Xiaomi_Aqara/">Xiaomi_Aqara</a>". Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27">Python >=3.5.3 on Synology</a>.
+Update: You can install a more recent Home Assistant (e.g, 0.84.2) by manually compiling a Python 3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as "<a href="/components/discovery/">Discovery</a>", "<a href="/components/cloud/">Cloud</a>" and "<a href="/components/Xiaomi_Aqara/">Xiaomi_Aqara</a>". Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372">Python >=3.5.3 on Synology</a>.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -196,7 +196,9 @@ DNAME="Home Assistant"
 
 # Others
 USER="homeassistant"
-PYTHON="/volume1/@appstore/py3k/usr/local/bin/python3"
+PYTHON_DIR="/volume1/@appstore/python3/bin"
+PYTHON="$PYTHON_DIR/python3"
+HASS="$PYTHON_DIR/hass"
 INSTALL_DIR="/volume1/homeassistant"
 PID_FILE="$INSTALL_DIR/home-assistant.pid"
 FLAGS="-v --config $INSTALL_DIR --pid-file $PID_FILE --daemon"

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -94,7 +94,7 @@ ed25519==1.4
 Add these edits to fix OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.  
 Edit "*~/spksrc/spk/python3/Makefile*" and add the following text above the text "**include ../../mk/spksrc.spk.mk**":
 ```makefile
-## Fix needed to fix "_openssl.so: undefined symbol: pthread_atfork" error when using "xiaomi_aqara" component.
+## Makefile variable needed to fix "_openssl.so: undefined symbol: pthread_atfork" error when using "xiaomi_aqara" component.
 export CFLAGS=-pthread
 ```
 #### {% linkable_title Compiling the Python 3 package %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -98,7 +98,7 @@ Edit "*~/spksrc/spk/python3/Makefile*" and add the following text above the text
 export CFLAGS=-pthread
 ```
 #### {% linkable_title Compiling the Python 3 package %}
-Make the Python 3 package for your Synology model, please replace "arch-**XXXX**" by the apporiate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spkrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU).
+Make the Python 3 package for your Synology model, please replace "arch-**XXXX**" by the apporiate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU).
 ```bash
 # sudo docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
 $ make setup

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -106,7 +106,7 @@ After the compilation is done, you can find the Python 3 package at "*~/spksrc/p
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different arch and version.
 
 #### {% linkable_title Extracting cross compiled packages %}
-Now you need to extract your "cross compiled module package" files which you added earlier to "*requirements.txt*".
+Now you need to extract the cross compiled module packages which you added earlier to "*requirements.txt*".
 Run these commands to extract the `.whl` files to a directory named "**Module-Packages**", please replace "python3_**XXXX**.spk" with the appropriate package filename:
 ```bash
 $ pyspk="$HOME/spksrc/packages/python3_XXXX.spk"
@@ -118,7 +118,7 @@ $ for file in $pyreq; do tar -x -f /tmp/package.tar share/wheelhouse/$file --str
 $ rand=$RANDOM; for module in *.whl; do unzip "$module" -d "temp$rand" && find "temp$rand" -name "*x86_64-linux-gnu*" -type f | while read -r file; do mv "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done && rm "$module" && (cd "temp$rand" && zip -r0 "../$module" ./) && rm -r "temp$rand"; done
 ```
 <p class="note">
-If you added any other modules to "*requirements.txt*", you can find the modules inside "**~/spksrc/packages/python3_XXXX.spk*" > "*package.tgz*" > "*share/wheelhouse/XXXX.whl*".
+If you added any modules to "*requirements.txt*", you can find the modules `.whl` packages at "**~/spksrc/packages/python3_XXXX.spk*" > "*package.tgz*" > "*share/wheelhouse/XXXX.whl*".d
 </p>
 
 ## {% linkable_title Using the Synology webadmin %}
@@ -173,39 +173,20 @@ In the case you turned on the firewall on your Synology device, please config it
 * Click on "*OK*"
 * Click on "*OK*" again
 
-
 ## {% linkable_title Installing Home Assistant %}
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
 Replace "*user*" with your Synology user and "x.x.x.x" with the its IP adress:
 ```bash
 $ ssh user@x.x.x.x
 ```
-Create a virtual Python environment where you will install Home Assistant into.
-This will leave the Python package untouched and make Home Assistant installable/updateable without superuser:
-```bash
-$ /volume1/@appstore/python3/bin/python3 -m venv /volume1/homeassistant/venv-hass
-```
-<p class="note">
-After you made a virtual Python environment, you can't relocate the folder, else it will break. 
-Make a new one if you need to change it's name, the path or Shared-Folder.
-</p>
-
-Activate the virtual Python environment:
-```bash
-$ source /volume1/homeassistant/venv-hass/bin/activate
-```
-Install the "cross compiled module package" files we compiled earlier.
+Install the cross compiled module `.whl` package files we compiled earlier.
 This command expects you have copied the "*Module-Packages*" directory to your "*homeassistant*" Shared-Folder.
 ```bash
 $ pip3 install /volume1/homeassistant/Module-Packages/*.whl
 ```
 Install Home Assistant:
 ```bash
-$ pip3 install homeassistant
-```
-Leave the virtual Python environment:
-```bash
-$ deactivate
+ /volume1/@appstore/python3/bin/python3 -m pip install homeassistant
 ```
 
 Create a file named "hass-daemon" in the "homeassistant" Shared-Folder with the script below as its content.
@@ -334,9 +315,7 @@ $ pip3 install --upgrade homeassistant
 $ deactivate
 ```
 <p class="note">
-If ever you need to update Python 3 or added a component of which the python modules requirements fail to install/compile on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, compile and add the new "cross compiled module package" names to the extracting commands.
-   
-You might also have to reinstall Home Assiatant, which can be done by deleting the '*venv-hass*' directory through SSH and redoing "[*Installing Home Assistant*](#Installing Home Assistant)".
+If you need a to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory, redo the steps from "[*Preparing compiling environment*](#Preparing compiling environment)", add the failed python modules to "*requirements.txt*" file, compile, extract and install the new cross compiled module `.whl` package files to your Synology.
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -39,7 +39,7 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 * Optionally start Home Assistant on bootup of your Synology
 
 
-Like you might have read above, at this time of writing, Synology has not provided a recent [Python 3](https://www.synology.com/nl-nl/dsm/packages/py3k) package, so we have to create a recent Python 3 package ourself.
+As you might have read in the note above, at this time of writing, Synology has not provided a recent [Python 3](https://www.synology.com/nl-nl/dsm/packages/py3k) package, so we have to create a recent Python 3 package ourself.
 Do not worry though, were gonna try keep this as painless as possible.
 
 Small summary: In this guide you will install [Docker](https://opensource.com/resources/what-docker) and run the [spksrc framework and Docker container](https://github.com/SynoCommunity/spksrc#docker) for the compiling environment. You will be using that to compile the new Python 3 package. Through the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM/help), you will install the package, configure settings and enable SSH, which you need to install Home Assistant on your Synology. Lastly you can autostart Home Assistant.
@@ -62,7 +62,7 @@ Add GPG key for the official Docker repository to your system:
 ```
 <p class="note">
 The "lsb_release -cs" sub-command below returns the name of your Ubuntu distribution, such as xenial.
-Sometimes, in a distribution like Linux Mint, you might need to change "lsb_release -cs" to your parent Ubuntu distribution.
+Sometimes, in a distribution like Linux Mint, you might need to change "*lsb_release -cs*" to your parent Ubuntu distribution.
 For example, if you are using Linux Mint **Tara** (e.g., 19), you could use **Bionic** (e.g., 18.04).
 </p>
 
@@ -103,7 +103,7 @@ You need to do this to get "cross compiled module package" files, which you requ
 These edits also enable you to use the "[Cloud](/components/cloud/)" component and fix the OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.
 
 
-Edit "*~/spksrc/spk/python3/src/requirements.txt*", add at the end of the file:
+Edit "*~/spksrc/spk/python3/src/requirements.txt*", add at the end of the file this text:
 ```
 ## It may happen you want to add components to Home Assistant, but you find these to fail requirements.
 ## Add the Python modules that fail to install/compile on the synology here for cross compilation.
@@ -122,7 +122,7 @@ pycryptodome==3.7.2
 #ed25519==1.4
 ```
 
-Edit "*~/spksrc/spk/python3/Makefile*", add above the line that says "<b>include ../../mk/spksrc.spk.mk</b>":
+Edit "*~/spksrc/spk/python3/Makefile*", above the line that says "**include ../../mk/spksrc.spk.mk**" add this text:
 ```makefile
 # Needed to fix "_openssl.so: undefined symbol: pthread_atfork" error caused by lack of libpthread linkage on Synology (Needed for SSL and "xiaomi_aqara" component)
 export CFLAGS=-pthread
@@ -145,8 +145,8 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 
 #### {% linkable_title Extracting cross compiled packages %}
 
-Now you need to extract your "cross compiled module package" files which you added earlier.
-Run these commands to extract the packages, please replace "python3_**XXXX**.spk" by the apporiate package filename:
+Now you need to extract your "cross compiled module package" files which you added earlier to "*requirements.txt*".
+Run these commands to extract the .whl files, please replace "python3_**XXXX**.spk" by the appropriate package filename:
 
 ```bash
 $ pyspk=python3_XXXX.spk
@@ -157,8 +157,8 @@ $ tar -x -f ~/spksrc/packages/$pyspk -C /tmp package.tgz; gzip -df /tmp/package.
 $ for file in $pyreq; do tar -x -f /tmp/package.tar share/wheelhouse/$file --strip=2; done
 ```
 <p class="note">
-If you added anything to "*requirements.txt*", modify the "*pyreq*" command to add the module filenames.
-You can find the modules at "*share/wheelhouse/XXXX.whl*" inside "*package.tar*", inside "*python3_XXXX.spk*".
+If you added any other modules to "*requirements.txt*", you can modify the "*pyreq*" command and add these modules filenames.
+You can find the modules inside "*python3_XXXX.spk*" > "*package.tgz*" > "*share/wheelhouse/XXXX.whl*".
 </p>
 
 This should give you a directory named "**Module-Packages**" with four .whl files, which you need to install later.
@@ -228,7 +228,7 @@ In the case you turned on the firewall on your Synology device, please config it
 * Go to "*Edit Rules*"
 * Click on "*Create*"
 * Select Custom: Destination port "TCP"
-* Type "8123" in port (e.g., setting in [*server_port*](/components/http/#server_port))
+* Type "8123" in port (e.g., setting of "[*server_port*](/components/http/#server_port)" in configuration.yaml)
 * Click on "*OK*"
 * Click on "*OK*" again
 
@@ -241,12 +241,15 @@ Replace "*user*" with your Synology user and "x.x.x.x" with the its IP adress:
 $ ssh user@x.x.x.x
 ```
 Create a virtual Python environment where we will install Home Assistant into.
-This will leave the Python package untouched, makes Home Assistant work better and installable/updateable without sudo.
-Note: After you made a virtual Python environment, you can't relocate the folder, else it will break. 
-Make a new one if you need to change it's name, the path or Shared-Folder.
+This will leave the Python package untouched and make Home Assistant installable/updateable without superuser:
 ```bash
 $ /volume1/@appstore/python3/bin/python3 -m venv /volume1/homeassistant/venv-hass
 ```
+<p class="note">
+After you made a virtual Python environment, you can't relocate the folder, else it will break. 
+Make a new one if you need to change it's name, the path or Shared-Folder.
+</p>
+
 Activate the virtual Python environment:
 ```bash
 $ source /volume1/homeassistant/venv-hass/bin/activate

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,11 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provide [Python 3.5.1](https://www.synology.com/nl-nl/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
-</p>
-
-<p class="note">
-Update: You can install a more recent Home Assistant (e.g, 0.84.2) by manually compiling a Python 3 package using the [spksrc compilation framework](https://github.com/SynoCommunity/spksrc). The new installation guide will be a little different though, but the upside is most failing components will now work, such as "[Discovery](/components/discovery/)", "[Cloud](/components/cloud/)" and "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)". Thread for more info: [Python >=3.5.3 on Synology](https://community.home-assistant.io/t/python-3-5-3-on-synology/46372).
+Synology only provides [Python 3.5.1](https://www.synology.com/nl-nl/dsm/packages/py3k), which is not which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed on their Python version. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -52,14 +48,11 @@ Start Docker and enable start on system boot
 # sudo systemctl start docker
 # sudo systemctl enable docker
 ```
-Download the spksrc Docker container:
+Download the [spksrc Docker container](https://github.com/SynoCommunity/spksrc#docker):
 ```bash
 # sudo docker pull synocommunity/spksrc
 ```
-
 #### {% linkable_title Preparing compiling environment %}
-You will now need to get the [spksrc framework and Docker container](https://github.com/SynoCommunity/spksrc#docker) for the compiling environment.
-
 Install Git
 ```bash
 # sudo apt-get install git
@@ -97,7 +90,6 @@ Edit "*~/spksrc/spk/python3/Makefile*", above the line that says "**include ../.
 # Needed to fix "_openssl.so: undefined symbol: pthread_atfork" error caused by lack of libpthread linkage on Synology (Needed for SSL and "xiaomi_aqara" component)
 export CFLAGS=-pthread
 ```
-
 #### {% linkable_title Compiling the Python 3 package %}
 Run the container, this will make your terminal run inside the Docker container:
 ```bash
@@ -114,7 +106,6 @@ After the compilation is done, you can find the Python 3 package at "*~/spksrc/p
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different arch and version.
 
 #### {% linkable_title Extracting cross compiled packages %}
-
 Now you need to extract your "cross compiled module package" files which you added earlier to "*requirements.txt*".
 Run these commands to extract the `.whl` files to a directory named "**Module-Packages**", please replace "python3_**XXXX**.spk" with the appropriate package filename:
 ```bash
@@ -131,7 +122,6 @@ If you added any other modules to "*requirements.txt*", you can find the modules
 </p>
 
 ## {% linkable_title Using the Synology webadmin %}
-
 Install the Python 3 package as follows:
 * Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
 * Press the "*Manual Install*" button on the top right of the window
@@ -185,7 +175,6 @@ In the case you turned on the firewall on your Synology device, please config it
 
 
 ## {% linkable_title Installing Home Assistant %}
-
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
 Replace "*user*" with your Synology user and "x.x.x.x" with the its IP adress:
 ```bash

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -42,13 +42,13 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 Like you might have read above, at this time of writing, Synology has not provided a recent [Python3](https://www.synology.com/nl-nl/dsm/packages/py3k) package, so we have to create a recent Python3 package ourself.
 Do not worry though, were gonna try keep this as painless as possible.
 
-## {% Preparing prerequisites %}
+## {% linkable_title Preparing prerequisites %}
 
 In this guide we are going to use a Linux based Operating System such as [Ubuntu](https://www.ubuntu.com/), [Mint](https://linuxmint.com/) or [Solus](https://getsol.us) to minimize difficulty. You will also need [Docker](https://docs.docker.com/install/).
 You can think of [Docker](https://docs.docker.com/install/) as a way more powerful [Chroot](https://help.ubuntu.com/community/BasicChroot) and containers as ready made mini operating systems.
 
 ---
-### {% Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
+### {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
 
 Refresh package lists:
 ```bash
@@ -80,7 +80,7 @@ Install Docker:
 # sudo apt-get install docker-ce
 ```
 ---
-### {% Installing Docker on [Solus](https://getsol.us) %}
+### {% linkable_title Installing Docker on [Solus](https://getsol.us) %}
 
 Update package lists:
 ```bash
@@ -146,7 +146,7 @@ Edit “*~/spksrc/spksrc/spk/python3/src/Makefile*”, add above the line that s
 export CFLAGS=-pthread
 ```
 
-## {% Compiling the Python3 package %}
+## {% linkable_title Compiling the Python3 package %}
 Run the container, this will make your terminal run inside the Docker container:
 ```bash
 # docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
@@ -199,7 +199,7 @@ Extract the .whl (these are zip archives), rename all files as described above, 
 </p>
 
 
-## {% Using the Synology webadmin: %}
+## {% linkable_title Using the Synology webadmin: %}
 
 Open Synology Package Center and press the “*Manual Install*” button.
 Click “*Browse*” and select the Python package we created, then press “*Next*”.
@@ -232,7 +232,7 @@ Incase you turned on the firewall on your Synology device, please update it as f
 * Click on OK again
 
 
-## {% Installing Home Assistent %}
+## {% linkable_title Installing Home Assistent %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
 Replace “<i>user</i>” with your Synology user and “x.x.x.x” with the its IP-Adress.
@@ -371,7 +371,7 @@ case $1 in
 esac
 ```
 
-## {% Controlling Home Assistent %}
+## {% linkable_title Controlling Home Assistent %}
 
 * Start Home Assistant:
 ```bash

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -101,7 +101,7 @@ $ make arch-XXXX
 $ exit
 ```
 After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
-It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different arch and version.
+It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
 
 #### {% linkable_title Extracting cross compiled packages %}
 Now you need to extract the cross compiled module `.whl` packages which you added earlier to "*requirements.txt*".

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -113,7 +113,7 @@ $ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz; gzip -df /tm
 $ for file in cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl curve25519_donna-1.3-cp35-none-any.whl ed25519-1.4-cp35-none-any.whl; do tar -x -f /tmp/package.tar share/wheelhouse/$file --strip=2; done
 ```
 Inside some of the `.whl` files (These are zip archives) you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is required for ARM based Synology's.  
-Run this command to all patch `.whl` files found in the current directory:
+Run this command to patch all `.whl` files found in the current directory:
 ```bash
 $ rand=$RANDOM; for module in *.whl; do unzip "$module" -d "temp$rand" && find "temp$rand" -name "*x86_64-linux-gnu*" -type f | while read -r file; do mv "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done && rm "$module" && (cd "temp$rand" && zip -r0 "../$module" ./) && rm -r "temp$rand"; done
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -16,10 +16,9 @@ Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/pac
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
 1. Using Docker (Recommended)
-2. Directly running on DSM
+1. Directly running on DSM
 
-Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.  
-Our recommendation is to run Home Assistant on Docker (If available) or a Raspberri Pi, as the instructions written below are a bit involved.
+Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below, but as the instructions below require compilation, our recommendation is to run Home Assistant on Docker (If available) or a Raspberri Pi.
 
 
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.
@@ -59,7 +58,7 @@ Install Git:
 ```
 Fork and clone [spksrc](https://github.com/SynoCommunity/spksrc), this will make a directory "~/spksrc":
 ```bash
-$ git clone https://github.com/SynoCommunity/spksrc.git ~/spksrc
+git clone https://github.com/SynoCommunity/spksrc.git ~/spksrc
 ```
 
 Edit the following 2 files.
@@ -90,7 +89,7 @@ curve25519-donna==1.3
 ed25519==1.4
 ```
 
-Add these edits to fix OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.  
+Add these edits to fix OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.<br/>
 Edit "*~/spksrc/spk/python3/Makefile*" and add the following text above the text "**include ../../mk/spksrc.spk.mk**":
 ```makefile
 ## Makefile variable needed to fix "_openssl.so: undefined symbol: pthread_atfork" error when using "xiaomi_aqara" component.
@@ -114,62 +113,62 @@ If you want to remove the Docker container downloaded by `docker run` to save dr
 ## {% linkable_title Using the Synology webadmin %}
 
 Install the Python 3 package as follows:
-* Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
-* Press the "*Manual Install*" button on the top right of the window
-* Click on "*Browse*" and select the Python 3 package you made earlier (e.g., "*~/spksrc/packages/python3_XXXX.spk*")
-* Click on "*Next*"
-* You will most likely get a unverified signature warning, click on "*Yes*"
-* Click on "*Apply*"
+1. Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
+1. Press the "*Manual Install*" button on the top right of the window
+1. Click on "*Browse*" and select the Python 3 package you made earlier (e.g., "*~/spksrc/packages/python3_XXXX.spk*")
+1. Click on "*Next*"
+1. You will most likely get a unverified signature warning, click on "*Yes*"
+1. Click on "*Apply*"
 
 Now while it's installing, you may setup the Shared-Folder for Home Assistant:
-* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
-* Go to "[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)" settings
-* Click on "*Create*"
-* In "*Name*" write "**homeassistant**"
-* in "*Description*" write "**Home Assistant**"
-* Click on "*Next*"
-* Click on "*Next*" again
-* Click on "*Apply*"
+1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+1. Go to "[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)" settings
+1. Click on "*Create*"
+1. In "*Name*" write "**homeassistant**"
+1. in "*Description*" write "**Home Assistant**"
+1. Click on "*Next*"
+1. Click on "*Next*" again
+1. Click on "*Apply*"
 
 As the "*homeassistant*" Shared-Folder has been made, copy the previously created "*~/Module-Packages*" directory there.
 
 Next setup the user:
-* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
-* Go to "[*User*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_user_desc)" settings
-* Click on "*Create*"
-* In "*Name*" write "**homeassistant**"
-* In "*Description*" write "**Home Assistant**"
-* The "*Password*" up to your choice
-* Click on "*Next*"
-* Make sure only "*users*" group is checked and click "*Next*"
-* Set the permission "*Read/Write*" for "*homeassistant*" and the all the other Shared-Folders to "*No access*"
-* Click on "*Next*"
-* Click on "*Next*" again
-* Click on "*Apply*"
+1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+1. Go to "[*User*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_user_desc)" settings
+1. Click on "*Create*"
+1. In "*Name*" write "**homeassistant**"
+1. In "*Description*" write "**Home Assistant**"
+1. The "*Password*" is up to your choice
+1. Click on "*Next*"
+1. Make sure only "*users*" group is checked and click "*Next*"
+1. Set the permission "*Read/Write*" for "*homeassistant*" and the all the other Shared-Folders to "*No access*"
+1. Click on "*Next*"
+1. Click on "*Next*" again
+1. Click on "*Apply*"
 
 Next you need to enable SSH:
-* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
-* Go to "[*Terminal & SNMP*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal)" settings
-* Click on the checkbox next to "*Enable SSH service*"
-* Click on "*Apply*"
+1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+1. Go to "[*Terminal & SNMP*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal)" settings
+1. Click on the checkbox next to "*Enable SSH service*"
+1. Click on "*Apply*"
 
 In the case you turned on the firewall on your Synology NAS, please config it to allow connections for Home Assistant:
-* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
-* Go to "[*Security*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_desc)" settings
-* Go to "[*Firewall*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_firewall)" settings
-* Go to "*Edit Rules*"
-* Click on "*Create*"
-* Select Custom: Destination port "TCP"
-* Type "8123" in port (e.g., setting of "[*server_port*](/components/http/#server_port)" in configuration.yaml)
-* Click on "*OK*"
-* Click on "*OK*" again
+1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+1. Go to "[*Security*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_desc)" settings
+1. Go to "[*Firewall*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_firewall)" settings
+1. Go to "*Edit Rules*"
+1. Click on "*Create*"
+1. Select Custom: Destination port "TCP"
+1. Type "8123" in port (e.g., setting of "[*server_port*](/components/http/#server_port)" in configuration.yaml)
+1. Click on "*OK*"
+1. Click on "*OK*" again
 
 ## {% linkable_title Installing Home Assistant %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
 Replace "*user*" with your Synology NAS user and "x.x.x.x" with the its IP address:
 ```bash
-$ ssh user@x.x.x.x
+ssh user@x.x.x.x
 ```
 Use `pip` to install Home Assistant.
 ```bash
@@ -285,15 +284,15 @@ esac
 
 * Start Home Assistant:
 ```bash
-$ /volume1/homeassistant/hass-daemon start
+/volume1/homeassistant/hass-daemon start
 ```
 * Stop Home Assistant:
 ```bash
-$ /volume1/homeassistant/hass-daemon stop
+/volume1/homeassistant/hass-daemon stop
 ```
 * Restart Home Assistant:
 ```bash
-$ /volume1/homeassistant/hass-daemon restart
+/volume1/homeassistant/hass-daemon restart
 ```
 * Upgrade Home Assistant:
 ```bash
@@ -306,15 +305,15 @@ If you need to update Python 3 or added a component which fails caused by a Pyth
 ## {% linkable_title Starting Home Assistant on bootup %}
 
 To have Home Assistant start on bootup of your Synology NAS, do as follows:
-* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
-* Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
-* Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
-* In "*Task*" write "**Home Assistant**"
-* Click on the checkbox next to "*Enabled*"
-* Make sure "*root*" is selected in "*User*"
-* Go to "*Task Settings* settings
-* in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
-* Click on "*OK*".
+1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+1. Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
+1. Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
+1. In "*Task*" write "**Home Assistant**"
+1. Click on the checkbox next to "*Enabled*"
+1. Make sure "*root*" is selected in "*User*"
+1. Go to "*Task Settings* settings
+1. in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
+1. Click on "*OK*".
 
 ---
 
@@ -338,9 +337,9 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 ### Install Synology provided Python 3
 
 Install Python 3 as follows:
-* Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
-* Go to "*All Packages*"
-* Scroll all the way down until you find "*Python3*" and click on "*Install*"
+1. Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
+1. Go to "*All Packages*"
+1. Scroll all the way down until you find "*Python3*" and click on "*Install*"
 
 Follow the other instructions at "[Using the Synology webadmin](#-linkable_title-using-the-synology-webadmin-)", ignore the  "Python 3 package" part.
 
@@ -467,27 +466,27 @@ esac
 ### Starting Home Assistant on bootup
 
 To have Home Assistant start on bootup of your Synology NAS, do as follows:
-* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
-* Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
-* Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
-* In "*Task*" write "**Home Assistant**"
-* Click on the checkbox next to "*Enabled*"
-* Make sure "*root*" is selected in "*User*"
-* Go to "*Task Settings* settings
-* in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
-* Click on "*OK*".
+1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+1. Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
+1. Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
+1. In "*Task*" write "**Home Assistant**"
+1. Click on the checkbox next to "*Enabled*"
+1. Make sure "*root*" is selected in "*User*"
+1. Go to "*Task Settings* settings
+1. in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
+1. Click on "*OK*".
 
 ### Controlling Home Assistant
 
 * Start Home Assistant:
 ```bash
-$ /volume1/homeassistant/hass-daemon start
+/volume1/homeassistant/hass-daemon start
 ```
 * Stop Home Assistant:
 ```bash
-$ /volume1/homeassistant/hass-daemon stop
+/volume1/homeassistant/hass-daemon stop
 ```
 * Restart Home Assistant:
 ```bash
-$ /volume1/homeassistant/hass-daemon restart
+/volume1/homeassistant/hass-daemon restart
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -19,6 +19,7 @@ There are 2 alternatives, when using Home Assistant on Synology NAS:
 2. Directly running on DSM
 
 Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.
+Our recommendation is you run Home Assistant on a Raspberri Pi, as this setup might be a bit more involved than you will like.
 
 
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -65,7 +65,7 @@ $ git clone https://github.com/SynoCommunity/spksrc.git
 
 Now you need to edit 2 files.
 Doing this will cross compile python modules, which are needed for Home Assistant to able to install.
-These edits also enable you to use the "[Cloud](/components/cloud/)" component and fix the OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.
+These edits also enable you to use the "[Cloud](/components/cloud/)", [Homekit](/components/homekit/) component and fix the OpenSSL errors when using the "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)" component.
 
 
 Edit "*~/spksrc/spk/python3/src/requirements.txt*", add at the end of the file this text:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/nl-nl/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -32,7 +32,8 @@ Running these commands will:
 Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM/help):
 * Install compiled Python 3 package using the [Synology Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
 * Create "homeassistant" user
-* Create "homeassistant" [Shared-Folder](https://www.synology.com/en-us/knowledgebase/DSM/help/DSM/AdminCenter/file_share_desc)
+* Create "homeassistant" [Shared-Folder](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_share_desc)
+* Enable [SSH](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal) service
 * Optionally start Home Assistant on bootup of your Synology
 
 ## {% linkable_title Getting prerequisites) %}
@@ -161,7 +162,7 @@ Next setup the user:
 
 Next you need to enable SSH:
 * Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
-* Go to "[*Terminal & SNMP*](https://www.synology.com/nl-nl/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal)" settings
+* Go to "[*Terminal & SNMP*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal)" settings
 * Click on the checkbox next to "*Enable SSH service*"
 * Click on "*Apply*"
 
@@ -319,7 +320,7 @@ If you need to update Python 3 or added a component which fails caused by python
 ## {% linkable_title Starting Home Assistant on bootup %}
 To have Home Assistant start on bootup of your Synology, do as follows:
 * Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
-* Go to "[*Task Scheduler*](https://www.synology.com/en-us/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
+* Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
 * Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
 * In "*Task*" write "**Home Assistant**"
 * Click on the checkbox next to "*Enabled*"

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -180,6 +180,8 @@ Extract the .whl (these are zip archives), rename all files as described above, 
 
 ## {% linkable_title Using the Synology webadmin %}
 
+
+Install the Python 3 package as follows:
 * Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
 * Press the "*Manual Install*" button on the top right of the window
 * Click on "*Browse*" and select the Python 3 package you created earlier
@@ -211,6 +213,12 @@ Next setup the user:
 * Set the permission "*Read/Write*" for "*homeassistant*" and the all the other Shared-Folders to "*No access*"
 * Click on "*Next*"
 * Click on "*Next*" again
+* Click on "*Apply*"
+
+Next you need to enable SSH:
+* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+* Go to "[*Terminal & SNMP*](https://www.synology.com/nl-nl/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal)" settings
+* Click on the checkbox next to "*Enable SSH service*"
 * Click on "*Apply*"
 
 In the case you turned on the firewall on your Synology device, please config it to allow connections for Home Assistant:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -164,7 +164,7 @@ Compile Python3 for your Synology model
 ```bash
 # make arch-XXXX
 ```
-After the compilation is done, you can find the Python package at “~/spksrc/spksrc/packages/python3_XXXX.spk”.
+After the compilation is done, you can find the Python package at “*~/spksrc/spksrc/packages/python3_XXXX.spk*”.
 It should be named something like “python3_armada370-6.1_3.5.5-7.spk”, of course with a possibly different arch and version.
 
 Now you need to extract your “cross compiled module package” files which you added earlier.
@@ -186,9 +186,9 @@ Run these commands to extract the packages
 # 7z e package.tar -o"Module-Packages" "share/wheelhouse/cryptography-2.3.1-cp35-none-any.whl"
 # 7z e package.tar -o"Module-Packages" "share/wheelhouse/pycryptodome-3.7.2-cp35-none-any.whl"
 ```
-This should give you a directory “Module-Packages” with four .whl files, which you need to install later.
-Inside some of the .whl archives we need to rename files with “**x86_64-linux-gnu**” to “**arm-linux-gnueabihf**”.
-If we dont, these will be ignored by Python on ARM based Synology's, causing Home Assistent to not function.
+This should give you a directory named “**Module-Packages**” with four .whl files, which you need to install later.
+Inside some of the .whl archives you need to rename all files containing the text “**x86_64-linux-gnu**” to “**arm-linux-gnueabihf**”.
+If you do not, these will be ignored by Python on ARM based Synology's, causing Home Assistent to not function.
 ```bash
 # 7z rn "Module-Packages/cffi-1.11.5-cp35-none-any.whl" "_cffi_backend.cpython-35m-x86_64-linux-gnu.so" "_cffi_backend.cpython-35m-arm-linux-gnueabihf.so"
 # 7z l "Module-Packages/pycryptodome-3.7.2-cp35-none-any.whl" | grep "x86_64-linux-gnu" | cut -c54- | while read -r file; do 7z rn "Module-Packages/pycryptodome-3.7.2-cp35-none-any.whl" "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done
@@ -196,29 +196,28 @@ If we dont, these will be ignored by Python on ARM based Synology's, causing Hom
 <p class='note'>
 The 7z <b>rn</b> (eg, rename) parameter was included from 7-Zip 9.30, in the case you are pitifully stuck on a older version, do as follows.
 Extract the .whl (these are zip archives), rename all files as described above, then rearchive as zip (ofcourse the same full name with .whl and without .zip).
-If that is not possible, then upgrade your base or switch to a recent distribution so you can.
 </p>
 
 
 ## {% Using the Synology webadmin: %}
 
-Open Synology Package Center and press the “Manual Install” button.
-Click “Browse” and select the Python package we created, then press “Next”.
-You will get a unverified package popup, press yes and next screen press Apply.
+Open Synology Package Center and press the “*Manual Install*” button.
+Click “*Browse*” and select the Python package we created, then press “*Next*”.
+You will get a unverified package popup, press yes and next screen press “*Apply*”.
 
-Now while it's installing, you can setup the user and Shared-Folder for Home Assistent.
+Now while it's installing, you may setup the user and Shared-Folder for Home Assistent.
 
-Open “Control Panel”, go to “Shared-Folder” settings and click on “Create”.
-In “Name” write “**homeassistant**”, in "Description” write “**Home Assistent**”
-Click “Next”, same for second screen, the third screen click “Apply”.
+Open “*Control Panel*”, go to “*Shared-Folder*” settings and click on “*Create*”.
+In “*Name*” write “**homeassistant**”, in "Description” write “**Home Assistent**”
+Click “*Next*”, same for second screen, the third screen click “*Apply*”.
 
-Next go to “User” settings and click on “Create”.
-In "Name" write “**homeassistant**”, in "Description” write “**Home Assistent**”, "Password" is up to you.
-Click “Next”, next screen leave only “users” group checked and click “Next”.
-In this screen, set permission “No access” for all Shared-Folders and only “homeassistent” Shared-Folder to “Read/Write.”
-Click “Next” on this screen and the next, on the last screen click “Apply”.
+Next go to “*User*” settings and click on “*Create*”.
+In "*Name*" write “**homeassistant**”, in "*Description*” write “**Home Assistent**”, "*Password*" is up to your choice.
+Click “*Next*”, next screen leave only “*users*” group checked and click “*Next*”.
+In this screen, set permission “*No access*” for all Shared-Folders and only “*homeassistent*” Shared-Folder to “*Read/Write*”.
+Click “*Next*” on this screen and the next, on the last screen click “*Apply*”.
 
-Now the “homeassistent” Shared-Folder has been made, you need to copy the “Module-Packages” directory there.
+Now the “*homeassistent*” Shared-Folder has been made, you need to copy the “*Module-Packages*” directory there.
 
 Incase you turned on the firewall on your Synology device, please update it as follows to allow connections for Home Assistent:
 
@@ -252,7 +251,7 @@ Activate the virtual Python environment
 # source /volume1/homeassistant/venv-hass/bin/activate
 ```
 Install the “cross compiled module package” files we compiled earlier.
-This command expects you have copied the “Module-Packages” directory to your “homeassistent” Shared-Folder.
+This command expects you have copied the “*Module-Packages*” directory to your “*homeassistent*” Shared-Folder.
 ```bash
 # cd /volume1/homeassistant/Module-Packages
 # pip3 install cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -171,7 +171,7 @@ Replace "*user*" with your Synology NAS user and "x.x.x.x" with the its IP addre
 ```bash
 $ ssh user@x.x.x.x
 ```
-Install Home Assistant.
+Use `pip` to install Home Assistant.
 ```bash
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install homeassistant
 ```
@@ -342,18 +342,18 @@ Install Python 3 as follows:
 
 Follow the other instructions at "[Using the Synology webadmin](#-linkable_title-using-the-synology-webadmin-)", ignore the  "Python 3 package" part.
 
-### Installing Home Assistant
+### Installing Home Assistant 0.64.3
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
 Replace "*user*" with your Synology NAS user and "x.x.x.x" with the its IP address:
 ```bash
 $ ssh user@x.x.x.x
 ```
-Install PIP (Python’s package management system)
+Install `pip` (Python’s package management system)
 ```bash
 # sudo /volume1/@appstore/py3k/usr/local/bin/python3 -m ensurepip
 ```
-Use PIP to install Homeassistant package 0.64.3
+Use `pip` to install Homeassistant package 0.64.3
 ```bash
 # sudo /volume1/@appstore/py3k/usr/local/bin/python3 -m pip install homeassistant==0.64.3
 ```
@@ -463,7 +463,17 @@ case $1 in
 esac
 ```
 ### Starting Home Assistant on bootup
-To have Home Assistant start on bootup of your Synology NAS, follow "[Starting Home Assistant on bootup](#-linkable_title-starting-home-assistant-on-bootup-)".
+
+To have Home Assistant start on bootup of your Synology NAS, do as follows:
+* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+* Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
+* Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
+* In "*Task*" write "**Home Assistant**"
+* Click on the checkbox next to "*Enabled*"
+* Make sure "*root*" is selected in "*User*"
+* Go to "*Task Settings* settings
+* in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
+* Click on "*OK*".
 
 ### Controlling Home Assistant
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -340,7 +340,7 @@ Install Python 3 as follows:
 * Go to "*All Packages*"
 * Scroll all the way down until you find "*Python3*" and click on "*Install*"
 
-Follow the other instructions from "[Using the Synology webadmin](#-linkable_title-using-the-synology-webadmin-)".
+Follow the other instructions at "[Using the Synology webadmin](#-linkable_title-using-the-synology-webadmin-)", ignore the  "Python 3 package" part.
 
 ### Installing Home Assistant
 
@@ -462,4 +462,20 @@ case $1 in
         ;;
 esac
 ```
+### Starting Home Assistant on bootup
 To have Home Assistant start on bootup of your Synology NAS, follow "[Starting Home Assistant on bootup](#-linkable_title-starting-home-assistant-on-bootup-)".
+
+### Controlling Home Assistant
+
+* Start Home Assistant:
+```bash
+$ /volume1/homeassistant/hass-daemon start
+```
+* Stop Home Assistant:
+```bash
+$ /volume1/homeassistant/hass-daemon stop
+```
+* Restart Home Assistant:
+```bash
+$ /volume1/homeassistant/hass-daemon restart
+```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -175,7 +175,7 @@ In the case you turned on the firewall on your Synology device, please config it
 
 ## {% linkable_title Installing Home Assistant %}
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
-Replace "*user*" with your Synology user and "x.x.x.x" with the its IP adress:
+Replace "*user*" with your Synology user and "x.x.x.x" with the its IP address:
 ```bash
 $ ssh user@x.x.x.x
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -111,7 +111,7 @@ Now you need to extract the Python module packages which you added earlier to "*
 Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "python3_**XXXX**.spk" points to the package file you made earlier.
 ```bash
 $ mkdir ~/Module-Packages && cd ~/Module-Packages
-$ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz; gzip -df /tmp/package.tgz && tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2
+$ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz && gzip -df /tmp/package.tgz && tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2
 ```
 Inside some of the `.whl` files (These are zip archives) you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is only required for ARM based Synology NAS.  
 Run this command to patch all `.whl` files found in the current directory:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -61,7 +61,7 @@ Install Git
 ```
 Fork and clone spksrc, this will make a directory named "spksrc".
 ```bash
-$ git clone https://github.com/SynoCommunity/spksrc.git
+$ git clone https://github.com/SynoCommunity/spksrc.git ~/spksrc
 ```
 
 Edit the following 2 files.
@@ -84,7 +84,7 @@ cffi==1.11.5
 bcrypt==3.1.4
 cryptography==2.3.1
 
-## Cross compilation requirement for installing "Warrent" module (Needed by "Cloud" Component)
+## Cross compilation requirement for installing "Warrant" module (Needed by "Cloud" Component)
 pycryptodome==3.7.2
 
 ## Cross compilation requirement for installing "HAP_python" module (Needed by "Homekit" Component)
@@ -101,11 +101,7 @@ export CFLAGS=-pthread
 #### {% linkable_title Compiling the Python 3 package %}
 Make the Python 3 package for your Synology model, please replace "arch-**XXXX**" by the apporiate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU).
 ```bash
-# sudo docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
-$ make setup
-$ cd spk/python3
-$ make arch-XXXX
-$ exit
+sudo docker run -it --rm -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
 ```
 After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
@@ -120,7 +116,7 @@ $ pyspk="$HOME/spksrc/packages/python3_XXXX.spk"
 $ tar -x -f $pyspk -C /tmp package.tgz; gzip -df /tmp/package.tgz
 $ tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2
 ```
-Inside some of the `.whl` files (These are zip archives) you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is only required for ARM based Synology's.  
+Inside some of the `.whl` files (These are zip archives) you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is only required for ARM based Synology NAS.  
 Run this command to patch all `.whl` files found in the current directory:
 ```bash
 $ rand=$RANDOM; for module in *.whl; do unzip "$module" -d "temp$rand" && find "temp$rand" -name "*x86_64-linux-gnu*" -type f | while read -r file; do mv "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done && rm "$module" && (cd "temp$rand" && zip -r0 "../$module" ./) && rm -r "temp$rand"; done

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can follow the instructions "[Using older Python 3 provided by Synology](#-linkable_title-using-older-python-3-provided-by-synology-)" way below of the document.
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can follow the instructions "[Using older Python 3 provided by Synology](#using-older-python-3-provided-by-synology)" way below of the document.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -19,7 +19,6 @@ There are 2 alternatives, when using Home Assistant on Synology NAS:
 1. Directly running on DSM
 
 Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below, but as the instructions below require compilation, our recommendation is to run Home Assistant on Docker (If available) or a Raspberri Pi.
-
 
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.
 
@@ -299,7 +298,7 @@ esac
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
-If you need to update Python 3 or added a component which fails caused by a Python module not installing on your on your Synology NAS with error code "*Failed building wheel for *Module_Name**", delete the "*~/spksrc*" directory and redo the guide, but add the failed python modules to "*requirements.txt*" from "[Preparing compiling environment](#-linkable_title-preparing-compiling-environment-)".
+If you need to update Python 3 or added a component which fails caused by a Python module not installing on your on your Synology NAS with error code "*Failed building wheel for *Module_Name**", delete the "*~/spksrc*" directory and redo the guide, but add the failed python modules to "*requirements.txt*" from "[Preparing compiling environment](#title-preparing-compiling-environment)".
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}
@@ -341,7 +340,7 @@ Install Python 3 as follows:
 1. Go to "*All Packages*"
 1. Scroll all the way down until you find "*Python3*" and click on "*Install*"
 
-Follow the other instructions at "[Using the Synology webadmin](#-linkable_title-using-the-synology-webadmin-)", ignore the  "Python 3 package" part.
+Follow the other instructions at "[Using the Synology webadmin](#title-using-the-synology-webadmin)", ignore the  "Python 3 package" part.
 
 ### {% linkable_title Installing Home Assistant 0.64.3 %}
 

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -103,8 +103,7 @@ Depending on your computer, compilation may take a hour or more (Significantly l
 ```bash
 # sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make clean && make setup && make -C spk/python3 arch-XXXX'
 ```
-After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".<br/>
-It should be named something like "python3_armada370-6.1_3.5.5-7.spk" with a possibly different architecture and version.
+After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*". It should be named something like "python3_armada370-6.1_3.5.5-7.spk" with a possibly different architecture and version.
 
 To remove the Docker container downloaded by `docker run` to save drive space, run the following command:
 ```bash

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -340,7 +340,7 @@ Install Python 3 as follows:
 * Go to "*All Packages*"
 * Scroll all the way down until you find "*Python3*" and click on "*Install*"
 
-Follow the other instructions from "[Using the Synology webadmin](#-linkable_title-using-the-Synology-webadmin)".
+Follow the other instructions from "[Using the Synology webadmin](#-linkable_title-using-the-synology-webadmin-)".
 
 ### Installing Home Assistant
 
@@ -462,4 +462,4 @@ case $1 in
         ;;
 esac
 ```
-To have Home Assistant start on bootup of your Synology NAS, follow "[Starting Home Assistant on bootup](#-linkable_title-starting-home-assistant-on-bootup)".
+To have Home Assistant start on bootup of your Synology NAS, follow "[Starting Home Assistant on bootup](#-linkable_title-starting-home-assistant-on-bootup-)".

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -180,8 +180,7 @@ Replace "*user*" with your Synology user and "x.x.x.x" with the its IP address:
 $ ssh user@x.x.x.x
 ```
 Install the `.whl` module package files you made earlier and Home Assistant.  
-This command expects you have copied the "*Module-Packages*" directory from "[Extracting cross compiled packages](#-linkable_title-controlling-home-assistant-)" to your "*homeassistant*" Shared-Folder.
-
+This command expects you have copied the "*Module-Packages*" directory from "[Extracting cross compiled packages](#-linkable_title-extracting-cross-compiled-packages-)" to your "*homeassistant*" "[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)".
 ```bash
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install homeassistant

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -45,7 +45,6 @@ Do not worry though, were gonna try keep this as painless as possible.
 ## {% linkable_title Preparing prerequisites %}
 
 In this guide we are going to use a Linux based Operating System such as [Ubuntu](https://www.ubuntu.com/), [Mint](https://linuxmint.com/) or [Solus](https://getsol.us) to minimize difficulty. You will also need [Docker](https://docs.docker.com/install/).
-You can think of [Docker](https://docs.docker.com/install/) as a way more powerful [Chroot](https://help.ubuntu.com/community/BasicChroot) and containers as ready made mini operating systems.
 
 
 ### {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -40,12 +40,12 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 
 #### {% linkable_title Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
 
-Install Docker
+Install Docker:
 ```bash
 # sudo apt-get update
 # sudo apt install docker.io
 ```
-Start Docker and enable start on system bootup
+Start Docker and enable start on system bootup:
 ```bash
 # sudo systemctl start docker
 # sudo systemctl enable docker
@@ -55,11 +55,11 @@ Download the [spksrc Docker container](https://github.com/SynoCommunity/spksrc#d
 # sudo docker pull synocommunity/spksrc
 ```
 #### {% linkable_title Preparing compiling environment %}
-Install Git
+Install Git:
 ```bash
 # sudo apt-get install git
 ```
-Fork and clone spksrc, this will make a directory "~/spksrc".
+Fork and clone spksrc, this will make a directory "~/spksrc":
 ```bash
 $ git clone https://github.com/SynoCommunity/spksrc.git ~/spksrc
 ```
@@ -99,7 +99,7 @@ Edit "*~/spksrc/spk/python3/Makefile*" and add the following text above the text
 export CFLAGS=-pthread
 ```
 #### {% linkable_title Compiling the Python 3 package %}
-Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "arch-**XXXX**" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU).
+Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "arch-**XXXX**" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
 ```bash
 sudo docker run -it --rm -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
 ```
@@ -108,7 +108,7 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 
 #### {% linkable_title Extracting cross compiled packages %}
 Now you need to extract the Python module packages which you added earlier to "*requirements.txt*".
-Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "python3_**XXXX**.spk" points to the package file you made earlier.
+Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "python3_**XXXX**.spk" points to the package file you made earlier:
 ```bash
 $ mkdir ~/Module-Packages && cd ~/Module-Packages
 $ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz && gzip -df /tmp/package.tgz && tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2
@@ -177,7 +177,7 @@ Replace "*user*" with your Synology user and "x.x.x.x" with the its IP address:
 $ ssh user@x.x.x.x
 ```
 Install the `.whl` module package files you made earlier and Home Assistant.  
-This command expects you have copied the "*~/Module-Packages*" directory from "[Extracting cross compiled packages](#-linkable_title-extracting-cross-compiled-packages-)" to your "*homeassistant*" "[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)".
+This command expects you have copied the "*~/Module-Packages*" directory from "[Extracting cross compiled packages](#-linkable_title-extracting-cross-compiled-packages-)" to your "*homeassistant*" "[*Shared-Folder*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_desc)":
 ```bash
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install homeassistant

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -164,9 +164,9 @@ Extract the .whl (these are zip archives), rename all files as described above, 
 
 ## {% linkable_title Using the Synology webadmin %}
 
-* Open [Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
+* Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
 * Press the "*Manual Install*" button on the top right of the window
-* Click on "*Browse*" and select the Python 3 spk package you created earlier
+* Click on "*Browse*" and select the Python 3 package you created earlier
 * Click on "*Next*"
 * You will most likely get a unverified signature warning, click on "*Yes*"
 * Click on "*Apply*"
@@ -195,7 +195,7 @@ Next setup the user:
 * Set the permission "*Read/Write*" for "*homeassistant*" and the all the other Shared-Folders to "*No access*"
 * Click on "*Next*"
 * Click on "*Next*" again
-* Click on "*Apply*".
+* Click on "*Apply*"
 
 In the case you turned on the firewall on your Synology device, please config it to allow connections for Home Assistant:
 * Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
@@ -212,7 +212,7 @@ In the case you turned on the firewall on your Synology device, please config it
 ## {% linkable_title Installing Home Assistant %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
-Replace "<i>user</i>" with your Synology user and "x.x.x.x" with the its IP-Adress.
+Replace "<i>user</i>" with your Synology user and "x.x.x.x" with the its IP adress.
 ```bash
 $ ssh user@x.x.x.x
 ```
@@ -242,7 +242,7 @@ Leave the virtual Python environment
 $ deactivate
 ```
 
-Create a file named "hass-daemon" in the "homeassistant" Shared-Folder with the script below as it's content.
+Create a file named "hass-daemon" in the "homeassistant" Shared-Folder with the script below as its content.
 You can use it to easily start, stop and restart Home Assistant like a service/daemon.
 
 ```sh
@@ -369,4 +369,14 @@ $ pip3 install --upgrade homeassistant
 $ deactivate
 ```
 
-## {% linkable_title Controlling Home Assistant %}
+## {% linkable_title Starting Home Assistant on bootup %}
+To have Home Assistant start on bootup of your Synology, do as follows:
+* Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+* Go to "[*Task Scheduler*](https://www.synology.com/en-us/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
+* Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
+* In "*Task*" write "**Home Assistant**"
+* Click on the checkbox next to "*Enabled*"
+* Make sure "*root*" is selected in "*User*"
+* Go to "*Task Settings* settings
+* in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
+* Click on "*OK*".

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,11 +11,11 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provide <a href="https://www.synology.com/nl-nl/dsm/packages/py3k">Python 3.5.1</a>, which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
+Synology only provide [Python 3.5.1](https://www.synology.com/nl-nl/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python 3 -m pip install homeassistant==0.64.3`
 </p>
 
 <p class="note">
-Update: You can install a more recent Home Assistant (e.g, 0.84.2) by manually compiling a Python 3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as "<a href="/components/discovery/">Discovery</a>", "<a href="/components/cloud/">Cloud</a>" and "<a href="/components/Xiaomi_Aqara/">Xiaomi_Aqara</a>". Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372">Python >=3.5.3 on Synology</a>.
+Update: You can install a more recent Home Assistant (e.g, 0.84.2) by manually compiling a Python 3 package using the [spksrc compilation framework](https://github.com/SynoCommunity/spksrc). The new installation guide will be a little different though, but the upside is most failing components will now work, such as "[Discovery](/components/discovery/)", "[Cloud](/components/cloud/)" and "[Xiaomi_Aqara](/components/Xiaomi_Aqara/)". Thread for more info: [Python >=3.5.3 on Synology](https://community.home-assistant.io/t/python-3-5-3-on-synology/46372).
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -63,7 +63,7 @@ Add GPG key for the official Docker repository to your system:
 <p class="note">
 The "lsb_release -cs" sub-command below returns the name of your Ubuntu distribution, such as xenial.
 Sometimes, in a distribution like Linux Mint, you might need to change "lsb_release -cs" to your parent Ubuntu distribution.
-For example, if you are using Linux Mint <b>Tara</b> (e.g., 19), you could use <b>Bionic</b> (e.g., 18.04).
+For example, if you are using Linux Mint **Tara** (e.g., 19), you could use **Bionic** (e.g., 18.04).
 </p>
 
 ```bash
@@ -157,8 +157,8 @@ $ tar -x -f ~/spksrc/packages/$pyspk -C /tmp package.tgz; gzip -df /tmp/package.
 $ for file in $pyreq; do tar -x -f /tmp/package.tar share/wheelhouse/$file --strip=2; done
 ```
 <p class="note">
-If you added anything to "<i>requirements.txt</i>", modify the "<i>pyreq</i>" command to add the module filenames.
-You can find the modules at "<i>share/wheelhouse/XXXX.whl</i>" inside "<i>package.tar</i>", inside "<i>python3_XXXX.spk</i>".
+If you added anything to "*requirements.txt*", modify the "*pyreq*" command to add the module filenames.
+You can find the modules at "*share/wheelhouse/XXXX.whl*" inside "*package.tar*", inside "*python3_XXXX.spk*".
 </p>
 
 This should give you a directory named "**Module-Packages**" with four .whl files, which you need to install later.
@@ -174,7 +174,7 @@ Run this command to rename all files containing "x86_64-linux-gnu" to "arm-linux
 $ for archive in *.whl; do 7z l "$archive" | grep "x86_64-linux-gnu" | cut -c54- | while read -r file; do 7z rn "$archive" "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done; done
 ```
 <p class="note">
-The 7z <b>rn</b> (e.g., rename) parameter was included from 7-Zip 9.30, in the case your distribution only has a older version available, do as follows.
+The 7z **rn** (e.g., rename) parameter was included from 7-Zip 9.30, in the case your distribution only has a older version available, do as follows.
 Extract the .whl (these are zip archives), rename all files as described above, then rearchive as zip (use the same full name with `.whl` as extension and not `.zip`).
 </p>
 
@@ -236,7 +236,7 @@ In the case you turned on the firewall on your Synology device, please config it
 ## {% linkable_title Installing Home Assistant %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
-Replace "<i>user</i>" with your Synology user and "x.x.x.x" with the its IP adress:
+Replace "*user*" with your Synology user and "x.x.x.x" with the its IP adress:
 ```bash
 $ ssh user@x.x.x.x
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -18,9 +18,8 @@ There are 2 alternatives, when using Home Assistant on Synology NAS:
 1. Using Docker
 2. Directly running on DSM
 
-Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.
-
-Our recommendation is you run Home Assistant on a Raspberri Pi, as this setup might be a bit more involved than you will like.
+Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.  
+Our recommendation is you run Home Assistant on Docker or a Raspberri Pi, as this setup might be a bit more involved than you will like.
 
 
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -230,7 +230,7 @@ Make a new one if you need to change it's name, the path or Shared-Folder.
 ```
 Activate the virtual Python environment
 ```bash
-# source ./venv-hass/bin/activate
+# source /volume1/homeassistant/venv-hass/bin/activate
 ```
 Install the “cross compiled module package” files we compiled earlier.
 This command expects you have copied the “Module-Packages” directory to your “homeassistent” Shared-Folder.
@@ -384,7 +384,7 @@ Here are some useful commands:
 ```
 * Upgrade Home Assistant:
 ```bash
-# source ./venv-hass/bin/activate
+# source /volume1/homeassistant/venv-hass/bin/activate
 # pip3 install --upgrade homeassistant
 # deactivate
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -104,16 +104,20 @@ These edits also enable you to use the "[Cloud](/components/cloud/)" component a
 
 Edit "*~/spksrc/spk/python3/src/requirements.txt*", add at the end of the file:
 ```
-##Cross compilation requirements for installing Home Assistant (Tested to work on 83.3).
-##In the future, the requirements may change (e.g., need newer version to work), modify as needed.
+## It may happen you want to add components to Home Assistant, but you find these to fail requirements.
+## Add the Python modules that fail to install/compile on the synology here for cross compilation.
+## In the future, the requirements may change (e.g., need newer version to work), modify as needed.
+
+## Cross compilation requirements for installing Home Assistant (Tested to work on 84.3).
 cffi==1.11.5
 bcrypt==3.1.4
 cryptography==2.3.1
-#Cross compilation requirement for installing "Warrent" module (Needed by "Cloud" Component)
+
+## Cross compilation requirement for installing "Warrent" module (Needed by "Cloud" Component)
 pycryptodome==3.7.2
 ```
 
-Edit "*~/spksrc/spk/python3/src/Makefile*", add above the line that says "<b>include ../../mk/spksrc.spk.mk</b>":
+Edit "*~/spksrc/spk/python3/Makefile*", add above the line that says "<b>include ../../mk/spksrc.spk.mk</b>":
 ```makefile
 # Needed to fix "_openssl.so: undefined symbol: pthread_atfork" error caused by lack of libpthread linkage on Synology (Needed for SSL and "xiaomi_aqara" component)
 export CFLAGS=-pthread

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -91,14 +91,11 @@ Edit "*~/spksrc/spk/python3/Makefile*", above the line that says "**include ../.
 export CFLAGS=-pthread
 ```
 #### {% linkable_title Compiling the Python 3 package %}
-Run the container, this will make your terminal run inside the Docker container:
+Compile Python 3 for your Synology model, please replace "arch-**XXXX**" by the apporiate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spkrc. Depending on your computer, compilation may take a hour or more (significantly less if you have a SSD and a good CPU).
 ```bash
 # sudo docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
 $ make setup
 $ cd spk/python3
-```
-Compile Python 3 for your Synology model, please replace "arch-**XXXX**" by the apporiate architecture of your Synology. For a list of architectures, look at the [list on architectures spkrc](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model). Depending on your device, compilation may take a hour or more (significantly less if you have a SSD and a good CPU).
-```bash
 $ make arch-XXXX
 $ exit
 ```

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -129,7 +129,7 @@ You need to do this to get “cross compiled module package” files, which you 
 These edits also enable you to use the “[Cloud](https://www.home-assistant.io/components/cloud)” component and fix the OpenSSL errors when using the “[Xiaomi_Aqara](https://www.home-assistant.io/components/Xiaomi_Aqara)” component.
 
 
-Edit “~/spksrc/spksrc/spk/python3/src/requirements.txt”, add at the end of the file:
+Edit “*~/spksrc/spksrc/spk/python3/src/requirements.txt*”, add at the end of the file:
 ```
 ##Cross compilation requirements for installing Home Assistent (Tested to work on 83.3).
 ##In the future, the requirements may change (need newer version to work, eg), modify as needed.
@@ -139,7 +139,8 @@ cryptography==2.3.1
 #Cross compilation requirement for installing “Warrent” module (Needed by “Cloud” Component)
 pycryptodome==3.7.2
 ```
-Edit “~/spksrc/spksrc/spk/python3/src/Makefile”, add above the line that says “<b>include ../../mk/spksrc.spk.mk</b>”:
+
+Edit “*~/spksrc/spksrc/spk/python3/src/Makefile*”, add above the line that says “<b>include ../../mk/spksrc.spk.mk</b>”:
 ```makefile
 # Needed to fix “_openssl.so: undefined symbol: pthread_atfork” error caused by lack of libpthread linkage on Synology (Needed for SSL and “xiaomi_aqara” component)
 export CFLAGS=-pthread

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -10,45 +10,45 @@ footer: true
 redirect_from: /getting-started/installation-synology/
 ---
 
-<p class='note warning'>
-Synology only provide Python 3.5.1, which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python3 -m pip install homeassistant==0.64.3`
+<p class="note warning">
+Synology only provide <a href="https://www.synology.com/nl-nl/dsm/packages/py3k">Python 3.5.1</a>, which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. You can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `./python3 -m pip install homeassistant==0.64.3`
 </p>
-<p class='note'>
-Update: You can install a more recent home assistent (Tested to work on Home Assistant 0.84.2) by manually compiling a python3 package using the spksrc compilation framework. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “Discovery”, “Cloud” and “Xiaomi_Aqara”. Thread for more info: [Python >=3.5.3 on Synology](https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27)
+
+<p class="note">
+Update: You can install a more recent home assistent (eg, 0.84.2) by manually compiling a python3 package using the <a href="https://github.com/SynoCommunity/spksrc">spksrc compilation framework</a>. The new installation guide will be a little different though, but the upside is most failing components will now work, such as “<a href="https://www.home-assistant.io/components/discovery">Discovery</a>”, “<a href="https://www.home-assistant.io/components/cloud">Cloud</a>” and “<a href="https://www.home-assistant.io/components/Xiaomi_Aqara">Xiaomi_Aqara</a>”. Thread for more info: <a href="https://community.home-assistant.io/t/python-3-5-3-on-synology/46372/27">Python >=3.5.3 on Synology</a>.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
-1. using Docker
-2. directly running on DSM
+1. Using Docker
+2. Directly running on DSM
 
 Option 1 is described on the [Docker installation page](/docs/installation/docker/), whereas Option 2 is described below.
 
 
-The following configuration has been tested on Synology 115j running DSM 6.2.1-23824 Update 1.
+The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.
 
 Running these commands will:
-* Compile the required new python3 package
+* Compile the required new Python3 package
 * Install Home Assistant
-* Enable Home Assistant to be launched on http://localhost:8123
+* Enable Home Assistant to be launched on http://*Synology_IP*:8123
 
-Using the Synology webadmin:
-* Install compiled python3 package using the Synology Package Center
+Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM):
+* Install compiled Python3 package using the [Synology Package Center](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)
 * Create “homeassistant” user and add to the “users” group
 * Create “homeassistant” “Shared-Folder”
 * Optionally Start Home Assistant on Bootup of Synology
 
 
-
-Like you might have read above, at this time of writing, Synology has not provided a recent Python3 package, so we will have to compile Python3 ourself.
+Like you might have read above, at this time of writing, Synology has not provided a recent [Python3](https://www.synology.com/nl-nl/dsm/packages/py3k) package, so we have to create a recent Python3 package ourself.
 Do not worry though, were gonna try keep this as painless as possible.
 
-## preparing prerequisites
+## {% Preparing prerequisites %}
 
-We are going to use a Linux based Operating System such as [Ubuntu](https://www.ubuntu.com/), [Mint](https://linuxmint.com/) or [Solus](https://getsol.us) to minimize difficulty. In this guide we will need [Docker](https://docs.docker.com/install/).
-You can think of Docker as a way more powerful Chroot and containers as ready made mini operating systems.
+In this guide we are going to use a Linux based Operating System such as [Ubuntu](https://www.ubuntu.com/), [Mint](https://linuxmint.com/) or [Solus](https://getsol.us) to minimize difficulty. You will also need [Docker](https://docs.docker.com/install/).
+You can think of [Docker](https://docs.docker.com/install/) as a way more powerful [Chroot](https://help.ubuntu.com/community/BasicChroot) and containers as ready made mini operating systems.
 
 ---
-### Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+### {% Installing Docker on [Mint, Ubuntu or derivatives](https://docs.docker.com/install/linux/docker-ce/ubuntu/) %}
 
 Refresh package lists:
 ```bash
@@ -62,10 +62,10 @@ Add GPG key for the official Docker repository to your system:
 ```bash
 # curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 ```
-<p class='note'>
-Note: The “lsb_release -cs” sub-command below returns the name of your Ubuntu distribution, such as xenial.
+<p class="note">
+The “lsb_release -cs” sub-command below returns the name of your Ubuntu distribution, such as xenial.
 Sometimes, in a distribution like Linux Mint, you might need to change “lsb_release -cs” to your parent Ubuntu distribution.
-For example, if you are using Linux Mint <b>Tara</b>“=19”, you could use <b>Bionic</b>“=18.04”.
+For example, if you are using Linux Mint <b>Tara</b> (eg, 19), you could use <b>Bionic</b> (eg, 18.04).
 </p>
 
 ```bash
@@ -80,7 +80,7 @@ Install Docker:
 # sudo apt-get install docker-ce
 ```
 ---
-### Installing Docker on Solus
+### {% Installing Docker on [Solus](https://getsol.us) %}
 
 Update package lists:
 ```bash
@@ -90,7 +90,7 @@ Install Docker:
 ```bash
 # sudo eopkg install docker
 ```
-Enable the Docker service at system boot:
+Enable the docker service at system boot:
 ```bash
 # sudo systemctl enable docker
 ```
@@ -99,29 +99,32 @@ Start the docker service:
 # sudo systemctl start docker
 ```
 ---
-To enable your user account to manage Docker without superuser privileges, add your “USER” account to the “docker” group:
+To enable your user account to manage Docker without superuser privileges, add your user account to the “docker” group:
 ```bash
-# sudo gpasswd -a USER docker
+# sudo gpasswd -a YOUR_USER_ACCOUNT docker
 ```
 
-You will now need to get the [spksrc Docker container](https://github.com/SynoCommunity/spksrc#docker) for the compiling environment.
+You will now need to get the [spksrc framework and Docker container](https://github.com/SynoCommunity/spksrc#docker) for the compiling environment.
 
-Pull/Download the spksrc Docker container, this will make a directory named “spksrc”.
+Install Git
+#### Ubuntu/Mint
 ```bash
-# docker pull synocommunity/spksrc
+# sudo apt-get install git
 ```
-Now run the container, this will make your terminal run inside the Docker container:
+#### Solus
 ```bash
-# docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
+# sudo eopkg install git
 ```
-While inside the container, clone/download the spkrc repository.
+Fork and clone spksrc, this will make a directory named “spksrc”.
 ```bash
-# git clone https://github.com/SynoCommunity/spksrc.git
+git clone https://You@github.com/You/spksrc.git ~/spksrc
+```
+Download the spksrc Docker container:
+```bash
+docker pull synocommunity/spksrc
 ```
 
-## Preparing to compile Python
-
-Before you continue in the container, you need to edit 2 files.
+Now you need to edit 2 files.
 You need to do this to get “cross compiled module package” files, which you require for Home Assistent to able to be installed.
 These edits also enable you to use the “Cloud” component and fix the OpenSSL errors when using the “Xiaomi_Aqara” component.
 
@@ -141,16 +144,17 @@ Edit “~/spksrc/spksrc/spk/python3/src/Makefile”, add above the line that say
 export CFLAGS=-pthread
 ```
 
-
-While still in the docker container, create the Python3 package:
+## {% Compiling the Python3 package %}
+Run the container, this will make your terminal run inside the Docker container:
 ```bash
+# docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash
 # cd spksrc/
 # make setup
 # cd spk/python3
 ```
 <p class='note'>
-    you have to change the arch-XXXX to the architecture of your Synology (eg, DS115j = arch-armada370)
-For information about the Arch of your Synology look at the {architecture List spkrc}[https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model]
+You need to change the arch-XXXX to the architecture of your Synology (eg, DS115j = arch-armada370)
+For information about the Arch of your Synology look at the <a href="https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model">list of architectures on spkrc</a>
 Depending on your device, compilation may take a hour or more (significantly less if you have a SSD and a good CPU).
 </p>
 
@@ -181,7 +185,7 @@ Run these commands to extract the packages
 # 7z e package.tar -o"Module-Packages" "share/wheelhouse/pycryptodome-3.7.2-cp35-none-any.whl"
 ```
 This should give you a directory “Module-Packages” with four .whl files, which you need to install later.
-Inside some of the .whl archives we need to rename files with “<b>x86_64-linux-gnu</b>” to “<b>arm-linux-gnueabihf</b>”.
+Inside some of the .whl archives we need to rename files with “**x86_64-linux-gnu**” to “**arm-linux-gnueabihf**”.
 If we dont, these will be ignored by Python on ARM based Synology's, causing Home Assistent to not function.
 ```bash
 # 7z rn "Module-Packages/cffi-1.11.5-cp35-none-any.whl" "_cffi_backend.cpython-35m-x86_64-linux-gnu.so" "_cffi_backend.cpython-35m-arm-linux-gnueabihf.so"
@@ -194,7 +198,7 @@ If that is not possible, then upgrade your base or switch to a recent distributi
 </p>
 
 
-## Using the Synology webadmin:
+## {% Using the Synology webadmin: %}
 
 Open Synology Package Center and press the “Manual Install” button.
 Click “Browse” and select the Python package we created, then press “Next”.
@@ -203,21 +207,34 @@ You will get a unverified package popup, press yes and next screen press Apply.
 Now while it's installing, you can setup the user and Shared-Folder for Home Assistent.
 
 Open “Control Panel”, go to “Shared-Folder” settings and click on “Create”.
-In “Name” write “<b>homeassistant</b>”, in "Description” write “<b>Home Assistent</b>”
+In “Name” write “**homeassistant**”, in "Description” write “**Home Assistent**”
 Click “Next”, same for second screen, the third screen click “Apply”.
 
 Next go to “User” settings and click on “Create”.
-In "Name" write “<b>homeassistant</b>”, in "Description” write “<b>Home Assistent</b>”, "Password" is up to you.
+In "Name" write “**homeassistant**”, in "Description” write “**Home Assistent**”, "Password" is up to you.
 Click “Next”, next screen leave only “users” group checked and click “Next”.
 In this screen, set permission “No access” for all Shared-Folders and only “homeassistent” Shared-Folder to “Read/Write.”
 Click “Next” on this screen and the next, on the last screen click “Apply”.
 
 Now the “homeassistent” Shared-Folder has been made, you need to copy the “Module-Packages” directory there.
 
-## Preparing to install Home Assistent
+Incase you turned on the firewall on your Synology device, please update it as follows to allow connections for Home Assistent:
 
-After the Python package has been installed, open terminal and open SSH to the synology.
-Replace “user” with your Synology user and “x.x.x.x” with the its IP-Adress.
+* Go to your Synology control panel
+* Go to security
+* Go to firewall
+* Go to Edit Rules
+* Click Create
+* Select Custom: Destination port "TCP"
+* Type "8123" in port (eg, setting in [server_port](https://www.home-assistant.io/components/http/#server_port)
+* Click on OK
+* Click on OK again
+
+
+## {% Installing Home Assistent %}
+
+After the Python 3 package has been installed, open terminal and open SSH to the synology.
+Replace “<i>user</i>” with your Synology user and “x.x.x.x” with the its IP-Adress.
 ```bash
 # ssh user@x.x.x.x
 ```
@@ -353,22 +370,7 @@ case $1 in
 esac
 ```
 
-Update your firewall (if it is turned on the Synology device):
-
-* Go to your Synology control panel
-* Go to security
-* Go to firewall
-* Go to Edit Rules
-* Click Create
-* Select Custom: Destination port "TCP"
-* Type "8123" in port
-* Click on OK
-* Click on OK again
-
-
-Copy your configuration.yaml file into the config folder That's it... you're all set to go
-
-Here are some useful commands:
+## {% Controlling Home Assistent %}
 
 * Start Home Assistant:
 ```bash

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -54,7 +54,9 @@ Download the [spksrc Docker container](https://github.com/SynoCommunity/spksrc#d
 ```bash
 # sudo docker pull synocommunity/spksrc
 ```
+
 #### {% linkable_title Preparing compiling environment %}
+
 Install Git:
 ```bash
 # sudo apt-get install git
@@ -98,7 +100,9 @@ Edit "*~/spksrc/spk/python3/Makefile*" and add the following text above the text
 ## Makefile variable needed to fix "_openssl.so: undefined symbol: pthread_atfork" error when using "xiaomi_aqara" component.
 export CFLAGS=-pthread
 ```
+
 #### {% linkable_title Compiling the Python 3 package %}
+
 Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
 ```bash
 sudo docker run -it --rm -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
@@ -106,8 +110,8 @@ sudo docker run -it --rm -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bas
 After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
 
-```
 ## {% linkable_title Using the Synology webadmin %}
+
 Install the Python 3 package as follows:
 * Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
 * Press the "*Manual Install*" button on the top right of the window
@@ -160,6 +164,7 @@ In the case you turned on the firewall on your Synology device, please config it
 * Click on "*OK*" again
 
 ## {% linkable_title Installing Home Assistant %}
+
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
 Replace "*user*" with your Synology user and "x.x.x.x" with the its IP address:
 ```bash
@@ -298,6 +303,7 @@ If you need to update Python 3 or added a component which fails caused by python
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}
+
 To have Home Assistant start on bootup of your Synology, do as follows:
 * Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
 * Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -181,8 +181,7 @@ $ ssh user@x.x.x.x
 ```
 Install the `.whl` module package files you made earlier and Home Assistant.  
 This command expects you have copied the "*Module-Packages*" directory from "[Extracting cross compiled packages]({https://github.com/home-assistant/home-assistant.io/blob/c41d2091e00ec4e93211331fdef910587dfceb22/source/_docs/installation/synology.markdown#-linkable_title-controlling-home-assistant-)" to your "*homeassistant*" Shared-Folder.
-
-[Test](#test)
+[Extracting cross compiled packages](#-linkable_title-controlling-home-assistant-)
 
 ```bash
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -101,7 +101,7 @@ Start the docker service:
 ---
 To enable your user account to manage Docker without superuser privileges, add your user account to the "docker" group:
 ```bash
-# sudo gpasswd -a *YOUR_USER_ACCOUNT* docker
+# sudo gpasswd -a YOUR_USER_ACCOUNT docker
 ```
 
 You will now need to get the [spksrc framework and Docker container](https://github.com/SynoCommunity/spksrc#docker) for the compiling environment.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -218,7 +218,7 @@ Now while it's installing, you may setup the Shared-Folder for Home Assistent:
 * Click on “*Next*” again
 * Click on “*Apply*”
 
-Now the “*homeassistent*” Shared-Folder has been made, you need to copy the (previously created) “*Module-Packages*” directory there.
+As the “*homeassistent*” Shared-Folder has been made, copy the (previously created) “*Module-Packages*” directory there.
 
 Next setup the user:
 * Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
@@ -234,7 +234,7 @@ Next setup the user:
 * Click on “*Next*” again
 * Click on “*Apply*”.
 
-Incase you turned on the firewall on your Synology device, please update it as follows to allow connections for Home Assistent:
+In the case you turned on the firewall on your Synology device, please config it to allow connections for Home Assistent:
 * Open “[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)”
 * Go to “[*Security*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_desc)” settings
 * Go to “[*Firewall*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_firewall)” settings

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -15,11 +15,11 @@ Synology only provides [Python 3.5.1](https://www.synology.com/nl-nl/dsm/package
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
-1. Using Docker
+1. Using Docker (Recommended)
 2. Directly running on DSM
 
 Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.  
-Our recommendation is to run Home Assistant on Docker or a Raspberri Pi, as this setup might be a bit more involved than you may like.
+Our recommendation is to run Home Assistant on Docker or a Raspberri Pi, as the instructions written below are a bit involved.
 
 
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,7 +11,7 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `/volume1/@appstore/python3/bin/python3 -m pip install homeassistant==0.64.3`
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can manually specify the version of Home Assistant to install, for example to install version 0.64.3 you would do `/volume1/@appstore/py3k/usr/local/bin/python3 -m pip install homeassistant==0.64.3`
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
@@ -34,7 +34,7 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 * Create "homeassistant" user
 * Create "homeassistant" [Shared-Folder](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_share_desc)
 * Enable [SSH](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal) service
-* Optionally start Home Assistant on bootup of your Synology
+* Optionally start Home Assistant on bootup of your Synology NAS
 
 ## {% linkable_title Getting prerequisites) %}
 
@@ -99,7 +99,7 @@ export CFLAGS=-pthread
 
 #### {% linkable_title Compiling the Python 3 package %}
 
-Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by [spksrc](https://github.com/SynoCommunity/spksrc). Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
+Make the Python 3 package for your Synology NAS model, please modify `docker run` command so the "**XXXX**" in "*arch-**XXXX***" contains the appropriate architecture of your Synology NAS. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by [spksrc](https://github.com/SynoCommunity/spksrc). Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
 ```bash
 # sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make clean && make setup && make -C spk/python3 arch-XXXX'
 ```
@@ -153,7 +153,7 @@ Next you need to enable SSH:
 * Click on the checkbox next to "*Enable SSH service*"
 * Click on "*Apply*"
 
-In the case you turned on the firewall on your Synology device, please config it to allow connections for Home Assistant:
+In the case you turned on the firewall on your Synology NAS, please config it to allow connections for Home Assistant:
 * Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
 * Go to "[*Security*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_desc)" settings
 * Go to "[*Firewall*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/connection_security_firewall)" settings
@@ -167,7 +167,7 @@ In the case you turned on the firewall on your Synology device, please config it
 ## {% linkable_title Installing Home Assistant %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
-Replace "*user*" with your Synology user and "x.x.x.x" with the its IP address:
+Replace "*user*" with your Synology NAS user and "x.x.x.x" with the its IP address:
 ```bash
 $ ssh user@x.x.x.x
 ```
@@ -300,12 +300,12 @@ $ /volume1/homeassistant/hass-daemon restart
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
-If you need to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory and redo the steps from "[Preparing compiling environment](#-linkable_title-preparing-compiling-environment-)", add the failed python modules to "*requirements.txt*" file, compile and reinstall the Python 3 package on your Synology.
+If you need to update Python 3 or added a component which fails caused by a Python module not installing on your on your Synology NAS with error code "*Failed building wheel for *Module_Name**", delete the "*~/spksrc*" directory and redo the guide, but add the failed python modules to "*requirements.txt*" from "[Preparing compiling environment](#-linkable_title-preparing-compiling-environment-)".
 </p>
 
 ## {% linkable_title Starting Home Assistant on bootup %}
 
-To have Home Assistant start on bootup of your Synology, do as follows:
+To have Home Assistant start on bootup of your Synology NAS, do as follows:
 * Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
 * Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
 * Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
@@ -315,3 +315,151 @@ To have Home Assistant start on bootup of your Synology, do as follows:
 * Go to "*Task Settings* settings
 * in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
 * Click on "*OK*".
+
+## {% linkable_title Using older Python 3 provided by Synology %}
+
+
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. The instructions above describes how to install newer Home Assistant on your Synology NAS. If you want to proceed with a older version of Home Assistant, follow the instructions below. Please note that you may not be able to use certain components, such as "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)".
+
+
+Running these commands will:
+* Install Home Assistant 0.64.3
+* Enable Home Assistant to be launched on http://*Synology_IP*:8123
+
+Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/DSM/help):
+* Install Python 3 using the Synology Package Center
+* Create "homeassistant" user
+* Create "homeassistant" [Shared-Folder](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_share_desc)
+* Enable [SSH](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal) service
+* Optionally start Home Assistant on bootup of your Synology NAS
+
+### Install Synology provided Python 3
+
+Install Python 3 as follows:
+* Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
+* Go to "*All Packages*"
+* Scroll all the way down until you find "*Python3*" and click on "*Install*"
+
+Follow the other instructions from "[Using the Synology webadmin](#-linkable_title-using-the-Synology-webadmin)".
+
+### Installing Home Assistant
+
+After the Python 3 package has been installed, open terminal and open SSH to the synology.
+Replace "*user*" with your Synology NAS user and "x.x.x.x" with the its IP address:
+```bash
+$ ssh user@x.x.x.x
+```
+Install PIP (Python’s package management system)
+```bash
+# sudo /volume1/@appstore/py3k/usr/local/bin/python3 -m ensurepip
+```
+Use PIP to install Homeassistant package 0.64.3
+```bash
+# sudo /volume1/@appstore/py3k/usr/local/bin/python3 -m pip install homeassistant==0.64.3
+```
+Create a file named "**hass-daemon**" in your "*homeassistant*" Shared-Folder with the script below as its content.
+You can use it to easily start, stop and restart Home Assistant like a service/daemon.
+```sh
+#!/bin/sh
+
+# Package
+PACKAGE="homeassistant"
+DNAME="Home Assistant"
+
+# Others
+USER="homeassistant"
+PYTHON_DIR="/volume1/@appstore/py3k/usr/local/bin"
+PYTHON="$PYTHON_DIR/python3"
+HASS="$PYTHON_DIR/hass"
+INSTALL_DIR="/volume1/homeassistant"
+PID_FILE="$INSTALL_DIR/home-assistant.pid"
+FLAGS="-v --config $INSTALL_DIR --pid-file $PID_FILE --daemon"
+REDIRECT="> $INSTALL_DIR/home-assistant.log 2>&1"
+
+start_daemon ()
+{
+    sudo -u ${USER} /bin/sh -c "$PYTHON $HASS $FLAGS $REDIRECT;"
+}
+
+stop_daemon ()
+{
+    sudo kill `cat ${PID_FILE}`
+    wait_for_status 1 20 || sudo kill -9 `cat ${PID_FILE}`
+    rm -f ${PID_FILE}
+}
+
+daemon_status ()
+{
+    if [ -f ${PID_FILE} ] && sudo kill -0 `cat ${PID_FILE}` > /dev/null 2>&1; then
+        return
+    fi
+    rm -f ${PID_FILE}
+    return 1
+}
+
+wait_for_status ()
+{
+    counter=$2
+    while [ ${counter} -gt 0 ]; do
+        daemon_status
+        [ $? -eq $1 ] && return
+        let counter=counter-1
+        sleep 1
+    done
+    return 1
+}
+
+case $1 in
+    start)
+        if daemon_status; then
+            echo ${DNAME} is already running
+            exit 0
+        else
+            echo Starting ${DNAME} ...
+            start_daemon
+            exit $?
+        fi
+        ;;
+    stop)
+        if daemon_status; then
+            echo Stopping ${DNAME} ...
+            stop_daemon
+            exit $?
+        else
+            echo ${DNAME} is not running
+            exit 0
+        fi
+        ;;
+        restart)
+        if daemon_status; then
+            echo Stopping ${DNAME} ...
+            stop_daemon
+            echo Starting ${DNAME} ...
+            start_daemon
+            exit $?
+        else
+            echo ${DNAME} is not running
+            echo Starting ${DNAME} ...
+            start_daemon
+            exit $?
+        fi
+        ;;
+    status)
+        if daemon_status; then
+            echo ${DNAME} is running
+            exit 0
+        else
+            echo ${DNAME} is not running
+            exit 1
+        fi
+        ;;
+    log)
+        echo ${LOG_FILE}
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+```
+To have Home Assistant start on bootup of your Synology NAS, follow "[Starting Home Assistant on bootup](#-linkable_title-starting-home-assistant-on-bootup)".

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -334,7 +334,7 @@ Using the [Synology webadmin](https://www.synology.com/en-global/knowledgebase/D
 * Enable [SSH](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_terminal) service
 * Optionally start Home Assistant on bootup of your Synology NAS
 
-### Install Synology provided Python 3
+### {% linkable_title Install Synology provided Python 3 %}
 
 Install Python 3 as follows:
 1. Open "[*Package Center*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/PkgManApp/PackageCenter_desc)"
@@ -343,7 +343,7 @@ Install Python 3 as follows:
 
 Follow the other instructions at "[Using the Synology webadmin](#-linkable_title-using-the-synology-webadmin-)", ignore the  "Python 3 package" part.
 
-### Installing Home Assistant 0.64.3
+### {% linkable_title Installing Home Assistant 0.64.3 %}
 
 After the Python 3 package has been installed, open terminal and open SSH to the synology.
 Replace "*user*" with your Synology NAS user and "x.x.x.x" with the its IP address:
@@ -463,20 +463,8 @@ case $1 in
         ;;
 esac
 ```
-### Starting Home Assistant on bootup
 
-To have Home Assistant start on bootup of your Synology NAS, do as follows:
-1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
-1. Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
-1. Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
-1. In "*Task*" write "**Home Assistant**"
-1. Click on the checkbox next to "*Enabled*"
-1. Make sure "*root*" is selected in "*User*"
-1. Go to "*Task Settings* settings
-1. in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
-1. Click on "*OK*".
-
-### Controlling Home Assistant
+### {% linkable_title Controlling Home Assistant 0.64.3 %}
 
 * Start Home Assistant:
 ```bash
@@ -490,3 +478,16 @@ To have Home Assistant start on bootup of your Synology NAS, do as follows:
 ```bash
 /volume1/homeassistant/hass-daemon restart
 ```
+
+### {% linkable_title Starting Home Assistant on bootup %}
+
+To have Home Assistant start on bootup of your Synology NAS, do as follows:
+1. Open "[*Control Panel*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/ControlPanel_desc)"
+1. Go to "[*Task Scheduler*](https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/system_taskscheduler)" settings
+1. Click on "*Create*" > "*Triggered Task*" > "*User-defined script*"
+1. In "*Task*" write "**Home Assistant**"
+1. Click on the checkbox next to "*Enabled*"
+1. Make sure "*root*" is selected in "*User*"
+1. Go to "*Task Settings* settings
+1. in "*User-defined script*" write "**/volume1/homeassistant/hass-daemon start**"
+1. Click on "*OK*".

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -63,9 +63,7 @@ git clone https://github.com/SynoCommunity/spksrc.git ~/spksrc
 
 Edit the following 2 files.
 
-These edits will make cross compiled Python module packages, which Home Assistant needs to install. These edits also enable use of the "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)" components.
-Most components will setup just fine, but certain components need a python package that compiles on installation, which will fail as Synology did not provide a compiler, causing said need for cross compilation.
-
+Add these edits to make cross compiled Python module packages which Home Assistant needs to install and enable usage of the "[Cloud](/components/cloud/)" and [Homekit](/components/homekit/)" components. Most components will setup just fine, but certain components need a python package that compiles on installation, which will fail as Synology did not provide a compiler, causing said need for cross compilation.<br/>
 Edit "*~/spksrc/spk/python3/src/requirements.txt*" and add the following text to the end of the file:
 ```
 ## It may happen you want to add a component to Home Assistant, but it fails to install a Python package.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -180,7 +180,10 @@ Replace "*user*" with your Synology user and "x.x.x.x" with the its IP address:
 $ ssh user@x.x.x.x
 ```
 Install the `.whl` module package files you made earlier and Home Assistant.  
-This command expects you have copied the "*Module-Packages*" directory from "[Extracting cross compiled packages]({#% linkable_title Extracting cross compiled packages %})" to your "*homeassistant*" Shared-Folder.
+This command expects you have copied the "*Module-Packages*" directory from "[Extracting cross compiled packages]({https://github.com/home-assistant/home-assistant.io/blob/c41d2091e00ec4e93211331fdef910587dfceb22/source/_docs/installation/synology.markdown#-linkable_title-controlling-home-assistant-)" to your "*homeassistant*" Shared-Folder.
+
+[Test](#test)
+
 ```bash
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
 # sudo /volume1/@appstore/python3/bin/python3 -m pip install homeassistant

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -196,16 +196,15 @@ DNAME="Home Assistant"
 
 # Others
 USER="homeassistant"
+PYTHON="/volume1/@appstore/py3k/usr/local/bin/python3"
 INSTALL_DIR="/volume1/homeassistant"
-VIRTENV_DIR="$INSTALL_DIR/venv-hass"
 PID_FILE="$INSTALL_DIR/home-assistant.pid"
 FLAGS="-v --config $INSTALL_DIR --pid-file $PID_FILE --daemon"
 REDIRECT="> $INSTALL_DIR/home-assistant.log 2>&1"
 
 start_daemon ()
 {
-   source "$VIRTENV_DIR/bin/activate"
-   sudo -u ${USER} /bin/sh -c "hass $FLAGS $REDIRECT;"
+    sudo -u ${USER} /bin/sh -c "$PYTHON $HASS $FLAGS $REDIRECT;"
 }
 
 stop_daemon ()

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -112,7 +112,7 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 
 #### {% linkable_title Extracting cross compiled packages %}
 Now you need to extract the Python module packages which you added earlier to "*requirements.txt*".
-Run these commands to extract the `.whl` files to a directory the "**~/Module-Packages**", please modify `pyspk` command so the "**XXXX**" in `python3_XXXX.spk` points to the package file you made earlier.
+Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `pyspk` command so the "**XXXX**" in `python3_XXXX.spk` points to the package file you made earlier.
 ```bash
 $ mkdir ~/Module-Packages
 $ cd ~/Module-Packages

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -108,13 +108,10 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 
 #### {% linkable_title Extracting cross compiled packages %}
 Now you need to extract the Python module packages which you added earlier to "*requirements.txt*".
-Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `pyspk` command so the "**XXXX**" in `python3_XXXX.spk` points to the package file you made earlier.
+Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "python3_**XXXX**.spk" points to the package file you made earlier.
 ```bash
-$ mkdir ~/Module-Packages
-$ cd ~/Module-Packages
-$ pyspk="$HOME/spksrc/packages/python3_XXXX.spk"
-$ tar -x -f $pyspk -C /tmp package.tgz; gzip -df /tmp/package.tgz
-$ tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2
+$ mkdir ~/Module-Packages && cd ~/Module-Packages
+$ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz; gzip -df /tmp/package.tgz && tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2
 ```
 Inside some of the `.whl` files (These are zip archives) you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is only required for ARM based Synology NAS.  
 Run this command to patch all `.whl` files found in the current directory:

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -99,7 +99,7 @@ Edit "*~/spksrc/spk/python3/Makefile*" and add the following text above the text
 export CFLAGS=-pthread
 ```
 #### {% linkable_title Compiling the Python 3 package %}
-Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "arch-**XXXX**" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
+Make the Python 3 package for your Synology model, please modify `docker run` command so the "**XXXX**" in "_arch-_**XXXX**" contains the appropriate architecture of your Synology. For a list of architectures, look at this [list of architectures](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model) accepted by spksrc. Depending on your computer, compilation may take a hour or more (Significantly less if you have a SSD and a moderately good CPU):
 ```bash
 sudo docker run -it --rm -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make setup && make -C spk/python3 arch-XXXX'
 ```
@@ -108,7 +108,7 @@ It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course
 
 #### {% linkable_title Extracting cross compiled packages %}
 Now you need to extract the Python module packages which you added earlier to "*requirements.txt*".
-Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "python3_**XXXX**.spk" points to the package file you made earlier:
+Run these commands to extract the `.whl` files to the directory "**~/Module-Packages**", please modify `tar` command so the "**XXXX**" in "*python3_*__XXXX__*.spk*" points to the package file you made earlier:
 ```bash
 $ mkdir ~/Module-Packages && cd ~/Module-Packages
 $ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz && gzip -df /tmp/package.tgz && tar -x -f /tmp/package.tar --wildcards share/wheelhouse/$file --strip=2

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -104,7 +104,7 @@ After the compilation is done, you can find the Python 3 package at "*~/spksrc/p
 It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different arch and version.
 
 #### {% linkable_title Extracting cross compiled packages %}
-Now you need to extract the cross compiled module packages which you added earlier to "*requirements.txt*".
+Now you need to extract the cross compiled module `.whl` packages which you added earlier to "*requirements.txt*".
 Run these commands to extract the `.whl` files to a directory named "**Module-Packages**", please replace "python3_**XXXX**.spk" with the appropriate package filename:
 ```bash
 $ mkdir ~/Module-Packages
@@ -112,12 +112,13 @@ $ cd ~/Module-Packages
 $ tar -x -f ~/spksrc/packages/python3_XXXX.spk -C /tmp package.tgz; gzip -df /tmp/package.tgz
 $ for file in cffi-1.11.5-cp35-none-any.whl bcrypt-3.1.4-cp35-none-any.whl cryptography-2.3.1-cp35-none-any.whl pycryptodome-3.7.2-cp35-none-any.whl curve25519_donna-1.3-cp35-none-any.whl ed25519-1.4-cp35-none-any.whl; do tar -x -f /tmp/package.tar share/wheelhouse/$file --strip=2; done
 ```
-Inside some of the .whl archives you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is required for ARM based Synology's.
+Inside some of the `.whl` archives you need to rename all files containing the text "**x86_64-linux-gnu**" to "**arm-linux-gnueabihf**", this is required for ARM based Synology's.
+Run this command to patch `.whl` files found in the current directory:
 ```bash
 $ rand=$RANDOM; for module in *.whl; do unzip "$module" -d "temp$rand" && find "temp$rand" -name "*x86_64-linux-gnu*" -type f | while read -r file; do mv "$file" "$(echo $file | sed "s/x86_64-linux-gnu/arm-linux-gnueabihf/")"; done && rm "$module" && (cd "temp$rand" && zip -r0 "../$module" ./) && rm -r "temp$rand"; done
 ```
 <p class="note">
-If you added any modules to "*requirements.txt*", you can find the modules `.whl` packages at "**~/spksrc/packages/python3_XXXX.spk*" > "*package.tgz*" > "*share/wheelhouse/XXXX.whl*".d
+If you added any modules to "*requirements.txt*", you can find the module `.whl` package files using a archive program in "**~/spksrc/packages/python3_XXXX.spk*" > "*package.tgz*" > "*share/wheelhouse/XXXX.whl*".d
 </p>
 
 ## {% linkable_title Using the Synology webadmin %}

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -19,7 +19,7 @@ There are 2 alternatives, when using Home Assistant on Synology NAS:
 2. Directly running on DSM
 
 Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.  
-Our recommendation is you run Home Assistant on Docker or a Raspberri Pi, as this setup might be a bit more involved than you will like.
+Our recommendation is to run Home Assistant on Docker or a Raspberri Pi, as this setup might be a bit more involved than you may like.
 
 
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -297,7 +297,7 @@ $ /volume1/homeassistant/hass-daemon restart
 ```
 * Upgrade Home Assistant:
 ```bash
-$ /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
+# sudo /volume1/@appstore/python3/bin/python3 -m pip install --upgrade homeassistant
 ```
 <p class="note">
 If you need to update Python 3 or added a component which fails caused by python modules not installing on your Synology, delete the "spksrc" directory and redo the steps from "[Preparing compiling environment](#-linkable_title-preparing-compiling-environment-)", add the failed python modules to "*requirements.txt*" file, compile and reinstall the Python 3 package on your Synology.

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -180,7 +180,7 @@ $ ssh user@x.x.x.x
 Install the cross compiled module `.whl` package files we compiled earlier.
 This command expects you have copied the "*Module-Packages*" directory to your "*homeassistant*" Shared-Folder.
 ```bash
-$ pip3 install /volume1/homeassistant/Module-Packages/*.whl
+$ /volume1/@appstore/python3/bin/python3 -m pip install /volume1/homeassistant/Module-Packages/*.whl
 ```
 Install Home Assistant:
 ```bash


### PR DESCRIPTION
This guide will help users in detail how to install any new Home Assistant version in the foreseeable future (until the next bump in the road that may cause incompatibility).

Synology only provide Python 3.5.1, which is not compatible with Home Assistant 0.65.0 or later (basically  a complete standstill), so I have created this documentation based on mine and others research from https://community.home-assistant.io/t/python-3-5-3-on-synology/46372

The key is installing and compiling newer Python, some fixes for SSL and broken components (which were previously broken too).
The rest is a more optimized installation that will may cause less issues to arise.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
