### PR TITLE
Updating rotted URL for certbot guide

### DIFF
--- a/source/_docs/ecosystem/haproxy.markdown
+++ b/source/_docs/ecosystem/haproxy.markdown
@@ -18,7 +18,7 @@ This will vary depending on your OS. Check out Google for this.
 ### {% linkable_title Obtain an SSL certificate %}
 
 There are multiple ways of obtaining an SSL certificate. Let’s Encrypt is one method.
-Use Google for this, but a good example of using Certbot can be found [here](https://www.digitalocean.com/community/tutorials/how-to-secure-haproxy-with-let-s-encrypt-on-ubuntu-12-04).
+Use Google for this, but a good example of using Certbot can be found [here](https://www.digitalocean.com/community/tutorials/how-to-secure-haproxy-with-let-s-encrypt-on-ubuntu-14-04).
 
 ### {% linkable_title HAPRoxy Configuration %}
 


### PR DESCRIPTION
**Description:**

HAProxy docs has a rotted URL to digital ocean guide
for certbot Let's Encrypt certificates.

Updated this URL to the newest guide.



**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
