### PR TITLE
Updating radio_type description for Deconz

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -50,7 +50,7 @@ zha:
 
 {% configuration %}
 radio_type:
-  description: One of `ezsp` or `xbee`.
+  description: One of `ezsp`, `xbee` or `deconz`.
   required: false
   type: string
   default: ezsp


### PR DESCRIPTION
Add `deconz` to `radio_type` description.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
