### PR TITLE
Cover position_topic type should be string, not integer

### DIFF
--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -83,7 +83,7 @@ state_closed:
 position_topic:
   description: The MQTT topic subscribed to receive cover position messages. If `position_topic` is set `state_topic` is ignored.
   required: false
-  type: integer
+  type: string
 position_open:
   description: Number which represents open position.
   required: false


### PR DESCRIPTION
**Description:**
The MQTT cover `position_topic` is currently listed as an integer, while it should be a string.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
