### PR TITLE
Updates for python36 and scl

### DIFF
--- a/source/_docs/installation/centos.markdown
+++ b/source/_docs/installation/centos.markdown
@@ -11,43 +11,48 @@ footer: true
 
 To run Python 3.x on [CentOS](https://www.centos.org/) or RHEL (Red Hat Enterprise Linux), [Software Collections](https://www.softwarecollections.org/en/scls/rhscl/rh-python36/) needs to be activated first.
 
-You must install Python 3.5.3 or later. Software Collections version of Python 3.5 is 3.5.1 so this guide uses Python 3.6.
-
 ### {% linkable_title Using Software Collections %}
 
-First of all install the software collection repository as root and scl utils. For example, on CentOS:
+First of all install the software collection repository as root and [scl utils](https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html-single/Software_Collections_Guide/). For example, on CentOS:
 
 ```bash
-$ yum install centos-release-scl
+$ sudo yum install centos-release-scl
 $ sudo yum-config-manager --enable centos-sclo-rh-testing
-$ yum install -y scl-utils
+$ sudo yum install -y scl-utils
 ```
 
 Install some dependencies you'll need later.
 
 ```bash
-$ yum install gcc gcc-c++ systemd-devel
+$ sudo yum install gcc gcc-c++ systemd-devel
 ```
 
-Then install the Python 3.6 package:
-(Note on CentOS7 you may have to install the packages for Python 3.6 using RHEL Methods listed here: https://www.softwarecollections.org/en/scls/rhscl/rh-python36/) for this to work as mentioned above.
+Then install the Python 3.6 package. If you are using CentOS 7 then you may have to install the packages for Python 3.6 using RHEL Methods listed here: https://www.softwarecollections.org/en/scls/rhscl/rh-python36/) for this to work as mentioned above.
 
+```bash
 $ sudo yum install rh-python36
-(This is part of the slight change when trying to install python36 and running the command python36 -V which will after install give you the correct version, but won't allow you to set the software collection using the scl command.  This command downloads the RH collection of Python to allow you to run scl command to enable the environment in bash and then run the automate command using the template) 
+```
+
+This is part of the slight change when trying to install Python 3.6 and running the command `python36 --version` which will after install give you the correct version, but won't allow you to set the software collection using the `scl` command. This command downloads the RH collection of Python to allow you to run `scl` command to enable the environment in `bash` and then run the automate command using the template.
 
 ```bash
 $ yum install rh-python36
 ```
-# 3. Start using software collections:
+
+### {% linkable_title Start using software collections %}
+
+```bash
 $ scl enable rh-python36 bash
+```
 
 Once installed, switch to your `homeassistant` user (if you've set one up), enable the software collection and check that it has set up the new version of Python:
 
+```bash
 $ python --version
 Python 3.6.3
 ```
 
-You will be in a command shell set up with Python 3.6 as your default version. The virtualenv and pip commands will be correct for this version, so you can now create a virtual environment and install Home Assistant following the main [instructions](/docs/installation/virtualenv/#step-4-set-up-the-virtualenv).
+You will be in a command shell set up with Python 3.6 as your default version. The `virtualenv` and `pip` commands will be correct for this version, so you can now create a virtual environment and install Home Assistant following the main [instructions](/docs/installation/virtualenv/#step-4-set-up-the-virtualenv).
 
 You will need to enable the software collection each time you log on before you activate your virtual environment.
 

--- a/source/_docs/installation/centos.markdown
+++ b/source/_docs/installation/centos.markdown
@@ -15,10 +15,12 @@ You must install Python 3.5.3 or later. Software Collections version of Python 3
 
 ### {% linkable_title Using Software Collections %}
 
-First of all install the software collection repository as root. For example, on CentOS:
+First of all install the software collection repository as root and scl utils. For example, on CentOS:
 
 ```bash
 $ yum install centos-release-scl
+$ sudo yum-config-manager --enable centos-sclo-rh-testing
+$ yum install -y scl-utils
 ```
 
 Install some dependencies you'll need later.
@@ -28,15 +30,19 @@ $ yum install gcc gcc-c++ systemd-devel
 ```
 
 Then install the Python 3.6 package:
+(Note on CentOS7 you may have to install the packages for Python 3.6 using RHEL Methods listed here: https://www.softwarecollections.org/en/scls/rhscl/rh-python36/) for this to work as mentioned above.
+
+$ sudo yum install rh-python36
+(This is part of the slight change when trying to install python36 and running the command python36 -V which will after install give you the correct version, but won't allow you to set the software collection using the scl command.  This command downloads the RH collection of Python to allow you to run scl command to enable the environment in bash and then run the automate command using the template) 
 
 ```bash
 $ yum install rh-python36
 ```
+# 3. Start using software collections:
+$ scl enable rh-python36 bash
 
 Once installed, switch to your `homeassistant` user (if you've set one up), enable the software collection and check that it has set up the new version of Python:
 
-```bash
-$ scl enable rh-python36 bash
 $ python --version
 Python 3.6.3
 ```


### PR DESCRIPTION
Latest changes to installing the scl environment don't include the scl command, scl-utils is needed along w/ the proper repository in Centos7 to be enabled via RH and then downloaded to the environment which you are building and then SCL commands will work and setting python environment for bash will work too.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
