### PR TITLE
Remove esphome breaking change

### DIFF
--- a/source/_posts/2019-06-05-release-94.markdown
+++ b/source/_posts/2019-06-05-release-94.markdown
@@ -57,7 +57,6 @@ Experiencing issues introduced by this release? Please report them in our [issue
 
 - Quiet the chatty sun.sun ([@Swamp-Ig] - [#23832]) ([sun docs]) (breaking change)
 - Doorbird Refactor ([@oblogic7] - [#23892]) ([doorbird docs]) (breaking change)
-- ESPHome component to use zeroconf discovery ([@Kane610] - [#24043]) ([esphome docs]) (breaking change)
 - Always update all Plex client types ([@jjlawren] - [#24038]) ([plex docs]) (breaking change)
 - Fix entity id naming when not using first install ([@tkjacobsen] - [#23606]) ([verisure docs]) (breaking change)
 - Update the name of Zestimate sensors ([@dreed47] - [#23770]) ([zestimate docs]) (breaking change)


### PR DESCRIPTION
**Description:**

See https://github.com/home-assistant/home-assistant/pull/24043#issuecomment-497360049 and https://github.com/home-assistant/home-assistant/pull/24043#issuecomment-497360925

Since ESPHome was only ever configurable through config flow. Plus it seems like the zeroconf change is not a breaking change yet anyway.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
