### PR TITLE
Grammar update

### DIFF
--- a/source/_components/person.markdown
+++ b/source/_components/person.markdown
@@ -15,9 +15,9 @@ ha_release: 0.88
 
 The person component allows connecting [device tracker](https://www.home-assistant.io/components/device_tracker/) entities to one or more person entities. The state updates of a connected device tracker will set the state of the person. When multiple device trackers are used, the state of person will be determined in this order:
 
-1. If there are stationary trackers (non-GPS trackers, ie. router or bluetooth 'device_trackers') presenting the status 'home', the tracker most recently updated will be used.
+1. If there are stationary trackers (non-GPS trackers, i.e., a router or Bluetooth 'device_trackers') presenting the status 'home', the tracker most recently updated will be used.
 2. If there are trackers of type 'gps', then the most recently updated tracker will be used.
-3. Otherwise the latest tracker with status 'not_home' will be used.
+3. Otherwise, the latest tracker with status 'not_home' will be used.
 
 Let's say, for example, that you have 3 trackers: 'tracker_gps', 'tracker_router' and 'tracker_ble'.
 

--- a/source/_components/person.markdown
+++ b/source/_components/person.markdown
@@ -31,9 +31,7 @@ Let's say, for example, that you have 3 trackers: 'tracker_gps', 'tracker_router
 
 TL;DR: When you're at home, your position is determined first by stationary trackers (if any) and then by GPS. When you're outside your home, your position is determined firstly by GPS and then by stationary trackers.
 
-
 **Hint**: When you use multiple device trackers together, especially stationary and GPS trackers, it's advisable to set `consider_home` for stationary trackers as low as possible see [device_tracker](https://www.home-assistant.io/components/device_tracker/#configuring-a-device_tracker-platform)).
-
 
 You can manage persons via the UI from the person page inside the configuration panel or via `YAML` in your `configuration.yaml` file.
 
@@ -76,7 +74,6 @@ person:
     required: false
     type: list, string
 {% endconfiguration %}
-
 
 An extended example would look like the following sample:
 

--- a/source/_components/person.markdown
+++ b/source/_components/person.markdown
@@ -13,29 +13,29 @@ ha_qa_scale: internal
 ha_release: 0.88
 ---
 
-The person component allows connecting device tracker entities to one or more person entities. The state updates of a connected device tracker will set the state of the person. When multiple device trackers used, the state of person will be determined next way:
+The person component allows connecting [device tracker](https://www.home-assistant.io/components/device_tracker/) entities to one or more person entities. The state updates of a connected device tracker will set the state of the person. When multiple device trackers are used, the state of person will be determined in this order:
 
-1. If there are stationary sources (which type is not 'gps') presenting status 'home', the latest of these sources will be taken.
-2. If there are sources of type 'gps', then the latest of these sources will be taken.
-3. Otherwise will be taken the latest source with status 'not_home'.
+1. If there are stationary trackers (non-GPS trackers, ie. router or bluetooth 'device_trackers') presenting the status 'home', the tracker most recently updated will be used.
+2. If there are trackers of type 'gps', then the most recently updated tracker will be used.
+3. Otherwise the latest tracker with status 'not_home' will be used.
 
 Let's say, for example, that you have 3 trackers: 'tracker_gps', 'tracker_router' and 'tracker_ble'.
 
-1. You're at home, all 3 devices show status 'home' - status of your Person entity will be 'home' with source 'tracker_router' or 'tracker_ble', whatever was latest.
-2. You're going out. 'tracker_gps' shows status 'not_home', but the other two trackers show status 'home' according to their setting 'consider_home'. You are still considered to be at home.
-3. After some time both stationary trackers show status 'not_home'. Now your Person entity has status 'not_home' with source 'tracker_gps'.
-4. While you are outside your home, your Home Assistant was suddenly restarted. Until 'tracker_gps' receives an update, your status will be determined by stationary tracker, which gets the latest update after a restart. Obviously, the status will be 'not_home'.
-5. Then you're going into the area marked as 'zone1', 'tracker_gps' is getting an update, and now your status is 'zone1' with source 'tracker_gps'.
-6. You've returned home and your mobile device has connected to the router, but GPS update yet didn't occur. Your status will be 'home' with source 'tracker_router'.
-7. After the GPS update occurs, your status will still be 'home' with source 'tracker_router' or 'tracker_ble', whatever updates latest.
+1. You're at home, all 3 devices show status 'home' - status of your Person entity will be 'home' with source 'tracker_router' or 'tracker_ble', whichever was most recently updated.
+2. You just left home. 'tracker_gps' shows status 'not_home', but the other two trackers show status 'home' (they may not have yet updated due to their 'consider_home' setting see [device_tracker](https://www.home-assistant.io/components/device_tracker/#configuring-a-device_tracker-platform)). Since the stationary trackers have priority, you are considered 'home'.
+3. After some time, both stationary trackers show status 'not_home'. Now your Person entity has status 'not_home' with source 'tracker_gps'.
+4. While you are away from home, your Home Assistant is restarted. Until 'tracker_gps' receives an update, your status will be determined by the stationary trackers, since they will have the most recent update after a restart. Obviously, the status will be 'not_home'.
+5. Then you're going into a zone you have defined as 'zone1', 'tracker_gps' sends an update, and now your status is 'zone1' with source 'tracker_gps'.
+6. You've returned home and your mobile device has connected to the router, but 'tracker_gps' hasn't updated yet. Your status will be 'home' with source 'tracker_router'.
+7. After the 'tracker_gps' update occurs, your status will still be 'home' with source 'tracker_router' or 'tracker_ble', whichever has the most recent update.
 
-TL;DR: When you're at home, your position is determined firstly by stationary trackers (if any) and then by GPS. When you're outside your home, your position is determined firstly by GPS and then by stationary trackers.
-
-
-**Hint**: When you use multiple device trackers together, especially stationary and GPS trackers, it's advisable to set `consider_home` for stationary trackers as low as possible.
+TL;DR: When you're at home, your position is determined first by stationary trackers (if any) and then by GPS. When you're outside your home, your position is determined firstly by GPS and then by stationary trackers.
 
 
-You can manage persons via the UI from the person page inside the configuration panel or via `YAML`.
+**Hint**: When you use multiple device trackers together, especially stationary and GPS trackers, it's advisable to set `consider_home` for stationary trackers as low as possible see [device_tracker](https://www.home-assistant.io/components/device_tracker/#configuring-a-device_tracker-platform)).
+
+
+You can manage persons via the UI from the person page inside the configuration panel or via `YAML` in your `configuration.yaml` file.
 
 ## {% linkable_title Configuring the `person` component via the Home Assistant configuration panel %}
 


### PR DESCRIPTION
I attempted to make it a bit more readable.

I'm trying to follow the logic. Maybe these hypothetical tests will clear things up. 

Example 1:
Let's say for example I have a bluetooth beacon and GPS and I leave home. If I forget my bluetooth beacon at home, but have my phone with me then I will be considered 'home' since both devices will be updating and the stationary tracker has priority. Correct? 

Example 2:
Let's say I have a router tracker and GPS and I arrive home. Let's also say that for some reason my WIFI is disabled on my phone. The router tracker hasn't updated in a long time (>1 hour), but my GPS just updated. According the the explained logic... I would be considered 'not_home' since the stationary tracker has priority, correct? Or is the state of 'home' the priority? Since I have a recently updated tracker reporting me as 'home,' then I am considered home?

I'd like to add similar examples to the person description to clear up the understanding of the logic after receiving feedback, or if you prefer, add examples yourself.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
