### PR TITLE
Add new info about OpenUV API key usage

### DIFF
--- a/source/_components/ness_alarm.markdown
+++ b/source/_components/ness_alarm.markdown
@@ -57,7 +57,7 @@ port:
 zones:
   description: List of zones to add
   required: false
-  type: [integer, list]
+  type: list
   keys:
     zone_id:
       description: ID of the zone on the alarm system (i.e Zone 1 -> Zone 16).

--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -20,7 +20,15 @@ The `openuv` component displays UV and Ozone data from [openuv.io](http://openuv
 To generate an API key, [simply log in to the OpenUV website](https://www.openuv.io/auth/google).
 
 <p class='note warning'>
-The "Limited" plan (which is what new users are given by default) is limited to 500 API requests per day. In order to leave a buffer, the `openuv` component queries the API every 30 minutes by default. This value can be modifed (via the `scan_interval` key), but please note that over-running the API will require you to upgrade to a paid plan (and may disable your access in the meantime).
+The "Limited" plan (which is what new users are given by default) is limited
+to 50 API requests per day. In order to leave a buffer, the `openuv` component
+queries the API every 30 minutes by default and stops querying the API after
+the sun has set (and resumes when the sun has risen).
+
+The 30-minute interval can be altered via the `scan_interval` key in the
+`configuration.yaml` file, but please note that over-running the API will
+require you to upgrade to a paid plan (and may disable your access in the
+meantime).
 </p>
 
 ## {% linkable_title Configuration %}

--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -13,27 +13,26 @@ ha_release: 0.76
 ha_iot_class: "Cloud Polling"
 ---
 
-The `openuv` component displays UV and Ozone data from [openuv.io](http://openuv.io).
+The `openuv` component displays UV and Ozone data from
+[openuv.io](http://openuv.io).
 
 ## {% linkable_title Generating an API Key %}
 
-To generate an API key, [simply log in to the OpenUV website](https://www.openuv.io/auth/google).
+To generate an API key,
+[simply log in to the OpenUV website](https://www.openuv.io/auth/google).
 
 <p class='note warning'>
-The "Limited" plan (which is what new users are given by default) is limited
-to 50 API requests per day. In order to leave a buffer, the `openuv` component
-queries the API every 30 minutes by default and stops querying the API after
-the sun has set (and resumes when the sun has risen).
-
-The 30-minute interval can be altered via the `scan_interval` key in the
-`configuration.yaml` file, but please note that over-running the API will
-require you to upgrade to a paid plan (and may disable your access in the
-meantime).
+Beginning February 1, 2019, the "Limited" plan (which is what new users are
+given by default) is limited to 50 API requests per day. Because different
+API plans and locations will have different requirements, the `openuv`
+component does not automatically query the API for new data after it initially
+loads. To request new data, the `update_data` service may be used.
 </p>
 
 ## {% linkable_title Configuration %}
 
-To retrieve data from OpenUV, add the following to your `configuration.yaml` file:
+To retrieve data from OpenUV, add the following to your `configuration.yaml`
+file:
 
 ```yaml
 openuv:
@@ -45,11 +44,6 @@ api_key:
   description: The OpenUV API key.
   required: true
   type: string
-scan_interval:
-  description: the frequency (in seconds) between data updates.
-  required: false
-  type: integer
-  default: 1800
 binary_sensors:
   description: The binary sensor-related configuration options.
   required: false
@@ -96,11 +90,15 @@ sensors:
           description: The approximate exposure time for skin type VI.
 {% endconfiguration %}
 
-The approximate number of minutes of a particular skin type can be exposed to the sun before burning/tanning starts is based on the [Fitzpatrick scale](https://en.wikipedia.org/wiki/Fitzpatrick_scale).
+The approximate number of minutes of a particular skin type can be exposed to
+the sun before burning/tanning starts is based on the
+[Fitzpatrick scale](https://en.wikipedia.org/wiki/Fitzpatrick_scale).
 
-## {% linkable_title Full example %}
+## {% linkable_title Full Configuration Example %}
 
-To configure additional functionality, add configuration options beneath a `binary_sensor` and/or `sensor` key within the `openuv` section of the `configuration.yaml` file as below:
+To configure additional functionality, add configuration options beneath a
+`binary_sensor` and/or `sensor` key within the `openuv` section of the
+`configuration.yaml` file as below:
 
 ```yaml
 openuv:
@@ -123,5 +121,51 @@ openuv:
 ```
 
 <p class='note warning'>
-The above guidelines constitute estimates and are intended to help informed decision making. They should not replace analysis, advice or diagnosis from a trained medical professional.
+The above guidelines constitute estimates and are intended to help informed
+decision making. They should not replace analysis, advice or diagnosis from a
+trained medical professional.
 </p>
+
+## {% linkable_title Services %}
+
+### {% linkable_title `openuv.update_data` %}
+
+Perform an on-demand update of OpenUV data.
+
+## {% linkable_title Examples of Updating Data %}
+
+One method to retrieve data every 30 minutes and still leave plenty of API key
+usage is to only retrieve data during the daytime:
+
+```yaml
+automation:
+  - alias: Update OpenUV every 30 minutes during the daytime
+    trigger:
+      platform: time
+      minutes: "/30"
+      seconds: 00
+    condition:
+      condition: and
+      conditions:
+        - condition: sun
+          after: sunrise
+        - condition: sun
+          before: sunset
+    action:
+      service: openuv.update_data
+```
+
+Another method (useful when monitoring locations other than the HASS latitude
+and longitude, in locations where there is a large amount of sunlight per day,
+etc.) might be to simply query the API less often:
+
+```yaml
+automation:
+  - alias: Update OpenUV every hour (24 of 50 calls per day)
+    trigger:
+      platform: time
+      minutes: "/60"
+      seconds: 00
+    action:
+      service: openuv.update_data
+```


### PR DESCRIPTION
**Description:**

This PR changes the documentation to reflect new API key usage info going into effect on February 1st.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/19949

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
