### PR TITLE
Note that stream component is only compatible with H.264

### DIFF
--- a/source/_components/stream.markdown
+++ b/source/_components/stream.markdown
@@ -15,7 +15,7 @@ ha_iot_class: Local Push
 ha_qa_scale: internal
 ---
 
-The `stream` component provides a way to proxy live streams through Home Assistant. The component currently only supports the HLS format.
+The `stream` component provides a way to proxy live streams through Home Assistant. The component currently only supports proxying H.264 source streams to the HLS format.
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
Note that stream component is only compatible with H.264 as documented in home-assistant/home-assistant.io#22424

**Description:**
Document that H.264 source stream is required.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>
N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
