### PR TITLE
Add Docker specific explanation for PS4 component

### DIFF
--- a/source/_components/media_player.ps4.markdown
+++ b/source/_components/media_player.ps4.markdown
@@ -57,6 +57,9 @@ There are varying methods to perform this, dependent on your OS that is running 
 `sudo setcap 'cap_net_bind_service=+ep' /usr/bin/python3.5`
 Replace "/usr/bin/python3.5" with your path to Python that is running Home Assistant.
 
+### {% linkable_title Docker %}
+
+When running Home Assistant using Docker, make sure that the Home Assistant container is discoverable by the PS4. This can be achieved by ensuring that the Home Assistant container uses the `host` network driver (by passing `--net=host` to the container when creating, or adding `network_mode: "host"` to your compose file when using `docker-compose`).
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
**Description:**

The new PS4 component requires some extra settings from Home Assistant if one is using Docker. I've added an entry in the docs to make sure these settings are clear for those who use Docker.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21074

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
