### PR TITLE
🐎Improves build speed by removing old platform logic

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -10,19 +10,8 @@
   </div>
 
   {%- assign file_parts = page.url | split: '/' | last | split: '.' -%}
-
-  {%- if file_parts.size == 2 -%}
-    {%- assign is_platform = true -%}
-    {%- assign imp_name = file_parts[1] -%}
-    {%- assign imp_url = imp_name | prepend: '/components/' | append: '/' -%}
-    {%- assign parent_name = file_parts[0] -%}
-    {%- assign parent_url = parent_name | prepend: '/components/' | append: '/' -%}
-    {%- assign parent_component = components | where: 'url', imp_url | first -%}
-  {%- else -%}
-    {%- assign is_platform = false -%}
-    {%- assign imp_name = file_parts | first -%}
-    {%- assign imp_url = imp_name | prepend: '/components/' | append: '/' -%}
-{%- endif -%}
+  {%- assign imp_name = file_parts | first -%}
+  {%- assign imp_url = imp_name | prepend: '/components/' | append: '/' -%}
 
   {%- if page.ha_iot_class -%}
     <div class='section'>
@@ -61,66 +50,6 @@
   <div class='section'>
     Source: <a href='{{github_main_repo}}{{imp_url}}'>{{imp_url}}</a>
   </div>
-
-  {%- if is_platform and parent_name != 'sensor' -%}
-    <div class='section'>
-      This is a platform for
-      <a href='{{parent_component.url}}'>the {{parent_component.title}} component</a>.
-    </div>
-
-  {%- elsif is_platform == false and imp_name != 'ifttt' -%}
-
-    {%- assign platforms_found = false -%}
-    {%- for component in components -%}
-      {%- if component.url != page.url -%}
-        {%- assign comp_imp_name = component.url | split: '/' | last | split: '.' | first -%}
-        {%- if comp_imp_name == imp_name %}
-          {%- unless platforms_found -%}
-            {%- assign platforms_found = true -%}
-            <h1 class='title delta'>Platforms</h1>
-            <ul class='divided'>
-          {%- endunless -%}
-          <li><a href='{{component.url}}'>
-            {{component.title}}
-          </a></li>
-        {% endif -%}
-      {%- endif -%}
-    {%- endfor -%}
-
-    {%- if platforms_found -%}
-      </ul>
-    {%- endif -%}
-
-  {%- endif -%}
-
-  {%- assign related_found = false -%}
-  {%- for component in components -%}
-    {%- if component.url != page.url -%}
-      {%- assign comp_file_parts = component.url | split: '/' | last | split: '.' -%}
-      {%- if comp_file_parts.size == 2 -%}
-        {%- assign comp_imp_name = comp_file_parts | last -%}
-      {%- else -%}
-        {%- assign comp_imp_name = comp_file_parts | first -%}
-      {%- endif -%}
-
-      {%- if comp_imp_name == imp_name -%}
-        {%- unless related_found -%}
-          {%- assign related_found = true -%}
-          <div class='section'>
-          <h1 class='title delta'>Related components</h1>
-          <ul class='divided'>
-        {%- endunless -%}
-        <li><a href='{{component.url}}'>
-          {{component.title}}
-        </a></li>
-      {%- endif -%}
-    {%- endif -%}
-  {%- endfor -%}
-
-  {%- if related_found -%}
-    </ul>
-    </div>
-  {%- endif -%}
 
   {%- if page.ha_category.first -%}
     <div class='section'>

--- a/source/components/index.html
+++ b/source/components/index.html
@@ -68,15 +68,6 @@ Support for these components is provided by the Home Assistant community.
   </div>
 </div>
 
-{% comment %}
-## Pages without categories
-{%- for component in components -%}
-  {% unless component.ha_category %}
-<p>{{ component.title }}</p>
-  {% endunless %}
-{%- endfor -%}
-{% endcomment %}
-
 <script src="https://code.jquery.com/jquery-2.2.4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/10.17.0/lazyload.min.js"></script>


### PR DESCRIPTION
**Description:**

Now the great migration has been finished, including the documentation, the old platform logic can be removed from our documentation templates.

As a result, this improves the build times significantly.

![image](https://user-images.githubusercontent.com/195327/55553160-c1c32c00-56df-11e9-863a-a7e5a8be5481.png)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
