### PR TITLE
Update NGINX proxy documentation

### DIFF
--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -96,7 +96,7 @@ http:
   # Update this line to be your domain
   base_url: https://example.com
   use_x_forwarded_for: true
-  # You must set the trusted proxy IP address so that home-assistant will properly accept connections
+  # You must set the trusted proxy IP address so that Home Assistant will properly accept connections
   # Set this to your NGINX machine IP, or localhost if hosted on the same machine.
   trusted_proxies: <NGINX IP address here, or 127.0.0.1 if hosted on the same machine>
 ```

--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -89,14 +89,17 @@ Home Assistant is still available without using the NGINX proxy. Restricting it 
 
 On your `configuration.yaml` file, edit the `http` component.
 
-{% configuration %}
+```yaml
 http:
-  server_host: 127.0.0.1
+  # For extra security set this to only accept connections on localhost if NGINX is on the same machine
+  # server_host: 127.0.0.1
   # Update this line to be your domain
   base_url: https://exemple.com
   use_x_forwarded_for: true
-  trusted_proxies: 127.0.0.1
-{% endconfiguration %}
+  # You must set the trusted proxy IP address so that home-assistant will properly accept connections
+  # Set this to your NGINX machine IP, or localhost if hosted on the same machine.
+  trusted_proxies: <NGINX IP address here, or 127.0.0.1 if hosted on the same machine>
+```
 
 ### {% linkable_title NGINX Config %}
 

--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -94,7 +94,7 @@ http:
   # For extra security set this to only accept connections on localhost if NGINX is on the same machine
   # server_host: 127.0.0.1
   # Update this line to be your domain
-  base_url: https://exemple.com
+  base_url: https://example.com
   use_x_forwarded_for: true
   # You must set the trusted proxy IP address so that home-assistant will properly accept connections
   # Set this to your NGINX machine IP, or localhost if hosted on the same machine.


### PR DESCRIPTION
**Description:**

This fixes some of the formatting to allow the http component documentation to show up, and updates it with some more descriptive comments from #8026.

Other configuration.yaml blocks from this area (like https://github.com/home-assistant/home-assistant.io/blob/current/source/_docs/ecosystem/apache.markdown) appear to also use this style.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
