### PR TITLE
Supporting for multiple Netatmo thermostates/valves

### DIFF
--- a/source/_components/climate.netatmo.markdown
+++ b/source/_components/climate.netatmo.markdown
@@ -18,7 +18,7 @@ The `netatmo` thermostat platform is consuming the information provided by a [Ne
 
 To enable the Netatmo thermostat, you first have to set up [netatmo](/components/netatmo/), this will use discovery to add your thermostat.
 
-If you want to select a specific home or specific rooms, set discovery to False for [netatmo](/components/netatmo/) and add the following lines to your `configuration.yaml`:
+If you want to select specific homes or specific rooms, set discovery to False for [netatmo](/components/netatmo/) and add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
@@ -27,27 +27,35 @@ climate:
 ```
 
 {% configuration %}
-home:
-  description: Will display the thermostats of this home only.
-  required: false
-  type: string
-rooms:
-  description: Rooms to be displayed. Multiple entities allowed.
+homes:
+  description: Will display the thermostats of the homes listed.
   required: false
   type: list
   keys:
-    room_name:
-      description: Name of the room to display.
+    name:
+      required: true
+      description: The home name.
+    rooms:
+      description: Rooms to be displayed. Multiple entities allowed.
+      required: false
+      type: [list, string]
+      description: List of the names of the rooms to be displayed.
 {% endconfiguration %}
 
-If **home** and **rooms** are not provided, all thermostats will be displayed.
+If **homes** and **rooms** are not provided, all thermostats will be displayed.
 
 ```yaml
 # Example configuration.yaml entry
 climate:
   platform: netatmo
-  home: home_name
-  rooms:
-    - room_name1
-    - room_name2
+  homes:
+    - name: home1_name
+      rooms:
+        - room1_name
+        - room2_name
+    - name: home2_name
+      rooms:
+        - room3_name
+        - room4_name
+        - room5_name
 ```

--- a/source/_components/climate.netatmo.markdown
+++ b/source/_components/climate.netatmo.markdown
@@ -18,7 +18,7 @@ The `netatmo` thermostat platform is consuming the information provided by a [Ne
 
 To enable the Netatmo thermostat, you first have to set up [netatmo](/components/netatmo/), this will use discovery to add your thermostat.
 
-If you want to select a specific thermostat, set discovery to False for [netatmo](/components/netatmo/) and add the following lines to your `configuration.yaml`:
+If you want to select a specific home or specific rooms, set discovery to False for [netatmo](/components/netatmo/) and add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry
@@ -27,26 +27,27 @@ climate:
 ```
 
 {% configuration %}
-relay:
-  description: Will display the thermostats of this relay only.
+home:
+  description: Will display the thermostats of this home only.
   required: false
   type: string
-thermostat:
-  description: Thermostat to use.
+rooms:
+  description: Rooms to be displayed. Multiple entities allowed.
   required: false
   type: list
   keys:
-    thermostat_name:
-      description: Name of the thermostat to display.
+    room_name:
+      description: Name of the room to display.
 {% endconfiguration %}
 
-If **relay** and **thermostat** are not provided, all thermostats will be displayed.
+If **home** and **rooms** are not provided, all thermostats will be displayed.
 
 ```yaml
 # Example configuration.yaml entry
 climate:
   platform: netatmo
-  relay: relay_name
-  thermostat:
-    - thermostat_name
+  home: home_name
+  rooms:
+    - room_name1
+    - room_name2
 ```


### PR DESCRIPTION
**Description:**
Documentation updating for adding support of multiple Netatmo thermostats/valves (breaking changes of configuration).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19407

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
