### PR TITLE
Picture elements tooltip

### DIFF
--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -257,7 +257,7 @@ icon:
   type: string
 title:
   required: false
-  description: Icon tooltip. Set to null to remove.
+  description: Icon tooltip. Set to null to hide.
   type: string
 entity:
   required: false
@@ -333,7 +333,7 @@ entity:
   type: string
 title:
   required: false
-  description: Image tooltip. Set to null to remove.
+  description: Image tooltip. Set to null to hide.
   type: string
 tap_action:
   required: false

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -56,6 +56,10 @@ style:
   description: Position and style the element using CSS.
   type: object
   default: "position: absolute, transform: translate(-50%, -50%)"
+title:
+  required: false
+  description: State badge tooltip. Set to null to hide.
+  type: string
 {% endconfiguration %}
 
 ### {% linkable_title Icon representing an entity state %}
@@ -72,6 +76,10 @@ entity:
 icon:
   required: false
   description: Overwrites icon.
+  type: string
+title:
+  required: false
+  description: Icon tooltip. Set to null to hide.
   type: string
 tap_action:
   required: false
@@ -148,6 +156,10 @@ prefix:
 suffix:
   required: false
   description: Text after entity state.
+  type: string
+title:
+  required: false
+  description: Label tooltip. Set to null to hide.
   type: string
 tap_action:
   required: false
@@ -245,7 +257,7 @@ icon:
   type: string
 title:
   required: false
-  description: Icon tooltip.
+  description: Icon tooltip. Set to null to remove.
   type: string
 entity:
   required: false
@@ -318,6 +330,10 @@ type:
 entity:
   required: false
   description: Entity to use for state_image and state_filter and also target for actions.
+  type: string
+title:
+  required: false
+  description: Image tooltip. Set to null to remove.
   type: string
 tap_action:
   required: false


### PR DESCRIPTION
Tooltip in picture elements.
This is partially a fix (some element supported a tooltip and it didn't say so in the docs)
and also an expansion since it's now possible to suppress the tooltip.

This depends on 2 PRs: one merged and the second one not yet. 
I'm not sure on the right branch though.

https://github.com/home-assistant/home-assistant-polymer/pull/3111
https://github.com/home-assistant/home-assistant-polymer/pull/3137