### PR TITLE
Add hint on how to restart on crash

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -134,3 +134,11 @@ When working on Home Assistant, you can easily restart the system and then watch
 $ sudo systemctl restart home-assistant@YOUR_USER && sudo journalctl -f -u home-assistant@YOUR_USER
 ```
 
+### {% linkable_title Automatically restarting Home Assistant on failure %}
+
+If you want to restart the Home Assistant service automatically after a crash, add the following lines to the `[Service]` section of your unit file:
+
+```
+Restart=on-failure
+RestartSec=5s
+```


### PR DESCRIPTION
I was experiencing crashes, when I requested too many data points for plotting. So, this configuration makes my system come back automatically.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
