### PR TITLE
Fix german word

### DIFF
--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -375,7 +375,7 @@ Software Required:
   ```bash
   java -jar abe.jar unpack backup.ab backup.tar
   ```
-  After that, you kann open the file with WinRaR or what ever you like.
+  After that, you will be able to open the file with WinRaR or what ever you like.
 6. Go to \apps\com.xiaomi.smarthome\db
 7. Open miio2.db with SQLite Browser
 8. You can find your device tokens in "devicerecord" table


### PR DESCRIPTION
**Description:**
Fix a german word in the documentation.



## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
