### PR TITLE
Added Epson ET-2650 to tested printers.

### DIFF
--- a/source/_components/epsonworkforce.markdown
+++ b/source/_components/epsonworkforce.markdown
@@ -67,6 +67,7 @@ Tested devices:
 - Epson WF3620
 - Epson WF3640
 - Epson EcoTank ET-77x0
+- Epson ET-2650
 
 To make this module work you need to connect your printer to your LAN.
 The best is to navigate to the status page of the printer to check if it shows the page with the ink levels on the URL http://<IP_ADDRESS>/PRESENTATION/HTML/TOP/PRTINFO.HTML


### PR DESCRIPTION
**Description:**
Added Epson ET-2650 to tested printers.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
