### PR TITLE
Added support for radiotherm humidity

### DIFF
--- a/source/_components/radiotherm.markdown
+++ b/source/_components/radiotherm.markdown
@@ -79,3 +79,4 @@ climate:
     - 192.168.99.137
     - 192.168.99.202
 ```
+Humidity is now available as the `current_humidity` attribute for each `climate.$HOST` entity. This only works for RadioThermostat devices that have a built in humidity sensor. 


### PR DESCRIPTION
**Description:**
Added documentation regarding home-assistant PR #24086. Humidity is now available from devices that have built in humidity sensors. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25024

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
