### PR TITLE
Added docker command for RPI in updating.markdown

### DIFF
--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -32,6 +32,13 @@ For a Docker container, simply pull the latest one:
 $ sudo docker pull homeassistant/home-assistant:latest
 ```
 
+For a Raspberry Pi Docker container, simply pull the latest one:
+
+```bash
+$ sudo docker pull homeassistant/raspberrypi3-homeassistant:latest
+```
+
+
 After updating, you must start/restart Home Assistant for the changes to take effect. This means that you will have to restart `hass` itself or the [autostarting](/docs/autostart/) daemon (if applicable). Startup can take considerable amount of time (i.e. minutes) depending on your device. This is because all requirements are updated as well.
 
 [BRUH automation](http://www.bruhautomation.com) has created [a tutorial video](https://www.youtube.com/watch?v=tuG2rs1Cl2Y) explaining how to upgrade Home Assistant.


### PR DESCRIPTION
I almost ran out of disk space by pulling the main home-assistant docker image and not the RPi version.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
