### PR TITLE
Updated docs for LCN light platform to support relay ports

### DIFF
--- a/source/_components/lcn.markdown
+++ b/source/_components/lcn.markdown
@@ -100,11 +100,11 @@ lights:
       required: true
       type: string
     output:
-      description: "Light source ([OUTPUT_PORT](/components/lcn#ports))."
+      description: "Light source ([OUTPUT_PORT](/components/lcn#ports), [RELAY_PORT](/components/lcn#ports))."
       required: true
       type: string
     dimmable:
-      description: Enable the dimming feature for this light
+      description: Enable the dimming feature for this light.
       required: false
       type: bool
       default: false
@@ -155,3 +155,4 @@ The platforms and service calls use several predefined constants as parameters.
 | Constant | Values |
 | -------- | ------ |
 | OUTPUT_PORT | `output1`, `output2`, `output3`, `output4` |
+| RELAY_PORT | `relay1`, `relay2`, `relay3`, `relay4`, `relay5`, `relay6`, `relay7`, `relay8` |

--- a/source/_components/light.lcn.markdown
+++ b/source/_components/light.lcn.markdown
@@ -16,6 +16,7 @@ ha_iot_class: "Local Push"
 The `lcn` light platform allows the control of the following [LCN](http://www.lcn.eu) ports:
 
 - (Dimmable) output ports
+- Relays
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
**Description:**
Updated documentation for LCN lights which are connected to the relays of LCN hardware devices.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19632

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
