### PR TITLE
Update dhcp_software option in docs to match code

### DIFF
--- a/source/_components/device_tracker.ubus.markdown
+++ b/source/_components/device_tracker.ubus.markdown
@@ -83,7 +83,7 @@ password:
   required: true
   type: string
 dhcp_software:
-  description: "The DHCP software used in your router: `dnsmasq`, `dhcpd`, or `none`."
+  description: "The DHCP software used in your router: `dnsmasq`, `odhcpd`, or `none`."
   required: false
   default: dnsmasq
   type: string


### PR DESCRIPTION
The code uses 'odhcpd' while the document listed the option as 'dhcpd'. Fixing documentation

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
