### PR TITLE
Add additional config parameter for HomematicIP Cloud

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -68,6 +68,7 @@ homematicip_cloud:
   - name: Location2
     accesspoint: IDENTIFIER2
     authtoken: AUTHTOKEN2
+    show_extra_attributes: true
 ```
 
 {% configuration %}
@@ -83,6 +84,11 @@ authtoken:
   required: true
   description: "Authentication token generated with `generate_auth_token.py`."
   type: string
+show_extra_attributes:
+  required: false
+  description: "Enables display of extra attributes per device (e.g. rssi)."
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 ## {% linkable_title Implemented and tested devices %}


### PR DESCRIPTION
**Description:**
Add additional config parameter `show_extra_attributes `for HomematicIP Cloud

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#21179

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
