### PR TITLE
fix media_player playack action name

### DIFF
--- a/source/_components/media_player.markdown
+++ b/source/_components/media_player.markdown
@@ -42,7 +42,7 @@ Available services: `turn_on`, `turn_off`, `toggle`, `volume_up`, `volume_down`,
 | `entity_id`            |      yes | Target a specific media player. Defaults to all.       |
 | `seek_position`        |       no | Position to seek to. The format is platform dependent. |
 
-#### {% linkable_title Service `media_player.media_play` %}
+#### {% linkable_title Service `media_player.play_media` %}
 
 | Service data attribute | Optional | Description                                                                                                                                                            |
 | -----------------------| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Action that accepts media content parameters is `play_media` not `media_play`

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
