### PR TITLE
Additional netgear_lte sensor types

### DIFF
--- a/source/_components/netgear_lte.markdown
+++ b/source/_components/netgear_lte.markdown
@@ -82,11 +82,37 @@ sensor:
     monitored_conditions:
       description: Sensor types to create.
       required: false
-      default: usage
+      default: usage, radio_quality
       type: list
       keys:
+        cell_id:
+          description: The Cell ID, a number identifying the base station.
+        connection:
+          description: The connection state, e.g. "Connected".
+        connection_text:
+          description: A connection text, e.g. "4G".
+        connection_type:
+          description: The connection type, e.g. "IPv4Only".
+        current_band:
+          description: The radio band used, e.g. "LTE B3".
+        current_ps_service_type:
+          description: The service type, e.g. "LTE".
+        radio_quality:
+          description: A number with the radio quality in percent, e.g. "55"
+        register_network_display:
+          description: The name of the service provider.
+        roaming:
+          description: A boolean showing whether the modem is currently roaming, e.g. "False".
+        rx_level:
+          description: The RSRP value, a measurement of the received power level, e.g. "-95".
         sms:
           description: Number of unread SMS messages in the modem inbox.
+        sms_total:
+          description: Number of SMS messages in the modem inbox.
+        tx_level:
+          description: Transmit power, e.g. "23".
+        upstream:
+          description: Current upstream connection, "WAN" or "LTE".
         usage:
           description: Amount of data transferred.
 {% endconfiguration %}

--- a/source/_components/netgear_lte.markdown
+++ b/source/_components/netgear_lte.markdown
@@ -88,31 +88,31 @@ sensor:
         cell_id:
           description: The Cell ID, a number identifying the base station.
         wire_connected:
-          description: The wired uplink connection state, e.g. "Disconnected".
+          description: The wired uplink connection state, e.g., "Disconnected".
         mobile_connected:
-          description: The LTE connection state, e.g. "Connected".
+          description: The LTE connection state, e.g., "Connected".
         connection_text:
-          description: A connection text, e.g. "4G".
+          description: A connection text, e.g., "4G".
         connection_type:
-          description: The connection type, e.g. "IPv4Only".
+          description: The connection type, e.g., "IPv4Only".
         current_band:
-          description: The radio band used, e.g. "LTE B3".
+          description: The radio band used, e.g., "LTE B3".
         current_ps_service_type:
           description: The service type, e.g. "LTE".
         radio_quality:
-          description: A number with the radio quality in percent, e.g. "55"
+          description: A number with the radio quality in percent, e.g., "55"
         register_network_display:
           description: The name of the service provider.
         roaming:
-          description: A boolean showing whether the modem is currently roaming, e.g. "False".
+          description: A boolean showing whether the modem is currently roaming, e.g., "False".
         rx_level:
-          description: The RSRP value, a measurement of the received power level, e.g. "-95".
+          description: The RSRP value, a measurement of the received power level, e.g., "-95".
         sms:
           description: Number of unread SMS messages in the modem inbox.
         sms_total:
           description: Number of SMS messages in the modem inbox.
         tx_level:
-          description: Transmit power, e.g. "23".
+          description: Transmit power, e.g., "23".
         upstream:
           description: Current upstream connection, "WAN" or "LTE".
         usage:

--- a/source/_components/netgear_lte.markdown
+++ b/source/_components/netgear_lte.markdown
@@ -87,8 +87,10 @@ sensor:
       keys:
         cell_id:
           description: The Cell ID, a number identifying the base station.
-        connection:
-          description: The connection state, e.g. "Connected".
+        wire_connected:
+          description: The wired uplink connection state, e.g. "Disconnected".
+        mobile_connected:
+          description: The LTE connection state, e.g. "Connected".
         connection_text:
           description: A connection text, e.g. "4G".
         connection_type:


### PR DESCRIPTION
**Description:**

New sensor types for connection quality and total number of SMS messages.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22558

Additional PR for the sms_total implementation will follow when the above is merged.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
