### PR TITLE
Add HomeKit low battery threshold documentation

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -38,6 +38,7 @@ homekit:
       code: 1234
     binary_sensor.living_room_motion:
       linked_battery_sensor: sensor.living_room_motion_battery
+      low_battery_threshold: 31
     light.kitchen_table:
       name: Kitchen Table Light
     lock.front_door:
@@ -121,6 +122,10 @@ homekit:
                 description: The `entity_id` of a `sensor` entity to use as the battery of the accessory. HomeKit will cache an accessory's feature set on the first run so a device must be removed and then re-added for any change to take effect.
                 required: false
                 type: string
+              low_battery_threshold:
+                description: Minimum battery level before the accessory starts reporting a low battery. Default is 20.
+                required: false
+                type: integer
               code:
                 description: Code to `arm / disarm` an alarm or `lock / unlock` a lock. Only applicable for `alarm_control_panel` or `lock` entities.
                 required: false

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -123,9 +123,10 @@ homekit:
                 required: false
                 type: string
               low_battery_threshold:
-                description: Minimum battery level before the accessory starts reporting a low battery. Default is 20.
+                description: Minimum battery level before the accessory starts reporting a low battery.
                 required: false
                 type: integer
+                default: 20
               code:
                 description: Code to `arm / disarm` an alarm or `lock / unlock` a lock. Only applicable for `alarm_control_panel` or `lock` entities.
                 required: false


### PR DESCRIPTION
**Description:**

This adds the ability to define the minimum value for the `low_battery` status at a per device level. Some of my Z-Wave devices (siren) behave weirdly at higher levels than 20 or they only report their battery level in increments of 10, so I would like to be able to have the accessory show a low battery when the level is 20 by setting `low_battery_threshold: 21`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23363

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html