### PR TITLE
Fixes broken device_class links (2019-0003)

### DIFF
--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -2,7 +2,7 @@ module Jekyll
   class ConfigurationBlock < Liquid::Block
     TYPE_LINKS = {
       'action'       => '/docs/scripts/',
-      'device_class' => '/components/%{component}/#device-class',
+      'device_class' => '/docs/configuration/customizing-devices/#device-class',
       'template'     => '/docs/configuration/templating/',
       'icon'         => '/docs/configuration/customizing-devices/#icon',
     }


### PR DESCRIPTION
**Description:**

Fixes the broken device class links by pointing it to a more generic location, which should still cover the reason for it being a link, without causing 404 pages.

Raised in #6791 and #7895.

This is a more permanent and a more logical solution IMHO, which is similar to how we link the icons.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html