### PR TITLE
Adding accuracy filter feature

### DIFF
--- a/source/_components/traccar.markdown
+++ b/source/_components/traccar.markdown
@@ -63,10 +63,14 @@ verify_ssl:
   type: boolean
   default: true
 max_accuracy:
-  description: Filter positions with higher accuracy than specified. Positions are not filtered if a custom _monitored_conditions_ is included, like an alarm.
+  description: Filter positions with higher accuracy than specified.
   required: false
   type: integer
   default: 0
+skip_accuracy_filter_on:
+  description: Skip filter positon by "max_accuracy filter" if any of specified attributes are pressent on the traccar message.
+  required: false
+  type: list
 monitored_conditions:
   description: Additional traccar computed attributes or device-related attributes to include in the scan.
   required: false

--- a/source/_components/traccar.markdown
+++ b/source/_components/traccar.markdown
@@ -62,6 +62,11 @@ verify_ssl:
   required: false
   type: boolean
   default: true
+max_accuracy:
+  description: Filter positions with higher accuracy than specified. Positions are not filtered if a custom _monitored_conditions_ is included, like an alarm.
+  required: false
+  type: integer
+  default: 0
 monitored_conditions:
   description: Additional traccar computed attributes or device-related attributes to include in the scan.
   required: false


### PR DESCRIPTION
**Description:** New funcionality for next verions who exclude positions readed from traccar if accuracy is higher than _max_accuracy_ value in configuration. Also include a second configuration option to skip this filter if any of the listed attibutes are receved from traccar position


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24277

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
