### PR TITLE
Fix link on Z-Wave Controllers page

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -39,7 +39,7 @@ The alternative to a stick is a hub that supports Z-Wave. Home Assistant support
 
 ### {% linkable_title Aeotec Stick %}
 
-By default this will turn on "disco lights", which you can turn off by following the instructions in the [device specific page](/docs/z-wave/device-specific/#aeon-z-stick)
+By default this will turn on "disco lights", which you can turn off by following the instructions in the [device specific page](/docs/z-wave/device-specific/#aeotec-z-stick)
 
 ### {% linkable_title Razberry Board %}
 


### PR DESCRIPTION
**Description:**

Fixes a link on the [Z-Wave Controllers](https://www.home-assistant.io/docs/z-wave/controllers/) page.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
