### PR TITLE
yeelight model rgb is color1

### DIFF
--- a/source/_components/yeelight.markdown
+++ b/source/_components/yeelight.markdown
@@ -27,7 +27,7 @@ After the lights are connected to the WiFi network and have been detected in Hom
 
 ```yaml
 # Example customize.yaml entry
-light.yeelight_rgb_XXXXXXXXXXXX:
+light.yeelight_color1_XXXXXXXXXXXX:
   friendly_name: Living Room
 light.yeelight_color2_XXXXXXXXXXXX:
   friendly_name: Downstairs Toilet


### PR DESCRIPTION
In example yeelight model 'rgb' must be 'color1'

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
