### PR TITLE
Remove homekit controller out-of-date  warning

### DIFF
--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -15,11 +15,6 @@ ha_iot_class: "Local Polling"
 
 [HomeKit](https://developer.apple.com/homekit/) controller integration for Home Assistant allows you to connect HomeKit accessories to Home Assistant. This component should not be confused with the [HomeKit](/components/homekit/) component, which allows you to control Home Assistant devices via HomeKit.
 
-<p class="note warning">
- You may need additional packages to support the HomeKit Python module:
- `$ sudo apt-get install libgmp-dev libmpfr-dev libmpc-dev`
-</p>
-
 There is currently support for the following device types within Home Assistant:
 
 - [Alarm Control Panel](/components/alarm_control_panel.homekit_controller/)


### PR DESCRIPTION
homekit==0.12.2 no longer depends on these packages, so we can remove the warning.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
