### PR TITLE
Clarify default value for mqtt.switch state_on / state_off

### DIFF
--- a/source/_components/switch.mqtt.markdown
+++ b/source/_components/switch.mqtt.markdown
@@ -54,12 +54,12 @@ state_on:
   description: The payload that represents the on state.
   required: false
   type: string
-  default: "`payload_on` if defined, else `\"ON\"`"
+  default: "`payload_on` if defined, else ON"
 state_off:
   description: The payload that represents the off state.
   required: false
   type: string
-  default: "`payload_off` if defined, else `\"OFF\"`"
+  default: "`payload_off` if defined, else OFF"
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false

--- a/source/_components/switch.mqtt.markdown
+++ b/source/_components/switch.mqtt.markdown
@@ -54,12 +54,12 @@ state_on:
   description: The payload that represents the on state.
   required: false
   type: string
-  default: payload_on if defined, otherwise "ON"
+  default: "payload_on" if defined, otherwise "ON"
 state_off:
   description: The payload that represents the off state.
   required: false
   type: string
-  default: payload_off if defined, otherwise "OFF"
+  default: "payload_off" if defined, otherwise "OFF"
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false

--- a/source/_components/switch.mqtt.markdown
+++ b/source/_components/switch.mqtt.markdown
@@ -54,12 +54,12 @@ state_on:
   description: The payload that represents the on state.
   required: false
   type: string
-  default: "ON"
+  default: `payload_on` if defined, otherwise "ON"
 state_off:
   description: The payload that represents the off state.
   required: false
   type: string
-  default: "OFF"
+  default: `payload_off` if defined, otherwise "OFF"
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false

--- a/source/_components/switch.mqtt.markdown
+++ b/source/_components/switch.mqtt.markdown
@@ -54,12 +54,12 @@ state_on:
   description: The payload that represents the on state.
   required: false
   type: string
-  default: "'payload_on' if defined, else \"ON\""
+  default: "`payload_on` if defined, else `\"ON\"`"
 state_off:
   description: The payload that represents the off state.
   required: false
   type: string
-  default: "'payload_off' if defined, else \"OFF\""
+  default: "`payload_off` if defined, else `\"OFF\"`"
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false

--- a/source/_components/switch.mqtt.markdown
+++ b/source/_components/switch.mqtt.markdown
@@ -54,12 +54,12 @@ state_on:
   description: The payload that represents the on state.
   required: false
   type: string
-  default: "payload_on" if defined, otherwise "ON"
+  default: "'payload_on' if defined, else \"ON\""
 state_off:
   description: The payload that represents the off state.
   required: false
   type: string
-  default: "payload_off" if defined, otherwise "OFF"
+  default: "'payload_off' if defined, else \"OFF\""
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false

--- a/source/_components/switch.mqtt.markdown
+++ b/source/_components/switch.mqtt.markdown
@@ -54,12 +54,12 @@ state_on:
   description: The payload that represents the on state.
   required: false
   type: string
-  default: `payload_on` if defined, otherwise "ON"
+  default: payload_on if defined, otherwise "ON"
 state_off:
   description: The payload that represents the off state.
   required: false
   type: string
-  default: `payload_off` if defined, otherwise "OFF"
+  default: payload_off if defined, otherwise "OFF"
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false


### PR DESCRIPTION
**Description:**
Clarify default value for mqtt.switch state_on / state_off

Fixes home-assistant/home-assistant#22532

## Checklist:

- [x] Branch: Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
