### PR TITLE
Note for iOS 10 Devices

### DIFF
--- a/source/_docs/ecosystem/ios/notifications/content_extensions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/content_extensions.markdown
@@ -61,7 +61,7 @@ You can use the attachment parameters `content-type` and `hide-thumbnail` with c
 
 You can view an example [here](https://www.youtube.com/watch?v=LmYwpxPKW0g).
 
-Note: This functionality is only available from iOS 11
+Note: This functionality is only available from iOS 11 onwards
 
 ```yaml
 service: notify.ios_<your_device_id_here>

--- a/source/_docs/ecosystem/ios/notifications/content_extensions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/content_extensions.markdown
@@ -61,7 +61,7 @@ You can use the attachment parameters `content-type` and `hide-thumbnail` with c
 
 You can view an example [here](https://www.youtube.com/watch?v=LmYwpxPKW0g).
 
-Note: This functionality is only available from iOS 11 onwards
+Note: This functionality is only available from iOS 11 onwards.
 
 ```yaml
 service: notify.ios_<your_device_id_here>

--- a/source/_docs/ecosystem/ios/notifications/content_extensions.markdown
+++ b/source/_docs/ecosystem/ios/notifications/content_extensions.markdown
@@ -61,6 +61,8 @@ You can use the attachment parameters `content-type` and `hide-thumbnail` with c
 
 You can view an example [here](https://www.youtube.com/watch?v=LmYwpxPKW0g).
 
+Note: This functionality is only available from iOS 11
+
 ```yaml
 service: notify.ios_<your_device_id_here>
 data:


### PR DESCRIPTION
This feature only works from iOS 11, on iOS 10 the user get a message with the text and thumbnail. Swipe the message only give the option to delete the message.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
