### PR TITLE
Fix typo in configuration.markdown

### DIFF
--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -82,7 +82,7 @@ panel_iframe:
     url: http://hassio.local:3218
 ```
 
- - Click the save icon in the top right to comit changes.
+ - Click the save icon in the top right to commit changes.
  - Verify the configuration by going to the config panel (Configuration in the sidebar) -> General -> Click the "Check Config" button and you should get "Configuration valid!"
  - Now Restart Home Assistant using the "restart" in the Server management section.
 


### PR DESCRIPTION
**Description:**
Typo fixed in configuration documentation page: comit -> commit


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
