### PR TITLE
Update trusted_networks

### DIFF
--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -72,7 +72,7 @@ trusted_proxies:
   type: string, list
 trusted_networks:
   description: "List of trusted networks, consisting of IP addresses or networks, that are allowed to bypass password protection when accessing Home Assistant.  If using a reverse proxy with the `use_x_forwarded_for` and `trusted_proxies` options enabled, requests proxied to Home Assistant with a trusted `X-Forwarded-For` header will appear to come from the IP given in that header instead of the proxy IP."
-  Configuring trusted_networks via the `http` component will be deprecated and moved to `auth_providers` instead. For instructions, see https://www.home-assistant.io/docs/authentication/providers/#trusted-networks. To avoid the warning message in Home Assistant 0.89 place the trusted network under both `http` and `auth_providers`.
+  Configuring trusted_networks via the `http` component will be deprecated and moved to `auth_providers` instead. For instructions, see https://www.home-assistant.io/docs/authentication/providers/#trusted-networks. In Home Assistant 0.89.0 and 0.89.1, you need place the trusted network under both `http` and `auth_providers` if you still want to use trusted networks features. You can remove it from `http` section starting from 0.89.2
   required: false
   type: string, list
 ip_ban_enabled:

--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -72,6 +72,7 @@ trusted_proxies:
   type: string, list
 trusted_networks:
   description: "List of trusted networks, consisting of IP addresses or networks, that are allowed to bypass password protection when accessing Home Assistant.  If using a reverse proxy with the `use_x_forwarded_for` and `trusted_proxies` options enabled, requests proxied to Home Assistant with a trusted `X-Forwarded-For` header will appear to come from the IP given in that header instead of the proxy IP."
+  Configuring trusted_networks via the http component has been deprecated. Use the trusted networks auth provider instead. For instructions, see https://www.home-assistant.io/docs/authentication/providers/#trusted-networks
   required: false
   type: string, list
 ip_ban_enabled:

--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -72,7 +72,7 @@ trusted_proxies:
   type: string, list
 trusted_networks:
   description: "List of trusted networks, consisting of IP addresses or networks, that are allowed to bypass password protection when accessing Home Assistant.  If using a reverse proxy with the `use_x_forwarded_for` and `trusted_proxies` options enabled, requests proxied to Home Assistant with a trusted `X-Forwarded-For` header will appear to come from the IP given in that header instead of the proxy IP."
-  Configuring trusted_networks via the http component has been deprecated. Use the trusted networks auth provider instead. For instructions, see https://www.home-assistant.io/docs/authentication/providers/#trusted-networks
+  Configuring trusted_networks via the `http` component will be deprecated and moved to `auth_providers` instead. For instructions, see https://www.home-assistant.io/docs/authentication/providers/#trusted-networks. To avoid the warning message in Home Assistant 0.89 place the trusted network under both `http` and `auth_providers`.
   required: false
   type: string, list
 ip_ban_enabled:

--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -71,12 +71,7 @@ trusted_proxies:
   required: false
   type: string, list
 trusted_networks:
-  description: "List of trusted networks, consisting of IP addresses or networks, that are allowed to bypass password protection when accessing Home Assistant.  If using a reverse proxy with the `use_x_forwarded_for` and `trusted_proxies` options enabled, requests proxied to Home Assistant with a trusted `X-Forwarded-For` header will appear to come from the IP given in that header instead of the proxy IP."
-  
-  <p class='note'>
-  Configuring trusted_networks via the `http` component will be deprecated and moved to `auth_providers` instead. For instructions, see https://www.home-assistant.io/docs/authentication/providers/#trusted-networks. In Home Assistant 0.89.0 and 0.89.1, you need place the trusted network under both `http` and `auth_providers` if you still want to use trusted networks features. You can remove it from `http` section starting from 0.89.2.
-  </p>
-  
+  description: "List of trusted networks, consisting of IP addresses or networks, that are allowed to bypass password protection when accessing Home Assistant. If using a reverse proxy with the `use_x_forwarded_for` and `trusted_proxies` options enabled, requests proxied to Home Assistant with a trusted `X-Forwarded-For` header will appear to come from the IP given in that header instead of the proxy IP."
   required: false
   type: string, list
 ip_ban_enabled:
@@ -95,6 +90,10 @@ ssl_profile:
   type: string
   default: modern
 {% endconfiguration %}
+
+<p class='note'>
+Configuring trusted_networks via the `http` component will be deprecated and moved to `auth_providers` instead. For instructions, see <a href="https://www.home-assistant.io/docs/authentication/providers/#trusted-networks">trusted networks</a>. In Home Assistant 0.89.0 and 0.89.1, you need place the trusted network under both `http` and `auth_providers` if you still want to use trusted networks features. You can remove it from `http` section starting from 0.89.2.
+</p>
 
 The sample below shows a configuration entry with possible values:
 

--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -72,7 +72,11 @@ trusted_proxies:
   type: string, list
 trusted_networks:
   description: "List of trusted networks, consisting of IP addresses or networks, that are allowed to bypass password protection when accessing Home Assistant.  If using a reverse proxy with the `use_x_forwarded_for` and `trusted_proxies` options enabled, requests proxied to Home Assistant with a trusted `X-Forwarded-For` header will appear to come from the IP given in that header instead of the proxy IP."
-  Configuring trusted_networks via the `http` component will be deprecated and moved to `auth_providers` instead. For instructions, see https://www.home-assistant.io/docs/authentication/providers/#trusted-networks. In Home Assistant 0.89.0 and 0.89.1, you need place the trusted network under both `http` and `auth_providers` if you still want to use trusted networks features. You can remove it from `http` section starting from 0.89.2
+  
+  <p class='note'>
+  Configuring trusted_networks via the `http` component will be deprecated and moved to `auth_providers` instead. For instructions, see https://www.home-assistant.io/docs/authentication/providers/#trusted-networks. In Home Assistant 0.89.0 and 0.89.1, you need place the trusted network under both `http` and `auth_providers` if you still want to use trusted networks features. You can remove it from `http` section starting from 0.89.2.
+  </p>
+  
   required: false
   type: string, list
 ip_ban_enabled:


### PR DESCRIPTION
**Description:**
@awarecan
Update the text for the trusted networks so it includes the text from 0.89
`Configuring trusted_networks via the http component has been deprecated. Use the trusted networks auth provider instead. For instructions, see https://www.home-assistant.io/docs/authentication/providers/#trusted-networks`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
