### PR TITLE
Add Zigbee2mqtt to list of software that supports MQTT discovery.

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -182,13 +182,14 @@ Supported abbreviations:
 
 ### {% linkable_title Support by third-party tools %}
 
-The following firmware for ESP8266, ESP32 and Sonoff unit has built-in support for MQTT discovery:
+The following software has built-in support for MQTT discovery:
 
 - [Sonoff-Tasmota](https://github.com/arendst/Sonoff-Tasmota) (starting with 5.11.1e)
 - [esphomeyaml](https://esphomelib.com/esphomeyaml/index.html)
 - [ESPurna](https://github.com/xoseperez/espurna)
 - [Arilux AL-LC0X LED controllers](https://github.com/mertenats/Arilux_AL-LC0X)
 - [room-assistant](https://github.com/mKeRix/room-assistant) (starting with 1.1.0)
+- [Zigbee2mqtt](https://github.com/koenkk/zigbee2mqtt)
 
 ### {% linkable_title Examples %}
 


### PR DESCRIPTION
Add Zigbee2mqtt to list of software that supports MQTT discovery.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** not applicable

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
