### PR TITLE
Update tellstick to match with new sensor configuration

### DIFF
--- a/source/_components/tellstick.markdown
+++ b/source/_components/tellstick.markdown
@@ -108,7 +108,7 @@ sensor:
   required: false
   type: string
 only_named:
-  description: Only show the named sensors. Add sensors to only include specified sensors. If this is not specified the all sensors will be imported and the names will be based on each sensors ID number.
+  description: Only add and include specified sensors. If this is not specified all sensors will be imported and the names will be based on each sensor's ID number.
   required: false
   default: false
   type: list

--- a/source/_components/tellstick.markdown
+++ b/source/_components/tellstick.markdown
@@ -108,10 +108,19 @@ sensor:
   required: false
   type: string
 only_named:
-  description: Only show the named sensors. Set to `true` to hide sensors.
+  description: Only show the named sensors. Add sensors to only include specified sensors. If this is not specified the all sensors will be imported and the names will be based on each sensors ID number.
   required: false
   default: false
-  type: boolean
+  type: list
+  keys:
+    id:
+      description: The ID-number of the sensor to include.
+      required: true
+      type: integer
+    name:
+      description: Specify the name of the selected sensor.
+      required: true
+      type: string
 temperature_scale:
   description: The scale of the temperature value.
   required: false
@@ -134,11 +143,13 @@ In this section you find some real-life examples of how to use this sensor.
 # Example configuration.yaml entry
 sensor:
   - platform: tellstick
-    135: Outside
-    21: Inside
-    only_named: true
     temperature_scale: "°C"
     datatype_mask: 1
+    only_named:
+      - id: 135
+        name: Outside
+      - id: 21
+        name: Inside
 ```
 
 ## {% linkable_title Switch %}


### PR DESCRIPTION
**Description:**
Sensor configuration will now use static identifiers instead of ID number to set the name of named sensors.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21402

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
