### PR TITLE
Update installation.markdown

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -122,7 +122,7 @@ To perform the Hass.io installation, run the following commands:
 ```bash
 sudo -i
 
-apt-get software-properties-common
+apt-get install software-properties-common
 
 add-apt-repository universe
 


### PR DESCRIPTION
Changed `apt-get software-properties-common` to `apt-get install software-properties-common`.

**Description:**

When we use the commands:
```
sudo -i

apt-get software-properties-common

add-apt-repository universe

apt-get update

apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat

curl -fsSL get.docker.com | sh

curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install" | bash -s
```

The package manager `apt-get software-properties-common` will not work without install, thats why we need to use `apt-get install software-properties-common`.

The result on _Ubuntu 18.04.2 LTS (GNU/Linux 4.15.0-46-generic x86_64)_ was:
```
root@homeassistant:~# apt-get software-properties-common
E: Invalid operation software-properties-common
```

When using it with **install** the package manager has no problems:
```
root@homeassistant:~# apt-get install software-properties-common
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  dirmngr gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libasn1-8-heimdal libassuan0 libgssapi3-heimdal libhcrypto4-heimdal
  libheimbase1-heimdal libheimntlm0-heimdal libhx509-5-heimdal libkrb5-26-heimdal libksba8 libldap-2.4-2 libldap-common libnpth0 libroken18-heimdal libsasl2-2
  libsasl2-modules libsasl2-modules-db libwind0-heimdal pinentry-curses python3-software-properties.......
```

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
