### PR TITLE
Add Motion Detector with Brightness Sensor - outdoor to Homematic IP

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -95,6 +95,7 @@ authtoken:
   * Window Rotary Handle Sensor (*HmIP-SRH*)
   * Smoke sensor and alarm (*HmIP-SWSD*)
   * Motion Detector with Brightness Sensor - indoor (*HmIP-SMI*)
+  * Motion Detector with Brightness Sensor - outdoor (*HmIP-SMO*)
   * Water Sensor (*HmIP-SWD*)
 
 * homematicip_cloud.climate
@@ -126,6 +127,7 @@ authtoken:
   * Temperature and Humidity Sensor with display - indoor (*HmIP-STHD*)
   * Temperature and Humidity sensor - outdoor (*HmIP-STHO, -A*)
   * Motion Detector with Brightness Sensor - indoor (*HmIP-SMI*)
+  * Motion Detector with Brightness Sensor - outdoor (*HmIP-SMO*)
   * Light Sensor - outdoor (*HmIP-SLO*)
 
 * homematicip_cloud.switch


### PR DESCRIPTION
**Description:**
Add Motion Detector with Brightness Sensor - outdoor

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22802

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
