### PR TITLE
Adds instructions for temp_offset.

### DIFF
--- a/source/_components/sensor.bme680.markdown
+++ b/source/_components/sensor.bme680.markdown
@@ -111,6 +111,11 @@ aq_humidity_bias:
   required: false
   default: 25
   type: integer
+temp_offset:
+  description: The temperature for the sensor will always be too high as it pulls heat from the components around it.  Consider adding a negative offset to ensure the sensor returns an accurate temperature. Note: This value is in celsius.
+  required: false
+  default: 0
+  type: float
 {% endconfiguration %}
 
 ## {% linkable_title Full Examples %}
@@ -139,6 +144,7 @@ sensor:
     aq_burn_in_time: 300
     aq_humidity_baseline: 40
     aq_humidity_bias: 25
+    temp_offset: -5.5
 ```
 
 ## {% linkable_title Customizing the sensor data %}

--- a/source/_components/sensor.bme680.markdown
+++ b/source/_components/sensor.bme680.markdown
@@ -112,7 +112,7 @@ aq_humidity_bias:
   default: 25
   type: integer
 temp_offset:
-  description: The temperature for the sensor will always be too high as it pulls heat from the components around it.  Consider adding a negative offset to ensure the sensor returns an accurate temperature. Note: This value is in celsius.
+  description: "The temperature for the sensor will always be too high as it pulls heat from the components around it.  Consider adding a negative offset to ensure the sensor returns an accurate temperature. Note: This value is in celsius."
   required: false
   default: 0
   type: float


### PR DESCRIPTION
**Description:**
Adds instructions for calibrating the sensor temperature using temp_offset.
This PR is dependent upon: https://github.com/home-assistant/home-assistant/pull/19684

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
