### PR TITLE
remove homeassistant_venv subdir

### DIFF
--- a/source/_docs/ecosystem/backup/backup_github.markdown
+++ b/source/_docs/ecosystem/backup/backup_github.markdown
@@ -132,7 +132,7 @@ You may need to adjust the paths in the script depending on your Home Assistant 
 #!/bin/bash
 
 cd /home/homeassistant/.homeassistant
-source /srv/homeassistant/homeassistant_venv/bin/activate
+source /srv/homeassistant/bin/activate
 hass --script check_config
 
 git add .


### PR DESCRIPTION
**Description:**
in the example gitupdate.sh script, there is a non-standard sub-directory path called `homeassistant_venv` within `/srv/homeassistant`
This conflicts with https://www.home-assistant.io/docs/installation/raspberry-pi/

This change removes it.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
