### PR TITLE
Add SmartThings Lock platform docs

### DIFF
--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -14,6 +14,7 @@ ha_category:
   - Binary Sensor
   - Fan
   - Light
+  - Lock
   - Sensor
   - Switch
 ha_release: "0.87"
@@ -25,6 +26,8 @@ redirect_from:
   - /components/fan.smartthings/
   - /components/smartthings.light/
   - /components/light.smartthings/
+  - /components/smartthings.lock/
+  - /components/lock.smartthings/
   - /components/smartthings.sensor/
   - /components/sensor.smartthings/
   - /components/smartthings.switch/
@@ -109,6 +112,7 @@ SmartThings represents devices as a set of [capabilities](https://smartthings.de
 - [Binary Sensor](#binary-sensor)
 - [Fan](#fan) 
 - [Light](#light) 
+- [Lock](#lock)
 - [Sensor](#sensor) 
 - [Switch](#switch)
 
@@ -146,6 +150,10 @@ The SmartThings Light platform lets you control devices that have light-related 
 | [`switchLevel`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch-Level)            | `brightness` and `transition`
 | [`colorControl`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Color-Control)            | `color`
 | [`colorTemperature`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Color-Temperature)            | `color_temp`
+
+### {% linkable_title Lock %}
+
+The SmartThings Lock platform lets you control devices that have the [`lock`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Lock) capability, showing current lock status and supporting lock and unlock commands.
 
 ### {% linkable_title Sensor %}
 


### PR DESCRIPTION
**Description:**
Adds docs for the SmartThings Lock platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#20977

## Checklist:
- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
