### PR TITLE
MQTT vacuum send_command description

### DIFF
--- a/source/_components/vacuum.mqtt.markdown
+++ b/source/_components/vacuum.mqtt.markdown
@@ -50,12 +50,12 @@ retain:
   type: boolean
   default: false
 payload_turn_on:
-  description: "The payload to send to the `command_topic` to begin the cleaning cycle."
+  description: The payload to send to the `command_topic` to begin the cleaning cycle.
   required: false
   type: string
   default: turn_on
 payload_turn_off:
-  description: "The payload to send to the `command_topic` to turn the vacuum off."
+  description: The payload to send to the `command_topic` to turn the vacuum off.
   required: false
   type: string
   default: turn_off
@@ -89,7 +89,7 @@ battery_level_topic:
   required: false
   type: string
 battery_level_template:
-  description: "Defines a [template](/topics/templating/) to define the battery level of the vacuum."
+  description: Defines a [template](/topics/templating/) to define the battery level of the vacuum.
   required: false
   type: string
 charging_topic:
@@ -97,7 +97,7 @@ charging_topic:
   required: false
   type: string
 charging_template:
-  description:  "Defines a [template](/topics/templating/) to define the charging state of the vacuum."
+  description: Defines a [template](/topics/templating/) to define the charging state of the vacuum.
   required: false
   type: string
 cleaning_topic:
@@ -105,7 +105,7 @@ cleaning_topic:
   required: false
   type: string
 cleaning_template:
-  description: "Defines a [template](/topics/templating/) to define the cleaning state of the vacuum."
+  description: Defines a [template](/topics/templating/) to define the cleaning state of the vacuum.
   required: false
   type: string
 docked_topic:
@@ -113,7 +113,7 @@ docked_topic:
   required: false
   type: string
 docked_template:
-  description: "Defines a [template](/topics/templating/) to define the docked state of the vacuum."
+  description: Defines a [template](/topics/templating/) to define the docked state of the vacuum.
   required: false
   type: string
 error_topic:
@@ -121,7 +121,7 @@ error_topic:
   required: false
   type: string
 error_template:
-  description: "Defines a [template](/topics/templating/) to define potential error messages emitted by the vacuum."
+  description: Defines a [template](/topics/templating/) to define potential error messages emitted by the vacuum.
   required: false
   type: string
 fan_speed_topic:
@@ -129,7 +129,7 @@ fan_speed_topic:
   required: false
   type: string
 fan_speed_template:
-  description: "Defines a [template](/topics/templating/) to define the fan speed of the vacuum."
+  description: Defines a [template](/topics/templating/) to define the fan speed of the vacuum.
   required: false
   type: string
 set_fan_speed_topic:
@@ -211,7 +211,7 @@ vacuum:
 
 The above configuration for this component expects an MQTT protocol like the following.
 
-#### Basic Commands
+#### {% linkable_title Basic Commands %}
 
 MQTT topic: `vacuum/command`
 
@@ -225,7 +225,7 @@ Possible MQTT payloads:
 - `locate` - Locate the vacuum (typically by playing a song)
 - `start_pause` - Toggle the vacuum between cleaning and stopping
 
-#### Set Fan Speed
+#### {% linkable_title Set Fan Speed %}
 
 MQTT topic: `vacuum/set_fan_speed`
 
@@ -236,7 +236,7 @@ Possible MQTT payloads:
 - `high` - High fan speed
 - `max` - Max fan speed
 
-#### Send Custom Command
+#### {% linkable_title Send Custom Command %}
 
 Vacuum send_command allows three parameters:
 
@@ -270,7 +270,7 @@ Service trigger example:
 
 MQTT topic: `vacuum/send_command`
 
-#### Status/Sensor Updates
+#### {% linkable_title Status/Sensor Updates %}
 
 MQTT topic: `vacuum/state`
 

--- a/source/_components/vacuum.mqtt.markdown
+++ b/source/_components/vacuum.mqtt.markdown
@@ -238,9 +238,37 @@ Possible MQTT payloads:
 
 #### Send Custom Command
 
-MQTT topic: `vacuum/send_command`
+Vacuum send_command allows three parameters:
 
-MQTT payload for `send_command` can be an arbitrary value handled by the vacuum's MQTT-enabled firmware.
+- entity_id
+- command
+- params - optional
+
+If params are not provided it sends command as payload to MQTT send_command topic.
+If params are provided service sends json as payload with such structure:
+```
+{
+  'command': 'command',
+  'param1-key': 'param1-value'
+}
+```
+
+Service trigger example:
+```
+- alias: Push command based on sensor
+    trigger:
+      - platform: state
+        entity_id: sensor.sensor
+    action:
+      service: vacuum.send_command
+      data:
+        entity_id: 'vacuum.vacuum_entity'
+        command: 'custom_command'
+        params:
+          - key: value
+```
+
+MQTT topic: `vacuum/send_command`
 
 #### Status/Sensor Updates
 


### PR DESCRIPTION
**Description:**
Made description of vacuum send_command service

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/23071

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
