### PR TITLE
Make name of telegram notify service lowercase

### DIFF
--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -86,15 +86,16 @@ telegram_bot:
       - CHAT_ID_3
 
 # Example configuration.yaml entry for the notifier
+# name must be lower case
 notify:
-  - name: NOTIFIER_NAME
+  - name: your_notifier_name
     platform: telegram
     chat_id: CHAT_ID_2
 ```
 
 {% configuration %}
 name:
-  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.your_notifier_name`.
   required: false
   default: notify
   type: string
@@ -111,7 +112,7 @@ To use notifications, please see the [getting started with automation page](/get
 ```yaml
 ...
 action:
-  service: notify.NOTIFIER_NAME
+  service: notify.your_notifier_name
   data:
     title: '*Send a message*'
     message: "That's an example that _sends_ a *formatted* message with a custom inline keyboard."
@@ -145,7 +146,7 @@ inline_keyboard:
 ```yaml
 ...
 action:
-  service: notify.NOTIFIER_NAME
+  service: notify.your_notifier_name
   data:
     title: Send an images
     message: "That's an example that sends an image."
@@ -214,7 +215,7 @@ homeassistant:
 ```yaml
 ...
 action:
-  service: notify.NOTIFIER_NAME
+  service: notify.your_notifier_name
   data:
     title: Send a video
     message: "That's an example that sends a video."
@@ -270,7 +271,7 @@ inline_keyboard:
 ```yaml
 ...
 action:
-  service: notify.NOTIFIER_NAME
+  service: notify.your_notifier_name
   data:
     title: Send a document
     message: "That's an example that sends a document and a custom keyboard."
@@ -325,7 +326,7 @@ inline_keyboard:
 ...
 
 action:
-  service: notify.NOTIFIER_NAME
+  service: notify.your_notifier_name
   data:
     title: Send location
     message: Location updated.


### PR DESCRIPTION
Lower case is now enforced, making the examples fail on a current version of Home Assistant.

Part of https://github.com/home-assistant/home-assistant.io/issues/8286

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
