### PR TITLE
Add support for HomeKit Controller covers

### DIFF
--- a/source/_components/cover.homekit_controller.markdown
+++ b/source/_components/cover.homekit_controller.markdown
@@ -1,0 +1,16 @@
+---
+layout: page
+title: "HomeKit Cover"
+description: "Instructions how to setup HomeKit covers within Home Assistant."
+date: 2019-1-8 5:30
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: apple-homekit.png
+ha_category: Cover
+ha_iot_class: "Local Polling"
+ha_release: 0.86
+---
+
+To get your HomeKit garage door openers, windows, or window coverings working with Home Assistant, follow the instructions for the general [HomeKit controller component](/components/homekit_controller/).

--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -23,6 +23,7 @@ ha_iot_class: "Local Polling"
 There is currently support for the following device types within Home Assistant:
 
 - [Climate](/components/climate.homekit_controller/)
+- [Cover](/components/cover.homekit_controller/)
 - [Light](/components/light.homekit_controller/)
 - [Switch](/components/switch.homekit_controller/)
 


### PR DESCRIPTION
**Description:**

This adds support for HomeKit windows, window coverings, and garage door openers to appear as covers in Home Assistant. There does not appear to be a way to send a stop command to covers in HomeKit.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19866

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html