### PR TITLE
Add missing config documentation for Spotify

### DIFF
--- a/source/_components/media_player.spotify.markdown
+++ b/source/_components/media_player.spotify.markdown
@@ -80,6 +80,11 @@ aliases:
   description: "Dictionary of device ids to be aliased, handy for devices that Spotify cannot properly determine the device name of. New devices will be logged to the `info` channel for ease of aliasing."
   required: false
   type: map
+name:
+  description: The name of the device used in the frontend.
+  required: false
+  type: string
+  default: Spotify
 {% endconfiguration %}
 
 ## {% linkable_title Setup %}


### PR DESCRIPTION
**Description:**
Spotify has a `name` configuration which is very useful in the case of multiple Spotify accounts.
It was not specified in the documentation


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
