### PR TITLE
Add minimum/maximum to counter

### DIFF
--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -101,7 +101,7 @@ With this service the counter is reset to its initial value.
 | ---------------------- | -------- | ----------- |
 | `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.my_custom_counter`. |
 
-#### {% linkable_title Service `counter.setup` %}
+#### {% linkable_title Service `counter.configure` %}
 
 With this service the properties of the counter can be changed while running.
 

--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -51,6 +51,14 @@ counter:
       required: false
       type: integer
       default: 1
+    minimum:
+      description: Minimum value the counter will have
+      required: false
+      type: integer
+    maximum:
+      description: Maximum value the counter will have
+      required: false
+      type: integer
     icon:
       description: Icon to display for the counter.
       required: false
@@ -93,6 +101,18 @@ With this service the counter is reset to its initial value.
 | ---------------------- | -------- | ----------- |
 | `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.my_custom_counter`. |
 
+#### {% linkable_title Service `counter.setup` %}
+
+With this service the properties of the counter can be changed while running.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.my_custom_counter`. |
+| `minimum`              |     yes  | Set new value for minimum. None disables minimum. |
+| `maximum`              |     yes  | Set new value for maximum. None disables maximum. |
+| `step`                 |     yes  | Set new value for step |
+
+
 
 ### {% linkable_title Use the service %}
 
@@ -103,4 +123,3 @@ Select <img src='/images/screenshots/developer-tool-services-icon.png' alt='serv
   "entity_id": "counter.my_custom_counter"
 }
 ```
-


### PR DESCRIPTION
**Description:**
Documentation changes to support the ability to have a minimum/maximum in the counter component, along with a new service to change the counter while HA is running. This is effectively a resubmission of #6802 (from @spacemanspiff2007) which went stale.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22608

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
