### PR TITLE
Fixes documentation for HSTS configuration options

### DIFF
--- a/source/_addons/nginx_proxy.markdown
+++ b/source/_addons/nginx_proxy.markdown
@@ -41,8 +41,8 @@ keyfile:
   required: true
   type: string
 hsts:
-  description: Value for the [`Strict-Transport-Security`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) HTTP header to send. If empty or `null`, the header is not sent.
-  required: false
+  description: Value for the [`Strict-Transport-Security`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) HTTP header to send. If empty, the header is not sent.
+  required: true
   type: string
 customize:
   description: If true, additional NGINX configuration files for the default server and additional servers are read from files in the `/share` directory specified by the `default` and `servers` variables.


### PR DESCRIPTION
If `"hsts"` is removed or `null` is provided, configuration cannot be saved.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
