### PR TITLE
Add service updates to RainMachine docs

### DIFF
--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -113,6 +113,40 @@ switches:
 
 ## {% linkable_title Services %}
 
+### {% linkable_title `rainmachine.disable_program` %}
+
+Disable a RainMachine program. This will mark the program switch as
+`Unavailable` in the UI.
+
+| Service Data Attribute    | Optional | Description             |
+|---------------------------|----------|-------------------------|
+| `program_id`              |      no  | The program to disable  |
+
+### {% linkable_title `rainmachine.disable_zone` %}
+
+Disable a RainMachine zone. This will mark the zone switch as
+`Unavailable` in the UI.
+
+| Service Data Attribute    | Optional | Description             |
+|---------------------------|----------|-------------------------|
+| `zone_id`                 |      no  | The zone to disable     |
+
+### {% linkable_title `rainmachine.enable_program` %}
+
+Enable a RainMachine program.
+
+| Service Data Attribute    | Optional | Description             |
+|---------------------------|----------|-------------------------|
+| `program_id`              |      no  | The program to enable   |
+
+### {% linkable_title `rainmachine.enable_zone` %}
+
+Enable a RainMachine zone.
+
+| Service Data Attribute    | Optional | Description             |
+|---------------------------|----------|-------------------------|
+| `zone_id`                 |      no  | The zone to enable      |
+
 ### {% linkable_title `rainmachine.pause_watering` %}
 
 Pause all watering activities for a number of seconds.


### PR DESCRIPTION
**Description:**

This PR adds docs to describe the changes in https://github.com/home-assistant/home-assistant/pull/21785.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/21785

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
