### PR TITLE
Updated to reflect the new API limits

### DIFF
--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -20,7 +20,7 @@ The `openuv` component displays UV and Ozone data from [openuv.io](http://openuv
 To generate an API key, [simply log in to the OpenUV website](https://www.openuv.io/auth/google).
 
 <p class='note warning'>
-The "Limited" plan (which is what new users are given by default) is limited to 500 API requests per day. In order to leave a buffer, the `openuv` component queries the API every 30 minutes by default. This value can be modifed (via the `scan_interval` key), but please note that over-running the API will require you to upgrade to a paid plan (and may disable your access in the meantime).
+The "Limited" plan (which is what new users are given by default) is limited to 50 API requests per day. In order to leave a buffer, the `openuv` component queries the API every 30 minutes by default. This value can be modifed (via the `scan_interval` key), but please note that over-running the API will require you to upgrade to a paid plan (and may disable your access in the meantime).
 </p>
 
 ## {% linkable_title Configuration %}


### PR DESCRIPTION
**Description:**

The free tier of OpenUV is now limited to 50, not 500.  All existing accounts will drop to that limit in February, but all new accounts have that limit.  The current scan_interval of 2/hr puts it at 48 calls/day (without any reboots triggering extras).  Should we adjust the default to be 1/hr or give documentation on how to not query it until the sun is above the horizon?

Fixes #8123

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
