### PR TITLE
Add pause/unpause service descriptions for RainMachine

### DIFF
--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -113,6 +113,14 @@ switches:
 
 ## {% linkable_title Services %}
 
+### {% linkable_title `rainmachine.pause_watering` %}
+
+Pause all watering activities for a number of seconds.
+
+| Service Data Attribute    | Optional | Description                    |
+|---------------------------|----------|--------------------------------|
+| `seconds`                 |      no  | The number of seconds to pause |
+
 ### {% linkable_title `rainmachine.start_program` %}
 
 Start a RainMachine program.
@@ -149,6 +157,10 @@ Stop a RainMachine zone.
 | Service Data Attribute    | Optional | Description          |
 |---------------------------|----------|----------------------|
 | `zone_id`                 |      no  | The zone to stop     |
+
+### {% linkable_title `rainmachine.unpause_watering` %}
+
+Unpause all watering activities.
 
 ## {% linkable_title Switch %}
 


### PR DESCRIPTION
**Description:**

This PR provdies documentation updates for new, forthcoming RainMachine services.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/21548

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
