### PR TITLE
Change the service for Google Travel Time

### DIFF
--- a/source/_components/sensor.google_travel_time.markdown
+++ b/source/_components/sensor.google_travel_time.markdown
@@ -160,7 +160,6 @@ You can also use the `homeassistant.update` service to update the sensor on-dema
         - thu
         - fri
   action:
-    - service: homeassistant.update
-      data:
-        entity_id: sensor.morning_commute
+    - service: homeassistant.update_entity
+      entity_id: sensor.morning_commute
 ```


### PR DESCRIPTION
**Description:**
@rohankapoorcom
The service `homeassistant.update` doesn't exist (in 0.89) so changed the description for the automations to `homeassistant.update_entity`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
