### PR TITLE
Make Liquid more strict

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,8 +32,12 @@ destination: public/
 plugins_dir: plugins
 code_dir: downloads/code
 category_dir: blog/categories
+
 markdown: kramdown
+highlighter: rouge
 timezone: UTC
+liquid:
+  error_mode: strict
 
 kramdown:
   input: GFM
@@ -43,8 +47,6 @@ kramdown:
   toc_levels:     1..6
   smart_quotes:   lsquo,rsquo,ldquo,rdquo
   parse_block_html: true
-
-highlighter: rouge
 
 plugins:
   - jekyll-redirect-from


### PR DESCRIPTION
**Description:**

Instead of warnings (by default) it should output error messages on the console for each error and stop the build. Therefore this changes the error_mode to `strict`, it happens far too often that people forget to use raw-tags.

This option is documented here: https://jekyllrb.com/docs/configuration/liquid/

**Note:**
strict_variables and strict_filters are still false by default, should we enable this as well? https://github.com/Shopify/liquid#undefined-variables-and-filters

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** NA

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
