### PR TITLE
Added to troubleshooting section for Philips TVs

### DIFF
--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -181,6 +181,9 @@ If you receive the error message `Error while setting up platform androidtv` in 
 
    * Home Assistant does not have the appropriate permissions for the `adbkey` file and so it is not able to use it. Once you fix the permissions, the component should work.
 
+4. Some Android TV devices (e.g. Philips TVs running Android TV) only accept the initial adb connection request over their wi-fi interface. If you have the TV wired, you need to connect it to wi-fi and try the initial connection again. Once the authentication has been granted via wi-fi, you can connect to the TV over the wired interface as well.
+
+
 ## {% linkable_title Services %}
 
 ### {% linkable_title `media_player.select_source` %}

--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -181,7 +181,7 @@ If you receive the error message `Error while setting up platform androidtv` in 
 
    * Home Assistant does not have the appropriate permissions for the `adbkey` file and so it is not able to use it. Once you fix the permissions, the component should work.
 
-4. Some Android TV devices (e.g. Philips TVs running Android TV) only accept the initial adb connection request over their wi-fi interface. If you have the TV wired, you need to connect it to wi-fi and try the initial connection again. Once the authentication has been granted via wi-fi, you can connect to the TV over the wired interface as well.
+4. Some Android TV devices (e.g., Philips TVs running Android TV) only accept the initial ADB connection request over their Wi-Fi interface. If you have the TV wired, you need to connect it to WiFi and try the initial connection again. Once the authentication has been granted via Wi-Fi, you can connect to the TV over the wired interface as well.
 
 ## {% linkable_title Services %}
 

--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -183,7 +183,6 @@ If you receive the error message `Error while setting up platform androidtv` in 
 
 4. Some Android TV devices (e.g. Philips TVs running Android TV) only accept the initial adb connection request over their wi-fi interface. If you have the TV wired, you need to connect it to wi-fi and try the initial connection again. Once the authentication has been granted via wi-fi, you can connect to the TV over the wired interface as well.
 
-
 ## {% linkable_title Services %}
 
 ### {% linkable_title `media_player.select_source` %}


### PR DESCRIPTION
Philips Android TVs only accept the initial handshake with adb connect over their wi-fi interface.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
