### PR TITLE
Update modbus.markdown

### DIFF
--- a/source/_components/modbus.markdown
+++ b/source/_components/modbus.markdown
@@ -149,7 +149,7 @@ modbus:
 | hub       | Hub name (defaults to 'default' when omitted) |
 | unit      | Slave address (set to 255 you talk to Modbus via TCP) |
 | address   | Address of the Register (e.g., 138) |
-| value     | An array of 16-bit values. Might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |
+| value     | A single value or an array of 16-bit values. Single value will call modbus function code 6. Array will call modbus function code 16. Array might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |
 
 ## {% linkable_title Building on top of Modbus %}
 


### PR DESCRIPTION
**Description:**

Add some info concerning the called modbus function codes when using modbus write_register with a single value or an array

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21621

## Checklist:

- [ x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
