### PR TITLE
Update time_pattern docs

### DIFF
--- a/source/_components/calendar.caldav.markdown
+++ b/source/_components/calendar.caldav.markdown
@@ -180,7 +180,7 @@ calendar:
   alias: worktime wakeup
   trigger:
     platform: time
-    at: 06:40:00
+    at: '06:40:00'
   action:
   - service: media_player.media_play
     entity_id: media_player.bedroom

--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -77,7 +77,7 @@ Check our [community forums](https://community.home-assistant.io/c/projects/them
 There are 2 themes-related services:
 
  - `frontend.reload_themes`: reloads theme configuration from your `configuration.yaml` file.
- - `frontend.set_theme(name)`: sets backend-preferred theme name. 
+ - `frontend.set_theme(name)`: sets backend-preferred theme name.
 
 Example in automation:
 
@@ -96,7 +96,7 @@ automation:
         name: happy
 ```
 
-To enable "night mode": 
+To enable "night mode":
 
 ```yaml
 automation:
@@ -104,7 +104,7 @@ automation:
     initial_state: true
     trigger:
       - platform: time
-        at: '21:00'
+        at: '21:00:00'
     action:
       - service: frontend.set_theme
         data:

--- a/source/_components/light.flux_led.markdown
+++ b/source/_components/light.flux_led.markdown
@@ -67,7 +67,7 @@ devices:
 {% endconfiguration %}
 
 <p class='note'>
-Depending on your controller or bulb type, there are two ways to configure brightness. 
+Depending on your controller or bulb type, there are two ways to configure brightness.
 The component defaults to rgbw. If your device has a separate white channel, you do not need to specify anything else; changing the white value will adjust the brightness of white channel keeping rgb color constant. However, if your device does not have a separate white channel, you will need to set the mode to rgb. In this mode, the device will keep the same color, and adjust the rgb values to dim or brighten the color.
 </p>
 
@@ -98,7 +98,7 @@ light:
 automation:
   alias: random_flux_living_room_lamp
   trigger:
-    platform: time
+    platform: time_pattern
     seconds: '/45'
   action:
     service: light.turn_on

--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -142,8 +142,7 @@ automation:
   - alias: Update OpenUV every 30 minutes during the daytime
     trigger:
       platform: time_pattern
-      minutes: "/30"
-      seconds: 00
+      minutes: '/30'
     condition:
       condition: and
       conditions:
@@ -164,8 +163,7 @@ automation:
   - alias: Update OpenUV every hour (24 of 50 calls per day)
     trigger:
       platform: time_pattern
-      minutes: "/60"
-      seconds: 00
+      minutes: '/60'
     action:
       service: openuv.update_data
 ```

--- a/source/_components/sensor.google_travel_time.markdown
+++ b/source/_components/sensor.google_travel_time.markdown
@@ -146,9 +146,8 @@ You can also use the `sensor.google_travel_sensor_update` service to update the 
   alias: "Commute - Update morning commute sensor"
   initial_state: 'on'
   trigger:
-    - platform: time
+    - platform: time_pattern
       minutes: '/2'
-      seconds: 00
   condition:
     - condition: time
       after: '08:00:00'

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -286,9 +286,8 @@ sensor:
 automation:
   - alias: 'nonsmoker_update'
     trigger:
-      - platform: time
+      - platform: time_pattern
         minutes: '/5'
-        seconds: 0
     action:
       - service: homeassistant.update_entity
         entity_id: sensor.nonsmoker

--- a/source/_components/sensor.tibber.markdown
+++ b/source/_components/sensor.tibber.markdown
@@ -33,7 +33,6 @@ The electricity price can be used to make automations. The sensor has a `max_pri
   trigger:
     platform: time_pattern
   # Matches every hour at 1 minutes past whole
-    hours: '*'
     minutes: 1
   condition:
     condition: template

--- a/source/_components/sensor.tibber.markdown
+++ b/source/_components/sensor.tibber.markdown
@@ -31,10 +31,10 @@ The electricity price can be used to make automations. The sensor has a `max_pri
 ```yaml
 - alias: "Electricity price"
   trigger:
-    platform: time
+    platform: time_pattern
   # Matches every hour at 1 minutes past whole
+    hours: '*'
     minutes: 1
-    seconds: 00
   condition:
     condition: template
     value_template: '{{ float(states.sensor.electricity_price_hamretunet_10.state) > 0.9 * float(states.sensor.electricity_price_hamretunet_10.attributes.max_price) }}'

--- a/source/_cookbook/automation_first_light.markdown
+++ b/source/_cookbook/automation_first_light.markdown
@@ -30,8 +30,8 @@ automation:
   - alias: Enable First Morning Trigger
     trigger:
       - platform: time
-        at: '5:00'
-    action: 
+        at: '05:00:00'
+    action:
       service: homeassistant.turn_on
       entity_id: input_boolean.trigger_first_morning
 
@@ -41,12 +41,12 @@ automation:
       - platform: sun
         event: sunrise
         offset: "01:00:00"
-    action: 
+    action:
       service: homeassistant.turn_off
       entity_id: input_boolean.trigger_first_morning
 
 
-      
+
 # This is the main automation. It triggers when my motion sensor is triggered
 # (in this case, a motion sensor from a security system attached to my Vera)
   - alias: First Morning Motion
@@ -59,17 +59,17 @@ automation:
         condition: state
         entity_id: input_boolean.trigger_first_morning
         state: 'on'
-        
+
     action:
       # turn off the "waiting" boolean regardless of whether lights will turn on
       # so that this happens only once
       - service: homeassistant.turn_off
         entity_id: input_boolean.trigger_first_morning
-        
+
       # But only turn on lights if the living room and kitchen lights are off or dimmed
-      # If a condition tests false, the automation will end 
+      # If a condition tests false, the automation will end
       - condition: and
-        conditions: 
+        conditions:
           - condition: numeric_state
             entity_id: light.livingroom_ec
             # if light is off, force a 0, otherwise use the brightness value
@@ -84,13 +84,13 @@ automation:
             entity_id: light.kitchen_ceiling
             value_template: {% raw %}'{% if states.light.kitchen_ceiling.state == "on"  %}{{ states.light.kitchen_ceiling.attributes.brightness }}{% else %}0{% endif %}'{% endraw %}
             below: 128
-                
+
       # Trigger a scene
       # You could add as many services or scenes as you'd like
       - service: scene.turn_on
         entity_id: scene.morning_first_motion
 
-      
+
 ```
 
 #### {% linkable_title The Scene %}
@@ -98,7 +98,7 @@ automation:
 Here is the Scene that is called via the Automations above.
 
 ```yaml
-# here's the scene that gets called. Lights in 
+# here's the scene that gets called. Lights in
 # my living room and kitchen turn on.
 scene:
   - name: Morning First Motion

--- a/source/_cookbook/automation_using_timeinterval_inputboolean.markdown
+++ b/source/_cookbook/automation_using_timeinterval_inputboolean.markdown
@@ -25,9 +25,8 @@ automation:
 # Changes Hue light every two minutes to random color if input boolean is set to on
 - alias: 'Set LivingColors to random color'
   trigger:
-    platform: time
+    platform: time_pattern
     minutes: '/2'
-    seconds: 0
   condition:
     condition: state
     entity_id: input_boolean.loop_livingcolors

--- a/source/_cookbook/send_a_reminder.markdown
+++ b/source/_cookbook/send_a_reminder.markdown
@@ -30,13 +30,9 @@ automation:
   - alias: Send message at a given time
     trigger:
       platform: time
-      hours: 12
-      minutes: 15
-      seconds: 0
+      at: '12:15:00'
     action:
       service: notify.jabber
       data:
         message: 'Time for lunch'
 ```
-
-

--- a/source/_posts/2017-03-28-http-to-mqtt-bridge.markdown
+++ b/source/_posts/2017-03-28-http-to-mqtt-bridge.markdown
@@ -54,9 +54,8 @@ rest_command:
 automation:
   alias: HTTP to MQTT keep alive
   trigger:
-    platform: time
+    platform: time_pattern
     minutes: '/10'
-    seconds: 00
   condition:
     condition: time
     after: '7:30:00'


### PR DESCRIPTION
This PR updates the docs to reflect the new `time_pattern` trigger.


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].
