### PR TITLE
Partner configuration was invalid

### DIFF
--- a/source/_components/eight_sleep.markdown
+++ b/source/_components/eight_sleep.markdown
@@ -50,10 +50,10 @@ password:
   description: The password associated with your Eight Sleep account.
   required: true
   type: string
-password:
+partner:
   description: Defines if you'd like to fetch data for both sides of the bed.
   required: false
-  type: string
+  type: boolean
   default: false
 {% endconfiguration %}
 


### PR DESCRIPTION
Partner was listed as "Password", and that the configuration was a string

Changed 2nd "Password" to "Partner" and changed "String" to "Boolean"

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
