### PR TITLE
Add urlbase configuration parameter to sabnzbd

### DIFF
--- a/source/_components/sabnzbd.markdown
+++ b/source/_components/sabnzbd.markdown
@@ -64,6 +64,11 @@ ssl:
   required: false
   default: false
   type: boolean
+urlbase:
+  description: The base URL SABnzbd is running under.
+  required: false
+  default: /
+  type: string
 {% endconfiguration %}
 
 Available sensors are:


### PR DESCRIPTION
**Description:**
Adds documentation for the optional urlbase configuration parameter

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21792

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
