### PR TITLE
Add SmartThings Light platform

### DIFF
--- a/source/_components/smartthings.light.markdown
+++ b/source/_components/smartthings.light.markdown
@@ -14,11 +14,12 @@ ha_iot_class: "Cloud Push"
 ---
 
 The SmartThings light platform lets you control Samsung SmartThings connected devices that have light-control related capabilities.
+
 | Capability        |Light Features
 |-------------------|------------------------------------------------------------|
-| [`switchLevel`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch-Level)            | `brightness`, `brightness_pct` and `transition`
-| [`colorControl`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Color-Control)            | `hs_color`, `xy_color`, `rgb_color` and `color_name`
-| [`colorTemperature`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Color-Temperature)            | `color_temp` and `kelvin`
+| [`switchLevel`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch-Level)            | `brightness` and `transition`
+| [`colorControl`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Color-Control)            | `color`
+| [`colorTemperature`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Color-Temperature)            | `color_temp`
 
 For a SmartThings device to be represented by the light platform, it must have one or more of the capabilities above in addition to the [`switch`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch) capability.
 

--- a/source/_components/smartthings.light.markdown
+++ b/source/_components/smartthings.light.markdown
@@ -1,0 +1,26 @@
+---
+layout: page
+title: "SmartThings Light"
+description: "Instructions on setting up Samsung SmartThings lights within Home Assistant."
+date: 2018-01-30 00:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: samsung_smartthings.png
+ha_category: Light
+ha_release: ""
+ha_iot_class: "Cloud Push"
+---
+
+The SmartThings light platform lets you control Samsung SmartThings connected devices that have light-control related capabilities.
+| Capability        |Light Features
+|-------------------|------------------------------------------------------------|
+| [`switchLevel`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch-Level)            | `brightness`, `brightness_pct` and `transition`
+| [`colorControl`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Color-Control)            | `hs_color`, `xy_color`, `rgb_color` and `color_name`
+| [`colorTemperature`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Color-Temperature)            | `color_temp` and `kelvin`
+
+For a SmartThings device to be represented by the light platform, it must have one or more of the capabilities above in addition to the [`switch`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch) capability.
+
+<p class='note'>
+Entities for this platform are loaded automatically when you configure the [SmartThings component](/components/smartthings). This platform cannot be manually configured.</p>

--- a/source/_components/smartthings.light.markdown
+++ b/source/_components/smartthings.light.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: samsung_smartthings.png
 ha_category: Light
-ha_release: ""
+ha_release: "0.87"
 ha_iot_class: "Cloud Push"
 ---
 

--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -68,7 +68,7 @@ SmartThings represents devices as a set of [capabilities](https://smartthings.de
 
 | Capabilities        |Platform
 |-------------------|------------------------------------------------------------|
-| `switchLevel`, `colorControl` and `colorTemperature`    | [`light`](/components/smartthings.light)
-| [`switch`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch)            | [`switch`](/components/smartthings.switch)
+| `switchLevel`, `colorControl` and `colorTemperature`    | [light](/components/smartthings.light)
+| `switch`          | [switch](/components/smartthings.switch)
 
 Support for additional capabilities will be added in the future.

--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -66,8 +66,9 @@ Advanced: If you have multiple locations in SmartThings, each can be integrated 
 
 SmartThings represents devices as a set of [capabilities](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html) and the SmartThings component follows the following rules to represent those as entities in Home Assistant:
 
-| Capability        |Platform
+| Capabilities        |Platform
 |-------------------|------------------------------------------------------------|
-| [switch](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch)            | [switch](/components/smartthings.switch)
+| `switchLevel`, `colorControl` and `colorTemperature`    | [`light`](/components/smartthings.light)
+| [`switch`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch)            | [`switch`](/components/smartthings.switch)
 
 Support for additional capabilities will be added in the future.

--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -50,7 +50,7 @@ The SmartThings component is configured exclusively through the front-end. Manua
 1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'SmartThings' and click 'Configure'.
 2. Enter the personal access token created above and click 'Submit'
 3. When prompted, install the SmartApp:
-    1. Open the SmartThings mobile app. Navigate to 'Automation' and select the 'SmartApps' tab.
+    1. Open the SmartThings Classic mobile app. Navigate to 'Automation' and select the 'SmartApps' tab.
     2. Click 'Add a SmartApp', scroll to the bottom, and select 'My Apps', then choose 'Home Assistant'.
     3. Optionally change the display name and press 'Done'
     4. Authorize the app by pressing 'Allow'


### PR DESCRIPTION
**Description:**
Adds documentation for the SmartThings Light platform and also clarifies to use the SmartThings Classic app to configure the component (based on user feedback).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20652

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
