### PR TITLE
Update mysensors validation text

### DIFF
--- a/source/_components/mysensors.markdown
+++ b/source/_components/mysensors.markdown
@@ -246,7 +246,13 @@ In MySensors version 2.2 the serial API changed from using `I_HEARTBEAT_RESPONSE
 
 Messages sent to or from Home Assistant from or to a MySensors device will be validated according to the MySensors [serial API](https://www.mysensors.org/download/serial_api_20). If a message doesn't pass validation, it will be dropped and not be passed forward either to or from Home Assistant. Make sure you follow the serial API for your version of MySensors when writing your Arduino sketch.
 
-If you experience dropped messages or that a device is not added to Home Assistant, please turn on debug logging for the `mysensors` component and the `mysensors` package.
+The log should warn you of messages that failed validation or if a child value is missing that is required for a certain child type. Home Assistant will log failed validations of child values at warning level if e.g. one required value type for a platform has been received, but other required value types are missing.
+
+Message validation was introduced in version 0.52 of Home Assistant.
+
+### {% linkable_title Debug logging %}
+
+If you experience dropped messages or that a device is not added to Home Assistant, please turn on debug logging for the `mysensors` component and the `mysensors` package. This will help you see what is going on. Make sure you use these logging settings to collect a log sample if you report an issue about the `mysensors` integration in our github issue tracker.
 ```yaml
 logger:
   default: info
@@ -254,9 +260,6 @@ logger:
     homeassistant.components.mysensors: debug
     mysensors: debug
 ```
-The log should inform you of messages that failed validation or if a child value is missing that is required for a certain child type. Note that the log will log all possible combinations of platforms for a child type that failed validation. It is normal to see some platforms fail validation if the child type supports multiple platforms and your sketch doesn't send all corresponding value types. e.g., the `S_BARO` child type supports both `V_PRESSURE` and `V_FORECAST` value types. If you only send a `V_PRESSURE` value, an `S_BARO` entity with `V_PRESSURE` value will be set up for the sensor platform. However, the log will inform of a sensor platform that failed validation due to missing `V_FORECAST` value type for the `S_BARO` child. Home Assistant will log failed validations of child values at warning level if one required value type for a platform has been received, but other required value types are missing. Most failed validations are logged at debug level.
-
-Message validation was introduced in version 0.52 of Home Assistant.
 
 
 Visit the [library API][MySensors library api] of MySensors for more information.


### PR DESCRIPTION
**Description:**
The mysensors child validation in Home Assistant has changed with the linked parent PR. Update the text to match the changes.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):**
https://github.com/home-assistant/home-assistant/pull/23482

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
