### PR TITLE
Removed reference to guest account

### DIFF
--- a/source/_addons/samba.markdown
+++ b/source/_addons/samba.markdown
@@ -37,7 +37,7 @@ workgroup:
   default: "`WORKGROUP`"
   type: string
 username:
-  description: Username for logging in if guest login is not used.
+  description: Username for logging in.
   required: true
   type: string
 password:


### PR DESCRIPTION
Guest access no longer exists. Removed reference to it as an option.

**Description:**
Removed reference to guest account

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [* ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [* ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
