### PR TITLE
Add an example with a template

### DIFF
--- a/source/_components/sensor.imap_email_content.markdown
+++ b/source/_components/sensor.imap_email_content.markdown
@@ -85,6 +85,7 @@ value_template:
 The following example shows the usage of the IMAP email content sensor to scan the subject of an email for text, in this case an email from the APC SmartConnect service which tells whether the UPS is running on battery or not.
 
 ```yaml
+sensor:
   - platform: imap_email_content
     server: imap.gmail.com
     name: house_electricity

--- a/source/_components/sensor.imap_email_content.markdown
+++ b/source/_components/sensor.imap_email_content.markdown
@@ -13,7 +13,6 @@ ha_iot_class: "Cloud Push"
 ha_release: 0.25
 ---
 
-
 The `imap_email_content` sensor platform will read emails from an IMAP email server and report them as a state change within Home Assistant. This is useful if you have a device that only reports its state via email.
 
 ## {% linkable_title Configuration %}
@@ -81,9 +80,9 @@ value_template:
 
 ## {% linkable_title Example %}
 
+The following example shows the usage of the IMAP email content sensor to scan the subject of an email for text, in this case, an email from the APC SmartConnect service which tells whether the UPS is running on battery or not.
 
-The following example shows the usage of the IMAP email content sensor to scan the subject of an email for text, in this case an email from the APC SmartConnect service which tells whether the UPS is running on battery or not.
-
+{% raw %}
 ```yaml
 sensor:
   - platform: imap_email_content
@@ -93,7 +92,7 @@ sensor:
     username: MY_EMAIL_USERNAME
     password: MY_EMAIL_PASSWORD
     senders:
-    - no-reply@smartconnect.apc.com
+      - no-reply@smartconnect.apc.com
     value_template: >-
       {% if 'UPS On Battery' in subject %}
         power_out
@@ -101,4 +100,6 @@ sensor:
         power_on
       {% endif %}
 ```
+{% endraw %}
+
 The same template structure can scan the date, body, or sender for matching text before setting the state of the sensor. 

--- a/source/_components/sensor.imap_email_content.markdown
+++ b/source/_components/sensor.imap_email_content.markdown
@@ -78,3 +78,26 @@ value_template:
     date:
       description: The date and time the email was sent.
 {% endconfiguration %}
+
+## {% linkable_title Example %}
+
+
+The following example shows the usage of the IMAP email content sensor to scan the subject of an email for text, in this case an email from the APC SmartConnect service which tells whether the UPS is running on battery or not.
+
+```yaml
+  - platform: imap_email_content
+    server: imap.gmail.com
+    name: house_electricity
+    port: 993
+    username: MY_EMAIL_USERNAME
+    password: MY_EMAIL_PASSWORD
+    senders:
+    - no-reply@smartconnect.apc.com
+    value_template: >-
+      {% if 'UPS On Battery' in subject %}
+        power_out
+      {% elif 'Power Restored' in subject %}
+        power_on
+      {% endif %}
+```
+The same template structure can scan the date, body, or sender for matching text before setting the state of the sensor. 


### PR DESCRIPTION
I found it very hard to find an example template for IMAP email sensor, so I think it would be helpful to include a working one here. This one works correctly and has been tested extensively with a popular cloud service.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
