### PR TITLE
Correct comment in script yaml.

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -135,7 +135,7 @@ You can also get the script to abort after the timeout by using `continue_on_tim
 
 {% raw %}
 ```yaml
-# Wait until a valve is < 10 or continue after 1 minute.
+# Wait until a valve is < 10 or abort after 1 minute.
 - wait_template: "{{ states.climate.kitchen.attributes.valve|int < 10 }}"
   timeout: '00:01:00'
   continue_on_timeout: 'false'


### PR DESCRIPTION
**Description:**
Documentation incorrectly states that the script will continue when continue_on_timeout is set to false. Commit updates text to stating that it will abort.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
