### PR TITLE
Additional clarification

### DIFF
--- a/source/_components/tts.markdown
+++ b/source/_components/tts.markdown
@@ -62,6 +62,9 @@ tts:
     time_memory: 300
     base_url: http://192.168.0.10:8123
 ```
+<p class='note'>
+In the above example, `base_url` is custom to this particular TTS platform configuration.  It is not suggesting that you use the `base_url` that you have set for your core Home Assistant configuration.  The reason you might need to do this is outlined in the next section.
+</p>
 
 ## {% linkable_title When do you need to set `base_url` here? %}
 

--- a/source/_components/tts.markdown
+++ b/source/_components/tts.markdown
@@ -62,8 +62,9 @@ tts:
     time_memory: 300
     base_url: http://192.168.0.10:8123
 ```
+
 <p class='note'>
-In the above example, `base_url` is custom to this particular TTS platform configuration.  It is not suggesting that you use the `base_url` that you have set for your core Home Assistant configuration.  The reason you might need to do this is outlined in the next section.
+In the above example, `base_url` is custom to this particular TTS platform configuration. It is not suggesting that you use the `base_url` that you have set for your core Home Assistant configuration. The reason you might need to do this is outlined in the next section.
 </p>
 
 ## {% linkable_title When do you need to set `base_url` here? %}


### PR DESCRIPTION
I was a bit confused about what the base url was supposed to be here and that setting it here was overriding the HTTP setting in configuration.yaml.  Often I see in the documentation that there are examples without explanation of why that was used as the example.  So for this one, I assumed that it was `asking` for the base_url that I had set, rather than allowing me to define a custom base url.

**Description:**
Helping other understand that the URL is being customized here, not requested.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
