### PR TITLE
Document dlna_dmr.callback_url_override option

### DIFF
--- a/source/_components/media_player.dlna_dmr.markdown
+++ b/source/_components/media_player.dlna_dmr.markdown
@@ -47,4 +47,8 @@ name:
   description: The name you would like to give to the device, e.g., `TV living room`.
   required: false
   type: string
+callback_url_override:
+  description: Override the advertised callback url. In case the home assistant instance is not directly reachable (e.g., running in a docker container without bridged-networking), advertise this callback URL for events.
+  required: false
+  type: string
 {% endconfiguration %}

--- a/source/_components/media_player.dlna_dmr.markdown
+++ b/source/_components/media_player.dlna_dmr.markdown
@@ -48,7 +48,7 @@ name:
   required: false
   type: string
 callback_url_override:
-  description: Override the advertised callback url. In case the home assistant instance is not directly reachable (e.g., running in a docker container without bridged-networking), advertise this callback URL for events.
+  description: Override the advertised callback URL. In case the home assistant instance is not directly reachable (e.g., running in a docker container without bridged-networking), advertise this callback URL for events.
   required: false
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**

Describe newly introduced dlna_dmr.callback_url_override option.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21583

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
