### PR TITLE
 Recommendations on lost connection detection

### DIFF
--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -406,7 +406,7 @@ When the connection to your HomeMatic CCU or Homegear is lost, Home Assistant wi
         service: homematic.reconnect
   ```
 
-- If you have a CCU you can also create a system variable on the CCU, which stores its last reboot time. Since Home Assistant can still refresh system variables from the CCU (even after a reboot), this is a pretty reliable way to detect situations where you need to call *homematic.reconnect*. This is how this can be done:
+- If you have a CCU you can also create a system variable on the CCU, which stores its last reboot time. Since Home Assistant can still refresh system variables from the CCU (even after a reboot). Even though this option might look preferrable to many **it is less fail-safe** than the former. Since the variable is only changed on boot any problem that causes the connection between Heom Assistant and the CCU to break will not be detected (eg. in case of Networking issues). This is how this can be done:
 
   1. Create a string variable **V_Last_Reboot** on the CCU
 

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -406,7 +406,7 @@ When the connection to your HomeMatic CCU or Homegear is lost, Home Assistant wi
         service: homematic.reconnect
   ```
 
-- If you have a CCU you can also create a system variable on the CCU, which stores its last reboot time. Since Home Assistant can still refresh system variables from the CCU (even after a reboot). Even though this option might look preferrable to many **it is less fail-safe** than the former. Since the variable is only changed on boot any problem that causes the connection between Heom Assistant and the CCU to break will not be detected (eg. in case of Networking issues). This is how this can be done:
+- If you have a CCU you can also create a system variable on the CCU, which stores its last reboot time. Since Home Assistant can still refresh system variables from the CCU (even after a reboot) this is another option to call *homematic.reconnect*. Even though this option might look preferrable to many since it does not rely on a sensor, **it is less fail-safe** than checking for updates of a sensor. Since the variable on the CCU is only changed on boot, any problem that causes the connection between Home Assistant and the CCU to break but will not result in a reboot will not be detected (eg. in case of networking issues). This is how this can be done:
 
   1. Create a string variable **V_Last_Reboot** on the CCU
 


### PR DESCRIPTION
**Description:**


After implementing the second option to detect lost connection I almost immediately ran into the issue that due to a network issue the connection between HASS and CCU was lost but HASS did not detect it.
Since Home Automation gas to be as reliable as possible I rephrased the introduction to the second option to address this problem and make anyone aware or this problem.