### PR TITLE
Add info regarding charset for Mariadb addon

### DIFF
--- a/source/_addons/mariadb.markdown
+++ b/source/_addons/mariadb.markdown
@@ -83,5 +83,5 @@ Use the following configuration in Home Assistant to use the database above:
 
 ```yaml
 recorder:
-  db_url: mysql://hass:securePassword@core-mariadb/homeassistant
+  db_url: mysql://hass:securePassword@core-mariadb/homeassistant?charset=utf8
 ```


### PR DESCRIPTION
**Description:**
Missing the charset indication

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
