### PR TITLE
Remove embedded video

### DIFF
--- a/source/lovelace/index.markdown
+++ b/source/lovelace/index.markdown
@@ -12,10 +12,6 @@ redirect_from: /components/lovelace/
 
 Lovelace is the name of the Home Assistant user interface. It is a fast, customizable and powerful way for users to manage their homes, working both on mobile and desktop.
 
-<div class='videoWrapper'>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/6FX9_leiikw" frameborder="0" allowfullscreen></iframe>
-</div>
-
 Lovelace is not the default UI just yet, but we're really close. Once you are ready to start using Lovelace UI as your main user interface, click on info, the "i" icon under 'Developer Tools" in the Home Assistant side-bar. Next, locate >>Set Lovelace as default page on this device<< under the Home Assistant version information and click it.
 
 Note that this is a per-device setting and will need to be changed on each device you access the UI from.


### PR DESCRIPTION
The video is from 0.73 beta, it's horribly horribly out of date. Either it needs to be kept updated, or we should remove it to avoid confusing people.
