### PR TITLE
Updated automation to switch tariffs

### DIFF
--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -117,25 +117,18 @@ a time based automation can be used:
 
 ```yaml
 automation:  
-  - alias: switch_tariff
-    initial_state: true
-    trigger:
-      - platform: homeassistant
-        event: start
-      - platform: time
-        at: '09:00:00'
-      - platform: time
-        at: '21:00:00'
-      - platform: state
-        entity_id: sensor.tariff
-    action:
-      - service: utility_meter.select_tariff
-        data_template:
-          entity_id: 'utility_meter.daily_energy'
-          tariff: '{%- if 9<= (now().strftime("%-H") | int) < 21 -%}peak{%- else -%}offpeak{%- endif -%}'
-      - service: utility_meter.select_tariff
-        data_template:
-          entity_id: 'utility_meter.monthly_energy'
-          tariff: '{%- if 9<= (now().strftime("%-H") | int) < 21 -%}peak{%- else -%}offpeak{%- endif -%}'
-
+  alias: switch_tariff
+  initial_state: true
+  trigger:
+    - platform: homeassistant
+      event: start
+    - platform: time
+      at: '09:00:00'
+    - platform: time
+      at: '21:00:00'
+  action:
+    - service: utility_meter.select_tariff
+      data_template:
+        entity_id: utility_meter.daily_energy, utility_meter.monthly_energy
+        tariff: '{%- if 9<= (now().strftime("%-H") | int) < 21 -%}peak{%- else -%}offpeak{%- endif -%}'
 ``` 

--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -117,14 +117,25 @@ a time based automation can be used:
 
 ```yaml
 automation:  
-  trigger:
-    - platform: time
-      at: '09:00:00'
-    - platform: time
-      at: '21:00:00'
-  action:
-    - service: utility_meter.next_tariff
-      entity_id: utility_meter.daily_energy 
-    - service: utility_meter.next_tariff
-      entity_id: utility_meter.monthly_energy
+  - alias: switch_tariff
+    initial_state: true
+    trigger:
+      - platform: homeassistant
+        event: start
+      - platform: time
+        at: '09:00:00'
+      - platform: time
+        at: '21:00:00'
+      - platform: state
+        entity_id: sensor.tariff
+    action:
+      - service: utility_meter.select_tariff
+        data_template:
+          entity_id: 'utility_meter.daily_energy'
+          tariff: '{%- if 9<= (now().strftime("%-H") | int) < 21 -%}peak{%- else -%}offpeak{%- endif -%}'
+      - service: utility_meter.select_tariff
+        data_template:
+          entity_id: 'utility_meter.monthly_energy'
+          tariff: '{%- if 9<= (now().strftime("%-H") | int) < 21 -%}peak{%- else -%}offpeak{%- endif -%}'
+
 ``` 

--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -114,10 +114,34 @@ Assuming your energy provider tariffs are time based according to:
 - *offpeak*: from 21h00 to 9h00 next day 
 
 a time based automation can be used:
-
 ```yaml
 automation:  
-  alias: switch_tariff
+  - alias: switch_tariff
+    initial_state: true
+    trigger:
+      - platform: homeassistant
+        event: start
+      - platform: time
+        at: '09:00:00'
+      - platform: time
+        at: '21:00:00'
+      - platform: state
+        entity_id: sensor.tariff
+    action:
+      - service: utility_meter.select_tariff
+        data_template:
+          entity_id: 'utility_meter.daily_energy'
+          tariff: '{%- if 9<= (now().strftime("%-H") | int) < 21 -%}peak{%- else -%}offpeak{%- endif -%}'
+      - service: utility_meter.select_tariff
+        data_template:
+          entity_id: 'utility_meter.monthly_energy'
+          tariff: '{%- if 9<= (now().strftime("%-H") | int) < 21 -%}peak{%- else -%}offpeak{%- endif -%}'
+``` 
+
+Or if you want to set the exact tariff and avoid wrong tariff switch if the desired switch time was missed (for example power outage):
+```yaml
+automation:  
+  alias: set_tariff
   initial_state: true
   trigger:
     - platform: homeassistant


### PR DESCRIPTION
Great sensor, automation is checking the condition after HA start (to avoid wrong tariff) and then triggers on the time of tariff change.
It would be great if tariff time would be possible to configure within a sensor setup

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
