### PR TITLE
updating 'pair_finish' command

### DIFF
--- a/source/_components/media_player.vizio.markdown
+++ b/source/_components/media_player.vizio.markdown
@@ -56,7 +56,7 @@ Initiation will show you two different values:
 Finally, at this point a PIN code should be displayed at the top of your TV. With all these values, you can now finish pairing:
 
 ```bash
-$ pyvizio --ip={ip} pair-finish --token={challenge_token} --pin={tv_pin}
+$ pyvizio --ip={ip} pair_finish --token={challenge_token} --pin={tv_pin}
 ```
 
 You will need the authentication token returned by this command to configure Home Assistant.


### PR DESCRIPTION
pair-finish is now called pair_finish instead. Just a documentation change. 

🦄   brandon@dumbo[~] > pyvizio
Usage: pyvizio [OPTIONS] COMMAND [ARGS]...

Options:
  --ip TEXT    [required]
  --auth TEXT
  --help       Show this message and exit.

Commands:
  channel
  discover
  input
  input_get
  input_list
  input_next
  mute
  pair
  pair_finish ******
  pair_stop
  power
  volume
  volume_current

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
