### PR TITLE
Add HA configuration when using NGINX

### DIFF
--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -83,6 +83,21 @@ Double check this configuration to ensure all settings are correct and start ngi
 
 Forward ports 443 and 80 to your server on your router. Do not forward port 8123.
 
+### {% linkable_title 9. Configure Home Assistant %}
+
+Home Assistant is still available without using the NGINX proxy. Restricting it to only listen to `127.0.0.1` will forbid direct accesses. Also, Home Assistant should be told to trust headers coming from the NGINX proxy only. Otherwise, incoming requests will always come from `127.0.0.1` and not the real IP address.
+
+On your `configuration.yaml` file, edit the `http` component.
+
+{% configuration %}
+http:
+  server_host: 127.0.0.1
+  # Update this line to be your domain
+  base_url: https://exemple.com
+  use_x_forwarded_for: true
+  trusted_proxies: 127.0.0.1
+{% endconfiguration %}
+
 ### {% linkable_title NGINX Config %}
 
 ```nginx


### PR DESCRIPTION
**Description:** Update the documentation when using the NGINX proxy. The configuration for Home Assistant is missing.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
