### PR TITLE
Add documentation for LCN sensor platform

### DIFF
--- a/source/_components/lcn.markdown
+++ b/source/_components/lcn.markdown
@@ -254,7 +254,7 @@ The [MOTOR_PORT](/components/lcn#ports) values specify which hardware relay conf
 | `motor3` | `relay5`     | `relay6`      |
 | `motor4` | `relay7`     | `relay8`      |
 
-#### {% linkable_title Variables and Units %}
+### {% linkable_title Variables and Units %}
 
 | Constant | Values |
 | -------- | ------ |
@@ -264,7 +264,7 @@ The [MOTOR_PORT](/components/lcn#ports) values specify which hardware relay conf
 | S0_INPUT | `s0input1`, `s0input2`, `s0input3`, `s0input4` |
 | VAR_UNIT | `native`, `°C`, `°K`, `°F`, `lux_t`, `lux_i`, `m/s`, `%`, `ppm`, `volt`, `ampere`, `degree` |
 
-#### {% linkable_title States %}:
+### {% linkable_title States %}:
 
 | Constant | Values |
 | -------- | ------ |

--- a/source/_components/lcn.markdown
+++ b/source/_components/lcn.markdown
@@ -12,6 +12,7 @@ ha_category:
   - Hub
   - Cover
   - Light
+  - Sensor
   - Switch
 ha_release: 0.85
 ha_iot_class: Local Push
@@ -30,6 +31,7 @@ There is currently support for the following device types within Home Assistant:
 
 - [Cover](#cover)
 - [Light](#light)
+- [Sensor](#sensor)
 - [Switch](#switch)
 
 ## {% linkable_title Configuration %}
@@ -59,6 +61,12 @@ lcn:
       dimmable: true
       transition: 5
 
+  sensors:
+    - name: Temperature
+      address: myhome.s0.m7
+      source: var3
+      unit_of_measuremnt: celsius 
+  
   switches:
     - name: Sprinkler switch
       address: myhome.s0.m7
@@ -67,7 +75,7 @@ lcn:
 
 {% configuration %}
 connections:
-  description: List of your connections
+  description: List of your connections.
   required: true
   type: map
   keys:
@@ -149,6 +157,29 @@ lights:
       type: int
       default: 0
 
+sensors:
+  description: List of your sensors.
+  required: false
+  type: map
+  keys:
+    name:
+      description: "Name of the sensor."
+      required: true
+      type: string
+    address:
+      description: "[Address](/components/lcn#lcn-addresses) of the module/group."
+      required: true
+      type: string
+    source:
+      description: "Sensor source ([VARIABLE](/components/lcn#variables-and-units), [SETPOINT](/components/lcn#variables-and-units), [THRESHOLD](/components/lcn#variables-and-units), [S0_INPUT](/components/lcn#variables-and-units), [LED_PORT](/components/lcn#ports), [LOGICOP_PORT](/components/lcn#ports))."
+      required: true
+      type: string
+    unit_of_measurement:
+      description: "Measurement unit ([VAR_UNIT](/components/lcn#variables-and-units))."
+      required: false
+      type: string
+      default: 'native'
+
 switches:
   description: List of your switches.
   required: false
@@ -211,6 +242,8 @@ The platforms and service calls use several predefined constants as parameters.
 | OUTPUT_PORT | `output1`, `output2`, `output3`, `output4` |
 | RELAY_PORT | `relay1`, `relay2`, `relay3`, `relay4`, `relay5`, `relay6`, `relay7`, `relay8` |
 | MOTOR_PORT | `motor1`, `motor2`, `motor3`, `motor4` |
+| LED_PORT | `led1`, `led2`, `led3`, `led4`, `led5`, `led6`, `led7`, `led8`, `led9`, `led10`, `led11`, `led12` |
+| LOGICOP_PORT | `logicop1`, `logicop2`, `logicop3`, `logicop4` |
 
 The [MOTOR_PORT](/components/lcn#ports) values specify which hardware relay configuration will be used:
 
@@ -221,18 +254,55 @@ The [MOTOR_PORT](/components/lcn#ports) values specify which hardware relay conf
 | `motor3` | `relay5`     | `relay6`      |
 | `motor4` | `relay7`     | `relay8`      |
 
-## {% linkable_title Cover %}
+#### {% linkable_title Variables and Units %}
+
+| Constant | Values |
+| -------- | ------ |
+| VARIABLE | `var1`, `var2`, `var3`, `var4`, `var5`, `var6`, `var7`, `var8`, `var9`, `var10`, `var11`, `var12`, `tvar`, `r1var`, `r2var` |
+| SETPOINT | `r1varsetpoint`, `r2varsetpoint` |
+| THRESHOLD | `thrs1`, `thrs2`, `thrs3`, `thrs4`, `thrs5`, `thrs2_1`, `thrs2_2`, `thrs2_3`, `thrs2_4`, `thrs3_1`, `thrs3_2`, `thrs3_3`, `thrs3_4`, `thrs4_1`, `thrs4_2`, `thrs4_3`, `thrs4_4` |
+| S0_INPUT | `s0input1`, `s0input2`, `s0input3`, `s0input4` |
+| VAR_UNIT | `native`, `celsius`, `kelvin`, `fahrenheit`, `lux_t`, `lux_i`, `m/s`, `%`, `ppm`, `volt`, `ampere`, `degree` |
+
+#### {% linkable_title States %}:
+
+| Constant | Values |
+| -------- | ------ |
+| LED_STATE | `on`. `off`, `blink`, `flicker` |
+| LOGICOP_STATE | `not`. `or`, `and` |
+
+## {% linkable_title Platforms %}
+
+### {% linkable_title Cover %}
 
 The `lcn` cover platform allows the control of [LCN](http://www.lcn.eu) relays which have been configured as motor controllers.
 
-## {% linkable_title Light %}
+### {% linkable_title Light %}
 
 The `lcn` light platform allows the control of the following [LCN](http://www.lcn.eu) ports:
 
 - (Dimmable) output ports
 - Relays
 
-## {% linkable_title Switch %}
+### {% linkable_title Sensor %}
+
+The `lcn` sensor platform allows the monitoring of the following [LCN](http://www.lcn.eu) data sources:
+
+- Variables
+- Regulator setpoints
+- Thresholds
+- S0 inputs
+- LED states
+- Logic operation states
+
+The sensor can be used in automation scripts or in conjunction with `template` platforms.
+
+<p class='note'>
+  Ensure that the LCN module is configured properly to provide the requested value.
+  Otherwise the module might show unexpected behavior or return error messages.
+</p>
+
+### {% linkable_title Switch %}
 
 The `lcn` switch platform allows the control of the following [LCN](http://www.lcn.eu) ports:
 

--- a/source/_components/lcn.markdown
+++ b/source/_components/lcn.markdown
@@ -65,7 +65,7 @@ lcn:
     - name: Temperature
       address: myhome.s0.m7
       source: var3
-      unit_of_measuremnt: celsius 
+      unit_of_measuremnt: °C
   
   switches:
     - name: Sprinkler switch
@@ -262,7 +262,7 @@ The [MOTOR_PORT](/components/lcn#ports) values specify which hardware relay conf
 | SETPOINT | `r1varsetpoint`, `r2varsetpoint` |
 | THRESHOLD | `thrs1`, `thrs2`, `thrs3`, `thrs4`, `thrs5`, `thrs2_1`, `thrs2_2`, `thrs2_3`, `thrs2_4`, `thrs3_1`, `thrs3_2`, `thrs3_3`, `thrs3_4`, `thrs4_1`, `thrs4_2`, `thrs4_3`, `thrs4_4` |
 | S0_INPUT | `s0input1`, `s0input2`, `s0input3`, `s0input4` |
-| VAR_UNIT | `native`, `celsius`, `kelvin`, `fahrenheit`, `lux_t`, `lux_i`, `m/s`, `%`, `ppm`, `volt`, `ampere`, `degree` |
+| VAR_UNIT | `native`, `°C`, `°K`, `°F`, `lux_t`, `lux_i`, `m/s`, `%`, `ppm`, `volt`, `ampere`, `degree` |
 
 #### {% linkable_title States %}:
 


### PR DESCRIPTION
**Description:**
Documentation is added for the LCN sensor platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21440

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
