### PR TITLE
port number typo on sesame sample URL

### DIFF
--- a/source/_addons/configurator.markdown
+++ b/source/_addons/configurator.markdown
@@ -120,7 +120,7 @@ loglevel:
   type: string
   default: info
 sesame:
-  description: Secret token to dynamically allow access from the IP the request originates from. Open your bookmark https://hassio.yourdomain.com:8123/somesecretnobodycanguess while `allowed_networks` is set to `[]` and your IP will get whitelisted. You can use the Network status menu to revoke IP addresses for which access has been granted. Regular authentication is still required.
+  description: Secret token to dynamically allow access from the IP the request originates from. Open your bookmark https://hassio.yourdomain.com:3218/somesecretnobodycanguess while `allowed_networks` is set to `[]` and your IP will get whitelisted. You can use the Network status menu to revoke IP addresses for which access has been granted. Regular authentication is still required.
   required: false
   type: string
 sesame_totp_secret:


### PR DESCRIPTION
The current version of the sample URL in the sesame section shows the port as 8123, like so ...

https://hassio.yourdomain.com:8123/somesecretnobodycanguess

..but I believe it should be port 3218, like so ...

https://hassio.yourdomain.com:3218/somesecretnobodycanguess

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
