### PR TITLE
Allow user to disable device tracker

### DIFF
--- a/source/_components/googlehome.markdown
+++ b/source/_components/googlehome.markdown
@@ -59,6 +59,11 @@ devices:
       required: false
       type: boolean
       default: false
+    track_devices:
+      description: Setting to tell the component to track nearby devices.
+      required: false
+      type: boolean
+      default: true
 {% endconfiguration %}
 
 ## {% linkable_title Device types %}


### PR DESCRIPTION

**Description:**

Useful for users who only wish to track alarms or only track devices from specific google home units.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21335

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
