### PR TITLE
Update detecting lost connections sample

### DIFF
--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -391,20 +391,32 @@ action:
 
 When the connection to your HomeMatic CCU or Homegear is lost, Home Assistant will stop getting updates from devices. This may happen after rebooting the CCU for example. Due to the nature of the communication protocol this cannot be handled automatically, so you must call *homematic.reconnect* in this case. That's why it is usually a good idea to check if your HomeMatic components are still updated properly, in order to detect connection losses. This can be done in several ways through an automation:
 
-- If you have a sensor which you know will be updated frequently (e.g., an outdoor temperature sensor or light sensor) you could set up an automation like this:
+- If you have a sensor which you know will be updated frequently (e.g., an outdoor temperature sensor, voltage sensor or light sensor) you could set up a helper binary sensor and an automation like this:
 
   ```yaml
+  binary_sensor:
+    - platform: template
+      sensors:
+        homematic_up:
+          friendly_name: "Homematic is sending updates"
+          entity_id:
+            - sensor.office_voltage
+            - sensor.time
+          value_template: >-
+            {{as_timestamp(now()) - as_timestamp(states.sensor.office_voltage.last_changed) < 600}}
+
   automation:
     - alias: Homematic Reconnect
       trigger:
         platform: state
-          entity_id: sensor.outdoor_light_level
-        for:
-          hours: 3
+        entity_id: binary_sensor.homematic_up
+        to: "off"
       action:
         # Reconnect, if sensor has not been updated for over 3 hours
         service: homematic.reconnect
   ```
+  
+  The important part is the `sensor.time` entiy (from time_date component). This will update the binary sensor on every change of the sensor and every minute. If the Homematic senso does not send any updates any more the `sensor.time` will set the binary sensor to off 10 minutes after the last sensor update. This will trigger the automation.
 
 - If you have a CCU you can also create a system variable on the CCU, which stores its last reboot time. Since Home Assistant can still refresh system variables from the CCU (even after a reboot) this is another option to call *homematic.reconnect*. Even though this option might look preferrable to many since it does not rely on a sensor, **it is less fail-safe** than checking for updates of a sensor. Since the variable on the CCU is only changed on boot, any problem that causes the connection between Home Assistant and the CCU to break but will not result in a reboot will not be detected (eg. in case of networking issues). This is how this can be done:
 

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -393,6 +393,7 @@ When the connection to your HomeMatic CCU or Homegear is lost, Home Assistant wi
 
 - If you have a sensor which you know will be updated frequently (e.g., an outdoor temperature sensor, voltage sensor or light sensor) you could set up a helper binary sensor and an automation like this:
 
+{% raw %}
   ```yaml
   binary_sensor:
     - platform: template
@@ -415,8 +416,9 @@ When the connection to your HomeMatic CCU or Homegear is lost, Home Assistant wi
         # Reconnect, if sensor has not been updated for over 3 hours
         service: homematic.reconnect
   ```
-  
-  The important part is the `sensor.time` entiy (from time_date component). This will update the binary sensor on every change of the sensor and every minute. If the Homematic senso does not send any updates any more the `sensor.time` will set the binary sensor to off 10 minutes after the last sensor update. This will trigger the automation.
+{% endraw %}
+
+  The important part is the `sensor.time` entity (from time_date component). This will update the binary sensor on every change of the sensor and every minute. If the Homematic sensor does not send any updates anymore, the `sensor.time` will set the binary sensor to `off` 10 minutes after the last sensor update. This will trigger the automation.
 
 - If you have a CCU you can also create a system variable on the CCU, which stores its last reboot time. Since Home Assistant can still refresh system variables from the CCU (even after a reboot) this is another option to call *homematic.reconnect*. Even though this option might look preferrable to many since it does not rely on a sensor, **it is less fail-safe** than checking for updates of a sensor. Since the variable on the CCU is only changed on boot, any problem that causes the connection between Home Assistant and the CCU to break but will not result in a reboot will not be detected (eg. in case of networking issues). This is how this can be done:
 


### PR DESCRIPTION
**Description:**
Old detecting lost connections using sensors does not work with current HA versions any more.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html