### PR TITLE
Fix new log entry example

### DIFF
--- a/source/_components/system_log.markdown
+++ b/source/_components/system_log.markdown
@@ -141,8 +141,9 @@ automation:
       to: 'on'
     action:
       service: system_log.write
-      message: 'Door opened!'
-      level: info
+      data_template:
+        message: 'Door opened!'
+        level: info
 ```
 {% endraw %}
 


### PR DESCRIPTION
**Description:**
The documentation for the system_log component is currently invalid because it doesn't use the data_template

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
