### PR TITLE
Update command to upgrade via hassbian-config

### DIFF
--- a/source/_docs/installation/hassbian/upgrading.markdown
+++ b/source/_docs/installation/hassbian/upgrading.markdown
@@ -20,7 +20,7 @@ $ sudo apt-get -y upgrade
 
 #### {% linkable_title Updating Home Assistant %}
 <p class='note'>
-You can use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade home-assistant`
+You can use `hassbian-config` to automate the process by running `sudo hassbian-config upgrade homeassistant`
 </p>
 
 To update the Home Assistant installation execute the following command as the `pi` user.


### PR DESCRIPTION

**Description:**
A typo error is present in the hassbian-config upgrade command, there is an hyphen not required in 'home-assistant'


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
