### PR TITLE
Add /secure path to host files need access with authentication

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -174,6 +174,11 @@ directory called `www` under the configuration path (`/config` on Hass.io,
 following URL `http://your.domain:8123/local/`, for example `audio.mp3` would
 be accessed as `http://your.domain:8123/local/audio.mp3`.
 
+You can also create a `www_secure` directory under the configuration path to 
+host files can be accessed by the following URL `http://your.domain:8123/secure/`
+with [authentication](developers/auth_api#making-authenticated-requests). 
+
 <p class='note'>
-  If you've had to create the `www/` folder for the first time, you'll need to restart Home Assistant.
+  If you've had to create the `www/` or `www_secure/` folder for the first time, 
+  you'll need to restart Home Assistant.
 </p>

--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -176,7 +176,7 @@ be accessed as `http://your.domain:8123/local/audio.mp3`.
 
 You can also create a `www_secure` directory under the configuration path to 
 host files can be accessed by the following URL `http://your.domain:8123/secure/`
-with [authentication](developers/auth_api#making-authenticated-requests). 
+with [authentication](https://developers.home-assistant.io/docs/en/auth_api.html#making-authenticated-requests). 
 
 <p class='note'>
   If you've had to create the `www/` or `www_secure/` folder for the first time, 


### PR DESCRIPTION
**Description:**

Allow user use `https://your_host/secure` to access files under `[config]/www_secure/` with access token or other way pass the authentication. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21104

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
