### PR TITLE
Add an easy link to claim the Plex Token

### DIFF
--- a/source/_components/plex.markdown
+++ b/source/_components/plex.markdown
@@ -37,7 +37,7 @@ If your Plex server has local authentication enabled or multiple users defined, 
   <img src='{{site_root}}/images/screenshots/plex-configure.png' />
 </p>
 
-If you don't know your token, see [Finding your account token / X-Plex-Token](https://support.plex.tv/hc/en-us/articles/204059436).
+To authorize your device, you'll first need to [click here to claim a token](https://plex.tv/claim).
 
 If your server enforces SSL connections, write "`on`" or "`true`" in the _"Use SSL"_ field. If it does not have a valid SSL certificate available but you still want to use it, write "`on`" or "`true`" in the _"Do not verify SSL"_ field as well.
 


### PR DESCRIPTION
Plex has since added a link for a page to claim the token without needing to dig into the HTTP headers.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
