### PR TITLE
Update hours_to_show

### DIFF
--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -33,7 +33,7 @@ entities:
   type: list
 hours_to_show:
   required: false
-  description: Hours to show.
+  description: Hours to show. (minimum of 10, maximum of 80)
   type: integer
   default: 24
 refresh_interval:

--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -33,7 +33,7 @@ entities:
   type: list
 hours_to_show:
   required: false
-  description: Hours to show. (minimum of 10, maximum of 80)
+  description: Hours to show. Minimum is 10 hours, maximum of 80 hours.
   type: integer
   default: 24
 refresh_interval:


### PR DESCRIPTION
Didn't know that there was a high and low limit to hours_to_show until I experimented with it. Thought it would be useful info for someone else.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
