### PR TITLE
google maps allow multiple accounts

### DIFF
--- a/source/_components/device_tracker.google_maps.markdown
+++ b/source/_components/device_tracker.google_maps.markdown
@@ -19,7 +19,7 @@ The `google_maps` platform allows you to detect presence using the unofficial AP
 
 You first need to create an additional Google account and share your location with that account. This platform will use that account to fetch the location of your device(s). You have to setup sharing through the Google Maps app on your mobile phone. You can find more information [here](https://support.google.com/accounts?p=location_sharing).
 
-This platform will create a file named `.google_maps_location_sharing.cookies` where it caches your login session.
+This platform will create a file named `.google_maps_location_sharing.cookies` extended with the slugified username where it caches your login session.
 
 <p class='note warning'>
 Since this platform is using an unofficial API with the help of [locationsharinglib](https://github.com/costastf/locationsharinglib), Google seems to block access to your data the first time you've logged in with this platform.


### PR DESCRIPTION
**Description:**
cookie file extension with username to allow multiple accounts for the google maps device-tracker component

Edit: adjusted parent pull request #

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19811

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
