### PR TITLE
Add abbreviation for position_topic

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -161,6 +161,7 @@ Supported abbreviations:
     'send_if_off':         'send_if_off',
     'set_pos_tpl':         'set_position_template',
     'set_pos_t':           'set_position_topic',
+    'pos_t':               'position_topic',
     'spd_cmd_t':           'speed_command_topic',
     'spd_stat_t':          'speed_state_topic',
     'spd_val_tpl':         'speed_value_template',


### PR DESCRIPTION
**Description:**
Add abbreviation for position_topic using in MQTT Cover component

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23740

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
