### PR TITLE
Clarify MDI version currently used by HA

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -58,7 +58,7 @@ entity_picture:
   required: false
   type: string
 icon:
-  description: Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://materialdesignicons.com/cheatsheet)). Prefix name with `mdi:`, ie `mdi:home`.
+  description: Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com)'s v.3.0.39 ([Cheatsheet](https://cdn.materialdesignicons.com/3.0.39/)). Prefix name with `mdi:`, ie `mdi:home`.
   required: false
   type: string
 assumed_state:


### PR DESCRIPTION
HA is currently using [mdi 3.0.39](https://cdn.materialdesignicons.com/3.0.39/), which is not the current one.
As per https://github.com/home-assistant/home-assistant-polymer/issues/2684

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
