### PR TITLE
Update systemd.markdown

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -70,7 +70,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=3
-ExecStart=/usr/bin/docker run --name="home-assistant-%i" -v /home/%i/.homeassistant/:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant
+ExecStart=/usr/bin/docker run --name=home-assistant-%i -v /home/%i/.homeassistant/:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant
 ExecStop=/usr/bin/docker stop -t 2 home-assistant-%i
 ExecStopPost=/usr/bin/docker rm -f home-assistant-%i
 


### PR DESCRIPTION
The quotation marks must be left off for the container name. Otherwise you will get the message
```/usr/bin/docker: Error response from daemon: Invalid container name ("home-assistant-pi"), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed.```
After I removed the quotation marks from my systemd service file, everything worked fine.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
