### PR TITLE
Consolidate the netgear_lte configuration

### DIFF
--- a/source/_components/netgear_lte.markdown
+++ b/source/_components/netgear_lte.markdown
@@ -19,7 +19,7 @@ redirect_from:
   - /components/sensor.netgear_lte/
 ---
 
-The Netgear LTE integration for Home Assistant allows you to observe and control [Netgear LTE modems](https://www.netgear.com/home/products/mobile-broadband/lte-modems/default.aspx), currently only tested with LB2120.
+The Netgear LTE integration for Home Assistant allows you to observe and control [Netgear LTE modems](https://www.netgear.com/home/products/mobile-broadband/lte-modems/default.aspx).
 
 There is currently support for the following device types within Home Assistant:
 
@@ -34,13 +34,21 @@ The integration provides:
 
 ## {% linkable_title Configuration %}
 
-To enable the component, add the following lines to your `configuration.yaml` file:
+To enable the integration, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 netgear_lte:
   - host: IP_ADDRESS
     password: SECRET
+    notify:
+      - name: sms
+        recipient: "+15105550123"
+    sensor:
+      monitored_conditions:
+        - usage
+        - sms
+
 ```
 
 {% configuration %}
@@ -52,63 +60,44 @@ password:
   description: The password used for the modem web interface.
   required: true
   type: string
+notify:
+  description: A list of notification services connected to this specific host.
+  required: false
+  type: list
+  keys:
+    recipient:
+      description: The phone number of a default recipient or a list with multiple recipients.
+      required: false
+      type: string, list
+    name:
+      description: The name of the notification service.
+      required: false
+      default: notify
+      type: string
+sensor:
+  description: Configuration options for sensors.
+  required: false
+  type: map
+  keys:
+    monitored_conditions:
+      description: Sensor types to create.
+      required: true
+      type: list
+      keys:
+        sms:
+          description: Number of unread SMS messages in the modem inbox.
+        usage:
+          description: Amount of data transferred.
 {% endconfiguration %}
 
 ## {% linkable_title Notifications %}
 
-The `netgear_lte` platform allows you to use a Netgear LTE modem for notifications from Home Assistant. The message will be sent as an SMS text message.
+The `netgear_lte` integration allows you to use a Netgear LTE modem for notifications from Home Assistant. The message will be sent as an SMS text message.
 
-```yaml
-# Example configuration.yaml entry
-notify:
-  - platform: netgear_lte
-    name: sms
-    target: "+15105550123"
-```
-
-{% configuration %}
-target:
-  description: The phone number of a default recipient or a list with multiple recipients.
-  required: true
-  type: string, list
-name:
-  description: Setting the optional parameter `name` allows multiple notifiers to be created.
-  required: false
-  default: notify
-  type: string
-host:
-  description: The modem to use. Not needed if you only have one.
-  required: false
-  type: string
-{% endconfiguration %}
+If you do not supply `notify` configuration, a default notification service with no default recipient is created.
 
 ## {% linkable_title Sensor %}
 
-The `netgear_lte` sensor platform allows you to monitor your Netgear LTE modem.
+The `netgear_lte` integration allows you to monitor your Netgear LTE modem.
 
-To enable the sensor, add the following lines to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: netgear_lte
-    sensors:
-      - sms
-      - usage
-```
-
-{% configuration %}
-sensors:
-  description: Sensor types to create.
-  required: true
-  type: list
-  keys:
-    sms:
-      description: Number of unread SMS messages in the modem inbox.
-    usage:
-      description: Amount of data transferred.
-host:
-  description: The modem to use. Not needed if you only have one.
-  required: false
-  type: string
-{% endconfiguration %}
+If you do not supply `sensor` configuration, a default set of sensors is created.

--- a/source/_components/netgear_lte.markdown
+++ b/source/_components/netgear_lte.markdown
@@ -81,7 +81,8 @@ sensor:
   keys:
     monitored_conditions:
       description: Sensor types to create.
-      required: true
+      required: false
+      default: usage
       type: list
       keys:
         sms:


### PR DESCRIPTION
**Description:**

This consolidates the configuration under the `netgear_lte` component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22105

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html