### PR TITLE
state_topic is required in the config.

### DIFF
--- a/source/_components/mqtt_room.markdown
+++ b/source/_components/mqtt_room.markdown
@@ -40,7 +40,7 @@ name:
   type: string
 state_topic:
   description: The topic that contains all subtopics for the rooms.
-  required: false
+  required: true
   default: room_presence
   type: string
 timeout:

--- a/source/_components/mqtt_room.markdown
+++ b/source/_components/mqtt_room.markdown
@@ -41,7 +41,6 @@ name:
 state_topic:
   description: The topic that contains all subtopics for the rooms.
   required: true
-  default: room_presence
   type: string
 timeout:
   description: "The time in seconds after which a room presence state is considered old. An example: device1 is reported at scanner1 with a distance of 1. No further updates are sent from scanner1. After 5 seconds scanner2 reports device1 with a distance of 2. The old location info is discarded in favor of the new scanner2 information as the timeout has passed."


### PR DESCRIPTION
**Description:**
hass is failing to setup the component without a state_topic.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
