### PR TITLE
Explain how to get the device running when running hass in docker

### DIFF
--- a/source/_components/sensor.dsmr.markdown
+++ b/source/_components/sensor.dsmr.markdown
@@ -129,6 +129,12 @@ and after that you need to reboot!
 $ sudo reboot
 ```
 
+Docker users have to allow Docker access to the device by adding `--device /dev/ttyUSB21:/dev/ttyUSB21` to the run command:
+
+```
+$ docker run --device /dev/ttyUSB0:/dev/ttyUSB0 -d --name="home-assistant" -v /home/USERNAME/hass:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant
+```
+
 ### {% linkable_title Technical overview %}
 
 DSMR is a standard to which Dutch smartmeters must comply. It specifies that the smartmeter must send out a 'telegram' every 10 seconds (every second for DSMR 5.0 devices) over a serial port.

--- a/source/_components/sensor.dsmr.markdown
+++ b/source/_components/sensor.dsmr.markdown
@@ -119,19 +119,19 @@ or
 
 [HASSbian](/getting-started/installation-raspberry-pi-image/) users have to give dialout permission to the user `homeassistant`:
 
-```
+```bash
 $ sudo usermod -a -G dialout homeassistant
 ```
 
 and after that you need to reboot!
 
-```
+```bash
 $ sudo reboot
 ```
 
 Docker users have to allow Docker access to the device by adding `--device /dev/ttyUSB21:/dev/ttyUSB21` to the run command:
 
-```
+```hass
 $ docker run --device /dev/ttyUSB0:/dev/ttyUSB0 -d --name="home-assistant" -v /home/USERNAME/hass:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant
 ```
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
