### PR TITLE
correcting hmip port

### DIFF
--- a/source/_addons/homematic.markdown
+++ b/source/_addons/homematic.markdown
@@ -118,7 +118,7 @@ homematic:
       port: 2000
     hmip:
       host: core-homematic
-      port: 2001
+      port: 2010
 ```
 
 ## {% linkable_title Raspberry Pi3 %}


### PR DESCRIPTION
correcting the hmip port of yaml configuration example

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
