### PR TITLE
Updates scan interval notice of Toon component

### DIFF
--- a/source/_components/toon.markdown
+++ b/source/_components/toon.markdown
@@ -80,4 +80,4 @@ The `toon` climate platform allows you to interact with your Toon thermostat. Fo
 
 It also supports setting the temperature manually.
 
-The Toon API is polled at a 30-second interval, so the status is relatively fresh without overloading the API.
+The Toon API is polled at a 300-second interval, so the status is relatively fresh without overloading the API.


### PR DESCRIPTION
**Description:**

Updates the change as per parent PR change: Scan interval is now 300 seconds.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22160

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
