### PR TITLE
Update homematic.markdown

### DIFF
--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -92,7 +92,7 @@ jsonport:
   required: false
   type: integer
 username:
-  description: When fetching names via JSON-RPC, you need to specify a user with guest-access to the CCU.
+  description: When fetching names via JSON-RPC, you need to specify a user with guest-access to the CCU. Admin-access is required if you work with variables on the CCU.
   required: false
   type: string
 password:
@@ -188,7 +188,7 @@ sensor:
 
 ### {% linkable_title Variables %}
 
-It is possible to read and set values of system variables you have setup on the CCU/Homegear. The supported types for setting values are float- and bool-variables.
+It is possible to read and set values of system variables you have setup on the CCU/Homegear. The supported types for setting values are float- and bool-variables. With the CCU a user with Admin-access is required.
 The states of the variables are available through the attributes of your hub entity (e.g., `homematic.ccu2`). Use templates (as mentioned above) to make your variables available to automations or as entities.
 The values of variables are polled from the CCU/Homegear in an interval of 30 seconds. Setting the value of a variable happens instantly and is directly pushed.
 


### PR DESCRIPTION
**Description:**
Recently there was confusion in the forum why the usage of variables didn't work. It requires a user with Admin-privileges, which the documentation does not mention yet. Hence this change.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
