### PR TITLE
Adding details here on running version

### DIFF
--- a/source/_docs/installation/hassbian/installation.markdown
+++ b/source/_docs/installation/hassbian/installation.markdown
@@ -96,3 +96,33 @@ SSH to your system as the user `pi` and run:
 ```bash
 $ sudo hassbian-config upgrade hassbian
 ```
+
+## {% linkable_title Run a specific version %}
+
+In the event that a Home Assistant version doesn't play well with your hardware setup, you can downgrade to a previous release. For example:
+
+```bash
+$ sudo hassbian-config upgrade homeassistant=0.XX.X
+```
+
+#### {% linkable_title Run the beta version %}
+
+If you would like to test next release before anyone else, you can install the beta version released every two weeks, for example:
+
+```bash
+$ sudo hassbian-config upgrade homeassistant --beta
+```
+
+## {% linkable_title Run the development version %}
+
+If you want to stay on the bleeding-edge Home Assistant development branch, you can upgrade to `dev`.
+
+<p class='note warning'>
+  The "dev" branch is likely to be unstable. Potential consequences include loss of data and instance corruption.
+</p>
+
+For example:
+
+```bash
+$ sudo hassbian-config upgrade homeassistant --dev
+```


### PR DESCRIPTION
Instead of missing this out here, pulling the details from the Hassbian scripts docs

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
