### PR TITLE
Add image and smallicon field for data

### DIFF
--- a/source/_components/joaoapps_join.markdown
+++ b/source/_components/joaoapps_join.markdown
@@ -62,7 +62,7 @@ device_names:
   type: string
 {% endconfiguration %}
 
-The notify service has two optional parameters: `icon` and `vibration`.
+The notify service has two optional parameters: `icon`, `smallicon`, `image` and `vibration`.
 You can use them like so:
 
 ```json
@@ -71,7 +71,9 @@ You can use them like so:
 	"title": "Home Assistant",
 	"data": {
 		"icon": "https://goo.gl/xeetdy",
-		"vibration": "0,65,706,86,657,95,668,100"
+		"smallicon": "https://goo.gl/xeetdy",
+		"vibration": "0,65,706,86,657,95,668,100",
+		"image": "https://www.home-assistant.io/images/favicon-192x192-full.png"
 	}
 }
 ```

--- a/source/_components/joaoapps_join.markdown
+++ b/source/_components/joaoapps_join.markdown
@@ -62,7 +62,7 @@ device_names:
   type: string
 {% endconfiguration %}
 
-The notify service has two optional parameters: `icon`, `smallicon`, `image` and `vibration`.
+The notify service has two optional parameters: `icon`, `smallicon`, `image`, `sound`, `url`, `notification_id`, `tts`, `tts_language` and `vibration`.
 You can use them like so:
 
 ```json
@@ -73,7 +73,12 @@ You can use them like so:
 		"icon": "https://goo.gl/xeetdy",
 		"smallicon": "https://goo.gl/xeetdy",
 		"vibration": "0,65,706,86,657,95,668,100",
-		"image": "https://www.home-assistant.io/images/favicon-192x192-full.png"
+		"image": "https://www.home-assistant.io/images/favicon-192x192-full.png",
+		"sound": "https://goo.gl/asasde.mp3",
+		"url": "https://home-assistant.io",
+		"notification_id": "hass-notification",
+		"tts": "Notification from Home Assistant",
+		"tts_language": "english"
 	}
 }
 ```


### PR DESCRIPTION
**Description:**
Add information about `image` and `smallicon` fields

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22472

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
