### PR TITLE
Replaced "nth-of-type()" tag by "index" variable

### DIFF
--- a/source/_components/scrape.markdown
+++ b/source/_components/scrape.markdown
@@ -118,7 +118,8 @@ sensor:
   - platform: scrape
     resource: http://www.bfs.de/DE/themen/opt/uv/uv-index/prognose/prognose_node.html
     name: Coast Ostsee
-    select: 'p:nth-of-type(19)'
+    select: 'p'
+    index: 19
     unit_of_measurement: 'UV Index'
 ```
 
@@ -145,7 +146,8 @@ sensor:
   - platform: scrape
     resource: https://hasspodcast.io/feed/podcast
     name: Home Assistant Podcast
-    select: 'enclosure:nth-of-type(1)'
+    select: 'enclosure'
+    index: 1
     attribute: url
 ```
 


### PR DESCRIPTION
"nth-of-type()" deprecated and replaced by index sensor variable, since HA 0.86 (approx.).

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
