### PR TITLE
Add water_heater to geniushub integration

### DIFF
--- a/source/_components/geniushub.markdown
+++ b/source/_components/geniushub.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Genius Hub"
 description: "Instructions on how to integrate Genius Hub with Home Assistant."
-date: 2019-03-03 16:00
+date: 2019-05-07 16:00
 sidebar: true
 comments: false
 sharing: true
@@ -10,40 +10,68 @@ footer: true
 logo: geniushub.png
 ha_category:
   - Climate
+  - Water heater
 ha_release: 0.92
 ha_iot_class: Local Polling
 ---
 
-The `geniushub` integration links Home Assistant with your Genius Hub for controlling climate devices (the hub does not have to be in the same network as HA).
+The `geniushub` integration links Home Assistant with your Genius Hub (the hub does not have to be in the same network as HA).
 
-Each Zone controlled by your Genius hub will report back the state, mode, setpoint and temperature. Other properties are available via the device's attributes.
+Currently only **Radiator** and **Hot Water Temperature** zones are supported. Within HA, each **Radiator** zone will appear as a `Climate` device, and each **Hot Water Temperature** zone will appear as a `WaterHeater` device.
 
-There are two distinct options for accessing a Genius Hub:
+The device's `operating_mode` can be set to one of `off`, `timer`, `on` (i.e. **Override** mode) or `eco`. The `eco` mode is a proxy for the **Footprint** mode and so is only available to **Radiator** zones that have room sensors.
 
-### {% linkable_title Option 1: hub token only %}
+Other properties are available via the device's state attributes, which includes a JSON data structure called `status`. For example, in the case of **Radiator** zones/`Climate` devices:
+```json
+{
+  "status": {
+    "type": "radiator",
+    "temperature": 19,
+    "occupied": False,
+    "override": {
+      "duration": 0,
+      "setpoint": 16
+    }
+  }
+}
+```
+This data can be accessed in automations, etc. via a value template. For example:
+{% raw %}
+```
+value_template: "{{ state_attr('water_heater.boiler_h_w', 'status').override.setpoint }}"
+```
+{% endraw %}
 
- - requires a **hub token** obtained from [https://my.geniushub.co.uk/tokens](https://my.geniushub.co.uk/tokens)
- - uses the v1 API - which is well-documented
- - polls Heat Genius' own servers (so is slower, say 10-20s response time)
+In the specific case of **Radiator** zones with room sensors:
+{% raw %}
+```
+value_template: "{{ state_attr('climate.main_room', 'status').occupied }}"
+```
+{% endraw %}
 
-### {% linkable_title Option 2: hub hostname/address with user credentials %}
-
- - requires your **username** & **password**, as used with [https://www.geniushub.co.uk/app](https://www.geniushub.co.uk/app)
- - uses the v3 API - results are WIP and may not be what you expect
- - polls the hub directly (so is faster, say 1s response time)
+Currently, there is no support for modifying schedules and neither do they appear in the state attributes.
 
 ## {% linkable_title Configuration %}
 
 To add your Genius Hub into your Home Assistant installation, add one of the following to your `configuration.yaml` file.
 
-If you want to poll Heat Genius' own servers:
+### {% linkable_title Option 1: hub token only %}
+
+ - requires a **hub token** obtained from [my.geniushub.co.uk/tokens](https://my.geniushub.co.uk/tokens)
+ - uses the v1 API - which is well-documented
+ - polls Heat Genius' own servers (so is slower, say 5-10s response time)
 
 ```yaml
 # Example configuration.yaml entry, using a Hub Token
 geniushub:
   token: GENIUS_HUB_TOKEN
 ```
-Alternatively, if you want to poll the hub directly:
+
+### {% linkable_title Option 2: hub hostname/address with user credentials %}
+
+ - requires your **username** & **password**, as used with [www.geniushub.co.uk/app](https://www.geniushub.co.uk/app)
+ - uses the v3 API - results are WIP and may not be what you expect
+ - polls the hub directly (so is faster, say 1s response time)
 
 ```yaml
 # Example configuration.yaml entry, directly polling the Hub

--- a/source/_components/geniushub.markdown
+++ b/source/_components/geniushub.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "Genius Hub"
 description: "Instructions on how to integrate Genius Hub with Home Assistant."
-date: 2019-05-07 16:00
+date: 2019-03-03 16:00
 sidebar: true
 comments: false
 sharing: true
@@ -22,6 +22,7 @@ Currently only **Radiator** and **Hot Water Temperature** zones are supported. W
 The device's `operating_mode` can be set to one of `off`, `timer`, `on` (i.e. **Override** mode) or `eco`. The `eco` mode is a proxy for the **Footprint** mode and so is only available to **Radiator** zones that have room sensors.
 
 Other properties are available via the device's state attributes, which includes a JSON data structure called `status`. For example, in the case of **Radiator** zones/`Climate` devices:
+
 ```json
 {
   "status": {
@@ -34,8 +35,11 @@ Other properties are available via the device's state attributes, which includes
     }
   }
 }
+
 ```
+
 This data can be accessed in automations, etc. via a value template. For example:
+
 {% raw %}
 ```
 value_template: "{{ state_attr('water_heater.boiler_h_w', 'status').override.setpoint }}"
@@ -43,6 +47,7 @@ value_template: "{{ state_attr('water_heater.boiler_h_w', 'status').override.set
 {% endraw %}
 
 In the specific case of **Radiator** zones with room sensors:
+
 {% raw %}
 ```
 value_template: "{{ state_attr('climate.main_room', 'status').occupied }}"

--- a/source/_components/geniushub.markdown
+++ b/source/_components/geniushub.markdown
@@ -99,5 +99,5 @@ username:
 password:
   description: Your Genius Hub password
   required: false
-  type: integer
+  type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Adds a water_heater to the Genius Hub integration. Also updates client library to latest version.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23384

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
