### PR TITLE
Add SmartThings cover platform and update cover device classes

### DIFF
--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -23,12 +23,15 @@ The display style of each entity can be modified in the [customize section](/get
 The way these sensors are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for covers:
 
 - **None**: Generic cover. This is the default and doesn't need to be set.
-- **curtain**: Curtain controller.
-- **damper**: Ventilation damper controller.
-- **door**: General door controller.
-- **garage**: Garage door controller.
-- **shade**: Shade controller.
-- **window**: Window controller.
+- **awning**: Control of a awning, such as for a windor or patio.
+- **blind**: Control of window blinds.
+- **curtain**: Control of window or call coverings, such as curtains and drapes.
+- **damper**: Control of ventilation damper or digital window tint/film and integrated digital window privacy filters.
+- **door**: Control of a door (more generic than garage door).
+- **garage**: Control of a garage door or gate (more specific than a door).
+- **shade**: Control of shades, such as for a window, patio or pergola.
+- **shutter**: Control of shutters, such as for a window or door.
+- **window**: Control of a window opening.
 
 ## {% linkable_title Services %}
 

--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -23,8 +23,11 @@ The display style of each entity can be modified in the [customize section](/get
 The way these sensors are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for covers:
 
 - **None**: Generic cover. This is the default and doesn't need to be set.
+- **curtain**: Curtain controller.
 - **damper**: Ventilation damper controller.
+- **door**: General door controller.
 - **garage**: Garage door controller.
+- **shade**: Shade controller.
 - **window**: Window controller.
 
 ## {% linkable_title Services %}

--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -23,14 +23,14 @@ The display style of each entity can be modified in the [customize section](/get
 The way these sensors are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for covers:
 
 - **None**: Generic cover. This is the default and doesn't need to be set.
-- **awning**: Control of an awning, such as an exterior retractible window, door, or patio cover.
-- **blind**: Control of blinds, which are linked slats that expand or collapse to cover an opening or may be tilted to partially cover an opening, such as window blinds.
+- **awning**: Control of an awning, such as an exterior retractable window, door, or patio cover.
+- **blind**: Control of blinds, which are linked slats that expand or collapse to cover an opening or may be tilted to partially covering an opening, such as window blinds.
 - **curtain**: Control of curtains or drapes, which is often fabric hung above a window or door that can be drawn open.
-- **damper**: Control of a mechanical damper that reduces air flow, sound, or light.
+- **damper**: Control of a mechanical damper that reduces airflow, sound, or light.
 - **door**: Control of a door or gate that provides access to an area.
 - **garage**: Control of a garage door that provides access to a garage.
-- **shade**: Control of shades, which are a continous plane of material or connected cells that expanded or collapsed over an opening, such as window shades.
-- **shutter**: Control of shutters, which are linked slats that swing out/in to cover an opening or may be tilted to partially cover an opening, such as indoor or exterior window shutters.
+- **shade**: Control of shades, which are a continuous plane of material or connected cells that expanded or collapsed over an opening, such as window shades.
+- **shutter**: Control of shutters, which are linked slats that swing out/in to covering an opening or may be tilted to partially cover an opening, such as indoor or exterior window shutters.
 - **window**: Control of a physical window that opens and closes or may tilt.
 
 ## {% linkable_title Services %}

--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -23,15 +23,15 @@ The display style of each entity can be modified in the [customize section](/get
 The way these sensors are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for covers:
 
 - **None**: Generic cover. This is the default and doesn't need to be set.
-- **awning**: Control of a awning, such as for a windor or patio.
-- **blind**: Control of window blinds.
-- **curtain**: Control of window or call coverings, such as curtains and drapes.
-- **damper**: Control of ventilation damper or digital window tint/film and integrated digital window privacy filters.
-- **door**: Control of a door (more generic than garage door).
-- **garage**: Control of a garage door or gate (more specific than a door).
-- **shade**: Control of shades, such as for a window, patio or pergola.
-- **shutter**: Control of shutters, such as for a window or door.
-- **window**: Control of a window opening.
+- **awning**: Control of an awning, such as an exterior retractible window, door, or patio cover.
+- **blind**: Control of blinds, which are linked slats that expand or collapse to cover an opening or may be tilted to partially cover an opening, such as window blinds.
+- **curtain**: Control of curtains or drapes, which is often fabric hung above a window or door that can be drawn open.
+- **damper**: Control of a mechanical damper that reduces air flow, sound, or light.
+- **door**: Control of a door or gate that provides access to an area.
+- **garage**: Control of a garage door that provides access to a garage.
+- **shade**: Control of shades, which are a continous plane of material or connected cells that expanded or collapsed over an opening, such as window shades.
+- **shutter**: Control of shutters, which are linked slats that swing out/in to cover an opening or may be tilted to partially cover an opening, such as indoor or exterior window shutters.
+- **window**: Control of a physical window that opens and closes or may tilt.
 
 ## {% linkable_title Services %}
 

--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -13,6 +13,7 @@ ha_category:
   - Hub
   - Binary Sensor
   - Climate
+  - Cover
   - Fan
   - Light
   - Lock
@@ -25,6 +26,8 @@ redirect_from:
   - /components/binary_sensor.smartthings/
   - /components/smartthings.climate/
   - /components/climate.smartthings/
+  - /components/smartthings.cover/
+  - /components/cover.smartthings/
   - /components/smartthings.fan/
   - /components/fan.smartthings/
   - /components/smartthings.light/
@@ -125,6 +128,7 @@ Event data payloads are logged at the debug level, see [debugging](#debugging) f
 SmartThings represents devices as a set of [capabilities](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html) and the SmartThings component maps those to entity platforms in Home Assistant. A single device may be represented by one or more platforms.
 - [Binary Sensor](#binary-sensor)
 - [Climate](#climate)
+- [Cover](#cover)
 - [Fan](#fan) 
 - [Light](#light) 
 - [Lock](#lock)
@@ -162,6 +166,18 @@ The SmartThings Climate platform lets you control devices that have thermostat-r
 | [`thermostatOperatingState`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Thermostat-Operating-State)          | `operating state` (state attribute)
 | [`thermostatFanMode`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Thermostat-Fan-Mode)                 | `fan mode`
 | [`relativeHumidityMeasurement`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Relative-Humidity-Measurement)       | `humidity` (state attribute)
+
+### {% linkable_title Cover %}
+
+The SmartThings Cover platform lets you control devices that have open/close related capabilities. For a device to be represented by the cover platform, it must have one of the capabilities from "set a" below.
+
+| Capability                          |Cover Features
+|-------------------------------------|--------------------------------------------|
+| [`doorControl`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Door-Control) (set a)            | `open` and `close`
+| [`garageDoorControl`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Garage-Door-Control) (seb a) | `open` and `close`
+| [`windowShade`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Window-Shade) (set a) | `open` and `close`
+| [`switchLevel`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch-Level)    |  `position`
+| [`battery`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Battery)          | `battery_level` (state attribute)
 
 ### {% linkable_title Fan %}
 
@@ -203,14 +219,12 @@ The SmartThings Sensor platform lets your view devices that have sensor-related 
 | [`carbonMonoxideDetector`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Carbon-Monoxide-Detector)        | `carbonMonoxide`
 | [`carbonMonoxideMeasurement`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Carbon-Monoxide-Measurement)  | `carbonMonoxideLevel`
 | [`dishwasherOperatingState`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Dishwasher-Operating-State)    | `machineState`, `dishwasherJobState` and `completionTime`
-| [`doorControl`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Door-Control)                               | `door`
 | [`dryerMode`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Dryer-Mode)                                   | `dryerMode`
 | [`dryerOperatingState`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Dryer-Operating-State)              | `machineState`, `dryerJobState` and `completionTime`
 | [`dustSensor`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Dust-Sensor)                                 | `fineDustLevel` and `dustLevel`
 | [`energyMeter`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Energy-Meter)                               | `energy`
 | [`equivalentCarbonDioxideMeasurement`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Equivalent-Carbon-Dioxide-Measurement) | `equivalentCarbonDioxideMeasurement`
 | [`formaldehydeMeasurement`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Formaldehyde-Measurement)       | `formaldehydeLevel`
-| [`garageDoorControl`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Garage-Door-Control)                  | `door`
 | [`illuminanceMeasurement`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Illuminance-Measurement)         | `illuminance`
 | [`infraredLevel`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Infrared-Level)                           | `infraredLevel`
 | [`lock`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Lock)                                              | `lock`
@@ -244,7 +258,6 @@ The SmartThings Sensor platform lets your view devices that have sensor-related 
 | [`voltageMeasurement`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Voltage-Measurement)                 | `voltage`
 | [`washerMode`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Washer-Mode)                                 | `washerMode`
 | [`washerOperatingState`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Washer-Operating-State)            | `machineState`, `washerJobState` and `completionTime`
-| [`windowShade`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Window-Shade)                               | `windowShade`
 
 ### {% linkable_title Switch %}
 


### PR DESCRIPTION
**Description:**
Adds documentation for the SmartThings Cover platform and updates the cover component device classes to support it per home-assistant/architecture/issues/153

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#21192

## Checklist:
- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html