### PR TITLE
Add note for purge service to explain behaviour

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -131,6 +131,10 @@ Call the service `recorder.purge` to start a purge task which deletes events and
 | `keep_days`            |      yes | The number of history days to keep in recorder database (defaults to the component `purge_keep_days` configuration)
 | `repack`               |      yes | Rewrite the entire database, possibly saving some disk space. Only supported for SQLite and requires at least as much disk space free as the database currently uses.
 
+<p class='note'>
+Purging does not necessarily remove all entries before a given date. For example, to be able to recover after startup, the last known state for each entry is never purged. This is true even if the entry is already removed from your configuration.
+</p>
+
 ## {% linkable_title Custom database engines %}
 
 | Database engine | `db_url`                                                 |


### PR DESCRIPTION
**Description:**

I recently thought my purge service did not work since there still were some entries in my database having a younger date than specified by the purge. It took me quite a while to find an answer as to why that is, so I thought adding a note to the documentation wouldn't hurt.

Source: https://community.home-assistant.io/t/recorder-does-not-purge/70077/2

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** n/a

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
