### PR TITLE
update nginx_proxy.markdown

### DIFF
--- a/source/_addons/nginx_proxy.markdown
+++ b/source/_addons/nginx_proxy.markdown
@@ -11,7 +11,7 @@ footer: true
 
 Sets up an SSL proxy with NGINX and redirect port 80 to 443. Make sure you have generated a certificate before you start this add-on.
 
-In the `http` section of the `configuration.yaml` file remove `ssl_certificate` and `ssl_key` and don't enter the port in the `base_url` to avoid an HTTP 502 error.
+In the `http` section of the `configuration.yaml` file remove `ssl_certificate`, `ssl_key` and `server_port` and don't enter the port or use https in the `base_url` to avoid an HTTP 502 error.
 
 ```json
 {

--- a/source/_addons/nginx_proxy.markdown
+++ b/source/_addons/nginx_proxy.markdown
@@ -11,7 +11,7 @@ footer: true
 
 Sets up an SSL proxy with NGINX and redirect port 80 to 443. Make sure you have generated a certificate before you start this add-on.
 
-In the `http` section of the `configuration.yaml` file remove `ssl_certificate`, `ssl_key` and `server_port` and don't enter the port or use https in the `base_url` to avoid an HTTP 502 error.
+In the `http` section of the `configuration.yaml` file remove `ssl_certificate`, `ssl_key` and `server_port` and don't enter the port in the `base_url` to avoid an HTTP 502 error.
 
 ```json
 {


### PR DESCRIPTION
missing information in what to remove from the http section of the configuration.yaml file

**Description:**
missing information in what to remove from the http section of the configuration.yaml file when setting up nginx_proxy addon

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
