### PR TITLE
Add support for multiple modbus hubs.

### DIFF
--- a/source/_components/binary_sensor.modbus.markdown
+++ b/source/_components/binary_sensor.modbus.markdown
@@ -25,9 +25,11 @@ binary_sensor:
   - platform: modbus
     coils:
       - name: Sensor1
+        hub: hub1
         slave: 1
         coil: 100
       - name: Sensor2
+        hub: hub1
         slave: 1
         coil: 110
 ```
@@ -41,6 +43,11 @@ coils:
     name:
       description: Name of the sensor.
       required: true
+      type: string
+    hub:
+      description: The name of the hub.
+      required: true
+      default: default
       type: string
     slave:
       description: The number of the slave (Optional for TCP and UDP Modbus).
@@ -64,9 +71,11 @@ binary_sensor:
     scan_interval: 10
     coils:
       - name: Sensor1
+        hub: hub1
         slave: 1
         coil: 100
       - name: Sensor2
+        hub: hub1
         slave: 1
         coil: 110
 ```

--- a/source/_components/binary_sensor.modbus.markdown
+++ b/source/_components/binary_sensor.modbus.markdown
@@ -46,7 +46,7 @@ coils:
       type: string
     hub:
       description: The name of the hub.
-      required: true
+      required: false
       default: default
       type: string
     slave:

--- a/source/_components/climate.flexit.markdown
+++ b/source/_components/climate.flexit.markdown
@@ -36,7 +36,7 @@ name:
   required: false
   type: string
 hub:
-  description: The name of the hub.
+  description: The name of the hub where this slave is located.
   required: false
   default: default
   type: string

--- a/source/_components/climate.flexit.markdown
+++ b/source/_components/climate.flexit.markdown
@@ -35,6 +35,11 @@ name:
   description: Displayed name of the A/C unit.
   required: false
   type: string
+hub:
+  description: The name of the hub.
+  required: false
+  default: default
+  type: string
 {% endconfiguration %}
 
 <p class='note'>

--- a/source/_components/climate.modbus.markdown
+++ b/source/_components/climate.modbus.markdown
@@ -25,6 +25,7 @@ To use your Modbus thermostat in your installation, add the following to your `c
 climate:
   - platform: modbus
     name: Watlow F4T
+    hub: hub1
     slave: 1
     target_temp_register: 2782
     current_temp_register: 27586
@@ -34,6 +35,11 @@ climate:
 name:
   description: Name of the device
   required: true
+  type: string
+hub:
+  description: The name of the hub.
+  required: true
+  default: default
   type: string
 slave:
   description: The number of the slave (Optional for tcp and upd Modbus, use 1).

--- a/source/_components/climate.modbus.markdown
+++ b/source/_components/climate.modbus.markdown
@@ -38,7 +38,7 @@ name:
   type: string
 hub:
   description: The name of the hub.
-  required: true
+  required: false
   default: default
   type: string
 slave:

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -48,8 +48,8 @@ port:
   required: true
   type: integer
 name:
-  description: a name to reference this connection. Required when setting up multiple instances.
-  required: true
+  description: Name for this hub. Must be unique, so it is required when setting up multiple instances.
+  required: false
   default: default
   type: string
 timeout:
@@ -106,8 +106,8 @@ parity:
   required: true
   type: string
 name:
-  description: a name to reference this connection. Required when setting up multiple instances.
-  required: true
+  description: Name for this hub. Must be unique, so it is required when setting up multiple instances.
+  required: false
   default: default
   type: string
 timeout:
@@ -146,7 +146,7 @@ modbus:
 
 | Attribute | Description |
 | --------- | ----------- |
-| hub       | Hub name. Needed when using multiple connections (defaults to 'default' when omitted) |
+| hub       | Hub name (defaults to 'default' when omitted) |
 | unit      | Slave address (set to 255 you talk to Modbus via TCP) |
 | address   | Address of the Register (e.g., 138) |
 | value     | An array of 16-bit values. Might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -26,8 +26,7 @@ The configuration for adding modbus to your installation depends on the connecti
 For a network connection, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example c
-onfiguration.yaml entry for a TCP connection
+# Example configuration.yaml entry for a TCP connection
 modbus:
   name: hub1
   type: tcp

--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -26,8 +26,10 @@ The configuration for adding modbus to your installation depends on the connecti
 For a network connection, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yaml entry for a TCP connection
+# Example c
+onfiguration.yaml entry for a TCP connection
 modbus:
+  name: hub1
   type: tcp
   host: IP_ADDRESS
   port: 2020
@@ -46,6 +48,11 @@ port:
   description: The network port for the communication.
   required: true
   type: integer
+name:
+  description: a name to reference this connection. Required when setting up multiple instances.
+  required: true
+  default: default
+  type: string
 timeout:
   description: Timeout for slave response in seconds.
   required: false
@@ -60,6 +67,7 @@ For a serial connection, add the following to your `configuration.yaml` file:
 ```yaml
 # Example configuration.yaml entry for a serial connection
 modbus:
+  name: hub1
   type: serial
   method: rtu
   port: /dev/ttyUSB0
@@ -98,6 +106,11 @@ parity:
   description: "The parity for the serial connection; can be `E`, `O` or `N`."
   required: true
   type: string
+name:
+  description: a name to reference this connection. Required when setting up multiple instances.
+  required: true
+  default: default
+  type: string
 timeout:
   description: Timeout for slave response in seconds.
   required: false
@@ -105,17 +118,36 @@ timeout:
   type: integer
 {% endconfiguration %}
 
+### {% linkable_title Multiple connections %}
+
+Multiple connections are possible, add something like the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry for multiple TCP connections
+modbus:
+  - type: tcp
+    host: IP_ADDRESS_1
+    port: 2020
+    hub: hub1
+    
+  - type: tcp
+    host: IP_ADDRESS_2
+    port: 501
+    hub: hub2
+```
+
 ### {% linkable_title Services %}
 
 
 | Service | Description |
 | ------- | ----------- |
-| write_register | Write register. Requires `unit`, `address` and `value` fields. `value` can be either single value or an array |
+| write_register | Write register. Requires `hub`, `unit`, `address` and `value` fields. `value` can be either single value or an array |
 
 #### {% linkable_title Service Data Attributes %}
 
 | Attribute | Description |
 | --------- | ----------- |
+| hub       | Hub name. Needed when using multiple connections (defaults to 'default' when omitted) |
 | unit      | Slave address (set to 255 you talk to Modbus via TCP) |
 | address   | Address of the Register (e.g., 138) |
 | value     | An array of 16-bit values. Might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |

--- a/source/_components/sensor.modbus.markdown
+++ b/source/_components/sensor.modbus.markdown
@@ -60,7 +60,7 @@ registers:
       type: string
     hub:
       description: The name of the hub.
-      required: true
+      required: false
       default: default
       type: string
     slave:

--- a/source/_components/sensor.modbus.markdown
+++ b/source/_components/sensor.modbus.markdown
@@ -26,15 +26,18 @@ sensor:
   platform: modbus
   registers:
     - name: Sensor1
+      hub: hub1
       unit_of_measurement: °C
       slave: 1
       register: 100
     - name: Sensor2
+      hub: hub1
       unit_of_measurement: mg
       slave: 1
       register: 110
       count: 2
     - name: Sensor3
+      hub: hub1
       unit_of_measurement: °C
       slave: 1
       register: 120
@@ -54,6 +57,11 @@ registers:
     name:
       description: Name of the sensor.
       required: true
+      type: string
+    hub:
+      description: The name of the hub.
+      required: true
+      default: default
       type: string
     slave:
       description: The number of the slave (Optional for tcp and upd Modbus).
@@ -118,6 +126,7 @@ sensor:
   scan_interval: 10
   registers:
     - name: Room_1
+      hub: hub1
       slave: 10
       register: 0
       register_type: holding

--- a/source/_components/switch.modbus.markdown
+++ b/source/_components/switch.modbus.markdown
@@ -49,7 +49,7 @@ coils:
   keys:
     hub:
       description: The name of the hub.
-      required: true
+      required: false
       default: default
       type: string
     slave:
@@ -71,7 +71,7 @@ register:
   keys:
     hub_name:
       description: The hub to use.
-      required: true
+      required: false
       default: default
       type: string
     slave:

--- a/source/_components/switch.modbus.markdown
+++ b/source/_components/switch.modbus.markdown
@@ -26,6 +26,7 @@ switch:
   slave: 1
   coils:
     - name: Switch1
+      hub: hub1
       slave: 1
       coil: 13
     - name: Switch2
@@ -33,6 +34,7 @@ switch:
       coil: 14
   registers:
     - name: Register1
+      hub: hub1
       slave: 1
       register: 11
       command_on: 1
@@ -45,6 +47,11 @@ coils:
   required: false
   type: map
   keys:
+    hub:
+      description: The name of the hub.
+      required: true
+      default: default
+      type: string
     slave:
       description: The number of the slave (can be omitted for tcp and udp Modbus).
       required: true
@@ -62,6 +69,11 @@ register:
   required: false
   type: map
   keys:
+    hub_name:
+      description: The hub to use.
+      required: true
+      default: default
+      type: string
     slave:
       description: The number of the slave (can be omitted for tcp and udp Modbus).
       required: true


### PR DESCRIPTION
**Description:**
Add support for multiple modbus hubs.
New config variables are introduced. "name" in the modbus component and "hub" in sensors, etc.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19726>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
