### PR TITLE
Adding warning about below Pi2

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -15,9 +15,9 @@ The following will take you through the steps required to install Hass.io.
 
    - As an image for your device:
   
-     - [Raspberry Pi Zero][pi1]
-     - [Raspberry Pi Zero W][pi0-w]
-     - [Raspberry Pi 1 Model B][pi1]
+     - [Raspberry Pi Zero][pi1] (not recommended for more than testing)
+     - [Raspberry Pi Zero W][pi0-w] (not recommended for more than testing)
+     - [Raspberry Pi 1 Model B][pi1] (not recommended for more than testing)
      - [Raspberry Pi 2 Model B][pi2]
      - [Raspberry Pi 3 Model B and B+ 32bit][pi3-32] (recommended)
      - [Raspberry Pi 3 Model B and B+ 64bit][pi3-64]


### PR DESCRIPTION
Too many folks have bought a Pi Zero and been unhappy at the experience. Adding a note here that they're not recommended.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
