### PR TITLE
Remove 'include_non_clients' config option

### DIFF
--- a/source/_components/plex.markdown
+++ b/source/_components/plex.markdown
@@ -94,7 +94,6 @@ You can customize the Plex component by adding any of the variables below to you
 media_player:
   - platform: plex
     entity_namespace: 'plex'
-    include_non_clients: true
     scan_interval: 5
     show_all_controls: false
     use_custom_entity_ids: true
@@ -108,11 +107,6 @@ entity_namespace:
   description: "Prefix for entity ID's. Useful when using overlapping components (ex. Apple TV and Plex components when you have Apple TV's you use as Plex clients). Go from _media_player.playroom2_ to _media_player.plex_playroom_"
   required: false
   type: string
-include_non_clients:
-  description: "Display non-recontrollable clients (ex. remote clients, PlexConnect Apple TV's)."
-  required: false
-  default: false
-  type: boolean
 scan_interval:
   description: "Amount in seconds in between polling for device’s current activity."
   required: false


### PR DESCRIPTION
**Description:**

Removing config option `include_non_clients` from Plex `media_player` component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24038

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
