### PR TITLE
Rename Etcher to balenaEtcher

### DIFF
--- a/source/_docs/installation/hassbian/installation.markdown
+++ b/source/_docs/installation/hassbian/installation.markdown
@@ -13,7 +13,7 @@ redirect_from: /docs/hassbian/installation/
 One of the easiest ways to install Home Assistant on your Raspberry Pi Zero, 2, 3 and 3B+ is by using Hassbian: a Raspberry Pi image with Home Assistant built-in. The image will install the latest version of Home Assistant on initial boot (~10 minutes).
 
  1. [Download the Hassbian image][image-download]
- 2. Use [Etcher][etcher] to flash the image to your SD card. We recommend at least a 32 GB SD card to avoid running out of space.
+ 2. Use [balenaEtcher][balenaEtcher] to flash the image to your SD card. We recommend at least a 32 GB SD card to avoid running out of space.
  3. Ensure your Raspberry Pi has wired access to the internet for the entire process or configure your [wireless network settings](#wireless-network) **before proceeding to step 4**.
  4. Insert SD card to Raspberry Pi and turn it on. Initial installation of Home Assistant will take about 10 minutes.
 
@@ -73,7 +73,7 @@ To unblock it, execute `$ sudo rfkill unblock wifi`.
  - The configuration is located at `/home/homeassistant/.homeassistant`
 
 [image-download]: https://github.com/home-assistant/pi-gen/releases/latest
-[etcher]: https://etcher.io/
+[balenaEtcher]: https://www.balena.io/etcher
 [http://hassbian.local:8123]: http://hassbian.local:8123
 [wifi-setup]: https://www.raspberrypi.org/documentation/configuration/wireless/wireless-cli.md
 

--- a/source/_posts/2017-05-01-home-assistant-on-raspberry-pi-zero-in-30-minutes.markdown
+++ b/source/_posts/2017-05-01-home-assistant-on-raspberry-pi-zero-in-30-minutes.markdown
@@ -33,7 +33,7 @@ First, download the HASSbian 1.21 image from [here](https://github.com/home-assi
 
 Unzip it.
 
-Flash it to the microSD card. If you need a flash tool, try [Etcher](https://etcher.io/)
+Flash it to the microSD card. If you need a flash tool, try [balenaEtcher](https://www.balena.io/etcher)
 
 When the flashing finishes, remove it and plug it back in. You should see a drive called "boot".
 

--- a/source/_posts/2017-05-13-home-assistant-on-orange-pi-zero.markdown
+++ b/source/_posts/2017-05-13-home-assistant-on-orange-pi-zero.markdown
@@ -19,7 +19,7 @@ This blog post is about the setup of Home Assistant on an [Orange Pi Zero](http:
 
 <!--more-->
 
-Download the [Armbian](https://www.armbian.com/orange-pi-zero/) and create the SD card with [Etcher](https://etcher.io/). There is no possibility to connect a display to the Orange Pi Zero. This means that you need a wired network setup with DHCP server. After your Orange Pi Zero is running, give it some time, and look for its IP address. The hostname is `orangepizero`.
+Download the [Armbian](https://www.armbian.com/orange-pi-zero/) and create the SD card with [balenaEtcher](https://www.balena.io/etcher). There is no possibility to connect a display to the Orange Pi Zero. This means that you need a wired network setup with DHCP server. After your Orange Pi Zero is running, give it some time, and look for its IP address. The hostname is `orangepizero`.
 
 If you found the IP address then use your SSH client to connect to the Orange Pi Zero. The default password is `1234`.
 

--- a/source/_posts/2018-07-11-hassio-images.markdown
+++ b/source/_posts/2018-07-11-hassio-images.markdown
@@ -38,7 +38,7 @@ You need to perform the following steps to upgrade:
 1. If you have installed the Bluetooth add-on, please remove it, since it is no longer required.
 2. Make a Hass.io snapshot of your current system and download it to your computer.
 3. Download the latest [Hass.io stable][installation] version.
-4. Flash the downloaded Hass.io image with [Etcher] to your SD card.
+4. Flash the downloaded Hass.io image with [balenaEtcher] to your SD card.
 5. Raspberry Pi: In case you have modified the `config.txt` (in the boot partition), you will also need to apply these changes to HassOS. Do **NOT** simply copy the file from your old setup into HassOS! Apply those changes manually!
 6. If you use a custom network configuration or have configured SSH development access, you need to create a configuration [USB stick]. Copy the resin-sample into the `network` folder on a USB stick and insert it into your device.
 7. Take the freshly flashed SD card with HassOS and place it into your device, and boot it by turning it on.
@@ -61,4 +61,4 @@ Feel free to jump into the project and help us to improve the documentation or o
 [AppArmor]: https://gitlab.com/apparmor/apparmor/wikis/home/
 [USB stick]: https://github.com/home-assistant/hassos/blob/rel-1/Documentation/configuration.md#automatic
 [installation]: /hassio/installation/
-[Etcher]: https://etcher.io/
+[balenaEtcher]: https://www.balena.io/etcher

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -30,15 +30,15 @@ We will need a few things to get started with installing Home Assistant. For bes
 ### {% linkable_title Software requirements %}
 
 - Download the Hass.io image for [your device](/hassio/installation/)
-- Download [Etcher] to write the image to an SD card
+- Download [balenaEtcher] to write the image to an SD card
 - Text Editor like [Visual Studio Code](https://code.visualstudio.com/)
 
-[Etcher]: https://etcher.io/
+[balenaEtcher]: https://www.balena.io/etcher
 
 ### {% linkable_title Installing Hass.io %}
 
 1. Put the SD card in your SD card reader.
-1. Open Etcher, select the Hass.io image and flash it to the SD card.
+1. Open balenaEtcher, select the Hass.io image and flash it to the SD card.
 1. WiFi and Static IP setup only: Format a USB-Stick with name `CONFIG`, create a folder named `network` and within that folder a file named `my-network`. Copy one of [the examples] to the `my-network` file.
 1. Unmount the SD card and remove it from your SD card reader.
 1. Insert the SD card into your Raspberry Pi 3. If you are going to use an Ethernet cable, connect that too.

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -36,7 +36,7 @@ The following will take you through the steps required to install Hass.io.
     
 2. Install Hass.io:
 
-   - Flash the downloaded image to an SD card using [Etcher][etcher]. We recommend at least a 32 GB SD card to avoid running out of space.
+   - Flash the downloaded image to an SD card using [balenaEtcher][balenaEtcher]. We recommend at least a 32 GB SD card to avoid running out of space.
    - Load the appliance image into your virtual machine software.
 
 3. Optional - set up the WiFi or static IP: On a USB stick, create the `network/my-network` file and follow the [HassOS howto][hassos-network].
@@ -112,7 +112,7 @@ When you use this installation method, the core SSH add-on may not function corr
 
 A detailed guide about running Hass.io as a virtual machine is available in the [blog][hassio-vm].
 
-[etcher]: https://etcher.io/
+[balenaEtcher]: https://www.balena.io/etcher
 [Virtual Appliance]: https://github.com/home-assistant/hassos/blob/dev/Documentation/boards/ova.md
 [hassos-network]: https://github.com/home-assistant/hassos/blob/dev/Documentation/network.md
 [pi0-w]: https://github.com/home-assistant/hassos/releases/download/1.13/hassos_rpi0-w-1.13.img.gz


### PR DESCRIPTION
**Description:**
Update the download links and name of *Etcher* (renamed to *balenaEtcher*)
> balenaEtcher was originally called Etcher, but its name was changed on October 29, 2018 when Resin.io changed its name to Balena, see https://www.balena.io/blog/resin-io-changes-name-to-balena-releases-open-source-edition/

