### PR TITLE
guide for asuswrt to use the rt-n56u project, Padavan custom firmware

### DIFF
--- a/source/_components/device_tracker.asuswrt.markdown
+++ b/source/_components/device_tracker.asuswrt.markdown
@@ -28,15 +28,13 @@ Follow these steps to setup the link.
 ```
 $ find / -name "dnsmasq.leases" 
 ```
-3. Copy the full path of, example: 
-```
-$ /tmp/dnsmasq.leases
-```
+3. Copy or remember the full path of, example: 
+`/tmp/dnsmasq.leases`
 4. Create the folder if it does not exist: 
 ```
 $ mkdir -p /var/lib/misc
 ```
-5. Add the linking process to the routers after started script (one line): 
+5. Add the linking process to the routers started script (one line): 
 ```
 $ echo "/bin/ln -s /tmp/dnsmasq.leases /var/lib/misc/dnsmasq.leases" >> /etc/storage/started_script.sh
 ```
@@ -45,6 +43,6 @@ $ echo "/bin/ln -s /tmp/dnsmasq.leases /var/lib/misc/dnsmasq.leases" >> /etc/st
 $ /bin/ln -s /tmp/dnsmasq.leases /var/lib/misc/dnsmasq.leases
 ```
 
-Note: The script is also accessable and editable in the web gui. `Advanced Settings -> Customization -> Scripts -> Custom User Script -> Run After Router Started`
+Note: The started script is also accessable and editable in the web gui. `Advanced Settings -> Customization -> Scripts -> Custom User Script -> Run After Router Started`
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.asuswrt.markdown
+++ b/source/_components/device_tracker.asuswrt.markdown
@@ -19,4 +19,17 @@ The platform will be automatically configured if Asuswrt component is configured
 
 For more configuration information see the [Asuswrt component](/components/asuswrt/) documentation.
 
+## {% linkable_title Padavan custom firmware (The rt-n56u project) %}
+The [rt-n56u project](https://bitbucket.org/padavan/rt-n56u) does not store `dnsmasq.leases` which is used to track devices at `/var/lib/misc/` as `asuswrt` do. However this component can still be used for the rt-n56u project by linking `dnsmasq.leases` at the router boot.
+
+Follow these steps to setup the link.
+1. SSH or Telnet into the router. (default ssh admin@my.router)
+2. Run the following command: `find / -name "dnsmasq.leases"`
+3. Copy the full path of, example: `/tmp/dnsmasq.leases`
+4. Create the folder if it does not exist: `mkdir -p /var/lib/misc`
+5. Add the linking process to the routers after started script: `echo "/bin/ln -s /tmp/dnsmasq.leases /var/lib/misc/dnsmasq.leases" >> /etc/storage/started_script.sh`
+6. Reboot the router or link the file: `/bin/ln -s /tmp/dnsmasq.leases /var/lib/misc/dnsmasq.leases`
+
+Note: The script is also accessable and editable in the web gui. `Advanced Settings -> Customization -> Scripts -> Custom User Script -> Run After Router Started`
+
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.asuswrt.markdown
+++ b/source/_components/device_tracker.asuswrt.markdown
@@ -24,11 +24,26 @@ The [rt-n56u project](https://bitbucket.org/padavan/rt-n56u) does not store `dns
 
 Follow these steps to setup the link.
 1. SSH or Telnet into the router. (default ssh admin@my.router)
-2. Run the following command: `find / -name "dnsmasq.leases"`
-3. Copy the full path of, example: `/tmp/dnsmasq.leases`
-4. Create the folder if it does not exist: `mkdir -p /var/lib/misc`
-5. Add the linking process to the routers after started script: `echo "/bin/ln -s /tmp/dnsmasq.leases /var/lib/misc/dnsmasq.leases" >> /etc/storage/started_script.sh`
-6. Reboot the router or link the file: `/bin/ln -s /tmp/dnsmasq.leases /var/lib/misc/dnsmasq.leases`
+2. Run the following command to find the file:
+```
+$ find / -name "dnsmasq.leases" 
+```
+3. Copy the full path of, example: 
+```
+$ /tmp/dnsmasq.leases
+```
+4. Create the folder if it does not exist: 
+```
+$ mkdir -p /var/lib/misc
+```
+5. Add the linking process to the routers after started script (one line): 
+```
+$ echo "/bin/ln -s /tmp/dnsmasq.leases /var/lib/misc/dnsmasq.leases" >> /etc/storage/started_script.sh
+```
+6. Reboot the router or link the file: 
+```
+$ /bin/ln -s /tmp/dnsmasq.leases /var/lib/misc/dnsmasq.leases
+```
 
 Note: The script is also accessable and editable in the web gui. `Advanced Settings -> Customization -> Scripts -> Custom User Script -> Run After Router Started`
 


### PR DESCRIPTION
**Description:** Guide for making it possible to use asuswrt device tracker on the rt-n56u project, as the only difference is where the `dnsmasq.leases` is stored. 
`asuswrt`: /var/lib/misc/dnsmasq.leases
`the rt-n56u project` (currently): /tmp/dnsmasq.leases


## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
