### PR TITLE
Add HEOS play_media URL documentation

### DIFF
--- a/source/_components/heos.markdown
+++ b/source/_components/heos.markdown
@@ -49,7 +49,7 @@ A connection to a single device enables control for all devices in the HEOS acco
 
 #### {% linkable_title Url %}
 
-You can play a url through a HEOS media player using the `media_player.play_media` service.  The HEOS player must be able to reach the URL.  Example service data payload:
+You can play a URL through a HEOS media player using the `media_player.play_media` service. The HEOS player must be able to reach the URL. Example service data payload:
 
 ```json
 {
@@ -63,7 +63,7 @@ You can play a url through a HEOS media player using the `media_player.play_medi
 | ---------------------- | ----------- | ----------- |
 | `entity_id`            | `entity_id` of the player to play the URL
 | `media_content_type`   | Set to the value `url`
-| `media_content_id`     | The full URL to the stream.
+| `media_content_id`     | The full URL to the stream
 
 
 ## {% linkable_title Notes %}

--- a/source/_components/heos.markdown
+++ b/source/_components/heos.markdown
@@ -45,9 +45,9 @@ A connection to a single device enables control for all devices in the HEOS acco
 
 ## {% linkable_title Services %}
 
-### {% linkable_title `media_player.play_media` %}
+### {% linkable_title Service `media_player.play_media` %}
 
-#### {% linkable_title Url %}
+#### {% linkable_title Play Url %}
 
 You can play a URL through a HEOS media player using the `media_player.play_media` service. The HEOS player must be able to reach the URL. Example service data payload:
 

--- a/source/_components/heos.markdown
+++ b/source/_components/heos.markdown
@@ -43,6 +43,29 @@ host:
 A connection to a single device enables control for all devices in the HEOS account. If you have multiple HEOS devices, enter the host of one that is connected to the LAN via wire or has the strongest wireless signal.
 </p>
 
+## {% linkable_title Services %}
+
+### {% linkable_title `media_player.play_media` %}
+
+#### {% linkable_title Url %}
+
+You can play a url through a HEOS media player using the `media_player.play_media` service.  The HEOS player must be able to reach the URL.  Example service data payload:
+
+```json
+{
+  "entity_id": "media_player.office",
+  "media_content_type": "url",
+  "media_content_id": "http://path.to/stream.mp3"
+}
+```
+
+| Attribute              | Description
+| ---------------------- | ----------- | ----------- |
+| `entity_id`            | `entity_id` of the player to play the URL
+| `media_content_type`   | Set to the value `url`
+| `media_content_id`     | The full URL to the stream.
+
+
 ## {% linkable_title Notes %}
 
 - HEOS groups are not currently supported.


### PR DESCRIPTION
**Description:**
Update the HEOS docs to specify how to play a URL through the play_media service.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#23273

## Checklist:
- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
