### PR TITLE
Add cpu_use_percent as a resource to the Glances sensor.

### DIFF
--- a/source/_components/sensor.glances.markdown
+++ b/source/_components/sensor.glances.markdown
@@ -125,6 +125,8 @@ resources:
       description: The number of threads.
     process_sleeping:
       description: The number of sleeping processes.
+    cpu_use_percent:
+      description: The used CPU in percent.
     cpu_temp:
       description: The CPU temperature (may not be available on all platforms).
     docker_active:


### PR DESCRIPTION
**Description:**
Add `cpu_use_percent` as a new resource to the Glances sensor.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#21455

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
