### PR TITLE
Update MQTT discovery for climate devices

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -255,7 +255,6 @@ Setting up a climate component (heat only) with abbreviated configuration variab
 ```yaml
 {
   "name":"Livingroom",
-  "dev_cla":"climate",
   "mode_cmd_t":"homeassistant/climate/livingroom/thermostatModeCmd",
   "mode_stat_t":"homeassistant/climate/livingroom/state",
   "mode_stat_tpl":"{{value_json.mode}}",


### PR DESCRIPTION
removed line ´"dev_cla":"climate",´ since it is not supported for climate devices and results in warnings in the log during discovery

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** not applicable

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
