### PR TITLE
Added LB230 to Supported Units section

### DIFF
--- a/source/_components/light.tplink.markdown
+++ b/source/_components/light.tplink.markdown
@@ -21,6 +21,7 @@ Supported units:
 - LB110
 - LB120
 - LB130
+- LB230
 
 To use your TP-Link light in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
I've tested and confirmed the TP-Link LB230 bulb works with this integration, so I added the model # to the Supported Units section.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
