### PR TITLE
Clarify that http.base_url doesn't support paths

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -41,7 +41,7 @@ server_port:
   type: integer
   default: 8123
 base_url:
-  description: "The URL that Home Assistant is available on the internet. For example: `https://hass-example.duckdns.org:8123`. The iOS app finds local installations, if you have an outside URL use this so that you can auto-fill when discovered in the app."
+  description: "The URL that Home Assistant is available on the internet. For example: `https://hass-example.duckdns.org:8123`. The iOS app finds local installations, if you have an outside URL use this so that you can auto-fill when discovered in the app. Note that setting may contain protocol, hostname and port; using a path is not currently supported."
   required: false
   type: string
   default: Your local IP address


### PR DESCRIPTION
**Description:**

Explain that paths aren't supported in the `http.base_url` setting to clarify expectations about this option. The term `base_url` implied that this option could be a _URL_ but in fact it may only currently be part of a URL.

Related: https://github.com/home-assistant/home-assistant/issues/21113

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
