### PR TITLE
Fix Markdown table in WAQI component

### DIFF
--- a/source/_components/waqi.markdown
+++ b/source/_components/waqi.markdown
@@ -48,8 +48,6 @@ stations:
 The value reported is an overall AQ index for the location. The values of the index can be interpreted as following:
 
 AQI | Status | Description
-redirect_from:
- - /components/sensor.waqi/
 ------- | :----------------: | ----------
 0 - 50  | **Good** | Air quality is considered satisfactory, and air pollution poses little or no risk
 51 - 100  | **Moderate** | Air quality is acceptable; however, for some pollutants there may be a moderate health concern for a very small number of people who are unusually sensitive to air pollution


### PR DESCRIPTION
**Description:**

The table at the end of the page was broken. Correct me if I'm wrong, but that `redirect_from` part was not meant to be placed there.

## Checklist

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
