### PR TITLE
Added an exclusion for group.all_automations

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -121,6 +121,8 @@ google_assistant:
     light.living_room:
       expose: false
       room: LIVING_ROOM
+    group.all_automations:
+      expose: false
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:**
The example exposes the group domain with no exclusions. This could lead new users unknowingly shutting off all of their automations by mistake

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
