### PR TITLE
Update sensor.imap_email_content.markdown

### DIFF
--- a/source/_components/sensor.imap_email_content.markdown
+++ b/source/_components/sensor.imap_email_content.markdown
@@ -55,7 +55,7 @@ password:
   description: Password for the IMAP server.
   required: true
   type: string
-password:
+folder:
   description: Folder to get mails from.
   required: false
   default: INBOX


### PR DESCRIPTION
Description of *password* and *folder* fixed.

**Description:**
password was written two times. this ended up in a wrong description. now fixed.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
