### PR TITLE
Add esphome to discovery components

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -25,6 +25,7 @@ Home Assistant can discover and automatically configure [zeroconf](https://en.wi
  * [DirecTV receivers](/components/media_player.directv/)
  * [DLNA DMR enabled devices](/components/media_player.dlna_dmr/)
  * [Enigma2 media player](/components/media_player.enigma2/)
+ * [ESPHome](/components/esphome/)
  * [Frontier Silicon internet radios](/components/media_player.frontier_silicon/)
  * [Google Cast](/components/media_player.cast/)
  * [HomeKit](/components/homekit_controller/)


### PR DESCRIPTION
**Description:**

Add esphome to discovery components


## Checklist:

- [ X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
