### PR TITLE
Fix typo in luftdaten docs

### DIFF
--- a/source/_components/luftdaten.markdown
+++ b/source/_components/luftdaten.markdown
@@ -25,7 +25,7 @@ The `luftdaten` component will query the open data API of [luftdaten.info](http:
 - To get the ID of a particle sensor you need to select it on the [Feinstaub map](http://deutschland.maps.luftdaten.info/) and find it in the sidebar (Column "Sensor ID").
 - To get the ID of a temperature/humidity sensor you need to find it on the map hosted on [Madavi](https://www.madavi.de/sensor/feinstaub-map-dht/).
 
-## {% linkable_title COnfiguration via the frontend %}
+## {% linkable_title Configuration via the frontend %}
 
 Menu: **Configuration** -> **Integrations**
 


### PR DESCRIPTION
**Description:**
Fixed a small typo in luftdaten docs

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
