### PR TITLE
Add brightness command template MQTT light doc

### DIFF
--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -65,6 +65,10 @@ command_topic:
   description: The MQTT topic to publish commands to change the switch state.
   required: true
   type: string
+brightness_command_template:
+  description: "Defines a [template](/docs/configuration/templating/) to compose message which will be sent to `brightness_command_topic`. Available variables: `brightness`."
+  required: false
+  type: string
 brightness_command_topic:
   description: The MQTT topic to publish commands to change the light’s brightness.
   required: false


### PR DESCRIPTION
**Description:**

Add documentation for `brightness_command_template` in MQTT Light component

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19712

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
