### PR TITLE
Elaborate on Caddy configuration process

### DIFF
--- a/source/_docs/ecosystem/caddy.markdown
+++ b/source/_docs/ecosystem/caddy.markdown
@@ -8,14 +8,59 @@ comments: false
 sharing: true
 footer: true
 ---
+[Caddy Server](https://caddyserver.com/) is a powerful HTTP/2 server, that enables HTTPS by default with automatically generated Let's Encrypt certificates, which allows a simple configuration procces.
 
-Configure [Caddy Server](https://caddyserver.com/) for use as a reverse proxy to Home Assistant.
+Using Caddy as a proxy for Home Assistant allows you to serve Home Assistant securely over standard ports. This configuration file and instructions will walk you through setting up Home Assistant over a secure connection.
+
+### {% linkable_title 1. Get a domain name forwarded to your IP %}
+
+Chances are, you have a dynamic IP address (your ISP changes your address periodically). If this is true, you can use a Dynamic DNS service to obtain a domain and set it up to update with you IP. If you purchase your own domain name, you will be able to easily get a trusted SSL certificate later.
+
+### {% linkable_title 2. Install Caddy on your server %}
+
+This will vary depending on your OS. Caddy has a [nice utillity](https://caddyserver.com/download) that generates an installer script.
+
+<p class='note'>
+    Make sure you include the `hook.service` plugin if you want to run Caddy as a service
+</p>
+
+### {% linkable_title 3. Port forwarding. %}
+
+Forward ports 443 and 80 to your server on your router. Do not forward port 8123.
+
+### {% linkable_title 4. Create Caddyfile. %}
+
+Use this as your Caddyfile, change the domain name to match yours.
 
 ```
-hass.example.org {
+example.com {
     proxy / localhost:8123 {
         websocket
         transparent
     }
 }
 ```
+
+### {% linkable_title 5. Configure Home Assistant %}
+
+Home Assistant is still available without using the NGINX proxy. Restricting it to only listen to `127.0.0.1` will forbid direct accesses. Also, Home Assistant should be told to trust headers coming from Caddy proxy only. Otherwise, incoming requests will always come from `127.0.0.1` and not the real IP address.
+
+On your `configuration.yaml` file, edit the `http` component.
+
+```yaml
+http:
+  # For extra security set this to only accept connections on localhost if NGINX is on the same machine
+  # server_host: 127.0.0.1
+  # Update this line to be your domain
+  base_url: https://example.com
+  use_x_forwarded_for: true
+  # You must set the trusted proxy IP address so that Home Assistant will properly accept connections
+  # Set this to your NGINX machine IP, or localhost if hosted on the same machine.
+  trusted_proxies: <NGINX IP address here, or 127.0.0.1 if hosted on the same machine>
+```
+
+### {% linkable_title 6. Start Caddy %}
+
+You can either start Caddy or [install it as a service](https://github.com/mholt/caddy/wiki/Caddy-as-a-service-examples), pass the Caddyfile path as a `conf` parameter.
+Home Assistant will be listening on port 443 (HTTPS) and all insecure traffic on port 80 will be redirected.
+

--- a/source/_docs/ecosystem/caddy.markdown
+++ b/source/_docs/ecosystem/caddy.markdown
@@ -43,20 +43,20 @@ example.com {
 
 ### {% linkable_title 5. Configure Home Assistant %}
 
-Home Assistant is still available without using the NGINX proxy. Restricting it to only listen to `127.0.0.1` will forbid direct accesses. Also, Home Assistant should be told to trust headers coming from Caddy proxy only. Otherwise, incoming requests will always come from `127.0.0.1` and not the real IP address.
+Home Assistant is still available without using the Caddy proxy. Restricting it to only listen to `127.0.0.1` will forbid direct accesses. Also, Home Assistant should be told to trust headers coming from Caddy proxy only. Otherwise, incoming requests will always come from `127.0.0.1` and not the real IP address.
 
 On your `configuration.yaml` file, edit the `http` component.
 
 ```yaml
 http:
-  # For extra security set this to only accept connections on localhost if NGINX is on the same machine
+  # For extra security set this to only accept connections on localhost if Caddy is on the same machine
   # server_host: 127.0.0.1
   # Update this line to be your domain
   base_url: https://example.com
   use_x_forwarded_for: true
   # You must set the trusted proxy IP address so that Home Assistant will properly accept connections
-  # Set this to your NGINX machine IP, or localhost if hosted on the same machine.
-  trusted_proxies: <NGINX IP address here, or 127.0.0.1 if hosted on the same machine>
+  # Set this to your Caddy machine IP, or localhost if hosted on the same machine.
+  trusted_proxies: <Caddy IP address here, or 127.0.0.1 if hosted on the same machine>
 ```
 
 ### {% linkable_title 6. Start Caddy %}


### PR DESCRIPTION
**Description:**
Made the Caddy configuration documentation a bit more elaborate. Drew inspiration from the NGINX configuration docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
