### PR TITLE
Update sensor.template.markdown

### DIFF
--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -253,14 +253,11 @@ sensor:
 
 The `template` sensors are not limited to use attributes from other entities but can also work with [Home Assistant's template extensions](/docs/configuration/templating/#home-assistant-template-extensions).
 
-This template contains no entities that will trigger an update, so we add an `entity_id:` line with an entity that will force an update - here we're using a [date sensor](/components/sensor.time_date/) to get a daily update:
+This template contains no entities that will trigger an update, so we add an `entity_id:` line with an entity that will force an update - here we're using a [date sensor](/components/sensor.time_date/) (which may need to be registered) to get a daily update:
 
 {% raw %}
 ```yaml
 sensor:
-- platform: time_date
-  display_options:
-  - date
 - platform: template
   sensors:
     nonsmoker:
@@ -271,7 +268,7 @@ sensor:
 ```
 {% endraw %}
 
-Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute. Be sure you register the `time_date` sensor if you choose this method!
+Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute.
 
 An alternative to this is to create an interval-based automation that calls the service `homeassistant.update_entity` for the entities requiring updates. This modified example updates every 5 minutes:
 

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -271,7 +271,7 @@ sensor:
 ```
 {% endraw %}
 
-Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute. Be sure you register the `time_date` sensor if choose this method!
+Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute. Be sure you register the `time_date` sensor if you choose this method!
 
 An alternative to this is to create an interval-based automation that calls the service `homeassistant.update_entity` for the entities requiring updates. This modified example updates every 5 minutes:
 

--- a/source/_components/sensor.template.markdown
+++ b/source/_components/sensor.template.markdown
@@ -258,6 +258,9 @@ This template contains no entities that will trigger an update, so we add an `en
 {% raw %}
 ```yaml
 sensor:
+- platform: time_date
+  display_options:
+  - date
 - platform: template
   sensors:
     nonsmoker:
@@ -268,7 +271,7 @@ sensor:
 ```
 {% endraw %}
 
-Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute.
+Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute. Be sure you register the `time_date` sensor if choose this method!
 
 An alternative to this is to create an interval-based automation that calls the service `homeassistant.update_entity` for the entities requiring updates. This modified example updates every 5 minutes:
 


### PR DESCRIPTION
I spend a bit of time troubleshooting why a template sensor wasn't updating, even though I had `sensor.time` listed in `entity_id`. It turns out that `sensor.time` didn't (yet) exist for me!

I've updated the documentation so that other folks don't get stuck on that.

As a side note, the source link on https://www.home-assistant.io/components/sensor.template/ is broken; it points to https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/template/sensor.py, which doesn't exist, but it should point to https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/sensor/template.py, which does; note `sensor/template.py` in the working URL. I'm not sure how this link is generated, since it doesn't appear in this documentation file.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
