### PR TITLE
Support device_class for rest sensor

### DIFF
--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -23,6 +23,7 @@ The way these sensors are displayed in the frontend can be modified in the [cust
 - **illuminance**: The current light level in lx or lm.
 - **temperature**: Temperature in °C or °F.
 - **pressure**: Pressure in hPa or mbar.
+- **timestamp**: Datetime object or timestamp string.
 
 <p class='img'>
 <img src='/images/screenshots/sensor_device_classes_icons.png' />

--- a/source/_components/sensor.rest.markdown
+++ b/source/_components/sensor.rest.markdown
@@ -52,6 +52,12 @@ name:
   required: false
   type: string
   default: REST Sensor
+device_class:
+  description: >
+    The [type/class](/components/sensor/) of
+    the sensor to set the icon in the frontend.
+  required: false
+  type: string
 value_template:
   description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the value."
   required: false


### PR DESCRIPTION
**Description:**
Support device_class configuration for [RESTful Sensor](https://www.home-assistant.io/components/sensor.rest/).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20132

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
