### PR TITLE
Adding details on upgrade, beta, and versions

### DIFF
--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -48,26 +48,55 @@ It is recommended to use the [advanced guide](/docs/installation/raspberry-pi/) 
     $ hass --open-ui
     ```
  8. You can now reach the web interface on `http://ipaddress:8123/` - the first start may take up to 20 minutes before the web interface is available
-
  
 ### {% linkable_title Upgrade %}
 
  1. Stop Home Assistant
 
- 2. Open the directory where the virtual environment is located:
-    ```
+ 2. Open the directory where the virtual environment is located, activate the virtual environment, then upgrade Home Assistant:
+    ```bash
     $ cd homeassistant
-    ```
- 3. Activate the virtual environment:
-    ```
     $ source bin/activate
-    ```
- 4. Upgrade Home Assistant:
-    ```
     $ python3 -m pip install --upgrade homeassistant
     ```
- 5. Start Home Assistant
- 6. You can now reach the web interface on `http://ipaddress:8123/` - the first start may take up to 20 minutes before the web interface is available
+ 3. Start Home Assistant
+ 4. You can now reach the web interface on `http://ipaddress:8123/` - the first start may take up to 20 minutes before the web interface is available
+
+### {% linkable_title Run a specific version %}
+
+In the event that a Home Assistant version doesn't play well with your hardware setup, you can downgrade to a previous release. For example:
+
+```bash
+$ cd homeassistant
+$ source bin/activate
+$ pip3 install homeassistant==0.XX.X
+```
+
+#### {% linkable_title Run the beta version %}
+
+If you would like to test next release before anyone else, you can install the beta version released every two weeks, for example:
+
+```bash
+$ cd homeassistant
+$ source bin/activate
+$ pip3 install --pre --upgrade homeassistant
+```
+
+#### {% linkable_title Run the development version %}
+
+If you want to stay on the bleeding-edge Home Assistant development branch, you can upgrade to `dev`.
+
+<p class='note warning'>
+  The "dev" branch is likely to be unstable. Potential consequences include loss of data and instance corruption.
+</p>
+
+For example:
+
+```bash
+$ cd homeassistant
+$ source bin/activate
+$ pip3 install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+```
 
 ### {% linkable_title Notes %}
 


### PR DESCRIPTION
Rather than incomplete instructions in the upgrade page, adding the details here

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
