### PR TITLE
Template sensor attribute docs

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -71,6 +71,10 @@ sensors:
           description: Defines a template for the entity picture of the sensor.
           required: false
           type: template
+        attribute_templates:
+          description: Defines templates for attributes of the sensor.
+          required: false
+          type: list, template
         delay_on:
           description: The amount of time the template state must be ***met*** before this sensor will switch to `on`.
           required: false
@@ -212,5 +216,34 @@ binary_sensor:
              or is_state('binary_sensor.living_room_139', 'on')
              or is_state('binary_sensor.porch_ms6_1_129', 'on')
              or is_state('binary_sensor.family_room_144', 'on') }}
+```
+{% endraw %}
+
+### {% linkable_title Device Tracker sensor with Latitude and Longitude Attributes %}
+
+This example shows how to combine an non-GPS (e.g. NMAP) and GPS device tracker while still including latitude and longitude attributes
+
+{% raw %}
+```yaml
+binary_sensor:
+  - platform: template
+    sensors:
+      my_device:
+        value_template: >-
+          {{ is_state('device_tracker.my_device_nmap','home') or is_state('device_tracker.my_device_gps','home') }}
+        device_class: 'presence'
+        attribute_templates:
+          latitude: >-
+            {% if is_state('device_tracker.my_device_nmap','home') %}
+              {{ state_attr('zone.home','latitude') }}
+            {% else %}
+              {{ state_attr('device_tracker.my_device_gps','latitude') }}
+            {% endif %}
+          longitude: >-
+            {% if is_state('device_tracker.my_device_nmap','home') %}
+              {{ state_attr('zone.home','longitude') }}
+            {% else %}
+              {{ state_attr('device_tracker.my_device_gps','longitude') }}
+            {% endif %}
 ```
 {% endraw %}

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -71,6 +71,10 @@ sensor:
         description: Defines a template for the entity picture of the sensor.
         required: false
         type: template
+      attribute_templates:
+        description: Defines templates for attributes of the sensor.
+        required: false
+        type: list, template
       device_class:
         description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
         required: false
@@ -246,6 +250,38 @@ sensor:
           {% end %}
         value_template: "{{ states('sensor.power_consumption') }}"
         unit_of_measurement: 'kW'
+```
+{% endraw %}
+
+### {% linkable_title Add Custom Attributes %}
+
+This example shows how to add custom attributes.
+
+{% raw %}
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      my_device:
+        value_template: >-
+          {% if is_state('device_tracker.my_device_nmap','home') %}
+            Home
+          {% else %}
+            {{ states('device_tracker.my_device_gps') }}
+          {% endif %}
+        attribute_templates:
+          latitude: >-
+            {% if is_state('device_tracker.my_device_nmap','home') %}
+              {{ state_attr('zone.home','latitude') }}
+            {% else %}
+              state_attr('device_tracker.my_device_gps','latitude')
+            {% endif %}
+          longitude: >-
+            {% if is_state('device_tracker.my_device_nmap','home') %}
+              {{ state_attr('zone.home','longitude') }}
+            {% else %}
+              {{ state_attr('device_tracker.my_device_gps','longitude') }}
+            {% endif %}
 ```
 {% endraw %}
 


### PR DESCRIPTION
**Description:**
Added documentation for the new **attribute_templates** option for the template snesor and binary sensor.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant/pull/20410

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
