### PR TITLE
Simplifying the `for:` section

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -73,7 +73,7 @@ automation:
     above: 17
     below: 25
 
-    # If given, will trigger when condition has been for X time.
+    # If given, will trigger when condition has been for X time, can also use days and milliseconds.
     for:
       hours: 1
       minutes: 10
@@ -85,6 +85,25 @@ automation:
 Listing above and below together means the numeric_state has to be between the two values.
 In the example above, a numeric_state that goes to 17.1-24.9 (from 17 or below, or 25 or above) would fire this trigger.
 </p>
+
+The `for:` can also be specified as `HH:MM:SS` like this:
+
+{% raw %}
+```yaml
+automation:
+  trigger:
+    platform: numeric_state
+    entity_id: sensor.temperature
+    # Optional
+    value_template: '{{ state.attributes.battery }}'
+    # At least one of the following required
+    above: 17
+    below: 25
+
+    # If given, will trigger when condition has been for X time.
+    for: '01:10:05'
+```
+{% endraw %}
 
 ### {% linkable_title State trigger %}
 
@@ -101,10 +120,7 @@ automation:
     to: 'home'
 
     # If given, will trigger when state has been the to state for X time.
-    for:
-      hours: 1
-      minutes: 10
-      seconds: 5
+    for: '01:10:05'
 ```
 
 <p class='note warning'>


### PR DESCRIPTION
The `for:` piece can be confusing for folks, providing the examples as human readable time, and mentioning that days and milliseconds are also supported.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
