### PR TITLE
Freebox added informations for initial setup

### DIFF
--- a/source/_components/freebox.markdown
+++ b/source/_components/freebox.markdown
@@ -56,7 +56,7 @@ returned json should contain an api_domain (`host`) and a https_port (`port`).
 ### {% linkable_title Initial setup %}
 
 <p class='note warning'>
-You must have set a password for your Freebox router web administration page. Enabled the option "Permettre les nouvelles demandes d'associations" and check that the option "Accès à distance sécurisé à Freebox OS" is active in "Gestion des ports" > "Connexions entrantes".
+You must have set a password for your Freebox router web administration page. Enable the option "Permettre les nouvelles demandes d'associations" and check that the option "Accès à distance sécurisé à Freebox OS" is active in "Gestion des ports" > "Connexions entrantes".
 </p>
 
 The first time Home Assistant will connect to your Freebox, you will need to

--- a/source/_components/freebox.markdown
+++ b/source/_components/freebox.markdown
@@ -56,7 +56,7 @@ returned json should contain an api_domain (`host`) and a https_port (`port`).
 ### {% linkable_title Initial setup %}
 
 <p class='note warning'>
-You must have set a password for your Freebox router web administration page and enabled the option "Permettre les nouvelles demandes d'associations".
+You must have set a password for your Freebox router web administration page. Enabled the option "Permettre les nouvelles demandes d'associations" and check that the option "Accès à distance sécurisé à Freebox OS" is active in "Gestion des ports" > "Connexions entrantes".
 </p>
 
 The first time Home Assistant will connect to your Freebox, you will need to


### PR DESCRIPTION
**Description:**
Due to an issue home-assistant/home-assistant#20734 some informations more are needed for initial setup.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
