### PR TITLE
Update  OpenHardwareMonitor documentation (How to open port on host)

### DIFF
--- a/source/_components/sensor.openhardwaremonitor.markdown
+++ b/source/_components/sensor.openhardwaremonitor.markdown
@@ -38,5 +38,14 @@ sensor:
 
 <p class='note'>
 OpenHardwareMonitor must be running on the host, with "Remote web server" active.
-You also need to open an inbound port for (TCP 8085) in the advanced firewall settings.
+You also need to open inbound port(TCP 8085) on host in the advanced firewall settings.
+ To open port:
+1. Navigate to Control Panel, System and Security and Windows Firewall.
+2. Select Advanced settings and highlight Inbound Rules in the left pane.
+3. Right click Inbound Rules and select New Rule.
+4. Add the port you need to open and click Next.
+5. Add the protocol (TCP) and the port number(8085) into the next window and click Next.
+6. Select Allow the connection in the next window and hit Next.
+7. Select the network type as you see fit and click Next.
+8. Name the rule and click Finish.
 </p>

--- a/source/_components/sensor.openhardwaremonitor.markdown
+++ b/source/_components/sensor.openhardwaremonitor.markdown
@@ -39,7 +39,8 @@ sensor:
 <p class='note'>
 OpenHardwareMonitor must be running on the host, with "Remote web server" active.
 You also need to open inbound port(TCP 8085) on host in the advanced firewall settings.
- To open port:
+</p>
+ To open port(on Windows):
 1. Navigate to Control Panel, System and Security and Windows Firewall.
 2. Select Advanced settings and highlight Inbound Rules in the left pane.
 3. Right click Inbound Rules and select New Rule.
@@ -48,4 +49,4 @@ You also need to open inbound port(TCP 8085) on host in the advanced firewall se
 6. Select Allow the connection in the next window and hit Next.
 7. Select the network type as you see fit and click Next.
 8. Name the rule and click Finish.
-</p>
+


### PR DESCRIPTION
I add a guide on how to open port on the host machine in OpenHardwareMonitor.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
