### PR TITLE
Document 'firetv.adb_command' service

### DIFF
--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -117,3 +117,21 @@ If you receive the error message `Issue: Error while setting up platform firetv`
 3. Home Assistant does not have the appropriate permissions for the `adbkey` file and so it is not able to use it.  Once you fix the permissions, the component should work.
 
 4. You are already connected to the Fire TV via ADB from another device.  Only one device can be connected, so disconnect the other device, restart the Fire TV (for good measure), and then restart Home Assistant.  
+
+
+## {% linkable_title Service %}
+
+A service `media_player.firetv_adb_cmd` is provided allowing you to send either keys or ADB shell commands to the Fire TV.
+
+```json
+{
+  "entity_id" : "media_player.fire_tv_living_room", 
+  "cmd" : "HOME"
+}
+```
+
+Service parameters:
+
+- **entity_id**: Name(s) of Fire TV entities.
+- **cmd**: Either a key command or an ADB shell command.
+  - Available key commands: `POWER`, `SLEEP`, `HOME`, `UP`, `DOWN`, `LEFT`, `RIGHT`, `ENTER`, `BACK`, or `MENU`

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -134,4 +134,4 @@ Service parameters:
 
 - **entity_id**: Name(s) of Fire TV entities.
 - **cmd**: Either a key command or an ADB shell command.
-  - Available key commands: `POWER`, `SLEEP`, `HOME`, `UP`, `DOWN`, `LEFT`, `RIGHT`, `ENTER`, `BACK`, or `MENU`
+  - Available key commands: `POWER`, `SLEEP`, `HOME`, `UP`, `DOWN`, `LEFT`, `RIGHT`, `CENTER`, `BACK`, or `MENU`

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -121,17 +121,32 @@ If you receive the error message `Issue: Error while setting up platform firetv`
 
 ## {% linkable_title Service %}
 
-A service `firetv.adb_command` is provided allowing you to send either keys or ADB shell commands to the Fire TV.
+The service `firetv.adb_command` allows you to send either keys or ADB shell commands to the Fire TV.
 
-```json
-{
-  "entity_id" : "media_player.fire_tv_living_room", 
-  "command" : "HOME"
-}
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |       no | Name(s) of Fire TV entities.
+| `command`              |       no | Either a key command or an ADB shell command.
+
+In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this:
+
+```yaml
+action:
+  service: firetv.adb_command
+  data:
+    entity_id: media_player.fire_tv_living_room
+    command: "HOME"
 ```
 
-Service parameters:
+Available key commands are:
 
-- **entity_id**: Name(s) of Fire TV entities.
-- **command**: Either a key command or an ADB shell command.
-  - Available key commands: `POWER`, `SLEEP`, `HOME`, `UP`, `DOWN`, `LEFT`, `RIGHT`, `CENTER`, `BACK`, or `MENU`
+* `POWER`
+* `SLEEP`
+* `HOME`
+* `UP`
+* `DOWN`
+* `LEFT`
+* `RIGHT`
+* `CENTER`
+* `BACK`
+* `MENU`

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -121,17 +121,17 @@ If you receive the error message `Issue: Error while setting up platform firetv`
 
 ## {% linkable_title Service %}
 
-A service `media_player.firetv_adb_cmd` is provided allowing you to send either keys or ADB shell commands to the Fire TV.
+A service `media_player.firetv_adb_command` is provided allowing you to send either keys or ADB shell commands to the Fire TV.
 
 ```json
 {
   "entity_id" : "media_player.fire_tv_living_room", 
-  "cmd" : "HOME"
+  "command" : "HOME"
 }
 ```
 
 Service parameters:
 
 - **entity_id**: Name(s) of Fire TV entities.
-- **cmd**: Either a key command or an ADB shell command.
+- **command**: Either a key command or an ADB shell command.
   - Available key commands: `POWER`, `SLEEP`, `HOME`, `UP`, `DOWN`, `LEFT`, `RIGHT`, `CENTER`, `BACK`, or `MENU`

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -121,7 +121,7 @@ If you receive the error message `Issue: Error while setting up platform firetv`
 
 ## {% linkable_title Service %}
 
-A service `media_player.firetv_adb_command` is provided allowing you to send either keys or ADB shell commands to the Fire TV.
+A service `firetv.adb_command` is provided allowing you to send either keys or ADB shell commands to the Fire TV.
 
 ```json
 {


### PR DESCRIPTION
**Description:**

Documentation for the `media_player.firetv_adb_cmd` service.  

Generated documentation: https://deploy-preview-8722--home-assistant-docs.netlify.com/components/media_player.firetv/

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/21419

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
