### PR TITLE
Add amcrest camera services and deprecate switches

### DIFF
--- a/source/_components/amcrest.markdown
+++ b/source/_components/amcrest.markdown
@@ -142,7 +142,7 @@ switches:
     Switches to display in the frontend.  
     
     **Note:** Switches are deprecated and will be removed in a future release.  
-    Use camera services and attributes instead.  
+    Use services and attributes instead.  
     
     The following switches can be monitored:
   required: false
@@ -167,7 +167,7 @@ Newer Amcrest firmware may not work, then **rtsp** is recommended instead.
 make sure to follow the steps mentioned at [FFMPEG](/components/ffmpeg/)
 documentation to install the `ffmpeg`.
 
-## {% linkable_title Camera Services %}
+## {% linkable_title Services %}
 
 Once loaded, the `amcrest` component will expose services that can be called to perform various actions. The `entity_id` service attribute can specify one or more specific cameras, or `all` can be used to specify all configured Amcrest cameras.
 

--- a/source/_components/amcrest.markdown
+++ b/source/_components/amcrest.markdown
@@ -167,22 +167,18 @@ Newer Amcrest firmware may not work, then **rtsp** is recommended instead.
 make sure to follow the steps mentioned at [FFMPEG](/components/ffmpeg/)
 documentation to install the `ffmpeg`.
 
-To check if your Amcrest camera is supported/tested, visit the
-[supportability matrix](https://github.com/tchellomello/python-amcrest#supportability-matrix)
-link from the `amcrest` project.
-
 ## {% linkable_title Camera Services %}
 
-Once loaded, the `camera` platform will expose Amcrest-specific services that can be called to perform various actions. The `entity_id` service attribute can specify one or more specific cameras, or `all` can be used to specify all configured Amcrest cameras.
+Once loaded, the `amcrest` component will expose services that can be called to perform various actions. The `entity_id` service attribute can specify one or more specific cameras, or `all` can be used to specify all configured Amcrest cameras.
 
 Available services:
-`amcrest_enable_audio`, `amcrest_disable_audio`,
-`amcrest_enable_motion_recording`, `amcrest_disable_motion_recording`,
-`amcrest_enable_recording`, `amcrest_disable_recording`,
-`amcrest_goto_preset`, `amcrest_set_color_bw`,
-`amcrest_start_tour` and `amcrest_stop_tour`
+`enable_audio`, `disable_audio`,
+`enable_motion_recording`, `disable_motion_recording`,
+`enable_recording`, `disable_recording`,
+`goto_preset`, `set_color_bw`,
+`start_tour` and `stop_tour`
 
-#### {% linkable_title Service `amcrest_enable_audio`/`amcrest_disable_audio` %}
+#### {% linkable_title Service `enable_audio`/`disable_audio` %}
 
 These services enable or disable the camera's audio stream.
 
@@ -190,7 +186,7 @@ Service data attribute | Optional | Description
 -|-|-
 `entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
 
-#### {% linkable_title Service `amcrest_enable_motion_recording`/`amcrest_disable_motion_recording` %}
+#### {% linkable_title Service `enable_motion_recording`/`disable_motion_recording` %}
 
 These services enable or disable the camera to record a clip to its configured storage location when motion is detected.
 
@@ -198,7 +194,7 @@ Service data attribute | Optional | Description
 -|-|-
 `entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
 
-#### {% linkable_title Service `amcrest_enable_recording`/`amcrest_disable_recording` %}
+#### {% linkable_title Service `enable_recording`/`disable_recording` %}
 
 These services enable or disable the camera to continuously record to its configured storage location.
 
@@ -206,7 +202,7 @@ Service data attribute | Optional | Description
 -|-|-
 `entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
 
-#### {% linkable_title Service `amcrest_goto_preset` %}
+#### {% linkable_title Service `goto_preset` %}
 
 This service will cause the camera to move to one of the PTZ locations configured within the camera.
 
@@ -215,7 +211,7 @@ Service data attribute | Optional | Description
 `entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
 `preset` | no | Preset number, starting from 1.
 
-#### {% linkable_title Service `amcrest_set_color_bw` %}
+#### {% linkable_title Service `set_color_bw` %}
 
 This service will set the color mode of the camera.
 
@@ -224,7 +220,7 @@ Service data attribute | Optional | Description
 `entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
 `color_bw` | no | One of `auto`, `bw` or `color`.
 
-#### {% linkable_title Service `amcrest_start_tour`/`amcrest_stop_tour` %}
+#### {% linkable_title Service `start_tour`/`stop_tour` %}
 
 These services start or stop the camera's PTZ tour function.
 

--- a/source/_components/amcrest.markdown
+++ b/source/_components/amcrest.markdown
@@ -29,7 +29,7 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor
 - Camera
 - Sensor
-- Switch
+- Switch (deprecated)
 
 ## {% linkable_title Configuration %}
 
@@ -128,8 +128,8 @@ sensors:
     motion_detector:
       description: >
         Return `true`/`false` when motion is detected.  
-
-        **Note:** This sensor is deprecated and will be removed in a future release.
+        
+        **Note:** The motion_detector sensor is deprecated and will be removed in a future release.
         Use **binary_sensors** option **motion_detected** instead.
     sdcard:
       description: Return the SD card usage by reporting the total and used space.
@@ -139,7 +139,11 @@ sensors:
         configured for the given camera.
 switches:
   description: >
-    Switches to display in the frontend.
+    Switches to display in the frontend.  
+    
+    **Note:** Switches are deprecated and will be removed in a future release.  
+    Use camera services and attributes instead.  
+    
     The following switches can be monitored:
   required: false
   type: list
@@ -167,6 +171,67 @@ To check if your Amcrest camera is supported/tested, visit the
 [supportability matrix](https://github.com/tchellomello/python-amcrest#supportability-matrix)
 link from the `amcrest` project.
 
+## {% linkable_title Camera Services %}
+
+Once loaded, the `camera` platform will expose Amcrest-specific services that can be called to perform various actions. The `entity_id` service attribute can specify one or more specific cameras, or `all` can be used to specify all configured Amcrest cameras.
+
+Available services:
+`amcrest_enable_audio`, `amcrest_disable_audio`,
+`amcrest_enable_motion_recording`, `amcrest_disable_motion_recording`,
+`amcrest_enable_recording`, `amcrest_disable_recording`,
+`amcrest_goto_preset`, `amcrest_set_color_bw`,
+`amcrest_start_tour` and `amcrest_stop_tour`
+
+#### {% linkable_title Service `amcrest_enable_audio`/`amcrest_disable_audio` %}
+
+These services enable or disable the camera's audio stream.
+
+Service data attribute | Optional | Description
+-|-|-
+`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
+
+#### {% linkable_title Service `amcrest_enable_motion_recording`/`amcrest_disable_motion_recording` %}
+
+These services enable or disable the camera to record a clip to its configured storage location when motion is detected.
+
+Service data attribute | Optional | Description
+-|-|-
+`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
+
+#### {% linkable_title Service `amcrest_enable_recording`/`amcrest_disable_recording` %}
+
+These services enable or disable the camera to continuously record to its configured storage location.
+
+Service data attribute | Optional | Description
+-|-|-
+`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
+
+#### {% linkable_title Service `amcrest_goto_preset` %}
+
+This service will cause the camera to move to one of the PTZ locations configured within the camera.
+
+Service data attribute | Optional | Description
+-|-|-
+`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
+`preset` | no | Preset number, starting from 1.
+
+#### {% linkable_title Service `amcrest_set_color_bw` %}
+
+This service will set the color mode of the camera.
+
+Service data attribute | Optional | Description
+-|-|-
+`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
+`color_bw` | no | One of `auto`, `bw` or `color`.
+
+#### {% linkable_title Service `amcrest_start_tour`/`amcrest_stop_tour` %}
+
+These services start or stop the camera's PTZ tour function.
+
+Service data attribute | Optional | Description
+-|-|-
+`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
+
 ## {% linkable_title Advanced Configuration %}
 
 You can also use this more advanced configuration example:
@@ -181,9 +246,6 @@ amcrest:
       - motion_detected
     sensors:
       - sdcard
-    switches:
-      - motion_detection
-      - motion_recording
 
   # Add second camera
   - host: IP_ADDRESS_CAMERA_2


### PR DESCRIPTION
**Description:**
Add new Amcrest-specific services and deprecate `switches` configuration variable.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22949

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
