### PR TITLE
Corrected default tilt open position

### DIFF
--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -162,7 +162,7 @@ tilt_opened_value:
   description: The value that will be sent on an `open_cover_tilt` command.
   required: false
   type: integer
-  default: 0
+  default: 100
 tilt_status_optimistic:
   description: Flag that determines if tilt works in optimistic mode.
   required: false


### PR DESCRIPTION
**Description:**
Default value for open_cover_tilt was wrong

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
