### PR TITLE
Update package name

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -74,7 +74,7 @@ This is the list of packages you need to have available on your system that will
  - ca-certificates
  - curl
  - dbus
- - docker
+ - docker.io
  - jq
  - network-manager
  - socat


### PR DESCRIPTION
Curl script will fail if Docker.io package not installed. This is needed for installation of Hass on Ubuntu 18.04 LTS.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
