### PR TITLE
Clarify z-wave polling.

### DIFF
--- a/source/_docs/z-wave/devices.markdown
+++ b/source/_docs/z-wave/devices.markdown
@@ -63,7 +63,7 @@ Where a device doesn't send updates on status changes to the controller, you can
 
 For example, with `polling_interval=60000` (which is the default) if you have 10 devices that are being polled at every interval, and each polling takes one secound (request/response round trip), then it will take 10 seconds to complete the polling list. This only leaves 50 seconds left for normal traffic. The more devices you poll, and the shorter the interval, the less bandwidth that's available for normal traffic.
 
-Polling is by default disabled and needs to be enabled per device. You can also specify the interval by setting the *polling intensity* of the device. See the [Node Management](/docs/z-wave/control-panel#z-wave-node-management) docs for details.
+Polling needs to be enabled per device. You can control this through the *polling intensity* (interval) of the device. See the [Node Management](/docs/z-wave/control-panel#z-wave-node-management) docs for details.
 
 ## {% linkable_title Central Scene support %}
 

--- a/source/_docs/z-wave/devices.markdown
+++ b/source/_docs/z-wave/devices.markdown
@@ -61,7 +61,9 @@ As long as your device lists Hail or Association in its Controlled Command Class
 
 Where a device doesn't send updates on status changes to the controller, you can work around this by using a thing called Polling. That causes the controller to ask the device to provide an update on all its sensors and states. This will cause a lot of traffic on the network, and if you poll too many devices too quickly, you can effectively break your Z-Wave network. Polling should only be used where there is no other choice, and you should use as large a polling interval as possible. Ideally you should replace the device.
 
-For example, with `polling_interval=60000` (which is the default) if you have 10 devices that are being polled, if a device can receive and acknowledge the poll within one second, then it will take 10 seconds to complete the polling list, which leaves 50 seconds left for normal traffic. The more devices you poll, and the shorter the interval, the less bandwidth that's available for normal traffic.
+For example, with `polling_interval=60000` (which is the default) if you have 10 devices that are being polled at every interval, and each polling takes one secound (request/response round trip), then it will take 10 seconds to complete the polling list. This only leaves 50 seconds left for normal traffic. The more devices you poll, and the shorter the interval, the less bandwidth that's available for normal traffic.
+
+Polling is by default disabled and needs to be anebled per device. You can also specify the interval by setting the *polling intensity* of the device. See the [Node Management](/docs/z-wave/control-panel#z-wave-node-management) docs for details.
 
 ## {% linkable_title Central Scene support %}
 

--- a/source/_docs/z-wave/devices.markdown
+++ b/source/_docs/z-wave/devices.markdown
@@ -63,7 +63,7 @@ Where a device doesn't send updates on status changes to the controller, you can
 
 For example, with `polling_interval=60000` (which is the default) if you have 10 devices that are being polled at every interval, and each polling takes one secound (request/response round trip), then it will take 10 seconds to complete the polling list. This only leaves 50 seconds left for normal traffic. The more devices you poll, and the shorter the interval, the less bandwidth that's available for normal traffic.
 
-Polling needs to be enabled per device. You can control this through the *polling intensity* (interval) of the device. See the [Node Management](/docs/z-wave/control-panel#z-wave-node-management) docs for details.
+Polling needs to be enabled per device, you can control this through the *polling intensity* (interval) of the device. See the [Node Management](/docs/z-wave/control-panel#z-wave-node-management) docs for details.
 
 ## {% linkable_title Central Scene support %}
 

--- a/source/_docs/z-wave/devices.markdown
+++ b/source/_docs/z-wave/devices.markdown
@@ -63,7 +63,7 @@ Where a device doesn't send updates on status changes to the controller, you can
 
 For example, with `polling_interval=60000` (which is the default) if you have 10 devices that are being polled at every interval, and each polling takes one secound (request/response round trip), then it will take 10 seconds to complete the polling list. This only leaves 50 seconds left for normal traffic. The more devices you poll, and the shorter the interval, the less bandwidth that's available for normal traffic.
 
-Polling is by default disabled and needs to be anebled per device. You can also specify the interval by setting the *polling intensity* of the device. See the [Node Management](/docs/z-wave/control-panel#z-wave-node-management) docs for details.
+Polling is by default disabled and needs to be enabled per device. You can also specify the interval by setting the *polling intensity* of the device. See the [Node Management](/docs/z-wave/control-panel#z-wave-node-management) docs for details.
 
 ## {% linkable_title Central Scene support %}
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
