### PR TITLE
Improves Docker-CE wording.

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -80,7 +80,7 @@ This is the list of packages you need to have available on your system that will
  - socat
  - software-properties-common
 
-You also need to have Docker-CE installed. There is well-documented procedures for installing Docker on Ubuntu at [Docker.com](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
+You also need to have Docker-CE installed. There are well-documented procedures for installing Docker on Ubuntu at [Docker.com](https://docs.docker.com/install/linux/docker-ce/ubuntu/), you can find installation steps for your Linux distribution in the menu on the left.
 
 <p class='note warning'>
   Some distributions, like Ubuntu, have a `docker.io` package available. Using that packages will cause issues!


### PR DESCRIPTION
**Description:**

Improves working on the Hass.io manual installation method, when installing Docker on other distributions (not Ubuntu).

As commented by @ludeeus in #7678 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
