### PR TITLE
fixed a typo

### DIFF
--- a/source/_components/fritzbox.markdown
+++ b/source/_components/fritzbox.markdown
@@ -43,7 +43,7 @@ devices:
     host:
       description: The hostname or IP address of the Fritzbox.
       required: true
-      type: optional
+      type: string
     username:
       description: The username for Smart Home access.
       required: true


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
