### PR TITLE
Update mqtt configuration example to use external broker

### DIFF
--- a/source/_docs/mqtt.markdown
+++ b/source/_docs/mqtt.markdown
@@ -11,14 +11,15 @@ footer: true
 
 MQTT (aka MQ Telemetry Transport) is a machine-to-machine or "Internet of Things" connectivity protocol on top of TCP/IP. It allows extremely lightweight publish/subscribe messaging transport.
 
-To integrate MQTT into Home Assistant, add the following section to your `configuration.yaml` file. Keep in mind that the minimal setup will run with [an embedded MQTT broker](/docs/mqtt/broker#embedded-broker):
+To integrate MQTT into Home Assistant, add the following section to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 mqtt:
+  broker: 192.168.1.100
 ```
 
-For other setup methods, please refer to the [MQTT broker](/docs/mqtt/broker) documentation.
+For detailed setup instructions, please refer to the [MQTT broker](/docs/mqtt/broker) documentation.
 
 ## {% linkable_title Additional features %}
 

--- a/source/_docs/mqtt.markdown
+++ b/source/_docs/mqtt.markdown
@@ -16,7 +16,7 @@ To integrate MQTT into Home Assistant, add the following section to your `config
 ```yaml
 # Example configuration.yaml entry
 mqtt:
-  broker: 192.168.1.100
+  broker: IP_ADDRESS
 ```
 
 For detailed setup instructions, please refer to the [MQTT broker](/docs/mqtt/broker) documentation.


### PR DESCRIPTION
**Description:**
The internal MQTT broker has been marked as deprecated. Update the documention to reflect this.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#22753

## Checklist:

- [x] Branch: Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
