### PR TITLE
API link updated and charge for API

### DIFF
--- a/source/_components/smappee.markdown
+++ b/source/_components/smappee.markdown
@@ -29,7 +29,7 @@ There is currently support for the following device types within Home Assistant:
 
 Will be automatically added when you connect to the Smappee controller.
 
-The smappee component gets information from [Smappee API](https://smappee.atlassian.net/wiki/display/DEVAPI/API+Methods).
+The smappee component gets information from [Smappee API](https://smappee.atlassian.net/wiki/spaces/DEVAPI/overview). Note: their cloud API now requires a subscription fee of €2.50 per month for Smappee Energy/Solar or €3 per month for Smappee Plus.
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
Update to API Link (previous link invalid. Added details of cost introduced to use their cloud API. I was informed of this when I recently requested my client_secret. I'm not sure if this affects existing users.

I was given the following from Smappee support but has yet to configure with local API via MQTT (Mosquitto & Node Red). If anyone knows how best to write this information into the page, would appreciate it.

Here are the links they provided:
How to find the UUID.pdf
https://support.smappee.com/attachments/token/y7MJ5O6e9P2kzuniuNfP5glFw/?name=How+to+find+the+UUID.pdf

Smappee local MQTT topics -20-09-2018.pdf
https://support.smappee.com/attachments/token/o5gKlg0jqbK2mVh0B6yfHArCy/?name=Smappee+local+MQTT+topics+-20-09-2018.pdf

Node Red, Smappee nodes:
https://flows.nodered.org/node/@smappee/node-red-contrib-smappee

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
