### PR TITLE
Partial reload IS supported with packages

### DIFF
--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -35,7 +35,8 @@ If you run into trouble while configuring Home Assistant, have a look at the [co
 
 ## {% linkable_title Reloading changes %}
 
-You will have to restart Home Assistant for most changes to `configuration.yaml` to take effect. You can load changes to [automations](/docs/automation/), [customize](/docs/configuration/customizing-devices/), [groups](/components/group/), and [scripts](/components/script/) without restarting if you're not using [packages](/docs/configuration/packages/).
+You will have to restart Home Assistant for most changes to `configuration.yaml` to take effect.
+You can load changes to [automations](/docs/automation/), [customize](/docs/configuration/customizing-devices/), [groups](/components/group/), and [scripts](/components/script/) without restarting.
 
 <p class='note warning'>
 If you've made any changes, remember to [check your configuration](https://www.home-assistant.io/docs/configuration/troubleshooting/#problems-with-the-configuration) before trying to reload or restart.


### PR DESCRIPTION
**Description:**

The docs says partial reloading (of automations, customize, groups and scripts) is not supported when using packages. However, it's supported since 0.84 (and should have been documented when merging that PR).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/18884

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
