### PR TITLE
Name attributed not supported for the platform

### DIFF
--- a/source/_components/remote.itach.markdown
+++ b/source/_components/remote.itach.markdown
@@ -23,7 +23,6 @@ To use your iTach remote in your installation, you will need to know the IR comm
 # Example configuration.yaml entry
 remote:
   - platform: itach
-    name: Living Room
     host: itach023fdc
     devices:
       - name: TV
@@ -36,10 +35,6 @@ remote:
 ```
 
 {% configuration %}
-name:
-  description: The iTach's name to display in the front end.
-  required: false
-  type: string
 host:
   description: The iTach's IP address.
   required: true


### PR DESCRIPTION
The Name attribute is not valid at the platform level. If the name attribute is set a warning appears in the log. The iTach device does not appear in the UI just the devices.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
