### PR TITLE
Add index configuration

### DIFF
--- a/source/_components/sensor.scrape.markdown
+++ b/source/_components/sensor.scrape.markdown
@@ -38,6 +38,11 @@ attribute:
   description: Get value of an attribute on the selected tag.
   required: false
   type: string
+index:
+  description: Defines which of the elements returned by the CSS selector to use.
+  required: false
+  default: 0
+  type: integer
 name:
   description: Name of the sensor.
   required: false


### PR DESCRIPTION
**Description:**

Adds an index configuration variable for cases where the CSS selector
returns more than one result.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21084

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
