### PR TITLE
:warning: breaking change on views id -> path

### DIFF
--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -11,6 +11,7 @@ footer: true
 ## {% linkable_title Changes in 0.84.0 %}
 
 ### Breaking Changes
+- ⚠️ [views]: Renamed `id` to `path`
 - ⚠️ [sensor card]: Removed configs `height`, `line_color` and `line_width`
 - ⚠️ [gauge card]: Renamed config `title` to `name`
 - ⚠️ [alarm panel card]: Renamed config `title` to `name`
@@ -205,6 +206,7 @@ footer: true
 
 - ❤️ Initial release of the Lovelace UI
 
+[views]: /lovelace/views/
 [alarm panel card]: /lovelace/alarm-panel/
 [conditional card]: /lovelace/conditional/
 [entities card]: /lovelace/entities/


### PR DESCRIPTION
## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
