### PR TITLE
add optional sender name to sendgrid

### DIFF
--- a/source/_components/notify.sendgrid.markdown
+++ b/source/_components/notify.sendgrid.markdown
@@ -45,6 +45,10 @@ sender:
   description: The e-mail address of the sender.
   required: true
   type: string
+sender_name:
+  description: The name of the sender. Defaults to "Home Assistant" if not set.
+  required: false
+  type: string
 recipient:
   description: The recipient of the notification.
   required: true


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21610

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
