### PR TITLE
Added note about compilation issues

### DIFF
--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -60,6 +60,10 @@ After updating the firmware of your IKEA Trådfri Gateway it might be necessary 
 
 ### {% linkable_title Compilation issues %}
 
+<p class='note'>
+  This does not apply to Hass.io or Docker
+</p>
+
 Please make sure you have `autoconf` installed (`$ sudo apt-get install autoconf`) if you want to use this component. Also, installing some dependencies might take considerable time (>1 h) on slow devices.
 
 ### {% linkable_title Setting the `api_key` %}

--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -27,7 +27,7 @@ The `tradfri` component support the IKEA Trådfri Gateway (a.k.a. IKEA Tradfri h
 You will be prompted to configure the gateway through the Home Assistant interface. The configuration process is very simple, when prompted, enter the security key printed on the physical sticker that is on the bottom of the IKEA Trådfri Gateway, then click configure.
 
 <p class='note'>
-If you see an "Unable to connect" message, restart the gateway and try again. Don't forget to assign a permanent IP to your IKEA Trådfri Gateway in your router / DHCP-server.
+If you see an "Unable to connect" message, restart the gateway and try again. Don't forget to assign a permanent IP address to your IKEA Trådfri Gateway in your router / DHCP-server.
 </p>
 
 ## {% linkable_title Configuration %}
@@ -61,7 +61,7 @@ After updating the firmware of your IKEA Trådfri Gateway it might be necessary 
 ### {% linkable_title Compilation issues %}
 
 <p class='note'>
-  This does not apply to Hass.io or Docker
+  This does not apply to Hass.io or Docker.
 </p>
 
 Please make sure you have `autoconf` installed (`$ sudo apt-get install autoconf`) if you want to use this component. Also, installing some dependencies might take considerable time (>1 h) on slow devices.


### PR DESCRIPTION
Adding a note that the need to install `autoconf` doesn't apply to Hass.io/Docker.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
