### PR TITLE
Added documentation for invert_percent configuration for zwave roller…

### DIFF
--- a/source/_components/zwave.markdown
+++ b/source/_components/zwave.markdown
@@ -131,13 +131,14 @@ Z-Wave garage doors, blinds, and roller shutters are supported as cover in Home 
 
 To get your Z-Wave covers working with Home Assistant, follow the instructions for the general [Z-Wave component](#configuration).
 
-If you discover that you need to [invert the operation](/docs/z-wave/installation/#invert_openclose_buttons) of open/close for a particular device, you may change this behavior in your Z-Wave section of your `configuration.yaml` file as follows:
+If you discover that you need to [invert the operation](/docs/z-wave/installation/#invert_openclose_buttons) of open/close for a particular device, you may change this behavior in your Z-Wave section of your `configuration.yaml` file as follows, in addition you can also [invert percent position](/docs/z-wave/installation/#invert_percent):
 
 ```yaml
 zwave:
   device_config:
     cover.my_cover:
       invert_openclose_buttons: true
+      invert_percent: true
 ```
 
 ## {% linkable_title Lock %}

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -82,6 +82,11 @@ device_config / device_config_domain / device_config_glob:
       required: false
       type: boolean
       default: false
+    invert_percent:
+      description: Inverts the percentage of the position for the cover domain. This will invert the position and state reporting.
+      required: false
+      type: boolean
+      default: false  
 {% endconfiguration %}
 
 ### {% linkable_title Network Key %}


### PR DESCRIPTION
**Description:**
Added documentation for invert_percent configuration for zwave rollershutter.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#23101

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
