### PR TITLE
✏️ Google pub/sub - Filter is required

### DIFF
--- a/source/_components/google_pubsub.markdown
+++ b/source/_components/google_pubsub.markdown
@@ -57,7 +57,6 @@ filter:
   description: Filter domains and entities for Google Cloud Pub/Sub.
   required: true
   type: map
-  default: Includes all entities from all domains
   keys:
     include_domains:
       description: List of domains to include (e.g., `light`).

--- a/source/_components/google_pubsub.markdown
+++ b/source/_components/google_pubsub.markdown
@@ -55,7 +55,7 @@ credentials_json:
   type: string
 filter:
   description: Filter domains and entities for Google Cloud Pub/Sub.
-  required: false
+  required: true
   type: map
   default: Includes all entities from all domains
   keys:


### PR DESCRIPTION
**Description:**
`filter` must be required, see also [here](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/google_pubsub/__init__.py#L30)

Related issue: #9465 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
