### PR TITLE
Adds instructions for adding BME680 to hass.io

### DIFF
--- a/source/_components/sensor.bme680.markdown
+++ b/source/_components/sensor.bme680.markdown
@@ -180,6 +180,33 @@ group:
       - sensor.bme680_sensor_air_quality
 ```
 
+## {% linkable_title Directions for enabling I2C interface on Hass.Io %}
+The BME680 sensor requires you to enable the I2C interface in the hass.io configuration via the command prompt.  **NOTE**: this will not work via an ssh connection.
+ 
+You will need: 
+* hdmi cable 
+* usb keyboard
+ 
+Power down your hass.io server.  Connect your hdmi cable and keyboard.  Power on the hass.io server.  When you see a login prompt, login as: `root` with no password.  
+ 
+After you login, you will see the Hass.IO command line welcome prompt.  You will need to access the shell by typing `shell`.  
+ 
+After you see the shell prompt, type `vi /etc/modules-load.d/rpi-i2c.conf` to create a new config file.  Add these two lines by typing: `i` then paste in:
+```bash
+i2c-bcm2708
+i2c-dev
+```
+
+Save and exit by typing `:wq`
+
+Now type `vi /boot/config.txt` to edit the boot configuration file. Add these two lines by typing `i` then:
+
+```bash
+dtparam=i2c1=on 
+dtparam=i2c_arm=on
+```
+Now reboot your hass.io.
+
 ## {% linkable_title Directions for installing SMBus support on Raspberry Pi %}
 
 Enable I2C interface with the Raspberry Pi configuration utility:


### PR DESCRIPTION
**Description:**
Adds instructions for adding BME680 to hass.io

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
