### PR TITLE
Enable GTFS state modes

### DIFF
--- a/source/_components/sensor.gtfs.markdown
+++ b/source/_components/sensor.gtfs.markdown
@@ -66,7 +66,7 @@ name:
   default: GTFS Sensor
   type: string
 mode:
-  description: You can choose how to display the state: `departure` (exact time), `timer` (in H:MM format), `countdown` (in minutes), `auto` (switches between _timer_ and _auto_ at the 1-hour mark). The unit of measurement will be **min** using _countdown_ or _auto_ when under 1 hour, otherwise will be blank.
+  description: "You can choose how to display the state: `departure` (exact time), `timer` (in H:MM format), `countdown` (in minutes), `auto` (switches between _timer_ and _auto_ at the 1-hour mark). The unit of measurement will be **min** using _countdown_ or _auto_ when under 1 hour, otherwise will be blank."
   required: false
   default: countdown
   type: string

--- a/source/_components/sensor.gtfs.markdown
+++ b/source/_components/sensor.gtfs.markdown
@@ -44,7 +44,6 @@ sensor:
     origin: STOP_ID
     destination: STOP_ID
     data: DATA_SOURCE
-    mode: auto
 ```
 
 {% configuration %}

--- a/source/_components/sensor.gtfs.markdown
+++ b/source/_components/sensor.gtfs.markdown
@@ -44,6 +44,7 @@ sensor:
     origin: STOP_ID
     destination: STOP_ID
     data: DATA_SOURCE
+    mode: auto
 ```
 
 {% configuration %}
@@ -63,6 +64,11 @@ name:
   description: Name to use in the frontend.
   required: false
   default: GTFS Sensor
+  type: string
+mode:
+  description: You can choose how to display the state: `departure` (exact time), `timer` (in H:MM format), `countdown` (in minutes), `auto` (switches between _timer_ and _auto_ at the 1-hour mark). The unit of measurement will be **min** using _countdown_ or _auto_ when under 1 hour, otherwise will be blank.
+  required: false
+  default: countdown
   type: string
 offset:
   description: A minimum delay to look for. If a departure is in less time than `offset`, it will be ignored.


### PR DESCRIPTION
**Description:**
This PR exposes an optional **mode** configuration variable that allows the state to either be the **departure** time in 24-hour format (`14:05`), a **timer** (`1:23`), the current **countdown** in minutes (default), or an **auto** mode that switches between _timer_ and _countdown_ at the 1-hour mark.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21053

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
