### PR TITLE
fix redirect_from annotation problem

### DIFF
--- a/source/_components/airvisual.markdown
+++ b/source/_components/airvisual.markdown
@@ -140,8 +140,6 @@ When configured, the platform will create three sensors for each configured air 
 - **Explanation:**
 
 AQI | Status | Description
-redirect_from:
- - /components/sensor.airvisual/
 ------- | :----------------: | ----------
 0 - 50  | **Good** | Air quality is considered satisfactory, and air pollution poses little or no risk
 51 - 100  | **Moderate** | Air quality is acceptable; however, for some pollutants there may be a moderate health concern for a very small number of people who are unusually sensitive to air pollution
@@ -164,8 +162,6 @@ redirect_from:
 - **Explanation:**
 
 Pollutant | Symbol | More Info
-redirect_from:
- - /components/sensor.airvisual/
 ------- | :----------------: | ----------
 Particulate (<= 2.5 μm) | PM2.5 | [EPA: Particulate Matter (PM) Pollution ](https://www.epa.gov/pm-pollution)
 Particulate (<= 10 μm) | PM10 | [EPA: Particulate Matter (PM) Pollution ](https://www.epa.gov/pm-pollution)

--- a/source/_components/clicksend_tts.markdown
+++ b/source/_components/clicksend_tts.markdown
@@ -12,8 +12,7 @@ ha_category:
   - Notifications
 ha_release: 0.55
 redirect_from: 
-  - /components/notify.clicksendaudio/
-redirect_from:
+ - /components/notify.clicksendaudio/
  - /components/notify.clicksend_tts/
 ---
 

--- a/source/_components/darksky.markdown
+++ b/source/_components/darksky.markdown
@@ -10,10 +10,10 @@ footer: true
 logo: dark_sky.png
 ha_category: Weather
 ha_release: "0.30"
-redirect_from: /components/sensor.forecast/
 ha_iot_class: Cloud Polling
 redirect_from:
  - /components/sensor.darksky/
+ - /components/sensor.forecast/
 ---
 
 The `darksky` platform uses the [Dark Sky](https://darksky.net/) web service as a source for meteorological data for your location. The location is based on the `longitude` and `latitude` coordinates configured in your `configuration.yaml` file. The coordinates are auto-detected but to take advantage of the hyper-local weather reported by Dark Sky, you can refine them down to your exact home address. GPS coordinates can be found by using [Google Maps](https://www.google.com/maps) and clicking on your home or [Openstreetmap](http://www.openstreetmap.org/).

--- a/source/_components/econet.markdown
+++ b/source/_components/econet.markdown
@@ -11,9 +11,9 @@ logo: econet.png
 ha_category: Water heater
 ha_release: 0.61
 ha_iot_class: Cloud Polling
-redirect_from: /components/climate.econet/
 redirect_from:
  - /components/water_heater.econet/
+ - /components/climate.econet/
 ---
 
 The `econet` water heater platform is consuming the information provided by a [EcoNet enabled Rheem water heater](http://www.rheem.com/EcoNet/Home). This platform allows you to set the temperature, the operation mode, and enable vacation mode.

--- a/source/_components/entur_public_transport.markdown
+++ b/source/_components/entur_public_transport.markdown
@@ -122,17 +122,13 @@ The stop id is the content after `id=` parameter in the url. Copy paste this int
 **Q:** I have multiple stop ids and have added whitelisting of a line. Now some of the stop places are showing `unknown`.
 
 **A:** A whitelisting of lines takes affect on all of the stops. So you have to whitelist all lines you are interested in on all stop places.
-
-redirect_from:
- - /components/sensor.entur_public_transport/
+ 
 ---
 
 **Q:** I have added whitelisting of lines, and everything has worked as fine before, but now it has stopped updating all of a sudden.
 
 **A:** Some transport companies, such as Kolumbus in Rogaland, have running numbers on the end of their line ids. These gets periodically updated and will make the whitelisting invalid. The new line ids needs to be added again. Most of the time it iterates by one.
 
-redirect_from:
- - /components/sensor.entur_public_transport/
 ---
 
 **Q:** Where do I find a line id to add to the whitelisting?

--- a/source/_components/ffmpeg_motion.markdown
+++ b/source/_components/ffmpeg_motion.markdown
@@ -10,8 +10,8 @@ footer: true
 logo: ffmpeg.png
 ha_category: Image Processing
 ha_release: 0.27
-redirect_from: /components/binary_sensor.ffmpeg/
 redirect_from:
+ - /components/binary_sensor.ffmpeg/
  - /components/binary_sensor.ffmpeg_motion/
 ---
 

--- a/source/_components/iss.markdown
+++ b/source/_components/iss.markdown
@@ -10,8 +10,8 @@ footer: true
 logo: nasa.png
 ha_category: Binary Sensor
 ha_release: 0.36
-redirect_from: /components/sensor.iss/
 redirect_from:
+ - /components/sensor.iss/
  - /components/binary_sensor.iss/
 ---
 

--- a/source/_components/loopenergy.markdown
+++ b/source/_components/loopenergy.markdown
@@ -11,8 +11,8 @@ logo: loop.png
 ha_category: Energy
 ha_release: 0.17
 ha_iot_class: Cloud Push
-redirect_from: /components/sensor.loop_energy/
 redirect_from:
+ - /components/sensor.loop_energy/
  - /components/sensor.loopenergy/
 ---
 

--- a/source/_components/nello.markdown
+++ b/source/_components/nello.markdown
@@ -54,8 +54,6 @@ password:
 Every time someone rings the bell, a `nello_bell_ring` event will be fired.
 
 Field | Description
-redirect_from:
- - /components/lock.nello/
 ----- | -----------
 `address` | Postal address of the lock.
 `date` | Date when the event occurred.

--- a/source/_components/openalpr_local.markdown
+++ b/source/_components/openalpr_local.markdown
@@ -10,8 +10,8 @@ footer: true
 logo: openalpr.png
 ha_category: Image Processing
 ha_release: 0.36
-redirect_from: /components/openalpr/
 redirect_from:
+ - /components/openalpr/
  - /components/image_processing.openalpr_local/
 ---
 

--- a/source/_components/opensensemap.markdown
+++ b/source/_components/opensensemap.markdown
@@ -11,8 +11,8 @@ logo: opensensemap.png
 ha_category: Health
 ha_release: 0.85
 ha_iot_class: Cloud Polling
-redirect_from: /components/air_pollutants.opensensemap/
 redirect_from:
+ - /components/air_pollutants.opensensemap/
  - /components/air_quality.opensensemap/
 ---
 

--- a/source/_components/pollen.markdown
+++ b/source/_components/pollen.markdown
@@ -86,8 +86,6 @@ Any index-related sensor will have a value between 0.0 and 12.0. The values
 map to the following human-friendly ratings:
 
 Range      | Rating
-redirect_from:
- - /components/sensor.pollen/
 ---------  | -----------
 0.0 - 2.4  | Low
 2.5 - 4.8  | Low/Medium
@@ -102,8 +100,6 @@ Several asthma-related sensors carry information regarding the top three
 Example values include:
 
 Pollutant | Symbol | More Info
-redirect_from:
- - /components/sensor.pollen/
 --------- | ------ | ---------
 Particulate (<= 2.5 μm) | PM2.5 | [EPA: Particulate Matter (PM) Pollution](https://www.epa.gov/pm-pollution)
 Particulate (<= 10 μm) | PM10 | [EPA: Particulate Matter (PM) Pollution](https://www.epa.gov/pm-pollution)


### PR DESCRIPTION
**Description:**

Fixing pages annotation problem with `redirect_from`, some are wrongly placed (double in header, or in page content)

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
