### PR TITLE
Added documentation for verify_ssl

### DIFF
--- a/source/_components/notify.nfandroidtv.markdown
+++ b/source/_components/notify.nfandroidtv.markdown
@@ -105,6 +105,8 @@ The following attributes can be placed inside `data` to send images.
 | `username`             |      yes | Username if the url requires authentication. Is placed inside `file`.
 | `password`             |      yes | Password if the url requires authentication. Is placed inside `file`.
 | `auth`                 |      yes | If set to `digest` HTTP-Digest-Authentication is used. If missing, HTTP-BASIC-Authentication is used. Is placed inside `file`.
+| `verify_ssl`           |      yes | If set to `False` it will ignore SSL Certificate errors. 
+
 
 Example for posting file from URL:
 
@@ -117,7 +119,8 @@ Example for posting file from URL:
       "url":"http://[url to image file]",
       "username":"optional user, if necessary",
       "password":"optional password, if necessary",
-      "auth":"digest"
+      "auth":"digest",
+      "verify_ssl": "False"
     }
   }
 }


### PR DESCRIPTION
Added explanation and added to example.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
