### PR TITLE
Update googlehome.markdown

### DIFF
--- a/source/_components/googlehome.markdown
+++ b/source/_components/googlehome.markdown
@@ -71,7 +71,7 @@ Device type | Description
 
 ## {% linkable_title Notes %}
 
-Devices will appear in the format `devicetracker.<home hub ip>_<device mac address>`. Note that dots are removed from the IP and BT MAC addresses.
+Devices will appear in the format `device_tracker.<home hub ip>_<device mac address>`. Note that dots are removed from the IP and BT MAC addresses.
 
 [googlehomeapi]: https://rithvikvibhu.github.io/GHLocalApi/
 [devicetrackerconfig]: /components/device_tracker/#configuring-a-device_tracker-platform


### PR DESCRIPTION
Corrected device entity id format (inserted missing underscore) in line 74.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ X ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
