### PR TITLE
Update installation.markdown

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -148,7 +148,7 @@ $ dmesg | grep USB
 If Home Assistant (`hass`) runs with another user (e.g., *homeassistant* on Hassbian) give access to the stick with:
 
 ```bash
-$ sudo usermod -a -G dialout homeassistant
+$ sudo usermod -aG dialout homeassistant
 ```
 
 <p class='Note'>


### PR DESCRIPTION
Change usermod "-G" to usermod "-aG" since we want the user added to dialout, not moved to dialout. Even though source shows "-a -G" only "-G" is showing on documentation.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
