### PR TITLE
Update tts.markdown

### DIFF
--- a/source/_components/tts.markdown
+++ b/source/_components/tts.markdown
@@ -94,6 +94,7 @@ Say to all `media_player` device entities:
 ```yaml
 # Replace google_say with <platform>_say when you use a different platform.
 service: tts.google_say
+entity_id: "all"
 data:
   message: 'May the Force be with you.'
 ```


### PR DESCRIPTION
Per warning from helpers/service.py:
Not passing an entity ID to a service to target all entities is deprecated. Use instead: entity_id: "all"

Tested in 0.86.2

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
