### PR TITLE
👕Removes lists from Lovelace examples

### DIFF
--- a/source/_lovelace/alarm-panel.markdown
+++ b/source/_lovelace/alarm-panel.markdown
@@ -18,8 +18,8 @@ Screenshot of the Alarm Panel card.
 </p>
 
 ```yaml
-- type: alarm-panel
-  entity: alarm_control_panel.alarm
+type: alarm-panel
+entity: alarm_control_panel.alarm
 ```
 
 {% configuration %}
@@ -70,12 +70,12 @@ Screenshot of the Alarm Panel card.
 Define the State List:
 
 ```yaml
-- type: alarm-panel
-  name: House Alarm
-  entity: alarm_control_panel.alarm
-  states:
-    - arm_home
-    - arm_away
-    - arm_night
-    - armed_custom_bypass
+type: alarm-panel
+name: House Alarm
+entity: alarm_control_panel.alarm
+states:
+  - arm_home
+  - arm_away
+  - arm_night
+  - armed_custom_bypass
 ```

--- a/source/_lovelace/conditional.markdown
+++ b/source/_lovelace/conditional.markdown
@@ -47,18 +47,18 @@ Note: Conditions with more than one entity are treated as an 'and' condition. Th
 ### {% linkable_title Examples %}
 
 ```yaml
-- type: conditional
-  conditions:
-    - entity: light.bed_light
-      state: "on"
-    - entity: switch.decorative_lights
-      state_not: "off"
-  card:
-    type: entities
-    entities:
-      - device_tracker.demo_paulus
-      - cover.kitchen_window
-      - group.kitchen
-      - lock.kitchen_door
-      - light.bed_light
+type: conditional
+conditions:
+  - entity: light.bed_light
+    state: "on"
+  - entity: switch.decorative_lights
+    state_not: "off"
+card:
+  type: entities
+  entities:
+    - device_tracker.demo_paulus
+    - cover.kitchen_window
+    - group.kitchen
+    - lock.kitchen_door
+    - light.bed_light
 ```

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -155,35 +155,35 @@ icon:
 Entity rows:
 
 ```yaml
-- type: entities
-  title: Entities card sample
-  show_header_toggle: true
-  entities:
-    - entity: alarm_control_panel.alarm
-      name: Alarm Panel
-    - device_tracker.demo_paulus
-    - switch.decorative_lights
-    - group.all_lights
-    - group.all_locks
+type: entities
+title: Entities card sample
+show_header_toggle: true
+entities:
+  - entity: alarm_control_panel.alarm
+    name: Alarm Panel
+  - device_tracker.demo_paulus
+  - switch.decorative_lights
+  - group.all_lights
+  - group.all_locks
 ```
 
 Special rows:
 
 ```yaml
-- type: entities
-  title: Entities card sample
-  show_header_toggle: true
-  entities:
-    - type: call-service
-      icon: mdi:power
-      name: Bed light
-      action_name: Toggle light
-      service: light.toggle
-      service_data:
-        entity_id: light.bed_light
-    - type: divider
-    - type: weblink
-      name: Home Assistant
-      url: https://www.home-assistant.io/
-      icon: mdi:home-assistant
+type: entities
+title: Entities card sample
+show_header_toggle: true
+entities:
+  - type: call-service
+    icon: mdi:power
+    name: Bed light
+    action_name: Toggle light
+    service: light.toggle
+    service_data:
+      entity_id: light.bed_light
+  - type: divider
+  - type: weblink
+    name: Home Assistant
+    url: https://www.home-assistant.io/
+    icon: mdi:home-assistant
 ```

--- a/source/_lovelace/entity-button.markdown
+++ b/source/_lovelace/entity-button.markdown
@@ -18,12 +18,8 @@ Screenshot of the Entity Button card.
 </p>
 
 ```yaml
-- type: entity-button
-  entity: light.living_room
-- type: entity-button
-  entity: light.office
-- type: entity-button
-  entity: light.bedroom
+type: entity-button
+entity: light.living_room
 ```
 
 {% configuration %}
@@ -106,14 +102,14 @@ theme:
 Title and Script Service Example:
 
 ```yaml
-- type: entity-button
-  name: Turn Off Lights
-  tap_action:
-    action: call-service
-    service: script.turn_on
-    service_data:
-      entity_id: script.turn_off_lights
-  entity: script.turn_off_lights
+type: entity-button
+name: Turn Off Lights
+tap_action:
+  action: call-service
+  service: script.turn_on
+  service_data:
+    entity_id: script.turn_off_lights
+entity: script.turn_off_lights
 ```
 
 <p class='img'>

--- a/source/_lovelace/entity-filter.markdown
+++ b/source/_lovelace/entity-filter.markdown
@@ -48,29 +48,29 @@ show_empty:
 
 Show only active switches or lights in the house
 ```yaml
-- type: entity-filter
-  entities:
-    - entity: light.bed_light
-      name: Bed
-    - light.kitchen_lights
-    - light.ceiling_lights
-  state_filter:
-    - "on"
+type: entity-filter
+entities:
+  - entity: light.bed_light
+    name: Bed
+  - light.kitchen_lights
+  - light.ceiling_lights
+state_filter:
+  - "on"
 ```
 
 Show only people that are at home using [glance](/lovelace/glance/):
 
 ```yaml
-- type: entity-filter
-  entities:
-    - device_tracker.demo_paulus
-    - device_tracker.demo_anne_therese
-    - device_tracker.demo_home_boy
-  state_filter:
-    - home
-  card: 
-    type: glance
-    title: People at home
+type: entity-filter
+entities:
+  - device_tracker.demo_paulus
+  - device_tracker.demo_anne_therese
+  - device_tracker.demo_home_boy
+state_filter:
+  - home
+card:
+  type: glance
+  title: People at home
 ```
 
 <p class='img'>

--- a/source/_lovelace/gauge.markdown
+++ b/source/_lovelace/gauge.markdown
@@ -18,8 +18,8 @@ Screenshot of the gauge card.
 </p>
 
 ```yaml
-- type: gauge
-  entity: sensor.cpu_usage
+type: gauge
+entity: sensor.cpu_usage
 ```
 
 {% configuration %}
@@ -79,10 +79,10 @@ severity:
 Title and Unit of Measurement Example:
 
 ```yaml
-- type: gauge
-  name: CPU Usuage
-  unit: '%'
-  entity: sensor.cpu_usage
+type: gauge
+name: CPU Usuage
+unit: '%'
+entity: sensor.cpu_usage
 ```
 
 <p class='img'>
@@ -93,12 +93,12 @@ Screenshot of the gauge card with custom title and unit of measurement.
 Define the severity map:
 
 ```yaml
-- type: gauge
-  name: With Severity
-  unit: '%'
-  entity: sensor.cpu_usage
-  severity:
-    green: 0
-    yellow: 45
-    red: 85
+type: gauge
+name: With Severity
+unit: '%'
+entity: sensor.cpu_usage
+severity:
+  green: 0
+  yellow: 45
+  red: 85
 ```

--- a/source/_lovelace/glance.markdown
+++ b/source/_lovelace/glance.markdown
@@ -124,16 +124,16 @@ hold_action:
 Basic example:
 
 ```yaml
-- type: glance
-  title: Glance card sample
-  entities:
-    - binary_sensor.movement_backyard
-    - light.bed_light
-    - binary_sensor.basement_floor_wet
-    - sensor.outside_temperature
-    - light.ceiling_lights
-    - switch.ac
-    - lock.kitchen_door
+type: glance
+title: Glance card sample
+entities:
+  - binary_sensor.movement_backyard
+  - light.bed_light
+  - binary_sensor.basement_floor_wet
+  - sensor.outside_temperature
+  - light.ceiling_lights
+  - switch.ac
+  - lock.kitchen_door
 ```
 
 <p class='img'>
@@ -144,18 +144,18 @@ Screenshot of the glance card with custom title.
 Define entities as objects and apply a custom name:
 
 ```yaml
-- type: glance
-  title: Better names
-  entities:
-    - entity: binary_sensor.movement_backyard
-      name: Movement?
-    - light.bed_light
-    - binary_sensor.basement_floor_wet
-    - sensor.outside_temperature
-    - light.ceiling_lights
-    - switch.ac
-    - lock.kitchen_door
-    - entity: switch.wall_plug_switch
-      tap_action:
-        action: toggle
+type: glance
+title: Better names
+entities:
+  - entity: binary_sensor.movement_backyard
+    name: Movement?
+  - light.bed_light
+  - binary_sensor.basement_floor_wet
+  - sensor.outside_temperature
+  - light.ceiling_lights
+  - switch.ac
+  - lock.kitchen_door
+  - entity: switch.wall_plug_switch
+    tap_action:
+      action: toggle
 ```

--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -65,10 +65,10 @@ name:
 ## {% linkable_title Example %}
 
 ```yaml
-- type: history-graph
-  title: 'My Graph'
-  entities:
-    - sensor.outside_temperature
-    - entity: media_player.lounge_room
-      name: Main player
+type: history-graph
+title: 'My Graph'
+entities:
+  - sensor.outside_temperature
+  - entity: media_player.lounge_room
+    name: Main player
 ```

--- a/source/_lovelace/horizontal-stack.markdown
+++ b/source/_lovelace/horizontal-stack.markdown
@@ -26,14 +26,14 @@ cards:
 ## {% linkable_title Example %}
 
 ```yaml
-- type: horizontal-stack
-  cards:
-    - type: picture-entity
-      image: /local/bed_1.png
-      entity: light.ceiling_lights
-    - type: picture-entity
-      image: /local/bed_2.png
-      entity: light.bed_light
+type: horizontal-stack
+cards:
+  - type: picture-entity
+    image: /local/bed_1.png
+    entity: light.ceiling_lights
+  - type: picture-entity
+    image: /local/bed_2.png
+    entity: light.bed_light
 ```
 
 <p class='img'>

--- a/source/_lovelace/iframe.markdown
+++ b/source/_lovelace/iframe.markdown
@@ -44,7 +44,7 @@ title:
 ### {% linkable_title Examples %}
 
 ```yaml
-- type: iframe
-  url: https://grafana.localhost/d/000000027/worldping-endpoint-summary?var-probe=All&panelId=2&fullscreen&orgId=3&theme=light
-  aspect_ratio: 75%
+type: iframe
+url: https://grafana.localhost/d/000000027/worldping-endpoint-summary?var-probe=All&panelId=2&fullscreen&orgId=3&theme=light
+aspect_ratio: 75%
 ```

--- a/source/_lovelace/light.markdown
+++ b/source/_lovelace/light.markdown
@@ -19,10 +19,8 @@ Screenshot of the Light card.
 </p>
 
 ```yaml
-- type: light
-  entity: light.bedroom
-- type: light
-  entity: light.office
+type: light
+entity: light.bedroom
 ```
 
 {% configuration %}
@@ -46,12 +44,15 @@ name:
 Overwriting names example:
 
 ```yaml
-- type: light
-  entity: light.bedroom
-  name: Kids Bedroom
-- type: light
-  entity: light.office
-  name: My Office
+type: light
+entity: light.bedroom
+name: Kids Bedroom
+```
+
+```yaml
+type: light
+entity: light.office
+name: My Office
 ```
 
 <p class='img'>

--- a/source/_lovelace/map.markdown
+++ b/source/_lovelace/map.markdown
@@ -58,18 +58,18 @@ default_zoom:
 ## {% linkable_title Examples %}
 
 ```yaml
-- type: map
-  aspect_ratio: 16:9
-  default_zoom: 8
-  entities:
-    - device_tracker.demo_paulus
-    - zone.home
+type: map
+aspect_ratio: 16:9
+default_zoom: 8
+entities:
+  - device_tracker.demo_paulus
+  - zone.home
 ```
 
 ```yaml
-- type: map
-  geo_location_sources:
-    - nsw_rural_fire_service_feed
-  entities:
-    - zone.home
+type: map
+geo_location_sources:
+  - nsw_rural_fire_service_feed
+entities:
+  - zone.home
 ```

--- a/source/_lovelace/markdown.markdown
+++ b/source/_lovelace/markdown.markdown
@@ -36,9 +36,9 @@ title:
 ## {% linkable_title Example %}
 
 ```yaml
-- type: markdown
-  content: >
-    ## Lovelace
+type: markdown
+content: >
+  ## Lovelace
 
-    Starting with Home Assistant 0.72, we're experimenting with a new way of defining your interface. We're calling it the **Lovelace UI**.
+  Starting with Home Assistant 0.72, we're experimenting with a new way of defining your interface. We're calling it the **Lovelace UI**.
 ```

--- a/source/_lovelace/media-control.markdown
+++ b/source/_lovelace/media-control.markdown
@@ -31,6 +31,6 @@ entity:
 ## {% linkable_title Example %}
 
 ```yaml
-- type: media-control
-  entity: media_player.lounge_room
+type: media-control
+entity: media_player.lounge_room
 ```

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -461,91 +461,91 @@ hold_action:
 ## {% linkable_title Example %}
 
 ```yaml
-- type: picture-elements
-  image: /local/floorplan.png
-  elements:
-    - type: state-icon
-      tap_action:
-        action: toggle
-      entity: light.ceiling_lights
-      style:
-        top: 47%
-        left: 42%
-    - type: state-icon
-      tap_action:
-        action: toggle
-      entity: light.kitchen_lights
-      style:
-        top: 30%
-        left: 15%
-    - type: state-label
-      entity: sensor.outside_temperature
-      style:
-        top: 82%
-        left: 79%
-    - type: service-button
-      title: Turn lights off
-      style:
-        top: 95%
-        left: 60%
-      service: homeassistant.turn_off
-      service_data:
-        entity_id: group.all_lights
-    - type: icon
-      icon: mdi:home
-      tap_action:
-        action: navigate
-        navigation_path: /lovelace/0
-      style:
-        top: 10%
-        left: 10%
+type: picture-elements
+image: /local/floorplan.png
+elements:
+  - type: state-icon
+    tap_action:
+      action: toggle
+    entity: light.ceiling_lights
+    style:
+      top: 47%
+      left: 42%
+  - type: state-icon
+    tap_action:
+      action: toggle
+    entity: light.kitchen_lights
+    style:
+      top: 30%
+      left: 15%
+  - type: state-label
+    entity: sensor.outside_temperature
+    style:
+      top: 82%
+      left: 79%
+  - type: service-button
+    title: Turn lights off
+    style:
+      top: 95%
+      left: 60%
+    service: homeassistant.turn_off
+    service_data:
+      entity_id: group.all_lights
+  - type: icon
+    icon: mdi:home
+    tap_action:
+      action: navigate
+      navigation_path: /lovelace/0
+    style:
+      top: 10%
+      left: 10%
 ```
 
 ## {% linkable_title Images Example %}
 
 ```yaml
-- type: picture-elements
-  image: /local/floorplan.png
-  elements:
-    # state_image & state_filter - toggle on click
-    - type: image
-      entity: light.living_room
-      tap_action:
-        action: toggle
-      image: /local/living_room.png
-      state_image:
-        "off": /local/living_room_off.png
-      filter: saturate(.8)
-      state_filter:
-        "on": brightness(120%) saturate(1.2)
-       style:
-         top: 25%
-         left: 75%
-         width: 15%
-    # Camera, red border, rounded-rectangle - show more-info on click
-    - type: image
-      entity: camera.driveway_camera
-      camera_image: camera.driveway_camera
+type: picture-elements
+image: /local/floorplan.png
+elements:
+  # state_image & state_filter - toggle on click
+  - type: image
+    entity: light.living_room
+    tap_action:
+      action: toggle
+    image: /local/living_room.png
+    state_image:
+      "off": /local/living_room_off.png
+    filter: saturate(.8)
+    state_filter:
+      "on": brightness(120%) saturate(1.2)
       style:
-        top: 5%
-        left: 10%
-        width: 10%
-        border: 2px solid red
-        border-radius: 10%
-    # Single image, state_filter - call-service on click
-    - type: image
-      entity: media_player.living_room
-      tap_action:
-        action: call-service
-        service: media_player.media_play_pause
-        service_data:
-          entity_id: media_player.living_room
-      image: /local/television.jpg
-      filter: brightness(5%)
-      state_filter:
-        playing: brightness(100%)
-      style:
-        top: 40%
+        top: 25%
         left: 75%
-        width: 5%
+        width: 15%
+  # Camera, red border, rounded-rectangle - show more-info on click
+  - type: image
+    entity: camera.driveway_camera
+    camera_image: camera.driveway_camera
+    style:
+      top: 5%
+      left: 10%
+      width: 10%
+      border: 2px solid red
+      border-radius: 10%
+  # Single image, state_filter - call-service on click
+  - type: image
+    entity: media_player.living_room
+    tap_action:
+      action: call-service
+      service: media_player.media_play_pause
+      service_data:
+        entity_id: media_player.living_room
+    image: /local/television.jpg
+    filter: brightness(5%)
+    state_filter:
+      playing: brightness(100%)
+    style:
+      top: 40%
+      left: 75%
+      width: 5%
 ```

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -113,17 +113,17 @@ hold_action:
 Basic example:
 
 ```yaml
-- type: picture-entity
-  entity: light.bed_light
-  image: /local/bed_light.png
+type: picture-entity
+entity: light.bed_light
+image: /local/bed_light.png
 ```
 
 Different images for each state:
 
 ```yaml
-- type: picture-entity
-  entity: light.bed_light
-  state_image:
-    "on": /local/bed_light_on.png
-    "off": /local/bed_light_off.png
+type: picture-entity
+entity: light.bed_light
+state_image:
+  "on": /local/bed_light_on.png
+  "off": /local/bed_light_off.png
 ```

--- a/source/_lovelace/picture-glance.markdown
+++ b/source/_lovelace/picture-glance.markdown
@@ -125,47 +125,47 @@ icon:
 ## {% linkable_title Examples %}
 
 ```yaml
-- type: picture-glance
-  title: Living room
-  entities:
-    - switch.decorative_lights
-    - light.ceiling_lights
-    - lock.front_door
-    - binary_sensor.movement_backyard
-    - binary_sensor.basement_floor_wet
-  image: /local/living_room.png
+type: picture-glance
+title: Living room
+entities:
+  - switch.decorative_lights
+  - light.ceiling_lights
+  - lock.front_door
+  - binary_sensor.movement_backyard
+  - binary_sensor.basement_floor_wet
+image: /local/living_room.png
 ```
 
 Display a camera image as background:
 
 ```yaml
-- type: picture-glance
-  title: Living room
-  entities:
-    - switch.decorative_lights
-    - light.ceiling_lights
-  camera_image: camera.demo_camera
+type: picture-glance
+title: Living room
+entities:
+  - switch.decorative_lights
+  - light.ceiling_lights
+camera_image: camera.demo_camera
 ```
 
 Display a camera image without additional entities:
 
 ```yaml
-- type: picture-glance
-  title: Front garden
-  entities: []
-  camera_image: camera.front_garden_camera
+type: picture-glance
+title: Front garden
+entities: []
+camera_image: camera.front_garden_camera
 ```
 
 Use different images based on entity state:
 
 ```yaml
-- type: picture-glance
-  title: Living room
-  entities:
-    - switch.decorative_lights
-    - light.ceiling_lights
-  state_image:
-    "on": /local/living_room_on.png
-    "off": /local/living_room_off.png
-  entity: group.living.room
+type: picture-glance
+title: Living room
+entities:
+  - switch.decorative_lights
+  - light.ceiling_lights
+state_image:
+  "on": /local/living_room_on.png
+  "off": /local/living_room_off.png
+entity: group.living.room
 ```

--- a/source/_lovelace/picture.markdown
+++ b/source/_lovelace/picture.markdown
@@ -83,11 +83,11 @@ hold_action:
 Navigate to another view:
 
 ```yaml
-- type: picture
-  image: /local/home.jpg
-  tap_action:
-    action: navigate
-    navigation_path: /lovelace/home
+type: picture
+image: /local/home.jpg
+tap_action:
+  action: navigate
+  navigation_path: /lovelace/home
 ```
 
 Check the [views](/lovelace/views/) setup on how to setup custom IDs.
@@ -95,9 +95,9 @@ Check the [views](/lovelace/views/) setup on how to setup custom IDs.
 Toggle entity using a service:
 
 ```yaml
-- type: picture
-  image: /local/light.png
-  service: light.toggle
-  service_data:
-    entity_id: light.ceiling_lights
+type: picture
+image: /local/light.png
+service: light.toggle
+service_data:
+  entity_id: light.ceiling_lights
 ```

--- a/source/_lovelace/plant-status.markdown
+++ b/source/_lovelace/plant-status.markdown
@@ -36,6 +36,6 @@ name:
 ## {% linkable_title Example %}
 
 ```yaml
-- type: plant-status
-  entity: plant.bonsai
+type: plant-status
+entity: plant.bonsai
 ```

--- a/source/_lovelace/sensor.markdown
+++ b/source/_lovelace/sensor.markdown
@@ -61,7 +61,7 @@ theme:
 ## {% linkable_title Example %}
 
 ```yaml
-- type: sensor
-  entity: sensor.illumination
-  name: Illumination
+type: sensor
+entity: sensor.illumination
+name: Illumination
 ```

--- a/source/_lovelace/shopping-list.markdown
+++ b/source/_lovelace/shopping-list.markdown
@@ -20,7 +20,7 @@ Screenshot of the Shopping List card.
 </p>
 
 ```yaml
-- type: shopping-list
+type: shopping-list
 ```
 
 {% configuration %}
@@ -39,6 +39,6 @@ title:
 Title Example:
 
 ```yaml
-- type: shopping-list
-  title: Shopping List
+type: shopping-list
+title: Shopping List
 ```

--- a/source/_lovelace/thermostat.markdown
+++ b/source/_lovelace/thermostat.markdown
@@ -36,6 +36,6 @@ name:
 ## {% linkable_title Example %}
 
 ```yaml
-- type: thermostat
-  entity: climate.nest
+type: thermostat
+entity: climate.nest
 ```

--- a/source/_lovelace/vertical-stack.markdown
+++ b/source/_lovelace/vertical-stack.markdown
@@ -28,14 +28,14 @@ cards:
 Basic example:
 
 ```yaml
-- type: vertical-stack
-  cards:
-    - type: picture-entity
-      entity: camera.demo_camera
-      show_info: false
-    - type: entities
-      entities:
-        - binary_sensor.movement_backyard
+type: vertical-stack
+cards:
+  - type: picture-entity
+    entity: camera.demo_camera
+    show_info: false
+  - type: entities
+    entities:
+      - binary_sensor.movement_backyard
 ```
 
 <p class="img">
@@ -46,19 +46,19 @@ Basic example:
 Combination of vertical and horizontal stack card:
 
 ```yaml
-- type: vertical-stack
-  cards:
-    - type: picture-entity
-      entity: group.all_lights
-      image:  /local/house.png
-    - type: horizontal-stack
-      cards:
-        - type: picture-entity
-          entity: light.ceiling_lights
-          image: /local/bed_1.png
-        - type: picture-entity
-          entity: light.bed_light
-          image: /local/bed_2.png
+type: vertical-stack
+cards:
+  - type: picture-entity
+    entity: group.all_lights
+    image:  /local/house.png
+  - type: horizontal-stack
+    cards:
+      - type: picture-entity
+        entity: light.ceiling_lights
+        image: /local/bed_1.png
+      - type: picture-entity
+        entity: light.bed_light
+        image: /local/bed_2.png
 ```
 
 <p class="img">

--- a/source/_lovelace/weather-forecast.markdown
+++ b/source/_lovelace/weather-forecast.markdown
@@ -36,8 +36,8 @@ name:
 {% linkable_title Example %}
 
 ```yaml
-- type: weather-forecast
-  entity: weather.dark_sky
+type: weather-forecast
+entity: weather.dark_sky
 ```
 
 <p class="note">


### PR DESCRIPTION
**Description:**

Removes all lists from the Lovelace examples (`-`) in front of each card.
This should be removed as the UI editor doesn't work with an array and makes copying and pasting difficult.

Closes #8429 

CC: @bramkragten 

Personal reference: `frenck-2019-0022`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
