### PR TITLE
ADS light: Add "friendly_name" config option

### DIFF
--- a/source/_components/light.ads.markdown
+++ b/source/_components/light.ads.markdown
@@ -39,6 +39,7 @@ light:
     required: false
     description: An identifier for the Light. If no friendly name is given, it is also used as name in the frontend
     type: string
+    default: ADS Light
   friendly_name:
     required: false
     description: Friendly name of the Light in the frontend

--- a/source/_components/light.ads.markdown
+++ b/source/_components/light.ads.markdown
@@ -37,10 +37,10 @@ light:
     type: integer
   name:
     required: false
-    description: Defines the entity ID of the Light. If no Friendly Name given, it is also used as an identifier for the Light in the frontend
+    description: An identifier for the Light. If no friendly name is given, it is also used as name in the frontend
     type: string
   friendly_name:
     required: false
-    description: An identifier for the Light in the frontend
+    description: Friendly name of the Light in the frontend
     type: string
 {% endconfiguration %}

--- a/source/_components/light.ads.markdown
+++ b/source/_components/light.ads.markdown
@@ -37,6 +37,10 @@ light:
     type: integer
   name:
     required: false
+    description: Defines the entity ID of the Light. If no Friendly Name given, it is also used as an identifier for the Light in the frontend
+    type: string
+  friendly_name:
+    required: false
     description: An identifier for the Light in the frontend
     type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Add config option friendly_name to ADS light component. When it's used, option "name" will only be used for entity id definition. This way we can have stable entity ids even if the friendly names change.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20511

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
