### PR TITLE
Add press hold for send command

### DIFF
--- a/source/_components/harmony.markdown
+++ b/source/_components/harmony.markdown
@@ -67,6 +67,11 @@ delay_secs:
   description: Default duration in seconds between sending commands to a device.
   required: false
   type: float
+  default: 0.4
+hold_secs:
+  description: Default duration in seconds between sending the "press" command and sending the "release" command
+  required: false
+  default: 0
 {% endconfiguration %}
 
 ### {% linkable_title Configuration file %}

--- a/source/_components/harmony.markdown
+++ b/source/_components/harmony.markdown
@@ -69,7 +69,7 @@ delay_secs:
   type: float
   default: 0.4
 hold_secs:
-  description: Default duration in seconds between sending the "press" command and sending the "release" command
+  description: Default duration in seconds between sending the "press" command and sending the "release" command.
   required: false
   default: 0
 {% endconfiguration %}

--- a/source/_components/harmony.markdown
+++ b/source/_components/harmony.markdown
@@ -82,7 +82,7 @@ Upon startup one file will be written to your Home Assistant configuration direc
 - List of all programmed device names and ID numbers
 - List of all available commands per programmed device
 
-This file will be overwritten whenever the Harmony HUB has a new configuration, there is no need to restart HASS.
+This file will be overwritten whenever the Harmony HUB has a new configuration, there is no need to restart Home Assistant.
 
 ### {% linkable_title Service `remote.turn_off` %}
 
@@ -90,7 +90,7 @@ Turn off all devices that were switched on from the start of the current activit
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on a specific remote, else target all.
+| `entity_id`            |       no | Entity ID to target.
 
 ### {% linkable_title Service `remote.turn_on` %}
 
@@ -98,7 +98,7 @@ Start an activity. Will start the default `activity` from configuration.yaml if 
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on a specific remote, else target all.
+| `entity_id`            |       no | Entity ID to target.
 | `activity`             |      yes | Activity ID or Activity Name to start.
 
 ##### {% linkable_title Example %}
@@ -132,7 +132,7 @@ Send a single command or a set of commands to one device, device ID and availabl
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on a specific remote, else target all.
+| `entity_id`            |       no | Entity ID to target.
 | `device`               |       no | Device ID or Device Name to send the command to.
 | `command`              |       no | A single command or a list of commands to send.
 | `num_repeats`          |      yes | The number of times to repeat the command(s).
@@ -164,7 +164,6 @@ In the file 'harmony_REMOTENAME.conf' you can find the available devices and com
 }
 ```
 
-
 A typical service call for sending several button presses looks like this:
 
 ```yaml
@@ -195,7 +194,7 @@ Sends the change channel command to the Harmony HUB
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |       no | Only act on a specific remote, else target all.
+| `entity_id`            |       no | Entity ID to target.
 | `channel`              |       no | Channel number to change to
 
 A typical service call for changing the channel would be::
@@ -213,7 +212,7 @@ Force synchronization between the Harmony device and the Harmony cloud.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on a specific remote, else target all.
+| `entity_id`            |       no | Entity ID to target.
 
 ### {% linkable_title Examples %}
 


### PR DESCRIPTION
**Description:**

Documentation with example for the new hold_secs parameter within the send_command.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19650

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html