### PR TITLE
Update sensor.wunderground.markdown

### DIFF
--- a/source/_components/sensor.wunderground.markdown
+++ b/source/_components/sensor.wunderground.markdown
@@ -16,7 +16,7 @@ ha_iot_class: "Cloud Polling"
 The `wunderground` platform uses [Weather Underground](http://www.wunderground.com) as a source for current weather information.
 
 <p class='note warning'>
-Obtain a WUnderground API key [here](https://www.wunderground.com/weather/api). They no longer offer free API keys, and all keys must be paid for. At this time existing free keys will continue to work, but will be disabled Dec 31, 2018.  As of Sept 6, 2018 Weather Underground states they are declaring the [End of Service for the Weather Underground API](https://apicommunity.wunderground.com/weatherapi/topics/end-of-service-for-the-weather-underground-api). They say they will develop new plans for non-commercial users.  No timeline for this has been announced.
+Obtain a WUnderground API key [here](https://www.wunderground.com/weather/api). They no longer offer free API keys, and all keys must be paid for. At this time existing free keys will continue to work, but will be disabled Dec 31, 2018, except you own a personal weather station and provide your data to WU (PWS Uploader).  As of Sept 6, 2018 Weather Underground states they are declaring the [End of Service for the Weather Underground API](https://apicommunity.wunderground.com/weatherapi/topics/end-of-service-for-the-weather-underground-api). They say they will develop new plans for non-commercial users.  No timeline for this has been announced.
 
 Please consider this when using the following information.
 </p>


### PR DESCRIPTION
"For PWS uploaders, the Weather Underground API will ﻿not﻿ close down on December 31."

**Description:**
API and free keys are only disabled for non PWS owners.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
