### PR TITLE
Updated docs for Yandex TTS

### DIFF
--- a/source/_components/tts.yandextts.markdown
+++ b/source/_components/tts.yandextts.markdown
@@ -41,7 +41,7 @@ codec:
   type: string
   default: "`mp3`"
 voice:
-  description: "The speaker voice. Supported female voices are `jane`, `oksana`, `alyss`, `omazh` and male voices are `zahar` and `ermil`."
+  description: "The speaker voice. Supported female voices are `jane`, `oksana`, `alyss`, `omazh`, `silaerkan`, `nastya`, `sasha`, `tanya`, `tatyana_abramova`, `voicesearch`, and `zombie`. Male voices are `zahar`, `ermil`, `levitan`, `ermilov`, `kolya`, `kostya`, `nick`, `erkanyavas`, `zhenya`, `anton_samokhvalov`, `ermil_with_tuning`, `robot`, `dude`, and `smoky`."
   required: false
   type: string
   default: "`zahar`"


### PR DESCRIPTION
**Description:**
Updated docs for Yandex TTS component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19603

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
