### PR TITLE
Add custom holidays to workday sensor

### DIFF
--- a/source/_components/binary_sensor.workday.markdown
+++ b/source/_components/binary_sensor.workday.markdown
@@ -31,6 +31,7 @@ binary_sensor:
   - platform: workday
     country: DE
     workdays: [mon, wed, fri]
+    add_holidays: ['2018-12-26','2018-12-31']
 ```
 
 {% configuration %}
@@ -63,11 +64,17 @@ days_offset:
   required: false
   type: integer
   default: 0
+add_holidays:
+  description: Add custom holidays (such as company, personal holidays, or vacations).
+  required: false
+  type: list
 {% endconfiguration %}
 
 Days are specified as follows: `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun`.
 The keyword `holiday` is used for public
 holidays identified by the holidays module.
+
+Custom holidays must be formatted as ['yyyy-mm-dd'] with commas separating each date to be added.
 
 <p class='note warning'>
 If you use the sensor for Norway (`NO`) you need to wrap `NO` in quotes or write the name in full.
@@ -98,4 +105,3 @@ automation:
 <p class='note'>
 Please remember that [as explained here](/docs/configuration/devices/) you can only have a single `automation:` entry. Add the automation to your existing automations.
 </p>
-

--- a/source/_components/binary_sensor.workday.markdown
+++ b/source/_components/binary_sensor.workday.markdown
@@ -30,8 +30,6 @@ To enable the `workday` sensor in your installation, add the following to your `
 binary_sensor:
   - platform: workday
     country: DE
-    workdays: [mon, wed, fri]
-    add_holidays: ['2018-12-26','2018-12-31']
 ```
 
 {% configuration %}
@@ -65,16 +63,13 @@ days_offset:
   type: integer
   default: 0
 add_holidays:
-  description: Add custom holidays (such as company, personal holidays, or vacations).
+  description: "Add custom holidays (such as company, personal holidays or vacations). Needs to formatted as `YYYY-MM-DD`." 
   required: false
   type: list
 {% endconfiguration %}
 
 Days are specified as follows: `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun`.
-The keyword `holiday` is used for public
-holidays identified by the holidays module.
-
-Custom holidays must be formatted as ['yyyy-mm-dd'] with commas separating each date to be added.
+The keyword `holiday` is used for public holidays identified by the holidays module.
 
 <p class='note warning'>
 If you use the sensor for Norway (`NO`) you need to wrap `NO` in quotes or write the name in full.
@@ -82,6 +77,22 @@ Otherwise the value is evaluated as `false`.
 If you use the sensor for Canada (`CA`) with Ontario (`ON`) as `province:` then you need to wrap `ON` in quotes.
 Otherwise the value is evaluated as `true` (check the YAML documentation for further details) and the sensor will not work.
 </p>
+
+## {% linkable_title Full example %}
+
+This examples excludes Saturdays, Sundays and holiday. Two custom holidays are added.
+
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+  - platform: workday
+    country: DE
+    workdays: [mon, wed, fri]
+    excludes: [sat, sun, holiday]
+    add_holidays: 
+      - '2018-12-26'
+      - '2018-12-31'
+```
 
 ## {% linkable_title Automation example %}
 


### PR DESCRIPTION
**Description:** Add custom holidays to workday sensor (such as company, personal holidays, or vacations)


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21718

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
