### PR TITLE
Update yaml-mode.markdown (add migrating UI)

### DIFF
--- a/source/lovelace/yaml-mode.markdown
+++ b/source/lovelace/yaml-mode.markdown
@@ -100,5 +100,10 @@ views:
         content: >
           Welcome to your **Lovelace UI**.
 ```
+Your previously customized Lovelace UI won't be modifiable anymore and wont follow after you start writing code in the `<config>/ui-lovelace.yaml` file, but you can easily import it if you wish.
+  - Go in the `Overview` tab
+  - Go in the three dots menu (top-right) and click on `Configure UI`
+  - Go in the three dots menu again and click on `Raw config editor`
+  - There you see the config for your actual Lovelace UI, you can copy that in the `<config>/ui-lovelace.yaml` file.
 
 Navigate to `<YOUR HASS URL>/lovelace`. When you make changes to `ui-lovelace.yaml`, you don't have to restart Home Assistant or refresh the page. Just hit the refresh button in the menu at the top of the UI.

--- a/source/lovelace/yaml-mode.markdown
+++ b/source/lovelace/yaml-mode.markdown
@@ -100,10 +100,12 @@ views:
         content: >
           Welcome to your **Lovelace UI**.
 ```
-Your previously customized Lovelace UI won't be modifiable anymore and wont follow after you start writing code in the `<config>/ui-lovelace.yaml` file, but you can easily import it if you wish.
-  - Go in the `Overview` tab
-  - Go in the three dots menu (top-right) and click on `Configure UI`
-  - Go in the three dots menu again and click on `Raw config editor`
-  - There you see the config for your actual Lovelace UI, you can copy that in the `<config>/ui-lovelace.yaml` file.
+
+Your previously customized Lovelace UI won't be modifiable anymore and won't follow after you start writing code in the `<config>/ui-lovelace.yaml` file, but you can easily import it if you wish.
+
+  - Go in the `Overview` tab.
+  - Go in the three dots menu (top-right) and click on `Configure UI`.
+  - Go in the three dots menu again and click on `Raw config editor`.
+  - There you see the config for your actual Lovelace UI, you can copy that into the `<config>/ui-lovelace.yaml` file.
 
 Navigate to `<YOUR HASS URL>/lovelace`. When you make changes to `ui-lovelace.yaml`, you don't have to restart Home Assistant or refresh the page. Just hit the refresh button in the menu at the top of the UI.


### PR DESCRIPTION

**Description:**

Update yaml-mode.markdown. Add instruction to migrate the actual Lovelace UI

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [current] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
