### PR TITLE
Update multi-factor-auth.markdown

### DIFF
--- a/source/_docs/authentication/multi-factor-auth.markdown
+++ b/source/_docs/authentication/multi-factor-auth.markdown
@@ -75,15 +75,17 @@ Add Notify MFA to your `configuration.yaml` file like this:
 homeassistant:
   auth_mfa_modules:
     - type: notify
+      include:
+        - notify_entity
 ```
 
 {% configuration %}
 exclude:
-  description: The list of notifying services you want to exclude.
+  description: The list of notifying service entitys you want to exclude.
   required: false
   type: list
 include:
-  description: The list of notifying services you want to include.
+  description: The list of notifying service entitys you want to include.
   required: false
   type: list
 message:

--- a/source/_docs/authentication/multi-factor-auth.markdown
+++ b/source/_docs/authentication/multi-factor-auth.markdown
@@ -85,7 +85,7 @@ exclude:
   required: false
   type: list
 include:
-  description: The list of notifying service entitys you want to include.
+  description: The list of notifying service entities you want to include.
   required: false
   type: list
 message:

--- a/source/_docs/authentication/multi-factor-auth.markdown
+++ b/source/_docs/authentication/multi-factor-auth.markdown
@@ -81,7 +81,7 @@ homeassistant:
 
 {% configuration %}
 exclude:
-  description: The list of notifying service entitys you want to exclude.
+  description: The list of notifying service entities you want to exclude.
   required: false
   type: list
 include:


### PR DESCRIPTION
Took me a while to get the config after it wasn't clear that I only have to define the entity_id without the domain.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
