### PR TITLE
Adds a page for the custom_deps add-on

### DIFF
--- a/source/_addons/custom_deps.markdown
+++ b/source/_addons/custom_deps.markdown
@@ -13,12 +13,14 @@ This add-on allows you to run custom python modules in Home Assistant deps. "Sta
 
 Configuration Example:
 
-```{
+```
+{
   "pypi": [
     "hap_python==2.4.1"
   ],
   "apk": []
-}```
+}
+```
 
 {% configuration %}
 

--- a/source/_addons/custom_deps.markdown
+++ b/source/_addons/custom_deps.markdown
@@ -1,0 +1,30 @@
+---
+layout: page
+title: "Custom deps deployment"
+description: "Manage custom python modules in Home Assistant deps."
+date: 2018-12-26 10:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+---
+
+This add-on allows you to run custom python modules in Home Assistant deps. "Start on boot" can be left disabled. Modify the config as desired, save and start the add-on. You should now see the modules inside config/deps which can be modified. A restart of Home Assistant is required for any changes to the custom modules to take effect.
+
+Configuration Example:
+
+```{
+  "pypi": [
+    "hap_python==2.4.1"
+  ],
+  "apk": []
+}```
+
+{% configuration %}
+
+pypi:
+  Set the name(s) and version(s) of a python module.
+
+apk
+  Specify a custom apk build.
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**

Currently, the "Custom deps deployment" add-on has no page on home-assistant.io and the link on the add-on leads to no where. This pull request is to add a page with some basic info on how to use the add-on.

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
