### PR TITLE
Improve Tellstick documentation

### DIFF
--- a/source/_addons/tellstick.markdown
+++ b/source/_addons/tellstick.markdown
@@ -92,6 +92,8 @@ code:
   type: string
 {% endconfiguration %}
 
+For more information about the configuration including protocols, see the [telldus documentation](https://developer.telldus.com/wiki/TellStick_conf).
+
 ## {% linkable_title Service calls %}
 
 If you wish to teach a self-learning device in your TellStick configuration:


### PR DESCRIPTION
The configuration format for Tellstick can be a bit confusing, but the official documentation is pretty good, so let's link to it.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
