### PR TITLE
Added support for Daikin AirBase units

### DIFF
--- a/source/_components/daikin.markdown
+++ b/source/_components/daikin.markdown
@@ -27,10 +27,8 @@ There is currently support for the following device types within Home Assistant:
 
 ## {% linkable_title Supported hardware %}
 
-**Only** the European versions of Daikin AC (models BRP069A41, 42, 43, 45).
-
-Some models do not support setting of fan speed or fan swing mode.
-
+This component supports the European versions of Daikin AC (BRP069A[41,42,43,45]) and AU AirBase units (BRP15B61).
+Some models do not support setting of fan speed or fan swing mode althogh it might show up in Home Assistant.
 Please note that some AC devices may report outside temperature only when they are turned on.
 
 ## {% linkable_title Configuration %}


### PR DESCRIPTION
**Description:**

pydaikin v1.2.0 adds support for AU AirBase units.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22382

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
