### PR TITLE
✏️ Change to the correct alarm category

### DIFF
--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -10,7 +10,7 @@ footer: true
 logo: apple-homekit.png
 ha_category:
   - Hub
-  - Alarm Panel Control
+  - Alarm
   - Climate
   - Cover
   - Light


### PR DESCRIPTION
**Description:**
See that I made a mistake during merge, wrong category name used for Alarm.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
