### PR TITLE
Add comment to value_template option

### DIFF
--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -86,7 +86,7 @@ device_class:
   required: false
   type: string
 value_template:
-  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload. Available variables: `entity_id`."
+  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload. Available variables: `entity_id`." Remove this option when 'payload_on' and 'payload_off' are sufficient to match your payloads.
   required: false
   type: string
 force_update:

--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -86,7 +86,7 @@ device_class:
   required: false
   type: string
 value_template:
-  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload. Available variables: `entity_id`." Remove this option when 'payload_on' and 'payload_off' are sufficient to match your payloads.
+  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload. Available variables: `entity_id`. Remove this option when 'payload_on' and 'payload_off' are sufficient to match your payloads."
   required: false
   type: string
 force_update:


### PR DESCRIPTION
When accidently included in the config (as seen in many examples) it may cause a trivial sensor item not to work for a neewbie of HA like me

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
