### PR TITLE
Document GTFS optional argument include_tomorrow

### DIFF
--- a/source/_components/sensor.gtfs.markdown
+++ b/source/_components/sensor.gtfs.markdown
@@ -69,4 +69,9 @@ offset:
   required: false
   default: 0
   type: [integer, time]
+include_tomorrow:
+  description: Also search through tomorrow's schedule if no more departures are set for today.
+  required: false
+  default: false
+  type: boolean
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Add optional variable `include_tomorrow` to GTFS sensor documentation.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20992

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
