### PR TITLE
Update input_datetime format description

### DIFF
--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -114,8 +114,9 @@ automation:
 {% endraw %}
 
 To dynamically set the `input_datetime` you can call
-`input_datetime.set_datetime`. The following example can be used in an
-automation rule:
+`input_datetime.set_datetime`. The values for `date` and `time` must be in a certain format for the call to be successful.
+You can use either `strftime("%Y-%m-%d")`/`strftime("%H:%M:%S")` or `timestamp_custom("%Y-%m-%d", true)`/`timestamp_custom("%H:%M:%S", true)` filter respectively.
+The following example can be used in an automation rule:
 
 ```yaml
 # Example configuration.yaml entry
@@ -126,8 +127,23 @@ automation:
     entity_id: input_boolean.example
     to: 'on'
   action:
-    service: input_datetime.set_datetime
+  - service: input_datetime.set_datetime
     entity_id: input_datetime.bedroom_alarm_clock_time
     data:
       time: '05:30:00'
+  - service: input_datetime.set_datetime
+    entity_id: input_datetime.another_time
+    data_template:
+      time: '{{ now().strftime("%H:%M:%S") }}'
+  - service: input_datetime.set_datetime
+    entity_id: input_datetime.another_date
+    data_template:
+      date: '{{ now().strftime("%Y-%m-%d") }}'
+  - service: input_datetime.set_datetime
+    data_template:
+     entity_id: input_datetime.date_and_time
+      date: >
+        {{ now().timestamp() | timestamp_custom("%Y-%m-%d", true) }}
+      time: >
+        {{ now().timestamp() | timestamp_custom("%H:%M:%S", true) }}
 ```

--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -118,6 +118,7 @@ To dynamically set the `input_datetime` you can call
 You can use either `strftime("%Y-%m-%d")`/`strftime("%H:%M:%S")` or `timestamp_custom("%Y-%m-%d", true)`/`timestamp_custom("%H:%M:%S", true)` filter respectively.
 The following example can be used in an automation rule:
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 # Sets input_datetime to '05:30' when an input_boolean is turned on.
@@ -147,3 +148,4 @@ automation:
       time: >
         {{ now().timestamp() | timestamp_custom("%H:%M:%S", true) }}
 ```
+{% endraw %}


### PR DESCRIPTION
Added description of correct format of date/time variables with automation examples.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
