### PR TITLE
Add the KL series as supported bulbs

### DIFF
--- a/source/_components/light.tplink.markdown
+++ b/source/_components/light.tplink.markdown
@@ -22,6 +22,9 @@ Supported units:
 - LB120
 - LB130
 - LB230
+- KL110
+- KL120
+- KL130
 
 To use your TP-Link light in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
This is a change only to documentation since the existing code works with these new bulbs

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
