### PR TITLE
Update greeneye_monitor docs with breaking change.

### DIFF
--- a/source/_components/greeneye_monitor.markdown
+++ b/source/_components/greeneye_monitor.markdown
@@ -22,7 +22,7 @@ Configure your GEM(s) to produce binary-format packets (for example, "Bin32 NET"
 greeneye_monitor:
   port: 8000
   monitors:
-    - serial_number: YOUR_SERIAL_NUMBER
+    - serial_number: "YOUR_SERIAL_NUMBER"
       channels:
         - number: 1
           name: total_power
@@ -53,9 +53,9 @@ monitors:
   type: list
   keys:
     serial_number:
-      description: Your 8-digit GEM serial number, as it appears in the UI (omitting leading zeroes).
+      description: Your 8-digit GEM serial number, as it appears in the UI.
       required: true
-      type: integer
+      type: string
     channels:
       description: The list of channels that should appear in Home Assistant for this monitor. Data from other channels will be ignored.
       required: false

--- a/source/_components/greeneye_monitor.markdown
+++ b/source/_components/greeneye_monitor.markdown
@@ -53,7 +53,7 @@ monitors:
   type: list
   keys:
     serial_number:
-      description: The last five digits (omitting leading zeroes) of your GEM serial number.
+      description: Your 8-digit GEM serial number, as it appears in the UI (omitting leading zeroes).
       required: true
       type: integer
     channels:


### PR DESCRIPTION
**Description:**
Doc update to match a breaking change in `greeneye_monitor`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19631

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
