### PR TITLE
Add Huawei LTE Notify docs

### DIFF
--- a/source/_components/notify.huawei_lte.markdown
+++ b/source/_components/notify.huawei_lte.markdown
@@ -1,0 +1,46 @@
+---
+layout: page
+title: "Huawei LTE Notify"
+description: "Instructions on how to add Huawei LTE notifications to Home Assistant."
+date: 2018-12-23 17:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: huawei.svg
+ha_category: Notifications
+ha_release: 0.86
+---
+
+The `huawei_lte` platform allows you to use a Huawei LTE router for
+notifications from Home Assistant. The messages will be sent as SMS
+text messages.
+
+This requires you to have set up the
+[Huawei LTE component](/components/huawei_lte/).
+
+```yaml
+# Example configuration.yaml entry
+notify:
+  - platform: huawei_lte
+    target: "+15105550123"
+```
+
+{% configuration %}
+target:
+  description: The phone number of a default recipient or a list with multiple recipients.
+  required: true
+  type: string, list
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: notify
+  type: string
+url:
+  description: The router to use. Not needed if you only have one.
+  required: false
+  type: url
+{% endconfiguration %}
+
+To use notifications, please see the
+[getting started with automation page](/getting-started/automation/).

--- a/source/_components/notify.huawei_lte.markdown
+++ b/source/_components/notify.huawei_lte.markdown
@@ -23,11 +23,11 @@ This requires you to have set up the
 # Example configuration.yaml entry
 notify:
   - platform: huawei_lte
-    target: "+15105550123"
+    recipient: "+15105550123"
 ```
 
 {% configuration %}
-target:
+recipient:
   description: The phone number of a default recipient or a list with multiple recipients.
   required: true
   type: string, list

--- a/source/_components/notify.huawei_lte.markdown
+++ b/source/_components/notify.huawei_lte.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: huawei.svg
 ha_category: Notifications
-ha_release: 0.86
+ha_release: 0.88
 ---
 
 The `huawei_lte` platform allows you to use a Huawei LTE router for


### PR DESCRIPTION
**Description:**

Docs for Huawei LTE Notify.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19544

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
