### PR TITLE
Update camera.uvc.markdown

### DIFF
--- a/source/_components/camera.uvc.markdown
+++ b/source/_components/camera.uvc.markdown
@@ -34,7 +34,6 @@ camera:
   - platform: uvc
     nvr: IP_ADDRESS
     key: API_KEY
-    ssl: USE_SSL
 ```
 
 {% configuration %}


### PR DESCRIPTION
Removed ssl from example configuration as its value was misleading and it defaults to false.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
