### PR TITLE
Remove hass.config from aws_lambda notify payload

### DIFF
--- a/source/_components/notify.aws_lambda.markdown
+++ b/source/_components/notify.aws_lambda.markdown
@@ -56,7 +56,7 @@ name:
   default: notify
   type: string
 context:
-  description: An optional dictionary you can provide to pass custom context through to the Lambda function. The `context` dictionary (if any) is combined with the same data available at the `/api/config` HTTP API route.
+  description: An optional dictionary you can provide to pass custom context through to the Lambda function.
   required: false
   type: string
 {% endconfiguration %}
@@ -82,15 +82,6 @@ The context will look like this:
 
 ```json
 {
-  "hass": {
-    "components": ["recorder", "logger", "http", "logbook", "api", "frontend"],
-    "latitude": 44.1234,
-    "location_name": "Home",
-    "longitude": 5.5678,
-    "unit_system": "metric",
-    "time_zone": "Europe/Zurich",
-    "version": "0.20.0.dev0"
-  },
   "custom": {
     "two": "three",
     "test": "one"


### PR DESCRIPTION
**Description:**

Remove hass.config from aws_lambda notify payload

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22125

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
