### PR TITLE
0.85.1 changelog for LL

### DIFF
--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -8,6 +8,10 @@ comments: false
 sharing: true
 footer: true
 ---
+## {% linkable_title Changes in 0.85.1 %}
+- 🔧 Fix removal of `resources` on save in Raw Config Editor
+- 🔧 [weblink row] Correctly wrap rows
+
 ## {% linkable_title Changes in 0.85.0 %}
 - 📣 [map card]: New config `geo_location_sources`
 - 📣 [alarm panel card]: Hide keypad if `code_format` attribute is not "Number"
@@ -259,3 +263,5 @@ footer: true
 [thermostat card]: /lovelace/thermostat/
 [vertical stack card]: /lovelace/vertical-stack/
 [weather forecast card]: /lovelace/weather-forecast/
+
+[weblink row]: /lovelace/entities/#weblink

--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -10,7 +10,8 @@ footer: true
 ---
 ## {% linkable_title Changes in 0.85.1 %}
 - 🔧 Fix removal of `resources` on save in Raw Config Editor
-- 🔧 [weblink row] Correctly wrap rows
+- 🔧 Auto-gen correctly converts weblink entities to [weblink row]
+- 🔧 The [weblink row] opens links in new tabs
 
 ## {% linkable_title Changes in 0.85.0 %}
 - 📣 [map card]: New config `geo_location_sources`


### PR DESCRIPTION
## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
