### PR TITLE
Update raspberry-pi.markdown

### DIFF
--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -45,7 +45,7 @@ $ sudo apt-get upgrade -y
 Install the dependencies.
 
 ```bash
-$ sudo apt-get install python3 python3-venv python3-pip libffi-dev
+$ sudo apt-get install python3 python3-venv python3-pip libffi-dev libssl-dev
 ```
 
 Add an account for Home Assistant called `homeassistant`.


### PR DESCRIPTION
Added additional dependency libssl-dev to avoid "fatal error: openssl/opensslv.h: No such file or directory” during pip3 install homeassistant step.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
