### PR TITLE
Since 0.85 mapping is optional

### DIFF
--- a/source/_components/upnp.markdown
+++ b/source/_components/upnp.markdown
@@ -14,7 +14,7 @@ ha_release: 0.18
 
 The `upnp` component enables you to collect network statistics from your router such as bytes in/out and packets in/out. This information is provided by the [UPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play)/[Internet Gateway Device (IGD) Protocol](https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol) if enabled on your router.
 
-The IGD automatically creates port forwarding mappings on your router for Home Assistant, exposing your installation to the internet. The mapping will never automatically expire. Upon stopping Home Assistant, the mapping will be removed from your router.
+The IGD can automatically create port forwarding mappings on your router for Home Assistant, exposing your installation to the internet. The mapping will never automatically expire. Upon stopping Home Assistant, the mapping will be removed from your router.
 
 Please note that UPnP or NAT-PMP needs to be enabled on your router for this component to work.
 


### PR DESCRIPTION
**Description:**

Updating the phrasing in accordance with 0.85 release fixes

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
