### PR TITLE
Replaced old method of theme selection with current steps

### DIFF
--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -114,7 +114,7 @@ automation:
 
 ### {% linkable_title Manual Theme Selection %}
 
-When themes are enabled in the `configuration.yaml` file, a new option will show up in the user profile menu (before 0.77 it was in the Configuration panel under **General**  called "Set a theme"). You can then choose any installed theme from the dropdown list and it will be applied immediately.
+When themes are enabled in the `configuration.yaml` file, a new option will show up in the user profile menu (accessed by clicking your user account initials at the top of the sidebar). You can then choose any installed theme from the dropdown list and it will be applied immediately.
 
 <p class='img'>
   <img src='/images/frontend/user-theme.png' />
@@ -139,7 +139,7 @@ Those will be loaded via `<link rel='import' href='{{ extra_url }}' async>` on a
 
 ### {% linkable_title Manual Language Selection %}
 
-The browser language is automatically detected. To use a different language, go to the user profile menu (before 0.77 it was found in **General** in the Configuration panel) and select one. It will be applied immediately.
+The browser language is automatically detected. To use a different language, go to the user profile menu (accessed by clicking your user account initials at the top of the sidebar) and select one. It will be applied immediately.
 
 <p class='img'>
   <img src='/images/frontend/user-language.png' />


### PR DESCRIPTION
**Description:**
Have removed information about how to access themes before Home Assistant version 0.77 (which was released eight months ago now - very few people should be using 8+ month old versions). This information seems like it'll only cause confusion for new users. 

Instead I replaced it with information on the *current way* of accessing user profile menu which seems way more important.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
