### PR TITLE
update ha_iot_class for songpal

### DIFF
--- a/source/_components/media_player.songpal.markdown
+++ b/source/_components/media_player.songpal.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: sony.png
 ha_category: Media Player
-ha_iot_class: "Local Polling"
+ha_iot_class: "Local Push"
 ha_release: 0.65
 ---
 


### PR DESCRIPTION
Songpal defaults to local push since https://github.com/home-assistant/home-assistant/pull/19129 .

**Description:**

After https://github.com/home-assistant/home-assistant/pull/20261 gets merged, this platform should qualify for IQS silver.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
