### PR TITLE
Added links for web addresses

### DIFF
--- a/source/_components/sensor.dsmr.markdown
+++ b/source/_components/sensor.dsmr.markdown
@@ -17,7 +17,7 @@ A sensor platform for Dutch Smart Meters which comply to DSMR (Dutch Smart Meter
 
 - Currently support DSMR V2.2, V3, V4 and V5 through the [dsmr_parser](https://github.com/ndokter/dsmr_parser) module by Nigel Dokter.
 - For official information about DSMR refer to: [DSMR Document](https://www.netbeheernederland.nl/dossiers/slimme-meter-15)
-- For official information about the P1 port refer to: https://www.wijhebbenzon.nl/media/kunena/attachments/3055/DSMRv5.0FinalP1.pdf
+- For official information about the P1 port refer to: <https://www.wijhebbenzon.nl/media/kunena/attachments/3055/DSMRv5.0FinalP1.pdf>
 - For unofficial hardware connection examples refer to: [Domoticx](http://domoticx.com/p1-poort-slimme-meter-hardware/)
 
 <p class='img'>
@@ -37,13 +37,13 @@ This component is known to work for:
 USB serial converters:
 
 - Cheap (Banggood/ebay) Generic PL2303
-- <a href="https://sites.google.com/site/nta8130p1smartmeter/webshop">https://sites.google.com/site/nta8130p1smartmeter/webshop</a>
-- <a href="https://www.sossolutions.nl/slimme-meter-kabel">https://www.sossolutions.nl/slimme-meter-kabel</a>
-- <a href="https://tweakers.net/gallery/269738/aanbod/">https://tweakers.net/gallery/269738/aanbod/</a>
+- <https://sites.google.com/site/nta8130p1smartmeter/webshop">https://sites.google.com/site/nta8130p1smartmeter/webshop>
+- <https://www.sossolutions.nl/slimme-meter-kabel>
+- <https://tweakers.net/gallery/269738/aanbod/>
 
 Serial to network proxies:
 
-- ser2net - http://ser2net.sourceforge.net/
+- ser2net - <http://ser2net.sourceforge.net/>
 
 ```yaml
 # Example configuration.yaml entry
@@ -138,4 +138,3 @@ The contents of this telegram differ between version but they generally consist 
 This module sets up an asynchronous reading loop using the `dsmr_parser` module which waits for a complete telegram, parser it and puts it on an async queue as a dictionary of `obis`/object mapping. The numeric value and unit of each value can be read from the objects attributes. Because the `obis` are know for each DSMR version the Entities for this component are create during bootstrap.
 
 Another loop (DSMR class) is setup which reads the telegram queue, stores/caches the latest telegram and notifies the Entities that the telegram has been updated.
-

--- a/source/_components/sensor.dsmr.markdown
+++ b/source/_components/sensor.dsmr.markdown
@@ -37,7 +37,7 @@ This component is known to work for:
 USB serial converters:
 
 - Cheap (Banggood/ebay) Generic PL2303
-- <https://sites.google.com/site/nta8130p1smartmeter/webshop">https://sites.google.com/site/nta8130p1smartmeter/webshop>
+- <https://sites.google.com/site/nta8130p1smartmeter/webshop>
 - <https://www.sossolutions.nl/slimme-meter-kabel>
 - <https://tweakers.net/gallery/269738/aanbod/>
 

--- a/source/_components/sensor.dsmr.markdown
+++ b/source/_components/sensor.dsmr.markdown
@@ -37,9 +37,9 @@ This component is known to work for:
 USB serial converters:
 
 - Cheap (Banggood/ebay) Generic PL2303
-- https://sites.google.com/site/nta8130p1smartmeter/webshop
-- https://www.sossolutions.nl/slimme-meter-kabel
-- https://tweakers.net/gallery/269738/aanbod/
+- <a href="https://sites.google.com/site/nta8130p1smartmeter/webshop">https://sites.google.com/site/nta8130p1smartmeter/webshop</a>
+- <a href="https://www.sossolutions.nl/slimme-meter-kabel">https://www.sossolutions.nl/slimme-meter-kabel</a>
+- <a href="https://tweakers.net/gallery/269738/aanbod/">https://tweakers.net/gallery/269738/aanbod/</a>
 
 Serial to network proxies:
 


### PR DESCRIPTION
**Description:**

The documentation for the DSMR sensor has a couple of links to external web sites. These were not enclosed by tags, so a user couldn't click on those links to go to the intended pages.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
