### PR TITLE
Use user variable in systemd venv service

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -51,7 +51,7 @@ After=network-online.target
 [Service]
 Type=simple
 User=%i
-ExecStart=/srv/homeassistant/bin/hass -c "/home/YOUR_USER/.homeassistant"
+ExecStart=/srv/homeassistant/bin/hass -c "/home/%i/.homeassistant"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Description:**
Tiny doc update

Since we are using systemd template, and that the user is already used as the variable, i think it is easier to manage like that.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
