### PR TITLE
Add docs for the ZoneMinder binary sensor

### DIFF
--- a/source/_components/binary_sensor.zoneminder.markdown
+++ b/source/_components/binary_sensor.zoneminder.markdown
@@ -1,0 +1,22 @@
+---
+layout: page
+title: "ZoneMinder Binary Sensor"
+description: "Provides the connectivity from Home Assistant to ZoneMinder."
+date: 2019-01-18 02:30
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: zoneminder.png
+ha_category: Binary Sensor
+ha_release: 0.87
+ha_iot_class: "Local Polling"
+---
+
+The `zoneminder` binary sensor platform lets you monitor the availability of your [ZoneMinder](https://www.zoneminder.com) install.
+
+<p class='note'>
+This platform is automatically loaded by the [ZoneMinder component](/components/zoneminder/) during it's setup.
+</p>
+
+Each binary_sensor created will be named after the hostname used when configuring the [ZoneMinder component](/components/zoneminder/).

--- a/source/_components/zoneminder.markdown
+++ b/source/_components/zoneminder.markdown
@@ -14,7 +14,7 @@ ha_release: 0.31
 ha_iot_class: "Local Polling"
 ---
 
-The ZoneMinder component sets up the integration with your [ZoneMinder](https://www.zoneminder.com) instance so that [cameras](/components/camera.zoneminder/), [sensors](/components/sensor.zoneminder/), and [switches](/components/switch.zoneminder) can use it.
+The ZoneMinder component sets up the integration with your [ZoneMinder](https://www.zoneminder.com) instance so that [cameras](/components/camera.zoneminder/), [sensors](/components/sensor.zoneminder/), and [switches](/components/switch.zoneminder) can use it. Configuring this component will automatically load the [binary_sensor](/components/binary_sensor.zoneminder) which tracks ZoneMinder availability.
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
**Description:**
The ZoneMinder binary sensor tracks the availability of the ZoneMinder hosts connected to Home Assistant.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20184

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
