### PR TITLE
Fix broken external link for Ambient Weather dashboard

### DIFF
--- a/source/_components/ambient_station.markdown
+++ b/source/_components/ambient_station.markdown
@@ -21,7 +21,7 @@ via personal weather stations from [Ambient Weather](https://ambientweather.net)
 
 Using this component requires both an Application Key and an API Key. To
 generate both, simply utilize the profile section of
-[your Ambient Weather dashboard](https:/dashboard.ambientweather.net).
+[your Ambient Weather dashboard](https://dashboard.ambientweather.net).
 
 ## {% linkable_title Configuration %}
 


### PR DESCRIPTION
There was a broken link on this page because it had one forward slash instead of two.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
