### PR TITLE
person component standardization & clarification for how to use configuration panel

### DIFF
--- a/source/_components/person.markdown
+++ b/source/_components/person.markdown
@@ -13,9 +13,17 @@ ha_qa_scale: internal
 ha_release: 0.88
 ---
 
-The person component allows to connect device tracker entities to one or more person entities. The last state update of a connected device tracker will set the state of the person. Eg if you connect your router and your owntracks device as trackers to your person, the last state update from either the router or your owntracks device will set the state of your person.
+The person component allows to connect device tracker entities to one or more person entities. The last state update of a connected device tracker will set the state of the person. For example if you connect your router and your OwnTracks device as trackers to your person, the last state update from either the router or your OwnTracks device will set the state of your person.
 
-You can manage persons via the UI from the person page inside the configuration panel.
+You can manage persons via the UI from the person page inside the configuration panel or via `YAML`.
+
+## {% linkable_title Configuring the `person` component via the Home Assistant configuration panel %}
+
+If you prefer to use the configuration panel to configure the `person` component simply add one line to your `configuration.yaml` file and restart Home Assistant.
+
+```yaml
+person:
+```
 
 ## {% linkable_title Configuring the `person` component via YAML %}
 


### PR DESCRIPTION
**Description:**

* Capitalize OwnTracks to comply with HomeAssistant [documentation standards](https://developers.home-assistant.io/docs/en/documentation_standards.html)

* Clarify that if you're going to use the configuration panel for configuring the `person` component you need to add `person:` to your `configuration.yaml` file and restart Home Assistant


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#

N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
