### PR TITLE
Big bad install index rewrite

### DIFF
--- a/source/_docs/installation.markdown
+++ b/source/_docs/installation.markdown
@@ -36,8 +36,8 @@ If you use these install methods, we assume that you know how to manage and admi
 
 **Method**|**You have**|**Recommended for**
 :-----|:-----|:-----
-[Manual<BR>(as another user)](https://www.home-assistant.io/docs/installation/raspberry-pi/)|Any Linux, Python 3.5.3 or later|Those familiar with their operating system
-[Manual<BR>(as your user)](https://www.home-assistant.io/docs/installation/virtualenv/)|Any Python 3.5.3 or later|Developers
+[Virtualenv<BR>(as another user)](https://www.home-assistant.io/docs/installation/raspberry-pi/)|Any Linux, Python 3.5.3 or later|Those familiar with their operating system
+[Virtualenv<BR>(as your user)](https://www.home-assistant.io/docs/installation/virtualenv/)|Any Python 3.5.3 or later|Developers
 
 <HR>
 

--- a/source/_docs/installation.markdown
+++ b/source/_docs/installation.markdown
@@ -20,7 +20,7 @@ Home Assistant provides multiple ways to be installed. The first start may take 
   Please remember to [secure your installation](/docs/configuration/securing/) once you've finished with the installation process.
 </p>
 
-## {% linkable_title Tier one - recommended %}
+## {% linkable_title Recommended %}
 
 These install options are fully supported by Home Assistant's documentation. For example, if a component requires that you install something to make it work on one of these methods then the component page will document the steps required.
 
@@ -30,7 +30,7 @@ These install options are fully supported by Home Assistant's documentation. For
 [Docker](https://www.home-assistant.io/docs/installation/docker/)|Docker|Anybody already running Docker
 [Hassbian](https://www.home-assistant.io/docs/hassbian/installation/)|Raspberry Pi|Those who want a more traditional Linux experience<BR>and either have experience with Linux, or intend to learn
 
-## {% linkable_title Tier two - alternative installs %}
+## {% linkable_title Alternative installs %}
 
 If you use these install methods, we assume that you know how to manage and administer the operating system you're using. Due to the range of platforms on which these install methods can be used, component documentation may only tell you what you have to install, not how to install it.
 

--- a/source/_docs/installation.markdown
+++ b/source/_docs/installation.markdown
@@ -28,7 +28,7 @@ These install options are fully supported by Home Assistant's documentation. For
 :-----|:-----|:-----
 [Hass.io](https://www.home-assistant.io/hassio/installation/)|Raspberry Pi<br>VM|Anybody
 [Docker](https://www.home-assistant.io/docs/installation/docker/)|Docker|Anybody already running Docker
-[Hassbian](https://www.home-assistant.io/docs/hassbian/installation/)|Raspberry Pi|Those who want a more traditional Linux experience<BR>and either have experience with Linux, or intend to learn
+[Hassbian](https://www.home-assistant.io/docs/hassbian/installation/)|Raspberry Pi|Those who want a more traditional Linux experience and either have experience with Linux, or intend to learn
 
 ## {% linkable_title Alternative installs %}
 
@@ -101,13 +101,3 @@ These guides are provided as-is. Some of these install methods are more limited 
     <div class='title'>FreeNAS</div>
   </a>
 </div>
-
-### {% linkable_title After installation %}
-
-Once Home Assistant is installed, execute the following code in a console/terminal to check if the setup was successful:
-
-```bash
-$ hass
-```
-
-For more details about `hass`, please refer to the [tools section](/docs/tools/hass/).

--- a/source/_docs/installation.markdown
+++ b/source/_docs/installation.markdown
@@ -11,55 +11,41 @@ redirect_from: /getting-started/installation/
 ---
 
 <p class='note'>
-Beginners should check our [Getting started guide](/getting-started/) first. This is for users that require advanced installations.
+Beginners should check our [Getting started guide](/getting-started/) first.
 </p>
 
-Home Assistant provides multiple ways to be installed. A requirement is that you have [Python 3.5.3 or later](https://www.python.org/downloads/) installed.
+Home Assistant provides multiple ways to be installed. The first start may take up to 20 minutes because the required packages will be downloaded and installed. The web interface will be served on `http://ip.add.re.ss:8123/` - replace `ip.add.re.ss` with the IP of the computer you installed it on.
 
 <p class='note warning'>
   Please remember to [secure your installation](/docs/configuration/securing/) once you've finished with the installation process.
 </p>
 
-## {% linkable_title Recommended options %}
+## {% linkable_title Tier one - recommended %}
+
+These install options are fully supported by Home Assistant's documentation. For example, if a component requires that you install something to make it work on one of these methods then the component page will document the steps required.
+
+**Method**|**You have**|**Recommended for**
+:-----|:-----|:-----
+[Hass.io](https://www.home-assistant.io/hassio/installation/)|Raspberry Pi<br>VM|Anybody
+[Docker](https://www.home-assistant.io/docs/installation/docker/)|Docker|Anybody already running Docker
+[Hassbian](https://www.home-assistant.io/docs/hassbian/installation/)|Raspberry Pi|Those who want a more traditional Linux experience<BR>and either have experience with Linux, or intend to learn
+
+## {% linkable_title Tier two - alternative installs %}
+
+If you use these install methods, we assume that you know how to manage and administer the operating system you're using. Due to the range of platforms on which these install methods can be used, component documentation may only tell you what you have to install, not how to install it.
+
+**Method**|**You have**|**Recommended for**
+:-----|:-----|:-----
+[Manual<BR>(as another user)](https://www.home-assistant.io/docs/installation/raspberry-pi/)|Any Linux, Python 3.5.3 or later|Those familiar with their operating system
+[Manual<BR>(as your user)](https://www.home-assistant.io/docs/installation/virtualenv/)|Any Python 3.5.3 or later|Developers
+
+<HR>
+
+## {% linkable_title Community provided guides %}
+
+These guides are provided as-is. Some of these install methods are more limited than the methods above - some components may not work due to limitations of the platform or because required Python packages aren't available for that platform.
 
 <div class="text-center hass-option-cards" markdown="0">
-  <a class='option-card' href='/getting-started/'>
-    <div class='img-container'>
-      <img src='/images/supported_brands/home-assistant.png' />
-    </div>
-    <div class='title'>Hass.io<br>(Beginner friendly)</div>
-  </a>
-  <a class='option-card' href='/docs/hassbian/installation/'>
-    <div class='img-container'>
-      <img src='/images/supported_brands/home-assistant.png' />
-    </div>
-    <div class='title'>Hassbian (for the Raspberry Pi)</div>
-  </a>
-  <a class='option-card' href='/docs/installation/docker/'>
-    <div class='img-container'>
-      <img src='/images/supported_brands/docker.png' />
-    </div>
-    <div class='title'>Docker</div>
-  </a>
-</div>
-
-## {% linkable_title Alternative installs %}
-
-The following installs are only recommended for experienced users of those platforms.
-
-<div class="text-center hass-option-cards" markdown="0">
-  <a class='option-card' href='/docs/installation/raspberry-pi/'>
-    <div class='img-container'>
-      <img src='/images/supported_brands/raspberry-pi.png' />
-    </div>
-    <div class='title'>Raspbian (but applies to any Debian based Linux)</div>
-  </a>
-  <a class='option-card' href='/docs/installation/virtualenv/'>
-    <div class='img-container'>
-      <img src='/images/supported_brands/python.svg' />
-    </div>
-    <div class='title'>On top of an existing Python 3.5.3+ installation</div>
-  </a>
   <a class='option-card' href='/docs/installation/armbian/'>
     <div class='img-container'>
       <img src='/images/supported_brands/armbian.png' />
@@ -116,7 +102,7 @@ The following installs are only recommended for experienced users of those platf
   </a>
 </div>
 
-## {% linkable_title After installation %}
+### {% linkable_title After installation %}
 
 Once Home Assistant is installed, execute the following code in a console/terminal to check if the setup was successful:
 
@@ -124,10 +110,4 @@ Once Home Assistant is installed, execute the following code in a console/termin
 $ hass
 ```
 
-The first start may take up to 20 minutes because the needed packages will be downloaded and installed. The web interface will be served on [http://localhost:8123](http://localhost:8123).
-
 For more details about `hass`, please refer to the [tools section](/docs/tools/hass/).
-
-If you're running a Linux-based platform, we suggest you follow the [VirtualEnv instructions](/docs/installation/virtualenv/) to avoid using `root`.
-
-You may need to install additional libraries depending on the platforms/components you want to use.


### PR DESCRIPTION
**Description:**

Following on from [this](https://github.com/home-assistant/architecture/issues/126#issuecomment-457819615) here is the first pass.

I've:

* Restructured the layout, simplifying the intro slightly, and moving more of the relevant things to know up there
* Removed redundant information
* Used slightly emotive _tier_ language, deliberately
* Put in a line and put the community provided guides underneath it

Feedback appreciated if this doesn't hit the mark

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
