### PR TITLE
Add documentation for Somfy MyLink platform

### DIFF
--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -15,7 +15,7 @@ ha_release: 0.92
 ha_iot_class: "Assumed State"
 ---
 
-The `Somfy MyLink` component platform is used as an interface to a compatible Somfy MyLink hub utilizing the `Synergy` API. It adds covers and scenes from the Somfy MyLink platform.
+The `Somfy MyLink` component platform is used as an interface to a compatible Somfy MyLink hub utilizing the `Synergy` API. It adds covers from the Somfy MyLink platform.
 
 To use your compatible `Somfy MyLink` devices in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -8,7 +8,10 @@ comments: false
 sharing: true
 footer: true
 logo: tahoma.png
-ha_category: Hub
+ha_category:
+  - Hub
+  - Cover
+  - Scene
 ha_release: 0.92
 ha_iot_class: "Assumed State"
 redirect_from:

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -15,7 +15,7 @@ ha_release: 0.92
 ha_iot_class: "Assumed State"
 ---
 
-The `Somfy MyLink` component platform is used as an interface to a compatible Somfy MyLink hub utilizing the `Synergy` API. It adds covers from the Somfy MyLink platform.
+The `Somfy MyLink` integration is used as an interface to a compatible Somfy MyLink hub utilizing the `Synergy` API. It allows the addition of covers from the Somfy MyLink platform to Home Assistant.
 
 To use your compatible `Somfy MyLink` devices in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -14,11 +14,6 @@ ha_category:
   - Scene
 ha_release: 0.92
 ha_iot_class: "Assumed State"
-redirect_from:
-  - /components/somfy_mylink.cover/
-  - /components/cover.somfy_mylink/
-  - /components/somfy_mylink.scene/
-  - /components/scene.somfy_mylink/
 ---
 
 The `Somfy MyLink` component platform is used as an interface to a compatible Somfy MyLink hub utilizing the `Synergy` API. It adds covers and scenes from the Somfy MyLink platform.

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -22,7 +22,7 @@ To use your compatible `Somfy MyLink` devices in your installation, add the foll
 ```yaml
 # Example configuration.yaml entry
 somfy_mylink:
-  host: 10.1.1.100
+  host: IP_ADDRESS
   system_id: mylink_id
 ```
 

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -39,6 +39,7 @@ default_reverse:
   description: Sets the default reversal status of the cover. Possible values are `true` or `false`. This value can be applied on a per-cover basis (see `entity_config` below)
   required: false
   type: boolean
+  default: false
 entity_config:
   description: Configuration for specific cover entities. All subordinate keys are the corresponding entity ids to the domains, e.g., `cover.bedroom_blinds`.
   required: false
@@ -53,6 +54,7 @@ entity_config:
           description: Reverses the direction of the cover. Possible values are `true` or `false`.
           required: false
           type: boolean
+          default: false
 {% endconfiguration %}
 
 ```yaml
@@ -60,8 +62,8 @@ entity_config:
 somfy_mylink:
   host: IP_ADDRESS
   system_id: SYSTEM_ID
-  default_reverse: false
+  default_reverse: true
   entity_config:
     cover.outdoor_awning:
-        reverse: true
+        reverse: false
 ```

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -1,0 +1,70 @@
+---
+layout: page
+title: "Somfy MyLink"
+description: "Instructions on how to integrate Somfy MyLink devices with Home Assistant."
+date: 2019-03-29 12:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: tahoma.png
+ha_category: Hub
+ha_release: 0.92
+ha_iot_class: "Assumed State"
+redirect_from:
+  - /components/somfy_mylink.cover/
+  - /components/cover.somfy_mylink/
+  - /components/somfy_mylink.scene/
+  - /components/scene.somfy_mylink/
+---
+
+The `Somfy MyLink` component platform is used as an interface to a compatible Somfy MyLink hub utilizing the `Synergy` API. It adds covers and scenes from the Somfy MyLink platform.
+
+To use your compatible `Somfy MyLink` devices in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+somfy_mylink:
+  host: 10.1.1.100
+  system_id: mylink_id
+```
+
+{% configuration %}
+host:
+  description: The IP address of the Somfy MyLink hub device.
+  required: true
+  type: string
+system_id:
+  description: The `System ID` of the Somfy MyLink hub. This can be found in the `Integration` menu in the mobile app.
+  required: true
+  type: string
+default_reverse:
+  description: Sets the default reversal status of the cover. Possible values are `true` or `false`. This value can be applied on a per-cover basis (see `entity_config` below)
+  required: false
+  type: boolean
+entity_config:
+  description: Configuration for specific cover entities. All subordinate keys are the corresponding entity ids to the domains, e.g., `cover.bedroom_blinds`.
+  required: false
+  type: map
+  keys:
+    '`<ENTITY_ID>`':
+      description: Additional options for specific entities.
+      required: false
+      type: map
+      keys:
+        reverse:
+          description: Reverses the direction of the cover. Possible values are `true` or `false`.
+          required: false
+          type: boolean
+{% endconfiguration %}
+
+```yaml
+# Advanced configuration.yaml entry setting specific options on a per-cover basis
+somfy_mylink:
+  host: 10.1.1.100
+  system_id: mylink_id
+  default_reverse: false
+  entity_config:
+    cover.outdoor_awning:
+        reverse: true
+```

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -11,7 +11,6 @@ logo: tahoma.png
 ha_category:
   - Hub
   - Cover
-  - Scene
 ha_release: 0.92
 ha_iot_class: "Assumed State"
 ---

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -23,7 +23,7 @@ To use your compatible `Somfy MyLink` devices in your installation, add the foll
 # Example configuration.yaml entry
 somfy_mylink:
   host: IP_ADDRESS
-  system_id: MYLINK_ID
+  system_id: SYSTEM_ID
 ```
 
 {% configuration %}
@@ -59,7 +59,7 @@ entity_config:
 # Advanced configuration.yaml entry setting specific options on a per-cover basis
 somfy_mylink:
   host: IP_ADDRESS
-  system_id: MYLINK_ID
+  system_id: SYSTEM_ID
   default_reverse: false
   entity_config:
     cover.outdoor_awning:

--- a/source/_components/somfy_mylink.markdown
+++ b/source/_components/somfy_mylink.markdown
@@ -23,7 +23,7 @@ To use your compatible `Somfy MyLink` devices in your installation, add the foll
 # Example configuration.yaml entry
 somfy_mylink:
   host: IP_ADDRESS
-  system_id: mylink_id
+  system_id: MYLINK_ID
 ```
 
 {% configuration %}
@@ -58,8 +58,8 @@ entity_config:
 ```yaml
 # Advanced configuration.yaml entry setting specific options on a per-cover basis
 somfy_mylink:
-  host: 10.1.1.100
-  system_id: mylink_id
+  host: IP_ADDRESS
+  system_id: MYLINK_ID
   default_reverse: false
   entity_config:
     cover.outdoor_awning:


### PR DESCRIPTION
**Description:**
This adds the documentation required for the Somfy MyLink platform based on the Synergy JsonRPC API.
The following component pages are included:

compenent/somfy_mylink.markdown

It might be a good idea to change the name of the current `tahoma.png` logo to `somfy.png` at some point, however in the spirit of introducing as little change at a time, I'm leaving it as `tahoma.png`.

Thanks!

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22514

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
