### PR TITLE
Add Home Assistant API example to RESTful command description

### DIFF
--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -120,3 +120,15 @@ automation:
         status: "At Work"
         emoji: ":calendar:"
 ```
+You can also use REST commands to access the Home Assistant API without using shell commands. This example uses a long-lived access token to access the Home Assistant API and set the state of a light to on.
+
+```yaml
+set_study_light_status_to_on:
+  url: http://localhost:8123/api/states/light.study_light
+  method: POST
+  headers: 
+    authorization: 'Bearer YOUR_LONG_LIVED_ACCESS_TOKEN'
+    content-type: 'application/json'
+  payload: '{"state":"on"}'
+```
+Replace YOUR_LONG_LIVED_ACCESS_TOKEN with your token. You can obtain a token by logging into the frontend using a web browser and going to your profile http://IP_ADDRESS:8123/profile.


### PR DESCRIPTION
I cannot find this type of example documented anywhere else in the manual, and the few examples on the forum are incorrect.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
