### PR TITLE
Adding some missing config options for Enigma2 media_player.

### DIFF
--- a/source/_components/media_player.enigma2.markdown
+++ b/source/_components/media_player.enigma2.markdown
@@ -48,12 +48,12 @@ media_player:
     description: The username of a user with privileges to access the box. This is only required if you have enabled the setting "Enable HTTP Authentication" in OpenWebif settings. _(e.g., on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_.
     required: false
     type: string
-    default: `root`
+    default: root
   password:
     description: The password for your given account. Again, this is only required if you have enabled the setting "Enable HTTP Authentication" in OpenWebif settings. _(e.g., on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_.
     required: false
     type: string
-    default: `dreambox`
+    default: dreambox
   ssl:
     description: Use HTTPS instead of HTTP to connect. This is only required if you have enabled the setting "Enable HTTPS" in OpenWebif settings. _(e.g., on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_. You will need to ensure you have a valid CA certificate in place or SSL verification will fail with this component.
     required: false

--- a/source/_components/media_player.enigma2.markdown
+++ b/source/_components/media_player.enigma2.markdown
@@ -45,17 +45,17 @@ media_player:
     type: integer
     default: 80
   username:
-    description: The username of a user with privileges to access the box. This is only required if you have enabled the setting "Enable HTTP Authentication" in OpenWebif settings: _(on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_
+    description: The username of a user with privileges to access the box. This is only required if you have enabled the setting "Enable HTTP Authentication" in OpenWebif settings. _(e.g., on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_.
     required: false
     type: string
     default: `root`
   password:
-    description: The password for your given account. Again, this is only required if you have enabled the setting "Enable HTTP Authentication" in OpenWebif settings: _(on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_
+    description: The password for your given account. Again, this is only required if you have enabled the setting "Enable HTTP Authentication" in OpenWebif settings. _(e.g., on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_.
     required: false
     type: string
     default: `dreambox`
   ssl:
-    description: Use HTTPS instead of HTTP to connect. This is only required if you have enabled the setting "Enable HTTPS" in OpenWebif settings: _(on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_
+    description: Use HTTPS instead of HTTP to connect. This is only required if you have enabled the setting "Enable HTTPS" in OpenWebif settings. _(e.g., on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_. You will need to ensure you have a valid CA certificate in place or SSL verification will fail with this component.
     required: false
     type: boolean
     default: false

--- a/source/_components/media_player.enigma2.markdown
+++ b/source/_components/media_player.enigma2.markdown
@@ -40,10 +40,25 @@ media_player:
     type: boolean
     default: false
   port:
-    description: Port which Openwebif is listening on.
+    description: Port which OpenWebif is listening on.
     required: false
     type: integer
     default: 80
+  username:
+    description: The username of a user with privileges to access the box. This is only required if you have enabled the setting "Enable HTTP Authentication" in OpenWebif settings: _(on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_
+    required: false
+    type: string
+    default: `root`
+  password:
+    description: The password for your given account. Again, this is only required if you have enabled the setting "Enable HTTP Authentication" in OpenWebif settings: _(on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_
+    required: false
+    type: string
+    default: `dreambox`
+  ssl:
+    description: Use HTTPS instead of HTTP to connect. This is only required if you have enabled the setting "Enable HTTPS" in OpenWebif settings: _(on the remote by pressing `Menu`>`Plugins`>`OpenWebif`)_
+    required: false
+    type: boolean
+    default: false
   name:
     description: A name for easy identification of the device.
     required: false


### PR DESCRIPTION
**Description:**
Adding documentation for existing config options for Enigma2 media_player (which I forgot about in the initial docs commit).

Here is a screenshot of the menu item mentioned in the docs (accessed on the E2 box itself via the remote control). 
![1_0_19_835_3EA_2174_EEEE0000_0_0_0_20190311101933](https://user-images.githubusercontent.com/254309/54117584-0ad9d600-43e9-11e9-9820-8a89cb71c2b7.jpg)


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].
