### PR TITLE
Give a hint to the Persistent Notification Component

### DIFF
--- a/source/_components/notify.markdown
+++ b/source/_components/notify.markdown
@@ -11,6 +11,8 @@ footer: true
 
 The `notify` component makes it possible to send notifications to a wide variety of platforms. Please check the sidebar for a full list of platforms that are supported.
 
+If you want to send notifications to the Home Assistant Web Interface you may use the [Persistent Notification Component](/components/persistent_notification/).
+
 ## {% linkable_title Configuration %}
 
 ```yaml


### PR DESCRIPTION
**Description:**
Again and again i was looking through this page and didn't find how to send persistent notifications to the Home Assistant Web Interface. That's why I propose to add that sentence.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
