### PR TITLE
Add severe weather sensor to Dark Sky

### DIFF
--- a/source/_components/darksky.markdown
+++ b/source/_components/darksky.markdown
@@ -147,6 +147,8 @@ monitored_conditions:
       description: The approximate distance to the nearest storm in miles.
     nearest_storm_bearing:
       description: The approximate direction of the nearest storm in degrees, with true north at 0° and progressing clockwise.
+    alerts:
+      description: Current severe weather advisories
 units:
   description: Specify the unit system. Valid options are `auto`, `us`, `si`, `ca` and `uk2`. `auto` will let Dark Sky decide the unit system based on location.
   required: false

--- a/source/_components/darksky.markdown
+++ b/source/_components/darksky.markdown
@@ -148,7 +148,7 @@ monitored_conditions:
     nearest_storm_bearing:
       description: The approximate direction of the nearest storm in degrees, with true north at 0° and progressing clockwise.
     alerts:
-      description: Current severe weather advisories
+      description: Current severe weather advisories.
 units:
   description: Specify the unit system. Valid options are `auto`, `us`, `si`, `ca` and `uk2`. `auto` will let Dark Sky decide the unit system based on location.
   required: false


### PR DESCRIPTION
**Description:**
This change adds a severe weather sensor to the Dark Sky component.  If there are multiple severe weather conditions each condition is appended to the sensor as an additional attribute.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22701

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
