### PR TITLE
Update installation.markdown

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -95,11 +95,13 @@ To perform the Hass.io installation, run the following commands:
 ```bash
 sudo -i
 
+apt-get software-properties-common
+
 add-apt-repository universe
 
 apt-get update
 
-apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat software-properties-common
+apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
 
 curl -fsSL get.docker.com | sh
 


### PR DESCRIPTION
It is not possible to run the command  `add-apt-repository universe` without installing `apt-get software-properties-common` first

**Description:**
Updating installation steps

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
