### PR TITLE
Fix indenting of Template component examples

### DIFF
--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -260,13 +260,13 @@ This template contains no entities that will trigger an update, so we add an `en
 {% raw %}
 ```yaml
 sensor:
-- platform: template
-  sensors:
-    nonsmoker:
-      value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
-      entity_id: sensor.date
-      friendly_name: 'Not smoking'
-      unit_of_measurement: "Days"
+  - platform: template
+    sensors:
+      nonsmoker:
+        value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
+        entity_id: sensor.date
+        friendly_name: 'Not smoking'
+        unit_of_measurement: "Days"
 ```
 {% endraw %}
 
@@ -277,13 +277,13 @@ An alternative to this is to create an interval-based automation that calls the 
 {% raw %}
 ```yaml
 sensor:
-- platform: template
-  sensors:
-    nonsmoker:
-      value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
-      entity_id: []
-      friendly_name: 'Not smoking'
-      unit_of_measurement: "Days"
+  - platform: template
+    sensors:
+      nonsmoker:
+        value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
+        entity_id: []
+        friendly_name: 'Not smoking'
+        unit_of_measurement: "Days"
 
 automation:
   - alias: 'nonsmoker_update'


### PR DESCRIPTION
**Description:**

This fixes the indenting of several examples of the Template component; they were previously un-indented and not sitting underneath the `sensor` key.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
