### PR TITLE
Add hourly forecast sensor documentation for Dark Sky Sensor

### DIFF
--- a/source/_components/sensor.darksky.markdown
+++ b/source/_components/sensor.darksky.markdown
@@ -36,6 +36,9 @@ sensor:
     api_key: YOUR_API_KEY
     forecast:
       - 0
+    hourly_forecast:
+      - 0
+      - 1
     monitored_conditions:
       - summary
       - icon
@@ -53,7 +56,11 @@ name:
   default: Dark Sky
   type: string
 forecast:
-  description: List of days in the 7-day forecast you would like to receive data on, starting with today as day 0 and ending with day 7. Any condition from `monitored_conditions` with a daily forecast by Dark Sky will generate a sensor with entity_id `<condition>_<day>`.
+  description: List of days in the 7-day forecast you would like to receive data on, starting with today as day 0 and ending with day 7. Any condition from `monitored_conditions` with a daily forecast by Dark Sky will generate a sensor with entity_id `<condition>_<day>d`.
+  required: false
+  type: list
+hourly_forecast:
+  description: List of hours in the 48-hour forecast you would like to receive data on, starting with this hour as hour 0 and ending with hour 48. Any condition from `monitored_conditions` with an hourly forecast by Dark Sky will generate a sensor with entity_id `<condition>_<hour>h`.
   required: false
   type: list
 language:
@@ -218,3 +225,4 @@ While the platform is called "darksky" the sensors will show up in Home Assistan
 More details about the API are available in the [Dark Sky API documentation][].
 
 [Dark Sky API documentation]: https://darksky.net/dev/docs
+


### PR DESCRIPTION
**Description:**
Dark Sky provides hourly forecasts for various monitored conditions. This change creates new sensors for each hourly forecasted condition with suffix _<hour>h while adding the suffix _<day>d to the daily forecasted conditions. For example, now a sensor.dark_sky_summary_<day>d and sensor.dark_sky_summary_<hour>h will be created if the forecast and hourly_forecast parameters are populated.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21820

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
