### PR TITLE
Add path option to SABnzbd component docs

### DIFF
--- a/source/_components/sabnzbd.markdown
+++ b/source/_components/sabnzbd.markdown
@@ -45,6 +45,10 @@ host:
   required: false
   default: localhost
   type: string
+path:
+  description: Path to your SABnzbd instance corresponding to its `url_base` setting, e.g., `/sabnzbd`.
+  required: false
+  type: string
 name:
   description: The name of your SABnzbd instance (this will be the prefix for all created sensors).
   required: false
@@ -87,6 +91,7 @@ Available sensors are:
 sabnzbd:
   api_key: YOUR_SABNZBD_API_KEY
   host: 192.168.1.32
+  path: /sabnzbd
   name: sab
   port: 9090
   ssl: true


### PR DESCRIPTION
**Description:**

Adds the `path` option to SABnzbd component docs. This allows support for SABnzbd installs that use a different `url_base` (typically a reverse proxied configuration; see https://sabnzbd.org/wiki/configuration/2.3/special).

Replaces PR #9210

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23846
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
