### PR TITLE
Fix 'hours' key name for Magicseaweed

### DIFF
--- a/source/_components/sensor.magicseaweed.markdown
+++ b/source/_components/sensor.magicseaweed.markdown
@@ -44,7 +44,7 @@ name:
   required: false
   default: MSW.
   type: string
-hour:
+hours:
   description: List of hours you would like to receive data for.
   required: false
   default: Defaults to current forecast.


### PR DESCRIPTION
**Description:**
Documentation incorrectly referenced 'hour' which is flagged as invalid as part of the config checks introduced in 0.88.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:
- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
