### PR TITLE
Document HEOS sign-in/out services

### DIFF
--- a/source/_components/heos.markdown
+++ b/source/_components/heos.markdown
@@ -21,7 +21,6 @@ The HEOS integration adds support for [HEOS](http://heosbydenon.denon.com) capab
 - Clear playlist
 - Select source from device physical inputs and HEOS favorites
 
-
 ## {% linkable_title Configuration %}
 
 HEOS devices are discovered and setup automatically when the [discovery](/components/discovery) component is enabled. Alternatively, the component can be setup through the frontend control panel integrations page or manually by adding the following to your `configuration.yaml` file:
@@ -63,7 +62,7 @@ Use the sign-in service to sign the connected controller into a HEOS account so 
 
 ### {% linkable_title Service `heos.sign_out` %}
 
-Use the sign-out service to sign the connected controller out of a HEOS account. An error message is logged if sign-out is unsuccessful.  There are no parameters to this service.
+Use the sign-out service to sign the connected controller out of a HEOS account. An error message is logged if sign-out is unsuccessful. There are no parameters to this service.
 
 ### {% linkable_title Service `media_player.play_media` %}
 
@@ -139,12 +138,10 @@ You can play a URL through a HEOS media player using the `media_player.play_medi
 | `media_content_type`   | Set to the value `url`
 | `media_content_id`     | The full URL to the stream
 
-
 ## {% linkable_title Notes %}
 
 - HEOS groups are not currently supported.
 - Receivers with multiple zones are represented as a single media player. They will be turned on when playback is started, but cannot be turned off by the integration at this time.
-
 
 ## {% linkable_title Troubleshooing %}
 

--- a/source/_components/heos.markdown
+++ b/source/_components/heos.markdown
@@ -63,7 +63,7 @@ Use the sign-in service to sign the connected controller into a HEOS account so 
 
 ### {% linkable_title Service `heos.sign_out` %}
 
-Use the sign-out service to sign the connected controller out of a HEOS account. An error message is logged if sign-in is unsuccessful.  There are no parameters to this service.
+Use the sign-out service to sign the connected controller out of a HEOS account. An error message is logged if sign-out is unsuccessful.  There are no parameters to this service.
 
 ### {% linkable_title Service `media_player.play_media` %}
 
@@ -165,4 +165,4 @@ logger:
 If the HEOS controller is not signed in to a HEOS account, HEOS favorites will not be populated in the media player source selection and the service `media_player.play_media` for `favorite` and `playlist` will fail. Additionally, the following warning will be logged at startup:
 > IP_ADDRESS is not logged in to a HEOS account and will be unable to retrieve HEOS favorites: Use the 'heos.sign_in' service to sign-in to a HEOS account
 
-To resolve this issue, use the `heos.sign_out` service to sign the controller into an account as documented above.
+To resolve this issue, use the `heos.sign_out` service to sign the controller into an account as documented above. This only needs to be performed once, as the controller will remain signed in while the account credentails are valid.

--- a/source/_components/heos.markdown
+++ b/source/_components/heos.markdown
@@ -45,6 +45,26 @@ A connection to a single device enables control for all devices on the network. 
 
 ## {% linkable_title Services %}
 
+### {% linkable_title Service `heos.sign_in` %}
+
+Use the sign-in service to sign the connected controller into a HEOS account so that it can retreive and play HEOS favorites and playlists. An error message is logged if sign-in is unsuccessful. Example service data payload:
+
+```json
+{
+  "username": "example@example.com",
+  "password": "password"
+}
+```
+
+| Attribute              | Description
+| ---------------------- | ---------------------------------------------------------|
+| `username`             | The username or email of the HEOS account. [Required]
+| `password`             | The password of the HEOS account. [Required]
+
+### {% linkable_title Service `heos.sign_out` %}
+
+Use the sign-out service to sign the connected controller out of a HEOS account. An error message is logged if sign-in is unsuccessful.  There are no parameters to this service.
+
 ### {% linkable_title Service `media_player.play_media` %}
 
 #### {% linkable_title Play Favorite %}
@@ -60,7 +80,7 @@ You can play a HEOS favorite by number or name with the `media_player.play_media
 ```
 
 | Attribute              | Description
-| ---------------------- | ----------- | ----------- |
+| ---------------------- | ---------------------------------------------------------|
 | `entity_id`            | `entity_id` of the player
 | `media_content_type`   | Set to the value `playlist`
 | `media_content_id`     | The nubmer (i.e. `1`) or name (i.e. `Thumbprint Radio`) of the HEOS favorite
@@ -78,7 +98,7 @@ You can play a HEOS playlist with the `media_player.play_media` service. Example
 ```
 
 | Attribute              | Description
-| ---------------------- | ----------- | ----------- |
+| ---------------------- | ---------------------------------------------------------|
 | `entity_id`            | `entity_id` of the player
 | `media_content_type`   | Set to the value `playlist`
 | `media_content_id`     | The name of the HEOS playlist
@@ -96,7 +116,7 @@ You can play a HEOS Quick Select by nubmer or name with the `media_player.play_m
 ```
 
 | Attribute              | Description
-| ---------------------- | ----------- | ----------- |
+| ---------------------- | ---------------------------------------------------------|
 | `entity_id`            | `entity_id` of the player
 | `media_content_type`   | Set to the value `quick_select`
 | `media_content_id`     | The quick select number (i.e. `1`) or name (i.e. `Quick Select 1`)
@@ -114,7 +134,7 @@ You can play a URL through a HEOS media player using the `media_player.play_medi
 ```
 
 | Attribute              | Description
-| ---------------------- | ----------- | ----------- |
+| ---------------------- | ---------------------------------------------------------|
 | `entity_id`            | `entity_id` of the player to play the URL
 | `media_content_type`   | Set to the value `url`
 | `media_content_id`     | The full URL to the stream
@@ -126,7 +146,9 @@ You can play a URL through a HEOS media player using the `media_player.play_medi
 - Receivers with multiple zones are represented as a single media player. They will be turned on when playback is started, but cannot be turned off by the integration at this time.
 
 
-## {% linkable_title Debugging %}
+## {% linkable_title Troubleshooing %}
+
+### {% linkable_title Debugging %}
 
 The HEOS component will log additional information about commands, events, and other messages when the log level is set to `debug`. Add the the relevent line below to the `configuration.yaml` to enable debug logging:
 
@@ -137,3 +159,10 @@ logger:
     homeassistant.components.heos: debug
     pyheos: debug
 ```
+
+### {% linkable_title Missing Favorites %}
+
+If the HEOS controller is not signed in to a HEOS account, HEOS favorites will not be populated in the media player source selection and the service `media_player.play_media` for `favorite` and `playlist` will fail. Additionally, the following warning will be logged at startup:
+> IP_ADDRESS is not logged in to a HEOS account and will be unable to retrieve HEOS favorites: Use the 'heos.sign_in' service to sign-in to a HEOS account
+
+To resolve this issue, use the `heos.sign_out` service to sign the controller into an account as documented above.


### PR DESCRIPTION
**Description:**
Update the HEOS documentation to describe the sign-in and sign-out services as well as add troubleshooting information for when this is necessary to invoke.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#23729

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
