### PR TITLE
Fixes empty categories being showed (2019-0017)

### DIFF
--- a/source/components/index.html
+++ b/source/components/index.html
@@ -50,8 +50,9 @@ Support for these components is provided by the Home Assistant community.
       <a href='#version/{{ added_two_ago_version }}' class="btn added_two_versions_ago">Added in {{ added_two_ago_version }} ({{ two_ago_version_components_count }})</a>
 
 {%- for category in categories -%}
-  {%- if category and category != 'Other' -%}
-    <a href='#{{ category | slugify }}' class="btn">{{ category }} ({{ components | where: 'ha_category', category | size }})</a>
+  {%- assign components_count = components | where: 'ha_category', category | size -%}
+  {%- if category and category != 'Other' and components_count != 0 -%}
+    <a href='#{{ category | slugify }}' class="btn">{{ category }} ({{ components_count }})</a>
   {%- endif -%}
 {%- endfor -%}
 


### PR DESCRIPTION
**Description:**

#8265 caused an issue showing an empty category, this PR fixes that.

![image](https://user-images.githubusercontent.com/195327/51713543-944c6900-2032-11e9-939e-90adb348ab71.png)


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
