### PR TITLE
Add best practice on how to upgrade Hass.io

### DIFF
--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -64,17 +64,17 @@ If you want to stay on the bleeding-edge Home Assistant development branch, you 
 $ pip3 install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
 ```
 
-# {% linkable_title Update Hass.io installation %}
+### {% linkable_title Update Hass.io installation %}
 
 Best practise for updating a Hass.io installation:
 
 1. Backup your installation
     - Use the snapshot functionallity by Hass.io
 2. Check the release notes for breaking changes on [Home Assistant release notes](https://github.com/home-assistant/home-assistant/releases)
-    - Use the search function in your browser (`STRG + F`) and search for **Breaking Changes**
-3. Check your configuration via the [Check Home Assistant configuration](/addons/check_config/) Add-On
+    - Use the search function in your browser (`STRG + f`) and search for **Breaking Changes**
+3. Check your configuration via the [Check Home Assistant configuration](/addons/check_config/) add-On
     - If this works you can safly update
     - If this does not work change your config accordingly
-4. If necassary change your home assistant configuration accordingly
+4. If necassary change your Home Assistant configuration accordingly
 5. Update Home Assistant
 6. Restart Home Assistant

--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -63,3 +63,18 @@ If you want to stay on the bleeding-edge Home Assistant development branch, you 
 ```bash
 $ pip3 install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
 ```
+
+# {% linkable_title Update Hass.io installation %}
+
+Best practise for updating a Hass.io installation:
+
+1. Backup your installation
+    - Use the snapshot functionallity by Hass.io
+2. Check the release notes for breaking changes on [Home Assistant release notes](https://github.com/home-assistant/home-assistant/releases)
+    - Use the search function in your browser (`STRG + F`) and search for **Breaking Changes**
+3. Check your configuration via the [Check Home Assistant configuration](/addons/check_config/) Add-On
+    - If this works you can safly update
+    - If this does not work change your config accordingly
+4. If necassary change your home assistant configuration accordingly
+5. Update Home Assistant
+6. Restart Home Assistant


### PR DESCRIPTION
**Description:**

This link can be send to users which have a broken Hass.io installation after upgrading.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
