### PR TITLE
Update documentation for friendly names in SolarEdge sensor

### DIFF
--- a/source/_components/sensor.solaredge.markdown
+++ b/source/_components/sensor.solaredge.markdown
@@ -32,7 +32,7 @@ sensor:
     site_id: SITE_ID
     monitored_conditions:
       - current_power
-      - last_day_data
+      - energy_today
 ```
 {% endraw %}
 
@@ -56,13 +56,13 @@ monitored_conditions:
   type: list
   default: current_power
   keys:
-    life_time_data:
+    lifetime_energy:
       description: Lifetime energy generated at your SolarEdge Site in Wh
-    last_year_data:
+    energy_this_year:
       description: Energy generated this year at your SolarEdge Site in Wh
-    last_month_data:
+    energy_this_month:
       description: Energy generated this month at your SolarEdge Site in Wh
-    last_day_data:
+    energy_today:
       description: Energy generated today at your SolarEdge Site in Wh
     current_power:
       description: Current generated power in W
@@ -84,10 +84,10 @@ sensor:
     name: SolarEdge
     monitored_conditions:
       - current_power
-      - last_day_data
-      - last_month_data
-      - last_year_data
-      - life_time_data
+      - energy_today
+      - energy_this_month
+      - energy_this_year
+      - lifetime_energy
 ```
 {% endraw %}
 
@@ -99,7 +99,7 @@ In case you would like to convert the values for example to kWh instead of the d
 sensors:
   platform: template
   sensors:
-    solaredge_last_year_data_template:
-      value_template: '{{(states.sensor.solaredge_last_year_data.state | float / 1000) | round(2)}}'
+    solaredge_energy_this_year_template:
+      value_template: '{{(states.sensor.solaredge_energy_this_year.state | float / 1000) | round(2)}}'
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**
The friendly names for the SolarEdge sensor have been fixed in my other PR (see below). This PR updates the documentation to reflect this change.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20109

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
