### PR TITLE
Update ESPHome links

### DIFF
--- a/source/_components/esphome.markdown
+++ b/source/_components/esphome.markdown
@@ -19,7 +19,7 @@ redirect_from:
  - /components/switch.esphome/
 ---
 
-This component allows you to connect your [ESPHome](https://esphomelib.com/esphomeyaml/index.html) devices directly into Home Assistant with the [native ESPHome API](https://esphomelib.com/esphomeyaml/components/api.html).
+This component allows you to connect your [ESPHome](https://esphome.io/index.html) devices directly into Home Assistant with the [native ESPHome API](https://esphome.io/components/api.html).
 
 ## {% linkable_title Setup the component via the integrations screen %}
 


### PR DESCRIPTION
**Description:**

Updates ESPHome links to the new domain. These links redirect, but it's best to keep up to date.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
