### PR TITLE
🌱 Add validate to AWS component (Cherry-pick)

### DIFF
--- a/source/_components/aws.markdown
+++ b/source/_components/aws.markdown
@@ -59,6 +59,11 @@ profile_name:
   description: A credentials profile name.
   required: false
   type: string
+validate:
+  description: Whether validate credential before use. Validate credential needs `IAM.GetUser` permission.
+  required: false
+  default: true
+  type: boolean
 {% endconfiguration %}
 
 ### {% linkable_title Configuration for notify %}


### PR DESCRIPTION
**Description:**
This change was lagging behind and should have been in the 0.92 release.

Original PR: #9196

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
