### PR TITLE
Update homekit.markdown

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -369,9 +369,8 @@ Pairing works fine when the filter is set to only include `demo.demo`, but fails
 
 #### {% linkable_title Pairing hangs - no error %}
 
-1) Make sure that you don't try to add more than 100 accessories, see [device limit](#device-limit). In rare cases, one of your entities doesn't work with the HomeKit component. Use the [filter](#configure-filter) to find out which one. Feel free to open a new issue in the `home-assistant` repo, so we can resolve it.
-
-2) Check logs, and search for `Starting accessory Home Assistant Bridge on address`. Make sure Home Assistant Bridge hook ups to a correct interface. If it did not, explicitly set `homekit.ip_address` configuration variable. 
+1. Make sure that you don't try to add more than 100 accessories, see [device limit](#device-limit). In rare cases, one of your entities doesn't work with the HomeKit component. Use the [filter](#configure-filter) to find out which one. Feel free to open a new issue in the `home-assistant` repo, so we can resolve it.
+2. Check logs, and search for `Starting accessory Home Assistant Bridge on address`. Make sure Home Assistant Bridge hook ups to a correct interface. If it did not, explicitly set `homekit.ip_address` configuration variable. 
 
 #### {% linkable_title Duplicate AID found when attempting to add accessory %}
 

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -369,7 +369,9 @@ Pairing works fine when the filter is set to only include `demo.demo`, but fails
 
 #### {% linkable_title Pairing hangs - no error %}
 
-Make sure that you don't try to add more than 100 accessories, see [device limit](#device-limit). In rare cases, one of your entities doesn't work with the HomeKit component. Use the [filter](#configure-filter) to find out which one. Feel free to open a new issue in the `home-assistant` repo, so we can resolve it.
+1) Make sure that you don't try to add more than 100 accessories, see [device limit](#device-limit). In rare cases, one of your entities doesn't work with the HomeKit component. Use the [filter](#configure-filter) to find out which one. Feel free to open a new issue in the `home-assistant` repo, so we can resolve it.
+
+2) Check logs, and search for `Starting accessory Home Assistant Bridge on address`. Make sure Home Assistant Bridge hook ups to a correct interface. If it did not, explicitly set `homekit.ip_address` configuration variable. 
 
 #### {% linkable_title Duplicate AID found when attempting to add accessory %}
 


### PR DESCRIPTION
Discovered new pairing hangs cause and resolution

**Description:**
Discovered new pairing hangs problem that was not listed on the official homekit component page.
