### PR TITLE
🌱 Updated SET_AWAY_MODE and TURN_ON/OFF on Daikin Climate (Cherry-pick)

### DIFF
--- a/source/_components/daikin.markdown
+++ b/source/_components/daikin.markdown
@@ -61,10 +61,12 @@ hosts:
 
 The `daikin` climate platform integrates Daikin air conditioning systems into Home Assistant, enabling control of setting the following parameters:
 
-- **mode** (cool, heat, dry, fan only or auto)
-- **target temperature**
-- **fan speed**
-- **swing mode**
+- [**mode**](https://www.home-assistant.io/components/climate#service-climateset_operation_mode) (cool, heat, dry, fan only or auto)
+- [**target temperature**](https://www.home-assistant.io/components/climate#service-climateset_temperature)
+- [**fan mode**](https://www.home-assistant.io/components/climate#service-climateset_fan_mode) (speed)
+- [**swing mode**](https://www.home-assistant.io/components/climate#service-climateset_swing_mode)
+- [**turn on/off**](https://www.home-assistant.io/components/climate#service-climateturn_on)
+- [**away mode**](https://www.home-assistant.io/components/climate#service-climateset_away_mode)
 
 Current inside temperature is displayed.
 


### PR DESCRIPTION
**Description:**
This change was lagging behind and should have been in the 0.93 release.

Original PR: #9370

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
