### PR TITLE
add documentation for zengge-wifi

### DIFF
--- a/source/_components/light.zengge-wifi.markdown
+++ b/source/_components/light.zengge-wifi.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Zengge Wi-Fi"
 description: "Instructions on how to integrate Zengge Wi-Fi bulbs into Home Assistant."
-date: 2017-01-14 08:00
+date: 2018-12-26 16:30
 sidebar: true
 comments: false
 sharing: true
@@ -17,30 +17,35 @@ The `zengge-wifi` platform allows you to integrate your [Zengge Wi-Fi bulbs](htt
 
 ## {% linkable_title Configuration %}
 
-To enable the lights, add the following lines to your `configuration.yaml` file:
+To enable the light, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 light:
   - platform: zengge-wifi
-    devices:
-      "192.168.1.39":
-        name: Living Room
+    host: IP_ADDRESS
 ```
 
 {% configuration %}
-devices:
-  description: The list of your devices/bulbs.
+name:
+  description: The name to use when displaying this bulb.
+  required: false
+  type: string
+  default: Zengge Bulb
+host:
+  description: "The IP address of your Zengge Wi-Fi bulb, eg. `192.168.1.100`."
   required: true
-  type: list
-  keys:
-    ip_address:
-      description: The IP address of the bulb.
-      required: true
-      type: list
-      keys:
-        name:
-          description: The friendly name for the frontend.
-          required: false
-          type: string
+  type: string
 {% endconfiguration %}
+
+## {% linkable_title Adding multiple lights %}
+
+You are able to add multiple lights by just adding multiple `zengge-wifi` platforms.
+
+```yaml
+light:
+  - platform: zengge-wifi
+    host: IP_ADDRESS_1
+  - platform: zengge-wifi
+    host: IP_ADDRESS_2
+```

--- a/source/_components/light.zengge-wifi.markdown
+++ b/source/_components/light.zengge-wifi.markdown
@@ -1,0 +1,46 @@
+---
+layout: page
+title: "Zengge Wi-Fi"
+description: "Instructions on how to integrate Zengge Wi-Fi bulbs into Home Assistant."
+date: 2017-01-14 08:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: zengge.png
+ha_category: Light
+ha_iot_class: "Local Polling"
+ha_release: 0.85
+---
+
+The `zengge-wifi` platform allows you to integrate your [Zengge Wi-Fi bulbs](http://www.zengge.com/) into Home Assistant.
+
+## {% linkable_title Configuration %}
+
+To enable the lights, add the following lines to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+light:
+  - platform: zengge-wifi
+    devices:
+      "192.168.1.39":
+        name: Living Room
+```
+
+{% configuration %}
+devices:
+  description: The list of your devices/bulbs.
+  required: true
+  type: list
+  keys:
+    ip_address:
+      description: The IP address of the bulb.
+      required: true
+      type: list
+      keys:
+        name:
+          description: The friendly name for the frontend.
+          required: false
+          type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**
Add documentation for new platform 'zengge-wifi'

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19568

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
