### PR TITLE
Add doc for infer_arming_state option in ness_alarm

### DIFF
--- a/source/_components/ness_alarm.markdown
+++ b/source/_components/ness_alarm.markdown
@@ -64,6 +64,11 @@ scan_interval:
   required: false
   default: '00:01:00'
   type: time
+infer_arming_state:
+  description:  Infer the disarmed arming state only via system status events. This works around a bug with some panels (`<v5.8`) which emit `update.status = []` when they are armed.
+  required: false
+  default: false
+  type: boolean
 zones:
   description: List of zones to add
   required: false

--- a/source/_components/ness_alarm.markdown
+++ b/source/_components/ness_alarm.markdown
@@ -65,7 +65,7 @@ scan_interval:
   default: '00:01:00'
   type: time
 infer_arming_state:
-  description:  Infer the disarmed arming state only via system status events. This works around a bug with some panels (`<v5.8`) which emit `update.status = []` when they are armed.
+  description: Infer the disarmed arming state only via system status events. This works around a bug with some panels (`<v5.8`) which emit `update.status = []` when they are armed.
   required: false
   default: false
   type: boolean


### PR DESCRIPTION
**Description:**
Introduce a new configuration option `infer_arming_state` which is passed down into the `nessclient` client library which attempts to fix an issue where the arming state is incorrectly reported shortly after the panel has been armed.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/22379

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
