### PR TITLE
Only the host name is used, not the protocol

### DIFF
--- a/source/_components/graphite.markdown
+++ b/source/_components/graphite.markdown
@@ -23,7 +23,7 @@ graphite:
 
 {% configuration %}
 host:
-  description: IP address of your graphite host, e.g., http://192.168.1.10.
+  description: IP address of your graphite host, e.g., 192.168.1.10.
   required: false
   type: string
   default: localhost


### PR DESCRIPTION
I searched a long time why there was nothing stored in graphite. I had to remove the protocol.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
