### PR TITLE
Telegram_bot: Add option to allow fetching data from unverified SSL e…

### DIFF
--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -186,6 +186,11 @@ authentication:
   required: false
   default: basic
   type: string
+verify_ssl:
+  description: Set to false to skip the validation of the server's SSL certificate.
+  required: false
+  default: true
+  type: boolean
 keyboard:
   description: List of rows of commands, comma-separated, to make a custom keyboard.
   required: false
@@ -255,6 +260,11 @@ authentication:
   required: false
   default: basic
   type: string
+verify_ssl:
+  description: Set to false to skip the validation of the server's SSL certificate.
+  required: false
+  default: true
+  type: boolean
 keyboard:
   description: List of rows of commands, comma-separated, to make a custom keyboard.
   required: false
@@ -309,6 +319,11 @@ authentication:
   required: false
   default: basic
   type: string
+verify_ssl:
+  description: Set to false to skip the validation of the server's SSL certificate.
+  required: false
+  default: true
+  type: boolean
 keyboard:
   description: List of rows of commands, comma-separated, to make a custom keyboard.
   required: false

--- a/source/_components/telegram_bot.markdown
+++ b/source/_components/telegram_bot.markdown
@@ -51,7 +51,8 @@ Send a photo.
 | `password`                |      yes | Password for a URL which requires HTTP basic authentication. |
 | `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
 | `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
-| `disable_notification`    |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |
+| `disable_notification     |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |
+| `verify_ssl`              |      yes | True/false for checking the SSL certificate of the server for HTTPS URLs. Defaults to True. |
 | `keyboard`                |      yes | List of rows of commands, comma-separated, to make a custom keyboard. Example: `["/command1, /command2", "/command3"]` |
 | `inline_keyboard`         |      yes | List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data. Example: `["/button1, /button2", "/button3"]` or `[[["Text btn1", "/button1"], ["Text btn2", "/button2"]], [["Text btn3", "/button3"]]]` |
 
@@ -69,6 +70,7 @@ Send a video.
 | `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
 | `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `disable_notification`    |      yes | True/false to send the message silently. iOS users and web users will not receive a notification. Android users will receive a notification with no sound. Defaults to False. |
+| `verify_ssl`              |      yes | True/false for checking the SSL certificate of the server for HTTPS URLs. Defaults to True. |
 | `keyboard`                |      yes | List of rows of commands, comma-separated, to make a custom keyboard. Example: `["/command1, /command2", "/command3"]` |
 | `inline_keyboard`         |      yes | List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data. Example: `["/button1, /button2", "/button3"]` or `[[["Text btn1", "/button1"], ["Text btn2", "/button2"]], [["Text btn3", "/button3"]]]` |
 
@@ -86,6 +88,7 @@ Send a document.
 | `authentication`          |      yes | Define which authentication method to use. Set to `digest` to use HTTP digest authentication. Defaults to `basic`. |
 | `target`                  |      yes | An array of pre-authorized chat_ids or user_ids to send the notification to. Defaults to the first allowed chat_id. |
 | `disable_notification`    |      yes | True/false for send the message silently. iOS users and web users will not receive a notification, Android users will receive a notification with no sound. Defaults to False. |
+| `verify_ssl`              |      yes | True/false for checking the SSL certificate of the server for HTTPS URLs. Defaults to True. |
 | `keyboard`                |      yes | List of rows of commands, comma-separated, to make a custom keyboard. Example: `["/command1, /command2", "/command3"]` |
 | `inline_keyboard`         |      yes | List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data. Example: `["/button1, /button2", "/button3"]` or `[[["Text btn1", "/button1"], ["Text btn2", "/button2"]], [["Text btn3", "/button3"]]]` |
 


### PR DESCRIPTION
**Description:**

This patch documents a new option (`verify_ssl`) that can be passed as part of the payload when calling certain services of the Telegram platform of the Notify component.

The variable is allowed to be unset, which means that nothing will be passed to `python-requests` relying therefore on the default behaviour of the library (currently it's to verify). From the documentation's POV the most correct description of the default behaviour would be then "python-requests' default" but I'm not sure that's very appropriate for user documentation. Your call.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22069

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
