### PR TITLE
Documentation for Exposing IMAP Search String

### DIFF
--- a/source/_components/sensor.imap.markdown
+++ b/source/_components/sensor.imap.markdown
@@ -57,4 +57,18 @@ folder:
   required: false
   default: inbox
   type: string
+search:
+  description: The IMAP search to perform on the watched folder.
+  required: false
+  default: UnSeen UnDeleted
+  type: string
 {% endconfiguration %}
+
+### {% linkable_title Configuring IMAP Searches %}
+
+By default, this component will count unread emails.  By configuring the search string, you can count other results, for example:
+
+* `ALL` to count all emails in a folder
+* `FROM`, `TO`, `SUBJECT` to find emails in a folder (see [IMAP RFC for all standard options](https://tools.ietf.org/html/rfc3501#section-6.4.4))
+* [Gmail's IMAP extensions](https://developers.google.com/gmail/imap/imap-extensions) allow raw Gmail searches, like `X-GM-RAW "in: inbox older_than:7d"` to show emails older than one week in your inbox.  Not that raw Gmail searches are no longer constrained to configured folder.
+

--- a/source/_components/sensor.imap.markdown
+++ b/source/_components/sensor.imap.markdown
@@ -70,5 +70,5 @@ By default, this component will count unread emails.  By configuring the search 
 
 * `ALL` to count all emails in a folder
 * `FROM`, `TO`, `SUBJECT` to find emails in a folder (see [IMAP RFC for all standard options](https://tools.ietf.org/html/rfc3501#section-6.4.4))
-* [Gmail's IMAP extensions](https://developers.google.com/gmail/imap/imap-extensions) allow raw Gmail searches, like `X-GM-RAW "in: inbox older_than:7d"` to show emails older than one week in your inbox.  Not that raw Gmail searches are no longer constrained to configured folder.
+* [Gmail's IMAP extensions](https://developers.google.com/gmail/imap/imap-extensions) allow raw Gmail searches, like `X-GM-RAW "in: inbox older_than:7d"` to show emails older than one week in your inbox.  Note that raw Gmail searches will ignore your folder configuration and search all emails in your account!
 


### PR DESCRIPTION
To accompany a PR to sensor/imap.py

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19749

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
