### PR TITLE
Update Plex sensor docs for SSL verification

### DIFF
--- a/source/_components/sensor.plex.markdown
+++ b/source/_components/sensor.plex.markdown
@@ -60,8 +60,13 @@ token:
   required: false
   type: string
 ssl:
-  description: Use HTTPS to connect to Plex server, *NOTE* host *must not* be an IP when this option is enabled.
+  description: Use HTTPS to connect to Plex server, **NOTE:** host **must not** be an IP when this option is enabled.
   required: false
   default: false
+  type: boolean
+verify_ssl:
+  description: Verify the SSL certificate of your Plex server. You may need to disable this check if your local server enforces secure connections with the default certificate.
+  required: false
+  default: true
   type: boolean
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Companion PR to home-assistant/home-assistant#21432, syncs docs to the new configuration option to toggle SSL certificate validation.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#21432

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
