### PR TITLE
Remove the google travel time update service

### DIFF
--- a/source/_components/sensor.google_travel_time.markdown
+++ b/source/_components/sensor.google_travel_time.markdown
@@ -139,7 +139,7 @@ sensor:
 
 ## {% linkable_title Updating sensors on-demand using Automation %}
 
-You can also use the `sensor.google_travel_sensor_update` service to update the sensor on-demand. For example, if you want to update `sensor.morning_commute` every 2 minutes on weekday mornings, you can use the following automation:
+You can also use the `homeassistant.update` service to update the sensor on-demand. For example, if you want to update `sensor.morning_commute` every 2 minutes on weekday mornings, you can use the following automation:
 
 ```yaml
 - id: update_morning_commute_sensor
@@ -160,7 +160,7 @@ You can also use the `sensor.google_travel_sensor_update` service to update the 
         - thu
         - fri
   action:
-    - service: sensor.google_travel_sensor_update
+    - service: homeassistant.update
       data:
         entity_id: sensor.morning_commute
 ```


### PR DESCRIPTION
**Description:**
This service was removed since `homeassistant.update` is sufficient.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21153

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
