### PR TITLE
Add encoding parameter to mqtt automation 

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -46,7 +46,7 @@ automation:
 
 ### {% linkable_title MQTT trigger %}
 
-Triggers when a specific message is received on given topic. Optionally can match on the payload being sent over the topic.
+Triggers when a specific message is received on given topic. Optionally can match on the payload being sent over the topic. The default payload encoding is 'utf-8'. For images and other byte payloads use '' as encoding.
 
 ```yaml
 automation:
@@ -55,6 +55,7 @@ automation:
     topic: living_room/switch/ac
     # Optional
     payload: 'on'
+    encoding: 'utf-8'
 ```
 
 ### {% linkable_title Numeric state trigger %}

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -46,7 +46,7 @@ automation:
 
 ### {% linkable_title MQTT trigger %}
 
-Triggers when a specific message is received on given topic. Optionally can match on the payload being sent over the topic. The default payload encoding is 'utf-8'. For images and other byte payloads use '' as encoding.
+Triggers when a specific message is received on given topic. Optionally can match on the payload being sent over the topic. The default payload encoding is 'utf-8'. For images and other byte payloads use `encoding: ''` to disable payload decoding completely.
 
 ```yaml
 automation:


### PR DESCRIPTION
**Description:**
This is needed to trigger on received images/other byte payloads via mqtt because otherwise the decode fails. See also home-assistant/home-assistant#16004


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20292

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html