### PR TITLE
Added aux and panic services description

### DIFF
--- a/source/_components/ness_alarm.markdown
+++ b/source/_components/ness_alarm.markdown
@@ -78,3 +78,23 @@ zones:
       default: motion
       type: string
 {% endconfiguration %}
+
+## {% linkable_title Services %}
+
+### {% linkable_title Service `aux` %}
+
+Trigger an aux output.  This requires PCB version 7.8 or higher.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `output_id` | No | The aux output you wish to change.  A number from 1-4.
+| `state` | Yes | The On/Off State, represented as true/false. Default is true.  If P14xE 8E is enabled then a value of true will pulse output x for the time specified in P14(x+4)E.
+
+### {% linkable_title Service `panic` %}
+
+Trigger a panic
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `code` | No | The user code to use to trigger the panic.
+


### PR DESCRIPTION
The Aux commands work on my new D16XD.  I haven't tested panic.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
