### PR TITLE
Add Z-Wave device model and bold shutdown directions for readability

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -167,7 +167,7 @@ Some models of the Zooz Toggle switches ship with an instruction manual with inc
 
 ## {% linkable_title Central Scene configuration %}
 
-To provide Central Scene support you need to shut Home Assistant down and modify your `zwcfg_*.xml` file according to the following guides.
+To provide Central Scene support you need to **shut Home Assistant down** and modify your `zwcfg_*.xml` file according to the following guides.
 
 ### {% linkable_title Inovelli Scene Capable On/Off and Dimmer Wall Switches %}
 
@@ -386,7 +386,7 @@ Button four release|4|1
 
 Use the same configuration as for the Aeotec Wallmote.
 
-### {% linkable_title HANK One-key Scene Controller HKZN-SCN01 %}
+### {% linkable_title HANK One-key Scene Controller HKZN-SCN01/HKZW-SCN01 %}
 
 For the HANK One-key Scene Controller, you may need to update the `COMMAND_CLASS_CENTRAL_SCENE` for each node in your `zwcfg` file with the following:
 

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -167,7 +167,7 @@ Some models of the Zooz Toggle switches ship with an instruction manual with inc
 
 ## {% linkable_title Central Scene configuration %}
 
-To provide Central Scene support you need to **shut Home Assistant down** and modify your `zwcfg_*.xml` file according to the following guides.
+To provide Central Scene support you need to **shutdown Home Assistant** and modify your `zwcfg_*.xml` file according to the following guides.
 
 ### {% linkable_title Inovelli Scene Capable On/Off and Dimmer Wall Switches %}
 


### PR DESCRIPTION
Added a device model for the Hank Z-Wave button: https://products.z-wavealliance.org/products/1918

I just bought one and used the same directions to get it working.

I also wanted to bold the directions telling the user to shutdown because I missed that paragraph and lost quite a bit of time trying to figure out why it wouldn't persist.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
