### PR TITLE
adding icon_template example to binary_sensor.template docs

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -215,3 +215,30 @@ binary_sensor:
              or is_state('binary_sensor.family_room_144', 'on') }}
 ```
 {% endraw %}
+
+### {% linkable_title Change the icon when state changes %}
+
+This example demonstrates how to use `icon_template` to change the entity's
+icon as its state changes, it evaluates the state of its own sensor and uses a 
+conditional statement to output the appropriate icon. 
+
+
+{% raw %}
+```yaml
+sun:
+binary_sensor:
+  - platform: template
+    sensors:
+      sun_up:
+        entity_id:
+          - sun.sun
+        value_template: >-
+          {{ is_state("sun.sun", "above_horizon") }}
+        icon_template: >-
+          {% if is_state("binary_sensor.sun_up", "on") %}
+            mdi:weather-sunset-up
+          {% else %}
+            mdi:weather-sunset-down
+          {% endif %}
+```
+{% endraw %}


### PR DESCRIPTION
**Description:**

I would like to add an additional example to the binary_sensor.template page after having difficulty tracing down a functional example last weekend.

I am still learning how to do this, please go easy on me 👍 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
