### PR TITLE
Documenting impact of state restore change

### DIFF
--- a/source/_posts/2018-12-12-release-84.markdown
+++ b/source/_posts/2018-12-12-release-84.markdown
@@ -33,6 +33,8 @@ We have a new more reliable way of state restoration introduced by [@armills]. I
 
 This comes with a downside: we will be unable to restore states the first time you start 0.84.
 
+This means that on upgrade to 0.84 any automation that doesn't have an `initial_state` defined **will be disabled**.
+
 ## {% linkable_title Improved service calling %}
 
 We have improved how we call services with better validation checks. This means that if you have an automation or a script that sends invalid data, we will now stop the execution and be better able to point out where your incorrect calls are coming from.


### PR DESCRIPTION
As it turns off all the automations without an `initial_state`, and it's hitting lots of folks, documenting it here ;)
