### PR TITLE
removing group from default domains and add a warning

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -193,8 +193,7 @@ Currently, the following domains are available to be used with Google Assistant,
 - vacuum (dock/start/stop/pause)
 
 <p class='note warning'>
-    The domain groups contains groups containing all items, by example group.all_automations. When telling google assistant to 
-    shut down everything, this will lead in this example to disabling all automations
+  The domain groups contains groups containing all items, by example group.all_automations. When telling Google Assistant to shut down everything, this will lead in this example to disabling all automations
 </p>
 
 ### {% linkable_title Media Player Sources %}

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -111,7 +111,6 @@ google_assistant:
   exposed_domains:
     - switch
     - light
-    - group
   entity_config:
     switch.kitchen:
       name: CUSTOM_NAME_FOR_GOOGLE_ASSISTANT
@@ -192,6 +191,11 @@ Currently, the following domains are available to be used with Google Assistant,
 - media_player (on/off/set volume (via set brightness)/source (via set input source))
 - climate (temperature setting, operation_mode)
 - vacuum (dock/start/stop/pause)
+
+<p class='note warning'>
+    The domain groups contains groups containing all items, by example group.all_automations. When telling google assistant to 
+    shut down everything, this will lead in this example to disabling all automations
+</p>
 
 ### {% linkable_title Media Player Sources %}
 


### PR DESCRIPTION
reason:
saying shut down all resulted in disabling all automations

**Description:**
removing group from default domains and add a warning

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
