### PR TITLE
Mqtt alarm code_arm_required

### DIFF
--- a/source/_components/alarm_control_panel.mqtt.markdown
+++ b/source/_components/alarm_control_panel.mqtt.markdown
@@ -85,6 +85,11 @@ code:
   description: If defined, specifies a code to enable or disable the alarm in the frontend.
   required: false
   type: string
+code_arm_required:
+  description: If true the code is required to arm the alarm
+  required: false
+  type: boolean
+  default: true
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false

--- a/source/_components/alarm_control_panel.mqtt.markdown
+++ b/source/_components/alarm_control_panel.mqtt.markdown
@@ -86,7 +86,7 @@ code:
   required: false
   type: string
 code_arm_required:
-  description: If true the code is required to arm the alarm
+  description: If true the code is required to arm the alarm.
   required: false
   type: boolean
   default: true


### PR DESCRIPTION
**Description:**
Updates documentation about new configuration option code_arm_required.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#19558

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

Override #7940 