### PR TITLE
Fixed the first link to the Datapoint API.

### DIFF
--- a/source/_components/weather.metoffice.markdown
+++ b/source/_components/weather.metoffice.markdown
@@ -13,7 +13,7 @@ ha_release: 0.42
 ha_iot_class: "Cloud Polling"
 ---
 
-The `metoffice` weather platform uses the Met Office's [DataPoint API][datapoint] for weather data.
+The `metoffice` weather platform uses the Met Office's [DataPoint API](http://www.metoffice.gov.uk/datapoint) for weather data.
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
The first link to the Datapoint API wasn't formatted or linked correctly.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
