### PR TITLE
Add nissan_leaf.start_charge service and doc fixes.

### DIFF
--- a/source/_components/nissan_leaf.markdown
+++ b/source/_components/nissan_leaf.markdown
@@ -15,10 +15,10 @@ ha_iot_class: "Cloud Polling"
 
 The `nissan_leaf` component offers integration with the [NissanConnect EV](http://youplus.nissan.co.uk/GB/en/YouPlus/ConnectedServices.html) cloud service. NissanConnect EV was previously known as Nissan Carwings. It offers:
 
-* sensors for the battery status and range
+* sensors for the battery status, range and charging status
 * a switch to start and stop the climate control
-* a switch to start the car charging (cannot be stopped remotely - API limitation)
 * a device tracker to locate the car (only on later Leaf models)
+* services to request updates from the car and to request the car starts charging.
 
 ## {% linkable_title Configuration %}
 
@@ -48,7 +48,7 @@ nissan_connect:
   description: If your car has the updated head unit (NissanConnect rather than Carwings) then the location can be aquired and exposed via a device tracker. If you have a pre-2014 24 kWh Leaf then you will have Carwings and this should be set to false.
   required: false
   type: boolean
-scan_interval:
+update_interval:
   description: The interval between updates if the climate control is off and the car is not charging. Set in any time unit (e.g. minutes, hours, days!).
   required: false
   default: 1 hour
@@ -76,7 +76,7 @@ nissan_leaf:
   password: "YOUR_PASSWORD"
   region: "YOUR_REGION"
   nissan_connect: true
-  scan_interval:
+  update_interval:
     hours: 1
   update_interval_charging:
     minutes: 15
@@ -85,9 +85,19 @@ nissan_leaf:
   force_miles: true
 ```
 
+## {% linkable_title Starting a Charge %}
+
+You can use the `nissan_leaf.start_charge` service to send a request to the Nissan servers to start a charge. The car must be plugged in!  The service requires you to provide the vehicle identification number (VIN) as a parameter. You can see the VIN on the attributes of all the entities created by this component, except the device_tracker.
+
+```yaml
+- service: nissan_leaf.start_charge
+  data:
+    vin: '1HGBH41JXMN109186'             # replace
+```
+
 ## {% linkable_title Updating on-demand using Automation %}
 
-You can also use the `nissan_leaf.update` service to request an on-demand update. To update almost exclusively via the service set the `update_interval` to a high value in the component configuration.  The service requires you to provide the vehicle identification number (VIN) as a parameter. You can see the VIN on the attributes of all the entities created by this component, except the device_tracker.
+You can also use the `nissan_leaf.update` service to request an on-demand update. To update almost exclusively via the service set the `update_interval` to a high value in the component configuration.  The service requests the VIN number as described above.
 
 ```yaml
 - id: update_when_driver_not_home
@@ -111,7 +121,9 @@ You can also use the `nissan_leaf.update` service to request an on-demand update
 * The update interval has a minimum of two minutes.
 * Requesting updates uses a small amount of power from the 12 V battery. The 12 V battery charges from the main traction battery when the car is not plugged in. If the car is left plugged in for a long time, or if the main traction battery is very low then the 12 V battery may gradually discharge. A low update interval may cause the 12 V battery to become flat.  When the 12 V battery is flat the car will not start. _Do not set the update interval too low.  Use at your own risk._
 * This component communicates with the Nissan Servers which then communicate with the car. The communication between the car and the Nissan Servers is very slow, and takes up to five minutes to get information from the car, therefore the default polling interval is set to one hour to not overwhelm the connection.
-* Responses from the Nissan servers are received separately for the battery/range, climate control and location. The `updated_on` attribute will show the last time the data was retrieved from the server. There are separate attributes for when the `next_update` is scheduled, and if an `update_inprogress`. The `nissan_leaf.update` service will reset the `next_update` attribute.
+* Responses from the Nissan servers are received separately for the battery/range, climate control and location. The `updated_on` attribute will show the last time the data was retrieved from the server. There are separate attributes for when the `next_update` is scheduled, and to indicate if `update_in_progress`. The `nissan_leaf.update` service will reset the `next_update` attribute.
+* The Nissan APIs do not allow charging to be stopped remotely.
+* The Nissan servers have a history of being unstable, therefore please confirm that the official Nissan Leaf app/website is working correctly before reporting bugs.
 
 Please report bugs using the following logger configuration.
 


### PR DESCRIPTION
**Description:**

Additional docs for the new Nissan leaf component, as part of PR https://github.com/home-assistant/home-assistant/pull/21145.  Should be included in the 0.89 release.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21145

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
