### PR TITLE
Additional information for Geolocation platforms

### DIFF
--- a/source/_components/geo_location.geo_json_events.markdown
+++ b/source/_components/geo_location.geo_json_events.markdown
@@ -40,7 +40,7 @@ radius:
   description: The distance in kilometers around the Home Assistant's coordinates in which events are considered.
   required: false
   type: float
-  default: 20km
+  default: 20.0
 latitude:
   description: Latitude of the coordinates around which events are considered.
   required: false

--- a/source/_components/geo_location.geo_json_events.markdown
+++ b/source/_components/geo_location.geo_json_events.markdown
@@ -53,6 +53,17 @@ longitude:
   default: Longitude defined in your `configuration.yaml`
 {% endconfiguration %}
 
+## {% linkable_title State Attributes %}
+
+The following state attributes are available for each entity in addition to the standard ones:
+
+| Attribute   | Description |
+|-------------|-------------|
+| latitude    | Latitude of the event. |
+| longitude   | Longitude of the event. |
+| source      | `geo_json_events` to be used in conjunction with `geo_location` automation trigger. |
+| external_id | The external ID used in the feed to identify the event in the feed. |
+
 ## {% linkable_title Advanced Configuration Example %}
 
 When integrating several GeoJSON feeds, it may be useful to distinguish the entities of different feeds. The easiest way to do that is by defining an [`entity_namespace`](/docs/configuration/platform_options/#entity-namespace/) for each platform which will prefix each entity ID with the defined value.

--- a/source/_components/geo_location.geo_json_events.markdown
+++ b/source/_components/geo_location.geo_json_events.markdown
@@ -39,7 +39,7 @@ url:
 radius:
   description: The distance in kilometers around the Home Assistant's coordinates in which events are considered.
   required: false
-  type: string
+  type: float
   default: 20km
 latitude:
   description: Latitude of the coordinates around which events are considered.

--- a/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
+++ b/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
@@ -44,7 +44,7 @@ radius:
   description: The distance in kilometers around Home Assistant's coordinates in which incidents are included.
   required: false
   type: float
-  default: 20km
+  default: 20.0
 categories:
   description: List of incident category names found in the feed. Only incidents from the feed that match any of these categories are included. Valid categories are 'Emergency Warning', 'Watch and Act', 'Advice', 'Not Applicable'.
   required: false

--- a/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
+++ b/source/_components/geo_location.nsw_rural_fire_service_feed.markdown
@@ -70,6 +70,7 @@ The following state attributes are available for each entity in addition to the 
 |--------------------|-------------|
 | latitude           | Latitude of the incident. |
 | longitude          | Longitude of the incident. |
+| source             | `nsw_rural_fire_service_feed` to be used in conjunction with `geo_location` automation trigger. |
 | external_id        | The external ID used in the feed to identify the incident in the feed. |
 | category           | One of 'Emergency Warning', 'Watch and Act', 'Advice', 'Not Applicable'. |
 | location           | Location details of where the incident takes place. |

--- a/source/_components/geo_location.usgs_earthquakes_feed.markdown
+++ b/source/_components/geo_location.usgs_earthquakes_feed.markdown
@@ -52,7 +52,7 @@ radius:
   description: The distance in kilometers around Home Assistant's coordinates in which seismic events are included.
   required: false
   type: float
-  default: 50
+  default: 50.0
 latitude:
   description: Latitude of the coordinates around which events are considered.
   required: false


### PR DESCRIPTION
**Description:**
Small additions to geolocation platforms:
* Added missing `source` to state attribute table for `nsw_rural_fire_service_feed`
* Added state attribute table for `geo_json_events`, similar to what exists for the other platforms
* Fixed type of config parameter for `geo_json_events`
* Corrected default radius to float value for `geo_json_events`, `nsw_rural_fire_service_feed` and `usgs_earthquakes_feed`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
