### PR TITLE
Add use_https configuration option to quantum_gateway component

### DIFF
--- a/source/_components/device_tracker.quantum_gateway.markdown
+++ b/source/_components/device_tracker.quantum_gateway.markdown
@@ -38,6 +38,11 @@ password:
   description: The password for the `admin` user. The default password may be printed on the gateway itself.
   required: true
   type: string
+use_https:
+  description: Use HTTPS when connecting to gateway. New firmware may require HTTPS while older may require this to be False.
+  required: false
+  type: boolean
+  default: True
 {% endconfiguration %}
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_components/device_tracker.quantum_gateway.markdown
+++ b/source/_components/device_tracker.quantum_gateway.markdown
@@ -38,7 +38,7 @@ password:
   description: The password for the `admin` user. The default password may be printed on the gateway itself.
   required: true
   type: string
-use_https:
+ssl:
   description: Use HTTPS when connecting to gateway. New firmware may require HTTPS while older may require this to be False.
   required: false
   type: boolean


### PR DESCRIPTION
**Description:**
Added HTTPS support for Quantum Gateway routers which may have been pushed a firmware update forcing HTTPS connections to query the device list.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21669

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
