### PR TITLE
Updated Automation Example with time_pattern

### DIFF
--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -141,7 +141,7 @@ usage is to only retrieve data during the daytime:
 automation:
   - alias: Update OpenUV every 30 minutes during the daytime
     trigger:
-      platform: time
+      platform: time_pattern
       minutes: "/30"
       seconds: 00
     condition:
@@ -163,7 +163,7 @@ etc.) might be to simply query the API less often:
 automation:
   - alias: Update OpenUV every hour (24 of 50 calls per day)
     trigger:
-      platform: time
+      platform: time_pattern
       minutes: "/60"
       seconds: 00
     action:


### PR DESCRIPTION
I'm 99% sure this needs to be time_pattern now as opposed to time.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
