### PR TITLE
Improve mqtt.publish service documentation

### DIFF
--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -12,6 +12,20 @@ logo: mqtt.png
 
 The MQTT component will register the service `mqtt.publish` which allows publishing messages to MQTT topics. There are two ways of specifying your payload. You can either use `payload` to hard-code a payload or use `payload_template` to specify a [template](/topics/templating/) that will be rendered to generate the payload.
 
+### {% linkable_title Service `mqtt.publish` %}
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `topic` | no | Topic to publish payload to.
+| `payload` | yes | Payload to publish.
+| `payload_template` | yes | Template to render as payload value. Ignored if payload given.
+| `qos` | yes | Quality of Service to use.
+| `retain` | yes | If message should have the retain flag set. (default: false)
+
+<p class='note'>
+You need to include either payload or payload_template, but not both.
+</p>
+
 ```json
 {
   "topic": "home-assistant/light/1/command",
@@ -36,3 +50,14 @@ The MQTT component will register the service `mqtt.publish` which allows publish
   "payload":"{\"Status\":\"off\", \"Data\":\"something\"}"
 }
 ``` 
+
+Example of how to use `qos` and `retain`:
+
+```json
+{
+  "topic": "home-assistant/light/1/command",
+  "payload": "on",
+  "qos": 2,
+  "retain": true
+}
+```


### PR DESCRIPTION
**Description:**
Current documentation doesn't mention the qos or retain attributes. I've added a table of attributes and an example where they're both used.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
