### PR TITLE
Deprecate conf_update_interval

### DIFF
--- a/source/_components/fastdotcom.markdown
+++ b/source/_components/fastdotcom.markdown
@@ -26,7 +26,7 @@ Currently fast.com only supports measuring download bandwidth. If you want to me
 
 Enabling this component will automatically create the Fast.com Sensor.
 
-By default, a speed test will be run every hour. The user can change the update frequency in the configuration by defining the `update_interval` for a speed test to run.
+By default, a speed test will be run every hour. The user can change the update frequency in the configuration by defining the `scan_interval` for a speed test to run.
 
 ## {% linkable_title Configuration %}
 
@@ -42,13 +42,13 @@ Every half hour of every day:
 
 ```yaml
 fastdotcom:
-  update_interval:
+  scan_interval:
       minutes: 30
 ```
 
 {% configuration %}
-update_interval:
-  description: "Minimum time interval between updates. Supported formats: `update_interval: 'HH:MM:SS'`, `update_interval: 'HH:MM'` and Time period dictionary (see example below)."
+scan_interval:
+  description: "Minimum time interval between updates. Supported formats: `scan_interval: 'HH:MM:SS'`, `scan_interval: 'HH:MM'` and Time period dictionary (see example below)."
   required: false
   default: 60 minutes
   type: time
@@ -62,7 +62,7 @@ manual:
 #### {% linkable_title Time period dictionary example %}
 
 ```yaml
-update_interval:
+scan_interval:
   # At least one of these must be specified:
   days: 0
   hours: 0

--- a/source/_components/freedns.markdown
+++ b/source/_components/freedns.markdown
@@ -44,7 +44,7 @@ freedns:
     description: The full update URL. This is exclusive to `access_token`.
     required: false
     type: string
-  update_interval:
+  scan_interval:
     description: How often to call the update service.
     required: false
     type: time period

--- a/source/_components/nissan_leaf.markdown
+++ b/source/_components/nissan_leaf.markdown
@@ -48,7 +48,7 @@ nissan_connect:
   description: If your car has the updated head unit (NissanConnect rather than Carwings) then the location can be aquired and exposed via a device tracker. If you have a pre-2014 24 kWh Leaf then you will have Carwings and this should be set to false.
   required: false
   type: boolean
-update_interval:
+scan_interval:
   description: The interval between updates if the climate control is off and the car is not charging. Set in any time unit (e.g. minutes, hours, days!).
   required: false
   default: 1 hour
@@ -76,7 +76,7 @@ nissan_leaf:
   password: "YOUR_PASSWORD"
   region: "YOUR_REGION"
   nissan_connect: true
-  update_interval:
+  scan_interval:
     hours: 1
   update_interval_charging:
     minutes: 15

--- a/source/_components/sensor.broadlink.markdown
+++ b/source/_components/sensor.broadlink.markdown
@@ -33,7 +33,7 @@ Configuration options:
 - **host** (*Required*): The hostname/IP address to connect to.
 - **mac** (*Required*):  Device mac address.
 - **name** (*Optional*): Default BL. Sensor name
-- **update_interval** (*Optional*): Time in seconds to fetch data from sensors. Default 300. 
+- **scan_interval** (*Optional*): Time in seconds to fetch data from sensors. Default 300.
 - **timeout** (*Optional*): Timeout in seconds for the connection to the device.
 - **monitored_conditions** array (*Required*): States to monitor.
     - 'temperature'
@@ -49,7 +49,7 @@ Obtain sensor data from an A1:
 ```yaml
 sensor:
   - platform: broadlink
-    update_interval: 60
+    scan_interval: 60
     host: IP_ADDRESS
     mac: 'MAC_ADDRESS'
     monitored_conditions:
@@ -65,7 +65,7 @@ Obtain temperature data from an RM2:
 ```yaml
 sensor:
   - platform: broadlink
-    update_interval: 60
+    scan_interval: 60
     host: IP_ADDRESS
     mac: 'MAC_ADDRESS'
     monitored_conditions:

--- a/source/_components/sensor.darksky.markdown
+++ b/source/_components/sensor.darksky.markdown
@@ -143,8 +143,8 @@ units:
   required: false
   default: "`si` or `us`, based on the temperature preference in Home Assistant."
   type: string
-update_interval:
-  description: "Minimum time interval between updates. Supported formats: `update_interval: 'HH:MM:SS'`, `update_interval: 'HH:MM'` and Time period dictionary (see example below)."
+scan_interval:
+  description: "Minimum time interval between updates. Supported formats: `scan_interval: 'HH:MM:SS'`, `scan_interval: 'HH:MM'` and Time period dictionary (see example below)."
   required: false
   default: 2 minutes
   type: time
@@ -153,7 +153,7 @@ update_interval:
 #### {% linkable_title Time period dictionary example %}
 
 ```yaml
-update_interval:
+scan_interval:
   # At least one of these must be specified:
   days: 0
   hours: 0

--- a/source/_components/sensor.fedex.markdown
+++ b/source/_components/sensor.fedex.markdown
@@ -32,11 +32,11 @@ Configuration options for the FedEx Sensor:
 - **username** (*Required*): The username to access the FedEx Delivery Manager service.
 - **password** (*Required*): The password for the given username.
 - **name** (*Optional*): Name the sensor.
-- **update_inverval** (*Optional*): Minimum time interval between updates. Default is 1 hour. Supported formats:
-  - `update_interval: 'HH:MM:SS'`
-  - `update_interval: 'HH:MM'`
+- **scan_inverval** (*Optional*): Minimum time interval between updates. Default is 1 hour. Supported formats:
+  - `scan_interval: 'HH:MM:SS'`
+  - `scan_interval: 'HH:MM'`
   - Time period dictionary, e.g.:
-    <pre>update_interval:
+    <pre>scan_interval:
         # At least one of these must be specified:
         days: 0
         hours: 0

--- a/source/_components/sensor.ups.markdown
+++ b/source/_components/sensor.ups.markdown
@@ -32,11 +32,11 @@ Configuration options for the UPS Sensor:
 - **username** (*Required*): The username to access the UPS My Choice service.
 - **password** (*Required*): The password for the given username.
 - **name** (*Optional*): Name the sensor.
-- **update_inverval** (*Optional*): Minimum time interval between updates. Default is 1 hour. Supported formats:
-  - `update_interval: 'HH:MM:SS'`
-  - `update_interval: 'HH:MM'`
+- **scan_inverval** (*Optional*): Minimum time interval between updates. Default is 1 hour. Supported formats:
+  - `scan_interval: 'HH:MM:SS'`
+  - `scan_interval: 'HH:MM'`
   - Time period dictionary, e.g.:
-    <pre>update_interval:
+    <pre>scan_interval:
         # At least one of these must be specified:
         days: 0
         hours: 0

--- a/source/_components/snips.markdown
+++ b/source/_components/snips.markdown
@@ -277,7 +277,7 @@ So now you can open and close your garage door, let's check the weather. Add the
 - platform: darksky
   name: "Dark Sky Weather"
   api_key: !secret dark_sky_key
-  update_interval:
+  scan_interval:
     minutes: 10
   monitored_conditions:
     - summary

--- a/source/_components/speedtestdotnet.markdown
+++ b/source/_components/speedtestdotnet.markdown
@@ -23,7 +23,7 @@ The `speedtestdotnet` component uses the [Speedtest.net](https://speedtest.net/)
 
 Enabling this component will automatically create the Speedtest.net Sensors for the monitored conditions (below).
 
-By default, a speed test will be run every hour. The user can change the update frequency in the configuration by defining the `update_interval` for a speed test to run.
+By default, a speed test will be run every hour. The user can change the update frequency in the configuration by defining the `scan_interval` for a speed test to run.
 
 ## {% linkable_title Configuration %}
 
@@ -56,8 +56,8 @@ speedtestdotnet:
     description: Specify the speed test server to perform the test against.
     required: false
     type: integer
-  update_interval:
-    description: "Minimum time interval between updates. Supported formats: `update_interval: 'HH:MM:SS'`, `update_interval: 'HH:MM'` and Time period dictionary (see example below)."
+  scan_interval:
+    description: "Minimum time interval between updates. Supported formats: `scan_interval: 'HH:MM:SS'`, `scan_interval: 'HH:MM'` and Time period dictionary (see example below)."
     required: false
     default: 60 minutes
     type: time
@@ -72,7 +72,7 @@ speedtestdotnet:
 #### {% linkable_title Time period dictionary example %}
 
 ```yaml
-update_interval:
+scan_interval:
   # At least one of these must be specified:
   days: 0
   hours: 0
@@ -112,7 +112,7 @@ Every half hour of every day:
 ```yaml
 # Example configuration.yaml entry
 speedtestdotnet:
-  update_interval:
+  scan_interval:
     minutes: 30
   monitored_conditions:
     - ping

--- a/source/_components/tellduslive.markdown
+++ b/source/_components/tellduslive.markdown
@@ -8,7 +8,7 @@ comments: false
 sharing: true
 footer: true
 logo: tellduslive.svg
-ha_category: 
+ha_category:
   - Hub
   - Binary Sensor
   - Cover
@@ -50,15 +50,15 @@ host:
   description: Host address to Tellstick Net or Tellstick ZNet for Local API, only useful when automatic discovery is not enabled.
   required: false
   type: string
-update_interval:
+scan_interval:
   description: Interval (in seconds) for polling the Telldus Live server (or the local server).
   required: false
   type: integer
   default: 60
 {% endconfiguration %}
 
-<p class='note'>  
-It is only possible to configure the `update_interval` when setting up the device. If the polling interval needs to be changed after the device is configured it must be changed manually by changing `"scan_interval": 60,` for the device in the file `.storage/core.config_entries`.
+<p class='note'>
+It is only possible to configure the `scan_interval` when setting up the device. If the polling interval needs to be changed after the device is configured it must be changed manually by changing `"scan_interval": 60,` for the device in the file `.storage/core.config_entries`.
 </p>
 
 The component will offer configuration through the Home Assistant user interface where it will let you associate it with your Telldus Live account.


### PR DESCRIPTION
**Description:**
We're deprecating `CONF_UPDATE_INTERVAL` and replacing with `CONF_SCAN_INTERVAL` across all components/platforms.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20924

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
