### PR TITLE
Remove "yesterday" monitored conditions

### DIFF
--- a/source/_components/iqvia.markdown
+++ b/source/_components/iqvia.markdown
@@ -39,14 +39,11 @@ iqvia:
     - allergy_average_forecasted
     - allergy_index_today
     - allergy_index_tomorrow
-    - allergy_index_yesterday
     - asthma_average_forecasted
     - asthma_index_today
     - asthma_index_tomorrow
-    - asthma_index_yesterday
     - disease_average_forecasted
     - disease_index_today
-    - disease_index_yesterday
 ```
 
 {% configuration %}
@@ -72,14 +69,11 @@ The following metrics can be monitored:
 * Allergy Index: Forecasted Average (`allergy_average_forecasted`): the average forecasted allergy index over the next 5 days
 * Allergy Index: Today (`allergy_index_today`): the allergy index for today
 * Allergy Index: Tomorrow (`allergy_index_tomorrow`): the allergy index for tomorrow
-* Allergy Index: Yesterday (`allergy_index_yesterday`): the allergy index for yesterday
 * Asthma Index: Forecasted Average (`asthma_average_forecasted`): the average forecasted asthma index over the next 5 days
 * Asthma Index: Today (`asthma_index_today`): the asthma index for today
 * Asthma Index: Tomorrow (`asthma_index_tomorrow`): the asthma index for tomorrow
-* Asthma Index: Yesterday (`asthma_index_yesterday`): the asthma index for yesterday
 * Cold & Flu: Forecasted Average (`disease_average_forecasted`): the average forecasted cold/flu index over the next 5 days
 * Cold & Flu Index: Today (`disease_index_today`): the cold/flu index for today
-* Cold & Flu Index: Yesterday (`disease_index_yesterday`): the cold/flu index for yesterday
 
 ## {% linkable_title Understanding the Indices %}
 


### PR DESCRIPTION
If you have any of the "yesterday" monitored conditions included in your config, you receive errors on the component.

```
Invalid config for [iqvia]: value is not allowed @ data['iqvia']['monitored_conditions'][10]. Got 'disease_index_yesterday'
value is not allowed @ data['iqvia']['monitored_conditions'][3]. Got 'allergy_index_yesterday'
value is not allowed @ data['iqvia']['monitored_conditions'][7]. Got 'asthma_index_yesterday'.
```

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
