### PR TITLE
Remove 24 link

### DIFF
--- a/source/lovelace/index.markdown
+++ b/source/lovelace/index.markdown
@@ -12,7 +12,7 @@ redirect_from: /components/lovelace/
 
 Lovelace is the name of the Home Assistant user interface. It is a fast, customizable and powerful way for users to manage their homes, working both on mobile and desktop.
 
- - [24 cards](https://www.home-assistant.io/lovelace/alarm-panel/) to place and configure as you like.
+ - 24 different cards to place and configure as you like.
  - UI Editor. A configuration UI to manage your Lovelace UI including live preview when editing cards.
  - Fast. Using a static config allows us to build up the UI once.
  - Customizable.


### PR DESCRIPTION
**Description:**
24 is now a link to an alarm panel. But the 24 cards are already showing on this page on the rigth. Confuses people. Removed the link. Added 'different' otherwise you might think you can only have 24 cards on your screen.
