### PR TITLE
Add platform Freebox switches

### DIFF
--- a/source/_components/freebox.markdown
+++ b/source/_components/freebox.markdown
@@ -13,7 +13,6 @@ ha_release: "0.85"
 ha_iot_class: "Local Polling"
 ---
 
-
 The `freebox` component allows you to observe and control [Freebox router](http://www.free.fr/).
 
 The integration provides:
@@ -56,7 +55,7 @@ You must have set a password for your Freebox router web administration page and
 </p>
 
 <p class='note warning'>
-By default the permissions granted to applications on the Freebox router are not correct to make switch platform available. You will need to add the permission "Modification des réglages de la Freebox" in "Gestion des accès", "Applications".
+By default, the permissions granted to applications on the Freebox router are not correct to make switch platform available. You will need to add the permission "Modification des réglages de la Freebox" in "Gestion des accès", "Applications".
 </p>
 
 The first time Home Assistant will connect to your Freebox, you will need to

--- a/source/_components/freebox.markdown
+++ b/source/_components/freebox.markdown
@@ -20,6 +20,7 @@ The integration provides:
 
 * a sensor with traffic metrics
 * a device tracker for connected devices
+* a switch to control WiFi access point
 
 ### {% linkable_title Configuration %}
 
@@ -52,6 +53,10 @@ returned json should contain an api_domain (`host`) and a https_port (`port`).
 
 <p class='note warning'>
 You must have set a password for your Freebox router web administration page and enabled the option "Permettre les nouvelles demandes d'associations".
+</p>
+
+<p class='note warning'>
+By default the permissions granted to applications on the Freebox router are not correct to make switch platform available. You will need to add the permission "Modification des réglages de la Freebox" in "Gestion des accès", "Applications".
 </p>
 
 The first time Home Assistant will connect to your Freebox, you will need to

--- a/source/_components/switch.freebox.markdown
+++ b/source/_components/switch.freebox.markdown
@@ -1,0 +1,19 @@
+---
+layout: page
+title: "Freebox Switches"
+description: "Instructions on how to integrate some switches to control a Freebox router in Home Assistant."
+date: 2018-05-16 23:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: freebox.svg
+ha_category: Switch
+ha_release: "0.86"
+ha_iot_class: "Local Polling"
+---
+
+
+This platform offers a switch to control the WiFi access point of a [Freebox](http://www.free.fr/) router.
+
+This requires you to have set up the [Freebox component](/components/freebox/)

--- a/source/_components/switch.freebox.markdown
+++ b/source/_components/switch.freebox.markdown
@@ -13,11 +13,10 @@ ha_release: "0.86"
 ha_iot_class: "Local Polling"
 ---
 
-
 This platform offers a switch to control the WiFi access point of a [Freebox](http://www.free.fr/) router.
 
 <p class='note warning'>
-By default the permissions granted to applications on the Freebox router are not correct to make this platform available. You will need to add the permission "Modification des réglages de la Freebox" in "Gestion des accès", "Applications".
+By default, the permissions granted to applications on the Freebox router are not correct to make this platform available. You will need to add the permission "Modification des réglages de la Freebox" in "Gestion des accès", "Applications".
 </p>
 
 This requires you to have set up the [Freebox component](/components/freebox/)

--- a/source/_components/switch.freebox.markdown
+++ b/source/_components/switch.freebox.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: freebox.svg
 ha_category: Switch
-ha_release: "0.86"
+ha_release: "0.87"
 ha_iot_class: "Local Polling"
 ---
 

--- a/source/_components/switch.freebox.markdown
+++ b/source/_components/switch.freebox.markdown
@@ -16,4 +16,8 @@ ha_iot_class: "Local Polling"
 
 This platform offers a switch to control the WiFi access point of a [Freebox](http://www.free.fr/) router.
 
+<p class='note warning'>
+By default the permissions granted to applications on the Freebox router are not correct to make this platform available. You will need to add the permission "Modification des réglages de la Freebox" in "Gestion des accès", "Applications".
+</p>
+
 This requires you to have set up the [Freebox component](/components/freebox/)


### PR DESCRIPTION
**Description:**
This is the documentation for Freebox Switches platform

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19942

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
