### PR TITLE
adding documentation for fritz.dect 100 sensor component

### DIFF
--- a/source/_components/sensor.fritzbox.markdown
+++ b/source/_components/sensor.fritzbox.markdown
@@ -15,7 +15,7 @@ ha_iot_class: "Local Polling"
 
 To get AVM Fritzbox temperature sensor (e.g. FRITZ!DECT Repeater 100) follow the instructions for the [Fritzbox component](/components/fritzbox/).
 
-### {% linkable_title Attributes %}
+## {% linkable_title Attributes %}
 
 The are several attributes that can be useful for automations and templates.
 

--- a/source/_components/sensor.fritzbox.markdown
+++ b/source/_components/sensor.fritzbox.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: avm.png
 ha_category: Sensor
-ha_release:
+ha_release: 0.87
 ha_iot_class: "Local Polling"
 ---
 

--- a/source/_components/sensor.fritzbox.markdown
+++ b/source/_components/sensor.fritzbox.markdown
@@ -1,0 +1,27 @@
+---
+layout: page
+title: "Fritzbox temperature sensor"
+description: "Instructions on how to integrate the AVM Fritzbox temperature sensor."
+date: 2019-01-22 20:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: avm.png
+ha_category: Sensor
+ha_release:
+ha_iot_class: "Local Polling"
+---
+
+To get AVM Fritzbox temperature sensor (e.g. FRITZ!DECT Repeater 100) follow the instructions for the [Fritzbox component](/components/fritzbox/).
+
+### {% linkable_title Attributes %}
+
+The are several attributes that can be useful for automations and templates.
+
+| Attribute | Description |
+| --------- | ----------- |
+| `device_locked` | The state of the key lock at the device.
+| `locked` | The state of the lock for configuring the device via the app or the Fritzbox web interface.
+| `temperature_unit` |  The unit of the temperature sensor.
+| `temperature` | The current temperature sensor reading.


### PR DESCRIPTION
**Description:**

Adding the documentation for the new sensor component for avm fritz boxes

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20308

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
