### PR TITLE
Update zha.markdown with deconz radio type as configuration variable

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -50,7 +50,7 @@ zha:
 
 {% configuration %}
 radio_type:
-  description: One of `ezsp` or `xbee`.
+  description: One of `ezsp`, `xbee` or `deconz`.
   required: false
   type: string
   default: ezsp


### PR DESCRIPTION
**Description:**

Added `deconz` to CONFIGURATION VARIABLES as additional radio type in zha.markdown.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
