### PR TITLE
Added possibility to define the data type for set_device_value

### DIFF
--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -354,6 +354,20 @@ action:
     value: 23.0
 ```
 
+Manually set the active profile on thermostat:
+
+```yaml
+...
+action:
+  service: homematic.set_device_value
+  data:
+    address: LEQ1234567
+    channel: 1
+    param: ACTIVE_PROFILE
+    value: 1
+    value_type: int
+```
+
 Set the week program of a wall thermostat:
 
 ```yaml


### PR DESCRIPTION
**Description:**

The Homematic CCU needs that we send the correct XML-RPC Data Type for setValue, this was added for set_device_value.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24078

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
