### PR TITLE
Indicate field to change in accesscontrollist

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -103,7 +103,7 @@ acl_file /share/mosquitto/accesscontrollist
 
 3. Create `/share/mosquitto/accesscontrollist` with the contents:
 ```text
-user your-mqtt-user
+user <your-mqtt-user>
 topic #
 ```
 

--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -103,7 +103,7 @@ acl_file /share/mosquitto/accesscontrollist
 
 3. Create `/share/mosquitto/accesscontrollist` with the contents:
 ```text
-user <your-mqtt-user>
+user [YOUR_MQTT_USER]
 topic #
 ```
 


### PR DESCRIPTION
Putting alligator brackets around "your-mqtt-user" will help indicate to users to enter their own user name.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
