### PR TITLE
Catchup

### DIFF
--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -70,6 +70,9 @@ Field | Description
 ----- | -----------
 `service_call_id` | String with the unique call id of the service call that was executed. Example: `23123-4`.
 
+<p class='note warning'>
+  Starting with 0.84, it is no longer possible to listen for event `service_executed`.
+</p>
 
 ### {% linkable_title Event `platform_discovered` %}
 Event `platform_discovered` is fired when a new platform has been discovered by the [`discovery`](/components/discovery/) component.


### PR DESCRIPTION
Apparently this was missed with the 0.84 updates 

https://github.com/home-assistant/home-assistant/pull/18720

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
