### PR TITLE
Add current disease config to the IQVIA docs

### DIFF
--- a/source/_components/iqvia.markdown
+++ b/source/_components/iqvia.markdown
@@ -46,6 +46,9 @@ iqvia:
     - asthma_index_tomorrow
     - asthma_index_yesterday
     - disease_average_forecasted
+    - disease_average_historical
+    - disease_index_today
+    - disease_index_yesterday
 ```
 
 {% configuration %}
@@ -79,6 +82,9 @@ The following metrics can be monitored:
 * Asthma Index: Tomorrow (`asthma_index_tomorrow`): the asthma index for tomorrow
 * Asthma Index: Yesterday (`asthma_index_yesterday`): the asthma index for yesterday
 * Cold & Flu: Forecasted Average (`disease_average_forecasted`): the average forecasted cold/flu index over the next 5 days
+* Cold & Flu: Historical Average (`disease_average_historical`): the average historical cold/flu index over the past 30 days
+* Cold & Flu Index: Today (`disease_index_today`): the cold/flu index for today
+* Cold & Flu Index: Yesterday (`disease_index_yesterday`): the cold/flu index for yesterday
 
 ## {% linkable_title Understanding the Indices %}
 

--- a/source/_components/iqvia.markdown
+++ b/source/_components/iqvia.markdown
@@ -36,17 +36,14 @@ iqvia:
   zip_code: "00544"
   monitored_conditions:
     - allergy_average_forecasted
-    - allergy_average_historical
     - allergy_index_today
     - allergy_index_tomorrow
     - allergy_index_yesterday
     - asthma_average_forecasted
-    - asthma_average_historical
     - asthma_index_today
     - asthma_index_tomorrow
     - asthma_index_yesterday
     - disease_average_forecasted
-    - disease_average_historical
     - disease_index_today
     - disease_index_yesterday
 ```
@@ -72,17 +69,14 @@ ZIP codes that start with 0 will cause errors.
 The following metrics can be monitored:
 
 * Allergy Index: Forecasted Average (`allergy_average_forecasted`): the average forecasted allergy index over the next 5 days
-* Allergy Index: Historical Average (`allergy_average_historical`): the average historical allergy index over the past 30 days
 * Allergy Index: Today (`allergy_index_today`): the allergy index for today
 * Allergy Index: Tomorrow (`allergy_index_tomorrow`): the allergy index for tomorrow
 * Allergy Index: Yesterday (`allergy_index_yesterday`): the allergy index for yesterday
 * Asthma Index: Forecasted Average (`asthma_average_forecasted`): the average forecasted asthma index over the next 5 days
-* Asthma Index: Historical Average (`asthma_average_historical`): the average historical asthma index over the past 30 days
 * Asthma Index: Today (`asthma_index_today`): the asthma index for today
 * Asthma Index: Tomorrow (`asthma_index_tomorrow`): the asthma index for tomorrow
 * Asthma Index: Yesterday (`asthma_index_yesterday`): the asthma index for yesterday
 * Cold & Flu: Forecasted Average (`disease_average_forecasted`): the average forecasted cold/flu index over the next 5 days
-* Cold & Flu: Historical Average (`disease_average_historical`): the average historical cold/flu index over the past 30 days
 * Cold & Flu Index: Today (`disease_index_today`): the cold/flu index for today
 * Cold & Flu Index: Yesterday (`disease_index_yesterday`): the cold/flu index for yesterday
 


### PR DESCRIPTION
**Description:**

This PR adds docs for current and historical disease info in IQVIA. It also removes references to no-longer-valid historical conditions.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/23052

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
