### PR TITLE
Add docs for verify_ssl configuration added to rest_command and switch.rest

### DIFF
--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -30,7 +30,7 @@ rest_command:
 {% configuration %}
 service_name:
   description: The name used to expose the service. E.g., in the above example, it would be 'rest_command.service_name'.
-  required: true 
+  required: true
   type: map
   keys:
     url:
@@ -59,7 +59,7 @@ service_name:
       required: false
       type: string
     timeout:
-      description: Timeout for requests in seconds. 
+      description: Timeout for requests in seconds.
       required: false
       type: string
       defaut: 10
@@ -67,6 +67,11 @@ service_name:
       description: Content type for the request.
       required: false
       type: string
+    verify_ssl:
+      description: Verify the SSL certificate of the endpoint.
+      required: false
+      type: boolean
+      default: true
 {% endconfiguration %}
 
 ## {% linkable_title Examples %}
@@ -80,11 +85,12 @@ rest_command:
   my_request:
     url: https://slack.com/api/users.profile.set
     method: POST
-    headers: 
+    headers:
       authorization: !secret rest_headers_secret
       accept: 'application/json, text/html'
     payload: '{"profile":{"status_text": "{{ status }}","status_emoji": "{{ emoji }}"}}'
     content_type:  'application/json; charset=utf-8'
+    verify_ssl: true
 ```
 {% endraw %}
 

--- a/source/_components/sensor.rest.markdown
+++ b/source/_components/sensor.rest.markdown
@@ -67,7 +67,7 @@ payload:
   required: false
   type: string
 verify_ssl:
-  description: Verify the certification of the endpoint.
+  description: Verify the SSL certificate of the endpoint.
   required: false
   type: boolean
   default: True
@@ -173,7 +173,7 @@ sensor:
       Content-Type: application/json
 ```
 
-The headers will contain all relevant details. This will also give you the ability to access endpoints that are protected by tokens. 
+The headers will contain all relevant details. This will also give you the ability to access endpoints that are protected by tokens.
 
 ```bash
 Content-Length: 1024
@@ -234,7 +234,7 @@ This sample fetches a weather report from [OpenWeatherMap](http://openweathermap
 sensor:
   - platform: rest
     name: OWM_report
-    json_attributes: 
+    json_attributes:
       - main
       - weather
     value_template: '{{ value_json["weather"][0]["description"].title() }}'

--- a/source/_components/switch.rest.markdown
+++ b/source/_components/switch.rest.markdown
@@ -72,6 +72,11 @@ headers:
   description: The headers for the request.
   required: false
   type: list, string
+verify_ssl:
+  description: Verify the SSL certificate of the endpoint.
+  required: false
+  type: boolean
+  default: true
 {% endconfiguration %}
 
 <p class='note warning'>
@@ -98,6 +103,7 @@ switch:
     is_on_template: '{{ value_json.is_active }}'
     headers:
       Content-Type: application/json
+    verify_ssl: true
 ```
 {% endraw %}
 


### PR DESCRIPTION
**Description:**
`verify_ssl` was added as a config option for the `rest_command` component and the `switch.rest` platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20207

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
