### PR TITLE
Explain an explicit ACL is now required; update example.

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -86,7 +86,7 @@ See the following links for more information:
 * [Mosquitto topic restrictions](http://www.steves-internet-guide.com/topic-restriction-mosquitto-configuration/)
 * [Mosquitto.conf man page](https://mosquitto.org/man/mosquitto-conf-5.html)
 
-Add the following configuration to enable unrestricted access to all topics.
+Add the following configuration to enable **unrestricted** access to all topics.
 
  1. Enable the customize flag
 ```json

--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -28,7 +28,7 @@ Set up [Mosquitto](https://mosquitto.org/) as MQTT broker.
 ```
 
 <p class='warning note'>
-Make sure you use logins and disable anonymous access if you want to secure the system.
+Since version 4.1 of the addon, an explicit ACL definition is now required, [see these instructions](https://www.home-assistant.io/addons/mosquitto/#access-control-lists-acls).
 </p>
 
 {% configuration %}
@@ -86,13 +86,24 @@ See the following links for more information:
 * [Mosquitto topic restrictions](http://www.steves-internet-guide.com/topic-restriction-mosquitto-configuration/)
 * [Mosquitto.conf man page](https://mosquitto.org/man/mosquitto-conf-5.html)
 
-Add the following configuration to enable ACLs:
+Add the following configuration to enable unrestricted access to all topics.
 
-1. Set the `active` flag within the `customize` section to `true` in your configuration.
-2. Create a file in `/share/mosquitto` named `acl.conf` with the following contents:
-```text
+ 1. Enable the customize flag
+```
+  "customize": {
+    "active": true,
+    "folder": "mosquitto"
+  },
+```
+
+2. Create `/share/mosquitto/acl.conf` with the contents:
+```
 acl_file /share/mosquitto/accesscontrollist
 ```
-3. Create a file in `/share/mosquitto` named `accesscontrollist` and add contents according to your requirements.
 
-The `/share` folder can be found on the host filesystem under `/usr/share/hassio/share`, or via the `Share` folder through SMB (Samba).
+3. Create `/share/mosquitto/accesscontrollist` with the contents:
+```
+topic readwrite #
+```
+
+The `/share` folder can be accessed via SMB, or on the host filesystem under `/usr/share/hassio/share`.

--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -63,7 +63,7 @@ To use the Mosquitto as [broker](/docs/mqtt/broker/#run-your-own), go to the int
 
 3. Once back on-line, return to `Configuration > Integrations` and select configure next to `MQTT`.
 
-```
+```text
   Broker: YOUR_HASSIO_IP_ADDRESS
   Port: 1883
   Username: MQTT_USERNAME
@@ -89,7 +89,7 @@ See the following links for more information:
 Add the following configuration to enable unrestricted access to all topics.
 
  1. Enable the customize flag
-```
+```json
   "customize": {
     "active": true,
     "folder": "mosquitto"
@@ -97,12 +97,12 @@ Add the following configuration to enable unrestricted access to all topics.
 ```
 
 2. Create `/share/mosquitto/acl.conf` with the contents:
-```
+```text
 acl_file /share/mosquitto/accesscontrollist
 ```
 
 3. Create `/share/mosquitto/accesscontrollist` with the contents:
-```
+```text
 topic readwrite #
 ```
 


### PR DESCRIPTION
The issue explained in https://github.com/home-assistant/hassio-addons/issues/545 outlines how an explicit ACL is now required for mosquitto to accept any traffic.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
