### PR TITLE
Update installation.markdown

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -249,7 +249,7 @@ $ groups homeassistant
 That should include `dialout`, if it doesn't then:
 
 ```bash
-$ sudo usermod -G dialout homeassistant
+$ sudo usermod -aG dialout homeassistant
 ```
 
 ### {% linkable_title Device path changes %}


### PR DESCRIPTION
Change from -G to -aG, since we want to add to the group and not change the group. (Sorry I didn't catch this with the last one.)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
