### PR TITLE
Fix platform links when using embedded components

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -16,6 +16,8 @@
     {%- assign imp_name = file_parts[1] -%}
     {%- assign parent_name = file_parts[0] -%}
     {%- assign parent_url = parent_name | prepend: '/components/' | append: '/' -%}
+    {%- assign embedded_url = imp_name | prepend: '/components/' | append: '/' -%}
+    {%- assign embedded_component = components | where: 'url', embedded_url | first -%}
     {%- assign parent_component = components | where: 'url', parent_url | first -%}
   {%- else -%}
     {%- assign is_platform = false -%}
@@ -59,7 +61,7 @@
   {%- if is_platform -%}
     <div class='section'>
       Source:
-      <a href='{{github_main_repo}}{{parent_url}}{{imp_name}}.py'>{{parent_name}}/{{imp_name}}.py</a>
+      <a href='{{github_main_repo}}{{embedded_url}}{{parent_name}}.py'>{{imp_name}}/{{parent_name}}.py</a>
     </div>
   {%- endif -%}
 


### PR DESCRIPTION
**Description:**

Fixes the platform source links when using embedded components. Note that this changes the source links to _only_ work with embedded components.

**For this reason, this should only be merged after https://github.com/home-assistant/home-assistant/pull/20677**

Fixes #8374

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
