### PR TITLE
add doc for date_time_iso to time_date component

### DIFF
--- a/source/_components/sensor.time_date.markdown
+++ b/source/_components/sensor.time_date.markdown
@@ -26,12 +26,13 @@ sensor:
       - 'time'
       - 'date'
       - 'date_time'
+      - 'date_time_iso'
       - 'time_date'
       - 'time_utc'
       - 'beat'
 ```
 
-- **display_options** array (*Required*): The option to display. The types *date_time* and *time_date* shows the date and the time. The other types just the time or the date. *beat* shows the [Swatch Internet Time](http://www.swatch.com/en_us/internet-time).
+- **display_options** array (*Required*): The option to display. The types *date_time*, *time_date*, and *date_time_iso* shows the date and the time. The other types just the time or the date. *beat* shows the [Swatch Internet Time](http://www.swatch.com/en_us/internet-time).
 
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/time_date.png' />


### PR DESCRIPTION
**Description:**

Adds docs for new display option for `time_date` component

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22199

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
