### PR TITLE
Update honeywell.markdown

### DIFF
--- a/source/_components/honeywell.markdown
+++ b/source/_components/honeywell.markdown
@@ -26,6 +26,7 @@ climate:
   - platform: honeywell
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
+    region: us
     scan_interval: 600
 ```
 <p class='note'>


### PR DESCRIPTION
region: us appears to be mandatory. My HoneyWell integration didn't work until I added `region: us` [See this thread](https://community.home-assistant.io/t/honeywell-thermostats/18148/11) Otherwise will need a pull request to default `region: us` if not specified.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
