### PR TITLE
Added description for new service `leave_chat` of Telegram bot

### DIFF
--- a/source/_components/telegram_bot.markdown
+++ b/source/_components/telegram_bot.markdown
@@ -21,7 +21,7 @@ If you don't need to receive messages, you can use the [broadcast](/components/t
 
 ## {% linkable_title Notification services %}
 
-Available services: `send_message`, `send_photo`, `send_document`, `send_location`, `send_sticker`, `edit_message`, `edit_replymarkup`, `edit_caption` and `answer_callback_query`.
+Available services: `send_message`, `send_photo`, `send_document`, `send_location`, `send_sticker`, `edit_message`, `edit_replymarkup`, `edit_caption`, `answer_callback_query`, `delete_message` and `leave_chat`.
 
 ### {% linkable_title Service `telegram_bot.send_message` %}
 
@@ -157,6 +157,14 @@ Delete a previously sent message in a conversation.
 |---------------------------|----------|--------------------------------------------------|
 | `message_id`              |       no | Id of the message to delete. When answering a callback from a pressed button, the id of the origin message is in: {% raw %}`{{ trigger.event.data.message.message_id }}`{% endraw %}. You can use `"last"` to refer to the last message sent to `chat_id`. |
 | `chat_id`                 |       no | The chat_id where to delete the message.  |
+
+### {% linkable_title Service `telegram_bot.leave_chat` %}
+
+Remove the bot from the chat group where it was added.
+
+| Service data attribute    | Optional | Description                                      |
+|---------------------------|----------|--------------------------------------------------|
+| `chat_id`                 |       no | The chat_id from where to remove the bot.  |
 
 ## {% linkable_title `telegram` notification platform %}
 


### PR DESCRIPTION
**Description:**

Added description for new service `leave_chat` of Telegram bot

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22259

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
