### PR TITLE
libjson0-dev no longer available

### DIFF
--- a/source/_components/media_player.pandora.markdown
+++ b/source/_components/media_player.pandora.markdown
@@ -24,7 +24,7 @@ This media player uses the [Pianobar command-line Pandora client](https://github
 The version of pianobar that comes with Jessie has a bug, so you have to build a more recent version. The latest version depends on a recent version of libraries associated with ffmpeg, so you should make sure you go through the backport process documented in [The FFmpeg component](/components/ffmpeg/) before doing this. Install the following basic dependencies:
 
 ```bash
-$ sudo apt-get install git libao-dev libgcrypt11-dev libfaad-dev libmad0-dev libjson0-dev make pkg-config  libcurl4-openssl-dev
+$ sudo apt-get install git libao-dev libgcrypt11-dev libfaad-dev libmad0-dev libjson-c-dev make pkg-config  libcurl4-openssl-dev
 ```
 
 And now install the backported ffmpeg-related libraries (note that if you're using an older version of ffmpeg for other things on this machine, you may encounter issues after doings this):


### PR DESCRIPTION
libjson0-dev is no longer available - replaced by libjson-c-dev

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
