### PR TITLE
Describe support of multiple elk devices

### DIFF
--- a/source/_components/elkm1.markdown
+++ b/source/_components/elkm1.markdown
@@ -45,6 +45,7 @@ elkm1:
   - host: elk://IP_ADDRESS_1
   ...
   - host: elk://IP_ADDRESS_2
+    prefix: gh  # for guest house controller
 ```
 
 {% configuration %}

--- a/source/_components/elkm1.markdown
+++ b/source/_components/elkm1.markdown
@@ -1,12 +1,6 @@
 ---
-layout: page
 title: "Elk-M1 Controller"
 description: "Instructions to setup the Elk-M1 controller."
-date: 2018-10-07 00:00
-sidebar: true
-comments: false
-sharing: true
-footer: true
 logo: elkproducts.png
 ha_release: 0.81
 ha_category:
@@ -40,7 +34,7 @@ There is currently support for the following device types within Home Assistant:
 - **Sensor** - Elk-M1 counters, keypads, panel, settings, and zones are represented as `sensor` entities.
 - **Switch** - Elk-M1 outputs are represented as `switch` entities.
 
-## {% linkable_title Configuration %}
+## Configuration
 
 To integrate one or more Elk-M1 controllers with Home Assistant, add the following
 section to your `configuration.yaml` file:

--- a/source/_components/elkm1.markdown
+++ b/source/_components/elkm1.markdown
@@ -42,18 +42,20 @@ There is currently support for the following device types within Home Assistant:
 
 ## {% linkable_title Configuration %}
 
-To integrate Elk-M1 controller with Home Assistant, add the following
+To integrate one or more Elk-M1 controllers with Home Assistant, add the following
 section to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 elkm1:
-  host: elk://IP_ADDRESS
+  - host: elk://IP_ADDRESS_1
+  ...
+  - host: elk://IP_ADDRESS_2
 ```
 
 {% configuration %}
 host:
-  description: Connection string to Elk of the form `<method>://<address>[:port]`. `<method>` is `elk` for non-secure connection, `elks` for secure connection, and `serial` for serial port connection. `<address>` is IP address or domain or for `serial` the serial port that the Elk is connected to. Optional `<port>` is the port to connect to on the Elk, defaulting to 2101 for `elk` and 2601 for `elks`. For `serial` method, _address_ is the path to the tty _/dev/ttyS1_ for example and `[:baud]` is the baud rate to connect with.
+  description: Connection string to Elk of the form `<method>://<address>[:port]`. `<method>` is `elk` for non-secure connection, `elks` for secure connection, and `serial` for serial port connection. `<address>` is IP address or domain or for `serial` the serial port that the Elk is connected to. Optional `<port>` is the port to connect to on the Elk, defaulting to 2101 for `elk` and 2601 for `elks`. For `serial` method, _address_ is the path to the tty _/dev/ttyS1_ for example and `[:baud]` is the baud rate to connect with.  You may have multiple host sections for connecting multiple controllers.
   required: true
   type: string
 username:
@@ -63,6 +65,10 @@ username:
 password:
   description: Password to login to Elk. Only required if using `elks` connection method.
   required: false
+  type: string
+prefix:
+  description: The prefix to use, if any, for all the devices created for this controller. At most one host can omit the prefix, all others must have a unique prefix within the home assistant instance.
+  require: false
   type: string
 temperature_unit:
   description: The temperature unit that the Elk panel uses. Valid values are `C` and `F`.


### PR DESCRIPTION
**Description:**
For an upcoming PR that supports multiple elk devices.  This is a doc update for the version of that PR (23839) that uses multiple host sections instead of a list of host sections under a devices tag (since that extra "devices" section would result in a breaking change).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23839

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
