### PR TITLE
Updated documents to go with PR #19737

### DIFF
--- a/source/_components/sensor.efergy.markdown
+++ b/source/_components/sensor.efergy.markdown
@@ -37,11 +37,12 @@ sensor:
     monitored_variables:
       - type: instant_readings
       - type: budget
-      - type: cost
-        period: day
+      - type: cost_day
         currency: $
-      - type: amount
-        period: day
+      - type: amount_day
+      - type: cost_week
+        currency: $
+      - type: amount_week
       - type: current_values
 ```
 
@@ -53,8 +54,7 @@ Configuration variables:
   - **type** (*Required*): Name of the variable.
     - **instant_readings**: Instant energy consumption.
     - **budget**: Monthly budget.
-    - **cost**: The cost for energy consumption (with the tariff that has been set in Efergy) over a given period.
-    - **amount**: The amount of energy consumed over a given period.
+    - **cost**: The cost for energy consumption (with the tariff that has been set in Efergy) over a given period, cost_day, _week, _month, _year. Multiple periods can be defined.
+    - **amount**: The amount of energy consumed over a given period, amount_day, _week, _month, _year. Multiple periods can be defined.
     - **current_values**: This returns the current energy usage of each device on your account, as `efergy_\<sid of device\>`. If you only have one device in your account, this is effectively the same as instant_readings.
-  - **period** (*Optional*): Some variables take a period argument. Valid options are "day", "week", "month", and "year".
   - **currency** (*Optional*): This is used to display the cost/period as the unit when monitoring the cost. It should correspond to the actual currency used in your dashboard.


### PR DESCRIPTION
Updated documentation to go with PR #19737

Removed 'Period' from examples and definitions. 

Added _day, _week, _month and _year to cost and amount including updated example.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19737

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
