### PR TITLE
Fix copy&paste error of raspyrfm docs that mixed up host and port

### DIFF
--- a/source/_components/switch.raspyrfm.markdown
+++ b/source/_components/switch.raspyrfm.markdown
@@ -49,10 +49,10 @@ host:
   required: false
   default: 127.0.0.1
   type: string
-host:
+port:
   description: Port of the gateway.
   required: false
-  default: depends on the gateway model
+  default: Depends on the gateway model.
   type: integer
 switches:
   description: List of switches that can be controlled with this gateway.


### PR DESCRIPTION
**Description:**

The `host` is not an integer :stuck_out_tongue_winking_eye:

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
