### PR TITLE
Update weather.darksky.markdown

### DIFF
--- a/source/_components/weather.darksky.markdown
+++ b/source/_components/weather.darksky.markdown
@@ -70,3 +70,4 @@ This platform is an alternative to the [`darksky`](/components/sensor.darksky/) 
 </p>
 
 Details about the API are available in the [Dark Sky documentation](https://darksky.net/dev/docs).
+


### PR DESCRIPTION
...it should be https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/weather/darksky.py

I'm not sure how to amend it.
If someone can give me a pointer on the file that needs amending I'll go ahead and fix it.

DO NOT PULL this change, it is for discussion only.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
