### PR TITLE
Update to MAC Address Format for LG WebOS TV Wake-on-LAN

### DIFF
--- a/source/_components/media_player.webostv.markdown
+++ b/source/_components/media_player.webostv.markdown
@@ -128,7 +128,7 @@ media_player:
     turn_on_action:
       service: wake_on_lan.send_magic_packet
       data:
-        mac: "B4-E6-2A-1E-11-0F"
+        mac: "B4:E6:2A:1E:11:0F"
 ```
 
 Any other [actions](/docs/automation/action/) to power on the device can be


### PR DESCRIPTION
Mac Addresses are colon delimited, not dash.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
