### PR TITLE
scan_interval mandatory

### DIFF
--- a/source/_components/sensor.fail2ban.markdown
+++ b/source/_components/sensor.fail2ban.markdown
@@ -43,6 +43,10 @@ name:
   required: false
   type: string
   default: fail2ban
+scan_interval:
+  description: wait time between fail2ban log checks
+  required: true
+  type: integer
 file_path:
   description: Path to the fail2ban log.
   required: false


### PR DESCRIPTION
As per @fronzbot message
https://community.home-assistant.io/t/fail2ban-sensor-error/32948/3
and own testing, it seems configuration variable scan_interval should be mandatory.