### PR TITLE
Add note about finding user_id

### DIFF
--- a/source/_components/person.markdown
+++ b/source/_components/person.markdown
@@ -48,7 +48,7 @@ person:
     required: true
     type: string
   user_id:
-    description: The user id of the Home Assistant user account for the person.
+    description: The user id of the Home Assistant user account for the person. *`user_id` (aka `ID`) of users can be inspected in the "Users"/"Manage users" screen in the configuration panel.*
     required: false
     type: string
   device_trackers:


### PR DESCRIPTION
Closes https://github.com/home-assistant/home-assistant.io/issues/8714

**Description:**
Directs new users to where to find the user_id when configuring `person` entities

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
