### PR TITLE
Patch 1

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -85,6 +85,7 @@ Valid values for ignore are:
  * `ikea_tradfri`: IKEA Trådfri (Tradfri)
  * `logitech_mediaserver`: Logitech media server (Squeezebox)
  * `netgear_router`: Netgear routers
+ * `octoprint`: Octoprint
  * `openhome`: Linn / Openhome
  * `panasonic_viera`: Panasonic Viera
  * `philips_hue`: Philips Hue

--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -30,6 +30,7 @@ Home Assistant can discover and automatically configure [zeroconf](https://en.wi
  * [Logitech Harmony Hub](/components/remote.harmony/)
  * [Logitech media server (Squeezebox)](/components/media_player.squeezebox/)
  * [Netgear routers](/components/device_tracker.netgear/)
+ * [Octoprint](/components/octoprint/)
  * [Panasonic Viera](/components/media_player.panasonic_viera/)
  * [Philips Hue](/components/light.hue/)
  * [Plex media server](/components/media_player.plex/)


### PR DESCRIPTION
**Description:**
I discovered that Discovery indeed supports ignoring octoprint as well. This is in reference to https://github.com/home-assistant/home-assistant/issues/18627 but does not necessarily close that issue since this commit is just about missing documentation.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
