### PR TITLE
Corrected action for template switch documentation

### DIFF
--- a/source/_components/switch.template.markdown
+++ b/source/_components/switch.template.markdown
@@ -37,7 +37,7 @@ switch:
           data:
             entity_id: switch.skylight_open
         turn_off:
-          service: switch.turn_on
+          service: switch.turn_off
           data:
             entity_id: switch.skylight_close
 ```


### PR DESCRIPTION
**Description:**

Changed `turn_on` to `turn_off`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html