### PR TITLE
fix automate command by adding dash

### DIFF
--- a/source/_docs/installation/hassbian/upgrading.markdown
+++ b/source/_docs/installation/hassbian/upgrading.markdown
@@ -20,7 +20,7 @@ $ sudo apt-get -y upgrade
 
 #### {% linkable_title Updating Home Assistant %}
 <p class='note'>
-You can use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade homeassistant`
+You can use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade home-assistant`
 </p>
 
 To update the Home Assistant installation execute the following command as the `pi` user.


### PR DESCRIPTION
I get 
```
pi@hassbian:~ $ sudo hassbian-config upgrade homeassistant
/usr/local/bin/hassbian-config: line 140: /opt/hassbian/suites/upgrade_homeassis                                                                                                                                    tant.sh: No such file or directory
/usr/local/bin/hassbian-config: line 141: homeassistant-upgrade-package: command                                                                                                                                     not found
```
when running what it currently is.
adding the dash in home-assistant fixes the issue

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
