### PR TITLE
Update switch.fritzdect.markdown

### DIFF
--- a/source/_components/switch.fritzdect.markdown
+++ b/source/_components/switch.fritzdect.markdown
@@ -24,6 +24,7 @@ Supported Firmwares (tested):
 
 - FRITZ!OS: 06.80 / FRITZ!DECT: 03.83
 - FRITZ!OS: 06.98-51288 (Beta) / FRITZ!DECT: 03.87
+- FRITZ!OS: 7.01 / FRITZ!DECT: 04.09
 
 To use your AVM FRITZ!DECT switch(es) in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**

Adds another tested combination (latest firmware versions) to switch.fritzdect.markdown to document it is working fine.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
