### PR TITLE
Update google_assistant.markdown

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -138,7 +138,7 @@ api_key:
   description: Your Homegraph API key (for the `google_assistant.request_sync` service)
   required: false
   type: string
-expose_by_default:
+expose_by_default: (Changed in 0.84. Will not sync devices if set to true)
   description: "Expose devices in all supported domains by default. If `exposed_domains` domains is set, only these domains are exposed by default. If `expose_by_default` is set to false, devices have to be manually exposed in `entity_config`."
   required: false
   default: true

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -138,8 +138,8 @@ api_key:
   description: Your Homegraph API key (for the `google_assistant.request_sync` service)
   required: false
   type: string
-expose_by_default: (Changed in 0.84. Will not sync devices if set to false)
-  description: "Expose devices in all supported domains by default. If `exposed_domains` domains is set, only these domains are exposed by default. If `expose_by_default` is set to false, devices have to be manually exposed in `entity_config`."
+expose_by_default:
+  description: "(Changed in 0.84. Will not sync devices if set to false) - Expose devices in all supported domains by default. If `exposed_domains` domains is set, only these domains are exposed by default. If `expose_by_default` is set to false, devices have to be manually exposed in `entity_config`."
   required: false
   default: true
   type: boolean

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -138,7 +138,7 @@ api_key:
   description: Your Homegraph API key (for the `google_assistant.request_sync` service)
   required: false
   type: string
-expose_by_default: (Changed in 0.84. Will not sync devices if set to true)
+expose_by_default: (Changed in 0.84. Will not sync devices if set to false)
   description: "Expose devices in all supported domains by default. If `exposed_domains` domains is set, only these domains are exposed by default. If `expose_by_default` is set to false, devices have to be manually exposed in `entity_config`."
   required: false
   default: true


### PR DESCRIPTION
This was changed in 0.84.0. If set to true Google will fail to link to your HA.

Did tons of troubleshooting to figure this out as it is not documented.
https://github.com/home-assistant/home-assistant/issues/23730

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
