### PR TITLE
Fixes Liquid warning (2019-0011)

### DIFF
--- a/source/_components/notify.group.markdown
+++ b/source/_components/notify.group.markdown
@@ -53,9 +53,11 @@ services:
 
 An example on how to use it in an automation:
 
+{% raw %}
 ```yaml
 action:
   service: notify.NAME_OF_NOTIFIER_GROUP
   data:
     message: "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"
 ```
+{% endraw %}


### PR DESCRIPTION
**Description:**

Fixes Liquid warning:

```txt
Liquid Warning: Liquid syntax error (line 45): Expected end_of_string but found open_round in "is_state('sun.sun', 'above_horizon')" in /Volumes/CODE/home-assistant/home-assistant.github.io/source/_components/notify.group.markdown
```

Caused the page not to be rendered as intended.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
