### PR TITLE
utility_meter net metering support

### DIFF
--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -53,7 +53,7 @@ offset:
 net_consumption:
   description: Set this to True if you would like to treat the source as a net meter. This will allow your counter to go both positive and negative.
   required: false
-  default: False
+  default: false
   type: boolean
 tariffs:
   description: List of tariffs supported by the utility meter.

--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -50,10 +50,10 @@ offset:
   required: false
   default: 0
   type: integer
-rollover:
-  description: Set this to False if the source keeps it's value and will never rollover.  Setting this to False will allow your utility_meter reading to go negative for net metering.
+net_consumption:
+  description: Set this to True if you would like to treat the source as a net meter.  This will allow your counter to go both positive and negative.
   required: false
-  default: True
+  default: False
   type: boolean
 tariffs:
   description: List of tariffs supported by the utility meter.

--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -50,6 +50,11 @@ offset:
   required: false
   default: 0
   type: integer
+rollover:
+  description: Set this to False if the source keeps it's value and will never rollover.  Setting this to False will allow your utility_meter reading to go negative for net metering.
+  required: false
+  default: True
+  type: boolean
 tariffs:
   description: List of tariffs supported by the utility meter.
   required: false

--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -51,7 +51,7 @@ offset:
   default: 0
   type: integer
 net_consumption:
-  description: Set this to True if you would like to treat the source as a net meter.  This will allow your counter to go both positive and negative.
+  description: Set this to True if you would like to treat the source as a net meter. This will allow your counter to go both positive and negative.
   required: false
   default: False
   type: boolean


### PR DESCRIPTION
Add documentation around net metering for utility_sensor.

**Description:**
Update documentation to support the net metering use-case.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21204

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
