### PR TITLE
Update aftership.markdown

### DIFF
--- a/source/_components/aftership.markdown
+++ b/source/_components/aftership.markdown
@@ -49,6 +49,25 @@ api_key:
   type: string
 {% endconfiguration %}
 
+## {% linkable_title Service `add_tracking` %}
+
+ You can use the service `aftership.add_tracking` to add trackings to Aftership.
+
+| Service data attribute | Required | Description |
+| ---------------------- | -------- | ----------- |
+| `tracking_number` | `True` | Tracking number
+| `slug` | `False` | Carrier e.g. `fedex`
+| `title` | `False` | Friendly name of package
+
+ ## {% linkable_title Service `remove_tracking` %}
+
+ You can use the service `aftership.remove_tracking` to remove trackings from Aftership.
+
+| Service data attribute | Required | Description |
+| ---------------------- | -------- | ----------- |
+| `tracking_number` | `True` | Tracking number
+| `slug` | `True` | Carrier e.g. `fedex`
+
 <p class='note info'>
 This component retrieves data from AfterShip public REST API, but the component is not affiliated with AfterShip.
 </p>


### PR DESCRIPTION
Replace https://github.com/home-assistant/home-assistant.io/pull/9001 as it is now current

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
