### PR TITLE
Discovery is not supported for Octoprint

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -30,7 +30,6 @@ Home Assistant can discover and automatically configure [zeroconf](https://en.wi
  * [Logitech Harmony Hub](/components/remote.harmony/)
  * [Logitech media server (Squeezebox)](/components/media_player.squeezebox/)
  * [Netgear routers](/components/device_tracker.netgear/)
- * [Octoprint](/components/octoprint/)
  * [Panasonic Viera](/components/media_player.panasonic_viera/)
  * [Philips Hue](/components/light.hue/)
  * [Plex media server](/components/media_player.plex/)


### PR DESCRIPTION
According to a developer of Octoprint component https://github.com/home-assistant/home-assistant/issues/18627#issuecomment-449625201 discovery is not yet supported. 

It is however still necessary to be able to ignore 'octoprint' due to an issue that affects users that have an Octoprint discoverable. 



**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
