### PR TITLE
Update spelling

### DIFF
--- a/source/_components/aws.markdown
+++ b/source/_components/aws.markdown
@@ -13,7 +13,7 @@ ha_category:
 ha_release: "0.91"
 ---
 
-The `aws` integration provides a single place to interact [Amazon Web Services](https://aws.amazon.com/). Current it provide a notification platform can send a message to [AWS SQS](https://aws.amazon.com/sqs/), [AWS SNS](https://aws.amazon.com/sns/), or invoke [AWS Lambda](https://aws.amazon.com/lambda/) functions.
+The `aws` integration provides a single place to interact with [Amazon Web Services](https://aws.amazon.com/). Currently it provides a notification platform that can send a message to [AWS SQS](https://aws.amazon.com/sqs/), [AWS SNS](https://aws.amazon.com/sns/), or invoke [AWS Lambda](https://aws.amazon.com/lambda/) functions.
 
 ## {% linkable_title Setup %}
 


### PR DESCRIPTION
Just fixed some minor spelling stuff.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
