### PR TITLE
Added the new ConBee II (ConBee 2) to known working Zigbee radios

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -35,13 +35,13 @@ There is currently support for the following device types within Home Assistant:
 - Switch
 - Fan
 
-ZHA exception and deviation handling:
+## {% linkable_title ZHA exception and deviation handling %}
 
 Zigbee devices that deviate from or do not fully conform to the standard specifications set by the [Zigbee Alliance](https://www.zigbee.org) may require the development of custom [ZHA Device Handlers](https://github.com/dmulcahey/zha-device-handlers) (ZHA custom quirks handler implementation) to for all their functions to work properly with the ZHA component in Home Assistant. These ZHA Device Handlers for Home Assistant can thus be used to parse custom messages to and from Zigbee devices.
 
 The custom quirks implementations for zigpy implemented as ZHA Device Handlers for Home Assistant are a similar concept to that of [Hub-connected Device Handlers for the SmartThings Classics platform](https://docs.smartthings.com/en/latest/device-type-developers-guide/) as well as that of [Zigbee-Shepherd Converters as used by Zigbee2mqtt](https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html), meaning they are each virtual representations of a physical device that expose additional functionality that is not provided out-of-the-box by the existing integration between these platforms.
 
-Known working Zigbee radio modules:
+## {% linkable_title Known working Zigbee radio modules %}
 
 - EmberZNet based radios using the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)
   - [Nortek GoControl QuickStick Combo Model HUSBZB-1 (Z-Wave & Zigbee USB Adapter)](https://www.nortekcontrol.com/products/2gig/husbzb-1-gocontrol-quickstick-combo/)
@@ -50,6 +50,7 @@ Known working Zigbee radio modules:
 - XBee Zigbee based radios (via the [zigpy-xbee](https://github.com/zigpy/zigpy-xbee) library for zigpy)
   - Digi XBee Series 2C (S2C) modules
 - Dresden-Elektronik deCONZ based Zigbee radios (via the [zigpy-deconz](https://github.com/zigpy/zigpy-deconz) library for zigpy)
+  - [ConBee II (a.k.a. ConBee 2) USB adapter from Dresden-Elektronik](https://shop.dresden-elektronik.de/conbee-2.html)
   - [ConBee USB adapter from Dresden-Elektronik](https://www.dresden-elektronik.de/conbee/)
   - [RaspBee Raspberry Pi Shield from Dresden-Elektronik](https://www.dresden-elektronik.de/raspbee/)
 


### PR DESCRIPTION
**Description:**

Added the new ConBee II (ConBee 2) to known working Zigbee radios

"ConBee II" (a.k.a. "ConBee 2") hardware has just now been released and is confirmed by Dresden-Elektronik employee @manup to be backwards compatible with the deCONZ serial protocol that zigpy-deconz radio module for zigpy utilizes. (He, @manup wrote that "the serial protocol is identical and will be maintained for all devices equally").

Ping @damarco & @Adminiuga & @dmulcahey & @rcloran for review with a friendly tip that @manup from Dresden-Elektronik has previously offered to ship free ConBee hardware for development to recognized home automation software developers like yourselves if they only ask him nicely here => https://github.com/dresden-elektronik/deconz-rest-plugin/issues/158

FYI; Apparently the new "ConBee II" ZigBee USB dongle/stick is based on a 32-bit ARM-Cortex-M0 SoC microcontroller (Microchip ATSAMR21E18A) instead of an 8-bit AVR based CMOS microcontroller (Atmel ATmega256RFR2) like the previous version of ConBee and the current RaspBee versions.

- https://shop.dresden-elektronik.de/conbee-2.html
- https://www.dresden-elektronik.de/fileadmin/Downloads/Dokumente/Produkte/11_Phoscon_gateway/Phoscon_ConBee-II_10-2018_eng.pdf
- http://www.amazon.de/dp/B01FDWOIHK

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** Not applicable.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
