### PR TITLE
Add SmartThings Scene platform docs

### DIFF
--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -265,7 +265,7 @@ The SmartThings Sensor platform lets your view devices that have sensor-related 
 
 ### {% linkable_title Scene %}
 
-The SmartThings Scene platform lets you activate scenes defined in SmartThings with an scene entity representing each SmartThings scenes within the location.
+The SmartThings Scene platform lets you activate scenes defined in SmartThings with a scene entity representing each SmartThings scenes within the location.
 
 ### {% linkable_title Switch %}
 

--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -18,6 +18,7 @@ ha_category:
   - Light
   - Lock
   - Sensor
+  - Scene
   - Switch
 ha_release: "0.87"
 ha_iot_class: "Cloud Push"
@@ -36,6 +37,8 @@ redirect_from:
   - /components/lock.smartthings/
   - /components/smartthings.sensor/
   - /components/sensor.smartthings/
+  - /components/smartthings.scene/
+  - /components/scene.smartthings/
   - /components/smartthings.switch/
   - /components/switch.smartthings/
 ---
@@ -132,7 +135,8 @@ SmartThings represents devices as a set of [capabilities](https://smartthings.de
 - [Fan](#fan) 
 - [Light](#light) 
 - [Lock](#lock)
-- [Sensor](#sensor) 
+- [Sensor](#sensor)
+- [Scene](#scene)
 - [Switch](#switch)
 
 Support for additional platforms will be added in the future.
@@ -258,6 +262,10 @@ The SmartThings Sensor platform lets your view devices that have sensor-related 
 | [`voltageMeasurement`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Voltage-Measurement)                 | `voltage`
 | [`washerMode`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Washer-Mode)                                 | `washerMode`
 | [`washerOperatingState`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Washer-Operating-State)            | `machineState`, `washerJobState` and `completionTime`
+
+### {% linkable_title Scene %}
+
+The SmartThings Scene platform lets you activate scenes defined in SmartThings with an scene entity representing each SmartThings scenes within the location.
 
 ### {% linkable_title Switch %}
 


### PR DESCRIPTION
**Description:**
Adds documentation for the SmartThings Scene platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#21405

## Checklist:
- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html