### PR TITLE
Removed extra key "authentication"

### DIFF
--- a/source/_components/camera.generic.markdown
+++ b/source/_components/camera.generic.markdown
@@ -45,11 +45,6 @@ password:
   description: The password for accessing your camera.
   required: false
   type: string
-authentication:
-  description: "Type for authenticating the requests `basic` or `digest`."
-  required: false
-  default: basic
-  type: string
 limit_refetch_to_url_change:
   description: Limits re-fetching of the remote image to when the URL changes. Only relevant if using a template to fetch the remote image.
   required: false


### PR DESCRIPTION
Received this extra key warning:

```
Your configuration contains extra keys that the platform does not support.
Please remove [auhentication].  (See /config/cameras.yaml, line 0).

```
The authentication key was still in the generic camera documentation.

Removing the key from my configuration did not affect correct operation of the camera. Assume this is now an invalid key so have submitted this PR to remove it.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
