### PR TITLE
Fix ha_category and link for LCN binary_sensor

### DIFF
--- a/source/_components/lcn.markdown
+++ b/source/_components/lcn.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: lcn.png
 ha_category:
   - Hub
+  - Binary Sensor
   - Cover
   - Light
   - Sensor
@@ -29,7 +30,7 @@ With this setup sending and receiving commands to and from LCN modules is possib
 
 There is currently support for the following device types within Home Assistant:
 
-- [Binary Sensor](#binary_sensor)
+- [Binary Sensor](#binary-sensor)
 - [Cover](#cover)
 - [Light](#light)
 - [Sensor](#sensor)


### PR DESCRIPTION
**Description:**

 The binary_sensor component for LCN does not show up in the components overview.

- Fixed missing ha_category entry.
- Fixed link in LCN component docs.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
