### PR TITLE
Fixing typos in deconz documentation

### DIFF
--- a/source/_components/deconz.markdown
+++ b/source/_components/deconz.markdown
@@ -75,7 +75,7 @@ logger:
 
 ## {% linkable_title Device services %}
 
-Available services: `configure` and `deconz.refresh_devices`.
+Available services: `configure` and `deconz.device_refresh`.
 
 ### {% linkable_title Service `deconz.configure` %}
 
@@ -97,7 +97,7 @@ Either `entity` or `field` must be provided. If both are present, `field` will b
 
 { "field": "/config", "data": {"permitjoin": 60} }
 
-#### {% linkable_title Service `deconz.refresh_devices` %}
+#### {% linkable_title Service `deconz.device_refresh` %}
 
 Refresh with devices added to deCONZ after Home Assistants latest restart.
 


### PR DESCRIPTION
The service to call to refresh devices added to deConz after latest start of Home Assistant is `deconz.device_refresh` (not `deconz.refresh_devices`), in latest current version (0.92.1).

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
