### PR TITLE
Update/Remove GTFS feeds.

### DIFF
--- a/source/_components/sensor.gtfs.markdown
+++ b/source/_components/sensor.gtfs.markdown
@@ -21,9 +21,7 @@ Here are some examples:
 
 - [Bay Area Rapid Transit (BART)](http://www.bart.gov/schedules/developers/gtfs) - The light rail system for the San Francisco Bay Area.
 - [Metropolitan Transit Authority of New York City (MTA)](http://web.mta.info/developers/) - Provides separate data feeds for subway, bus, LIRR and Metro-North of the greater New York City metropolitan region.
-- [GBRail.info](http://www.gbrail.info/) - Provides data feeds for most if not all rail companies in Britain.
-- [Official Timetable Switzerland](http://www.fahrplanfelder.ch/en/timetable-data.html) - The official timetable data for Switzerland.
-- [Public Transport Victoria (Australia)](https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs) - Official PTV GTFS dataset.
+- [Official Timetable Switzerland](https://opentransportdata.swiss/en/dataset/timetable-2019-gtfs) - The official timetable data for Switzerland in 2019.
 
 You need to download a GTFS ZIP file and put it into a folder named `gtfs` in your configuration directory. For ease of use, it is suggested that you rename the file to just the agency/data source name (i.e. `bart.zip` instead of `google_transit_20160328_v1.zip`). You can also unzip and place a folder in the `gtfs` folder.
 


### PR DESCRIPTION
**Description:**

Update the GTFS sensor markdown to:
- Remove obsolete/dead links for GBrail.info and PTV Australia.
- Update the Switzerland link for 2019.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html