### PR TITLE
Newer MDI icons not immediately available

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -58,7 +58,7 @@ entity_picture:
   required: false
   type: string
 icon:
-  description: "Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://cdn.materialdesignicons.com/3.5.95/)). Prefix name with `mdi:`, ie `mdi:home`. Note:  Newer icons may not yet be available in the current Home Assistant release. You can check when an icon was added to MaterialDesignIcons.com at [MDI History](https://materialdesignicons.com/history)."
+  description: "Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://cdn.materialdesignicons.com/3.5.95/)). Prefix name with `mdi:`, ie `mdi:home`. Note: Newer icons may not yet be available in the current Home Assistant release. You can check when an icon was added to MaterialDesignIcons.com at [MDI History](https://materialdesignicons.com/history)."
   required: false
   type: string
 assumed_state:

--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -58,7 +58,7 @@ entity_picture:
   required: false
   type: string
 icon:
-  description: Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://cdn.materialdesignicons.com/3.5.95/)). Prefix name with `mdi:`, ie `mdi:home`. Note:  Newer icons may not yet be available in the current Home Assistant release. You can check when an icon was added to MaterialDesignIcons.com at [MDI History](https://materialdesignicons.com/history).
+  description: "Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://cdn.materialdesignicons.com/3.5.95/)). Prefix name with `mdi:`, ie `mdi:home`. Note:  Newer icons may not yet be available in the current Home Assistant release. You can check when an icon was added to MaterialDesignIcons.com at [MDI History](https://materialdesignicons.com/history)."
   required: false
   type: string
 assumed_state:

--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -58,7 +58,7 @@ entity_picture:
   required: false
   type: string
 icon:
-  description: Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://cdn.materialdesignicons.com/3.5.95/)). Prefix name with `mdi:`, ie `mdi:home`.
+  description: Any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com) ([Cheatsheet](https://cdn.materialdesignicons.com/3.5.95/)). Prefix name with `mdi:`, ie `mdi:home`. Note:  Newer icons may not yet be available in the current Home Assistant release. You can check when an icon was added to MaterialDesignIcons.com at [MDI History](https://materialdesignicons.com/history).
   required: false
   type: string
 assumed_state:


### PR DESCRIPTION
Add a note that newer MDI icons may not be available in the current Home Assistant release. Confusion as to why certain icons don't show up is common in the Community.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
