### PR TITLE
Added documentation for MCP23017 component: binary sensor and switch …

### DIFF
--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -18,13 +18,15 @@ ha_iot_class: Local Polling
 
 The `mcp23017` component is the base for all related mcp23017 platforms in Home Assistant. There is no setup needed for the component itself, for the platforms please check their corresponding sections.
 
+For more details about the MCP23017 I2C I/O port expander you can find its datasheet here: [MCP23017](https://www.microchip.com/wwwproducts/en/MCP23017).
+
 ## {% linkable_title Binary Sensor %}
 
 The `mcp23017` binary sensor platform allows you to read sensor values from the I/O pins of your [MCP23017 I2C I/O expander](https://www.adafruit.com/product/732).
 
 The pin numbers are from 0 to 15 where: 0-7 correspond to port A (A1-A8) and 8-15 to port B (B1-B8).
 
-## {% linkable_title Configuration %}
+### {% linkable_title Configuration %}
 
 To use the I/O pins of an mcp23017 connected to an I2C bus of your Raspberry Pi as binary sensors, add the following to your `configuration.yaml` file:
 
@@ -74,15 +76,13 @@ pull_mode:
 
 NOTE: MCP23017 only has internal pull-up resistors, if you want to use pull-down you will have to wire your own pull-down resistors.
 
-For more details about the MCP23017 I2C I/O port expander you can find its datasheet here: [MCP23017](https://www.microchip.com/wwwproducts/en/MCP23017).
-
 ## {% linkable_title Switch %}
 
 The `mcp23017` switch platform allows you to write to the I/O pins of your [MCP23017 I2C I/O expander](https://www.adafruit.com/product/732).
 
 The pin numbers are from 0 to 15 where: 0-7 correspond to port A (A1-A8) and 8-15 to port B (B1-B8).
 
-## {% linkable_title Configuration %}
+### {% linkable_title Configuration %}
 
 To use the I/O pins of an mcp23017 connected to an I2C bus of your Raspberry Pi as switches, add the following to your `configuration.yaml` file:
 
@@ -117,5 +117,3 @@ invert_logic:
   default: false
   type: boolean
 {% endconfiguration %}
-
-For more details about the MCP23017 I2C I/O port expander you can find its datasheet here: [MCP23017](https://www.microchip.com/wwwproducts/en/MCP23017).

--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -74,7 +74,9 @@ pull_mode:
   default: "`UP`"
 {% endconfiguration %}
 
-NOTE: MCP23017 only has internal pull-up resistors, if you want to use pull-down you will have to wire your own pull-down resistors.
+<p class='note warning'>
+  MCP23017 only has internal pull-up resistors, if you want to use pull-down you will have to wire your own pull-down resistors.
+</p>
 
 ## {% linkable_title Switch %}
 

--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -26,7 +26,7 @@ The pin numbers are from 0 to 15 where: 0-7 correspond to port A (A1-A8) and 8-1
 
 ## {% linkable_title Configuration %}
 
-To use the I/O pins of an mcp23017 connected to and I2C bus of your Raspberry Pi as binary sensors, add the following to your `configuration.yaml` file:
+To use the I/O pins of an mcp23017 connected to an I2C bus of your Raspberry Pi as binary sensors, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -12,7 +12,7 @@ ha_category:
   - DIY
   - Binary Sensor
   - Switch
-ha_release: 0.92
+ha_release: 0.94
 ha_iot_class: Local Polling
 ---
 

--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -1,0 +1,128 @@
+---
+layout: page
+title: "MCP23017 I2C GPIO expander"
+description: "Instructions on how to integrate the MCP23017 GPIO pin expander with I2C interface into Home Assistant."
+date: 2019-04-14 07:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: raspberry-pi.png
+ha_category:
+  - DIY
+  - Binary Sensor
+  - Switch
+ha_release: 0.92
+ha_iot_class: Local Polling
+redirect_from:
+  - /components/binary_sensor.mcp23017/
+  - /components/switch.mcp23017/
+---
+
+The `mcp23017` component is the base for all related mcp23017 platforms in Home Assistant. There is no setup needed for the component itself, for the platforms please check their corresponding pages.
+
+## {% linkable_title Binary Sensor %}
+
+The `mcp23017` binary sensor platform allows you to read sensor values from the I/O pins of your [MCP23017 I2C I/O expander](https://www.adafruit.com/product/732).
+
+The pin numbers are from 0 to 15 where: 0-7 correspond to port A (A1-A8) and 8-15 to port B (B1-B8).
+
+## {% linkable_title Configuration %}
+
+To use the I/O pins of an mcp23017 connected to and I2C bus of your Raspberry Pi as binary sensors, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+  - platform: mcp23017
+    i2c_address: 0x20
+    pins:
+      0: PIR Office
+      1: PIR Bedroom
+```
+
+{% configuration %}
+i2c_address:
+  description: i2c address of MCP23017 chip.
+  required: false
+  type: integer
+  default: "`0x20`"
+pins:
+  description: List of used pins.
+  required: true
+  type: map
+  keys:
+    "pin: name":
+      description: The pin numbers (from 0 to 15) and corresponding names.
+      required: true
+      type: [integer, string]
+scan_interval:
+  description: Interval to scan for sensor state changes in seconds.
+  required: false
+  type: integer
+  default: 15
+invert_logic:
+  description: If `true`, inverts the output logic to ACTIVE LOW.
+  required: false
+  type: boolean
+  default: "`false` (ACTIVE HIGH)"
+pull_mode:
+  description: >
+    Type of internal pull resistor to use.
+    Options are `UP` - pull-up resistor and `DOWN` - pull-down resistor.
+  required: false
+  type: string
+  default: "`UP`"
+{% endconfiguration %}
+
+NOTE: MCP23017 only has internal pull-up resistors, if you want to use pull-down you will have to wire your own pull-down resistors.
+
+For more details about the MCP23017 I2C I/O port expander you can find its datasheet here: [MCP23017](https://www.microchip.com/wwwproducts/en/MCP23017).
+
+## {% linkable_title Switch %}
+
+The `mcp23017` switch platform allows you to write to the I/O pins of your [MCP23017 I2C I/O expander](https://www.adafruit.com/product/732).
+
+The pin numbers are from 0 to 15 where: 0-7 correspond to port A (A1-A8) and 8-15 to port B (B1-B8).
+
+## {% linkable_title Configuration %}
+
+To use the I/O pins of an mcp23017 connected to and I2C bus of your Raspberry Pi as switches, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: mcp23017
+    i2c_address: 0x20
+    ports:
+      11: Fan Office
+      12: Light Desk
+```
+
+{% configuration %}
+i2c_address:
+  description: i2c address of MCP23017 chip.
+  required: false
+  type: integer
+  default: "`0x20`"
+ports:
+  description: Array of used pins.
+  required: true
+  type: list
+  keys:
+    port:
+      description: The pin numbers (from 0 to 15) and corresponding names.
+      required: true
+      type: [integer, string]
+invert_logic:
+  description: If true, inverts the output logic to ACTIVE LOW.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
+
+For more details about the MCP23017 I2C I/O port expander you can find its datasheet here: [MCP23017](https://www.microchip.com/wwwproducts/en/MCP23017).
+
+<p class='note warning'>
+Note that a pin managed by HASS is expected to be exclusive to HASS.
+</p>

--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -14,9 +14,6 @@ ha_category:
   - Switch
 ha_release: 0.92
 ha_iot_class: Local Polling
-redirect_from:
-  - /components/binary_sensor.mcp23017/
-  - /components/switch.mcp23017/
 ---
 
 The `mcp23017` component is the base for all related mcp23017 platforms in Home Assistant. There is no setup needed for the component itself, for the platforms please check their corresponding pages.

--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -91,7 +91,7 @@ To use the I/O pins of an mcp23017 connected to and I2C bus of your Raspberry Pi
 switch:
   - platform: mcp23017
     i2c_address: 0x20
-    ports:
+    pins:
       11: Fan Office
       12: Light Desk
 ```
@@ -119,7 +119,3 @@ invert_logic:
 {% endconfiguration %}
 
 For more details about the MCP23017 I2C I/O port expander you can find its datasheet here: [MCP23017](https://www.microchip.com/wwwproducts/en/MCP23017).
-
-<p class='note warning'>
-Note that a pin managed by HASS is expected to be exclusive to HASS.
-</p>

--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -16,7 +16,7 @@ ha_release: 0.92
 ha_iot_class: Local Polling
 ---
 
-The `mcp23017` component is the base for all related mcp23017 platforms in Home Assistant. There is no setup needed for the component itself, for the platforms please check their corresponding pages.
+The `mcp23017` component is the base for all related mcp23017 platforms in Home Assistant. There is no setup needed for the component itself, for the platforms please check their corresponding sections.
 
 ## {% linkable_title Binary Sensor %}
 

--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -84,7 +84,7 @@ The pin numbers are from 0 to 15 where: 0-7 correspond to port A (A1-A8) and 8-1
 
 ## {% linkable_title Configuration %}
 
-To use the I/O pins of an mcp23017 connected to and I2C bus of your Raspberry Pi as switches, add the following to your `configuration.yaml` file:
+To use the I/O pins of an mcp23017 connected to an I2C bus of your Raspberry Pi as switches, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
MCP23017

**Description:**
Documentation for new component MCP23017: binary sensor and switch platforms. In preparation for PR on home-assistant to be added as a new core component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23127

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
