### PR TITLE
Add path option to octoprint component documentation

### DIFF
--- a/source/_components/octoprint.markdown
+++ b/source/_components/octoprint.markdown
@@ -53,7 +53,7 @@ octoprint:
       description: The URL path of the Octoprint instance.
       required: false
       type: string
-      default: 80
+      default: /
     ssl:
       description: Enable or disable SSL/TLS.
       required: false

--- a/source/_components/octoprint.markdown
+++ b/source/_components/octoprint.markdown
@@ -49,6 +49,11 @@ octoprint:
       required: false
       type: integer
       default: 80
+    path:
+      description: The URL path of the Octoprint instance.
+      required: false
+      type: string
+      default: 80
     ssl:
       description: Enable or disable SSL/TLS.
       required: false


### PR DESCRIPTION
**Description:**

Added documentation for a new configuration key for the octoprint component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20302

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html