### PR TITLE
✏️ Fix broken link to appdaemon

### DIFF
--- a/source/_docs/ecosystem/hadashboard.markdown
+++ b/source/_docs/ecosystem/hadashboard.markdown
@@ -37,4 +37,4 @@ HADashboard is a modular, skinnable dashboard for [Home Assistant](/) that is in
     Glassic Theme
 </p>
 
-For full installation instructions see the HADashboard section in the [AppDaemon Project Documentation](http://appdaemon.readthedocs.io/en/stable/DASHBOARD_INSTALL.html). If you're using Hassbian, then the [Hassbian scripts](https://github.com/home-assistant/hassbian-scripts/blob/dev/docs/appdaemon.md) make it easy to install AppDaemon.
+For full installation instructions see the HADashboard section in the [AppDaemon Project Documentation](http://appdaemon.readthedocs.io/en/stable/DASHBOARD_INSTALL.html). If you're using Hassbian, then the [Hassbian scripts](https://github.com/home-assistant/hassbian-scripts/blob/dev/docs/suites/appdaemon.md) make it easy to install AppDaemon.


### PR DESCRIPTION
**Description:**
Current link provided a 404

related issue: #9477 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
