### PR TITLE
Add documentation for splitting up the dovado sensor

### DIFF
--- a/source/_components/dovado.markdown
+++ b/source/_components/dovado.markdown
@@ -1,0 +1,46 @@
+---
+layout: page
+title: "Dovado"
+description: "How to integrate Dovado within Home Assistant."
+date: 2019-01-26 15:45
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: System Monitor
+logo: dovado.png
+ha_release: 0.87
+ha_iot_class: "Local Polling"
+---
+
+The `dovado` component manages communication with the [Dovado](http://www.dovado.com/) router. Once you've setup this component, you should enable the [sensor](/components/sensor.dovado) and [notify](/components/notity.dovado) platforms to use Dovado.
+
+To add a Dovado component to your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+dovado:
+  username: YOUR_USERNAME
+  password: YOUR_PASSWORD
+```
+
+{% configuration %}
+username:
+  description: Your Dovado username.
+  required: true
+  type: string
+password:
+  description: Your Dovado password.
+  required: true
+  type: string
+host:
+  description: The IP address of your router.
+  required: false
+  type: string
+  default: Home Assistant's default gateway
+port:
+  description:  The port number of your router.
+  required: false
+  type: integer
+  default: 6435
+{% endconfiguration %}

--- a/source/_components/notify.dovado.markdown
+++ b/source/_components/notify.dovado.markdown
@@ -1,0 +1,46 @@
+---
+layout: page
+title: "Dovado SMS"
+description: "How to integrate Dovado SMS notifications within Home Assistant."
+date: 2019-01-26 15:45
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: System Monitor
+logo: dovado.png
+ha_release: 0.87
+ha_iot_class: "Local Polling"
+---
+
+The `dovado` notify platform allows you to send SMS from your [Dovado](http://www.dovado.com/) router, if it supports it.
+
+<p class='note'>
+You must have the [Dovado component](/components/dovado/) configured to use this notify platform.
+</p>
+
+To add the Dovado notify platform to your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+notify:
+  - platform: dovado
+```
+
+### {% linkable_title Usage %}
+
+This is a notify platform and thus can be controlled by calling the notify service [as described here](/components/notify/). It will send an SMS notification to a single phone number in the notification **target**.
+
+```yaml
+# Example automation notification entry
+automation:
+  - alias: The sun has set
+    trigger:
+      platform: sun
+      event: sunset
+    action:
+      service: notify.dovado
+      data:
+        message: 'The sun has set'
+        target: '+14151234567'
+```

--- a/source/_components/sensor.dovado.markdown
+++ b/source/_components/sensor.dovado.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Dovado"
+title: "Dovado Sensor"
 description: "How to integrate Dovado sensors within Home Assistant."
 date: 2016-11-05 08:00
 sidebar: true
@@ -13,7 +13,7 @@ ha_release: 0.32
 ha_iot_class: "Local Polling"
 ---
 
-The `dovado` platform let you monitor your router from [Dovado](http://www.dovado.com/). If the router provides SMS functionality, a service for sending SMS will also be registered in Home Assistant.
+The `dovado` sensor platform let you monitor your [Dovado](http://www.dovado.com/) router.
 
 To add a Dovado sensor to your installation, add the following to your `configuration.yaml` file:
 
@@ -21,31 +21,11 @@ To add a Dovado sensor to your installation, add the following to your `configur
 # Example configuration.yaml entry
 sensor:
   - platform: dovado
-    username: YOUR_USERNAME
-    password: YOUR_PASSWORD
     sensors:
       - network
 ```
 
 {% configuration %}
-username:
-  description: Your Dovado username.
-  required: true
-  type: string
-password:
-  description: Your Dovado password.
-  required: true
-  type: string
-host:
-  description: The IP address of your router.
-  required: false
-  type: string
-  default: Home Assistant's default gateway
-port:
-  description:  The port number of your router.
-  required: false
-  type: integer
-  default: 6435
 sensors:
   description: Conditions to display in the frontend. Only accepts the values listed here.
   required: true


### PR DESCRIPTION
**Description:**
The dovado sensor has been split into a component with a sensor and notify platforms.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20339

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
