### PR TITLE
Update zha.markdown to mention ZHA Device Handlers

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -37,7 +37,7 @@ There is currently support for the following device types within Home Assistant:
 
 ZHA exception and deviation handling:
 
-Zigbee devices that deviate or do not fully conform from standard specification set by the [Zigbee Alliance](https://www.zigbee.org) may require the development of custom [ZHA Device Handlers](https://github.com/dmulcahey/zha-device-handlers) (a.k.a. ZHA quirks handler  implementation) to for all their functions to work properly with the ZHA component in Home Assistant.
+Zigbee devices that deviate from or do not fully conform to the standard specification set by the [Zigbee Alliance](https://www.zigbee.org) may require the development of custom [ZHA Device Handlers](https://github.com/dmulcahey/zha-device-handlers) (ZHA quirks handler implementation) to for all their functions to work properly with the ZHA component in Home Assistant.
 
 Known working Zigbee radio modules:
 

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -35,6 +35,10 @@ There is currently support for the following device types within Home Assistant:
 - Switch
 - Fan
 
+ZHA exception and deviation handling:
+
+Zigbee devices that deviate or do not fully conform from standard specification set by the [Zigbee Alliance](https://www.zigbee.org) may require the development of custom [ZHA Device Handlers](https://github.com/dmulcahey/zha-device-handlers) (a.k.a. ZHA quirks handler  implementation) to for all their functions to work properly with the ZHA component in Home Assistant.
+
 Known working Zigbee radio modules:
 
 - EmberZNet based radios using the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)


### PR DESCRIPTION
Update zha.markdown to mention the [ZHA Device Handlers](https://github.com/dmulcahey/zha-device-handlers)  (a.k.a. ZHA quirks handler) by @dmulcahey 

https://www.home-assistant.io/components/zha/

**Description:**

This proposes adding text: "Zigbee devices that deviate or do not fully conform from standard specification set by the [Zigbee Alliance](https://www.zigbee.org) may require the development of custom [ZHA Device Handlers](https://github.com/dmulcahey/zha-device-handlers) (a.k.a. ZHA quirks handler implementation) to for all their functions to work properly with the ZHA component in Home Assistant."

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
