### PR TITLE
Adding link to the LLAT section of the docs

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -27,7 +27,7 @@ http:
 
 {% configuration %}
 api_password:
-  description: Protect the Home Assistant API with a password - this password can also be used to log in to the frontend. Where your client or other software supports it, you should use [long lasting access token](https://www.home-assistant.io/docs/authentication/#your-account-profile) instead, as [shown in the REST API](https://developers.home-assistant.io/docs/en/external_api_rest.html) and [websocket API](https://developers.home-assistant.io/docs/en/external_api_websocket.html) documentation.
+  description: Protect the Home Assistant API with a password - this password can also be used to log in to the frontend. Where your client or other software supports it, you should use [long lasting access token](/docs/authentication/#your-account-profile) instead, as [shown in the REST API](https://developers.home-assistant.io/docs/en/external_api_rest.html) and [websocket API](https://developers.home-assistant.io/docs/en/external_api_websocket.html) documentation.
   required: false
   type: string
 server_host:

--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -27,7 +27,7 @@ http:
 
 {% configuration %}
 api_password:
-  description: Protect the Home Assistant API with a password - this password can also be used to log in to the frontend. Where possible you should use a long lasting access token instead of this.
+  description: Protect the Home Assistant API with a password - this password can also be used to log in to the frontend. Where your client or other software supports it, you should use [long lasting access token](https://www.home-assistant.io/docs/authentication/#your-account-profile) instead, as [shown in the REST API](https://developers.home-assistant.io/docs/en/external_api_rest.html) and [websocket API](https://developers.home-assistant.io/docs/en/external_api_websocket.html) documentation.
   required: false
   type: string
 server_host:


### PR DESCRIPTION
Adding link to the LLAT section of the docs, and to the API docs. This should hopefully make it clearer to folks that this isn't a drop in replacement.
