### PR TITLE
Add examples of log level settings for custom components

### DIFF
--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -34,6 +34,7 @@ logger:
   logs:
     homeassistant.components.device_tracker: critical
     homeassistant.components.camera: critical
+    custom_components.my_integration: critical
 ```
 
 To ignore all messages lower than critical and log event for specified
@@ -48,6 +49,7 @@ logger:
     homeassistant.components.rfxtrx: debug
     homeassistant.components.device_tracker: critical
     homeassistant.components.camera: critical
+    custom_components.my_integration: debug
 ```
 
 {% configuration %}
@@ -106,6 +108,7 @@ service: logger.set_level
 data:
   homeassistant.components: warning
   homeassistant.components.media_player.yamaha: debug
+  custom_components.my_integration: debug
 ```
 
 The log information are stored in the


### PR DESCRIPTION
**Description:**
Add in the examples, the syntax to define log level for custom components


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
