### PR TITLE
Readability improvements to components/ecobee

### DIFF
--- a/source/_components/ecobee.markdown
+++ b/source/_components/ecobee.markdown
@@ -48,21 +48,23 @@ Now login to the regular consumer portal, and in the hamburger menu there will b
 
 Now under the Name and Summary Section you will have an API key. Copy this key and use it in you configuration section below. Click the **X** to close the Developer section.
 
-The first time you run Home Assistant with this component it will give you a PIN code that you need to authorize in the [ecobee consumer portal](https://www.ecobee.com/consumerportal/index.html). You can do this by clicking **Add Application** in the **My Apps** section in the sidebar.
-
-The PIN can be found from the Home Assistant portal on the Ecobee card or from the **configurator.ecobee** entity in states in the portal.
-
-- If you do not have an ecobee card, you may be using groups with `default_view` that don't show the card. To get around this you can temporarily comment out the `default_view` section or add the `configurator.ecobee` component to your `default_view` and restart Home Assistant.
-
-Once you enter the PIN on the ecobee site, wait approximately 5 minutes and then click on the **I have authorized the app** link at the bottom of the ecobee pop-up window. If everything worked correctly, you should now be able to restart Home Assistant again to see the full ecobee card with all of the sensors populated or see the list of sensors in the developer tools. Now you can re-enable your `default_view` (if you had to disable it) and add the ecobee sensors to a group and/or view.
-
-To set it up, add the following information to your `configuration.yaml` file:
+To add the Ecobee component to Home Assistant, add the following information to your [`configuration.yaml`](https://www.home-assistant.io/docs/configuration/) file:
 
 ```yaml
 # Example configuration.yaml entry
 ecobee:
   api_key: YOUR_API_KEY
 ```
+
+[Restart Home Assistant](https://www.home-assistant.io/docs/configuration/#reloading-changes) for the changes to take effect.
+
+The first time you (re)run Home Assistant with this component it will give you a PIN code that you need to authorize in the [ecobee consumer portal](https://www.ecobee.com/consumerportal/index.html). You can do this by clicking **Add Application** in the **My Apps** section in the sidebar.
+
+The PIN can be found from the Home Assistant portal on the Ecobee card or from the **configurator.ecobee** entity in states in the portal.
+
+- If you do not have an ecobee card, you may be using groups with `default_view` that don't show the card. To get around this you can temporarily comment out the `default_view` section or add the `configurator.ecobee` component to your `default_view` and restart Home Assistant.
+
+Once you enter the PIN on the ecobee site, wait approximately 5 minutes and then click on the **I have authorized the app** link at the bottom of the ecobee pop-up window. If everything worked correctly, you should now be able to restart Home Assistant again to see the full ecobee card with all of the sensors populated or see the list of sensors in the developer tools. Now you can re-enable your `default_view` (if you had to disable it) and add the ecobee sensors to a group and/or view.
 
 {% configuration %}
 api_key:

--- a/source/_components/ecobee.markdown
+++ b/source/_components/ecobee.markdown
@@ -48,7 +48,7 @@ Now login to the regular consumer portal, and in the hamburger menu there will b
 
 Now under the Name and Summary Section you will have an API key. Copy this key and use it in you configuration section below. Click the **X** to close the Developer section.
 
-To add the Ecobee component to Home Assistant, add the following information to your [`configuration.yaml`](https://www.home-assistant.io/docs/configuration/) file:
+To add the Ecobee component to Home Assistant, add the following information to your [`configuration.yaml`](/docs/configuration/) file:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
Made it more clear where and how to modify `configuration.yaml` to add the Ecobee component.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
