### PR TITLE
Added components to Homematic IP Overview

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -64,7 +64,7 @@ authtoken:
     - Security zones (*HmIP-SecurityZone*)
 
 - homematicip_cloud.binary_sensor  
-    - Window and door contact (*HmIP-SWDO*)
+    - Window and door contact (*HmIP-SWDO, HmIP-SWDO-I*)
     - Rotary Handle Sensor (*HmIP-SRH*)
     - Smoke sensor and alarm (*HmIP-SWSD*)
     - Motion detectors (*HmIP-SMI*)
@@ -86,6 +86,8 @@ authtoken:
     - Temperature and humidity Sensor with display (*HmIP-STHD*)
     - Outdoor temperature and humidity sensor (*HmIP-STHO*)
     - Illuminance sensor (*HmIP-SMI, 55*)
+    - Light sensor (HmIP-SLO*)
   
 - homematicip_cloud.switch
     - Pluggable Switch and Meter (*HmIP-PSM*)
+    - Full flush Switch and Meter (*HmIP-FSM, HmIP-FSM16*)

--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -86,7 +86,7 @@ authtoken:
     - Temperature and humidity Sensor with display (*HmIP-STHD*)
     - Outdoor temperature and humidity sensor (*HmIP-STHO*)
     - Illuminance sensor (*HmIP-SMI, 55*)
-    - Light sensor (HmIP-SLO*)
+    - Light sensor Outdoor (HmIP-SLO*)
   
 - homematicip_cloud.switch
     - Pluggable Switch and Meter (*HmIP-PSM*)

--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -86,7 +86,7 @@ authtoken:
     - Temperature and humidity Sensor with display (*HmIP-STHD*)
     - Outdoor temperature and humidity sensor (*HmIP-STHO*)
     - Illuminance sensor (*HmIP-SMI, 55*)
-    - Light sensor Outdoor (HmIP-SLO*)
+    - Light sensor Outdoor (*HmIP-SLO*)
   
 - homematicip_cloud.switch
     - Pluggable Switch and Meter (*HmIP-PSM*)


### PR DESCRIPTION
Added additional HmIP components to overview


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20747

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
