### PR TITLE
Fixed typo in relative URL

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -137,7 +137,7 @@ terminology used around Home Assistant. Home Assistant's
 ## {% linkable_title HTTP sensors %}
 
 To use those kind of [sensors](/components/sensor.http/) or
-[binary sensors](components/binary_sensor.http/) in your installation no
+[binary sensors](/components/binary_sensor.http/) in your installation no
 configuration in Home Assistant is needed. All configuration is done on the
 devices themselves. This means that you must be able to edit the target URL or
 endpoint and the payload.


### PR DESCRIPTION
Relative link to /components/binary_sensor.http was missing a leading "/", which caused the URL to incorrectly lead to a 404 page at "https://www.home-assistant.io/components/http/components/binary_sensor.http/".

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant# Not applicable.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
