### PR TITLE
Update trigger.markdown

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -261,7 +261,7 @@ When your want your automation rule to have multiple triggers, just prefix the f
 automation:
   trigger:
       # first trigger
-    - platform: time
+    - platform: time_pattern
       minutes: 5
       seconds: 00
       # our second trigger is the sunset


### PR DESCRIPTION
The latest example is not modified to the new time_pattern

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
