### PR TITLE
Add warning re hub version.

### DIFF
--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -16,7 +16,7 @@ redirect_from: /components/xiaomi/
 
 The `xiaomi_aqara` component allows you to integrate [Xiaomi](http://www.mi.com/en/) Aqara-compatible devices into Home Assistant.
 
-Please note, there are two versions of the hub v1 and v2.  Only v1 can be used with HomeAssistant to date, as there is no way to enable the local API for v2. Xiaomi have suggested this is in the pipeline.
+Please note, there are two versions of the hub v1 and v2. v1 can be used with Home Assistant without any problem, however, v2 might be less straight forward when it comes to enabling the local API and might even require you to open up your device in order to do so. Xiaomi has suggested this is in the pipeline.
 
 ## {% linkable_title Supported Devices %}
 

--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -16,7 +16,7 @@ redirect_from: /components/xiaomi/
 
 The `xiaomi_aqara` component allows you to integrate [Xiaomi](http://www.mi.com/en/) Aqara-compatible devices into Home Assistant.
 
-Please note, there are two versions of the hub v1 and v2. v1 can be used with Home Assistant without any problem, however, v2 might be less straight forward when it comes to enabling the local API and might even require you to open up your device in order to do so. Xiaomi has suggested this is in the pipeline.
+Please note, there are two versions of the hub: v1 and v2. v1 can be used with Home Assistant without any problems, however, v2 might be less straight forward when it comes to enabling the local API, and might even require you to open up your device in order to do so. Xiaomi has suggested this is in the pipeline.
 
 ## {% linkable_title Supported Devices %}
 

--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -16,6 +16,8 @@ redirect_from: /components/xiaomi/
 
 The `xiaomi_aqara` component allows you to integrate [Xiaomi](http://www.mi.com/en/) Aqara-compatible devices into Home Assistant.
 
+Please note, there are two versions of the hub v1 and v2.  Only v1 can be used with HomeAssistant to date, as there is no way to enable the local API for v2. Xiaomi have suggested this is in the pipeline.
+
 ## {% linkable_title Supported Devices %}
 
 - Aqara Air Conditioning Companion (lumi.acpartner.v3)


### PR DESCRIPTION
Make clarification on hub API access status as it really was not clear.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
