### PR TITLE
Update automation.markdown

### DIFF
--- a/source/_components/automation.markdown
+++ b/source/_components/automation.markdown
@@ -25,8 +25,8 @@ Starting with 0.28 your automation rules can be controlled with the frontend.
 This allows one to reload the automation without restarting Home Assistant
 itself. If you don't want to see the automation rule in your frontend use
 `hide_entity: true` to hide it.
-You can also use `initial_state: 'false'` so that the automation
-is not automatically turned on after a Home Assistant reboot.
+You can also use `initial_state: 'true'` so that the automation
+is automatically turned on after a Home Assistant reboot.
 
 ```yaml
 automation:


### PR DESCRIPTION
Automations are no longer automatically started on reboot unless `initial_state: 'true' has been set.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
