### PR TITLE
Fix example automation not triggering

### DIFF
--- a/source/_docs/ecosystem/ios/notifications/actions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/actions.markdown
@@ -132,7 +132,8 @@ automation:
       platform: event
       event_type: ios.notification_action_fired
       event_data:
-        actionName: SOUND_ALARM
+        data:
+          actionName: SOUND_ALARM
     action:
       ...
 ```


### PR DESCRIPTION
I couldn't get the "ios.notification_action_fired" event to trigger an automation using this guide. Through trial and error, I found the automation yaml needs an additional line "data:" below "event_data:"

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
