### PR TITLE
Remove warning for timezone in alert component

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -23,11 +23,6 @@ water leak sensors, or any condition that may need your attention.
 Alerts will add an entity to the front end only when they are firing.
 This entity allows you to silence an alert until it is resolved.
 
-<p class='note warning'>
-When using the `alert` component, it is important that the time zone used for Home Assistant and the underlying operating system match.
-Failing to do so may result in multiple alerts being sent at the same time (such as when Home Assistant is set to the `America/Detroit` time zone but the operating system uses `UTC`).
-</P>
-
 ### {% linkable_title Basic Example %}
 
 The `alert` component makes use of any of the `notifications` components. To


### PR DESCRIPTION
**Description:**

Removes the warning about timezones.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23945

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
