### PR TITLE
Added required option to Utility Meter sample config

### DIFF
--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -30,6 +30,7 @@ To enable the Utility Meter Sensor in your installation, add the following to yo
 utility_meter:
   energy:
     source: sensor.energy_in_kwh
+    cycle: monthly
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:**

`cycle: ` is a required configuration option for this sensor, and was missing from the sample configuration.
Added `cycle: monthly` to the displayed sample configuration to make it a valid config.


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
