### PR TITLE
Fix wrong update interval for SolarEdge sensor

### DIFF
--- a/source/_components/sensor.solaredge.markdown
+++ b/source/_components/sensor.solaredge.markdown
@@ -16,7 +16,7 @@ ha_iot_class: "Cloud Polling"
 The `solaredge` platform uses the [SolarEdge Monitoring API](https://www.solaredge.com/sites/default/files/se_monitoring_api.pdf) to allow you to get details from your SolarEdge solar power setup and integrate these in your Home Assistant installation.
 
 <p class='note'>
-The SolarEdge Monitoring API has a daily rate limit of 300 requests. In order to stay under this limit, and alow for some additional requests, the `solaredge` platform will update the site overview every 5 minutes.
+The SolarEdge Monitoring API has a daily rate limit of 300 requests. In order to stay under this limit, and alow for some additional requests, the `solaredge` platform will update the site overview every 10 minutes.
 </p>
 
 ## {% linkable_title Configuration %}


### PR DESCRIPTION
**Description:**
While working on another PR I noticed that the documentation says that the SolarEdge sensor updates every 5 minutes, but I think this should be 10 minutes [according to these lines](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/sensor/solaredge.py#L25-L26).

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
