### PR TITLE
Spelling of person in first paragraph

### DIFF
--- a/source/_components/person.markdown
+++ b/source/_components/person.markdown
@@ -13,7 +13,7 @@ ha_qa_scale: internal
 ha_release: 0.88
 ---
 
-The person component allows to connect device tracker entities to one or more person entities. The state updates of a connected device trackers will set the state of the person. When multiple device tracers used, the state of berson will be determined next way:
+The person component allows to connect device tracker entities to one or more person entities. The state updates of a connected device trackers will set the state of the person. When multiple device tracers used, the state of person will be determined next way:
 
 1. If there are stationary sources (which type is not 'gps') presenting status 'home', than latest of this sources will be taken.
 2. If there are sources of type 'gps', than latest of this sources will be taken.


### PR DESCRIPTION
Changed 'berson' to 'person'

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
