### PR TITLE
Add SmartThings climate support for Air Conditioners

### DIFF
--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -163,6 +163,7 @@ The SmartThings Climate platform lets you control devices that have air conditio
 #### {% linkable_title Air Conditioners %}
 
 For a SmartThings Air Conditioner to be represented by the climate platform, it must have all of the following required capabilities:
+
 | Capability                          |Climate Features
 |-------------------------------------|--------------------------------------------|
 | [`airConditionerMode`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Air-Conditioner-Mode) (required)            | `operation mode`

--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -158,7 +158,25 @@ The SmartThings Binary Sensor platform lets you view devices that have binary se
 
 ### {% linkable_title Climate %}
 
-The SmartThings Climate platform lets you control devices that have thermostat-related capabilities. For a SmartThings device to be represented by the climate platform, it must have all the capabilities from either "set a" _or_ "set b":
+The SmartThings Climate platform lets you control devices that have air conditioner or thermostat related capabilities.
+
+#### {% linkable_title Air Conditioners %}
+
+For a SmartThings Air Conditioner to be represented by the climate platform, it must have all of the following required capabilities:
+| Capability                          |Climate Features
+|-------------------------------------|--------------------------------------------|
+| [`airConditionerMode`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Air-Conditioner-Mode) (required)            | `operation mode`
+| [`fanSpeed`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Fan-Speed) (required) | `fan mode`
+| [`switch`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Switch) (required) | `on/off`
+| [`temperatureMeasurement`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Temperature-Measurement) (required)    | `temperature`
+| [`thermostatCoolingSetpoint`](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Thermostat-Cooling-Setpoint) (required) | `target temp`
+| [`demandResponseLoadControl`](https://docs.smartthings.com/en/latest/capabilities-reference.html#demand-response-load-control) | `drlc_status_duration` (state attribute), `drlc_status_level` (state attribute), `drlc_status_override` (state attribute), `drlc_status_start` (state attribute)
+| [`powerConsumptionReport`](https://docs.smartthings.com/en/latest/capabilities-reference.html#power-consumption-report) | `power_consumption_end` (state attribute), `power_consumption_energy` (state attribute), `power_consumption_power` (state attribute), `power_consumption_start` (state attribute)
+  
+
+#### {% linkable_title Thermostats %}
+
+For a SmartThings thermostat to be represented by the climate platform, it must have all the capabilities from either "set a" _or_ "set b":
 
 | Capability                          |Climate Features
 |-------------------------------------|--------------------------------------------|


### PR DESCRIPTION
**Description:**
Adds docs for Air Conditioners to the SmartThings climate platform.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#21840

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
