### PR TITLE
Add docs for new google service

### DIFF
--- a/source/_components/calendar.google.markdown
+++ b/source/_components/calendar.google.markdown
@@ -173,7 +173,6 @@ Otherwise everything following the hash sign would be considered a YAML comment.
  - **start_time**: Start time of event.
  - **end_time**: End time of event.
 
-
 ### {% linkable_title Service `google.add_event` %}
 
 You can use the service `google.add_event` to create a new calendar event in a calendar. Calendar id's can be found in the file `google_calendars.yaml`. All dates and times are in your local time, the component gets your time zone from your `configuration.yaml` file.
@@ -192,7 +191,6 @@ You can use the service `google.add_event` to create a new calendar event in a c
 <p class='note'>
 You either use `start_date_time` and `end_date_time`, or `start_date` and `end_date`, or `in`.
 </p>
-
 
 ## {% linkable_title Using calendar in automations %}
 

--- a/source/_components/calendar.google.markdown
+++ b/source/_components/calendar.google.markdown
@@ -19,6 +19,7 @@ The sensors created can trigger based on any event on the calendar or only for
 matching events. When you first setup this component it will generate a new
 configuration file `google_calendars.yaml` that will contain information about
 all of the calendars you can see.
+It also exposes a service to add an event to one of your Google Calendars.
 
 ## {% linkable_title Prerequisites %}
 
@@ -171,6 +172,27 @@ Otherwise everything following the hash sign would be considered a YAML comment.
  - **location**: The event Location.
  - **start_time**: Start time of event.
  - **end_time**: End time of event.
+
+
+### {% linkable_title Service `google.add_event` %}
+
+You can use the service `google.add_event` to create a new calendar event in a calendar. Calendar id's can be found in the file `google_calendars.yaml`. All dates and times are in your local time, the component gets your time zone from your `configuration.yaml` file.
+
+| Service data attribute | Optional | Description | Example |
+| ---------------------- | -------- | ----------- | --------|
+| `calendar_id` | no | The id of the calendar you want. |	Your email
+| `summary` | no | Acts as the title of the event. | Bowling
+| `description` | yes | The description of the event. | Birthday bowling
+| `start_date_time` | yes | The date and time the event should start. | 2019-03-10 20:00:00
+| `end_date_time` | yes | The date and time the event should end. | 2019-03-10 23:00:00
+| `start_date` | yes | The date the whole day event should start. | 2019-03-10
+| `end_date` | yes | The date the whole day event should end. | 2019-03-11
+| `in` | yes | Days or weeks that you want to create the event in. | "days": 2
+
+<p class='note'>
+You either use `start_date_time` and `end_date_time`, or `start_date` and `end_date`, or `in`.
+</p>
+
 
 ## {% linkable_title Using calendar in automations %}
 


### PR DESCRIPTION
**Description:**
Adds documentation for new service google.add_event that allows you to create events in a Google calendar.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22473

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
