### PR TITLE
Split out mopar into multiple platforms

### DIFF
--- a/source/_components/mopar.markdown
+++ b/source/_components/mopar.markdown
@@ -17,8 +17,6 @@ ha_release: 0.53
 ha_iot_class: Cloud Polling
 redirect_from:
  - /components/sensor.mopar/
- - /components/lock.mopar/
- - /components/switch.mopar/
 ---
 
 The `mopar` component provides the following for owners of FCA vehicles with a uConnect subscription:

--- a/source/_components/mopar.markdown
+++ b/source/_components/mopar.markdown
@@ -8,15 +8,25 @@ comments: false
 sharing: true
 footer: true
 logo: mopar.png
-ha_category: Car
+ha_category:
+  - Car
+  - Sensor
+  - Switch
+  - Lock
 ha_release: 0.53
 ha_iot_class: Cloud Polling
+redirect_from:
+ - /components/sensor.mopar/
+ - /components/lock.mopar/
+ - /components/switch.mopar/
 ---
 
-The `mopar` sensor provides the following for owners of FCA vehicles with a uConnect subscription:
+The `mopar` component provides the following for owners of FCA vehicles with a uConnect subscription:
 
 - Sensor per vehicle with vehicle health report and other meta-data
-- Service for remote commands: Lock/unlock, Engine on/off, Horn & lights
+- Lock per vehicle allowing to lock/unlock the vehicle
+- Switch per vehicle allowing to turn the engine on and off
+- A service for running the horn & lights
 
 ## {% linkable_title Setup %}
 
@@ -24,15 +34,14 @@ Be sure you have a [mopar.com](http://mopar.com) account with your vehicle(s) re
 
 ## {% linkable_title Configuration %}
 
-To enable this sensor, add the following lines to your `configuration.yaml`.
+To enable this component, add the following lines to your `configuration.yaml`. All platforms will be automatically loaded.
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: mopar
-    username: YOUR_USERNAME
-    password: YOUR_PASSWORD
-    pin: YOUR_UCONNECT_PIN
+mopar:
+  username: YOUR_USERNAME
+  password: YOUR_PASSWORD
+  pin: YOUR_UCONNECT_PIN
 ```
 
 {% configuration %}
@@ -52,16 +61,15 @@ pin:
 
 ## {% linkable_title Service %}
 
-Call the `sensor.mopar_remote_command` service to perform a remote command on your vehicle.
+Call the `mopar.sound_horn` service to sound the horn and flash the lights on your vehicle.
 
-- **vehicle_index** (*Required*): `vehicle_index` attribute found on sensor.
-- **command** (*Required*): One of `LOCK/UNLOCK/START/STOP/HORN_LIGHT`.
+| Service data attribute | Description |
+| `vehicle_index`        | The index of the vehicle to trigger. This is exposed in the sensor's device attributes. |
 
 Example data:
 
 ```json
 {
-  "vehicle_index": 0,
-  "command": "unlock"
+  "vehicle_index": 0
 }
 ```


### PR DESCRIPTION
**Description:**
The Mopar sensor has been split into multiple platforms.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#21526

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
