### PR TITLE
Add HmIP-BSL to Overview for homematicip cloud

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -78,6 +78,7 @@ authtoken:
 - homematicip_cloud.light
     - Switch actuator and meter for brand switches (*HmIP-BSM*)
     - Dimming actuator for brand switches (*HmIP-BDT*)
+    - Switch Actuator for brand switches – with signal lamp (*HmIP-BSL*)
   
 - homematicip_cloud.sensor
     - Accesspoint duty-cycle (*HmIP-HAP*)


### PR DESCRIPTION
**Description:**
- Added Device HmIP-BSL to Overview

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20865

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
