### PR TITLE
Update sensor.google_travel_time.markdown

### DIFF
--- a/source/_components/sensor.google_travel_time.markdown
+++ b/source/_components/sensor.google_travel_time.markdown
@@ -83,7 +83,7 @@ options:
       description: "Indicate what google should avoid when calculating the travel time, you can choose from: `tolls`, `highways`, `ferries`, `indoor`."
       required: false
       type: string
-    transit_model:
+    transit_mode:
       description: "If you opted for `transit` at `travel_mode`, you can use this variable to specify which public transport you want to use: `bus`, `subway`, `train`, `tram` or `rail`."
     transit_routing_preference:
       description: "for the travel time calculation for public transport you can also specify the preference for: `less_walking` or `fewer_transfers`."


### PR DESCRIPTION
**Description:**

Change optional configuration key `transit_model` to `transit_mode` to match the Distance Matrix API documentation [0]. `transit_model` is an invalid key and will cause the sensor to fail.

[0]: https://developers.google.com/maps/documentation/distance-matrix/intro#RequestParameters


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
