### PR TITLE
Explicit scan_interval unit

### DIFF
--- a/source/_components/sensor.airvisual.markdown
+++ b/source/_components/sensor.airvisual.markdown
@@ -18,7 +18,7 @@ The `airvisual` sensor platform queries the [AirVisual](https://airvisual.com/) 
 This platform requires an AirVisual API key, which can be obtained [here](https://airvisual.com/api). Note that the platform was designed using the "Community" package; the "Startup" and "Enterprise" package keys should continue to function, but actual results may vary (or not work at all).
 
 <p class='note warning'>
-The "Community" API key is limited to 10,000 calls per month. In order to leave a buffer, the `airvisual` platform queries the API every 10 minutes by default. Modification of this (via the `scan_interval` key) to a too-low value may result in your API key being deactivated.
+The "Community" API key is limited to 10,000 calls per month. In order to leave a buffer, the `airvisual` platform queries the API every 10 minutes (600 seconds) by default. Modification of this (via the `scan_interval` key) to a too-low value may result in your API key being deactivated.
 </p>
 
 ## {% linkable_title Configuration %}
@@ -47,7 +47,7 @@ show_on_map:
   type: boolean
   default: true
 scan_interval:
-  description: "The rate at which AirVisual should be polled for new data."
+  description: "The rate in seconds at which AirVisual should be polled for new data."
   required: optional
   type: integer
   default: 600
@@ -86,7 +86,7 @@ sensor:
     monitored_conditions:
       - cn
     show_on_map: false
-    scan_interval: 30
+    scan_interval: 300
     latitude: 42.81212
     longitude: 108.12422
 ```
@@ -100,7 +100,7 @@ sensor:
     monitored_conditions:
       - us
     show_on_map: false
-    scan_interval: 30
+    scan_interval: 300
     city: Los Angeles
     state: California
     country: USA


### PR DESCRIPTION
**Description:**
It's not clear what is the unit at which scan_interval is defined. 
Text mentions default of 10 min, while examples show 30 (misleading reader to believe this also minutes).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
