### PR TITLE
fixed error in Warning in Documentation of fritz.box device tracker 

### DIFF
--- a/source/_components/device_tracker.fritz.markdown
+++ b/source/_components/device_tracker.fritz.markdown
@@ -18,8 +18,8 @@ The `fritz` platform offers presence detection by looking at connected devices t
 ## {% linkable_title Setup %}
 
 <p class='note warning'>
-It might be necessary to install additional packages: <code>$ sudo apt-get install python3-lxml</code>
-If you installed Home Assistant in a virtualenv, run the following commands inside it: <code>$ sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev; pip3 install lxml</code>; be patient this will take a while.</p>
+It might be necessary to install additional packages: <code>$ sudo apt-get install python3-lxml libxslt-dev libxml2-dev zlib1g-dev</code>
+If you installed Home Assistant in a virtualenv, run the following commands inside it: <code>$ pip3 install lxml</code>; be patient this will take a while.</p>
 
 ## {% linkable_title Configuration %}
 
@@ -47,7 +47,7 @@ password:
 {% endconfiguration %}
 
 <p class='note'>
-It seems that it is not necessary to use it in current generation Fritz!Box routers because the necessary data can be retrieved anonymously.
+It seems that it is not necessary to use the password in current generation Fritz!Box routers because the necessary data can be retrieved anonymously.
 </p>
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
It's not possible to run the sudo command inside the venv. I just tested the new, changed way (only run "pip3 install lxml" in venv)  and it works. 

Also the note regarding the password wasn't clear, so i changed "it" to "the password"

This is my first contribution so feel free to give feedback regarding the process. Thanks.
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
