### PR TITLE
Corrected incorrect naming

### DIFF
--- a/source/_components/epsonworkforce.markdown
+++ b/source/_components/epsonworkforce.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Epson Printer"
+title: "Epson Workforce"
 description: "Instructions on how to integrate Epson Workforce Printer into Home Assistant."
 date: 2019-04-09 16:00
 sidebar: true
@@ -13,15 +13,15 @@ ha_release: 0.92
 ha_iot_class: Local Polling
 ---
 
-The `epson printer` platform allows you to monitor the ink levels of a Epson Workforce printer from Home
+The `epson workforce` platform allows you to monitor the ink levels of a Epson Workforce printer from Home
 Assistant.
 
-To add Epson Printer to your installation, add the following to your `configuration.yaml` file:
+To add Epson Workforce to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 sensor:
-   - platform: epsonprinter
+   - platform: epsonworkforce
      host: IP_ADDRESS
      monitored_conditions:
      - black
@@ -33,7 +33,7 @@ sensor:
 
 {% configuration %}
 host:
-  description: The host name or address of the Epson printer
+  description: The host name or address of the Epson workforce printer
   required: true
   type: string
 monitored_conditions:
@@ -62,4 +62,4 @@ Tested devices:
 - Epson WF3540
 
 To make this module work you need to connect your printer to your LAN.
-The best is to navigate to the IP of the printer to check.
+The best is to navigate to the IP of the printer to check if it shows a status page.


### PR DESCRIPTION
**Description:**
In my attempt to recreate the PR yesterday to get the documentation up to date (For reasons I still not understand the original PR was closed.) I did not check if the version was correct. As I had to rename the component I also updated the configuration information. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23144

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
