### PR TITLE
Add missing link to hass-cli blog post

### DIFF
--- a/source/_posts/2019-02-04-introducing-home-assistant-cli.markdown
+++ b/source/_posts/2019-02-04-introducing-home-assistant-cli.markdown
@@ -38,7 +38,7 @@ looking for to do from a CLI.
 
 ## Usage
 
-For the basic intro to `hass-cli` see the docs at https://github.com/home-assistant/home-assistant-cli.
+For the basic intro to `hass-cli` see the docs at [github](github-hass-cli).
 
 ## Installation
 


### PR DESCRIPTION
**Description:** Add a missing link for hass-cli blog post.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
