### PR TITLE
Add control of Amcrest indicator light

### DIFF
--- a/source/_components/amcrest.markdown
+++ b/source/_components/amcrest.markdown
@@ -158,7 +158,7 @@ control_light:
     Automatically control the camera's indicator light, turning it on if the audio or video streams are enabled, and turning it off if both streams are disabled.
   required: false
   type: boolean
-  default: True
+  default: true
 {% endconfiguration %}
 
 **Note:** Amcrest cameras with newer firmware no longer have the ability to

--- a/source/_components/amcrest.markdown
+++ b/source/_components/amcrest.markdown
@@ -153,6 +153,12 @@ switches:
       description: Enable/disable motion detection setting.
     motion_recording:
       description: Enable/disable recording on motion detection setting.
+control_light:
+  description: >
+    Automatically control the camera's indicator light, turning it on if the audio or video streams are enabled, and turning it off if both streams are disabled.
+  required: false
+  type: boolean
+  default: True
 {% endconfiguration %}
 
 **Note:** Amcrest cameras with newer firmware no longer have the ability to


### PR DESCRIPTION
**Description:**

Automatically control the camera's indicator light, turning it on if the audio or video streams are enabled, and turning it off if both streams are disabled.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23986

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
