### PR TITLE
Update traccar documentation with new parameters

### DIFF
--- a/source/_components/device_tracker.traccar.markdown
+++ b/source/_components/device_tracker.traccar.markdown
@@ -70,3 +70,12 @@ monitored_conditions:
   required: false
   type: list
 {% endconfiguration %}
+
+The parameter `monitored_conditions` allows you to track non standard attributes from the traccar platform and use them in your Home Assistant. For example if you need to monitor the state of the non standard attribute `alarm` and a custom computed attribute `mycomputedattribute` just fill the configuration with:
+
+```yaml
+device_tracker:
+  - platform: traccar
+    ...
+    monitored_conditions: ['alarm', 'mycomputedattribute']
+```

--- a/source/_components/device_tracker.traccar.markdown
+++ b/source/_components/device_tracker.traccar.markdown
@@ -60,11 +60,6 @@ verify_ssl:
   required: false
   type: boolean
   default: true
-scan_interval:
-  description: Defines the polling interval.
-  required: false
-  type: time
-  default: 00:00:30
 monitored_conditions:
   description: Additional traccar computed attributes or device-related attributes to include in the scan.
   required: false

--- a/source/_components/device_tracker.traccar.markdown
+++ b/source/_components/device_tracker.traccar.markdown
@@ -60,4 +60,13 @@ verify_ssl:
   required: false
   type: boolean
   default: true
+scan_interval:
+  description: Defines the polling interval.
+  required: false
+  type: time
+  default: 00:00:30
+monitored_conditions:
+  description: Additional traccar computed attributes or device-related attributes to include in the scan.
+  required: false
+  type: list
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Added scan_interval and monitored_conditions

**Pull requests in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21149
home-assistant/home-assistant#21079

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
