### PR TITLE
Adds documentation for Edimax power sensor

### DIFF
--- a/source/_components/switch.edimax.markdown
+++ b/source/_components/switch.edimax.markdown
@@ -44,3 +44,25 @@ name:
   default: Edimax Smart Plug
   type: string
 {% endconfiguration %}
+
+## {% linkable_title Power consumption sensor %}
+
+Starting with [version 2 of the firmware](https://www.edimax.com/edimax/download/download/data/edimax/global/download/), the Edimax switches can also report the current and accumulated daily power consumption in their state objects. Use a [template sensor](/components/sensor.template/) to extract their values:
+
+{% raw %}
+```yaml
+  - platform: template
+    sensors:
+      edimax_current_power:
+        friendly_name: Edimax Current power consumption
+        unit_of_measurement: 'W'
+        value_template: "{{ state_attr('switch.edimax_smart_plug',  'current_power_w') | replace('None', 0) }}"
+
+      edimax_total_power:
+        friendly_name: Edimax Accumulated daily power consumption
+        unit_of_measurement: 'kWh'
+        value_template: "{{ state_attr('switch.edimax_smart_plug',  'today_energy_kwh') | replace('None', 0) }}"
+```
+{% endraw %}
+
+Note that if the smart plug is off, these states report the string `None`. By using a `replace()` in the template, these sensors report purely numerical values.

--- a/source/_components/switch.edimax.markdown
+++ b/source/_components/switch.edimax.markdown
@@ -12,7 +12,7 @@ ha_category: Switch
 ha_release: pre 0.7
 ---
 
-This `edimax` switch platform allows you to control the state of your [Edimax](http://www.edimax.com/edimax/merchandise/merchandise_list/data/edimax/global/home_automation_smart_plug/) switches.
+This `edimax` switch platform allows you to control the state of your [Edimax](https://www.edimax.com/edimax/merchandise/merchandise_list/data/edimax/global/home_automation_smart_plug/) switches.
 
 To use your Edimax switch in your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**

Adds documentation for Edimax power sensor on the Edimax switch page.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** -

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html