### PR TITLE
Bump up HA_VERSION for orangepi

### DIFF
--- a/source/_components/orangepi_gpio.markdown
+++ b/source/_components/orangepi_gpio.markdown
@@ -10,7 +10,7 @@ footer: true
 ha_category:
   - DIY
   - Binary Sensor
-ha_release: 0.92
+ha_release: 0.93
 ha_iot_class: Local Push
 ---
 


### PR DESCRIPTION
**Description:**

@klaasnicolaas reminded me that I forgot to bump this before merging in #9072.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
