### PR TITLE
Update Air visual doc to include API key expiry

### DIFF
--- a/source/_components/sensor.airvisual.markdown
+++ b/source/_components/sensor.airvisual.markdown
@@ -17,6 +17,8 @@ The `airvisual` sensor platform queries the [AirVisual](https://airvisual.com/) 
 
 This platform requires an AirVisual API key, which can be obtained [here](https://airvisual.com/api). Note that the platform was designed using the "Community" package; the "Startup" and "Enterprise" package keys should continue to function, but actual results may vary (or not work at all).
 
+The Community API key is valid for 12 months after which it will expire. You must then go back to the Airvisual website, delete your old key, create a new one following the same steps and update your configuration with the new key. 
+
 <p class='note warning'>
 The "Community" API key is limited to 10,000 calls per month. In order to leave a buffer, the `airvisual` platform queries the API every 10 minutes (600 seconds) by default. Modification of this (via the `scan_interval` key) to a too-low value may result in your API key being deactivated.
 </p>


### PR DESCRIPTION
**Description:**

Air Visual API key expires after 12 months and needs to be deleted and re-initialised.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
