### PR TITLE
Remove config.yaml entry for Geofency

### DIFF
--- a/source/_components/geofency.md
+++ b/source/_components/geofency.md
@@ -17,28 +17,4 @@ This component sets up integration with [Geofency](http://www.geofency.com/). Ge
 
 Enabling this component will automatically enable the [Geofency Device Tracker](/components/device_tracker.geofency/).
 
-To integrate Geofency in Home Assistant, add the following section to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-geofency:
-```
-
-{% configuration %}
-mobile_beacons:
-  description: List of beacon names that are to be treated as *mobile*. The name must match the name you configure in Geofency. By default, beacons will be treated as *stationary*.
-  required: false
-  type: list
-{% endconfiguration %}
-
-A full sample configuration for the `geofency` component is shown below:
-
-```yaml
-# Example configuration.yaml entry
-geofency:
-  mobile_beacons:
-    - car
-    - keys
-```
-
 To configure Geofency, you must set it up via the integrations panel in the configuration screen. You must then configure the iOS app (via the Webhook feature) to send a POST request to your Home Assistant server at the webhook URL provided by the integration during setup. Use the default POST format. Make sure to enable the 'Update Geo-Position' functionality for mobile beacons.

--- a/source/_components/geofency.md
+++ b/source/_components/geofency.md
@@ -18,3 +18,22 @@ This component sets up integration with [Geofency](http://www.geofency.com/). Ge
 Enabling this component will automatically enable the [Geofency Device Tracker](/components/device_tracker.geofency/).
 
 To configure Geofency, you must set it up via the integrations panel in the configuration screen. You must then configure the iOS app (via the Webhook feature) to send a POST request to your Home Assistant server at the webhook URL provided by the integration during setup. Use the default POST format. Make sure to enable the 'Update Geo-Position' functionality for mobile beacons.
+
+When using mobile beacons (optional) an entry in `configuration.yaml` is still needed as this can't be added via the integrations panel.
+
+{% configuration %}
+mobile_beacons:
+  description: List of beacon names that are to be treated as *mobile*. The name must match the name you configure in Geofency. By default, beacons will be treated as *stationary*.
+  required: false
+  type: list
+{% endconfiguration %}
+
+A sample configuration for the `geofency` component when using mobile beacons is shown below:
+
+```yaml
+# Example configuration.yaml entry
+geofency:
+  mobile_beacons:
+    - car
+    - keys
+```


### PR DESCRIPTION
**Description:**
As part of PR home-assistant/home-assistant#20631 an entry in configuration.yaml is no longer necessary.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20631

cc: @rohankapoorcom

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
