### PR TITLE
Add command to check configuration from command line

### DIFF
--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -26,7 +26,7 @@ If you have incorrect entries in your configuration files you can use the [`chec
 
 One of the most common problems with Home Assistant is an invalid `configuration.yaml` file. 
  
- - You can test your configuration using the command line with: `hass --script check_config`. On Hass.io you can use the [hassio command](/hassio/commandline/#home-assistant): `hassio homeassistant check`. Also, you can run `python3 -m homeassistant -c /config --script check_config` from the command line when you have a shell prompt at `/usr/src/app`
+ - You can test your configuration using the command line with: `hass --script check_config`. On Hass.io you can use the [hassio command](/hassio/commandline/#home-assistant): `hassio homeassistant check`. Also, you can run `python3 -m homeassistant --script check_config` from the command line when you have a shell prompt at `/usr/src/app`
  - You can verify your configuration's yaml structure using [this online YAML parser](http://yaml-online-parser.appspot.com/) or [YAML Lint](http://www.yamllint.com/).
  - To learn more about the quirks of YAML, read [YAML IDIOSYNCRASIES](https://docs.saltstack.com/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html) by SaltStack (the examples there are specific to SaltStack, but do explain YAML issues well).
 

--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -26,7 +26,7 @@ If you have incorrect entries in your configuration files you can use the [`chec
 
 One of the most common problems with Home Assistant is an invalid `configuration.yaml` file. 
  
- - You can test your configuration using the command line with: `hass --script check_config`. On Hass.io you can use the [hassio command](/hassio/commandline/#home-assistant): `hassio homeassistant check`.
+ - You can test your configuration using the command line with: `hass --script check_config`. On Hass.io you can use the [hassio command](/hassio/commandline/#home-assistant): `hassio homeassistant check`. Also, you can run `python3 -m homeassistant -c /config --script check_config` from the command line when you have a shell prompt at `/usr/src/app`
  - You can verify your configuration's yaml structure using [this online YAML parser](http://yaml-online-parser.appspot.com/) or [YAML Lint](http://www.yamllint.com/).
  - To learn more about the quirks of YAML, read [YAML IDIOSYNCRASIES](https://docs.saltstack.com/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html) by SaltStack (the examples there are specific to SaltStack, but do explain YAML issues well).
 


### PR DESCRIPTION
**Description:**

Add another way to check configuration from the command line.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
