### PR TITLE
Change of thermostat states for Toon component

### DIFF
--- a/source/_components/toon.markdown
+++ b/source/_components/toon.markdown
@@ -73,7 +73,7 @@ The `toon` climate platform allows you to interact with your Toon thermostat. Fo
 
 | Home Assistant | Toon    |
 |:---------------|:--------|
-| Performance    | Comfort |
+| Auto           | Comfort |
 | Heat           | Thuis   |
 | Eco            | Weg     |
 | Cool           | Slapen  |


### PR DESCRIPTION
**Description:**

When testing the new component the mode performance is not available in the toon component. 
The frontend uses `STATE_AUTO` 


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
