### PR TITLE
Add documentation for homekit_controller motion device

### DIFF
--- a/source/_components/binary_sensor.homekit_controller.markdown
+++ b/source/_components/binary_sensor.homekit_controller.markdown
@@ -1,0 +1,20 @@
+---
+layout: page
+title: "HomeKit Binary Sensors"
+description: "Instructions on how to setup HomeKit binary sensors within Home Assistant."
+date: 2019-01-28 21:42
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: apple-homekit.png
+ha_category: Binary Sensor
+ha_iot_class: "Local Polling"
+ha_release: 0.84
+---
+
+To get your HomeKit binary sensors working with Home Assistant, follow the instructions for the general [HomeKit controller component](/components/homekit_controller/).
+
+The following sensor types are supported:
+
+ * Motion


### PR DESCRIPTION
**Description:**

PR in HA adds a HomeKit motion sensor device. This adds documentation in line with the other homekit devices.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20555

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
