### PR TITLE
Update sensor.synologydsm.markdown

### DIFF
--- a/source/_components/sensor.synologydsm.markdown
+++ b/source/_components/sensor.synologydsm.markdown
@@ -139,6 +139,10 @@ After booting Home Assistant it can take up to 15 minutes for the sensors to sho
 This sensor will wake up your Synology NAS if it's in hibernation mode.
 </p>
 
+<p class='note warning'>
+  If you set <b>ssl</b> to <b>false</b>, you <i>have</i> to also explicitly set <b>port</b> to <b>5000</b>
+</p>
+
 ## {% linkable_title Separate User Configuration %}
 
 Due to the nature of the Synology DSM API it is required to grant the user admin rights. This is related to the fact that utilization information is stored in the core module.

--- a/source/_components/sensor.synologydsm.markdown
+++ b/source/_components/sensor.synologydsm.markdown
@@ -140,7 +140,7 @@ This sensor will wake up your Synology NAS if it's in hibernation mode.
 </p>
 
 <p class='note warning'>
-  If you set <b>ssl</b> to <b>false</b>, you <i>have</i> to also explicitly set <b>port</b> to <b>5000</b>
+  If you set `ssl:` to `False`, you *have* to also explicitly set `port:` to **5000**.
 </p>
 
 ## {% linkable_title Separate User Configuration %}


### PR DESCRIPTION
add warning about changing default port in case SSL is turned off

**Description:**

People report problems using the sensor, stemming from the fact that default port value is 5001 which is HTTPS only. Until the code is able to help by changing the default port to 5000 if ssl is set to false, this warning will help.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
