### PR TITLE
Adds redirect_from /components/remote.harmony/

### DIFF
--- a/source/_components/harmony.markdown
+++ b/source/_components/harmony.markdown
@@ -11,6 +11,8 @@ logo: logitech.png
 ha_category: Remote
 ha_iot_class: "Local Push"
 ha_release: "0.34"
+redirect_from:
+  - /components/remote.harmony/
 ---
 
 The `harmony` remote platform allows you to control the state of your [Harmony Hub Device](http://www.logitech.com/en-us/product/harmony-hub).


### PR DESCRIPTION
**Description:**

https://www.home-assistant.io/components/remote.harmony/ Does no longer work and does not _currently_ redirect to this page.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
