### PR TITLE
Add HmIP Radiator thermostat to sensors

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -99,12 +99,11 @@ authtoken:
   * Water Sensor (*HmIP-SWD*)
 
 * homematicip_cloud.climate
-  * Heating-Thermostat Radiator with Display (*HmIP-eTRV,-2*) - should also work with (*HmIP-eTRV-2-UK, -B, -B1, -C*)
   * Climate group (*HmIP-HeatingGroup*)
   * This includes temperature/humidity measures for climate devices of a room delivered by:
     * Wall-mounted thermostat (*HmIP-WTH, WTH-2*)
     * Brand Wall-mounted thermostat (*HmIP-BWTH, BWTH-24*)
-    * Radiator thermostat (*HmIP-eTRV,-2*) - should also work with (*HmIP-eTRV-2-UK, -B, -B1, -C*)
+    * Radiator thermostat (*HmIP-eTRV,-2,-C*) - should also work with (*HmIP-eTRV-2-UK, -B, -B1*)
     * Temperature and humidity sensor (*HmIP-STH*)
     * Temperature and humidity Sensor with display (*HmIP-STHD*)
     
@@ -123,6 +122,7 @@ authtoken:
 * homematicip_cloud.sensor
   * Cloud Access point duty-cycle (*HmIP-HAP, -B1*)
   * Wall Mounted Thermostat Pro with Display (*HmIP-WTH, WTH2*)
+  * Radiator thermostat (*HmIP-eTRV,-2, -C*) - should also work with (*HmIP-eTRV-2-UK, -B, -B1*)
   * Temperature and Humidity Sensor without display - indoor (*HmIP-STH*)
   * Temperature and Humidity Sensor with display - indoor (*HmIP-STHD*)
   * Temperature and Humidity sensor - outdoor (*HmIP-STHO, -A*)


### PR DESCRIPTION
**Description:**
Add Radiator thermostat to sensors

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23263

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
