### PR TITLE
 ✏️ Fix the link to Dyson website

### DIFF
--- a/source/_components/dyson.markdown
+++ b/source/_components/dyson.markdown
@@ -23,7 +23,7 @@ redirect_from:
   - /components/sensor.dyson/
 ---
 
-The `dyson` component is the main component to integrate all [Dyson](https://dyson.com) related platforms.
+The `dyson` component is the main component to integrate all [Dyson](https://www.dyson.com) related platforms.
 
 There is currently support for the following device types within Home Assistant:
 


### PR DESCRIPTION
**Description:**
I found that the current link gave an error message in the area of SSL, not exactly a nice entry when you visit a website.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
