### PR TITLE
Update meteoalarm.markdown

### DIFF
--- a/source/_components/meteoalarm.markdown
+++ b/source/_components/meteoalarm.markdown
@@ -88,19 +88,18 @@ There are a few awareness levels:
 
 Below you find an example of an automation.
 
-{% raw %}
-automation:
-  - alias: Alert me about weather warnings
-    trigger:
-      platform: state
-      entity_id: binary_sensor.meteoalarm
-      from: ‘off’
-    action:
-      - service: notify.notify
-        data_template:
-          title: '{{state_attr('binary_sensor.meteoalarm', 'headline')}}'
-          message: "{{state_attr('binary_sensor.meteoalarm', 'description')}} is effective on {{state_attr('binary_sensor.meteoalarm', 'effective')}}"
-{% endraw %}
+```yaml
+  alias: Alert me about weather warnings
+  trigger:
+    platform: state
+    entity_id: binary_sensor.meteoalarm
+    from: 'off'
+  action:
+    - service: persistent_notification.create
+      data_template:
+        title: "{{state_attr('binary_sensor.meteoalarm', 'headline')}}"
+        message: "{{state_attr('binary_sensor.meteoalarm', 'description')}} is effective on {{state_attr('binary_sensor.meteoalarm', 'effective')}}"
+```
 
 <p class='note warning'>
 This component is not affiliated with MeteoAlarm and retrieves data from the website by using the XML feeds. Use it at your own risk.


### PR DESCRIPTION
Changed to correct ' and ". Also changed to persistent_notification.create for ease of use for user who not have notify configured.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
