### PR TITLE
Add deprecation warning.

### DIFF
--- a/source/_components/sensor.ruter.markdown
+++ b/source/_components/sensor.ruter.markdown
@@ -13,6 +13,12 @@ ha_iot_class: "Cloud Polling"
 ha_release: 0.83
 ---
 
+<p class='note warning'>
+The API used for this sensor is shutting down soon, you should consider starting to use the [`entur_public_transport`](https://www.home-assistant.io/components/sensor.entur_public_transport/) sensor before that happen.
+To read the deprecation warning visit [ruter.no/labs](https://ruter.no/labs/),
+</p>
+
+
 The `ruter` sensor will provide you departure information for the larger Oslo area in Norway from the [Ruter][ruter] public transportation service.
 
 This platform is using the [Ruter reisapi API][ruter-api] to gather the information.

--- a/source/_components/sensor.ruter.markdown
+++ b/source/_components/sensor.ruter.markdown
@@ -18,7 +18,6 @@ The API used for this sensor is shutting down soon, you should consider starting
 To read the deprecation warning visit [ruter.no/labs](https://ruter.no/labs/),
 </p>
 
-
 The `ruter` sensor will provide you departure information for the larger Oslo area in Norway from the [Ruter][ruter] public transportation service.
 
 This platform is using the [Ruter reisapi API][ruter-api] to gather the information.


### PR DESCRIPTION
**Description:**

Adds deprecation warning.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19515

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
