### PR TITLE
Fix ha_version for SmartThings component and switch

### DIFF
--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -10,7 +10,7 @@ footer: true
 featured: true
 logo: samsung_smartthings.png
 ha_category: Hub
-ha_release: ""
+ha_release: "0.87"
 ha_iot_class: "Cloud Push"
 ---
 

--- a/source/_components/smartthings.switch.markdown
+++ b/source/_components/smartthings.switch.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: samsung_smartthings.png
 ha_category: Switch
-ha_release: ""
+ha_release: "0.87"
 ha_iot_class: "Cloud Push"
 ---
 


### PR DESCRIPTION
**Description:**
#8184 was merged before the `ha_version` was updated.  This updates the release milestone as specified in the original PR.