### PR TITLE
Removed old configuration example

### DIFF
--- a/source/_components/hue.markdown
+++ b/source/_components/hue.markdown
@@ -70,19 +70,6 @@ hue:
       allow_hue_groups: true
 ```
 
-### {% linkable_title Migrating from older configuration %}
-
-In previous versions of the `hue` component the configuration looked different:
-
-```yaml
-# Example configuration.yaml entry
-light:
-  - platform: hue
-    host: DEVICE_IP_ADDRESS
-```
-
-You will need to convert each bridge into an entry in the new configuration style. See above for an example.
-
 ### {% linkable_title Multiple Hue bridges %}
 
 Multiple Hue bridges work transparently with discovery, you don't have to do anything. If you prefer to configure them manually and use multiple Hue bridges then it's needed that you provide a configuration file for every bridge. The bridges can't share a single configuration file.


### PR DESCRIPTION
**Description:**
The old configuration example because it's just adding to confusion for people that are adding this component for the first time. Moving forward I don't think this section is necessary anymore.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
