### PR TITLE
Fix ha_release version

### DIFF
--- a/source/_components/orangepi_gpio.markdown
+++ b/source/_components/orangepi_gpio.markdown
@@ -10,7 +10,7 @@ footer: true
 ha_category:
   - DIY
   - Binary Sensor
-ha_release: 0.92
+ha_release: 0.93
 ha_iot_class: Local Push
 ---
 


### PR DESCRIPTION
**Description:**

Because of delay between PR and merge, version numbers have diverged. This PR fixes this. (see https://github.com/home-assistant/home-assistant.io/pull/9072/files/776ec3bfa5e96ba78078b8bb21fef4bf8ba733e5#r276630318)

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
