### PR TITLE
Adds docs for enabling I2C on Hass.io 

### DIFF
--- a/source/_components/sensor.bme680.markdown
+++ b/source/_components/sensor.bme680.markdown
@@ -13,7 +13,6 @@ ha_release: 0.62
 ha_iot_class: "Local Push"
 ---
 
-
 The `bme680` sensor platform allows you to read temperature, humidity, pressure and gas resistance values of a [Bosch BME680 Environmental sensor](https://cdn-shop.adafruit.com/product-files/3660/BME680.pdf) connected via an [I2C](https://en.wikipedia.org/wiki/I²C) bus (SDA, SCL pins). It allows you to use all the operation modes of the sensor described in its datasheet. In addition, it includes a basic air quality calculation that uses gas resistance and humidity measurements to calculate a percentage based air quality measurement.
 
 Tested devices:
@@ -187,11 +186,8 @@ group:
 ```
 
 ## {% linkable_title Directions for enabling I2C interface on Hass.io %}
-Follow the instructions here to [enable I2C on Hass.io.][enable-i2c-hassio]  
 
-OR
-
-If you're installing on system that doesn't have Hass.io follow the instructions below.
+Follow the instructions here to [enable I2C on Hass.io.](/hassio/enable_i2c/).
 
 ## {% linkable_title Directions for installing SMBus support on Raspberry Pi %}
 
@@ -239,6 +235,3 @@ It will output a table like this:
 ```
 
 So you can see the sensor address that you are looking for is **0x76** (there is another I2C device on that Raspberry Pi).
-
-
-[enable-i2c-hassio]: /hassio/enable_i2c/

--- a/source/_components/sensor.bme680.markdown
+++ b/source/_components/sensor.bme680.markdown
@@ -186,6 +186,13 @@ group:
       - sensor.bme680_sensor_air_quality
 ```
 
+## {% linkable_title Directions for enabling I2C interface on Hass.io %}
+Follow the instructions here to [enable I2C on Hass.io.][enable-i2c-hassio]  
+
+OR
+
+If you're installing on system that doesn't have Hass.io follow the instructions below.
+
 ## {% linkable_title Directions for installing SMBus support on Raspberry Pi %}
 
 Enable I2C interface with the Raspberry Pi configuration utility:
@@ -232,3 +239,6 @@ It will output a table like this:
 ```
 
 So you can see the sensor address that you are looking for is **0x76** (there is another I2C device on that Raspberry Pi).
+
+
+[enable-i2c-hassio]: /hassio/enable_i2c/

--- a/source/_includes/asides/hassio_navigation.html
+++ b/source/_includes/asides/hassio_navigation.html
@@ -19,6 +19,7 @@
           <li>{% active_link /hassio/zwave/ Z-Wave %}</li>
           <li>{% active_link /hassio/external_storage/ External storage %}</li>
           <li>{% active_link /hassio/run_local/ Execute local things %}</li>
+          <li>{% active_link /hassio/enable_i2c/ Enable I2C %}</li>
         </ul>
       </li>
     </ul>

--- a/source/hassio/enable_i2c.markdown
+++ b/source/hassio/enable_i2c.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Enable HassOS i2c"
-description: "Instructions on how to enable i2c on a Raspberry PI for Hass.io."
+description: "Instructions on how to enable I2C on a Raspberry PI for Hass.io."
 date: 2018-01-11 20:08
 sidebar: true
 comments: false
@@ -11,32 +11,41 @@ footer: true
 
 Hass.io is a managed environment, which means you can't use existing methods to enable the I2C bus on a Raspberry Pi.
 
-If you're attempting to add an external sensor, you will have to enable the I2C interface in the hass.io configuration via the USB Configuration prompt.  **NOTE**: this will not work via an ssh connection.
+If you're attempting to add an external sensor, you will have to [enable the I2C interface in the Hass.io configuration](https://github.com/home-assistant/hassos/blob/dev/Documentation/boards/raspberrypi.md#i2c) using a USB stick.
 
-You will need: 
-* USB drive
-* A way to add files to the USB drive
-* A way to connect the drive to your Raspberry Pi
+## {% linkable_title Step by step instructions %}
 
-Step 1 - Prepare the USB drive.
-Connect the USB drive to a device capable of adding and editing files to the USB drive.  Format a USB stick with FAT32/EXT4/NTFS and name the drive `CONFIG`. 
-DO NOT skip this step. 
+You will need:
 
-Step 2 - Add files to enable I2C.
-In the root of the USB drive add a folder called /modules.  Inside that folder add a text file called `rpi-i2c.conf`.  Open that file and add
-these two lines:
-```
-i2c-bcm2708
-i2c-dev
-```
+- USB drive
+- A way to add files to the USB drive
+- A way to connect the drive to your Raspberry Pi
 
-In the root of the USB drive add a file called `config.txt`.  Open that file and add these lines:
-```
-dtparam=i2c1=on 
-dtparam=i2c_arm=on
-```
+### {% linkable_title Step 1 - Prepare the USB drive %}
 
-Step 3 - Load the new USB config.
-Insert the USB drive into your Raspberry PI.  Now go to the admin page http://hassio.local:8123/states, then in the sidebar click Hass.io > System.
-Now click `Import from USB`.  This will restart your Hass.io instance, and load the new USB configuration. When the service has restarted, you will have 
-an working I2C interface.
+Connect the USB drive to a device capable of adding and editing files to the USB drive.
+
+Format a USB stick with FAT32/EXT4/NTFS and name the drive `CONFIG` (uppercase).
+
+### {% linkable_title Step 2 - Add files to enable I2C %}
+
+- In the root of the USB drive add a folder called `/modules`.
+- Inside that folder add a text file called `rpi-i2c.conf` with the following contents:
+  ```
+  i2c-bcm2708
+  i2c-dev
+  ```
+- In the root of the USB drive add a file called `config.txt` with the following contents:
+  ```
+  dtparam=i2c1=on 
+  dtparam=i2c_arm=on
+  ```
+
+### {% linkable_title Step 3 - Load the new USB config %}
+
+- Insert the USB drive into your Raspberry PI.
+- Now go to your Home Assistant web interface, in the sidebar click **Hass.io** > **System**.
+- Now click `Import from USB`.
+- This will restart your Hass.io instance, and load the new USB configuration.
+
+When the service has restarted, you will have a working I2C interface.

--- a/source/hassio/enable_i2c.markdown
+++ b/source/hassio/enable_i2c.markdown
@@ -1,0 +1,42 @@
+---
+layout: page
+title: "Enable HassOS i2c"
+description: "Instructions on how to enable i2c on a Raspberry PI for Hass.io."
+date: 2018-01-11 20:08
+sidebar: true
+comments: false
+sharing: true
+footer: true
+---
+
+Hass.io is a managed environment, which means you can't use existing methods to enable the I2C bus on a Raspberry Pi.
+
+If you're attempting to add an external sensor, you will have to enable the I2C interface in the hass.io configuration via the USB Configuration prompt.  **NOTE**: this will not work via an ssh connection.
+
+You will need: 
+* USB drive
+* A way to add files to the USB drive
+* A way to connect the drive to your Raspberry Pi
+
+Step 1 - Prepare the USB drive.
+Connect the USB drive to a device capable of adding and editing files to the USB drive.  Format a USB stick with FAT32/EXT4/NTFS and name the drive `CONFIG`. 
+DO NOT skip this step. 
+
+Step 2 - Add files to enable I2C.
+In the root of the USB drive add a folder called /modules.  Inside that folder add a text file called `rpi-i2c.conf`.  Open that file and add
+these two lines:
+```
+i2c-bcm2708
+i2c-dev
+```
+
+In the root of the USB drive add a file called `config.txt`.  Open that file and add these lines:
+```
+dtparam=i2c1=on 
+dtparam=i2c_arm=on
+```
+
+Step 3 - Load the new USB config.
+Insert the USB drive into your Raspberry PI.  Now go to the admin page http://hassio.local:8123/states, then in the sidebar click Hass.io > System.
+Now click `Import from USB`.  This will restart your Hass.io instance, and load the new USB configuration. When the service has restarted, you will have 
+an working I2C interface.


### PR DESCRIPTION
**Description:**
Adds documentation for enabling I2C on Hass.io


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
