### PR TITLE
Add precision parameter to dsmr sensor

### DIFF
--- a/source/_components/sensor.dsmr.markdown
+++ b/source/_components/sensor.dsmr.markdown
@@ -64,6 +64,11 @@ sensor:
     description: "Version of DSMR used by meter. Choices: 2.2, 4, 5. Defaults to 2.2."
     required: false
     type: string
+  precision:
+    description: Defines the precision of the calculated values, through the argument of round().
+    required: false
+    type: integer
+    default: 3
 {% endconfiguration %}
 
 Full configuration examples can be found below:


### PR DESCRIPTION
**Description:**

Added precision parameter to the dsmr sensor.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19873

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html