### PR TITLE
Extended map to support geo location entities

### DIFF
--- a/source/_lovelace/map.markdown
+++ b/source/_lovelace/map.markdown
@@ -24,7 +24,11 @@ type:
   type: string
 entities:
   required: true
-  description: List of entity IDs.
+  description: List of entity IDs. Either this or the `geo_location_sources` configuration option is required.
+  type: list
+geo_location_sources:
+  required: true
+  description: List of geo location sources. All current entities with that source will be displayed on the map. See [Geo Location](/components/geo_location/) platform for valid sources. Either this or the `entities` configuration option is required.
   type: list
 title:
   required: false
@@ -59,5 +63,13 @@ default_zoom:
   default_zoom: 8
   entities:
     - device_tracker.demo_paulus
+    - zone.home
+```
+
+```yaml
+- type: map
+  geo_location_sources:
+    - nsw_rural_fire_service_feed
+  entities:
     - zone.home
 ```

--- a/source/_lovelace/map.markdown
+++ b/source/_lovelace/map.markdown
@@ -28,7 +28,7 @@ entities:
   type: list
 geo_location_sources:
   required: true
-  description: List of geo location sources. All current entities with that source will be displayed on the map. See [Geo Location](/components/geo_location/) platform for valid sources. Either this or the `entities` configuration option is required.
+  description: List of geolocation sources. All current entities with that source will be displayed on the map. See [Geo Location](/components/geo_location/) platform for valid sources. Either this or the `entities` configuration option is required.
   type: list
 title:
   required: false


### PR DESCRIPTION
**Description:**
This describes the new configuration option for the map card to display geo location entities. And I added an example illustrating that new option.

I marked `entities` and `geo_location_sources` as required, but actually only at least one of the two is required, i.e. either one of the two or both must be defined.
Please let me know if there is a smarter way to express this.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant-polymer/pull/2337

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
