### PR TITLE
Update lets_encrypt.markdown

### DIFF
--- a/source/_addons/lets_encrypt.markdown
+++ b/source/_addons/lets_encrypt.markdown
@@ -79,10 +79,11 @@ Use this in your `automations.yaml` to attempt certificate renewal each day at m
       addon: core_letsencrypt
 ```
 
-If you're running another service like the [Nginx Proxy] you will need need to stop this during the renewal process. This can be achieved by stopping the service whilst restarting the Let's Encrypt addon:
+If you are using the [Nginx Proxy add-on] you will need need to stop this during the renewal process. This can be achieved by stopping the service whilst restarting the Let's Encrypt addon. This can be achieved the following configuration: 
 
 ```yaml
-- alias: 'LetsEncrypt renewal'
+- id: letsencrypt-renewal
+  alias: 'LetsEncrypt renewal'
   trigger:
   - platform: time
     at: '00:00:00'

--- a/source/_addons/lets_encrypt.markdown
+++ b/source/_addons/lets_encrypt.markdown
@@ -79,4 +79,25 @@ Use this in your `automations.yaml` to attempt certificate renewal each day at m
       addon: core_letsencrypt
 ```
 
+If you're running another service like the [Nginx Proxy] you will need need to stop this during the renewal process. This can be achieved by stopping the service whilst restarting the Let's Encrypt addon:
+
+```yaml
+- alias: 'LetsEncrypt renewal'
+  trigger:
+  - platform: time
+    at: '00:00:00'
+  action:
+  - service: hassio.addon_stop
+    data:
+      addon: core_nginx_proxy
+  - service: hassio.addon_restart
+    data:
+      addon: core_letsencrypt
+  - delay: '00:01:30'
+  - service: hassio.addon_start
+    data:
+      addon: core_nginx_proxy
+```
+
 [DuckDNS add-on]: /addons/duckdns/
+[Nginx Proxy add-on]: /addons/nginx_proxy/

--- a/source/_addons/lets_encrypt.markdown
+++ b/source/_addons/lets_encrypt.markdown
@@ -79,7 +79,7 @@ Use this in your `automations.yaml` to attempt certificate renewal each day at m
       addon: core_letsencrypt
 ```
 
-If you are using the [Nginx Proxy add-on] you will need need to stop this during the renewal process. This can be achieved by stopping the service whilst restarting the Let's Encrypt addon. This can be achieved the following configuration: 
+If you are using the [Nginx Proxy add-on] you will need need to stop this during the renewal process. This can be achieved by stopping the add-on whilst restarting the Let's Encrypt add-on. This can be achieved the following configuration: 
 
 ```yaml
 - id: letsencrypt-renewal


### PR DESCRIPTION
**Description:**

Added example for when using nginx proxy to free up port 80 when doing renewal.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
