### PR TITLE
Add new service media_player.firetv_key

### DIFF
--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -107,3 +107,19 @@ If you receive the error message `Issue: Error while setting up platform firetv`
 3. Home Assistant does not have the appropriate permissions for the `adbkey` file and so it is not able to use it.  Once you fix the permissions, the component should work.
 
 4. You are already connected to the Fire TV via ADB from another device.  Only one device can be connected, so disconnect the other device, restart the Fire TV (for good measure), and then restart Home Assistant.  
+
+### {% linkable_title Service %}
+
+A service `firetv_key` is provided allowing you to send a keystroke to the Fire TV.
+
+```json
+{
+  "entity_id" : "media_player.fire_tv", 
+  "key" : "HOME"
+}
+```
+
+Service parameters:
+
+- **entity_id**: Entity ID of the Fire TV.
+- **key**: The key that should be sent: `POWER`, `SLEEP`, `HOME`, `UP`, `DOWN`, `LEFT`, `RIGHT`, `ENTER`, `BACK`, `SPACE` or `MENU`


### PR DESCRIPTION
**Description:**
Add new service media_player.firetv_key in order to send keys to Fire TV. E.g. key "HOME" can be used to switch to home screen and to turn on attached TV by CEC.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20673

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
