### PR TITLE
Fix SmartThings Switch Platform

### DIFF
--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -11,12 +11,8 @@ featured: true
 logo: samsung_smartthings.png
 ha_category:
   - Hub
-  - Switch
 ha_release: "0.87"
 ha_iot_class: "Cloud Push"
-redirect_from:
-  - /components/smartthings.switch/
-  - /components/switch.smartthings/
 ---
 
 Samsung SmartThings is integrated into Home Assistant through the SmartThings Cloud API. The SmartThings component is the main component to integrate all SmartThings related platforms. The basic features of this integration include:
@@ -25,10 +21,6 @@ Samsung SmartThings is integrated into Home Assistant through the SmartThings Cl
 2. Entities automatically added, removed, or updated when changed in SmartThings (upon Home Assistant restart).
 3. Support for multiple SmartThings accounts and locations, each represented as a unique integration in the front-end configuration.
 4. No brokers, bridges, or additional dependencies.
-
-There is currently support for the following device types within Home Assistant:
-
-- Switch ([SmartThings switch platform](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch))
 
 ## {% linkable_title Basic requirements %}
 

--- a/source/_components/smartthings.switch.markdown
+++ b/source/_components/smartthings.switch.markdown
@@ -1,0 +1,19 @@
+---
+layout: page
+title: "SmartThings Switch"
+description: "Instructions on setting up Samsung SmartThings switches within Home Assistant."
+date: 2018-01-14 00:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: samsung_smartthings.png
+ha_category: Switch
+ha_release: "0.87"
+ha_iot_class: "Cloud Push"
+---
+
+The SmartThings switch platform lets you control Samsung SmartThings connected devices that have the [switch capability](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch).
+
+<p class='note'>
+Entities for this platform are loaded automatically when you configure the [SmartThings component](/components/smartthings). This platform cannot be manually configured.</p>


### PR DESCRIPTION
**Description:**
Reverts the changes of #8357 so that the switch platform is consistent with the other platforms that have integration details (#8388, #8376, and #8365).

While switch doesn't have details today, it will in the future, once it supports other capabilities, like power meter.  To keep the component page lean (instructions for setting up the integration), the SmartThings-device-to-platform mapping details are within each platform page.

## Checklist:
- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html