### PR TITLE
Fix example automation trigger

### DIFF
--- a/source/_docs/ecosystem/ios/notifications/actions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/actions.markdown
@@ -131,9 +131,7 @@ automation:
     trigger:
       platform: event
       event_type: ios.notification_action_fired
-      event_data:
-        data:
-          actionName: SOUND_ALARM
+      event_data: {'actionName': 'SOUND_ALARM'}
     action:
       ...
 ```


### PR DESCRIPTION
I requested a change earlier today that turned out to be incorrect. It solved the problem of the trigger not firing, but it caused the 'event_data' field to be ignored. I have updated this so not only does the trigger fire, but the event data works correctly as well.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
