### PR TITLE
Add documentation for camera_view

### DIFF
--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -375,7 +375,7 @@ camera_image:
   type: string
 camera_view:
   required: false
-  description: "live" will show the live view if `stream` is enabled.  Default: auto.
+  description: '"live" will show the live view if `stream` is enabled.  Default: auto.'
   type: string
 state_image:
   required: false

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -373,6 +373,10 @@ camera_image:
   required: false
   description: A camera entity.
   type: string
+camera_view:
+  required: false
+  description: "live" will show the live view if `stream` is enabled.  Default: auto.
+  type: string
 state_image:
   required: false
   description: '[State-based images](#how-to-use-state_image)'

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -375,7 +375,8 @@ camera_image:
   type: string
 camera_view:
   required: false
-  description: '"live" will show the live view if `stream` is enabled.  Default: auto.'
+  description: '"live" will show the live view if `stream` is enabled.'
+  default: auto
   type: string
 state_image:
   required: false

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -30,6 +30,10 @@ camera_image:
   required: false
   description: "Camera `entity_id` to use. (not required if `entity` is already a camera-entity)."
   type: string
+camera_view:
+  required: false
+  description: "live" will show the live view if `stream` is enabled.  Default: auto.
+  type: string
 image:
   required: false
   description: URL of an image.

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -32,7 +32,7 @@ camera_image:
   type: string
 camera_view:
   required: false
-  description: "live" will show the live view if `stream` is enabled.  Default: auto.
+  description: '"live" will show the live view if `stream` is enabled.  Default: auto.'
   type: string
 image:
   required: false

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -32,7 +32,8 @@ camera_image:
   type: string
 camera_view:
   required: false
-  description: '"live" will show the live view if `stream` is enabled.  Default: auto.'
+  description: '"live" will show the live view if `stream` is enabled.'
+  default: auto
   type: string
 image:
   required: false

--- a/source/_lovelace/picture-glance.markdown
+++ b/source/_lovelace/picture-glance.markdown
@@ -38,6 +38,10 @@ camera_image:
   required: false
   description: Camera entity as Background image.
   type: string
+camera_view:
+  required: false
+  description: "live" will show the live view if `stream` is enabled.  Default: auto.
+  type: string
 state_image:
   required: false
   description: Background image based on entity state.

--- a/source/_lovelace/picture-glance.markdown
+++ b/source/_lovelace/picture-glance.markdown
@@ -40,7 +40,7 @@ camera_image:
   type: string
 camera_view:
   required: false
-  description: "live" will show the live view if `stream` is enabled.  Default: auto.
+  description: '"live" will show the live view if `stream` is enabled.  Default: auto.'
   type: string
 state_image:
   required: false

--- a/source/_lovelace/picture-glance.markdown
+++ b/source/_lovelace/picture-glance.markdown
@@ -40,7 +40,8 @@ camera_image:
   type: string
 camera_view:
   required: false
-  description: '"live" will show the live view if `stream` is enabled.  Default: auto.'
+  description: '"live" will show the live view if `stream` is enabled.'
+  default: auto
   type: string
 state_image:
   required: false


### PR DESCRIPTION
**Description:**

Adds documentation to show live camera view in Lovelace.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant-polymer/#3086

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
