### PR TITLE
Added Section to show which lovelace card to use

### DIFF
--- a/source/_components/stream.markdown
+++ b/source/_components/stream.markdown
@@ -58,7 +58,7 @@ action:
 ## {% linkable_title Streaming in Lovelace %}
 
 As of Homeassistant version 0.92 you can now live-stream a camera feed directly in lovelace.
-To do this add a [picture-entity](/lovelace/picture-entity/) card with your stream-ready camera entity to one of your lovelace views.
+To do this add either [picture-entity](/lovelace/picture-entity/), [picture-glance](/lovelace/picture-glance/) or [picture-elements](/lovelace/picture-elements/), set `camera_image` to a stream-ready camera entity and set `camera_view` to `live` in one of your lovelace views.
 
 ## {% linkable_title Troubleshooting %}
 

--- a/source/_components/stream.markdown
+++ b/source/_components/stream.markdown
@@ -55,6 +55,11 @@ action:
     filename: '/tmp/my_stream.mp4'
 ```
 
+## {% linkable_title Streaming in Lovelace %}
+
+As of Homeassistant version 0.92 you can now live-stream a camera feed directly in lovelace.
+To do this add a [picture-entity](/lovelace/picture-entity/) card with your stream-ready camera entity to one of your lovelace views.
+
 ## {% linkable_title Troubleshooting %}
 
 Some users on manual installs may see the following error in their logs after restarting:


### PR DESCRIPTION
**Description:**
Added a section to indicate which lovelace card to use in order to live-stream a camera feed. When looking for the correct card I would have never pinned "picture"-entity to be the correct card for video streaming.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
