### PR TITLE
Correct tap/hold action options and default

### DIFF
--- a/source/_lovelace/picture.markdown
+++ b/source/_lovelace/picture.markdown
@@ -33,9 +33,9 @@ tap_action:
   keys:
     action:
       required: true
-      description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `none`)"
+      description: "Action to perform (`call-service`, `navigate`, `none`)"
       type: string
-      default: "`more-info`"
+      default: "`none`"
     navigation_path:
       required: false
       description: "Path to navigate to (e.g. `/lovelace/0/`) when `action` defined as `navigate`"
@@ -58,9 +58,9 @@ hold_action:
   keys:
     action:
       required: true
-      description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `none`)"
+      description: "Action to perform (`call-service`, `navigate`, `none`)"
       type: string
-      default: "`more-info`"
+      default: "`none`"
     navigation_path:
       required: false
       description: "Path to navigate to (e.g. `/lovelace/0/`) when `action` defined as `navigate`"


### PR DESCRIPTION
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
