### PR TITLE
fix for overriding user browser history - replaceState to pushState - user can go back and forward

### DIFF
--- a/source/components/index.html
+++ b/source/components/index.html
@@ -147,7 +147,7 @@ allComponents.pop(); // remove placeholder element at the end
     var data = {
       components: [],
       image: function () {
-        if(this.logo === '') {
+        if (this.logo === '') {
           return '';
         } else {
           return '<img data-src="/images/supported_brands/' + this.logo + '">';
@@ -216,8 +216,8 @@ allComponents.pop(); // remove placeholder element at the end
    * update the browser location hash. This enables users to use the browser-history
    */
   function updateHash(newHash) {
-    if ('replaceState' in history) {
-      history.replaceState('', '', newHash);
+    if ('pushState' in history) {
+      history.pushState('', '', newHash);
     } else {
       location.hash = newHash;
     }


### PR DESCRIPTION
**Description:**

With `history.replaceState` user browser history is being replaced and when searching components or changing categories, user cannot go back in history. This fixes this problem.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
