### PR TITLE
Added a note relating to a Netgear Issue

### DIFF
--- a/source/_components/netgear.markdown
+++ b/source/_components/netgear.markdown
@@ -18,6 +18,10 @@ redirect_from:
 
 This platform allows you to detect presence by looking at connected devices to a [Netgear](http://www.netgear.com/) device.
 
+<p class='note'>
+A recent updates of Orbi APs introduced a bug which takes several hours to detects presence on your local network. The current workaround is to force this component to use the Orbi's API v2 by adding the `accesspoints:` node to your configuration.
+</p>
+
 To use this device tracker in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
**Description:**
The Netgear component uses [pynetgear](https://github.com/MatMaul/pynetgear) which uses the v1 API from the Netgear router. Recent changes into the Orbi firmware introduced a bug which causes from 30 minutes to 2 hours to detect home prescences, the current workaround is to force the v2 API by adding `accesspoint:` node. I was facing this bug on my Orbi RBK50, it works a lot better now after this change.

Related issue https://github.com/MatMaul/pynetgear/issues/71

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
