### PR TITLE
Correctly map Nest hvac_state to Home Assistant states.

### DIFF
--- a/source/_components/sensor.nest.markdown
+++ b/source/_components/sensor.nest.markdown
@@ -51,12 +51,12 @@ The following conditions are available by device:
   - operation\_mode
   - temperature
   - target
-  - hvac\_state: The currently active state of the HVAC system, `heat`, `cool`, or `off` (previously `heating`, `cooling`, or `off`).
+  - hvac\_state: The currently active state of the HVAC system, `heat`, `cool` or `off` (previously `heating`, `cooling` or `off`).
 - Nest Protect:
-  - co\_status: `Ok`, `Warning`, or `Emergency`
-  - smoke\_status: `Ok`, `Warning`, or `Emergency`
+  - co\_status: `Ok`, `Warning` or `Emergency`
+  - smoke\_status: `Ok`, `Warning` or `Emergency`
   - battery\_health: `Ok` or `Replace`
-  - color\_status: `gray`, `green`, `yellow`, or `red`. Indicates device status by color in the Nest app UI. It is an aggregate condition for battery+smoke+CO states, and reflects the actual color indicators displayed in the Nest app.
+  - color\_status: `gray`, `green`, `yellow` or `red`. Indicates device status by color in the Nest app UI. It is an aggregate condition for battery+smoke+CO states, and reflects the actual color indicators displayed in the Nest app.
 - Nest Camera: none
 
 ## {% linkable_title Security State %}

--- a/source/_components/sensor.nest.markdown
+++ b/source/_components/sensor.nest.markdown
@@ -51,7 +51,7 @@ The following conditions are available by device:
   - operation\_mode
   - temperature
   - target
-  - hvac\_state: The currently active state of the HVAC system, `heating`, `cooling`, or `off`.
+  - hvac\_state: The currently active state of the HVAC system, `heat`, `cool`, or `off` (previously `heating`, `cooling`, or `off`).
 - Nest Protect:
   - co\_status: `Ok`, `Warning`, or `Emergency`
   - smoke\_status: `Ok`, `Warning`, or `Emergency`


### PR DESCRIPTION
**Description:**
Updates values described for Nest `hvac_state`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19895

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
