### PR TITLE
Fix release and add OpenWebif to title

### DIFF
--- a/source/_components/media_player.enigma2.markdown
+++ b/source/_components/media_player.enigma2.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Enigma2"
+title: "Enigma2 (OpenWebif)"
 description: "Instructions on how to integrate an Enigma2 based box running OpenWebif into Home Assistant."
 date: 2019-02-21 12:02
 sidebar: true
@@ -10,7 +10,7 @@ footer: true
 logo: openwebif.png
 ha_category: Media Player
 featured: false
-ha_release: 0.90
+ha_release: "0.90"
 ha_iot_class: "Local Polling"
 ---
 


### PR DESCRIPTION
**Description:**

![screenshot 2019-03-08 at 14 48 26](https://user-images.githubusercontent.com/254309/54035463-543fe080-41b1-11e9-9b4b-527520aff535.png)

In looking at the preview for this page, I noticed the released version said `v0.9` which I guess will be wrong.

Also, the search box doesn't find the platform when I type `OpenWebif` so I am adding that to the page title.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html