### PR TITLE
Make obvious that Python API is no longer available

### DIFF
--- a/source/_docs/ecosystem/notebooks/api.markdown
+++ b/source/_docs/ecosystem/notebooks/api.markdown
@@ -10,4 +10,4 @@ footer: true
 redirect_from: /ecosystem/notebooks/api/
 ---
 
-You can interact with Home Assistant live from Jupyter notebooks by using the Home Assistant [Python API](/developers/python_api/). [See this example notebook](http://nbviewer.jupyter.org/github/home-assistant/home-assistant-notebooks/blob/master/home-assistant-python-api.ipynb).
+Python API is deprecated.


### PR DESCRIPTION


**Description:**
This pages is the first result when googling "homeassistant python API". Stating clearly that the API is not available anymore will prevent others from troubleshooting an outdated script.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
