### PR TITLE
Clarification of Templates using now()

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -330,11 +330,9 @@ To evaluate a response, go to the <img src='/images/screenshots/developer-tool-t
 ### {% linkable_title `entity_id` that begins with a number %}
 If your template uses an `entity_id` that begins with a number (example: `states.device_tracker.2008_gmc`) you must use a bracket syntax to avoid errors caused by rendering the `entity_id` improperly. In the example given, the correct syntax for the device tracker would be: `states.device_tracker['2008_gmc']`
 
-
-
 ### {% linkable_title Templates without entities using `now()` %}
 
-Note that templates that depend on time (`now()`) and do not use any entities will not be updated as it only happens on entity state changes. For more information and examples refer to [Template Sensor documentation](https://www.home-assistant.io/components/sensor.template/#working-without-entities)
+Note that templates that depend on time (`now()`) and do not use any entities will not be updated as it only happens on entity state changes. For more information and examples refer to [`template` sensor documentation](/components/sensor.template/#working-without-entities)
 
 
 ### {% linkable_title Priority of operators %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -332,9 +332,9 @@ If your template uses an `entity_id` that begins with a number (example: `states
 
 
 
-### {% linkable_title Templates using `now()` %}
+### {% linkable_title Templates without entities using `now()` %}
 
-Rendering templates with time (`now()`) is dangerous as updates only trigger templates in sensors based on entity state changes.
+Note that templates that depend on time (`now()`) and do not use any entities will not be updated as it only happens on entity state changes. For more information and examples refer to [Template Sensor documentation](https://www.home-assistant.io/components/sensor.template/#working-without-entities)
 
 
 ### {% linkable_title Priority of operators %}


### PR DESCRIPTION
**Description:**
The current content of that section is hard to understand and there is no example.
Hope the link to some examples will help.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
