### PR TITLE
Fix broken link to component source

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -60,7 +60,7 @@
 
   <div class='section'>
     {%- if is_platform -%}
-      Source: <a href='{{github_main_repo}}{{imp_url}}{{parent_name}}.py'>{{imp_name}}/{{parent_name}}.py</a>
+      Source: <a href='{{github_main_repo}}{{parent_url}}{{imp_name}}.py'>{{parent_name}}/{{imp_name}}.py</a>
     {%- else -%}
       Source: <a href='{{github_main_repo}}{{imp_url}}'>{{imp_url}}</a>
     {%- endif -%}


### PR DESCRIPTION
**Description:**
Fixes https://github.com/home-assistant/home-assistant/issues/22000 by changing the order of URL parts to resolve broken links to component source on documentation pages like [“iRobot Roomba”](
https://www.home-assistant.io/components/vacuum.roomba/) and [“Hook Switch”](https://www.home-assistant.io/components/switch.hook/).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html