### PR TITLE
Add HEOS debug logging instructions and general clean-up

### DIFF
--- a/source/_components/heos.markdown
+++ b/source/_components/heos.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Denon HEOS speakers"
+title: "Denon HEOS"
 description: "Instructions on how to integrate Denon HEOS into Home Assistant."
 date: 2019-03-06 22:00
 sidebar: true
@@ -13,13 +13,13 @@ ha_release: 0.92
 ha_iot_class: Local Push
 ---
 
-The HEOS component integrates [HEOS](http://heosbydenon.denon.com) capable products, such as speakers, amps, and receivers (Denon and Marantz) into Home Assistant. Features currently include:
+The HEOS integration adds support for [HEOS](http://heosbydenon.denon.com) capable products, such as speakers, amps, and receivers (Denon and Marantz) into Home Assistant. Features currently include:
 
 - Each device is represented as a media player entity
 - View the currently playing media
-- Control play mode (play, pause, stop), volume, and mute
-- Clear playlist support
-- Play previous and next tracks
+- Control play mode (play, pause, stop, next and previous), volume, mute and shuffle
+- Clear playlist
+- Select source from device physical inputs and HEOS favorites
 
 
 ## {% linkable_title Configuration %}
@@ -40,10 +40,23 @@ host:
 {% endconfiguration %}
 
 <p class='note info'>
-A connection to a single device enables control for all devices in the HEOS account. If you have multiple HEOS devices, enter the host of one that is connected to the LAN via wire or has the strongest wireless signal.
+A connection to a single device enables control for all devices on the network. If you have multiple HEOS devices, enter the host of one that is connected to the LAN via wire or has the strongest wireless signal.
 </p>
 
 ## {% linkable_title Notes %}
 
 - HEOS groups are not currently supported.
-- Receivers with multiple zones are represented as a single media player. They can be turned on, but not off by this integration.
+- Receivers with multiple zones are represented as a single media player. They will be turned on when playback is started, but cannot be turned off by the integration at this time.
+
+
+## {% linkable_title Debugging %}
+
+The HEOS component will log additional information about commands, events, and other messages when the log level is set to `debug`. Add the the relevent line below to the `configuration.yaml` to enable debug logging:
+
+```yaml
+logger:
+  default: info
+  logs:
+    homeassistant.components.heos: debug
+    pyheos: debug
+```


### PR DESCRIPTION
**Description:**
Add instructions to enable debug logging and misc clean-up of the HEOS documentation.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
