### PR TITLE
Fix syntax error in template documentation.

### DIFF
--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -245,7 +245,7 @@ sensor:
             Power Consumption
           {% else %}
             Power Production
-          {% end %}
+          {% endif %}
         value_template: "{{ states('sensor.power_consumption') }}"
         unit_of_measurement: 'kW'
 ```


### PR DESCRIPTION
**Description:** Documentation contained invalid syntax, for which this is a small fix.

## Checklist:

- [X] Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
