### PR TITLE
Update documentation for rpi_gpio

### DIFF
--- a/source/_components/binary_sensor.rpi_gpio.markdown
+++ b/source/_components/binary_sensor.rpi_gpio.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Raspberry Pi GPIO Binary Sensor"
 description: "Instructions on how to integrate the GPIO sensor capability of a Raspberry Pi or Orange Pi into Home Assistant."
-date: 2018-01-16 13:00
+date: 2015-08-30 19:00
 sidebar: true
 comments: false
 sharing: true

--- a/source/_components/binary_sensor.rpi_gpio.markdown
+++ b/source/_components/binary_sensor.rpi_gpio.markdown
@@ -1,8 +1,8 @@
 ---
 layout: page
 title: "Raspberry Pi GPIO Binary Sensor"
-description: "Instructions on how to integrate the GPIO sensor capability of a Raspberry Pi into Home Assistant."
-date: 2015-08-30 19:00
+description: "Instructions on how to integrate the GPIO sensor capability of a Raspberry Pi or Orange Pi into Home Assistant."
+date: 2018-01-16 13:00
 sidebar: true
 comments: false
 sharing: true
@@ -13,7 +13,7 @@ ha_release: pre 0.7
 ha_iot_class: "Local Push"
 ---
 
-The `rpi_gpio` binary sensor platform allows you to read sensor values of the GPIOs of your [Raspberry Pi](https://www.raspberrypi.org/).
+The `rpi_gpio` binary sensor platform allows you to read sensor values of the GPIOs of your [Raspberry Pi](https://www.raspberrypi.org/) or [Orange Pi](http://www.orangepi.org/).
 
 ## {% linkable_title Configuration %}
 
@@ -35,7 +35,7 @@ ports:
   type: map
   keys:
     "port: name":
-      description: The port numbers (BCM mode pin numbers) and corresponding names.
+      description: Port numbers and corresponding names (GPIO number). For Raspberry Pi boards this is the BCM style pin numbering, for Orange Pi it is the SUNXI style pin numbering (i.e. PA7).
       required: true
       type: string
 bouncetime:

--- a/source/_components/rpi_gpio.markdown
+++ b/source/_components/rpi_gpio.markdown
@@ -1,8 +1,8 @@
 ---
 layout: page
 title: "Raspberry Pi GPIO"
-description: "Instructions on how to integrate the GPIO capability of a Raspberry Pi into Home Assistant."
-date: 2016-08-30 19:00
+description: "Instructions on how to integrate the GPIO capability of a Raspberry Pi or Orange Pi into Home Assistant."
+date: 2018-01-16 13:00
 sidebar: true
 comments: false
 sharing: true
@@ -13,5 +13,17 @@ ha_release: pre 0.7
 ha_iot_class: "Local Push"
 ---
 
-The `rpi_gpio` component is the base for all related GPIO platforms in Home Assistant. There is no setup needed for the component itself, for the platforms please check their corresponding pages.
+The `rpi_gpio` component is the base for all related GPIO platforms in Home Assistant. This component supports both Raspberry Pi, as well as the Orange Pi boards.
 
+```yaml
+# Example configuration.yaml entry
+rpi_gpio:
+  board_family: raspberry_pi
+```
+
+{% configuration %}
+board_family:
+  description: The type of board. The default is "raspberry_pi", but "orange_pi" is also supported.
+  required: false
+  type: string
+{% endconfiguration %}

--- a/source/_components/rpi_gpio.markdown
+++ b/source/_components/rpi_gpio.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Raspberry Pi GPIO"
 description: "Instructions on how to integrate the GPIO capability of a Raspberry Pi or Orange Pi into Home Assistant."
-date: 2018-01-16 13:00
+date: 2016-08-30 19:00
 sidebar: true
 comments: false
 sharing: true

--- a/source/_components/switch.rpi_gpio.markdown
+++ b/source/_components/switch.rpi_gpio.markdown
@@ -1,8 +1,8 @@
 ---
 layout: page
 title: "Raspberry Pi GPIO Switch"
-description: "Instructions on how to integrate the GPIO of a Raspberry Pi into Home Assistant as a switch."
-date: 2015-08-07 14:00
+description: "Instructions on how to integrate the GPIO of a Raspberry Pi or Orange Pi into Home Assistant as a switch."
+date: 2018-01-16 13:00
 sidebar: true
 comments: false
 sharing: true
@@ -14,7 +14,7 @@ ha_iot_class: "Local Push"
 ---
 
 
-The `rpi_gpio` switch platform allows you to control the GPIOs of your [Raspberry Pi](https://www.raspberrypi.org/).
+The `rpi_gpio` switch platform allows you to control the GPIOs of your [Raspberry Pi](https://www.raspberrypi.org/) or [Orange Pi](http://www.orangepi.org/).
 
 ## {% linkable_title Configuration %}
 
@@ -36,7 +36,7 @@ ports:
   type: list
   keys:
     port:
-      description:  Port numbers and corresponding names (GPIO #).
+      description: Port numbers and corresponding names (GPIO number). For Raspberry Pi boards this is the BCM style pin numbering, for Orange Pi it is the SUNXI style pin numbering (i.e. PA7).
       required: true
       type: [integer, string]
 invert_logic:

--- a/source/_components/switch.rpi_gpio.markdown
+++ b/source/_components/switch.rpi_gpio.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Raspberry Pi GPIO Switch"
 description: "Instructions on how to integrate the GPIO of a Raspberry Pi or Orange Pi into Home Assistant as a switch."
-date: 2018-01-16 13:00
+date: 2015-08-07 14:00
 sidebar: true
 comments: false
 sharing: true


### PR DESCRIPTION
**Description:**

Update documentation for rpi_gpio and sub-components to cover new Orange Pi support.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19732
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
