### PR TITLE
Update notify.html5.markdown

### DIFF
--- a/source/_components/notify.html5.markdown
+++ b/source/_components/notify.html5.markdown
@@ -19,7 +19,7 @@ HTML5 push notifications **do not** work on iOS.
 </p>
 
 <p class='note warning'>
-The GCM configuration option is deprecated and will stop working in April 2019, see [https://developers.google.com/cloud-messaging/faq](https://developers.google.com/cloud-messaging/faq). If you are installing this platform for the first time, follow the VAPID configuration steps. To migrate your current installation from GCM to VAPID configuration, follow the instructions below. You can skip the first 3 steps and continue in step 4 with your existing project. You will also need to [re-enable the notifications in your browser](#setting-up-your-browser).
+The GCM configuration option is deprecated and will stop working in April 2019, see [https://developers.google.com/cloud-messaging/faq](https://developers.google.com/cloud-messaging/faq). If you are installing this platform for the first time, follow the VAPID configuration steps. To migrate your current installation from GCM to VAPID configuration, follow the instructions below. You can skip the first 3 steps and continue in step 4 with your existing project. You will also need to delete `html5_push_registrations.conf` and [re-enable the notifications in your browser](#setting-up-your-browser).
 </p>
 
 ## {% linkable_title Configuration %}


### PR DESCRIPTION
**Description:**
Added a note on having to delete `html5_push_registrations.conf` when switching from GCM to VAPID.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
