### PR TITLE
Make asuswrt sensor optional

### DIFF
--- a/source/_components/asuswrt.markdown
+++ b/source/_components/asuswrt.markdown
@@ -63,6 +63,20 @@ require_ip:
   required: false
   type: boolean
   default: true
+sensors:
+  description: List of enabled sensors
+  required: false
+  type: list
+  default: all (`upload`, `download`, `upload_speed`, `download_speed`)
+  keys:
+    "upload":
+      description: TX upload sensor
+    "download":
+      description: RX download sensor
+    "download_speed":
+      description: download mbit/s sensor
+    "upload_speed":
+      description: upload mbit/s sensor
 {% endconfiguration %}
 
 <p class='note warning'>

--- a/source/_components/sensor.asuswrt.markdown
+++ b/source/_components/sensor.asuswrt.markdown
@@ -13,12 +13,6 @@ ha_iot_class: "Local Polling"
 ha_release: 0.83
 ---
 
-The `asuswrt` platform allows you to get data from your [ASUSWRT](http://event.asus.com/2013/nw/ASUSWRT/) sensors from within Home Assistant.
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-    - platform: asuswrt
-```
+The `asuswrt` sensor platform allows you to get upload and download data from your [ASUSWRT](http://event.asus.com/2013/nw/ASUSWRT/) within Home Assistant.
 
 For more configuration information see the [Asuswrt component](/components/asuswrt/) documentation.

--- a/source/_components/sensor.asuswrt.markdown
+++ b/source/_components/sensor.asuswrt.markdown
@@ -14,7 +14,11 @@ ha_release: 0.83
 ---
 
 The `asuswrt` platform allows you to get data from your [ASUSWRT](http://event.asus.com/2013/nw/ASUSWRT/) sensors from within Home Assistant.
-  
-The sensor platform will be automatically configured if Asuswrt component is configured.
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+    - platform: asuswrt
+```
 
 For more configuration information see the [Asuswrt component](/components/asuswrt/) documentation.


### PR DESCRIPTION
**Description:**
This is for changing the asuswrt sensor to optional

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19736

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
