### PR TITLE
add homekit battery config

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -114,8 +114,7 @@ homekit:
                 required: false
                 type: string
               battery:
-                description: The `entity_id` of the battery entity for the accessory. The entity must
-                have the device_class of `battery` for it to function properly.
+                description: The `entity_id` of the battery entity for the accessory. The entity must have the device_class of `battery` for it to function properly.
                 required: false
                 type: string
                 default: '`<No entity_id>`'

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -31,6 +31,8 @@ homekit:
       - alarm_control_panel
       - light
       - media_player
+    include_entities:
+      - binary_sensor.living_room_motion
   entity_config:
     alarm_control_panel.home:
       code: 1234
@@ -116,7 +118,7 @@ homekit:
                 required: false
                 type: string
               linked_battery_sensor:
-                description: The `entity_id` of the `sensor` entity to use as the battery of the accessory. HomeKit will cache an accessory's feature set on the first run so a device must be removed and then re-added for any change to take effect.
+                description: The `entity_id` of a `sensor` entity to use as the battery of the accessory. HomeKit will cache an accessory's feature set on the first run so a device must be removed and then re-added for any change to take effect.
                 required: false
                 type: string
               code:
@@ -446,6 +448,6 @@ Unfortunately, that sometimes happens at the moment. It might help to close the 
 
 To fix this, you need to unpair the `Home Assistant Bridge`, delete the `.homekit.state` file ([guide](#deleting-the-homekitstate-file)) and pair it again. This should only be an issue if you're upgrading from `0.65.x` or below.
 
-#### {% linkable_title The linked battery sensor isn't recognized? %}
+#### {% linkable_title The linked battery sensor isn't recognized %}
 
 Try removing the entity from HomeKit and then adding it again. If you are adding this config option to an existing entity in HomeKit, any changes you make to this entity's config options won't appear until the accessory is removed from HomeKit and then re-added.

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -113,6 +113,12 @@ homekit:
                 description: Name of the entity to show in HomeKit. HomeKit will cache the name on the first run so a device must be removed and then re-added for any change to take effect.
                 required: false
                 type: string
+              battery:
+                description: The `entity_id` of the battery entity for the accessory. The entity must
+                have the device_class of `battery` for it to function properly.
+                required: false
+                type: string
+                default: '`<No entity_id>`'
               code:
                 description: Code to `arm / disarm` an alarm or `lock / unlock` a lock. Only applicable for `alarm_control_panel` or `lock` entities.
                 required: false

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -34,6 +34,8 @@ homekit:
   entity_config:
     alarm_control_panel.home:
       code: 1234
+    binary_sensor.living_room_motion:
+      linked_battery_sensor: sensor.living_room_motion_battery
     light.kitchen_table:
       name: Kitchen Table Light
     lock.front_door:
@@ -114,10 +116,9 @@ homekit:
                 required: false
                 type: string
               linked_battery_sensor:
-                description: The `entity_id` of the battery entity for the accessory.
+                description: The `entity_id` of the `sensor` entity to link to use as the battery of the accessory. HomeKit will cache an accessory's feature set on the first run so a device must be removed and then re-added for any change to take effect.
                 required: false
                 type: string
-                default: '`<No entity_id>`'
               code:
                 description: Code to `arm / disarm` an alarm or `lock / unlock` a lock. Only applicable for `alarm_control_panel` or `lock` entities.
                 required: false
@@ -444,3 +445,7 @@ Unfortunately, that sometimes happens at the moment. It might help to close the 
 #### {% linkable_title Accessories not responding / behaving unusual - Upgrade from `0.65.x` %}
 
 To fix this, you need to unpair the `Home Assistant Bridge`, delete the `.homekit.state` file ([guide](#deleting-the-homekitstate-file)) and pair it again. This should only be an issue if you're upgrading from `0.65.x` or below.
+
+#### {% linkable_title The linked battery sensor isn't recognized? %}
+
+Try removing the entity from HomeKit and then adding it again. If you are adding this config option to an existing entity in HomeKit, any changes you make to this entity's config options won't appear until the accessory is removed from HomeKit and then re-added.

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -113,8 +113,8 @@ homekit:
                 description: Name of the entity to show in HomeKit. HomeKit will cache the name on the first run so a device must be removed and then re-added for any change to take effect.
                 required: false
                 type: string
-              battery:
-                description: The `entity_id` of the battery entity for the accessory. The entity must have the device_class of `battery` for it to function properly.
+              linked_battery_sensor:
+                description: The `entity_id` of the battery entity for the accessory.
                 required: false
                 type: string
                 default: '`<No entity_id>`'
@@ -405,7 +405,7 @@ Pairing works fine when the filter is set to only include `demo.demo`, but fails
 #### {% linkable_title Pairing hangs - no error %}
 
 1. Make sure that you don't try to add more than 100 accessories, see [device limit](#device-limit). In rare cases, one of your entities doesn't work with the HomeKit component. Use the [filter](#configure-filter) to find out which one. Feel free to open a new issue in the `home-assistant` repo, so we can resolve it.
-2. Check logs, and search for `Starting accessory Home Assistant Bridge on address`. Make sure Home Assistant Bridge hook ups to a correct interface. If it did not, explicitly set `homekit.ip_address` configuration variable. 
+2. Check logs, and search for `Starting accessory Home Assistant Bridge on address`. Make sure Home Assistant Bridge hook ups to a correct interface. If it did not, explicitly set `homekit.ip_address` configuration variable.
 
 #### {% linkable_title Duplicate AID found when attempting to add accessory %}
 

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -116,7 +116,7 @@ homekit:
                 required: false
                 type: string
               linked_battery_sensor:
-                description: The `entity_id` of the `sensor` entity to link to use as the battery of the accessory. HomeKit will cache an accessory's feature set on the first run so a device must be removed and then re-added for any change to take effect.
+                description: The `entity_id` of the `sensor` entity to use as the battery of the accessory. HomeKit will cache an accessory's feature set on the first run so a device must be removed and then re-added for any change to take effect.
                 required: false
                 type: string
               code:


### PR DESCRIPTION
**Description:**

Adds the ability to link an accessory to pull its battery level from a separate entity. I have many Z-Wave devices with template sensors for their main states and separate template sensors for their battery levels. This would allow users to define where to pull their battery level from, in case the `battery_level` attribute is absent on the main entity for the accessory.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22788

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html