### PR TITLE
Workaround for missing adbkey.pub

### DIFF
--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -171,9 +171,7 @@ If you receive the error message `Error while setting up platform androidtv` in 
 
    * Home Assistant does not have the appropriate permissions for the `adbkey` file and so it is not able to use it. Once you fix the permissions, the component should work.
 
-   * Newer ADB binaries do not generate `adbkey.pub`. In this case, generating
-   an empty `adbkey.pub` in the same directory with e.g. `touch adbkey.pub`
-   is enough.
+   * Newer ADB binaries do not generate an `adbkey.pub` file for you. This can be resolved by creating an empty `adbkey.pub` in the same directory, e.g., by running `touch adbkey.pub`.
 
 ## {% linkable_title Services %}
 

--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -171,6 +171,10 @@ If you receive the error message `Error while setting up platform androidtv` in 
 
    * Home Assistant does not have the appropriate permissions for the `adbkey` file and so it is not able to use it. Once you fix the permissions, the component should work.
 
+   * Newer ADB binaries do not generate `adbkey.pub`. In this case, generating
+   an empty `adbkey.pub` in the same directory with e.g. `touch adbkey.pub`
+   is enough.
+
 ## {% linkable_title Services %}
 
 ### {% linkable_title `media_player.select_source` %}


### PR DESCRIPTION
**Description:**

Newer versions of the ADB binary from the platform-tools package (at least version 28.0.2 is confirmed) do not generate a file `adbkey.pub` anymore.
This file is still needed by the `python-adb` library used by the androidtv component.
Using an empty file is an acceptable workaround (tested)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22377

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
