### PR TITLE
Correct URL link

### DIFF
--- a/source/_docs/ecosystem/ios.markdown
+++ b/source/_docs/ecosystem/ios.markdown
@@ -31,7 +31,7 @@ The `ios` component is the companion component for the Home Assistant iOS app. W
 
 Loading the `ios` component will also load the [`device_tracker`](/components/device_tracker), [`zeroconf`](/components/zeroconf) and [`notify`](/components/notify) platforms.
 
-In order to save credentials and adjust settings within the iOS Home Assistant app, the Optional (`api_password`)[https://www.home-assistant.io/components/http/#api_password] must be set. 
+In order to save credentials and adjust settings within the iOS Home Assistant app, the Optional [`api_password`](/components/http/#api_password) must be set. 
 
 ## {% linkable_title Setup %}
 

--- a/source/_docs/ecosystem/ios.markdown
+++ b/source/_docs/ecosystem/ios.markdown
@@ -31,7 +31,7 @@ The `ios` component is the companion component for the Home Assistant iOS app. W
 
 Loading the `ios` component will also load the [`device_tracker`](/components/device_tracker), [`zeroconf`](/components/zeroconf) and [`notify`](/components/notify) platforms.
 
-In order to save credentials and adjust settings within the iOS Home Assistant app, the Optional [`api_password`](/components/http/#api_password) must be set. 
+In order to save credentials and adjust settings within the iOS Home Assistant app, the optional [`api_password`](/components/http/#api_password) must be set. 
 
 ## {% linkable_title Setup %}
 


### PR DESCRIPTION
The markdown syntax for the link was reversed.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
