### PR TITLE
Add suport for the power socket of the Xiaomi AC Partner V3

### DIFF
--- a/source/_components/switch.xiaomi_miio.markdown
+++ b/source/_components/switch.xiaomi_miio.markdown
@@ -51,6 +51,14 @@ Supported models: `qmi.powerstrip.v1`, `zimi.powerstrip.v2`
   - Wifi LED
   - Mode (Power Strip V1 only)
 
+### {% linkable_title Xiaomi Air Conditioning Companion V3 %}
+
+Supported models: `lumi.acpartner.v3` (the socket of the `acpartner.v1` and `v2` isn't switchable!)
+
+* Power (on, off)
+* Attributes
+  - Load power
+
 ## {% linkable_title Configuration %}
 
 To add a plug to your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22205