### PR TITLE
ZHA Add Host ModemManager fix

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -106,4 +106,4 @@ In case you want to add Philips Hue bulbs that have previously been added to ano
 
 ## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
 
-On Linux hosts ZHA can fail to start during HA startup or restarts because the HUSBZB-1 device is being claimed by the host's modemmanager service.  To fix this disable the modemmanger on the host system.
+On Linux hosts ZHA can fail to start during HA startup or restarts because the HUSBZB-1 device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -106,4 +106,4 @@ In case you want to add Philips Hue bulbs that have previously been added to ano
 
 ## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
 
-On Linux hosts ZHA can fail to start during HA startup or restarts because the HUSBZB-1 device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.
+On Linux hosts ZHA can fail to start during HA startup or restarts because the zigbee USB device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -102,3 +102,8 @@ enable_quirks:
 To add new devices to the network, call the `permit` service on the `zha` domain. Do this by clicking the Service icon in Developer tools and typing `zha.permit` in the **Service** dropdown box. Next, follow the device instructions for adding, scanning or factory reset.
 
 In case you want to add Philips Hue bulbs that have previously been added to another bridge, have a look at: [https://github.com/vanviegen/hue-thief/](https://github.com/vanviegen/hue-thief/)
+
+
+## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
+
+On Linux hosts ZHA can fail to start during HA startup or restarts because the HUSBZB-1 device is being claimed by the host's modemmanager service.  To fix this disable the modemmanger on the host system.

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -103,12 +103,14 @@ To add new devices to the network, call the `permit` service on the `zha` domain
 
 In case you want to add Philips Hue bulbs that have previously been added to another bridge, have a look at: [https://github.com/vanviegen/hue-thief/](https://github.com/vanviegen/hue-thief/)
 
+## {% linkable_title Troubleshooting %}
 
-## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
+### {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
 
 On Linux hosts ZHA can fail to start during HA startup or restarts because the zigbee USB device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.
 
 To remove modemmanager from an Debian/Ubuntu host run this command:
-```
+
+```bash
 sudo apt-get purge modemmanager
 ```

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -107,3 +107,8 @@ In case you want to add Philips Hue bulbs that have previously been added to ano
 ## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
 
 On Linux hosts ZHA can fail to start during HA startup or restarts because the zigbee USB device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.
+
+To remove modemmanager from an Debian/Ubuntu host run this command:
+```
+sudo apt-get purge modemmanager
+```


### PR DESCRIPTION
**Description:**

Add blurb to describe fix for zha unavaible on HA start because of ModemManager.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
