### PR TITLE
xiaomi vacuum with zone and reps

### DIFF
--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -112,7 +112,7 @@ Start the cleaning operation in the areas selected for the number of reps indica
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific robot; default targets all       |
-| `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. example: [[23510,25311,25110,26361]]|
+| `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. \n Example: [[23510,25311,25110,26361]]|
 | `reps`                    |       no | Number of cleaning reps for each zone between 1 and 3. |
 
 ## {% linkable_title Attributes %}

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -172,7 +172,6 @@ automation:
           - 26032
           - 26496
 ```
-
 ## {% linkable_title Attributes %}
 
 In addition to [all of the attributes provided by the `vacuum` component](/components/vacuum/#attributes),

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -114,6 +114,64 @@ Start the cleaning operation in the areas selected for the number of reps indica
 | `entity_id`               |      yes | Only act on specific robot; default targets all       |
 | `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
 | `reps`                    |       no | Number of cleaning reps for each zone between 1 and 3. |
+| `reps_template`           |       no | Template that rapresents the number of cleaning reps for each zone between 1 and 3. |
+
+Example of `vacuum.xiaomi_clean_zone_start` use:
+Inline array:
+```yaml
+automation:
+  - alias: Test vacuum zone3
+    trigger:
+    - event: start
+      platform: homeassistant
+    condition: []
+    action:
+    - service: vacuum.xiaomi_clean_zone_start
+      data:
+        entity_id: vacuum.xiaomi_vacuum
+        reps_template: '{{states.input_number.vacuum_passes.state|int}}'
+        zone: [[2555, 2555, 2555, 2555], [2300, 2300, 2300, 2300]]
+```
+Array with inline zone:
+```yaml
+automation:
+  - alias: Test vacuum zone3
+    trigger:
+    - event: start
+      platform: homeassistant
+    condition: []
+    action:
+    - service: vacuum.xiaomi_clean_zone_start
+      data:
+        entity_id: vacuum.xiaomi_vacuum
+        reps_template: '{{states.input_number.vacuum_passes.state|int}}'
+        zone: 
+        - [2555, 2555, 2555, 2555]
+        - [2300, 2300, 2300, 2300]
+```
+Array mode:
+```yaml
+automation:
+  - alias: Test vacuum zone3
+    trigger:
+    - event: start
+      platform: homeassistant
+    condition: []
+    action:
+    - service: vacuum.xiaomi_clean_zone_start
+      data:
+        entity_id: vacuum.xiaomi_vacuum
+        reps: 1
+        zone: 
+        - - 2555
+          - 2555
+          - 2555
+          - 2555
+        - - 2300
+          - 2300
+          - 2300 
+          - 2300
+```
 
 ## {% linkable_title Attributes %}
 

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -64,6 +64,7 @@ In addition to all of the services provided by the `vacuum` component (`start`, 
 - `xiaomi_remote_control_stop`
 - `xiaomi_remote_control_move`
 - `xiaomi_remote_control_move_step`
+- `xiaomi_clean_zone_start`
 
 ### {% linkable_title Service `vacuum.xiaomi_remote_control_start` %}
 
@@ -102,6 +103,16 @@ Enter remote control mode, make one move, stop, and exit remote control mode.
 | `velocity`                |       no | Speed: between -0.29 and 0.29                             |
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
+
+### {% linkable_title Service `vacuum.xiaomi_clean_zone_start` %}
+
+Start the cleaning operation in the areas selected for the number of reps indicated.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific robot; default targets all       |
+| `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. example: [[23510,25311,25110,26361]]|
+| `reps`                    |       no | Number of cleaning reps for each zone between 1 and 3. |
 
 ## {% linkable_title Attributes %}
 

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -114,7 +114,6 @@ Start the cleaning operation in the areas selected for the number of repeats ind
 | `entity_id`               |      yes | Only act on specific robot; default targets all       |
 | `zone`                    |       no | List of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
 | `repeats`                    |       no | Number of cleaning repeats for each zone between 1 and 3. |
-| `repeats_template`           |       no | Template that rapresents the number of cleaning repeats for each zone between 1 and 3. |
 
 Example of `vacuum.xiaomi_clean_zone` use:
 Inline array:
@@ -127,7 +126,7 @@ automation:
     condition: []
     action:
     - service: vacuum.xiaomi_clean_zone
-      data:
+      data_template:
         entity_id: vacuum.xiaomi_vacuum
         repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
         zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]
@@ -142,7 +141,7 @@ automation:
     condition: []
     action:
     - service: vacuum.xiaomi_clean_zone
-      data:
+      data_template:
         entity_id: vacuum.xiaomi_vacuum
         repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
         zone:

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -116,6 +116,7 @@ Start the cleaning operation in the areas selected for the number of repeats ind
 | `repeats`                    |       no | Number of cleaning repeats for each zone between 1 and 3. |
 
 Example of `vacuum.xiaomi_clean_zone` use:
+
 Inline array:
 ```yaml
 automation:

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -362,27 +362,6 @@ Software Required:
 - [Mi-Home version 5.0.30](https://www.apkmirror.com/apk/xiaomi-inc/mihome/mihome-5-0-30-release/)
 - [Android Backup Extractor](https://sourceforge.net/projects/adbextractor/)
 - [SQLite Browser](https://sqlitebrowser.org/)
-<<<<<<< HEAD
-
-Steps to take:
-
-1. Install an old Version of MiHome (e.g. Mi-Home version 5.0.30) on your Android-Device.
-2. Open MiHome, log-in and add your devices.
-3. Enable USB-Debugging on your Android.
-4. Create a backup from your MiHome App, by using adb:
-    ```bash
-    adb backup com.xiaomi.smarthome
-    ```
-    Now the backup App opens on you Android-Device. You don't need to set a password, just click save.
-5. Extract the backup-file with android-backup-extractor:
-    ```bash
-    java -jar abe.jar unpack backup.ab backup.tar
-    ```
-    After that, extract the file with WinRAR, 7-Zip (or similar).
-6. Go to `\apps\com.xiaomi.smarthome\db`.
-7. Open `miio2.db` with the SQLite Browser.
-8. You can find your device tokens in `devicerecord` table.
-=======
 1. Install an old Version of MiHome (e.g. Mi-Home version 5.0.30) on your Android-Device
 2. Open MiHome, log-in and add your devices
 3. Enable USB-Debugging on your Android
@@ -399,4 +378,3 @@ Steps to take:
 6. Go to \apps\com.xiaomi.smarthome\db
 7. Open miio2.db with SQLite Browser
 8. You can find your device tokens in "devicerecord" table
->>>>>>> rytilahti tips

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -112,7 +112,7 @@ Start the cleaning operation in the areas selected for the number of repeats ind
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific robot; default targets all       |
-| `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
+| `zone`                    |       no | List of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
 | `repeats`                    |       no | Number of cleaning repeats for each zone between 1 and 3. |
 | `repeats_template`           |       no | Template that rapresents the number of cleaning repeats for each zone between 1 and 3. |
 
@@ -130,7 +130,7 @@ automation:
       data:
         entity_id: vacuum.xiaomi_vacuum
         repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
-        zone: [[2555, 2555, 2555, 2555], [2300, 2300, 2300, 2300]]
+        zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]
 ```
 Array with inline zone:
 ```yaml
@@ -145,9 +145,9 @@ automation:
       data:
         entity_id: vacuum.xiaomi_vacuum
         repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
-        zone: 
-        - [2555, 2555, 2555, 2555]
-        - [2300, 2300, 2300, 2300]
+        zone:
+        - [30914,26007,35514,28807]
+        - [20232,22496,26032,26496]
 ```
 Array mode:
 ```yaml
@@ -162,15 +162,15 @@ automation:
       data:
         entity_id: vacuum.xiaomi_vacuum
         repeats: 1
-        zone: 
-        - - 2555
-          - 2555
-          - 2555
-          - 2555
-        - - 2300
-          - 2300
-          - 2300 
-          - 2300
+        zone:
+        - - 30914
+          - 26007
+          - 35514
+          - 28807
+        - - 20232
+          - 22496
+          - 26032
+          - 26496
 ```
 
 ## {% linkable_title Attributes %}
@@ -363,6 +363,7 @@ Software Required:
 - [Mi-Home version 5.0.30](https://www.apkmirror.com/apk/xiaomi-inc/mihome/mihome-5-0-30-release/)
 - [Android Backup Extractor](https://sourceforge.net/projects/adbextractor/)
 - [SQLite Browser](https://sqlitebrowser.org/)
+<<<<<<< HEAD
 
 Steps to take:
 
@@ -382,3 +383,21 @@ Steps to take:
 6. Go to `\apps\com.xiaomi.smarthome\db`.
 7. Open `miio2.db` with the SQLite Browser.
 8. You can find your device tokens in `devicerecord` table.
+=======
+1. Install an old Version of MiHome (e.g. Mi-Home version 5.0.30) on your Android-Device
+2. Open MiHome, log-in and add your devices
+3. Enable USB-Debugging on your Android
+4. Create a backup from your MiHome App, by using adb
+  ```bash
+  adb backup com.xiaomi.smarthome
+  ```
+  Now the backup App opens on you Android-Device. You don't need to set a password, just click save.
+5. Extract the backup-file with android-backup-extractor
+  ```bash
+  java -jar abe.jar unpack backup.ab backup.tar
+  ```
+  After that, you kann open the file with WinRaR or what ever you like.
+6. Go to \apps\com.xiaomi.smarthome\db
+7. Open miio2.db with SQLite Browser
+8. You can find your device tokens in "devicerecord" table
+>>>>>>> rytilahti tips

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -25,6 +25,7 @@ Currently supported services are:
 - `clean_spot`
 - `set_fan_speed`
 - remote control of your robot.
+- `xiaomi_clean_zone_start`
 
 ## {% linkable_title Configuration %}
 

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -25,7 +25,7 @@ Currently supported services are:
 - `clean_spot`
 - `set_fan_speed`
 - remote control of your robot.
-- `xiaomi_clean_zone_start`
+- `xiaomi_clean_zone`
 
 ## {% linkable_title Configuration %}
 
@@ -65,7 +65,7 @@ In addition to all of the services provided by the `vacuum` component (`start`, 
 - `xiaomi_remote_control_stop`
 - `xiaomi_remote_control_move`
 - `xiaomi_remote_control_move_step`
-- `xiaomi_clean_zone_start`
+- `xiaomi_clean_zone`
 
 ### {% linkable_title Service `vacuum.xiaomi_remote_control_start` %}
 
@@ -105,7 +105,7 @@ Enter remote control mode, make one move, stop, and exit remote control mode.
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
 
-### {% linkable_title Service `vacuum.xiaomi_clean_zone_start` %}
+### {% linkable_title Service `vacuum.xiaomi_clean_zone` %}
 
 Start the cleaning operation in the areas selected for the number of repeats indicated.
 
@@ -116,7 +116,7 @@ Start the cleaning operation in the areas selected for the number of repeats ind
 | `repeats`                    |       no | Number of cleaning repeats for each zone between 1 and 3. |
 | `repeats_template`           |       no | Template that rapresents the number of cleaning repeats for each zone between 1 and 3. |
 
-Example of `vacuum.xiaomi_clean_zone_start` use:
+Example of `vacuum.xiaomi_clean_zone` use:
 Inline array:
 ```yaml
 automation:
@@ -126,7 +126,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: vacuum.xiaomi_clean_zone_start
+    - service: vacuum.xiaomi_clean_zone
       data:
         entity_id: vacuum.xiaomi_vacuum
         repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
@@ -141,7 +141,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: vacuum.xiaomi_clean_zone_start
+    - service: vacuum.xiaomi_clean_zone
       data:
         entity_id: vacuum.xiaomi_vacuum
         repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
@@ -158,7 +158,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: vacuum.xiaomi_clean_zone_start
+    - service: vacuum.xiaomi_clean_zone
       data:
         entity_id: vacuum.xiaomi_vacuum
         repeats: 1

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -112,7 +112,7 @@ Start the cleaning operation in the areas selected for the number of reps indica
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific robot; default targets all       |
-| `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. \n Example: [[23510,25311,25110,26361]]|
+| `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]]|
 | `reps`                    |       no | Number of cleaning reps for each zone between 1 and 3. |
 
 ## {% linkable_title Attributes %}

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -107,14 +107,14 @@ Enter remote control mode, make one move, stop, and exit remote control mode.
 
 ### {% linkable_title Service `vacuum.xiaomi_clean_zone_start` %}
 
-Start the cleaning operation in the areas selected for the number of reps indicated.
+Start the cleaning operation in the areas selected for the number of repeats indicated.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific robot; default targets all       |
 | `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
-| `reps`                    |       no | Number of cleaning reps for each zone between 1 and 3. |
-| `reps_template`           |       no | Template that rapresents the number of cleaning reps for each zone between 1 and 3. |
+| `repeats`                    |       no | Number of cleaning repeats for each zone between 1 and 3. |
+| `repeats_template`           |       no | Template that rapresents the number of cleaning repeats for each zone between 1 and 3. |
 
 Example of `vacuum.xiaomi_clean_zone_start` use:
 Inline array:
@@ -129,7 +129,7 @@ automation:
     - service: vacuum.xiaomi_clean_zone_start
       data:
         entity_id: vacuum.xiaomi_vacuum
-        reps_template: '{{states.input_number.vacuum_passes.state|int}}'
+        repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
         zone: [[2555, 2555, 2555, 2555], [2300, 2300, 2300, 2300]]
 ```
 Array with inline zone:
@@ -144,7 +144,7 @@ automation:
     - service: vacuum.xiaomi_clean_zone_start
       data:
         entity_id: vacuum.xiaomi_vacuum
-        reps_template: '{{states.input_number.vacuum_passes.state|int}}'
+        repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
         zone: 
         - [2555, 2555, 2555, 2555]
         - [2300, 2300, 2300, 2300]
@@ -161,7 +161,7 @@ automation:
     - service: vacuum.xiaomi_clean_zone_start
       data:
         entity_id: vacuum.xiaomi_vacuum
-        reps: 1
+        repeats: 1
         zone: 
         - - 2555
           - 2555

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -112,7 +112,7 @@ Start the cleaning operation in the areas selected for the number of reps indica
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |      yes | Only act on specific robot; default targets all       |
-| `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]]|
+| `zone`                    |       no | Array of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
 | `reps`                    |       no | Number of cleaning reps for each zone between 1 and 3. |
 
 ## {% linkable_title Attributes %}

--- a/source/_docs/automation/editor.markdown
+++ b/source/_docs/automation/editor.markdown
@@ -72,8 +72,8 @@ You can use the `automation:` and `automation old:` sections at the same time:
  - `automation:` to save the automation created by the online editor
 
 ```yaml
-automation: !include automations.yaml
-automation old: !include_dir_merge_list automations
+automation: !include_dir_merge_list automations/
+automation old: !include automations.yaml
 ```
 
 

--- a/source/_docs/automation/editor.markdown
+++ b/source/_docs/automation/editor.markdown
@@ -72,8 +72,8 @@ You can use the `automation:` and `automation old:` sections at the same time:
  - `automation:` to save the automation created by the online editor
 
 ```yaml
-automation: !include_dir_merge_list automations/
-automation old: !include automations.yaml
+automation: !include automations.yaml
+automation old: !include_dir_merge_list automations
 ```
 
 


### PR DESCRIPTION
**Description:**
Add functionality to clean a specific zone and set the number of repetitions with Xiaomi Vacuum

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19777

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
