### PR TITLE
device_tracker zone state is case sensitive

### DIFF
--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -114,7 +114,7 @@ If you want to track whether either your GPS based tracker or your local network
 
 ## {% linkable_title Device states %}
 
-The state of your tracked device will be `'home'` if it is in the [home zone](/components/zone#home-zone), detected by your network or Bluetooth based presence detection. If you're using a presence detection method that includes coordinates then when it's in a zone the state will be the name of the zone (in lower case). When a device isn't at home and isn't in any zone, the state will be `'not_home'`.
+The state of your tracked device will be `'home'` if it is in the [home zone](/components/zone#home-zone), detected by your network or Bluetooth based presence detection. If you're using a presence detection method that includes coordinates then when it's in a zone the state will be the name of the zone (case sensitive). When a device isn't at home and isn't in any zone, the state will be `'not_home'`.
 
 ## {% linkable_title `device_tracker.see` service %}
 


### PR DESCRIPTION
**Description:**
The state of the device_tracker component **does keep case information of the zone** despite the docs explicitly stating that it is lower case.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** Not applicable

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
