### PR TITLE
Deprecate travel_mode option

### DIFF
--- a/source/_components/sensor.google_travel_time.markdown
+++ b/source/_components/sensor.google_travel_time.markdown
@@ -54,7 +54,7 @@ name:
   required: false
   type: string
 travel_mode:
-  description: "You can choose between: `driving`, `walking`, `bicycling` or `transit`."
+  description: "You can choose between: `driving`, `walking`, `bicycling` or `transit`." This method is now deprecated, use `mode` under `options`.
   required: false
   type: string
 options:

--- a/source/_components/sensor.google_travel_time.markdown
+++ b/source/_components/sensor.google_travel_time.markdown
@@ -54,7 +54,7 @@ name:
   required: false
   type: string
 travel_mode:
-  description: "You can choose between: `driving`, `walking`, `bicycling` or `transit`." This method is now deprecated, use `mode` under `options`.
+  description: "You can choose between: `driving`, `walking`, `bicycling` or `transit`. This method is now deprecated, use `mode` under `options`."
   required: false
   type: string
 options:


### PR DESCRIPTION
The logs state that travel_mode is deprecated and mode should be used.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
