### PR TITLE
Update Blink docs with new options

### DIFF
--- a/source/_components/blink.markdown
+++ b/source/_components/blink.markdown
@@ -74,14 +74,15 @@ sensors:
       type: list
       default: all (`battery`, `temperature`, `wifi_strength`)
 offset:
-  description: How far back in time to look for motion.  Motion is determined if a new video has been recorded between now and the last time you refreshed plus this offset.  Defaults to 1 minute.
+  description: How far back in time (minutes) to look for motion. Motion is determined if a new video has been recorded between now and the last time you refreshed plus this offset.
   required: false
   type: integer
+  default: 1
 mode:
-  description: Set to 'legacy' to enable use of old API endpoint subdomains (APIs can differ based on region, so use this if you are having issues with the integration).  Defaults to '' (everything other than 'legacy' is ignored).
+  description: Set to 'legacy' to enable use of old API endpoint subdomains (APIs can differ based on region, so use this if you are having issues with the integration).
   required: false
   type: string
-
+  default: not set
 {% endconfiguration %}
 
 Once Home Assistant starts, the `blink` component will create the following platforms:

--- a/source/_components/blink.markdown
+++ b/source/_components/blink.markdown
@@ -73,6 +73,15 @@ sensors:
       required: false
       type: list
       default: all (`battery`, `temperature`, `wifi_strength`)
+offset:
+  description: How far back in time to look for motion.  Motion is determined if a new video has been recorded between now and the last time you refreshed plus this offset.  Defaults to 1 minute.
+  required: false
+  type: integer
+mode:
+  description: Set to 'legacy' to enable use of old API endpoint subdomains (APIs can differ based on region, so use this if you are having issues with the integration).  Defaults to '' (everything other than 'legacy' is ignored).
+  required: false
+  type: string
+
 {% endconfiguration %}
 
 Once Home Assistant starts, the `blink` component will create the following platforms:


### PR DESCRIPTION
**Description:**
Adds new config options to blink.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24097

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].
