### PR TITLE
New working device

### DIFF
--- a/source/_components/media_player.panasonic_viera.markdown
+++ b/source/_components/media_player.panasonic_viera.markdown
@@ -30,6 +30,7 @@ Currently known supported models:
 - TX-P50GT30Y
 - TX-P50GT60E
 - TH-32ES500
+- TX-42AS650
 
 If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.github.io/blob/next/source/_components/media_player.panasonic_viera.markdown).
 


### PR DESCRIPTION
Added TX-42AS650 to supported models.

**Home Assistant release:**
0.86.4
**Operating environment (Hass.io/Docker/Windows/etc.):**
Hass.io via docker on Xubuntu x64 Intel386
**Component:**
panasonic_viera

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
