### PR TITLE
Remove documentation on removed `excluded_entities` key

### DIFF
--- a/source/lovelace/yaml-mode.markdown
+++ b/source/lovelace/yaml-mode.markdown
@@ -46,9 +46,7 @@ resources:
 
 # Optional background for all views. Check https://developer.mozilla.org/en-US/docs/Web/CSS/background for more examples.
 background: center / cover no-repeat url("/background.png") fixed
-# Exclude entities from "Unused entities" view
-excluded_entities:
-  - weblink.router
+
 views:
     # View tab title.
   - title: Example


### PR DESCRIPTION
**Description:** This was removed a while ago


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** https://github.com/home-assistant/home-assistant-polymer/pull/2754

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
