### PR TITLE
Corrected example automation

### DIFF
--- a/source/_docs/ecosystem/ios/notifications/actions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/actions.markdown
@@ -132,8 +132,7 @@ automation:
       platform: event
       event_type: ios.notification_action_fired
       event_data:
-        data:
-          actionName: SOUND_ALARM
+        actionName: SOUND_ALARM
     action:
       ...
 ```


### PR DESCRIPTION
The trigger in the example automation contained the line 'data:' below the event_data, which is redundant.
If used this way the automation triggers on any iOS action and ignores the actionName.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
