### PR TITLE
Clarifies expose_by_default and exposed_domains in google_assistant config

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -139,12 +139,12 @@ api_key:
   required: false
   type: string
 expose_by_default:
-  description: "Expose devices in all supported domains by default. If set to false, you need to either expose domains or add the expose configuration option to each entity in `entity_config` and set it to true."
+  description: "Expose devices in all supported domains by default. If `exposed_domains` domains is set, only these domains are exposed by default. If `expose_by_default` is set to false, devices have to be manually exposed in `entity_config`."
   required: false
   default: true
   type: boolean
 exposed_domains:
-  description: List of entity domains to expose to Google Assistant.
+  description: List of entity domains to expose to Google Assistant if `expose_by_default` is set to true. This has no effect if `expose_by_default` is set to false.
   required: false
   type: list
 entity_config:


### PR DESCRIPTION
**Description:**

Clarifies the documentation on the `expose_by_default` and `exposed_domains` config fields in the Google Assistant config.
These have caused confusion among users in the past (see https://github.com/home-assistant/home-assistant/issues/21577).

Ideally, the behaviour would be fixed in the code but this would break existing configs at least in some edge cases (see https://github.com/home-assistant/home-assistant/pull/17745).

The proposed new description should explain the current behaviour of these options.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html