### PR TITLE
Fixing missing `binary_`

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -115,7 +115,7 @@ determine if the furnace is running by checking that it is over some threshold:
 
 {% raw %}
 ```yaml
-sensor:
+binary_sensor:
   - platform: template
     sensors:
       furnace_on:


### PR DESCRIPTION
One of the sensor templates was a sensor template, not a binary_sensor template
