### PR TITLE
git_pull note

### DIFF
--- a/source/_addons/git_pull.markdown
+++ b/source/_addons/git_pull.markdown
@@ -61,7 +61,7 @@ Load and update configuration files for Home Assistant from a [Git](https://git-
 * **interval** (*Required*): The interval in seconds to poll the repo for if automatic polling is enabled.
 - **deployment_user** (*Optional*): Username to use when authenticating to a repository with a username and password.
 - **deployment_password** (*Optional*): Password to use when authenticating to a repository.  Ignored if `deployment_user` is not set.
-- **deployment_key** (*Optional*): A private SSH key that will be used for communication during Git operations. This key is mandatory for ssh-accessed repositories, which are the ones with the following pattern: `<user>@<host>:<repository path>`.
+- **deployment_key** (*Optional*): A private SSH key that will be used for communication during Git operations. This key is mandatory for ssh-accessed repositories, which are the ones with the following pattern: `<user>@<host>:<repository path>`. This key is to be created without a passphrase.
 - **deployment_key_protocol** (*Optional*): The key protocol. Default is `rsa`. Valid protocols are:
 
   * **dsa**

--- a/source/_addons/git_pull.markdown
+++ b/source/_addons/git_pull.markdown
@@ -61,7 +61,7 @@ Load and update configuration files for Home Assistant from a [Git](https://git-
 * **interval** (*Required*): The interval in seconds to poll the repo for if automatic polling is enabled.
 - **deployment_user** (*Optional*): Username to use when authenticating to a repository with a username and password.
 - **deployment_password** (*Optional*): Password to use when authenticating to a repository.  Ignored if `deployment_user` is not set.
-- **deployment_key** (*Optional*): A private SSH key that will be used for communication during Git operations. This key is mandatory for ssh-accessed repositories, which are the ones with the following pattern: `<user>@<host>:<repository path>`. This key is to be created without a passphrase.
+- **deployment_key** (*Optional*): A private SSH key that will be used for communication during Git operations. This key is mandatory for ssh-accessed repositories, which are the ones with the following pattern: `<user>@<host>:<repository path>`. This key has to be created without a passphrase.
 - **deployment_key_protocol** (*Optional*): The key protocol. Default is `rsa`. Valid protocols are:
 
   * **dsa**


### PR DESCRIPTION
**Description:**
added a note to the doc for git_pull

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
