### PR TITLE
HomematicIP Cloud add cover devices platform

### DIFF
--- a/source/_components/cover.homematicip_cloud.markdown
+++ b/source/_components/cover.homematicip_cloud.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: homematicip_cloud.png
 ha_category: Cover
-ha_release: 0.86
+ha_release: 0.87
 ha_iot_class: "Cloud Push"
 ---
 

--- a/source/_components/cover.homematicip_cloud.markdown
+++ b/source/_components/cover.homematicip_cloud.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: homematicip_cloud.png
-ha_category: Switch
+ha_category: Cover
 ha_release: 0.86
 ha_iot_class: "Cloud Push"
 ---

--- a/source/_components/cover.homematicip_cloud.markdown
+++ b/source/_components/cover.homematicip_cloud.markdown
@@ -1,0 +1,21 @@
+---
+layout: page
+title: "HomematicIP Cloud Cover"
+description: "Instructions on how to integrate HomematicIP covers within Home Assistant."
+date: 2019-04-13 13:40
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: homematicip_cloud.png
+ha_category: Switch
+ha_release: 0.86
+ha_iot_class: "Cloud Push"
+---
+
+The `homematicip_cloud` cover platform allows you to control
+[HomematicIP](http://www.homematic-ip.com) covers through Home Assistant.
+
+Devices will be configured automatically. Please refer to the
+[component](/components/homematicip_cloud/) configuration on how to setup
+HomematicIP Cloud.


### PR DESCRIPTION
**Description:**
Add HomematicIP cover platform 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19794

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
