### PR TITLE
Updates documentation for BME680

### DIFF
--- a/source/_components/sensor.bme680.markdown
+++ b/source/_components/sensor.bme680.markdown
@@ -154,12 +154,16 @@ customize:
   sensor.bme680_sensor_humidity:
     icon: mdi:water
     friendly_name: Humidity
+    device_class: humidity
+    unit_of_measurement: "%"
   sensor.bme680_sensor_pressure:
     icon: mdi:gauge
     friendly_name: Pressure
   sensor.bme680_sensor_air_quality:
     icon: mdi:blur
     friendly_name: Air Quality
+    device_class: pm25
+    unit_of_measurement: "%"
 ```
 
 To create a group, add the following to your `group` section.


### PR DESCRIPTION
**Description:**
Updates documentation to add device_class to allow for sensor detection in other platforms e.g. Homekit.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
