### PR TITLE
Fix 404 link for react example

### DIFF
--- a/source/_cookbook/custom_panel_using_react.markdown
+++ b/source/_cookbook/custom_panel_using_react.markdown
@@ -18,7 +18,7 @@ This is a [React](https://facebook.github.io/react/) implementation of [TodoMVC]
 - It uses the user configuration for the component in the `configuration.yaml` file for rendering.
 - It allows toggling the sidebar.
 
-Download the source [here](https://github.com/home-assistant/example-custom-config/blob/master/panels/react.html). Copy the file to `<config dir>/panels/` (you might have to create the directory if it doesn't exist).
+[Download the source for React Starter Kit here](https://github.com/home-assistant/custom-panel-starter-kit-react). Copy the file to `<config dir>/panels/` (you might have to create the directory if it doesn't exist).
 
 Create an entry for the panel in your `configuration.yaml` file to enable it.
 


### PR DESCRIPTION
The link for the react example returns a 404

Seems it has been moved to https://github.com/home-assistant/custom-panel-starter-kit-react

Updated the link description for better accessibility (when used with text-to-speech software used by visually impaired users).

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
