### PR TITLE
Add support for HomeKit Controller Locks

### DIFF
--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -24,6 +24,7 @@ There is currently support for the following device types within Home Assistant:
 
 - [Climate](/components/climate.homekit_controller/)
 - [Light](/components/light.homekit_controller/)
+- [Lock](/components/lock.homekit_controller/)
 - [Switch](/components/switch.homekit_controller/)
 
 The component will be automatically configured if the [`discovery:`](/components/discovery/) component is enabled and an enable entry added for HomeKit:

--- a/source/_components/lock.homekit_controller.markdown
+++ b/source/_components/lock.homekit_controller.markdown
@@ -1,0 +1,16 @@
+---
+layout: page
+title: "HomeKit Lock"
+description: "Instructions how to setup HomeKit locks within Home Assistant."
+date: 2019-1-8 7:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: apple-homekit.png
+ha_category: Lock
+ha_iot_class: "Local Polling"
+ha_release: 0.86
+---
+
+To get your HomeKit lock working with Home Assistant, follow the instructions for the general [HomeKit controller component](/components/homekit_controller/).


### PR DESCRIPTION
**Description:**

This adds the necessary documentation stating support for HomeKit locks being exposed  through Home Assistant.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19867

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html