### PR TITLE
Minor code formatting fixes in Owntracks document

### DIFF
--- a/source/_components/owntracks.markdown
+++ b/source/_components/owntracks.markdown
@@ -44,12 +44,12 @@ In the OwnTracks app, open sidebar and click on preferences, then on connection.
  - Mode: Private HTTP
  - Host: `<url given to you when setting up the integration above>`
  - Identification:
-   - Username:<Username>
+   - Username: `<Username>`
    - Password: Can be left blank.
-   - Device ID: `<Device name>
-   - Tracker ID: <xx> Two character tracker ID. (can be left blank)
+   - Device ID: `<Device name>`
+   - Tracker ID: `<xx>` Two character tracker ID. (can be left blank)
 
-Your tracker device will be known in home assistant as <Username>_<Device name>. If you entered a Tracker ID the tid attribute will  be set to that ID.
+Your tracker device will be known in home assistant as `<Username>_<Device name>`. If you entered a Tracker ID the tid attribute will  be set to that ID.
 
 ### {% linkable_title Configuring the app - iOS %}
 


### PR DESCRIPTION
**Description:**

This fixes a bug with the code formatting in a few places of the owntracks document. Several times, example values are in the document using the format \<text\>. I believe that markdown is treating these as HTML tags, when really they are not. As a result, some of the text inside of these tags are not displayed.

This problem can be seen here: https://www.home-assistant.io/components/owntracks/#configuring-the-app---android

Several of these issues have been fixed by using markdown code formatting around the example values, which is consistent with the rest of the document.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
