### PR TITLE
Added the maximum possible number of characters

### DIFF
--- a/source/_components/input_text.markdown
+++ b/source/_components/input_text.markdown
@@ -49,7 +49,7 @@ input_text:
         type: integer
         default: 0
       max:
-        description: Maximum length for the text value.
+        description: Maximum length for the text value. 255 is the maximum number of characters allowed in an entity state.
         required: false
         type: integer
         default: 100


### PR DESCRIPTION
**Description:**
Entity states are only allowed to go up to 255 characters. The current docs are ambiguous on how high this number can go.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
