### PR TITLE
Alternative hass.io Install Doc Patch 

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -100,6 +100,8 @@ apt-get update
 
 apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat software-properties-common
 
+curl -fsSL get.docker.com | sh
+
 curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install" | bash -s
 ```
 


### PR DESCRIPTION
**Description:**
Added the following to hass.io Alternative Install documentation:

`curl -fsSL get.docker.com | sh` that will detect distribution, predict package manager, and install Docker CE (not docker.io).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#8162

## Checklist:

- [:white_check_mark:] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [:white_check_mark:] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
