### PR TITLE
Allow light.toggle service to accept all service light turn on params

### DIFF
--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -77,7 +77,7 @@ Turns one or multiple lights off.
 ### {% linkable_title Service `light.toggle` %}
 
 Toggles the state of one or multiple lights using [groups]({{site_root}}/components/group/). 
-Takes the same arguments as [TURN_ON](#service-lightturn_on) service.
+Takes the same arguments as [`turn_on`](#service-lightturn_on) service.
 
 *Note*: If `light.toggle` is used for a group of lights, it will toggle the individual state of each light.
 

--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -76,11 +76,8 @@ Turns one or multiple lights off.
 
 ### {% linkable_title Service `light.toggle` %}
 
-Toggles the state of one or multiple lights using [groups]({{site_root}}/components/group/).
+Toggles the state of one or multiple lights using [groups]({{site_root}}/components/group/). 
+Takes the same arguments as [TURN_ON](#service-lightturn_on) service.
 
 *Note*: If `light.toggle` is used for a group of lights, it will toggle the individual state of each light.
 
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Else targets all.
-| `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds.


### PR DESCRIPTION
**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/20912

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].