### PR TITLE
improve Configuration for Credentials

### DIFF
--- a/source/_components/aws.markdown
+++ b/source/_components/aws.markdown
@@ -59,11 +59,6 @@ profile_name:
   description: A credentials profile name.
   required: false
   type: string
-region_name:
-  description: The region identifier to connect to.
-  required: true
-  default: "`us-east-1`"
-  type: string
 name:
   description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
   required: false


### PR DESCRIPTION
Hi there.  I found this page only because of the log warning that the lambda notify component would be deprecated, so I suspect that means it is new.  I was able to get the new component working, but a edits would have helped a bit. 

1.)  The current doc lists `region_name`as required, so I configured it, but then received and invalid option error when checking the configuration.yaml in dev tools ... so I rather think it does not belong and am suggesting it be removed.  

2.) I was unclear how the credentials section and notify sections should work together, but I think the idea is to list credentials once, and then each notifier underneath it will refer to it ... yes?  I am not sure what edits to suggest, but I did notice that the comment in the example, `# use the first credential defined in aws component by default` did not hold true in my case.  I had to explicitly define credentials inside my notifier.  So maybe the current state of the component and the doc' are not in synch yet?

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
