### PR TITLE
Add invert to netdata documentation

### DIFF
--- a/source/_components/sensor.netdata.markdown
+++ b/source/_components/sensor.netdata.markdown
@@ -57,6 +57,13 @@ sensor:
       cpu:
         data_group: system.cpu
         element: system
+      network_downstream:
+        data_group: net.eth1
+        element: received
+      network_upstream:
+        data_group: net.eth1
+        element: sent
+        invert: true
 ```
 
 {% configuration %}
@@ -98,5 +105,10 @@ resources:
           required: false
           type: icon
           default: "mdi:desktop-classic"
+        invert:
+          description: Invert the sensor values. Used for networking sensors that return a negative value.
+          required: false
+          type: boolean
+          default: false
 {% endconfiguration %}
 

--- a/source/_components/sensor.netdata.markdown
+++ b/source/_components/sensor.netdata.markdown
@@ -57,13 +57,6 @@ sensor:
       cpu:
         data_group: system.cpu
         element: system
-      network_downstream:
-        data_group: net.eth1
-        element: received
-      network_upstream:
-        data_group: net.eth1
-        element: sent
-        invert: true
 ```
 
 {% configuration %}
@@ -106,9 +99,29 @@ resources:
           type: icon
           default: "mdi:desktop-classic"
         invert:
-          description: Invert the sensor values. Used for networking sensors that return a negative value.
+          description: Invert the sensor values.
           required: false
           type: boolean
           default: false
 {% endconfiguration %}
 
+
+## {% linkable_title Full examples %}
+
+### {% linkable_title Network interface details %}
+
+Netdata returns all bandwidth related sensors as positive/negative numbers related to the interface.
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: netdata
+    resources:
+      network_downstream:
+        data_group: net.eth1
+        element: received
+      network_upstream:
+        data_group: net.eth1
+        element: sent
+        invert: true
+```


### PR DESCRIPTION
Add invert to netdata documentation

**Description:**
Add docs for netdata change

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21711

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
