### PR TITLE
Add a note about Synology livestream API

### DIFF
--- a/source/_components/camera.synology.markdown
+++ b/source/_components/camera.synology.markdown
@@ -16,7 +16,7 @@ ha_iot_class: "Local Polling"
 The `synology` camera platform allows you to watch the live streams of your [Synology](https://www.synology.com/) Surveillance Station based IP cameras in Home Assistant.
 
 <p class='note'>
-Synology removed the live streaming API in Surveillance Station version 8.2.3-5828. Thus, the cameras may not work if you are on 8.2.3-5828.
+Synology has disabled the livestreaming API and the component is currently broken if you are using Surveillance Station version 8.2.3-5828S.
 </p>
 
 ## {% linkable_title Configuration %}

--- a/source/_components/camera.synology.markdown
+++ b/source/_components/camera.synology.markdown
@@ -15,6 +15,10 @@ ha_iot_class: "Local Polling"
 
 The `synology` camera platform allows you to watch the live streams of your [Synology](https://www.synology.com/) Surveillance Station based IP cameras in Home Assistant.
 
+<p class='note'>
+Synology removed the live streaming API in Surveillance Station version 8.2.3-5828. Thus, the cameras may not work if you are on 8.2.3-5828.
+</p>
+
 ## {% linkable_title Configuration %}
 
 To enable your Surveillance Station cameras in your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
Added a note that Synology has disabled the livestreaming API and the component is currently broken in Surveillance Station version 8.2.3-5828. 

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].
