### PR TITLE
Fixes link to access tokens

### DIFF
--- a/source/_components/sensor.github.markdown
+++ b/source/_components/sensor.github.markdown
@@ -17,7 +17,7 @@ The GitHub sensor integrates data from [GitHub](https://github.com/) to monitor 
 
 ## {% linkable_title Setup %}
 
-To set up this sensor you will need a [personal access token][accesstoken]. You will need to check the `repo` scope for the sensor to function.
+To set up this sensor you will need a [personal access token](https://github.com/settings/tokens). You will need to check the `repo` scope for the sensor to function.
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
**Description:**

Not sure how I missed this, but the link was broken to the personal access tokens. This fixes that

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
