### PR TITLE
Update recorder.markdown

### DIFF
--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -142,6 +142,7 @@ Purging does not necessarily remove all entries before a given date. For example
 | SQLite          | `sqlite:////PATH/TO/DB_NAME`                             |
 | MariaDB         | `mysql+pymysql://SERVER_IP/DB_NAME?charset=utf8`                 |
 | MariaDB         | `mysql+pymysql://user:password@SERVER_IP/DB_NAME?charset=utf8`   |
+| MariaDB         | `mysql://user:password@SERVER_IP:3307/DB_NAME?charset=utf8`   |
 | MySQL           | `mysql://SERVER_IP/DB_NAME?charset=utf8`         |
 | MySQL           | `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8` |
 | PostgreSQL      | `postgresql://SERVER_IP/DB_NAME`                         |


### PR DESCRIPTION

**Description:**

On my up-to-date Hassio installation, the 'mysql+pymysql' syntax doesn't work for MariaDB.  Using just 'mysql:' and specifying the port works fine.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
