### PR TITLE
Address config error of ness_alarm

### DIFF
--- a/source/_components/ness_alarm.markdown
+++ b/source/_components/ness_alarm.markdown
@@ -57,7 +57,7 @@ port:
 zones:
   description: List of zones to add
   required: false
-  type: [integer, list]
+  type: list
   keys:
     zone_id:
       description: ID of the zone on the alarm system (i.e Zone 1 -> Zone 16).


### PR DESCRIPTION
**Description:**

Address retrospective review comments in: https://github.com/home-assistant/home-assistant.io/pull/7630


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
