### PR TITLE
Fix Typo

### DIFF
--- a/source/_docs/installation/hassbian/common-tasks.markdown
+++ b/source/_docs/installation/hassbian/common-tasks.markdown
@@ -11,7 +11,7 @@ redirect_from: /docs/hassbian/common-tasks/
 ---
 
 ### {% linkable_title Login to the Raspberry Pi %}
-To login to your Raspberry Pi running Hassbian you're going to be using a ssh client. Depending on your platform there are several alternatives for doing this. Linux and Max OS generally have a ssh client installed. Windows users are recommended to download and install the ssh client [Putty][ssh-putty].
+To login to your Raspberry Pi running Hassbian you're going to be using a ssh client. Depending on your platform there are several alternatives for doing this. Linux and Mac OS generally have a ssh client installed. Windows users are recommended to download and install the ssh client [Putty][ssh-putty].
 
 Connect to the Raspberry Pi over ssh. Default user name is `pi` and password is `raspberry`.
 Linux and Mac OS users execute the following command in a terminal.


### PR DESCRIPTION
Changed "Max OS" to "Mac OS"

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
