### PR TITLE
add device_class_power to sensor

### DIFF
--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -23,6 +23,7 @@ The way these sensors are displayed in the frontend can be modified in the [cust
 - **humidity**: Percentage of humidity in the air.
 - **illuminance**: The current light level in lx or lm.
 - **temperature**: Temperature in °C or °F.
+- **power**: Power in W or kW.
 - **pressure**: Pressure in hPa or mbar.
 - **timestamp**: Datetime object or timestamp string.
 


### PR DESCRIPTION
**Description:**
add device_class_power to sensor
See home-assistant/architecture#140

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22691

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
