### PR TITLE
fix search problem - only if input is not empty change to search hash location

### DIFF
--- a/source/components/index.html
+++ b/source/components/index.html
@@ -61,7 +61,7 @@ Support for these components is provided by the Home Assistant community.
   <div class="grid__item five-sixths lap-one-whole palm-one-whole">
     <div class="component-search">
       <form onsubmit="event.preventDefault(); return false">
-        <input type="text" name="search" id="search" class="search" placeholder="Search components...">
+        <input type="text" name="search" id="search" class="search" placeholder="Search components..." autofocus />
       </form>
     </div>
     <div class="hass-option-cards" id="componentContainer"> </div>
@@ -265,9 +265,11 @@ allComponents.pop(); // remove placeholder element at the end
   $('.component-search input').keyup(debounce(function() {
     var text = $(this).val();
     // sanitize input
-    text = text.replace(/[(\?|\&\{\}\(\))]/gi, '');
-    updateHash('#search/' + text);
-    applyFilter();
+    text = text.replace(/[(\?|\&\{\}\(\))]/gi, '').trim();
+    if (typeof text === "string" && text.length !== 0) {
+        updateHash('#search/' + text);
+        applyFilter();
+    }
   }, 500));
 
   window.addEventListener('hashchange', applyFilter);


### PR DESCRIPTION
**Description:**

Fixes problems with accidental hash changes when search string is empty, or is just a space. A more proper way of handling hash location changes when using input with autofocus.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
