### PR TITLE
Document json_attributes_topic for MQTT Lock

### DIFF
--- a/source/_components/lock.mqtt.markdown
+++ b/source/_components/lock.mqtt.markdown
@@ -90,7 +90,7 @@ payload_not_available:
   type: string
   default: offline
 json_attributes_topic:
-  description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/docs/components/sensor.mqtt/#json-attributes-topic-configuration) documentation.
+  description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/components/sensor.mqtt/#json-attributes-topic-configuration) documentation.
   required: false
   type: string
 unique_id:

--- a/source/_components/lock.mqtt.markdown
+++ b/source/_components/lock.mqtt.markdown
@@ -89,6 +89,10 @@ payload_not_available:
   required: false
   type: string
   default: offline
+json_attributes_topic:
+  description: The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor attributes. Usage example can be found in [MQTT sensor](/docs/components/sensor.mqtt/#json-attributes-topic-configuration) documentation.
+  required: false
+  type: string
 unique_id:
    description: An ID that uniquely identifies this lock. If two locks have the same unique ID, Home Assistant will raise an exception.
    required: false


### PR DESCRIPTION
**Description:**
Document json_attributes_topic

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20241

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
