### PR TITLE
Generate Let's Encrypt certificate for Duck DNS sub sub domains

### DIFF
--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -69,3 +69,15 @@ You'll need to forward the port you listed in your configuration (8123 in the ex
 Ensure that you allocate the Home Assistant system a fixed IP on your network before you configure port forwarding. You can do this either on the computer itself (see the [install guide](/hassio/installation/) or via a static lease on your router.
 
 Restart Home Assistant for the configured changes to take effect. When you access the Home Assistant frontend you will now need to use `https`, even when accessing local instances, for example at `https://192.168.0.1:8123`.
+
+## {% linkable_title Generate Let's Encrypt certificate for Duck DNS sub sub domains  %}
+
+To generate certificates for nr.my-domain.duckdns.org update the domain json settings to:
+
+```json
+{
+  ...
+  "domains": ["my-domain.duckdns.org","*.my-domain.duckdns.org"],
+  ...
+}
+```

--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -72,7 +72,7 @@ Restart Home Assistant for the configured changes to take effect. When you acces
 
 ## {% linkable_title Generate Let's Encrypt certificate for Duck DNS sub sub domains  %}
 
-To generate certificates for nr.my-domain.duckdns.org update the domain json settings to:
+To generate certificates for nr.my-domain.duckdns.org update the domain JSON settings to:
 
 ```json
 {


### PR DESCRIPTION
Needed to do this when using the NGINX Home Assistant SSL proxy for customized servers.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
