### PR TITLE
Update the docs for the Xiaomi Gateway component

### DIFF
--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -285,7 +285,7 @@ That means that Home Assistant is not getting any response from your Xiaomi gate
   - Open a serial terminal application (e.g. PuTTY) and connect to the serial port assigned to the USB-UART module (baudrate: 115 200).
   - Wait until the gateway is booted up, connect the RX, TX and GND wires to the UART module (don't connect the Vcc (power) wire!).
   - You will see all the messages from the gateway.
-  - Send command `psm-set network.open_pf 3` (the command have to end with a `CR` newline character).
-  - Check your param executing the command `psm-get network.open_pf` to be sure it's OK.
+  - Send the command `psm-set network.open_pf 3` (the command has to end with a `CR` newline character).
+  - Check your settings executing the command `psm-get network.open_pf` to be sure it's OK.
   - Restart the gateway
   - Check the port `9898` again, it should be opened now.

--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -277,7 +277,7 @@ That means that Home Assistant is not getting any response from your Xiaomi gate
   - You should generate the key again using an Android Phone or alternatively an emulator such as [bluestacks](https://www.bluestacks.com). In some instances, there is an issue with keys being generated using the iOS application.
   - You need to make sure to have multicast support on your network. If you are running Home Assistant in a virtual machine (like Proxmox), try `echo 0 >/sys/class/net/vmbr0/bridge/multicast_snooping` on the host and restart the service or reboot the host.
 - If the required library "PyXiaomiGateway" cannot be installed you will need to install some missing system dependencies `python3-dev`, `libssl-dev`, `libffi-dev` manually (e.g., `$ sudo apt-get install python3-dev libssl-dev libffi-dev`).
-- If your gateway's MAC address starts with `04:CF:8C`, there is a good chance that the required port `9898` is closed on your gateway (you can check it with the Nmap utility, using the command `Nmap - sU {gateway_ip} -p 9898`). To fix that issue, you need to do these steps:
+- If your gateway's MAC address starts with `04:CF:8C`, there is a good chance that the required port `9898` is closed on your gateway (you can check it with the Nmap utility, using the command `sudo nmap - sU {gateway_ip} -p 9898`). To fix that issue, you need to do these steps:
   - Find a specific screw bit (like a fork) to open the gateway case.
   - Find a USB-UART cable/module and connect it to your computer.
   - Solder 3 wires - RX, TX and GND like [here](http://cs5-3.4pda.to/14176168/IMG_20181020_201150.jpg).
@@ -288,4 +288,4 @@ That means that Home Assistant is not getting any response from your Xiaomi gate
   - Send command `psm-set network.open_pf 3` (the command have to end with a `CR` newline character).
   - Check your param executing the command `psm-get network.open_pf` to be sure it's OK.
   - Restart the gateway
-  - Check your the port `- Find a specific screw bit (like a fork) to open the gateway case.
+  - Check the port `9898` again, it should be opened now.

--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -282,10 +282,9 @@ That means that Home Assistant is not getting any response from your Xiaomi gate
   - Find a USB-UART cable/module and connect it to your computer.
   - Solder 3 wires - RX, TX and GND like [here](http://cs5-3.4pda.to/14176168/IMG_20181020_201150.jpg).
   - Turn on the gateway (220V).
-  - Open a serial terminal application (e.g. PuTTY) and connect to the serial port assigned to the USB-UART module (baudrate: 115 200).
+  - Open a serial terminal application (e.g. PuTTY) and connect to the serial port assigned to the USB-UART module (baudrate: 115200).
   - Wait until the gateway is booted up, connect the RX, TX and GND wires to the UART module (don't connect the Vcc (power) wire!).
   - You will see all the messages from the gateway.
   - Send the command `psm-set network.open_pf 3` (the command has to end with a `CR` newline character).
   - Check your settings executing the command `psm-get network.open_pf` to be sure it's OK.
-  - Restart the gateway
-  - Check the port `9898` again, it should be opened now.
+  - Restart the gateway.

--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -277,3 +277,15 @@ That means that Home Assistant is not getting any response from your Xiaomi gate
   - You should generate the key again using an Android Phone or alternatively an emulator such as [bluestacks](https://www.bluestacks.com). In some instances, there is an issue with keys being generated using the iOS application.
   - You need to make sure to have multicast support on your network. If you are running Home Assistant in a virtual machine (like Proxmox), try `echo 0 >/sys/class/net/vmbr0/bridge/multicast_snooping` on the host and restart the service or reboot the host.
 - If the required library "PyXiaomiGateway" cannot be installed you will need to install some missing system dependencies `python3-dev`, `libssl-dev`, `libffi-dev` manually (e.g., `$ sudo apt-get install python3-dev libssl-dev libffi-dev`).
+- If your gateway's MAC address starts with `04:CF:8C`, there is a good chance that the required port `9898` is closed on your gateway (you can check it with the Nmap utility, using the command `Nmap - sU {gateway_ip} -p 9898`). To fix that issue, you need to do these steps:
+  - Find a specific screw bit (like a fork) to open the gateway case.
+  - Find a USB-UART cable/module and connect it to your computer.
+  - Solder 3 wires - RX, TX and GND like [here](http://cs5-3.4pda.to/14176168/IMG_20181020_201150.jpg).
+  - Turn on the gateway (220V).
+  - Open a serial terminal application (e.g. PuTTY) and connect to the serial port assigned to the USB-UART module (baudrate: 115 200).
+  - Wait until the gateway is booted up, connect the RX, TX and GND wires to the UART module (don't connect the Vcc (power) wire!).
+  - You will see all the messages from the gateway.
+  - Send command `psm-set network.open_pf 3` (the command have to end with a `CR` newline character).
+  - Check your param executing the command `psm-get network.open_pf` to be sure it's OK.
+  - Restart the gateway
+  - Check your the port `- Find a specific screw bit (like a fork) to open the gateway case.


### PR DESCRIPTION
**Description:**
Some new models of gateways don't have the required port `9898` opened. As reported in discussions, it affects devices with MAC addresses starting with `04:CF:8C` combined with the latest firmware.  So, I've added the steps to fix that issue (I also did the provided steps to fix my gateway with success).

Links to discussions:
https://community.home-assistant.io/t/xiaomi-gateway-no-longer-connecting-on-latest-firmware-invalid-config/80052/67
https://community.openhab.org/t/solved-openhab2-xiaomi-mi-gateway-does-not-respond/52963/114?u=dominikpalo
https://github.com/home-assistant/home-assistant/issues/21830#issuecomment-471178998