### PR TITLE
Clarification regarding last_xxx being in UTC

### DIFF
--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -23,8 +23,8 @@ Field | Description
 `state.domain` | Domain of the entity. Example: `light`.
 `state.object_id` | Object ID of entity. Example: `kitchen`.
 `state.name` | Name of the entity. Based on `friendly_name` attribute with fall back to object ID. Example: `Kitchen Ceiling`.
-`state.last_updated` | Time the state was written to the state machine. Note that writing the exact same state including attributes will not result in this field being updated. Example: `2017-10-28 08:13:36.715874+00:00`. As all internal times are UTC times, you may need to convert them to local times when representing to user in any form (displaying in GUI/writing to text file/including in email etc).
-`state.last_changed` | Time the state changed. This is not updated when there are only updated attributes. Example: `2017-10-28 08:13:36.715874+00:00`. As all internal times are UTC times, you may need to convert them to local times when representing to user in any form (displaying in GUI/writing to text file/including in email etc).
+`state.last_updated` | Time the state was written to the state machine in UTC time. Note that writing the exact same state including attributes will not result in this field being updated. Example: `2017-10-28 08:13:36.715874+00:00`.
+`state.last_changed` | Time the state changed in the state machine in UTC time. This is not updated when there are only updated attributes. Example: `2017-10-28 08:13:36.715874+00:00`.
 `state.attributes` | A dictionary with extra attributes related to the current state.
 
 The attributes of an entity are optional. There are a few attributes that are used by Home Assistant for representing the entity in a specific way. Each component will also have its own attributes to represent extra state data about the entity. For example, the light component has attributes for the current brightness and color of the light. When an attribute is not available, Home Assistant will not write it to the state.

--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -23,8 +23,8 @@ Field | Description
 `state.domain` | Domain of the entity. Example: `light`.
 `state.object_id` | Object ID of entity. Example: `kitchen`.
 `state.name` | Name of the entity. Based on `friendly_name` attribute with fall back to object ID. Example: `Kitchen Ceiling`.
-`state.last_updated` | Time the state was written to the state machine. Note that writing the exact same state including attributes will not result in this field being updated. Example: `2017-10-28 08:13:36.715874+00:00`.
-`state.last_changed` | Time the state changed. This is not updated when there are only updated attributes. Example: `2017-10-28 08:13:36.715874+00:00`.
+`state.last_updated` | Time the state was written to the state machine. Note that writing the exact same state including attributes will not result in this field being updated. Example: `2017-10-28 08:13:36.715874+00:00`. As all internal times are UTC times, you may need to convert them to local times when representing to user in any form (displaying in GUI/writing to text file/including in email etc).
+`state.last_changed` | Time the state changed. This is not updated when there are only updated attributes. Example: `2017-10-28 08:13:36.715874+00:00`. As all internal times are UTC times, you may need to convert them to local times when representing to user in any form (displaying in GUI/writing to text file/including in email etc).
 `state.attributes` | A dictionary with extra attributes related to the current state.
 
 The attributes of an entity are optional. There are a few attributes that are used by Home Assistant for representing the entity in a specific way. Each component will also have its own attributes to represent extra state data about the entity. For example, the light component has attributes for the current brightness and color of the light. When an attribute is not available, Home Assistant will not write it to the state.


### PR DESCRIPTION
**Description:**
It worth to mention that last_xxx times are in UTC and should be converted to local time when exposed to user/exported in any human-readable form

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
