### PR TITLE
Add support for homekit controller sensors

### DIFF
--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -17,6 +17,7 @@ ha_category:
   - Lock
   - Switch
   - Binary Sensor
+  - Sensor
 ha_release: 0.68
 ha_iot_class: "Local Polling"
 redirect_from:
@@ -26,6 +27,7 @@ redirect_from:
   - /components/light.homekit_controller/
   - /components/lock.homekit_controller/
   - /components/switch.homekit_controller/
+  - /components/sensor.homekit_controller/
 ---
 
 [HomeKit](https://developer.apple.com/homekit/) controller integration for Home Assistant allows you to connect HomeKit accessories to Home Assistant. This component should not be confused with the [HomeKit](/components/homekit/) component, which allows you to control Home Assistant devices via HomeKit.
@@ -39,6 +41,7 @@ There is currently support for the following device types within Home Assistant:
 - Lock (HomeKit lock)
 - Switch (HomeKit switches)
 - Binary Sensor (HomeKit motion sensors)
+- Sensor (HomeKit humidity, temperature, and light level sensors)
 
 The component will be automatically configured if the [`discovery:`](/components/discovery/) component is enabled and an enable entry added for HomeKit:
 


### PR DESCRIPTION
Adds support for homekit devices with temperature, humidity, and
light level characteristics

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21535

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
