### PR TITLE
Document Android TV functionality in Fire TV component

### DIFF
--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -192,11 +192,11 @@ stop_netflix:
 
 ### {% linkable_title `firetv.adb_command` %}
 
-The service `firetv.adb_command` allows you to send either keys or ADB shell commands to the Fire TV.
+The service `firetv.adb_command` allows you to send either keys or ADB shell commands to your Android TV / Fire TV device.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |       no | Name(s) of Fire TV entities.
+| `entity_id`            |       no | Name(s) of Android TV / Fire TV entities.
 | `command`              |       no | Either a key command or an ADB shell command.
 
 In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this:

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -54,7 +54,7 @@ media_player:
 
 {% configuration %}
 host:
-  description: The IP address for your Fire TV device.
+  description: The IP address for your Android TV / Fire TV device.
   required: true
   type: string
 name:
@@ -63,7 +63,7 @@ name:
   default: Amazon Fire TV
   type: string
 port:
-  description: The port for your Fire TV device.
+  description: The port for your Android TV / Fire TV device.
   required: false
   default: 5555
   type: integer

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -81,7 +81,7 @@ adb_server_port:
   default: 5037
   type: port
 get_sources:
-  description: Whether or not to retrieve the running apps as the list of sources.
+  description: Whether or not to retrieve the running apps as the list of sources for Fire TV devices; not used for Android TV devices.
   required: false
   default: true
   type: boolean

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Fire TV"
-description: "Instructions on how to integrate Fire-TV into Home Assistant."
+description: "Instructions on how to integrate Android TV and Fire TV devices into Home Assistant."
 date: 2015-10-23 18:00
 sidebar: true
 comments: false
@@ -107,11 +107,19 @@ media_player:
   # don't get the running apps, and provide an app name
   - platform: firetv
     name: Fire TV
+    device_class: firetv
     host: 192.168.0.222
     adbkey: "/config/android/adbkey"
     get_sources: false
     apps:
       com.amazon.tv.launcher: "Fire TV"
+
+  # Use an ADB server to setup an Android TV device
+  - platform: firetv
+    name: Android TV
+    device_class: androidtv
+    host: 192.168.0.222
+    adb_server_ip: 127.0.0.1
 ```
 
 
@@ -119,40 +127,70 @@ media_player:
 
 This component works by sending ADB commands to your Android TV / Fire TV device.  There are two ways to accomplish this:
 
-1. Using the `adb` Python package.  If your device requires ADB authentication, you will need to follow the instructions in the "ADB Authentication (for Fire TV devices with recent software)" section below.  Once you have an authenticated key, this approach does not require any additional setup or addons.  However, users with newer devices may find that the ADB connection is unstable.  If setting the `get_sources` configuration option to `false` does not help, they should use the next option.  
-2. Using an ADB server.  For Hass.io users, you can install the [Android Debug Bridge](https://github.com/hassio-addons/addon-adb/blob/v0.1.0/README.md) addon.  With this approach, Home Assistant will send the ADB commands to the server, which will then send them to the Android TV / Fire TV device and report back to Home Assistant.  To use this option, add the `adb_server_ip` option to your configuration.  If you are running the server on the same machine as Home Assistant, you can use `127.0.0.1` for this value.
+
+### {% linkable_title 1. ADB Server %}
+
+You can use an ADB server to connect to your Android TV and Fire TV devices.  For Hass.io users, you can install the [Android Debug Bridge](https://github.com/hassio-addons/addon-adb/blob/v0.1.0/README.md) addon.  With this approach, Home Assistant will send the ADB commands to the server, which will then send them to the Android TV / Fire TV device and report back to Home Assistant.  To use this option, add the `adb_server_ip` option to your configuration.  If you are running the server on the same machine as Home Assistant, you can use `127.0.0.1` for this value.
 
 
-### {% linkable_title ADB Authentication (for Fire TV devices with recent software) %}
+### {% linkable_title 2. Python ADB Implementation %}
 
-If you get a "Device authentication required, no keys available" error when trying to set up Fire TV, then you'll need to create an adbkey and add its path to your configuration.  Follow the instructions on this page to connect to your Fire TV from your computer: [Connecting to Fire TV Through adb](https://developer.amazon.com/zh/docs/fire-tv/connecting-adb-to-device.html).  
+The second option is to connect to your device using the `adb` Python package.  If your device requires ADB authentication, you will need to follow the instructions in the [ADB Authentication](#adb-authentication) section below.  Once you have an authenticated key, this approach does not require any additional setup or addons.  However, users with newer devices may find that the ADB connection is unstable.  For a Fire TV device, you can try setting the `get_sources` configuration option to `false`.  If the problem cannot be resolved, you should use the ADB server option.
+
+
+### {% linkable_title ADB Authentication %}
+
+If you get a "Device authentication required, no keys available" error when trying to set up Fire TV, then you'll need to create an adbkey and add its path to your configuration.  Follow the instructions on this page to connect to your Fire TV from your computer: [Connecting to Fire TV Through adb](https://developer.amazon.com/zh/docs/fire-tv/connecting-adb-to-device.html).
 
 <p class='note warning'>
-  In the dialog appearing on your Fire TV, you must check the box that says "always allow connections from this device."  ADB authentication in Home Assistant will only work using a trusted key.
+  In the dialog appearing on your Android TV / Fire TV, you must check the box that says "always allow connections from this device."  ADB authentication in Home Assistant will only work using a trusted key.
 </p>
 
-Once you've successfully connected to your Fire TV via the command `adb connect <ipaddress>`, the files `adbkey` and `adbkey.pub` will be created on your computer.  The default locations for these files are (from [https://developer.android.com/studio/command-line/adb](https://developer.android.com/studio/command-line/adb)):
+Once you've successfully connected to your Android TV / Fire TV via the command `adb connect <ipaddress>`, the files `adbkey` and `adbkey.pub` will be created on your computer.  The default locations for these files are (from [https://developer.android.com/studio/command-line/adb](https://developer.android.com/studio/command-line/adb)):
 
 * Linux and Mac: `$HOME/.android.`
 * Windows: `%userprofile%\.android.`
 
-Copy the `adbkey` and `adbkey.pub` files to your Home Assistant folder and add the path to the `adbkey` file to your configuration.  
+Copy the `adbkey` and `adbkey.pub` files to your Home Assistant folder and add the path to the `adbkey` file to your configuration.
 
 
-#### ADB Troubleshooting
+#### {% linkable_title ADB Troubleshooting %}
 
 If you receive the error message `Issue: Error while setting up platform firetv` in your log when trying to set up a Fire TV device with an ADB key, then there is probably an issue with your ADB key.  Here are some possible causes.
 
-1. ADB is not enabled on your Fire TV.  To remedy this, enable ADB by following the instructions above.  
+1. ADB is not enabled on your device.
 
-2. Your key is not pre-authenticated.  Before using the `adbkey` in Home Assistant, you _**must**_ connect to your Fire TV device using the ADB binary and tell the Fire TV to always allow connections from this computer.  For more information, see the section "ADB Authentication (for Fire TV devices with recent software)" above.
+2. Your key is not pre-authenticated.  Before using the `adbkey` in Home Assistant, you _**must**_ connect to your Fire TV device using the ADB binary and tell the Fire TV to always allow connections from this computer.  For more information, see the section [ADB Authentication](#adb-authentication) above.
 
 3. Home Assistant does not have the appropriate permissions for the `adbkey` file and so it is not able to use it.  Once you fix the permissions, the component should work.
 
-4. You are already connected to the Fire TV via ADB from another device.  Only one device can be connected, so disconnect the other device, restart the Fire TV (for good measure), and then restart Home Assistant.  
+4. You are already connected to the Android TV / Fire TV via ADB from another device.  Only one device can be connected, so disconnect the other device, restart the Android TV / Fire TV (for good measure), and then restart Home Assistant.
 
 
-## {% linkable_title Service %}
+## {% linkable_title Services %}
+
+### {% linkable_title `media_player.select_source` %}
+
+For Fire TV devices, you can launch an app using the `media_player.select_source` command.  Simply provide the app ID as the `source`.  You can also stop an app by prefixing the app ID with a `!`.  For example, you could define [scripts](/docs/scripts) to start and stop Netflix as follows:
+
+```yaml
+start_netflix:
+  sequence:
+  - service: media_player.select_source
+    data:
+      entity_id: media_player.fire_tv_living_room
+      source: 'com.netflix.ninja'
+
+stop_netflix:
+  sequence:
+  - service: media_player.select_source
+    data:
+      entity_id: media_player.fire_tv_living_room
+      source: '!com.netflix.ninja'
+```
+
+
+### {% linkable_title `firetv.adb_command` %}
 
 The service `firetv.adb_command` allows you to send either keys or ADB shell commands to the Fire TV.
 
@@ -183,3 +221,7 @@ Available key commands include:
 * `CENTER`
 * `BACK`
 * `MENU`
+
+The full list of key commands can be found [here](https://github.com/JeffLIrion/python-androidtv/blob/e1c07176efc9216cdcff8245c920224c0234ea56/androidtv/constants.py#L115-L155).
+
+You can also use the command `GET_PROPERTIES` to retrieve the properties used by Home Assistant to update the device's state.  These will be logged at the INFO level and can be used to help improve state detection in the backend [androidtv](https://github.com/JeffLIrion/python-androidtv) package.

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -14,7 +14,7 @@ ha_iot_class: "Local Polling"
 ---
 
 
-The `firetv` platform allows you to control an [Amazon Fire TV/stick](https://www.amazon.com/b/?node=8521791011).
+The `firetv` platform allows you to control an Android TV device or [Amazon Fire TV](https://www.amazon.com/b/?node=8521791011) device.
 
 Steps to configure your Amazon Fire TV stick with Home Assistant:
 
@@ -25,6 +25,8 @@ Steps to configure your Amazon Fire TV stick with Home Assistant:
 - Find Amazon Fire TV device IP:
   - From the main (Launcher) screen, select Settings.
   - Select System > About > Network.
+
+For Android TV devices, you will need to enable ADB debugging. Please consult the documentation for your device.
 
 
 ## {% linkable_title Configuration %}
@@ -88,6 +90,11 @@ apps:
   required: false
   default: {}
   type: dict
+device_class:
+  description: "The type of device: `auto` (detect whether it is an Android TV or Fire TV device)), `androidtv`, or `firetv`."
+  required: false
+  default: auto
+  type: string
 {% endconfiguration %}
 
 
@@ -110,10 +117,10 @@ media_player:
 
 ## {% linkable_title ADB Setup %}
 
-This component works by sending ADB commands to your Fire TV device.  There are two ways to accomplish this:
+This component works by sending ADB commands to your Android TV / Fire TV device.  There are two ways to accomplish this:
 
 1. Using the `adb` Python package.  If your device requires ADB authentication, you will need to follow the instructions in the "ADB Authentication (for Fire TV devices with recent software)" section below.  Once you have an authenticated key, this approach does not require any additional setup or addons.  However, users with newer devices may find that the ADB connection is unstable.  If setting the `get_sources` configuration option to `false` does not help, they should use the next option.  
-2. Using an ADB server.  For Hass.io users, you can install the [Android Debug Bridge](https://github.com/hassio-addons/addon-adb/blob/v0.1.0/README.md) addon.  With this approach, Home Assistant will send the ADB commands to the server, which will then send them to the Fire TV device and report back to Home Assistant.  To use this option, add the `adb_server_ip` option to your configuration.  If you are running the server on the same machine as Home Assistant, you can use `127.0.0.1` for this value.
+2. Using an ADB server.  For Hass.io users, you can install the [Android Debug Bridge](https://github.com/hassio-addons/addon-adb/blob/v0.1.0/README.md) addon.  With this approach, Home Assistant will send the ADB commands to the server, which will then send them to the Android TV / Fire TV device and report back to Home Assistant.  To use this option, add the `adb_server_ip` option to your configuration.  If you are running the server on the same machine as Home Assistant, you can use `127.0.0.1` for this value.
 
 
 ### {% linkable_title ADB Authentication (for Fire TV devices with recent software) %}
@@ -164,7 +171,7 @@ action:
     command: "HOME"
 ```
 
-Available key commands are:
+Available key commands include:
 
 * `POWER`
 * `SLEEP`

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -140,7 +140,7 @@ The second option is to connect to your device using the `adb` Python package.  
 
 ### {% linkable_title ADB Authentication %}
 
-If you get a "Device authentication required, no keys available" error when trying to set up Fire TV, then you'll need to create an adbkey and add its path to your configuration.  Follow the instructions on this page to connect to your Fire TV from your computer: [Connecting to Fire TV Through adb](https://developer.amazon.com/zh/docs/fire-tv/connecting-adb-to-device.html).
+If you get a "Device authentication required, no keys available" error when trying to set up your Android TV or Fire TV, then you'll need to create an adbkey and add its path to your configuration.  Follow the instructions on this page to connect to your device from your computer: [Connecting to Fire TV Through adb](https://developer.amazon.com/zh/docs/fire-tv/connecting-adb-to-device.html).
 
 <p class='note warning'>
   In the dialog appearing on your Android TV / Fire TV, you must check the box that says "always allow connections from this device."  ADB authentication in Home Assistant will only work using a trusted key.
@@ -156,11 +156,11 @@ Copy the `adbkey` and `adbkey.pub` files to your Home Assistant folder and add t
 
 #### {% linkable_title ADB Troubleshooting %}
 
-If you receive the error message `Issue: Error while setting up platform firetv` in your log when trying to set up a Fire TV device with an ADB key, then there is probably an issue with your ADB key.  Here are some possible causes.
+If you receive the error message `Issue: Error while setting up platform firetv` in your log when trying to set up an Android TV or Fire TV device with an ADB key, then there is probably an issue with your ADB key.  Here are some possible causes.
 
 1. ADB is not enabled on your device.
 
-2. Your key is not pre-authenticated.  Before using the `adbkey` in Home Assistant, you _**must**_ connect to your Fire TV device using the ADB binary and tell the Fire TV to always allow connections from this computer.  For more information, see the section [ADB Authentication](#adb-authentication) above.
+2. Your key is not pre-authenticated.  Before using the `adbkey` in Home Assistant, you _**must**_ connect to your device using the ADB binary and tell it to always allow connections from this computer.  For more information, see the section [ADB Authentication](#adb-authentication) above.
 
 3. Home Assistant does not have the appropriate permissions for the `adbkey` file and so it is not able to use it.  Once you fix the permissions, the component should work.
 

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -91,7 +91,7 @@ apps:
   default: {}
   type: dict
 device_class:
-  description: "The type of device: `auto` (detect whether it is an Android TV or Fire TV device)), `androidtv`, or `firetv`."
+  description: "The type of device: `auto` (detect whether it is an Android TV or Fire TV device), `androidtv`, or `firetv`."
   required: false
   default: auto
   type: string

--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -16,7 +16,7 @@ ha_iot_class: "Local Polling"
 
 The `firetv` platform allows you to control an Android TV device or [Amazon Fire TV](https://www.amazon.com/b/?node=8521791011) device.
 
-Steps to configure your Amazon Fire TV stick with Home Assistant:
+Steps to configure your Amazon Fire TV with Home Assistant:
 
 - Turn on ADB Debugging on your Amazon Fire TV:
   - From the main (Launcher) screen, select Settings.


### PR DESCRIPTION
**Description:**

Document Android TV functionality in Fire TV component. 

**Generated documentation:** [Fire TV](https://deploy-preview-8893--home-assistant-docs.netlify.com/components/media_player.firetv/)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/21872

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
