### PR TITLE
Update to reflect new Blink default scan interval

### DIFF
--- a/source/_components/blink.markdown
+++ b/source/_components/blink.markdown
@@ -50,7 +50,7 @@ password:
   required: true
   type: string
 scan_interval:
-  description: How frequently to query for new data. Defaults to 60 seconds.
+  description: How frequently to query for new data. Defaults to 300 seconds (5 minutes).
   required: false
   type: integer
 binary_sensors:
@@ -93,7 +93,7 @@ Below is an example showing every possible entry:
 blink:
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
-  scan_interval: 60
+  scan_interval: 300
   binary_sensors:
     monitored_conditions:
       - motion_enabled


### PR DESCRIPTION
**Description:**
Just updates default scan interval values 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21041

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].
