### PR TITLE
Update rejseplanen.markdown

### DIFF
--- a/source/_components/rejseplanen.markdown
+++ b/source/_components/rejseplanen.markdown
@@ -46,6 +46,18 @@ The `stop_id` can be obtained by following this guide:
 ```
 - Find the name of you stop on the list, and the "id" is the one you are looking for.
 
+Full sensor configuration.yaml using the stop id guide:
+```yaml
+# Example using the stop id guide
+sensor:
+  - platform: rejseplanen
+    name: "Rejseplanen, Jernaldervej til Aarhus"
+    stop_id: '713000702'
+    route: 'Bus 200'
+    direction:
+      - 'Skanderborg Busterminal'
+```
+
 The sensor can filter the timetables by one or more routes, directions and types. The known types are listed in the table below.
 
 | Departure type | Description |

--- a/source/_components/rejseplanen.markdown
+++ b/source/_components/rejseplanen.markdown
@@ -17,6 +17,32 @@ redirect_from:
 
 The `rejseplanen` sensor will provide you with travel details for Danish public transport, using timetable data from [Rejseplanen](https://www.rejseplanen.dk/).
 
+## {% linkable_title Setup %}
+
+The `stop_id` can be obtained through the following steps:
+
+- Go to [http://rejseplanen.dk](http://rejseplanen.dk)
+- Make a search and fill in the location you want to find stop ID for in the from's (a) section. 
+- Fill in either a random or the destination into the (b) section of the form.
+- Press on "detaljer" and find the name of the stop you are looking for.
+- Example search:
+    - Jernaldervej 1, Søften, 8382 Hinnerup
+    - Odense St. (detaljer) 
+- Now insert the stop name in the end of this URL: http://xmlopen.rejseplanen.dk/bin/rest.exe/location?format=json&input=STOP_NAME
+
+For "Engdalsvej/Århusvej" you would have to use: http://xmlopen.rejseplanen.dk/bin/rest.exe/location?format=json&input=Engdalsvej/%C3%85rhusvej
+You will se a output like this:
+
+```json
+"StopLocation":[{
+    "name":"Engdalsvej/Århusvej (Favrskov Kom)",
+    "x":"10078598",
+    "y":"56243456",
+    "id":"713000702"
+```
+
+Find the name of your stop in the list and the "id" is the one you are looking for to us as value for `stop_id:`.
+
 ## {% linkable_title Configuration %}
 
 Add a sensor to your `configuration.yaml` file as shown in the example:
@@ -28,49 +54,9 @@ sensor:
     stop_id: 'YOUR_STOP_ID'
 ```
 
-The `stop_id` can be obtained by following this guide:
-- Go to <https://www.rejseplanen.dk/>
-- Make a search and fill in the location you want to find stop id for in the from (a) section. 
-- Fill in either a random or the destination in to (b) section.
-- Press on "detaljer" and find the name of the stop you are looking to find the stop id for.
-- Example search: (a): Jernaldervej 1, Søften, 8382 Hinnerup / (b): Odense St. (detaljer): Name of stop in this search is: Engdalsvej/Århusvej.
-- Now insert the stop name in the end of the base url <http://xmlopen.rejseplanen.dk/bin/rest.exe/location?format=json&input=STOP_NAME>
-- In this case you will have to use this: <http://xmlopen.rejseplanen.dk/bin/rest.exe/location?format=json&input=Engdalsvej/%C3%85rhusvej>
-- You will se a output like this:
-```yaml
-"StopLocation":[{
-    "name":"Engdalsvej/Århusvej (Favrskov Kom)",
-    "x":"10078598",
-    "y":"56243456",
-    "id":"713000702"
-```
-- Find the name of you stop on the list, and the "id" is the one you are looking for.
-
-Full sensor configuration.yaml using the stop id guide:
-```yaml
-# Example using the stop id guide
-sensor:
-  - platform: rejseplanen
-    name: "Rejseplanen, Jernaldervej til Aarhus"
-    stop_id: '713000702'
-    route: 'Bus 200'
-    direction:
-      - 'Skanderborg Busterminal'
-```
-
-The sensor can filter the timetables by one or more routes, directions and types. The known types are listed in the table below.
-
-| Departure type | Description |
-|--------------|-------------|
-| BUS | Normal bus |
-| EXB | Express bus |
-| M | Metro |
-| S | S-train |
-| REG | Regional train |
-
 {% configuration %}
 stop_id:
-  description: The id of the public transport stop.
+  description: The ID of the public transport stop.
   required: true
   type: string
 route:
@@ -89,8 +75,8 @@ departure_type:
 
 ## {% linkable_title Direction %}
 
-If you use the direction filter it's important to put correct destination, or else the sensor will not work at all.
-The direction has to be the destination(s) for the transport type(s) for the departure stop destination, and NOT the stop where you want to get off. Check <http://rejseplanen.dk> and make a search, and use the destinations from there in your configuration. Make sure you use the exact name as the destination(s)
+If you use the direction filter it's important to put correct destination or else the sensor will not work at all.
+The direction has to be the destination(s) for the transport type(s) for the departure stop destination, and NOT the stop where you want to get off. Check [http://rejseplanen.dk](http://rejseplanen.dk), make a search and use the destinations from there in your configuration. Make sure you use the exact name as the destination(s).
 
 A working example on how to use this sensor with direction:
 
@@ -114,6 +100,7 @@ sensor:
     direction:
       - 'København H'
 ```
+
 It fails because the destination from the departure is NOT København H, but 'CPH Lufthavn', 'Helsingør St.' and others.
 
 ## {% linkable_title Examples %}
@@ -130,3 +117,13 @@ sensor:
       - 'Herlev St.'
       - 'Ballerup St.'
 ```
+
+The sensor can filter the timetables by one or more routes, directions and types. The known types are listed in the table below.
+
+| Departure type | Description |
+|--------------|-------------|
+| BUS | Normal bus |
+| EXB | Express bus |
+| M | Metro |
+| S | S-train |
+| REG | Regional train |

--- a/source/_components/rejseplanen.markdown
+++ b/source/_components/rejseplanen.markdown
@@ -33,7 +33,7 @@ The `stop_id` can be obtained through the following steps:
 For "Engdalsvej/Århusvej" you would have to use: http://xmlopen.rejseplanen.dk/bin/rest.exe/location?format=json&input=Engdalsvej/%C3%85rhusvej
 You will se a output like this:
 
-```json
+```text
 "StopLocation":[{
     "name":"Engdalsvej/Århusvej (Favrskov Kom)",
     "x":"10078598",

--- a/source/_components/rejseplanen.markdown
+++ b/source/_components/rejseplanen.markdown
@@ -28,11 +28,23 @@ sensor:
     stop_id: 'YOUR_STOP_ID'
 ```
 
-The `stop_id` can be obtained by looking up the name of the stop at this link:
-
-<http://xmlopen.rejseplanen.dk/bin/rest.exe/location?format=json&input=STOP_NAME>
-(Replace "STOP_NAME" with city or location you want id for)
-find the stop and copy the `id` field with the trailing zeros.
+The `stop_id` can be obtained by following this guide:
+- Go to <https://www.rejseplanen.dk/>
+- Make a search and fill in the location you want to find stop id for in the from (a) section. 
+- Fill in either a random or the destination in to (b) section.
+- Press on "detaljer" and find the name of the stop you are looking to find the stop id for.
+- Example search: (a): Jernaldervej 1, Søften, 8382 Hinnerup / (b): Odense St. (detaljer): Name of stop in this search is: Engdalsvej/Århusvej.
+- Now insert the stop name in the end of the base url <http://xmlopen.rejseplanen.dk/bin/rest.exe/location?format=json&input=STOP_NAME>
+- In this case you will have to use this: <http://xmlopen.rejseplanen.dk/bin/rest.exe/location?format=json&input=Engdalsvej/%C3%85rhusvej>
+- You will se a output like this:
+```yaml
+"StopLocation":[{
+    "name":"Engdalsvej/Århusvej (Favrskov Kom)",
+    "x":"10078598",
+    "y":"56243456",
+    "id":"713000702"
+```
+- Find the name of you stop on the list, and the "id" is the one you are looking for.
 
 The sensor can filter the timetables by one or more routes, directions and types. The known types are listed in the table below.
 


### PR DESCRIPTION
The guide was missing the steps to find the id in most cases, due to the old guide gave the "adr" output i most cases and not the "id"

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
