### PR TITLE
Update trigger markdown to expand twilight discussion and sunrise timing

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -127,7 +127,7 @@ automation:
     offset: '-00:45:00'
 ```
 
-Sometimes you may want more granular control over an automation based on the elevation of the sun. This can be used to layer automations to occur as the sun lowers on the horizon or even after it is below the horizon. This is also useful when the "sunset" event is not dark enough outside and you would like the automation to run later at a precise solar angle instead of the time offset such as turning on exterior lighting. For most things a general number like -4 degrees is suitable and is used in this example
+Sometimes you may want more granular control over an automation based on the elevation of the sun. This can be used to layer automations to occur as the sun lowers on the horizon or even after it is below the horizon. This is also useful when the "sunset" event is not dark enough outside and you would like the automation to run later at a precise solar angle instead of the time offset such as turning on exterior lighting. For most things, a general number like -4 degrees is suitable and is used in this example:
 
 {% raw %}
 ```yaml
@@ -145,7 +145,7 @@ automation:
 ```
 {% endraw %}
 
-If you want to get more precise, start with the US Naval Observatory [tool](http://aa.usno.navy.mil/data/docs/AltAz.php) that will help you estimate what the solar angle will be at any specific time. Then from this you can select from the defined twilight numbers. Although the actual amount of light depends on weather, topography and land cover, they are defined as:
+If you want to get more precise, start with the US Naval Observatory [tool](http://aa.usno.navy.mil/data/docs/AltAz.php) that will help you estimate what the solar angle will be at any specific time. Then from this, you can select from the defined twilight numbers. Although the actual amount of light depends on weather, topography and land cover, they are defined as:
 
 - Civil twilight: Solar angle > -6°
 - Nautical twilight: Solar angle > -12°
@@ -201,7 +201,7 @@ automation 3:
   Remember that if you are using matching to include both `minutes` and `seconds`.  Without `seconds`, your automation will trigger 60 times during the matching minute.
 </p>
 
-As mentioned in the Sun trigger section, sunrise is a different day than any time prior to midnight.  If you want to trigger an action with a large enough amout of time before sunrise that it precedes midnight, this must be accounted for properly.  One way is to convert the sunrise time to a timestamp (seconds since 1 Jan 1970). Then do the same for the offset desired (in seconds). This is done with the _as_timestamp_ method explained in the [Templating - Home Assistant template extensions](/docs/configuration/templating/#home-assistant-template-extensions) section.
+As mentioned in the Sun trigger section, sunrise is a different day than any time prior to midnight.  If you want to trigger an action with a large enough amount of time before sunrise that it precedes midnight, this must be accounted for properly.  One way is to convert the sunrise time to a timestamp (seconds since 1 Jan 1970). Then do the same for the offset desired (in seconds). This is done with the _as_timestamp_ method explained in the [Templating - Home Assistant template extensions](/docs/configuration/templating/#home-assistant-template-extensions) section.
 
 
 ### {% linkable_title Webhook trigger %}

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -115,7 +115,7 @@ automation:
 
 Triggers when the sun is setting or rising. An optional time offset can be given to have it trigger a set time before or after the sun event (i.e. 45 minutes before sunset, when dusk is setting in).
 
->Note: Sunrise as a trigger may need special attention as explained in time triggers below.  This is due to the date changing at midnight and sunrise is at an earlier time on the following day.
+Sunrise as a trigger may need special attention as explained in time triggers below. This is due to the date changing at midnight and sunrise is at an earlier time on the following day.
 
 ```yaml
 automation:
@@ -143,16 +143,15 @@ automation:
     service: switch.turn_on
     entity_id: switch.exterior_lighting
 ```
-}{% endraw %}
+{% endraw %}
 
-If you want to get more precise, start with the US Naval Observatory [tool](http://aa.usno.navy.mil/data/docs/AltAz.php) that will help you estimate what the solar angle will be at any specific time. Then from this you can select from the defined twilight numbers.  Although the actual amount of light depends on weather, topography, and land cover, they are defined as:
+If you want to get more precise, start with the US Naval Observatory [tool](http://aa.usno.navy.mil/data/docs/AltAz.php) that will help you estimate what the solar angle will be at any specific time. Then from this you can select from the defined twilight numbers. Although the actual amount of light depends on weather, topography and land cover, they are defined as:
 
-   *Civil twilight: Solar angle > -6°
-   *Nautical twilight: Solar angle > -12°
-   *Astronomical twilight: Solar angle > -18°
+- Civil twilight: Solar angle > -6°
+- Nautical twilight: Solar angle > -12°
+- Astronomical twilight: Solar angle > -18°
     
-A very thorough explanation of this is on [Wikipedia - Twilight](https://en.wikipedia.org/wiki/Twilight).
-
+A very thorough explanation of this is available in the Wikipedia article about the [Twilight](https://en.wikipedia.org/wiki/Twilight).
 
 ### {% linkable_title Template trigger %}
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -115,6 +115,8 @@ automation:
 
 Triggers when the sun is setting or rising. An optional time offset can be given to have it trigger a set time before or after the sun event (i.e. 45 minutes before sunset, when dusk is setting in).
 
+>Note: Sunrise as a trigger may need special attention as explained in time triggers below.  This is due to the date changing at midnight and sunrise is at an earlier time on the following day.
+
 ```yaml
 automation:
   trigger:
@@ -125,7 +127,7 @@ automation:
     offset: '-00:45:00'
 ```
 
-Sometimes you may want more granular control over an automation based on the elevation of the sun. This can be used to layer automations to occur as the sun lowers on the horizon or even after it is below the horizon. This is also useful when the "sunset" event is not dark enough outside and you would like the automation to run later at a precise solar angle instead of the time offset such as turning on exterior lighting.
+Sometimes you may want more granular control over an automation based on the elevation of the sun. This can be used to layer automations to occur as the sun lowers on the horizon or even after it is below the horizon. This is also useful when the "sunset" event is not dark enough outside and you would like the automation to run later at a precise solar angle instead of the time offset such as turning on exterior lighting. For most things a general number like -4 degrees is suitable and is used in this example
 
 {% raw %}
 ```yaml
@@ -143,7 +145,14 @@ automation:
 ```
 }{% endraw %}
 
-The US Naval Observatory has a [tool](http://aa.usno.navy.mil/data/docs/AltAz.php) that will help you estimate what the solar angle will be at any specific time.
+If you want to get more precise, start with the US Naval Observatory [tool](http://aa.usno.navy.mil/data/docs/AltAz.php) that will help you estimate what the solar angle will be at any specific time. Then from this you can select from the defined twilight numbers.  Although the actual amount of light depends on weather, topography, and land cover, they are defined as:
+
+   *Civil twilight: Solar angle > -6°
+   *Nautical twilight: Solar angle > -12°
+   *Astronomical twilight: Solar angle > -18°
+    
+A very thorough explanation of this is on [Wikipedia - Twilight](https://en.wikipedia.org/wiki/Twilight).
+
 
 ### {% linkable_title Template trigger %}
 
@@ -192,6 +201,9 @@ automation 3:
 <p class='note warning'>
   Remember that if you are using matching to include both `minutes` and `seconds`.  Without `seconds`, your automation will trigger 60 times during the matching minute.
 </p>
+
+As mentioned in the Sun trigger section, sunrise is a different day than any time prior to midnight.  If you want to trigger an action with a large enough amout of time before sunrise that it precedes midnight, this must be accounted for properly.  One way is to convert the sunrise time to a timestamp (seconds since 1 Jan 1970). Then do the same for the offset desired (in seconds). This is done with the _as_timestamp_ method explained in the [Templating - Home Assistant template extensions](/docs/configuration/templating/#home-assistant-template-extensions) section.
+
 
 ### {% linkable_title Webhook trigger %}
 


### PR DESCRIPTION
These changes expand on the sun angle for addition darkness by including detail on the three twilight definitions. A brief discussion has also been added to the time trigger section to explain why many automations that are relative to sunrise often fail.  Since sunrise is a different day than any time before midnight, using timestamps is a reasonable option.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
