### PR TITLE
Add info about power mode icon

### DIFF
--- a/source/_components/yeelight.markdown
+++ b/source/_components/yeelight.markdown
@@ -82,6 +82,11 @@ devices:
           description: "Yeelight model. Possible values are `mono1`, `color1`, `color2`, `strip1`, `bslamp1`, `ceiling1`, `ceiling2`, `ceiling3`, `ceiling4`. The setting is used to enable model specific features f.e. a particular color temperature range."
           required: false
           type: string
+        power_mode_icon:
+          description: Enable icon change, depending on power mode. Currently supported power modes, that results in icon change: `normal`, `flowing`, `nightlight`
+          required: false
+          type: boolean
+          default: false
 custom_effects:
   description: List of custom effects to add. Check examples below.
   required: false
@@ -186,6 +191,7 @@ yeelight:
       transition: 1000
       use_music_mode: true
       save_on_change: true
+      power_mode_icon: true
 ```
 
 ### {% linkable_title Multiple bulbs %}

--- a/source/_components/yeelight.markdown
+++ b/source/_components/yeelight.markdown
@@ -83,7 +83,7 @@ devices:
           required: false
           type: string
         power_mode_icon:
-          description: Enable icon change, depending on power mode. Currently supported power modes, that results in icon change: `normal`, `flowing`, `nightlight`
+          description: "Enable icon change, depending on power mode. Currently supported power modes, that results in icon change: `normal`, `flowing`, `nightlight`."
           required: false
           type: boolean
           default: false


### PR DESCRIPTION
**Description:**
Add info about power_mode_icon optional option.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/22434

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
