### PR TITLE
Update MJPEG docs to include Blue Iris integration

### DIFF
--- a/source/_components/camera.mjpeg.markdown
+++ b/source/_components/camera.mjpeg.markdown
@@ -70,7 +70,7 @@ camera:
 
 Example of integrating Blue Iris Cameras from a Blue Iris server.
 
-```
+```yaml
 camera:
   - platform: mjpeg
     name: Livingroom Camera

--- a/source/_components/camera.mjpeg.markdown
+++ b/source/_components/camera.mjpeg.markdown
@@ -75,7 +75,7 @@ camera:
   - platform: mjpeg
     name: Livingroom Camera
     mjpeg_url: http://IP:PORT/mjpg/CAMERASHORTNAME/video.mjpeg
-    username: Blue Iris Username
-    password: Blue Iris Password
+    username: BLUE_IRIS_USERNAME
+    password: BLUE_IRIS_PASSWORD
     authentication: basic
 ```

--- a/source/_components/camera.mjpeg.markdown
+++ b/source/_components/camera.mjpeg.markdown
@@ -67,3 +67,15 @@ camera:
     still_image_url: http://IP/image.jpg
     mjpeg_url: http://IP/video/mjpg.cgi
 ```
+
+Example of integrating Blue Iris Cameras from a Blue Iris server.
+
+```
+camera:
+  - platform: mjpeg
+    name: Livingroom Camera
+    mjpeg_url: http://IP:PORT/mjpg/CAMERASHORTNAME/video.mjpeg
+    username: Blue Iris Username
+    password: Blue Iris Password
+    authentication: basic
+```


### PR DESCRIPTION
Added a second example to include a configuration for pulling Blue Iris camera feeds into Home Assistant.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
