### PR TITLE
Adds throughput_network_in/out to sensor.systemmonitor

### DIFF
--- a/source/_components/sensor.systemmonitor.markdown
+++ b/source/_components/sensor.systemmonitor.markdown
@@ -47,29 +47,31 @@ resources:
 The table contains types and their argument to use in your `configuration.yaml`
 file.
 
-| Type (`type:`)      | Argument (`arg:`)         |
-| :------------------ |:--------------------------|
-| disk_use_percent    | Path, e.g., `/`             |
-| disk_use            | Path, e.g., `/`             |
-| disk_free           | Path, e.g., `/`             |
-| memory_use_percent  |                           |
-| memory_use          |                           |
-| memory_free         |                           |
-| swap_use_percent    |                           |
-| swap_use            |                           |
-| swap_free           |                           |
-| load_1m             |                           |
-| load_5m             |                           |
-| load_15m            |                           |
-| network_in          | Interface, e.g., `eth0`     |
-| network_out         | Interface, e.g., `eth0`     |
-| packets_in          | Interface, e.g., `eth0`     |
-| packets_out         | Interface, e.g., `eth0`     |
-| ipv4_address        | Interface, e.g., `eth0`     |
-| ipv6_address        | Interface, e.g., `eth0`     |
-| processor_use       |                           |
-| process             | Binary, e.g., `octave-cli` |
-| last_boot           |                           |
+| Type (`type:`)         | Argument (`arg:`)         |
+| :--------------------- |:--------------------------|
+| disk_use_percent       | Path, e.g., `/`           |
+| disk_use               | Path, e.g., `/`           |
+| disk_free              | Path, e.g., `/`           |
+| memory_use_percent     |                           |
+| memory_use             |                           |
+| memory_free            |                           |
+| swap_use_percent       |                           |
+| swap_use               |                           |
+| swap_free              |                           |
+| load_1m                |                           |
+| load_5m                |                           |
+| load_15m               |                           |
+| network_in             | Interface, e.g., `eth0`   |
+| network_out            | Interface, e.g., `eth0`   |
+| throughput_network_in  | Interface, e.g., `eth0`   |
+| throughput_network_out | Interface, e.g., `eth0`   |
+| packets_in             | Interface, e.g., `eth0`   |
+| packets_out            | Interface, e.g., `eth0`   |
+| ipv4_address           | Interface, e.g., `eth0`   |
+| ipv6_address           | Interface, e.g., `eth0`   |
+| processor_use          |                           |
+| process                | Binary, e.g., `octave-cli` |
+| last_boot              |                           |
 
 ## {% linkable_title Linux specific %}
 


### PR DESCRIPTION
**Description:**

Adds 2 new types of sensor to sensor.systemmonitor

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21575

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
