### PR TITLE
Add ClickSend "caller" option

### DIFF
--- a/source/_components/notify.clicksend_tts.markdown
+++ b/source/_components/notify.clicksend_tts.markdown
@@ -26,6 +26,7 @@ notify:
     username: CLICKSEND_USERNAME
     api_key: CLICKSEND_API_KEY
     recipient: PHONE_NO
+    caller: PHONE_NO
 ```
 
 {% configuration %}
@@ -43,8 +44,12 @@ api_key:
   required: true
   type: string
 recipient:
-  description: Your phone number. This is where you want to send your notification SMS messages (e.g., `09171234567`).
+  description: Recipient phone number. This is the phone number that you want to call and notify via TTS (e.g., `09171234567`).
   required: true
+  type: string
+caller:
+  description: Caller phone number. This is the phone number that you want to be the TTS call originator (e.g., `09181234567`). If not defined the recipient number is used.
+  required: false
   type: string
 language:
   description: The language you want to use to convert the message to audio. Accepted values are found in the [ClickSend Documentation](http://docs.clicksend.apiary.io/#reference/voice/voice-languages).

--- a/source/_components/notify.clicksend_tts.markdown
+++ b/source/_components/notify.clicksend_tts.markdown
@@ -8,9 +8,11 @@ comments: false
 sharing: true
 footer: true
 logo: clicksend.png
-ha_category: Notifications
+ha_category:
+  - Notifications
 ha_release: 0.55
-redirect_from: /components/notify.clicksendaudio/
+redirect_from: 
+  - /components/notify.clicksendaudio/
 ---
 
 The `clicksend_tts` platform uses [ClickSend](https://clicksend.com) to deliver text-to-speech (TTS) notifications from Home Assistant.
@@ -22,7 +24,6 @@ To add ClickSend to your installation, add the following to your Home Assistant 
 ```yaml
 notify:
   - platform: clicksend_tts
-    name: ClickSend
     username: CLICKSEND_USERNAME
     api_key: CLICKSEND_API_KEY
     recipient: PHONE_NO

--- a/source/_components/notify.clicksend_tts.markdown
+++ b/source/_components/notify.clicksend_tts.markdown
@@ -26,7 +26,6 @@ notify:
     username: CLICKSEND_USERNAME
     api_key: CLICKSEND_API_KEY
     recipient: PHONE_NO
-    caller: PHONE_NO
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:**
Added optional "caller" parameter to let ClickSend API call be more compliant with some cellular networks that do not allow incoming calls from the same recipient number.
If "caller" is not defined, then the recipient parameter value is used.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#20780

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
