### PR TITLE
Update automation.markdown

### DIFF
--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -50,7 +50,9 @@ Actions are all about calling services. To explore the available services open t
 ### {% linkable_title Automation initial state %}
 
 When you create a new automation, it will be disabled (and therefore won't trigger) unless you explicitly add `initial_state: true` to it or turn it on manually via UI/another automation/developer tools.
-If you always want your automations to be enabled or disabled upon Home Assistant restart, then you have to set an initial state in your automations. Otherwise the previous state will be restored. Please note that if for some reason Home Assistant startup is interrupted or failed and/or the previous state cannot be restored, that will result in the automation being disabled on the next Home Assistant restart.
+
+In case automations need to be enabled or disabled upon Home Assistant restart, then you have to set the `initial_state` in your automations. Otherwise, the previous state will be restored. Please note that if for some reason Home Assistant cannot restore the previous state, e.g., because of an interrupted or failed startup, it will result in the automation being disabled on the next Home Assistant startup.
+
 ```text
 automation:
 - alias: Automation Name

--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -52,6 +52,7 @@ Actions are all about calling services. To explore the available services open t
 If you always want your automations to be enabled or disabled upon Home Assistant restart, then you have to set an initial state in your automations. Otherwise the previous state will be restored.
 
 If an automation is disabled (turned off) then it will never trigger. Only automations that are enabled (turned on) will trigger.
+To have your automation enabled you should either add `initial_state: true` to your automation description (it will always make it enabled on Home Assistant startup) or turn it on manually via UI/another automation/developer tools (that way the last stored state of the automation will be restored on the next Home Assistant startup).
 
 ```text
 automation:

--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -52,7 +52,7 @@ Actions are all about calling services. To explore the available services open t
 If you always want your automations to be enabled or disabled upon Home Assistant restart, then you have to set an initial state in your automations. Otherwise the previous state will be restored.
 
 If an automation is disabled (turned off) then it will never trigger. Only automations that are enabled (turned on) will trigger.
-To have your automation enabled you should either add `initial_state: true` to your automation description (it will always make it enabled on Home Assistant startup) or turn it on manually via UI/another automation/developer tools (that way the last stored state of the automation will be restored on the next Home Assistant startup).
+To have your automation enabled you should either add `initial_state: true` to your automation description (it will always make it enabled on Home Assistant startup) or turn it on manually via UI/another automation/developer tools (that way the last stored state of the automation will be restored on the next Home Assistant startup). Please note that if for some reason Home Assistant startup is interrupted or failed and the previous state cannot be restored, that will result in the automation being disabled on the next stratup.
 
 ```text
 automation:

--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -49,11 +49,8 @@ Actions are all about calling services. To explore the available services open t
 
 ### {% linkable_title Automation initial state %}
 
-If you always want your automations to be enabled or disabled upon Home Assistant restart, then you have to set an initial state in your automations. Otherwise the previous state will be restored.
-
-If an automation is disabled (turned off) then it will never trigger. Only automations that are enabled (turned on) will trigger.
-To have your automation enabled you should either add `initial_state: true` to your automation description (it will always make it enabled on Home Assistant startup) or turn it on manually via UI/another automation/developer tools (that way the last stored state of the automation will be restored on the next Home Assistant startup). Please note that if for some reason Home Assistant startup is interrupted or failed and the previous state cannot be restored, that will result in the automation being disabled on the next stratup.
-
+When you create a new automation, it will be disabled (and therefore won't trigger) unless you explicitly add `initial_state: true` to it or turn it on manually via UI/another automation/developer tools.
+If you always want your automations to be enabled or disabled upon Home Assistant restart, then you have to set an initial state in your automations. Otherwise the previous state will be restored. Please note that if for some reason Home Assistant startup is interrupted or failed and/or the previous state cannot be restored, that will result in the automation being disabled on the next Home Assistant restart.
 ```text
 automation:
 - alias: Automation Name


### PR DESCRIPTION
Clarification of initial_state behaviour

**Description:**
It it now unclear that automation is disabled by default and one need to enable each and every one the one way or another, which creates a lot of discussions like [that](https://community.home-assistant.io/t/all-automations-are-off-on-restart/91445)


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html