### PR TITLE
Use valid commands for open ports on xiaomi_aqara

### DIFF
--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -287,6 +287,6 @@ That means that Home Assistant is not getting any response from your Xiaomi gate
   - Open a serial terminal application (e.g. PuTTY) and connect to the serial port assigned to the USB-UART module (baudrate: 115200).
   - Wait until the gateway is booted up, connect the RX, TX and GND wires to the UART module (don't connect the Vcc (power) wire!).
   - You will see all the messages from the gateway.
-  - Send the command `psm-set network.open_pf 3` (the command has to end with a `CR` newline character).
-  - Check your settings executing the command `psm-get network.open_pf` to be sure it's OK.
+  - Send the command `psm-set network open_pf 3` (the command has to end with a `CR` newline character).
+  - Check your settings executing the command `psm-get network open_pf` to be sure it's OK.
   - Restart the gateway.


### PR DESCRIPTION
From specification:
`psm-get <module> <variable>`
`psm-set <module> <variable> <value>`