### PR TITLE
add ADS cover platform

### DIFF
--- a/source/_components/ads.markdown
+++ b/source/_components/ads.markdown
@@ -83,7 +83,7 @@ Service parameters:
 
 The `ads` binary sensor platform can be used to monitor a boolean value on your ADS device.
 
-To use your ADS device, you first have to set up your [ADS hub](/components/ads/) and then add the following to your `configuration.yaml`
+To use your ADS device, you first have to set up your [ADS hub](#configuration) and then add the following to your `configuration.yaml`
 file:
 
 ```yaml
@@ -112,7 +112,7 @@ device_class:
 
 The `ads` light platform allows you to control your connecte ADS lights.
 
-To use your ADS device, you first have to set up your [ADS hub](/components/ads/) and then add the following to your `configuration.yaml`
+To use your ADS device, you first have to set up your [ADS hub](#configuration) and then add the following to your `configuration.yaml`
 file:
 
 ```yaml
@@ -142,7 +142,7 @@ name:
 
 The `ads` sensor platform allows reading the value of a numeric variable on your ADS device. The variable can be of type *INT*, *UINT*,  *BYTE*, *DINT* or *UDINT*.
 
-To use your ADS device, you first have to set up your [ADS hub](/components/ads/) and then add the following to your `configuration.yaml`
+To use your ADS device, you first have to set up your [ADS hub](#configuration) and then add the following to your `configuration.yaml`
 file:
 
 ```yaml
@@ -181,7 +181,7 @@ The *factor* can be used to implement fixed decimals. E.g., set *factor* to 100 
 
 The `ads` switch platform accesses a boolean variable on the connected ADS device. The variable is identified by its name.
 
-To use your ADS device, you first have to set up your [ADS hub](/components/ads/) and then add the following to your `configuration.yaml`
+To use your ADS device, you first have to set up your [ADS hub](#configuration) and then add the following to your `configuration.yaml`
 file:
 
 ```yaml
@@ -206,7 +206,7 @@ name:
 
 The `ads` cover platform allows you to control your connected ADS covers.
 
-To use your ADS device, you first have to set up your [ADS hub](/components/ads/) and then add the following to your `configuration.yaml`
+To use your ADS device, you first have to set up your [ADS hub](#configuration) and then add the following to your `configuration.yaml`
 file:
 
 ```yaml

--- a/source/_components/ads.markdown
+++ b/source/_components/ads.markdown
@@ -22,7 +22,6 @@ redirect_from:
   - /components/light.ads/
   - /components/sensor.ads/
   - /components/switch.ads/
-  - /components/cover.ads/
 ---
 
 The ADS (automation device specification) describes a device-independent and fieldbus independent interface for communication between [Beckhoff](https://www.beckhoff.com/) automation devices running [TwinCAT](http://www.beckhoff.hu/english.asp?twincat/default.htm) and other devices implementing this interface.

--- a/source/_components/ads.markdown
+++ b/source/_components/ads.markdown
@@ -251,6 +251,6 @@ name:
   type: string
 device_class:
   required: false
-  description: Sets the class of the device, changing the device state and icon that is displayed on the UI
+  description: Sets the class of the device, changing the device state and icon that is displayed on the UI (awning, blind, curtain, damper, door, garage, shade, shutter, window)
   type: device_class
 {% endconfiguration %}

--- a/source/_components/ads.markdown
+++ b/source/_components/ads.markdown
@@ -14,6 +14,7 @@ ha_category:
   - Light
   - Sensor
   - Switch
+  - Cover
 ha_release: "0.60"
 ha_iot_class: Local Push
 redirect_from:
@@ -21,6 +22,7 @@ redirect_from:
   - /components/light.ads/
   - /components/sensor.ads/
   - /components/switch.ads/
+  - /components/cover.ads/
 ---
 
 The ADS (automation device specification) describes a device-independent and fieldbus independent interface for communication between [Beckhoff](https://www.beckhoff.com/) automation devices running [TwinCAT](http://www.beckhoff.hu/english.asp?twincat/default.htm) and other devices implementing this interface.
@@ -31,6 +33,7 @@ There is currently support for the following device types within Home Assistant:
 - [Light](#light)
 - [Sensor](#sensor)
 - [Switch](#switch)
+- [Cover](#cover)
 
 ## {% linkable_title Configuration %}
 
@@ -128,7 +131,7 @@ adsvar:
 adsvar_brightness:
   required: false
   description: The name of the variable that controls the brightness, use an unsigned integer on the PLC side
-  type: integer
+  type: string
 name:
   required: false
   description: An identifier for the Light in the frontend
@@ -197,4 +200,57 @@ name:
   required: false
   description: An identifier for the switch in the frontend.
   type: string
+{% endconfiguration %}
+
+## {% linkable_title Cover %}
+
+The `ads` cover platform allows you to control your connected ADS covers.
+
+To use your ADS device, you first have to set up your [ADS hub](/components/ads/) and then add the following to your `configuration.yaml`
+file:
+
+```yaml
+# Example configuration.yaml entry
+cover:
+  - platform: ads
+    name: Curtain master bed room
+    adsvar_open: covers.master_bed_room_open
+    adsvar_close: covers.master_bed_room_close
+    adsvar_stop: covers.master_bed_room_stop
+    device_class: curtain
+```
+
+{% configuration %}
+adsvar:
+  required: true
+  description: The name of the boolean variable that returns the current status of the cover (`True` = closed)
+  type: string
+adsvar_position:
+  required: false
+  description: The name of the variable that returns the current cover position, use a byte variable on the PLC side
+  type: string
+adsvar_set_position:
+  required: false
+  description: The name of the variable that sets the new cover position, use a byte variable on the PLC side
+  type: string
+adsvar_open:
+  required: false
+  description: The name of the boolean variable that triggers the cover to open
+  type: string
+adsvar_close:
+  required: false
+  description: The name of the boolean variable that triggers the cover to close
+  type: string
+adsvar_stop:
+  required: false
+  description: The name of the boolean variable that triggers the cover to stop
+  type: string
+name:
+  required: false
+  description: An identifier for the Cover in the frontend
+  type: string
+device_class:
+  required: false
+  description: Sets the class of the device, changing the device state and icon that is displayed on the UI
+  type: device_class
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Adds new cover platform for ADS integration

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23377

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
