### PR TITLE
Add documentation for LCN switch platform

### DIFF
--- a/source/_components/lcn.markdown
+++ b/source/_components/lcn.markdown
@@ -23,6 +23,8 @@ With this setup sending and receiving commands to and from LCN modules is possib
 There is currently support for the following device types within Home Assistant:
 
 - [Light](/components/light.lcn)
+- [Switch](/components/switch.lcn)
+
 
 ## {% linkable_title Configuration %}
 
@@ -46,6 +48,11 @@ lcn:
       output: output1
       dimmable: true
       transition: 5
+  
+  switches:
+    - name: Sprinkler switch
+      address: myhome.s0.m7
+      output: relay1
 ```
 
 {% configuration %}
@@ -113,6 +120,24 @@ lights:
       required: false
       type: int
       default: 0
+
+switches:
+  description: List of your switches.
+  required: false
+  type: map
+  keys:
+    name:
+      description: "Name of the switch."
+      required: true
+      type: string
+    address:
+      description: "[Address](/components/lcn#lcn-addresses) of the module/group."
+      required: true
+      type: string
+    output:
+      description: "Switch source ([OUTPUT_PORT](/components/lcn#ports), [RELAY_PORT](/components/lcn#ports))."
+      required: true
+      type: string
 {% endconfiguration %}
 
 

--- a/source/_components/switch.lcn.markdown
+++ b/source/_components/switch.lcn.markdown
@@ -1,0 +1,24 @@
+---
+layout: page
+title: "LCN Switch"
+description: "Instructions on how to setup LCN switches within Home Assistant."
+date: 2018-11-01 08:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: lcn.png
+ha_category: Switch
+ha_release: 0.86
+ha_iot_class: "Local Push"
+---
+
+The `lcn` switch platform allows the control of the following [LCN](http://www.lcn.eu) ports:
+
+- Output ports
+- Relays
+
+## {% linkable_title Configuration %}
+
+The `lcn` component must be configured correctly, see [LCN component](/components/lcn).
+This platform is configured within the `lcn` component.

--- a/source/_components/switch.lcn.markdown
+++ b/source/_components/switch.lcn.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: lcn.png
 ha_category: Switch
-ha_release: 0.86
+ha_release: 0.87
 ha_iot_class: "Local Push"
 ---
 


### PR DESCRIPTION
**Description:**
Documentation is added for the LCN switch platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20267

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
