### PR TITLE
Add yeelight info about sensor

### DIFF
--- a/source/_components/yeelight.markdown
+++ b/source/_components/yeelight.markdown
@@ -20,6 +20,7 @@ The `yeelight` component allows you to control your Yeelight Wifi bulbs with Hom
 There is currently support for the following device types within Home Assistant:
 
 - **Light** - The yeelight platform for supporting lights.
+- **Sensor** - The yeelight platform for supporting sensors. Currenctly only nightlight mode sensor, for ceiling lights.
 
 ### {% linkable_title Example configuration (Automatic) %}
 After the lights are connected to the WiFi network and have been detected in Home Assistant, the discovered names will be shown in the `Light` section of the `Overview` view. Add the following lines to your `customize.yaml` file:


### PR DESCRIPTION
**Description:**
Add info about yeelight sensor for daylight / nightlight.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/22345

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
