### PR TITLE
emulated_hue note for sleep cycle

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -35,7 +35,7 @@ Both Google Home and Alexa use the device they were initially set up with for co
 </p>
 
 <p class='note'>
-Sleep Cycle: smart alarm clock app can use emulated_hue to turn on and off enitites. This feature is only implemented in the iOS app. The app requires the same configuration as Google Home and does not work if type is defined as alexa in configuration.
+Sleep Cycle: smart alarm clock app can use emulated_hue to turn on and off enitites. This feature is only implemented in the iOS app, see <a href="https://support.sleepcycle.com/hc/en-us/articles/207670385-Does-Sleep-Cycle-integrates-with-Phillips-Hue-" target="_blank">Sleep Cycle support</a>. The app requires the same configuration as Google Home and does not work if type is defined as alexa in configuration.
 </p>
 
 ### {% linkable_title Configuration %}

--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -34,6 +34,10 @@ It is recommended to assign a static IP address to the computer running Home Ass
 Both Google Home and Alexa use the device they were initially set up with for communication with emulated_hue. In other words: if you remove/replace this device you will also break emulated_hue.
 </p>
 
+<p class='note'>
+Sleep Cycle: smart alarm clock app can use emulated_hue to turn on and off enitites. This feature is only implemented in the iOS app. The app requires the same configuration as Google Home and does not work if type is defined as alexa in configuration.
+</p>
+
 ### {% linkable_title Configuration %}
 
 To enable the emulated Hue bridge, add one of the following configs to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**
Note describing how to use sleep cycle in emulated hue

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23775

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html