### PR TITLE
Add documentation for Synology SRM device tracker

### DIFF
--- a/source/_components/device_tracker.synology_srm.markdown
+++ b/source/_components/device_tracker.synology_srm.markdown
@@ -14,6 +14,8 @@ ha_release: 0.87
 
 This platform allows you to detect presence by looking at connected devices to a [Synology SRM](https://www.synology.com/en-us/srm) router.
 
+## {% linkable_title Configuration %}
+
 To use this device tracker in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -58,7 +60,8 @@ verify_ssl:
 It's not possible to create another account in SRM with admin permissions. You'll need to use your admin account (or the one you renamed at creation) for this connection.
 
 List of models known to be supported:
+
 - RT1900ac
 - RT2600ac
 
-See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.
+See the [device tracker component page](/components/device_tracker/) for instructions on how to configure the people to be tracked.

--- a/source/_components/device_tracker.synology_srm.markdown
+++ b/source/_components/device_tracker.synology_srm.markdown
@@ -1,0 +1,64 @@
+---
+layout: page
+title: "Synology SRM"
+description: "Instructions on how to integrate Synology SRM routers into Home Assistant."
+date: 2019-01-22 13:43
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: synology.png
+ha_category: Presence Detection
+ha_release: 0.87
+---
+
+This platform allows you to detect presence by looking at connected devices to a [Synology SRM](https://www.synology.com/en-us/srm) router.
+
+To use this device tracker in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+device_tracker:
+  - platform: synology_srm
+    host: 192.168.1.254
+    password: YOUR_ADMIN_PASSWORD
+```
+
+{% configuration %}
+host:
+  description: The Synology SRM router host or IP address, e.g., `192.168.1.1` or `router.mydomain.local`
+  required: true
+  type: string
+port:
+  description: The port to connect to the Synology SRM router.
+  required: false
+  default: 8001
+  type: int
+username:
+  description: The username of a user with administrative privileges.
+  required: false
+  default: admin
+  type: string
+password:
+  description: The password for your given admin account.
+  required: true
+  type: string
+ssl:
+  description: Use HTTPS instead of HTTP to connect.
+  required: false
+  default: true
+  type: boolean
+verify_ssl:
+  description: Enable or disable SSL certificate verification.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
+
+It's not possible to create another account in SRM with admin permissions. You'll need to use your admin account (or the one you renamed at creation) for this connection.
+
+List of models known to be supported:
+- RT1900ac
+- RT2600ac
+
+See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
**Description:**

This PR adds the documentation for the new Synology SRM router device tracker.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20320

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
