### PR TITLE
Add device tracker support for Cisco Mobility Express

### DIFF
--- a/source/_components/device_tracker.cisco_mobility_express.markdown
+++ b/source/_components/device_tracker.cisco_mobility_express.markdown
@@ -1,0 +1,43 @@
+---
+layout: page
+title: "Cisco Mobility Express"
+description: "Instructions on how to integrate Cisco Mobility Express wireless controllers into Home Assistant."
+date: 2019-02-27 11:59
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: cisco.png
+ha_category: Presence Detection
+ha_release: 0.89
+---
+
+This is a presence detection scanner for [Cisco](https://www.cisco.com) Mobility Express wireless controllers.
+
+To use this device tracker in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+device_tracker:
+  - platform: cisco_mobility_express
+    host: CONTROLLER_IP_ADDRESS
+    username: YOUR_ADMIN_USERNAME
+    password: YOUR_ADMIN_PASSWORD
+```
+
+{% configuration %}
+host:
+  description: The IP address of your controller, e.g., 192.168.10.150.
+  required: true
+  type: string
+username:
+  description: The username of an user with administrative privileges.
+  required: true
+  type: string
+password:
+  description: The password for your given admin account.
+  required: true
+  type: string
+{% endconfiguration %}
+
+See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.cisco_mobility_express.markdown
+++ b/source/_components/device_tracker.cisco_mobility_express.markdown
@@ -38,6 +38,16 @@ password:
   description: The password for your given admin account.
   required: true
   type: string
+ssl:
+  description: Use HTTPS instead of HTTP to connect.
+  required: false
+  type: boolean
+  default: false
+verify_ssl:
+  description: Enable or disable SSL certificate verification. Set to false if you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification.
+  required: false
+  default: true
+  type: boolean
 {% endconfiguration %}
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.cisco_mobility_express.markdown
+++ b/source/_components/device_tracker.cisco_mobility_express.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: cisco.png
 ha_category: Presence Detection
-ha_release: 0.90
+ha_release: "0.90"
 ---
 
 This is a presence detection scanner for [Cisco](https://www.cisco.com) Mobility Express wireless controllers.
@@ -31,7 +31,7 @@ host:
   required: true
   type: string
 username:
-  description: The username of an user with administrative privileges.
+  description: The username of a user with administrative privileges.
   required: true
   type: string
 password:

--- a/source/_components/device_tracker.cisco_mobility_express.markdown
+++ b/source/_components/device_tracker.cisco_mobility_express.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: cisco.png
 ha_category: Presence Detection
-ha_release: 0.89
+ha_release: 0.90
 ---
 
 This is a presence detection scanner for [Cisco](https://www.cisco.com) Mobility Express wireless controllers.


### PR DESCRIPTION
**Description:**
This platform adds device tracker support for Cisco Mobility Express wireless controllers.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#21531

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html