### PR TITLE
Update proximity.markdown

### DIFF
--- a/source/_components/proximity.markdown
+++ b/source/_components/proximity.markdown
@@ -33,6 +33,11 @@ The Proximity entity which is created has the following values:
   - 'unknown'
   - 'stationary'
 - `dist_to_zone`: Distance from the monitored zone (in km)
+- `unit_of_measurement`: Measurement of distance. Values are:
+  - 'km'
+  - 'm'
+  - 'mi'
+  - 'ft'
 
 To enable this component in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
I added different values that were available for 'unit_of_measurement'. This information was missing from the help page.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
