### PR TITLE
Update default tap_action

### DIFF
--- a/source/_lovelace/entity-button.markdown
+++ b/source/_lovelace/entity-button.markdown
@@ -50,7 +50,7 @@ tap_action:
       required: true
       description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `none`)"
       type: string
-      default: "`more-info`"
+      default: "`toggle`"
     navigation_path:
       required: false
       description: "Path to navigate to (e.g. `/lovelace/0/`) when `action` defined as `navigate`"


### PR DESCRIPTION
**Description:**


https://github.com/home-assistant/home-assistant-polymer/pull/2897

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
