### PR TITLE
Update media_player.samsungtv.markdown

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -54,7 +54,28 @@ mac:
   type: string
 {% endconfiguration %}
 
-Currently known supported models:
+Changing channels can be done by calling the `media_player.play_media` service
+with the following data:
+
+```json
+{
+  "entity_id": "media_player.office_tv",
+  "media_content_id": "590",
+  "media_content_type": "channel"
+}
+```
+
+### {% linkable_title Supported models %}
+
+Below you will find a list of supported and unsupported models.
+Currently the ability to select a source is not implemented.
+
+For some models additional configuration is needed,
+indicated by the following footnote markers:
+[^port8001]: The port must be set to 8001.
+[^pip3]: `pip3 install websocket-client` must be executed, this is not needed on Hass.io.
+
+**Currently known supported models:**
 
 - C7700
 - D5500
@@ -74,31 +95,31 @@ Currently known supported models:
 - F6400AF
 - F6500
 - F8000BF
-- K5579 (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
+- K5579 (On/Off, Forward/Backward, Volume control, but no Play button) [^port8001]
 - K5600AK (partially supported, turn on works but state is not updated)
-- K6500AF (port must be set to 8001)
-- KS7005 (port must be set to 8001, and `pip3 install websocket-client` must be executed, MAC address must be provided, On/Off, Volume are OK, no channel change)
-- KS7502 (port must be set to 8001, and `pip3 install websocket-client` must be executed, turn on doesn't work, turn off works fine)
-- KS8000 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KS8005 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KS8500 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KU6020 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KU6100 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KU6290 (port must be set to 8001)
-- KU6400U (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KU7000 (port must be set to 8001)
-- M5620 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- MU6170UXZG (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- NU7400 (port set to 8001 and `pip3 install websocket-client` executed)
+- K6500AF [^port8001]
+- KS7005 (MAC address must be provided, On/Off, Volume are OK, no channel change) [^port8001] [^pip3]
+- KS7502 (turn on doesn't work, turn off works fine) [^port8001] [^pip3]
+- KS8000 [^port8001] [^pip3]
+- KS8005 [^port8001] [^pip3]
+- KS8500 [^port8001] [^pip3]
+- KU6020 [^port8001] [^pip3]
+- KU6100 [^port8001] [^pip3]
+- KU6290 [^port8001]
+- KU6400U [^port8001] [^pip3]
+- KU7000 [^port8001]
+- M5620 [^port8001] [^pip3]
+- MU6170UXZG [^port8001] [^pip3]
+- NU7400 [^port8001] [^pip3]
 - NU8000
-- Q7F (port must be set to 8001, MAC must be specified for Power On)
-- U6000 (port must be set to 8001)
-- U6300 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- Q7F (MAC must be specified for Power On) [^port8001]
+- U6000 [^port8001]
+- U6300 [^port8001] [^pip3]
 - D7000
-- UE6199UXZG (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
-- UE65KS8005 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
+- UE6199UXZG (On/Off, Forward/Backward, Volume control, but no Play button) [^port8001]
+- UE65KS8005 (On/Off, Forward/Backward, Volume are OK, but no Play button) [^port8001]
 
-Currently tested but not working models:
+**Currently tested but nonworking models:**
 
 - J5200 - Unable to see state and unable to control
 - J5500 - State is always "on" and unable to control (but port 8001 *is* open)
@@ -109,29 +130,18 @@ Currently tested but not working models:
 - JS9500 - State is always "on" and unable to control (but port 8001 *is* open)
 - JU7000 - Unable to see state and unable to control (but port 8001 *is* open)
 - JU7500 - Unable to see state and unable to control
-- MU6300 - Port set to 8001, `pip3 install websocket-client` must be executed, turning on works, status not working reliably, turning off is not permanent (it comes back on)
+- MU6300 - turning on works, status not working reliably, turning off is not permanent (it comes back on) [^port8001] [^pip3]
 
 None of the 2014 (H) and 2015 (J) model series (e.g., J5200) will work,
 since Samsung have used a different (encrypted) type of interface for these.
 
+**Other models:**
+
 If your model is not on the list then give it a test,
 if everything works correctly then add it to the list on
-[GitHub](https://github.com/home-assistant/home-assistant.github.io/tree/current/source/_components/media_player.samsungtv.markdown).
+[GitHub](https://github.com/home-assistant/home-assistant.io/blob/current/source/_components/media_player.samsungtv.markdown).
 The first letter (U, P, L, H & K) represent the screen type, e.g., LED or
 Plasma. The second letter represents the region, E is Europe, N is North America
 and A is Asia & Australia.
 The two numbers following that represent the screen size.
 If you add your model remember to remove these first 4 characters before adding to the list.
-
-Changing channels can be done by calling the `media_player.play_media` service
-with the following payload:
-
-```javascript
-{
-  "entity_id": "media_player.office_tv",
-  "media_content_id": "590",
-  "media_content_type": "channel"
-}
-```
-
-Currently the ability to select a source is not implemented.


### PR DESCRIPTION
**Description:**
A user asked how to install the websocket-client package on Hass.io.
However, this is not needed at all, hence updating the docs.

- Clarify that `websocket-client` does not need to be installed on Hass.io
- Use a subtitle for the lists of supported and unsupported models
- Move the service call info above the supported model section
- Use footnotes to group and define common remarks
- code block is actually json, not javascript
- not working --> nonworking

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** NA

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
