### PR TITLE
Document json_attributes_topic for MQTT Vacuum

### DIFF
--- a/source/_components/vacuum.mqtt.markdown
+++ b/source/_components/vacuum.mqtt.markdown
@@ -159,7 +159,7 @@ payload_not_available:
   type: string
   default: offline
 json_attributes_topic:
-  description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/docs/components/sensor.mqtt/#json-attributes-topic-configuration) documentation.
+  description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/components/sensor.mqtt/#json-attributes-topic-configuration) documentation.
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_components/vacuum.mqtt.markdown
+++ b/source/_components/vacuum.mqtt.markdown
@@ -158,6 +158,10 @@ payload_not_available:
   required: false
   type: string
   default: offline
+json_attributes_topic:
+  description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/docs/components/sensor.mqtt/#json-attributes-topic-configuration) documentation.
+  required: false
+  type: string
 {% endconfiguration %}
 
 ### {% linkable_title Full configuration example %}


### PR DESCRIPTION
**Description:**
Document json_attributes_topic

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20242

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
