### PR TITLE
Add 'icon' parameter documentation

### DIFF
--- a/source/_components/switch.broadlink.markdown
+++ b/source/_components/switch.broadlink.markdown
@@ -68,6 +68,10 @@ switches:
           description: The name used to display the switch in the frontend.
           required: false
           type: string
+        icon:
+          description: The icon used to display the switch in the frontend.
+          required: false
+          type: string
 slots:
   description: Friendly names of 4 slots of MP1 power strip. If not configured, slot name will be `switch's friendly_name + 'slot {slot_index}'`. e.g 'MP1 slot 1'
   required: false


### PR DESCRIPTION
**Description:**
Th PR adds documentation for new `Icon` attribute for Broadlink RM mini switches (see https://github.com/home-assistant/home-assistant/pull/20692)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/20692

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
