### PR TITLE
Add Path to Tautulli documentation

### DIFF
--- a/source/_components/sensor.tautulli.markdown
+++ b/source/_components/sensor.tautulli.markdown
@@ -54,6 +54,10 @@ port:
   required: false
   default: 8181
   type: integer
+path:
+  description: The Base Url path of your Tautulli server.
+  required: false
+  type: string
 ssl:
   description: Use HTTPS to connect to Tautulli server. *NOTE* A host *cannot* be an IP address when this option is enabled.
   required: false


### PR DESCRIPTION
**Description:**
Add Path as a configuration entry in the Tautulli sensor

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19491

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
