### PR TITLE
image-element missing aspect_ratio config

### DIFF
--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -385,6 +385,11 @@ state_filter:
   required: false
   description: '[State-based CSS filters](#how-to-use-state_filter)'
   type: object
+aspect_ratio:
+  required: false
+  description: Height-width-ratio.
+  type: string
+  default: "50%"
 style:
   required: true
   description: Position and style the element using CSS.


### PR DESCRIPTION
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
