### PR TITLE
Added some details about port 1400 usage

### DIFF
--- a/source/_components/sonos.markdown
+++ b/source/_components/sonos.markdown
@@ -137,7 +137,7 @@ sonos:
 
 ## {% linkable_title Additional information %}
 
-This component is using the SoCo project internally, see more details about it on [SoCo](https://github.com/SoCo/SoCo) 
+This component is using the [SoCo](https://github.com/SoCo/SoCo) project.  
 
-To be able to support the Sonos components and features it is mandatory to have port 1400 opened. This is used to receive events about changes on the Sonos network. For more details please see the official documentation and source code of the SoCo project.
+To be able to support the Sonos components and features it is mandatory to have TCP port 1400 opened. This port is used to receive events about changes on the Sonos network. For more details please see the [SoCo documentation](https://github.com/SoCo/SoCo)  and source code of the SoCo project.
 

--- a/source/_components/sonos.markdown
+++ b/source/_components/sonos.markdown
@@ -134,3 +134,10 @@ sonos:
       - 192.0.2.26
       - 192.0.2.27
 ```
+
+## {% linkable_title Additional information %}
+
+This component is using the SoCo project internally, see more details about it on [SoCo](https://github.com/SoCo/SoCo) 
+
+To be able to support the Sonos components and features it is mandatory to have port 1400 opened. This is used to receive events about changes on the Sonos network. For more details please see the official documentation and source code of the SoCo project.
+


### PR DESCRIPTION
**Description:**

As identified on https://github.com/home-assistant/home-assistant.io/issues/8067 the documentation could be enhanced to give some reference on the usage of port 1400 within this component which originates from the SoCo lib and configuration.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
