### PR TITLE
Remove warning

### DIFF
--- a/source/_components/blink.markdown
+++ b/source/_components/blink.markdown
@@ -23,8 +23,6 @@ redirect_form:
   - /components/sensor.blink/
 ---
 
-<p class='note warning'>Blink has started blocking Home Assistant users. More info in <a href="https://community.home-assistant.io/t/blink-block-account/98718">the forums</a>.</p>
-
 The `blink` component lets you view camera images and motion events from [Blink](http://blinkforhome.com) camera and security systems.
 
 ## {% linkable_title Setup %}
@@ -108,6 +106,8 @@ blink:
 ```
 
 ## {% linkable_title Services %}
+
+Any sequential calls to services relating to blink should have a minimum of a 5 second delay in between them to prevent the calls fro being throttled and ignored.
 
 ### {% linkable_title `blink.blink_update` %}
 


### PR DESCRIPTION
**Description:**
A warning was added to the blink docs regarding suspension of user accounts.  The issue has been resolved and was related to frequent api calls that are now internally throttled in the `blinkpy` library itself.  Blink was only suspending accounts that had large amounts of api calls in quick succession, and was not targeting third-party integrations.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21578

## Checklist:
- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].
