### PR TITLE
Add some clarifications for the new neato service call

### DIFF
--- a/source/_components/neato.markdown
+++ b/source/_components/neato.markdown
@@ -84,9 +84,9 @@ Some information about the capabilities might be found on the [Neato Developer P
 | ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | Only act on a specific robot                                                                                                                                                  |
 | `mode`                 | yes      | Set the cleaning mode: 1 for eco and 2 for turbo. Defaults to turbo if not set.                                                                                               |
-| `navigation`           | yes      | Set the navigation mode: 1 for normal, 2 for extra care, 3 for deep. Defaults to normal if not set.                                                                           |
+| `navigation`           | yes      | Set the navigation mode: 1 for normal, 2 for extra care, 3 for deep. Defaults to normal if not set. Deep cleaning is only supported on the Botvac D7.                                                                           |
 | `category`             | yes      | Whether to use a persistent map or not for cleaning (i.e. No go lines): 2 for no map, 4 for map. Default to using map if not set (and fallback to no map if no map is found). |
-| `zone`                 | yes      | Only supported on the Botvac D7. Name of the zone to clean. Defaults to no zone i.e. complete house cleanup.                                                                  |
+| `zone`                 | yes      | Only supported on the Botvac D7. Name of the zone to clean from the Neato app. Use unique names for the zones to avoid the wrong zone from running. Defaults to no zone i.e. complete house cleanup.                                                                  |
 
 
 ## {% linkable_title Camera %}


### PR DESCRIPTION
**Description:**

Add some more clarifications to the new service call.  A user in discord had the incorrect zone running and it was discovered that they had 2 zones with the same name.  Also make sure that users with different models don't try to run deep cleaning.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant# N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
