### PR TITLE
Clarify which password to use with velux component

### DIFF
--- a/source/_components/velux.markdown
+++ b/source/_components/velux.markdown
@@ -33,7 +33,7 @@ A `velux` section must be present in the `configuration.yaml` file and contain t
 # Example configuration.yaml entry
 velux:
   host: "192.168.1.23"
-  password: "velux123"
+  password: "A3C4u10A12c"
 ```
 
 {% configuration %}
@@ -42,7 +42,7 @@ host:
   required: true
   type: string
 password:
-  description: The password of the KLF 200 interface.
+  description: The password of the KLF 200 interface. Note that this is the same as the WiFi password (in the upper box on the back), *not* the password for the web login.
   required: true
   type: string
 {% endconfiguration %}

--- a/source/_components/velux.markdown
+++ b/source/_components/velux.markdown
@@ -33,7 +33,7 @@ A `velux` section must be present in the `configuration.yaml` file and contain t
 # Example configuration.yaml entry
 velux:
   host: "192.168.1.23"
-  password: "A3C4u10A12c"
+  password: "VELUX_PASSWORD"
 ```
 
 {% configuration %}


### PR DESCRIPTION
Previous examples everywhere use the "velux123" string. That is the web login password the KLF 200 defaults to. The password actually required is the other one, which is both significantly more complex and set elsewhere.
Changing the example will hopefully help others to not waste as much time on this as I did ;-)



**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
