### PR TITLE
Fix fastdotcom redirect_from param

### DIFF
--- a/source/_components/fastdotcom.markdown
+++ b/source/_components/fastdotcom.markdown
@@ -14,7 +14,7 @@ ha_category:
 featured: false
 ha_release: 0.88
 ha_iot_class: "Cloud Polling"
-redirect_form:
+redirect_from:
   - /components/sensor.fastdotcom/
 ---
 


### PR DESCRIPTION
**Description:**
There's a typo in `redirect_from` and the permissions got messed up on fastdotcom from #8377. Fixing both.

CC: @frenck 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
