### PR TITLE
Yaml formatting on input_select example

### DIFF
--- a/source/_components/input_select.markdown
+++ b/source/_components/input_select.markdown
@@ -23,8 +23,8 @@ input_select:
   who_cooks:
     name: Who cooks today
     options:
-     - Paulus
-     - Anne Therese
+      - Paulus
+      - Anne Therese
     initial: Anne Therese
     icon: mdi:panda
   living_room_preset:


### PR DESCRIPTION
Added extra space before Paulus and Anne Therese

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
