### PR TITLE
Fixing typo

### DIFF
--- a/source/_components/gpslogger.md
+++ b/source/_components/gpslogger.md
@@ -60,7 +60,7 @@ https://YOUR.DNS.HOSTNAME:PORT/api/webhook/WEBHOOK_ID
 ```text
 latitude=%LAT&longitude=%LON&device=%SER&accuracy=%ACC&battery=%BATT&speed=%SPD&direction=%DIR&altitude=%ALT&provider=%PROV&activity=%ACT
 ```
-- You can change the name of your device name by replacing `&device=%SER` with `&device=%DEVICE_NAME`.
+- You can change the name of your device name by replacing `&device=%SER` with `&device=DEVICE_NAME`.
 - Check that the **HTTP Headers** setting contains
 ```text
 Content-Type: application/x-www-form-urlencoded


### PR DESCRIPTION
There's no such variable as %DEVICE_NAME - originally it was just DEVICE_NAME to indicate to people to put the name there.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
