### PR TITLE
Update hue.markdown

### DIFF
--- a/source/_components/hue.markdown
+++ b/source/_components/hue.markdown
@@ -47,7 +47,7 @@ filename:
   required: false
   type: string
 allow_hue_groups:
-  description: Enable this to stop Home Assistant from importing the groups defined on the Hue bridge.
+  description: Disable this to stop Home Assistant from importing the groups defined on the Hue bridge.
   required: false
   type: boolean
 {% endconfiguration %}


### PR DESCRIPTION
Had the inverse description for allow_hue_groups

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
