### PR TITLE
Needs libffi-dev to compile on Debian 9.7.

### DIFF
--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -45,7 +45,7 @@ $ sudo apt-get upgrade -y
 Install the dependencies.
 
 ```bash
-$ sudo apt-get install python3 python3-venv python3-pip
+$ sudo apt-get install python3 python3-venv python3-pip libffi-dev
 ```
 
 Add an account for Home Assistant called `homeassistant`.


### PR DESCRIPTION
**Description:**

I needed this when installing home assistant on Debian 9.7.