### PR TITLE
Update getting-started configurator section

### DIFF
--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -40,30 +40,6 @@ The first add-on we should install is the HASS Configurator. With the HASS Confi
 
 Go to the add-on store (see the previous step), click on Configurator and click on "INSTALL". When installation is complete, the UI will go to the add-on details page for the configurator. Here you will be able to change settings, start and stop the add-on. Follow the steps below to setup the add-on.
 
- - Set a password on the Config box, don't forget to use quotes on your password
- 
- ```json
-{
-  "username": "admin",
-  "password": "YOUR_PASSWORD_WITH_QUOTES",
-  "certfile": "fullchain.pem",
-  "keyfile": "privkey.pem",
-  "ssl": false,
-  "allowed_networks": [
-    "192.168.0.0/16"
-  ],
-  "banned_ips": [
-    "8.8.8.8"
-  ],
-  "banlimit": 0,
-  "ignore_pattern": [
-    "__pycache__"
-  ],
-  "dirsfirst": false
-}
-```
-
- - Click on "SAVE" to save your new password
  - "START" the add-on
  - You will be able to click the "OPEN WEB UI" link to open the Web UI on a new window
  - Type your username and password that you recently saved


### PR DESCRIPTION
Younger versions of the HASS Configurator have a
reduced set of config options, especially username and
password are gone. "Save" fails if trying to use the currently
documented set of options. The default config needs no change
at first install anymore. Reflect this in the getting started docs.