### PR TITLE
add country support to mychevy

### DIFF
--- a/source/_components/mychevy.markdown
+++ b/source/_components/mychevy.markdown
@@ -41,8 +41,9 @@ password:
   required: true
   type: string
 country:
-  description: Which country's servers to contact. Defaults to 'us', also supports 'ca'.
+  description: Which country's servers to contact. Supports 'us' or 'ca'.
   required: false
+  default: us
   type: string
 {% endconfiguration %}
 

--- a/source/_components/mychevy.markdown
+++ b/source/_components/mychevy.markdown
@@ -40,6 +40,10 @@ password:
   description: The password for your given my.chevrolet account.
   required: true
   type: string
+country:
+  description: Which country's servers to contact. Defaults to 'us', also supports 'ca'.
+  required: false
+  type: string
 {% endconfiguration %}
 
 
@@ -49,7 +53,6 @@ The architecture of the GM automotive networking imposes some limitations on the
 
 The OnStar network link is very slow, and takes 1 - 3 minutes to get information back from the car. As such the mychevy component only polls every 30 minutes to not overwhelms that connection.
 
-The OnStar network (or more specifically the gateway used by the my.chevrolet website) appears to suffer more than most networks when the car is a) in a garage, and b) it's cold outside (like < 15 degrees F). One of the provided sensors is a status sensor which indicates if we got connectivity with the car on the last polling cycle or not. 
+The OnStar network (or more specifically the gateway used by the my.chevrolet website) appears to suffer more than most networks when the car is a) in a garage, and b) it's cold outside (like < 15 degrees F). One of the provided sensors is a status sensor which indicates if we got connectivity with the car on the last polling cycle or not.
 
 The "API" for this is written through using some existing API calls from the Javascript web user interfae. As such, it only currently is known to work if you have a Chevy Bolt EV or a Chevy Volt, and only 1 Chevy car connected to OnStar. Patches for extended support should go to the [https://github.com/sdague/mychevy](https://github.com/sdague/mychevy) project first, then Home Assistant can be extended.
-


### PR DESCRIPTION
**Description:**

This adds support for the new country parameter for the mychevy component so it can work for folks in canada.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19727

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
