### PR TITLE
Fix octoprint number_of_tools default value

### DIFF
--- a/source/_components/octoprint.markdown
+++ b/source/_components/octoprint.markdown
@@ -68,7 +68,7 @@ octoprint:
       description: Number of temperature adjustable tools, e.g., nozzle.
       required: false
       type: integer
-      default: 1
+      default: 0
     sensors:
       description: Configuration for the sensors.
       required: false


### PR DESCRIPTION
**Description:**
Default value for `number_of_tools` options is 0 in code. ( https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/octoprint.py#L87 )

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
