### PR TITLE
Update device-specific.markdown

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -45,7 +45,13 @@ Turn on "Disco lights":
 $ echo -e -n "\x01\x08\x00\xF2\x51\x01\x01\x05\x01\x50" > /dev/serial/by-id/usb-0658_0200-if00
 ```
 
-If the above two commands give errors about not having that device, you should try replacing the `/dev/serial/by-id/usb-0658_0200-if00` with `/dev/ttyACM0` or `/dev/ttyACM1` (depending on which tty your aeotec stick is addressed to).  
+If the above two commands give errors about not having that device, you should try replacing the `/dev/serial/by-id/usb-0658_0200-if00` with `/dev/ttyACM0` or `/dev/ttyACM1` (depending on which tty your aeotec stick is addressed to).
+
+On some systems, such as macOS, you need to pipe the output of the `echo` command, rather than redirecting to the serial device, to something like `cu` (replacing `/dev/zstick` acccordingly) to properly set the baud rate to 115200 bps:
+
+```bash
+$ echo -e -n "...turn on/off string from examples above..." | cu -l /dev/zstick -s 115200
+```
 
 ### {% linkable_title Razberry Board %}
 

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -45,12 +45,12 @@ Turn on "Disco lights":
 $ echo -e -n "\x01\x08\x00\xF2\x51\x01\x01\x05\x01\x50" > /dev/serial/by-id/usb-0658_0200-if00
 ```
 
-If the above two commands give errors about not having that device, you should try replacing the `/dev/serial/by-id/usb-0658_0200-if00` with `/dev/ttyACM0` or `/dev/ttyACM1` (depending on which tty your aeotec stick is addressed to).
+If the above two commands give errors about not having that device, you should try replacing the `/dev/serial/by-id/usb-0658_0200-if00` with `/dev/ttyACM0` or `/dev/ttyACM1` (depending on which tty your Aeotec stick is addressed to).
 
 On some systems, such as macOS, you need to pipe the output of the `echo` command, rather than redirecting to the serial device, to something like `cu` (replacing `/dev/zstick` acccordingly) to properly set the baud rate to 115200 bps:
 
 ```bash
-$ echo -e -n "...turn on/off string from examples above..." | cu -l /dev/zstick -s 115200
+echo -e -n "...turn on/off string from examples above..." | cu -l /dev/zstick -s 115200
 ```
 
 ### {% linkable_title Razberry Board %}


### PR DESCRIPTION
Expand Aeotec Z-Stick section to provide alternative "pipe to cu" syntax for enabling/disabling "disco lights" on systems where redirection to serial devices doesn't work because the baud rate on the serial device reverts to 9600 when haas isn't running.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
