### PR TITLE
Add HS103 to supported devices

### DIFF
--- a/source/_components/switch.tplink.markdown
+++ b/source/_components/switch.tplink.markdown
@@ -18,6 +18,7 @@ The `tplink` switch platform allows you to control the state of your [TP-Link sm
 Supported units:
 
 - HS100
+- HS103
 - HS105
 - HS110
 - HS200


### PR DESCRIPTION
See https://www.reddit.com/r/homeassistant/comments/ad7oqk/tplink_hs103_not_on_list/edewohh/

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
