### PR TITLE
Update device_tracker.snmp.markdown

### DIFF
--- a/source/_components/device_tracker.snmp.markdown
+++ b/source/_components/device_tracker.snmp.markdown
@@ -23,23 +23,24 @@ The following OID examples pull the current MAC Address table from a router. Thi
 
 | Brand | Device/Firmware | OID |
 |---|---|---|---|
+| Aerohive | AP230 | `1.3.6.1.4.1.26928.1.1.1.2.1.2.1.1` |
+| Apple | Airport Express (2nd gen.) 7.6.9 |  `1.3.6.1.2.1.3.1.1.2` or `1.3.6.1.2.1.4.22.1.2`|
+| Aruba | IAP325 on AOS 6.5.4.8 | `1.3.6.1.4.1.14823.2.3.3.1.2.4.1.1` |
+| BiPAC | 7800DXL Firmware 2.32e | `1.3.6.1.2.1.17.7.1.2.2.1.1` |
+| DD-WRT | unknown version/model |  `1.3.6.1.2.1.4.22.1.2` |
 | Mikrotik | unknown RouterOS version/model | `1.3.6.1.4.1.14988.1.1.1.2.1.1` |
 | Mikrotik | RouterOS 6.x on RB2011 | `1.3.6.1.2.1.4.22.1.2` |
-| Aruba | IAP325 on AOS 6.5.4.8 | `1.3.6.1.4.1.14823.2.3.3.1.2.4.1.1` |
-| pfSense | 2.2.4  | `1.3.6.1.2.1.4.22.1.2` |
-| BiPAC | 7800DXL Firmware 2.32e | `1.3.6.1.2.1.17.7.1.2.2.1.1` |
 | OpenWrt | Chaos Calmer 15.05 | `1.3.6.1.2.1.4.22.1.2` |
+| pfSense | 2.2.4  | `1.3.6.1.2.1.4.22.1.2` |
+| Ruckus | ZoneDirector 9.13.3 | `1.3.6.1.4.1.25053.1.2.2.1.1.3.1.1.1.6` |
 | TP-Link | Archer VR2600v |  `1.3.6.1.2.1.3.1.1.2.19.1` |
 | TP-Link | Archer VR600 | `1.3.6.1.2.1.3.1.1.2` |
-| EdgeRouter | Lite v1.9.0 | `1.3.6.1.2.1.4.22.1.2` |
-| Ruckus | ZoneDirector 9.13.3 | `1.3.6.1.4.1.25053.1.2.2.1.1.3.1.1.1.6` |
-| DD-WRT | unknown RouterOS version/model |  `1.3.6.1.2.1.4.22.1.2` |
-| Apple Airport Express (2nd gen.) | 7.6.9 |  `1.3.6.1.2.1.3.1.1.2` or `1.3.6.1.2.1.4.22.1.2`|
+| Ubiquiti | Edgerouter Lite v1.9.0 | `1.3.6.1.2.1.4.22.1.2` |
 
-To use the SNMP version 1 platform in your installation, add the following to your `configuration.yaml` file:
+To use the SNMP version 1 or 2c platform in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yaml entry for SNMP version 1
+# Example configuration.yaml entry for SNMP version 1 or 2c
 device_tracker:
   - platform: snmp
     host: 192.168.1.1


### PR DESCRIPTION
Added baseoid for Aerohive AP230 and rearranged table of devices alphabetically.