### PR TITLE
Added 2 new PLC types DINT and UDINT

### DIFF
--- a/source/_components/ads.markdown
+++ b/source/_components/ads.markdown
@@ -40,7 +40,7 @@ To enable ADS, add the following lines to your `configuration.yaml` file:
 # Example configuration.yaml entry
 ads:
   device: '127.0.0.1.1.1'
-  port: 48898
+  port: 801
 ```
 
 {% configuration %}
@@ -137,7 +137,7 @@ name:
 
 ## {% linkable_title Sensor %}
 
-The `ads` sensor platform allows reading the value of a numeric variable on your ADS device. The variable can be of type *INT*, *UINT* or *BYTE*.
+The `ads` sensor platform allows reading the value of a numeric variable on your ADS device. The variable can be of type *INT*, *UINT*,  *BYTE*, *DINT* or *UDINT*. 
 
 To use your ADS device, you first have to set up your [ADS hub](/components/ads/) and then add the following to your `configuration.yaml`
 file:
@@ -158,7 +158,7 @@ adsvar:
   type: string
 adstype:
   required: false
-  description: The datatype of the ADS variable, possible values are int, uint, byte.
+  description: The datatype of the ADS variable, possible values are int, uint, byte, dint, udint.
   default: int
   type: string
 name:


### PR DESCRIPTION
1) added 2 new PLC types. 
2) Correction in the configuration.yaml example: port is typically 801 or 851, not 48898 (48898 is the TCP port on the PLC. 801 (twincat 2) or 851 (twincat 3) are the default ADS ports under which the PLC runtime is accessible.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
