### PR TITLE
Add how-to for Check Home Assistant configuration Add-On

### DIFF
--- a/source/_addons/check_config.markdown
+++ b/source/_addons/check_config.markdown
@@ -11,13 +11,13 @@ footer: true
 
 You can use this add-on to check whether your configuration files are valid against the new version of Home Assistant before you actually update your Home Assistant installation. This add-on will help you avoid errors due to breaking changes, resulting in a smooth update.
 
-### {% linkable_title How to use this Add-On %} 
+### {% linkable_title How to use this add-On %} 
 
-1. Just start the Add-On
+1. Just start the add-On
 2. Wait (On a Raspberry Pi it can take several minutes)
-3. If you see the following output you are good to go to update Home Assistant: `[Info] Configuration check finished - no error found! :)`
+3. If you see the following output then you are good to go to update Home Assistant: `[Info] Configuration check finished - no error found! :)`
 
-If you get errors you should look for **Breaking Changes** against the version you specified for this add-on and change your configuration accordingly.
+If you get errors then you should look for **Breaking Changes** against the version you specified for this add-on and change your configuration accordingly.
 
 ```json
 {

--- a/source/_addons/check_config.markdown
+++ b/source/_addons/check_config.markdown
@@ -11,13 +11,15 @@ footer: true
 
 You can use this add-on to check whether your configuration files are valid against the new version of Home Assistant before you actually update your Home Assistant installation. This add-on will help you avoid errors due to breaking changes, resulting in a smooth update.
 
-### {% linkable_title How to use this add-On %} 
+### {% linkable_title How to use this add-on %} 
 
-1. Just start the add-On
-2. Wait (On a Raspberry Pi it can take several minutes)
-3. If you see the following output then you are good to go to update Home Assistant: `[Info] Configuration check finished - no error found! :)`
+1. Just start the add-on.
+2. Wait (On a Raspberry Pi it can take several minutes).
+3. If you see the following output then you are good to go to update Home Assistant: `[Info] Configuration check finished - no error found! :)`.
 
-If you get errors then you should look for **Breaking Changes** against the version you specified for this add-on and change your configuration accordingly.
+If you get errors, then you should look for **Breaking Changes** against the version you specified for this add-on and change your configuration accordingly.
+
+### {% linkable_title Add-on configuration %}
 
 ```json
 {

--- a/source/_addons/check_config.markdown
+++ b/source/_addons/check_config.markdown
@@ -11,7 +11,7 @@ footer: true
 
 You can use this add-on to check whether your configuration files are valid against the new version of Home Assistant before you actually update your Home Assistant installation. This add-on will help you avoid errors due to breaking changes, resulting in a smooth update.
 
-### How to use this Add-On
+### {% linkable_title How to use this Add-On %} 
 
 1. Just start the Add-On
 2. Wait (On a Raspberry Pi it can take several minutes)

--- a/source/_addons/check_config.markdown
+++ b/source/_addons/check_config.markdown
@@ -11,6 +11,14 @@ footer: true
 
 You can use this add-on to check whether your configuration files are valid against the new version of Home Assistant before you actually update your Home Assistant installation. This add-on will help you avoid errors due to breaking changes, resulting in a smooth update.
 
+### How to use this Add-On
+
+1. Just start the Add-On
+2. Wait (On a Raspberry Pi it can take several minutes)
+3. If you see the following output you are good to go to update Home Assistant: `[Info] Configuration check finished - no error found! :)`
+
+If you get errors you should look for **Breaking Changes** against the version you specified for this add-on and change your configuration accordingly.
+
 ```json
 {
   "version": "latest"


### PR DESCRIPTION
**Description:**

Add usage instructions for Check Home Assistant configuration Add-On

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
