### PR TITLE
✏️ Change ha_category for Mysensor platforms

### DIFF
--- a/source/_components/binary_sensor.mysensors.markdown
+++ b/source/_components/binary_sensor.mysensors.markdown
@@ -8,7 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: mysensors.png
-ha_category: DIY
+ha_category: 
+  - DIY
+  - Binary Sensor
 ha_release: 0.14
 ha_iot_class: "Local Push"
 ---

--- a/source/_components/climate.mysensors.markdown
+++ b/source/_components/climate.mysensors.markdown
@@ -8,7 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: mysensors.png
-ha_category: DIY
+ha_category:
+  - DIY
+  - Climate
 ha_release: 0.29
 ha_iot_class: "Local Push"
 ---

--- a/source/_components/cover.mysensors.markdown
+++ b/source/_components/cover.mysensors.markdown
@@ -8,7 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: mysensors.png
-ha_category: DIY
+ha_category:
+  - DIY
+  - Cover
 ha_release: "0.30"
 ha_iot_class: "Local Push"
 ---

--- a/source/_components/device_tracker.mysensors.markdown
+++ b/source/_components/device_tracker.mysensors.markdown
@@ -8,7 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: mysensors.png
-ha_category: DIY
+ha_category:
+  - DIY
+  - Presence Detection
 ha_release: "0.38"
 ha_iot_class: "Local Push"
 ---

--- a/source/_components/light.mysensors.markdown
+++ b/source/_components/light.mysensors.markdown
@@ -8,7 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: mysensors.png
-ha_category: DIY
+ha_category:
+  - DIY
+  - Light
 ha_release: 0.13
 ha_iot_class: "Local Push"
 ---

--- a/source/_components/notify.mysensors.markdown
+++ b/source/_components/notify.mysensors.markdown
@@ -8,7 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: mysensors.png
-ha_category: DIY
+ha_category:
+  - DIY
+  - Notifications
 ha_release: 0.36
 ha_iot_class: "Local Push"
 ---

--- a/source/_components/sensor.mysensors.markdown
+++ b/source/_components/sensor.mysensors.markdown
@@ -8,7 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: mysensors.png
-ha_category: DIY
+ha_category:
+  - DIY
+  - Sensor
 featured: false
 ha_iot_class: "Local Push"
 ---

--- a/source/_components/switch.mysensors.markdown
+++ b/source/_components/switch.mysensors.markdown
@@ -8,7 +8,9 @@ comments: false
 sharing: true
 footer: true
 logo: mysensors.png
-ha_category: DIY
+ha_category:
+  - DIY
+  - Switch
 featured: false
 ha_iot_class: "Local Push"
 ---


### PR DESCRIPTION
**Description:**
The `ha_category` adjusted so that the platforms are also shown in the categories where they should appear.

Related to: #8593  

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
