### PR TITLE
Update alarm_control_panel.concord232.markdown

### DIFF
--- a/source/_components/alarm_control_panel.concord232.markdown
+++ b/source/_components/alarm_control_panel.concord232.markdown
@@ -40,4 +40,13 @@ port:
   required: false
   type: integer
   default: 5007
+code:
+  description: If defined, specifies a code to enable or disable the alarm in the frontend.
+  required: false
+  type: string
+mode:
+  description: audible/silent if defined, specifies wether Alarm Panel should be audible or silent when armed in Home Mode.
+  required: false
+  type: string
+  default: audible
 {% endconfiguration %}


### PR DESCRIPTION
## Description: Added functionality to Concord232 Alarm Panel. 2 additional attributes can be defined in configuration.yaml. 'code' which allows for defining a code and 'mode' which allows for silent activation of the ARM HOME option

**Related issue: Currently Concord232 Server can Arm/Disarm without providing code or by providing wrong code. Updated code adds functionality to define a code in configuration.yaml.
code
  (string)(Optional) If defined, specifies a code to enable or disable the alarm in the frontend.

mode
  (string)(Optional) audible/silent if defined, specifies wether Alarm Panel should be audible or silent when armed in Home Mode.
  Default Value: audible



**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22892
## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
