### PR TITLE
Make device_class type a string

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -69,7 +69,7 @@ assumed_state:
 device_class:
   description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
   required: false
-  type: device_class
+  type: device class
   default: None
 unit_of_measurement:
   description: Defines the units of measurement, if any. This will also influence the graphical presentation in the history visualisation as continuous value. Sensors with missing `unit_of_measurement` are showing as discrete values.


### PR DESCRIPTION

**Description:**
As mentioned in #6791, we should have "device_class" as a string in the documentation.

That pull was closed and there was not change for "device_class" on the template documentation page. This should correct it, having it still say "device class" but will not link to a non-existent page.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
