### PR TITLE
new: expire_after and force_update variables

### DIFF
--- a/source/_components/sensor.rflink.markdown
+++ b/source/_components/sensor.rflink.markdown
@@ -65,7 +65,7 @@ devices:
           required: false
           type: string
         expire_after:
-        description: Defines the number of seconds after the value expires (becomes None) if it's not updated.
+          description: Defines the number of seconds after the value expires (becomes None) if it's not updated.
           required: false
           type: integer
           default: 0

--- a/source/_components/sensor.rflink.markdown
+++ b/source/_components/sensor.rflink.markdown
@@ -64,6 +64,16 @@ devices:
           description: Override automatically detected unit of sensor.
           required: false
           type: string
+        expire_after:
+        description: Defines the number of seconds after the value expires (becomes None) if it's not updated.
+          required: false
+          type: integer
+          default: 0
+        force_update:
+          description: Write a new state to the state machine even if the value has not changed (that will update sensor's last_updated timestamp). Useful for sensors that only sends `On`.
+          required: false
+          type: boolean
+          default: false
         aliases:
           description: "Alternative RFLink ID's this device is known by."
           required: false


### PR DESCRIPTION
**Description:**
Adding description of new expire_after and force_update config variables


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22670

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
