### PR TITLE
pkg-update doesn't have "assume yes" flag

### DIFF
--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -23,7 +23,7 @@ Create the user and group that Home Assistant will run as. The user/group ID of 
 Install the necessary Python packages:
 
 ```bash
-# pkg update -y
+# pkg update
 # pkg upgrade
 # pkg install -y python37 py37-sqlite3 ca_root_nss
 # python3.7 -m ensurepip


### PR DESCRIPTION
I'm guessing the -y was meant to be on pkg upgrade, instead?

from pkg help update:
     pkg update [-fq] [-r reponame]
     pkg update [--{force,quiet}] [--repository reponame]

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
