### PR TITLE
Add SmartThings Binary Sensor platform

### DIFF
--- a/source/_components/smartthings.binary_sensor.markdown
+++ b/source/_components/smartthings.binary_sensor.markdown
@@ -1,19 +1,19 @@
 ---
 layout: page
-title: "SmartThings binary_sensor"
-description: "Instructions on setting up Samsung SmartThings binary_sensors within Home Assistant."
+title: "SmartThings Binary Sensor"
+description: "Instructions on setting up Samsung SmartThings Binary Sensors within Home Assistant."
 date: 2018-01-30 00:00
 sidebar: true
 comments: false
 sharing: true
 footer: true
 logo: samsung_smartthings.png
-ha_category: Light
+ha_category: Binary Sensor
 ha_release: ""
 ha_iot_class: "Cloud Push"
 ---
 
-The SmartThings binary_sensor platform lets you view Samsung SmartThings connected devices that have sensor-reading capabilities. A binary_sensor entity will be created for each attribute (below) supported by the SmartThings device.
+The SmartThings Binary Sensor platform lets you view Samsung SmartThings connected devices that have sensor-reading capabilities. A Binary Sensor entity will be created for each attribute (below) supported by the SmartThings device.
 
 | Capability        |Attribute     |On-Value        |binary_sensor Device Class
 |-------------------|--------------|----------------|---------------------------------|

--- a/source/_components/smartthings.binary_sensor.markdown
+++ b/source/_components/smartthings.binary_sensor.markdown
@@ -1,0 +1,30 @@
+---
+layout: page
+title: "SmartThings binary_sensor"
+description: "Instructions on setting up Samsung SmartThings binary_sensors within Home Assistant."
+date: 2018-01-30 00:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: samsung_smartthings.png
+ha_category: Light
+ha_release: ""
+ha_iot_class: "Cloud Push"
+---
+
+The SmartThings binary_sensor platform lets you view Samsung SmartThings connected devices that have sensor-reading capabilities. A binary_sensor entity will be created for each attribute (below) supported by the SmartThings device.
+
+| Capability        |Attribute     |On-Value        |binary_sensor Device Class
+|-------------------|--------------|----------------|---------------------------------|
+| [`accelerationSensor`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Acceleration-Sensor) | `acceleration` | `active`   | `moving`
+| [`contactSensor`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Contact-Sensor)           | `contact`      | `open`     | `opening`
+| [`filterStatus`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Filter-Status)             | `filterStatus` | `replace`  | `problem`
+| [`motionSensor`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Motion-Sensor)             | `motion`       | `active`   | `motion`
+| [`presenceSensor`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Presence-Sensor)         | `presence`     | `present`  | `presence`
+| [`tamperAlert`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Tamper-Alert)               | `tamper`       | `detected` | `problem`
+| [`valve`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Valve)                            | `valve`        | `open`     | `opening`
+| [`waterSensor`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Water-Sensor)               | `water`        | `wet`      | `moisture`
+
+<p class='note'>
+Entities for this platform are loaded automatically when you configure the [SmartThings component](/components/smartthings). This platform cannot be manually configured.</p>

--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -75,9 +75,10 @@ Advanced: If you have multiple locations in SmartThings, each can be integrated 
 
 SmartThings represents devices as a set of [capabilities](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html) and the SmartThings component follows the following rules to represent those as entities in Home Assistant:
 
-| Capabilities        |Platform
-|-------------------|------------------------------------------------------------|
-| `switchLevel`, `colorControl` and `colorTemperature`    | [light](/components/smartthings.light)
-| `switch`          | [switch](/components/smartthings.switch)
+| Platform                                               |Capabilities
+|--------------------------------------------------------|--------------------------------------------------------------------------------------------|
+[binary_sensor](/components/smartthings.binary_sensor)   | `accelerationSensor`, `contactSensor`, `filterStatus`, `motionSensor`, `presenceSensor`, `tamperAlert`, `valve` and `waterSensor`
+[light](/components/smartthings.light)                   | `switchLevel`, `colorControl` and `colorTemperature`
+[switch](/components/smartthings.switch)                 | `switch`
 
 Support for additional capabilities will be added in the future.


### PR DESCRIPTION
**Description:**
Adds documentation for the SmartThings Binary Sensor platform and improves readability of the hub page.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#TBD

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
