### PR TITLE
Update ha_release for danfoss component pages

### DIFF
--- a/source/_components/binary_sensor.danfoss_air.markdown
+++ b/source/_components/binary_sensor.danfoss_air.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: danfoss_air.png
 ha_category: Binary Sensor
-ha_release: "0.86"
+ha_release: "0.87"
 ha_iot_class: "Local Polling"
 ---
 
@@ -18,4 +18,4 @@ To get your Danfoss Air binary sensors working with Home Assistant, follow the i
 </p>
 
 The following binary sensor is supported.
-* **Bypass active:** Indicator if heat recovery is currrently bypassed. 
+* **Bypass active:** Indicator if heat recovery is currrently bypassed.

--- a/source/_components/danfoss_air.markdown
+++ b/source/_components/danfoss_air.markdown
@@ -8,8 +8,8 @@ comments: false
 sharing: true
 footer: true
 ha_category: Climate
-ha_release: "0.86"
-logo: danfoss_air.png 
+ha_release: "0.87"
+logo: danfoss_air.png
 ha_iot_class: "Local Polling"
 ---
 

--- a/source/_components/sensor.danfoss_air.markdown
+++ b/source/_components/sensor.danfoss_air.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: danfoss_air.png
 ha_category: Sensor
-ha_release: "0.86"
+ha_release: "0.87"
 ha_iot_class: "Local Polling"
 ---
 
@@ -17,9 +17,9 @@ ha_iot_class: "Local Polling"
 To get your Danfoss Air sensors working with Home Assistant, follow the instructions for the general [Danfoss Air component](/components/danfoss_air/).
 </p>
 
-The following sensors are supported. 
+The following sensors are supported.
 * **Outdoor temperature:** Outdoor air temperature.
 * **Supply temperature:** Air temperature of the air supplied to the house.
-* **Extract temperature:** Air temperature of the air extracted from the house. 
+* **Extract temperature:** Air temperature of the air extracted from the house.
 * **Exhaust temperature:** Exhausted air temperature.
-* **Remaining filter lifetime:** Reamining filter lifetime measured in percent. 
+* **Remaining filter lifetime:** Reamining filter lifetime measured in percent.


### PR DESCRIPTION
**Description:**
I merged the Danfoss component pages without properly updating the ha_release. Updating ha_release on Danfoss component pages from 0.86 -> 0.87

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
