### PR TITLE
Updated entur platform with line_whitelist and faq

### DIFF
--- a/source/_components/sensor.entur_public_transport.markdown
+++ b/source/_components/sensor.entur_public_transport.markdown
@@ -19,6 +19,9 @@ For each stop place given in the configuration, a sensor will be mounted for tha
 
 Real-time data is fetched from [Entur](https://www.entur.org). Entur is a service which collects and delivers information about all public transport available in Norway under an [open source license](https://data.norge.no/nlod/no). 
 
+<p class='note'>Note that the underlying API is rate limited and to avoid getting your instance blocked from entur the sensor is only fetching new information once a minute. It's recommended to only define one platform in the configuration at one time to not hit the rate limiting. 
+</p>
+
 ## {% linkable_title Configuration %}
 
 ```yaml
@@ -50,9 +53,15 @@ show_on_map:
   required: false
   type: boolean
   default: false
+line_whitelist: 
+  description: List of lines that should be whitelisted in the resulting sensors, and will only show when the defined lines are expected to leave the platform or station. All lines that you want on any of the sensors should be included in the list. 
+  required: false
+  type: list
 {% endconfiguration %}
 
 ## {% linkable_title Example usage %}
+
+Example of multiple stop places, with expanded sensors for each platform under the station, and with the platforms added to the map.
 
 ```yaml
 # Example configuration.yaml entry
@@ -70,6 +79,22 @@ sensor:
       - 'NSR:Quay:48550'      # Fiskepiren bus stop platform 1
 ```
 
+Example with whitelisting of one line on each stop place.
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: entur_public_transport
+    stop_ids:
+      - 'NSR:Quay:7333'
+      - 'NSR:Quay:48550'
+      - 'NSR:StopPlace:596'
+    line_whitelist:
+      - 'RUT:Line:1'
+      - 'KOL:Line:1000_236'
+      - 'NSB:Line:59'
+```
+
 ## {% linkable_title Obtaining a stop id %}
 
 [Entur's travel planer](https://en-tur.no) has a map of all stops used in Norway. Use the map to find the stops you're interested in. When you have found one of your stops, click on it. 
@@ -79,3 +104,21 @@ Now the web browser should contain an URL with the id in it. Such as this:
 `https://en-tur.no/nearby-stop-place-detail?id=NSR:StopPlace:32376`
 
 The stop id is the content after `id=` parameter in the url. Copy paste this into the configuration. 
+
+## {% linkable_title FAQ - Troubleshooting %}
+
+**Q:** I have multiple stop ids and have added whitelisting of a line. Now some of the stop places are showing `unknown`.
+
+**A:** A whitelisting of lines takes affect on all of the stops. So you have to whitelist all lines you are interested in on all stop places. 
+
+---
+
+**Q:** I have added whitelisting of lines, and everything has worked as fine before, but now it has stopped updating all of a sudden. 
+
+**A:** Some transport companies, such as Kolumbus in Rogaland, have running numbers on the end of their line ids. These gets periodically updated and will make the whitelisting invalid. The new line ids needs to be added again. Most of the time it iterates by one.
+
+--- 
+
+**Q:** Where do I find a line id to add to the whitelisting?
+
+**A:** The sensor will show the line id, and is the recommended way to find it, while we wait for 'Nasjonalt Stoppestedregister' to become public. It is also possible to see the line ids by using the developer tool in the browser while looking at the trafic in [Entur's travel planer](https://en-tur.no).


### PR DESCRIPTION
**Description:**

Updates documentation with updates about new configuration option `line_whitelist` on entur public transport sensor platform. Also extended with warning about rate limiting in the underlying data repository and a troubleshooter. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19539

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
