### PR TITLE
Add more description to the OpenUV API key usage docs

### DIFF
--- a/source/_components/openuv.markdown
+++ b/source/_components/openuv.markdown
@@ -35,6 +35,23 @@ component does not automatically query the API for new data after it initially
 loads. To request new data, the `update_data` service may be used.
 </p>
 
+<p class='note warning'>
+Each use of the `update_data` service will consume 1 or 2 API calls, depending
+on which monitored conditions are configured.
+
+If the OpenUV component is configured through the Home Assistant UI (via the
+`Configuration >> Integrations` panel), each service call will consume 2 API
+calls from the daily quota.
+
+If the OpenUV component is configured via `configuration.yaml`, service calls
+will consume 2 API calls if `monitored_conditions` contains both
+`uv_protection_window` and any other condition; any other scenarios will only
+consume 1 API call.
+
+Ensure that you understand these specifications when calling the `update_data`
+service.
+</p>
+
 ## {% linkable_title Configuration %}
 
 To retrieve data from OpenUV, add the following to your `configuration.yaml`


### PR DESCRIPTION
**Description:**

Adds additional documentation related to how Home Assistant consumes the OpenUV API. Comparing this to `current`, as it does constitute a "bugfix". Fixes https://github.com/home-assistant/home-assistant/issues/20644.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
