### PR TITLE
Clarify device description

### DIFF
--- a/source/_components/media_player.dlna_dmr.markdown
+++ b/source/_components/media_player.dlna_dmr.markdown
@@ -26,12 +26,12 @@ To add a DLNA DMR device to your installation, add the following to your `config
 # Example configuration.yaml entry
 media_player:
   - platform: dlna_dmr
-    url: http://192.168.0.10:9197/dmr
+    url: http://192.168.0.10:9197/description.xml
 ```
 
 {% configuration %}
 url:
-  description: The URL to the device description, e.g., `http://192.168.0.10:9197/dmr`.
+  description: The URL to the device description .xml file, e.g., `http://192.168.0.10:9197/description.xml`.
   required: true
   type: string
 listen_ip:


### PR DESCRIPTION
I propose to clarify to the upnp-unexperienced user better, that the device description is a xml file that is (as far as I know) often called description.xml.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
