### PR TITLE
As a link it doesn't work.

### DIFF
--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -55,7 +55,7 @@ Use the following configuration in Home Assistant to use the generated certifica
 
 ```yaml
 http:
-  base_url: https://my-domain.duckdns.org:8123
+  base_url: my-domain.duckdns.org:8123
   ssl_certificate: /ssl/fullchain.pem
   ssl_key: /ssl/privkey.pem
 ```


### PR DESCRIPTION
```yaml
http:
  base_url: https://my-domain.duckdns.org:8123
  ssl_certificate: /ssl/fullchain.pem
  ssl_key: /ssl/privkey.pem
```

The "https://" must be leaved away. If it stays it doesn't work. First http: and then followed with https: causes errors.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
