### PR TITLE
Update calendar.google.markdown

### DIFF
--- a/source/_components/calendar.google.markdown
+++ b/source/_components/calendar.google.markdown
@@ -129,7 +129,8 @@ entities:
     offset:
       description: >
         A set of characters that precede a number in the event title
-        for designating a pre-trigger state change on the sensor.
+        for designating a pre-trigger state change on the sensor. 
+        This should be in the format of HH:MM or MM.
       required: false
       type: string
       default: "!!"


### PR DESCRIPTION
Add in the expected format for the offset to help prevent bugs being entered that it only supports 2 digits (it does but it supports hours)
https://github.com/home-assistant/home-assistant/issues/20168
https://github.com/home-assistant/home-assistant/issues/11886
https://github.com/home-assistant/home-assistant/issues/5791

**Description:**

The doc for offset appears to be missing the expected format.  This has led to several bugs being filed when people attempt to use an offset over 2 digits since it is looking for MM or HH:MM format and not MMM format

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
