### PR TITLE
adding temp extension to accesscontrollist

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -106,5 +106,6 @@ acl_file /share/mosquitto/accesscontrollist
 user your-mqtt-user
 topic #
 ```
+You may need to add .txt to the end of accesscontrollist to get it to save.  Then after it is saved rename the file and remove the .txt
 
 The `/share` folder can be accessed via SMB, or on the host filesystem under `/usr/share/hassio/share`.


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
