### PR TITLE
Added example configuration using absolute times

### DIFF
--- a/source/_components/binary_sensor.tod.markdown
+++ b/source/_components/binary_sensor.tod.markdown
@@ -32,6 +32,11 @@ binary_sensor:
     after: sunrise
     after_offset: '-02:00'
     before: '07:00'
+    
+  - platform: tod
+    name: Late Morning
+    after: '10:00'
+    before: '12:00'
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:**
Added documentation example configuration using absolute times

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
