### PR TITLE
Add discovery to HEOS configuration options

### DIFF
--- a/source/_components/heos.markdown
+++ b/source/_components/heos.markdown
@@ -13,7 +13,7 @@ ha_release: 0.92
 ha_iot_class: Local Push
 ---
 
-The HEOS component integrates [HEOS](http://heosbydenon.denon.com) capable products, such as speakers, amps, and receivers (Dennon and Marantz) into Home Assistant. Features currently include:
+The HEOS component integrates [HEOS](http://heosbydenon.denon.com) capable products, such as speakers, amps, and receivers (Denon and Marantz) into Home Assistant. Features currently include:
 
 - Each device is represented as a media player entity
 - View the currently playing media
@@ -24,7 +24,7 @@ The HEOS component integrates [HEOS](http://heosbydenon.denon.com) capable produ
 
 ## {% linkable_title Configuration %}
 
-HEOS devices are discovered and setup automatically when the [discovery](/components/discovery) component is enabled. Alternatively, the component can be setup through the frontend control pannel integrations page or manually by adding the following to your `configuration.yaml` file:
+HEOS devices are discovered and setup automatically when the [discovery](/components/discovery) component is enabled. Alternatively, the component can be setup through the frontend control panel integrations page or manually by adding the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/heos.markdown
+++ b/source/_components/heos.markdown
@@ -13,7 +13,7 @@ ha_release: 0.92
 ha_iot_class: Local Push
 ---
 
-The Heos component integrates [HEOS](http://heosbydenon.denon.com) capable products, such as speakers, amps, and receivers (Dennon and Marantz) into Home Assistant. Features currently include:
+The HEOS component integrates [HEOS](http://heosbydenon.denon.com) capable products, such as speakers, amps, and receivers (Dennon and Marantz) into Home Assistant. Features currently include:
 
 - Each device is represented as a media player entity
 - View the currently playing media
@@ -24,7 +24,7 @@ The Heos component integrates [HEOS](http://heosbydenon.denon.com) capable produ
 
 ## {% linkable_title Configuration %}
 
-To add a Denon HEOS speaker to your installation, add the following to your `configuration.yaml` file:
+HEOS devices are discovered and setup automatically when the [discovery](/components/discovery) component is enabled. Alternatively, the component can be setup through the frontend control pannel integrations page or manually by adding the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -40,7 +40,7 @@ host:
 {% endconfiguration %}
 
 <p class='note info'>
-A connection to a single device enables control for all devices in the HEOS account. If you have multiple Heos devices, enter the host of one that is connected to the LAN via wire or has the strongest wireless signal.
+A connection to a single device enables control for all devices in the HEOS account. If you have multiple HEOS devices, enter the host of one that is connected to the LAN via wire or has the strongest wireless signal.
 </p>
 
 ## {% linkable_title Notes %}


### PR DESCRIPTION
**Description:**
Add discovery to HEOS configuration options

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#22652

**Pull request in [netdisco](https://github.com/home-assistant/netdisco):** home-assistant/netdisco#250

## Checklist:
- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
