### PR TITLE
Update initial_states

### DIFF
--- a/source/_components/automation.markdown
+++ b/source/_components/automation.markdown
@@ -25,14 +25,14 @@ Starting with 0.28 your automation rules can be controlled with the frontend.
 This allows one to reload the automation without restarting Home Assistant
 itself. If you don't want to see the automation rule in your frontend use
 `hide_entity: true` to hide it.
-You can also use `initial_state: 'off'` so that the automation
+You can also use `initial_state: 'false'` so that the automation
 is not automatically turned on after a Home Assistant reboot.
 
 ```yaml
 automation:
   - alias: Door alarm
     hide_entity: true
-    initial_state: 'off'
+    initial_state: 'true'
     trigger:
       - platform: state
   ...


### PR DESCRIPTION
Edited to show true/false instead of on/off

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
