### PR TITLE
Add changes for alarm_control_panel.homekit_controller

### DIFF
--- a/source/_components/alarm_control_panel.homekit_controller.markdown
+++ b/source/_components/alarm_control_panel.homekit_controller.markdown
@@ -1,0 +1,16 @@
+---
+layout: page
+title: "HomeKit Alarm Control Panel"
+description: "Instructions how to setup HomeKit security systems within Home Assistant."
+date: 2018-12-27 20:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: apple-homekit.png
+ha_category: Alarm Control Panel
+ha_iot_class: "Local Polling"
+ha_release: 0.85
+---
+
+To get your HomeKit security system working with Home Assistant, follow the instructions for the general [HomeKit controller component](/components/homekit_controller/).

--- a/source/_components/alarm_control_panel.homekit_controller.markdown
+++ b/source/_components/alarm_control_panel.homekit_controller.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: apple-homekit.png
 ha_category: Alarm Control Panel
 ha_iot_class: "Local Polling"
-ha_release: 0.85
+ha_release: 0.86
 ---
 
 To get your HomeKit security system working with Home Assistant, follow the instructions for the general [HomeKit controller component](/components/homekit_controller/).

--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -22,10 +22,10 @@ ha_iot_class: "Local Polling"
 
 There is currently support for the following device types within Home Assistant:
 
+- [Alarm Control Panel](/components/alarm_control_panel.homekit_controller/)
 - [Climate](/components/climate.homekit_controller/)
 - [Light](/components/light.homekit_controller/)
 - [Switch](/components/switch.homekit_controller/)
-- [Alarm Control Panel](/components/alarm_control_panel.homekit_controller/)
 
 The component will be automatically configured if the [`discovery:`](/components/discovery/) component is enabled and an enable entry added for HomeKit:
 

--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -25,6 +25,7 @@ There is currently support for the following device types within Home Assistant:
 - [Climate](/components/climate.homekit_controller/)
 - [Light](/components/light.homekit_controller/)
 - [Switch](/components/switch.homekit_controller/)
+- [Alarm Control Panel](/components/alarm_control_panel.homekit_controller/)
 
 The component will be automatically configured if the [`discovery:`](/components/discovery/) component is enabled and an enable entry added for HomeKit:
 


### PR DESCRIPTION
**Description:**

This adds the necessary documentation stating support for HomeKit security systems being exposed as alarm control panels through Home Assistant.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19612

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html