### PR TITLE
Allow Negative Filter on Entity-Filter card

### DIFF
--- a/source/_lovelace/entity-filter.markdown
+++ b/source/_lovelace/entity-filter.markdown
@@ -29,8 +29,12 @@ entities:
   description: "List of entities to filter."
   type: list
 state_filter:
-  required: true
+  required: false
   description: List of strings representing states.
+  type: list
+state_filter_not:
+  required: false
+  description: List of strings representing states to filter out.
   type: list
 card:
   required: false
@@ -77,3 +81,18 @@ Show only people that are at home using [glance](/lovelace/glance/):
   <img src='/images/lovelace/lovelace_entity_filter_glance.png' alt='Entity filter combined with glance card'>
   Entity filter combined with glance card.
 </p>
+
+Show only people that are not at home using [glance](/lovelace/glance/):
+
+```yaml
+- type: entity-filter
+  entities:
+    - device_tracker.demo_paulus
+    - device_tracker.demo_anne_therese
+    - device_tracker.demo_home_boy
+  state_filter_not:
+    - home
+  card: 
+    type: glance
+    title: People not at home
+```


### PR DESCRIPTION
**Description:**
Updated documentation to align with new feature that allows a negative filter on entity-filter card

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** home-assistant/home-assistant-polymer#2353

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
