### PR TITLE
Geo Location -> Geolocation

### DIFF
--- a/source/_components/demo.markdown
+++ b/source/_components/demo.markdown
@@ -24,7 +24,7 @@ Available demo platforms:
 - [Climate](/components/climate/) (`climate`)
 - [Cover](/components/cover/) (`cover`)
 - [Fan](/components/fan/) (`fan`)
-- [Geo Location](/components/geo_location/) (`geo_location`)
+- [Geolocation](/components/geo_location/) (`geo_location`)
 - [Image Processing](/components/image_processing/) (`image_processing`)
 - [Light](/components/light/) (`light`)
 - [Lock](/components/lock/) (`lock`)

--- a/source/_components/demo.markdown
+++ b/source/_components/demo.markdown
@@ -17,7 +17,7 @@ The `demo` platform allows you to use components which are providing a demo of t
 
 Available demo platforms:
 
-- [Air Pollutants]((/components/air_pollutants/) (`air_pollutants`)
+- [Air Pollutants](/components/air_pollutants/) (`air_pollutants`)
 - [Alarm control panel](/components/alarm_control_panel/) (`alarm_control_panel`)
 - [Binary sensor](/components/binary_sensor/) (`binary_sensor`)
 - [Camera](/components/camera/) (`camera`)

--- a/source/_components/geo_location.geo_json_events.markdown
+++ b/source/_components/geo_location.geo_json_events.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: geo_location.png
-ha_category: Geo Location
+ha_category: Geolocation
 ha_iot_class: "Cloud Polling"
 ha_release: "0.79"
 ---

--- a/source/_components/geo_location.markdown
+++ b/source/_components/geo_location.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "Geo Location"
-description: "Instructions on how to integrate geo location aware platforms into Home Assistant."
+title: "Geolocation"
+description: "Instructions on how to integrate geolocation aware platforms into Home Assistant."
 date: 2018-08-27 08:00
 sidebar: true
 comments: false
@@ -11,13 +11,13 @@ logo: geo_location.png
 ha_release: "0.78"
 ---
 
-Geo Location aware entities are typically related to events in the real world in the vicinity of Home Assistant's location, like for example weather events, bush fires or earthquakes.
+Geolocation aware entities are typically related to events in the real world in the vicinity of Home Assistant's location, like for example weather events, bush fires or earthquakes.
 
-Entities can have associated geo location coordinates (latitude and longitude) so that they are displayed on the map. The distance from the entity's coordinates to Home Assistant's location can be used for filtering.
+Entities can have associated geolocation coordinates (latitude and longitude) so that they are displayed on the map. The distance from the entity's coordinates to Home Assistant's location can be used for filtering.
 
-## {% linkable_title Geo Location trigger %}
+## {% linkable_title Geolocation trigger %}
 
-The [Geo Location trigger](/docs/automation/trigger/#geo-location-trigger) can be used in automations triggered by Geo Location entities appearing in or disappearing from zones. The following value must be used as `source` of the trigger depending on which platform is managing the entities:
+The [Geolocation trigger](/docs/automation/trigger/#geolocation-trigger) can be used in automations triggered by Geolocation entities appearing in or disappearing from zones. The following value must be used as `source` of the trigger depending on which platform is managing the entities:
 
 | Platform                                          | Source                        |
 |---------------------------------------------------|-------------------------------|
@@ -27,7 +27,7 @@ The [Geo Location trigger](/docs/automation/trigger/#geo-location-trigger) can b
 
 Conditions can be used to further filter entities, for example by inspecting their state attributes.
 
-## {% linkable_title Geo Location notification example %}
+## {% linkable_title Geolocation notification example %}
 
 The following example automation creates a notification on the screen when a fire classified as 'Bush Fire' is reported within a predefined bush fire alert zone:
 

--- a/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
+++ b/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: nsw-rural-fire-service.png
-ha_category: Geo Location
+ha_category: Geolocation
 ha_iot_class: "Cloud Polling"
 ha_release: "0.81"
 ---

--- a/source/_components/geo_location.usgs_earthquakes_feed.markdown
+++ b/source/_components/geo_location.usgs_earthquakes_feed.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: us-geological-survey.png
-ha_category: Geo Location
+ha_category: Geolocation
 ha_iot_class: "Cloud Polling"
 ha_release: 0.84
 ---

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -220,10 +220,10 @@ automation:
     event: enter  # or "leave"
 ```
 
-### {% linkable_title Geo Location trigger %}
+### {% linkable_title Geolocation trigger %}
 
-Geo Location triggers can trigger when an entity is appearing in or disappearing from a zone. Entities that are created by a [Geo Location](/components/geo_location/) platform support reporting GPS coordinates.
-Because entities are generated and removed by these platforms automatically, the entity id normally cannot be predicted. Instead, this trigger requires the definition of a `source` which is directly linked to one of the Geo Location platforms.
+Geolocation triggers can trigger when an entity is appearing in or disappearing from a zone. Entities that are created by a [Geolocation](/components/geo_location/) platform support reporting GPS coordinates.
+Because entities are generated and removed by these platforms automatically, the entity id normally cannot be predicted. Instead, this trigger requires the definition of a `source` which is directly linked to one of the Geolocation platforms.
 
 ```yaml
 automation:

--- a/source/_lovelace/map.markdown
+++ b/source/_lovelace/map.markdown
@@ -28,7 +28,7 @@ entities:
   type: list
 geo_location_sources:
   required: true
-  description: List of geolocation sources. All current entities with that source will be displayed on the map. See [Geo Location](/components/geo_location/) platform for valid sources. Either this or the `entities` configuration option is required.
+  description: List of geolocation sources. All current entities with that source will be displayed on the map. See [Geolocation](/components/geo_location/) platform for valid sources. Either this or the `entities` configuration option is required.
   type: list
 title:
   required: false


### PR DESCRIPTION
**Description:**
Fixed all occurrences in the text from "geo location" to "geolocation"; as discussed in https://github.com/home-assistant/architecture/issues/42#issuecomment-451145350
Left filenames and any code references, examples, etc. unchanged.

I made these changes on the `next` branch. Please let me know if you prefer this on top of `current` instead.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
