### PR TITLE
Expand Google pub/sub topic config description

### DIFF
--- a/source/_components/google_pubsub.markdown
+++ b/source/_components/google_pubsub.markdown
@@ -45,7 +45,7 @@ project_id:
   required: true
   type: string
 topic_name:
-  description: The Pub/Sub topic name.
+  description: The Pub/Sub [relative](https://cloud.google.com/pubsub/docs/admin#resource_names) topic name (looks like `hass`).
   required: true
   type: string
 credentials_json:


### PR DESCRIPTION
**Description:**
Make it more clear that the user should use the short relative pubsub name like "mytopic" and
not the longer like "projects/myproject/topics/mytopic".


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
