### PR TITLE
Note how !include_dir* funcs do not support .yml extension

### DIFF
--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -165,7 +165,7 @@ You can get help from the command line using: `hass --script check_config --help
 
 ### {% linkable_title Advanced Usage %}
 
-We offer four advanced options to include whole directories at once.
+We offer four advanced options to include whole directories at once. Please note that your files must have the `.yaml` file extension; `.yml` is not supported.
 - `!include_dir_list` will return the content of a directory as a list with each file content being an entry in the list.
 - `!include_dir_named` will return the content of a directory as a dictionary which maps filename => content of file.
 - `!include_dir_merge_list` will return the content of a directory as a list by merging all files (which should contain a list) into 1 big list.


### PR DESCRIPTION
**Description:**
Addresses home-assistant/home-assistant#16808.  I don't believe it's necessary to support `.yml` files, but explicitly noting this would be helpful for others.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
