### PR TITLE
Deprecation of Honeywell EU

### DIFF
--- a/source/_components/geniushub.markdown
+++ b/source/_components/geniushub.markdown
@@ -21,8 +21,10 @@ The `geniushub` integration links Home Assistant with your Genius Hub for contro
 
 It uses the [geniushub-client](https://pypi.org/project/geniushub-client/) library.
 
-### Zones
+### {% linkable_title Zones %}
+
 Each Zone controlled by your Genius hub will be exposed as either a:
+
  - `Climate` entity, for **Radiator** Zones, and
  - `Water Heater`, for **Hot Water Temperature** Zones
 
@@ -32,14 +34,17 @@ Each such entity will report back its mode, state, setpoint and current temperat
 
 In addition, the entity's mode and setpoint can be changed. The entity's `operating_mode` can be set to one of `off`, `timer`, `on` (i.e. **Override** mode) or `eco`. The `eco` mode is a proxy for the **Footprint** mode and so is only available to **Radiator** Zones that have room sensors.
 
-### Devices
+### {% linkable_title Devices %}
+
 If the Hub is directly polled using the v3 API (see below), then each Device controlled by your Genius hub will be exposed as either a:
+
  - `Sensor` entity with a % battery, for any Device with a battery (e.g. a Genius Valve), or
  - `Binary Sensor` entity with on/off state for any Device that is a switch (e.g. a Smart Plug)
 
 Each such entity will report back its primary state; in addition, `assigned_zone` and `last_comms` (last communications time) are available via the entity's attributes.
 
-### State Attributes
+### {% linkable_title State Attributes %}
+
 Other properties are available via each entity's state attributes. For example, in the case of **Radiator** Zones/`Climate` devices:
 
 ```json

--- a/source/_components/geniushub.markdown
+++ b/source/_components/geniushub.markdown
@@ -11,17 +11,36 @@ logo: geniushub.png
 ha_category:
   - Climate
   - Water heater
+  - Sensor
+  - Binary sensor
 ha_release: 0.92
 ha_iot_class: Local Polling
 ---
 
-The `geniushub` integration links Home Assistant with your Genius Hub (the hub does not have to be in the same network as HA).
+The `geniushub` integration links Home Assistant with your Genius Hub for controlling its Zones and Devices. Currently, there is no support for Genius Hub issues and Zone schedules.
 
-Currently only **Radiator** and **Hot Water Temperature** zones are supported. Within HA, each **Radiator** zone will appear as a `Climate` device, and each **Hot Water Temperature** zone will appear as a `WaterHeater` device.
+It uses the [geniushub-client](https://pypi.org/project/geniushub-client/) library.
 
-The device's `operating_mode` can be set to one of `off`, `timer`, `on` (i.e. **Override** mode) or `eco`. The `eco` mode is a proxy for the **Footprint** mode and so is only available to **Radiator** zones that have room sensors.
+### Zones
+Each Zone controlled by your Genius hub will be exposed as either a:
+ - `Climate` entity, for **Radiator** Zones, and
+ - `Water Heater`, for **Hot Water Temperature** Zones
 
-Other properties are available via the device's state attributes, which includes a JSON data structure called `status`. For example, in the case of **Radiator** zones/`Climate` devices:
+Other Zone types, such as **On / Off** Zones, are not currently supported.
+
+Each such entity will report back its mode, state, setpoint and current temperature; other properties are available via its attributes (see below).
+
+In addition, the entity's mode and setpoint can be changed. The entity's `operating_mode` can be set to one of `off`, `timer`, `on` (i.e. **Override** mode) or `eco`. The `eco` mode is a proxy for the **Footprint** mode and so is only available to **Radiator** Zones that have room sensors.
+
+### Devices
+If the Hub is directly polled using the v3 API (see below), then each Device controlled by your Genius hub will be exposed as either a:
+ - `Sensor` entity with a % battery, for any Device with a battery (e.g. a Genius Valve), or
+ - `Binary Sensor` entity with on/off state for any Device that is a switch (e.g. a Smart Plug)
+
+Each such entity will report back its primary state; in addition, `assigned_zone` and `last_comms` (last communications time) are available via the entity's attributes.
+
+### State Attributes
+Other properties are available via each entity's state attributes. For example, in the case of **Radiator** Zones/`Climate` devices:
 
 ```json
 {
@@ -35,7 +54,6 @@ Other properties are available via the device's state attributes, which includes
     }
   }
 }
-
 ```
 
 This data can be accessed in automations, etc. via a value template. For example:
@@ -53,8 +71,6 @@ In the specific case of **Radiator** zones with room sensors:
 value_template: "{{ state_attr('climate.main_room', 'status').occupied }}"
 ```
 {% endraw %}
-
-Currently, there is no support for modifying schedules and neither do they appear in the state attributes.
 
 ## {% linkable_title Configuration %}
 

--- a/source/_components/honeywell.markdown
+++ b/source/_components/honeywell.markdown
@@ -17,9 +17,19 @@ redirect_from:
 ---
 
 
-The `honeywell` climate platform let you control Honeywell Connected thermostats from Home Assistant.
+The `honeywell` climate platform lets you control Honeywell Connected thermostats from Home Assistant.
 
-To set it up, add the following information to your `configuration.yaml` file:
+Unusually, this integration is a combination of two distinct Honeywell products, one based in the US (using the [somecomfort](https://github.com/kk7ds/somecomfort) client library) and the other in the EU (using [evohomeclient](https://github.com/watchforstock/evohome-client)).
+
+The EU-based functionality is being [deprecated](https://github.com/home-assistant/home-assistant/pull/23913) as support for such systems is now provided by the [evohome integration](https://www.home-assistant.io/components/evohome/). If you are using evohomeclient, you should switch to using that integration instead of this one.
+
+### {% linkable_title Configuration %}
+
+To set up this integration, add the following information to your `configuration.yaml` file:
+
+<p class='note warning'>
+  If your system does not require `region: us`, then use [evohome](https://www.home-assistant.io/components/evohome/) instead.
+</p>
 
 ```yaml
 climate:
@@ -27,6 +37,7 @@ climate:
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
     scan_interval: 600
+    region: us
 ```
 <p class='note'>
 Scan interval is expressed in seconds. Omitting or mis-configuring `scan_interval` may result in too-frequent polling and cause you to be rate-limited by Honeywell.
@@ -42,7 +53,7 @@ password:
   required: true
   type: string
 region:
-  description: Region identifier (either 'eu' or 'us').  Use the `somecomfort` client library for `us`, and evohome-client for `eu`.
+  description: Region identifier (either 'eu' or 'us'). Note that support for 'eu' regions is being deprecated (see above).
   required: false
   default: eu
   type: string


### PR DESCRIPTION
Mismerged - so closed in favour of #9480 

## Description:
The **honeywell** component actually contains two mutually-exclusive integrations, based upon either the `somecomfort` (US) or `evohome-client` (EU) client libraries.  The `evohome` functionality is better provided in the **evohome** component, which uses the same client library.

This PR will add a warning to users of the `honeywell` component that support for EU-based systems is deprecated in favour of the `evohome` integration.  

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23469

This Change should go against `current` rather than `next`.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
