### PR TITLE
Document Netatmo sensor health_idx

### DIFF
--- a/source/_components/sensor.netatmo.markdown
+++ b/source/_components/sensor.netatmo.markdown
@@ -65,6 +65,8 @@ modules:
           description: Noise level in dB.
         humidity:
           description: "Humidity in %."
+        health_idx:
+          description: "Air health as one of the values Healthy, Fine, Fair, Poor, Unhealthy."
         rain:
           description: Estimated rainfall for today in mm.
         sum_rain_1:


### PR DESCRIPTION
**Description:**
Documentation for the Netatmo sensor module health_idx

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#20274

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html