### PR TITLE
Added docs for command line auth provider

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -112,6 +112,8 @@ Leading and trailing whitespace, as well as lines starting with `#` are ignored.
 
 * `name`: The real name of the user to be displayed in his profile.
 
+Stdaerr is not read at all and just passed through to that of the Home Assistant process, hence you can use it for status messages or suchlike.
+
 <p class='note'>
 For now, meta variables are only respected the first time a particular user is authenticated. Upon subsequent authentications of the same user, the previously created user object with the old values is reused.
 </p>

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -83,6 +83,43 @@ http:
     - fd00::/8
 ```
 
+### {% linkable_title Command Line %}
+
+The Command Line auth provider executes a configurable shell command to
+perform user authentication. Two environment variables, `username`
+and `password`, are passed to the command. Access is granted when
+the command exits successfully (with exit code 0).
+
+Here is a configuration example:
+
+```yaml
+homeassistant:
+  auth_providers:
+    - type: command_line
+      command: /absolute/path/to/command
+      # Optionally, define a list of arguments to pass to the command.
+      #args: ["--first", "--second"]
+      # Uncomment to enable parsing of meta variables (see below).
+      #meta: true
+```
+
+When `meta: true` is set in the auth provider's configuration, your
+command can write some variables to standard output to populate the user
+account created in Home Assistant with additional data. These variables
+have to be printed in the form:
+
+```
+name = John Doe
+```
+
+Leading and trailing whitespace, as well as lines starting with `#` are ignored. The following variables are supported. More may be added in the future.
+
+* `name`: The real name of the user to be displayed in his profile.
+
+<p class='note'>
+For now, meta variables are only respected the first time a particular user is authenticated. Upon subsequent authentications of the same user, the previously created user object with the old values is reused.
+</p>
+
 ### {% linkable_title Legacy API password %}
 
 <p class='note warning'>

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -114,8 +114,8 @@ Leading and trailing whitespace, as well as lines starting with `#` are ignored.
 
 Stdaerr is not read at all and just passed through to that of the Home Assistant process, hence you can use it for status messages or suchlike.
 
-<p class='note warning'>
-Make sure the script you configure for authentication doesn't strip whitespace from usernames before matching them. Home Assistant doesn't do this itself, and logins with `"valid-username "` and `"valid-username"` would - if stripped - both succeed, but create two different user accounts.
+<p class='note'>
+Any leading and trailing whitespace is stripped from usernames before they're passed to the configured command. For instance, " hello  " will be rewritten to just "hello".
 </p>
 
 <p class='note'>

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -114,6 +114,10 @@ Leading and trailing whitespace, as well as lines starting with `#` are ignored.
 
 Stdaerr is not read at all and just passed through to that of the Home Assistant process, hence you can use it for status messages or suchlike.
 
+<p class='note warning'>
+Make sure the script you configure for authentication doesn't strip whitespace from usernames before matching them. Home Assistant doesn't do this itself, and logins with `"valid-username "` and `"valid-username"` would - if stripped - both succeed, but create two different user accounts.
+</p>
+
 <p class='note'>
 For now, meta variables are only respected the first time a particular user is authenticated. Upon subsequent authentications of the same user, the previously created user object with the old values is reused.
 </p>

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -85,10 +85,9 @@ http:
 
 ### {% linkable_title Command Line %}
 
-The Command Line auth provider executes a configurable shell command to
-perform user authentication. Two environment variables, `username`
-and `password`, are passed to the command. Access is granted when
-the command exits successfully (with exit code 0).
+The Command Line auth provider executes a configurable shell command to perform user authentication. Two environment variables, `username` and `password`, are passed to the command. Access is granted when the command exits successfully (with exit code 0).
+
+This provider can be used to integrate Home Assistant with arbitrary external authentication services, from plaintext databases over LDAP to RADIUS. A compatible script for LDAP authentication is [this one](https://github.com/efficiosoft/ldap-auth-sh), for instance.
 
 Here is a configuration example:
 
@@ -103,10 +102,7 @@ homeassistant:
       #meta: true
 ```
 
-When `meta: true` is set in the auth provider's configuration, your
-command can write some variables to standard output to populate the user
-account created in Home Assistant with additional data. These variables
-have to be printed in the form:
+When `meta: true` is set in the auth provider's configuration, your command can write some variables to standard output to populate the user account created in Home Assistant with additional data. These variables have to be printed in the form:
 
 ```
 name = John Doe


### PR DESCRIPTION
**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19985

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
