### PR TITLE
Add temperature sensor config documentation for Konnected

### DIFF
--- a/source/_components/konnected.markdown
+++ b/source/_components/konnected.markdown
@@ -27,8 +27,13 @@ The component currently supports the following device types in Home Assistant:
 
 - Binary Sensor: Wired door and window sensors, motion detectors, glass-break detectors, leak sensors, smoke & CO detectors or any open/close switch.
 - Switch: Actuate a siren, strobe, buzzer or relay module.
+- Sensor: Periodic measurements from DHT temperature/humidity sensors and DS18B20 temperature sensors.
 
-This component requires the [`discovery`](/components/discovery) component to be enabled.
+This component uses the [`discovery`](/components/discovery) component, which must be enabled for device discovery to work. If you don't want to use discovery, set the _host_ and _port_ for each device in the description.  
+
+<p class='note info'>
+Konnected devices communicate with Home Assistant over your local LAN -- there is no cloud component! For best performance we recommend allowing unsecured HTTP API traffic between Konnected devices and Home Assistant on your LAN. This means that you should not use the `http` component to serve SSL/TLS certificates. Instead, use a proxy like Nginx or Caddy to serve SSL/TLS. [Read more.](https://help.konnected.io/support/solutions/articles/32000023964-set-up-hass-io-with-secure-remote-access-using-duckdns-and-nginx-proxy)  
+</p>
 
 ### {% linkable_title Configuration %}
 
@@ -78,7 +83,7 @@ devices:
       type: list
       keys:
         pin:
-          description: The number corresponding to the _IO index_ of the labeled pin on the NodeMCU dev board. See the [NodeMCU GPIO documentation](https://nodemcu.readthedocs.io/en/master/en/modules/gpio/) for more details. Valid values are 1, 2, 5, 6, 7 and 9.
+          description: The number corresponding to the _IO index_ of the labeled pin on the NodeMCU dev board. See the [NodeMCU GPIO documentation](https://nodemcu.readthedocs.io/en/master/en/modules/gpio/) for more details. Valid values are `1`, `2`, `5`, `6`, `7` and `9`.
           required: exclusive
         zone:
           description: The number corresponding to the labeled zone on the [Konnected Alarm Panel](https://konnected.io) board. Valid values are `1`, `2`, `3`, `4`, `5` and `6`.
@@ -101,7 +106,7 @@ devices:
       type: list
       keys:
         pin:
-          description: The number corresponding to the _IO index_ of the labeled pin on the NodeMCU dev board. See the [NodeMCU GPIO documentation](https://nodemcu.readthedocs.io/en/master/en/modules/gpio/) for more details. Valid values for sensors are 1, 2, 5, 6, 7 and 9.
+          description: The number corresponding to the _IO index_ of the labeled pin on the NodeMCU dev board. See the [NodeMCU GPIO documentation](https://nodemcu.readthedocs.io/en/master/en/modules/gpio/) for more details. Valid values for sensors are `1`, `2`, `5`, `6`, `7` and `9`.
           required: exclusive
         zone:
           description: The number corresponding to the labeled zone on the [Konnected Alarm Panel](https://konnected.io) board. Valid values for sensors are `1`, `2`, `3`, `4`, `5` and `6`.
@@ -111,8 +116,13 @@ devices:
           required: false
           default: automatically generated
         type:
-          description: The type of sensor. Valid values are`dht` or `ds18b20`
+          description: The type of sensor. Valid values are `dht` or `ds18b20`
           required: true
+        poll_interval:
+          type: integer
+          description: The frequency (in minutes) that the Konnected device will report sensor data. Minimum `1` minute. _Note:_ this is only implemented for `dht` sensors.
+          required: false
+          default: not set (device default is 3 minutes)
     switches:
       description: A list of actuators (on/off switches) connected to the device. See [Konnected Switch](/components/switch.konnected/) for configuration variables.
       required: false
@@ -203,17 +213,22 @@ konnected:
       binary_sensors:
         - pin: 1
           type: motion
-          name: 'Office Motion'
+          name: Office Motion
         - pin: 2
           type: door
-          name: 'Office Door'
+          name: Office Door
       switches:
         - pin: 5
-          name: 'Garage Door'
+          name: Garage Door
           activation: low
           momentary: 500
         - pin: 8
           name: LED Light
+      sensors:
+        - pin: 6
+          name: Kitchen
+          type: dht
+          
 ```
 
 ### {% linkable_title Pin Mapping %}

--- a/source/_components/konnected.markdown
+++ b/source/_components/konnected.markdown
@@ -12,6 +12,7 @@ ha_category:
   - Alarm
   - Binary Sensor
   - Switch
+  - Sensor
 ha_release: "0.70"
 redirect_from:
   - /components/binary_sensor.konnected/
@@ -94,6 +95,24 @@ devices:
           description: Inverts the open/closed meaning of a binary sensor circuit. Commonly needed for normally open wired smoke alarm circuits.
           required: false
           default: false
+    sensors:
+      description: A list of digital sensors (currently supported: DHT and DS18B20 sensors) connected to the device
+      required: false
+      type: list
+      keys:
+        pin:
+          description: The number corresponding to the _IO index_ of the labeled pin on the NodeMCU dev board. See the [NodeMCU GPIO documentation](https://nodemcu.readthedocs.io/en/master/en/modules/gpio/) for more details. Valid values are 1, 2, 5, 6, 7 and 8.
+          required: exclusive
+        zone:
+          description: The number corresponding to the labeled zone on the [Konnected Alarm Panel](https://konnected.io) board or the word `out` to specify the dedicated ALARM/OUT terminal on the Konnected board. Valid values are `1`, `2`, `3`, `4`, `5` and `out`.
+          required: exclusive
+        name:
+          description: The name of the device used in the front end.
+          required: false
+          default: automatically generated
+        type:
+          description: The type of sensor. Valid values: `dht` or `ds18b20`
+          required: true
     switches:
       description: A list of actuators (on/off switches) connected to the device. See [Konnected Switch](/components/switch.konnected/) for configuration variables.
       required: false
@@ -212,6 +231,10 @@ Konnected runs on an ESP8266 board with the NodeMCU firmware. It is commonly use
 | ALARM or OUT | D8 | 8 | GPIO15 |
 
 ### {% linkable_title Revision History %}
+
+#### 0.89
+
+- Added support for `dht` and `ds18b20` temperature sensors
 
 #### 0.80
 

--- a/source/_components/konnected.markdown
+++ b/source/_components/konnected.markdown
@@ -96,22 +96,22 @@ devices:
           required: false
           default: false
     sensors:
-      description: A list of digital sensors (currently supported: DHT and DS18B20 sensors) connected to the device
+      description: A list of digital sensors (currently supports DHT and DS18B20 sensors) connected to the device
       required: false
       type: list
       keys:
         pin:
-          description: The number corresponding to the _IO index_ of the labeled pin on the NodeMCU dev board. See the [NodeMCU GPIO documentation](https://nodemcu.readthedocs.io/en/master/en/modules/gpio/) for more details. Valid values are 1, 2, 5, 6, 7 and 8.
+          description: The number corresponding to the _IO index_ of the labeled pin on the NodeMCU dev board. See the [NodeMCU GPIO documentation](https://nodemcu.readthedocs.io/en/master/en/modules/gpio/) for more details. Valid values for sensors are 1, 2, 5, 6, 7 and 9.
           required: exclusive
         zone:
-          description: The number corresponding to the labeled zone on the [Konnected Alarm Panel](https://konnected.io) board or the word `out` to specify the dedicated ALARM/OUT terminal on the Konnected board. Valid values are `1`, `2`, `3`, `4`, `5` and `out`.
+          description: The number corresponding to the labeled zone on the [Konnected Alarm Panel](https://konnected.io) board. Valid values for sensors are `1`, `2`, `3`, `4`, `5` and `6`.
           required: exclusive
         name:
           description: The name of the device used in the front end.
           required: false
           default: automatically generated
         type:
-          description: The type of sensor. Valid values: `dht` or `ds18b20`
+          description: The type of sensor. Valid values are`dht` or `ds18b20`
           required: true
     switches:
       description: A list of actuators (on/off switches) connected to the device. See [Konnected Switch](/components/switch.konnected/) for configuration variables.


### PR DESCRIPTION
**Description:**
Adds documentation for `dht` and `ds18b20` devices via Konnected firmware.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** https://github.com/home-assistant/home-assistant/pull/21189

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
