### PR TITLE
Correct example automation for vacuum.xiaomi_clean_zone

### DIFF
--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -129,7 +129,7 @@ automation:
     - service: vacuum.xiaomi_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
-        repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
+        repeats: '{{states.input_number.vacuum_passes.state|int}}'
         zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]
 ```
 Array with inline zone:
@@ -144,7 +144,7 @@ automation:
     - service: vacuum.xiaomi_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
-        repeats_template: '{{states.input_number.vacuum_passes.state|int}}'
+        repeats: '{{states.input_number.vacuum_passes.state|int}}'
         zone:
         - [30914,26007,35514,28807]
         - [20232,22496,26032,26496]


### PR DESCRIPTION
Replace "repeats_template" with "repeats" for xiaomi_clean_zone automation example. I was unable to get the automation with repeats_template working

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
