### PR TITLE
Add Lock device type to zha.markdown

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -13,6 +13,7 @@ ha_category:
   - Binary Sensor
   - Fan
   - Light
+  - Lock
   - Sensor
   - Switch
 ha_release: 0.44
@@ -22,6 +23,7 @@ redirect_from:
   - /components/binary_sensor.zha/
   - /components/fan.zha/
   - /components/light.zha/
+  - /components/lock.zha/
   - /components/sensor.zha/
   - /components/switch.zha/
 ---
@@ -34,6 +36,7 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor
 - Sensor
 - Light
+- Lock
 - Switch
 - Fan
 

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -23,7 +23,6 @@ redirect_from:
   - /components/binary_sensor.zha/
   - /components/fan.zha/
   - /components/light.zha/
-  - /components/lock.zha/
   - /components/sensor.zha/
   - /components/switch.zha/
 ---


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24126

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
