### PR TITLE
Fix Ring sensor docs

### DIFF
--- a/source/_components/sensor.ring.markdown
+++ b/source/_components/sensor.ring.markdown
@@ -30,20 +30,21 @@ monitored_conditions:
   type: list
   required: false
   description: Conditions to display in the frontend. The following conditions can be monitored. If not specified, all conditions below will be enabled.
-  battery:
-     description: Return the battery level from device.
-  last_activity:
-     description: Return the timestamp from the last event captured (ding/motion/on demand) by the Ring doorbell camera.
-  last_ding:
-     description: Return the timestamp from the last time the Ring doorbell button was pressed.
-  last_motion:
-     description: Return the timestamp from the last motion event captured by the Ring doorbell camera.
-  volume:
-     description: Return the volume level from the device.
-  wifi_signal_category:
-     description: Return the WiFi signal level from the device.
-  wifi_signal_strength:
-     description: Return the WiFi signal strength (dBm) from the device.
+  keys:
+    battery:
+       description: Return the battery level from device.
+    last_activity:
+       description: Return the timestamp from the last event captured (ding/motion/on demand) by the Ring doorbell camera.
+    last_ding:
+       description: Return the timestamp from the last time the Ring doorbell button was pressed.
+    last_motion:
+       description: Return the timestamp from the last motion event captured by the Ring doorbell camera.
+    volume:
+       description: Return the volume level from the device.
+    wifi_signal_category:
+       description: Return the WiFi signal level from the device.
+    wifi_signal_strength:
+       description: Return the WiFi signal strength (dBm) from the device.
 {% endconfiguration %}
 
 Currently it supports doorbell, external chimes and stickup cameras.


### PR DESCRIPTION
**Description:**
The configuration is missing `keys`  and hence the `monitored_conditions` are empty currently. 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html