### PR TITLE
Remove invalid example

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -241,29 +241,6 @@ alert:
 
 The resulting message could be `Plant Officeplant needs help (moisture low)`.
 
-The next example uses a template for the alert name.
-
-{% raw %}
-```yaml
-alert:
-  garage_door:
-    name: Garage has been open for {{ relative_time(states.binary_sensor.garage.last_changed) }}
-    done_message: Garage is closed
-    entity_id: binary_sensor.garage
-    state: 'on'
-    repeat:
-      - 30
-      - 60
-      - 120
-    can_acknowledge: true
-    skip_first: true
-    notifiers:
-      - ryans_phone
-```
-{% endraw %}
-
-The resulting title of the alert could be `Garage has been open for 30 min`.
-
 ### {% linkable_title Additional parameters for notifiers  %}
 
 Some notifiers support more parameters (e.g., to set text color or action


### PR DESCRIPTION
The example of a template for the `name` variable is not supported by the component. Templates are valid for the `title` and `message` only as evidenced by the component schema.

```
ALERT_SCHEMA = vol.Schema({
    vol.Required(CONF_NAME): cv.string,
    vol.Required(CONF_ENTITY_ID): cv.entity_id,
    vol.Required(CONF_STATE, default=STATE_ON): cv.string,
    vol.Required(CONF_REPEAT): vol.All(cv.ensure_list, [vol.Coerce(float)]),
    vol.Required(CONF_CAN_ACK, default=DEFAULT_CAN_ACK): cv.boolean,
    vol.Required(CONF_SKIP_FIRST, default=DEFAULT_SKIP_FIRST): cv.boolean,
    vol.Optional(CONF_ALERT_MESSAGE): cv.template,
    vol.Optional(CONF_DONE_MESSAGE): cv.template,
    vol.Optional(CONF_TITLE): cv.template,
    vol.Optional(CONF_DATA): dict,
vol.Required(CONF_NOTIFIERS): cv.ensure_list})
```

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
