### PR TITLE
Documentation for home-assistant/home-assistant-polymer#2489

### DIFF
--- a/source/_lovelace/map.markdown
+++ b/source/_lovelace/map.markdown
@@ -28,7 +28,7 @@ entities:
   type: list
 geo_location_sources:
   required: true
-  description: List of geolocation sources. All current entities with that source will be displayed on the map. See [Geolocation](/components/geo_location/) platform for valid sources. Either this or the `entities` configuration option is required.
+  description: List of geolocation sources. All current entities with that source will be displayed on the map. See [Geolocation](/components/geo_location/) platform for valid sources. Set to `all` to use all available sources. Either this or the `entities` configuration option is required.
   type: list
 title:
   required: false
@@ -51,7 +51,7 @@ default_zoom:
 
 <p class="note">
   The `default_zoom` value will be ignored if it is set higher than the current zoom level
-  after fitting all visible entity markers in the map window. In other words, this can only 
+  after fitting all visible entity markers in the map window. In other words, this can only
   be used to zoom the map _out_ by default.
 </p>
 


### PR DESCRIPTION
**Description:**
Documentation for home-assistant/home-assistant-polymer#2489

(I also removed random trailing whitespace)

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
