### PR TITLE
Update documentation for locative with the new webhook setup

### DIFF
--- a/source/_components/locative.md
+++ b/source/_components/locative.md
@@ -31,7 +31,7 @@ Install on your smartphone:
 - [Android](https://play.google.com/store/apps/details?id=io.locative.app)
 - [iOS](https://itunes.apple.com/us/app/geofancy/id725198453)
 
-To configure Locative, you must set up the app to send a `GET` or `POST` request to your Home Assistant server at `http://<ha_server>/api/locative`. Make sure to include the API password if you have configured a password in Home Assistant (add `?api_password=<password>` to the end of the URL). When you enter or exit a geofence, Locative will send the appropriate request to that URL, updating Home Assistant.  You are not able to specify a device name in Locative.  Instead, you will need to look in your known_devices.yaml file for a new device that Locative will have created on it's first `GET`.  If you had been or are using Owntracks as well, you will need to update the device name used in the Owntracks setup with the name that Locative generated.
+To configure Locative, you must set it up via the integrations panel in the configuration screen. You must set up the app to send a POST request to your Home Assistant server at the webhook URL provided by the integration during setup. When you enter or exit a geofence, Locative will send the appropriate request to that URL, updating Home Assistant. You are not able to specify a device name in Locative. Instead, you will need to look in your known_devices.yaml file for a new device that Locative will have created on it's first `GET`. If you had been or are using Owntracks as well, you will need to update the device name used in the Owntracks setup with the name that Locative generated.
 
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/locative.png'/>


### PR DESCRIPTION
**Description:**
Locative now uses the webhook integration.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20043

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
