### PR TITLE
Current

### DIFF
--- a/source/_components/alarm_control_panel.markdown
+++ b/source/_components/alarm_control_panel.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Alarm
+ha_qa_scale: internal
 ha_release: 0.7.3
 ---
 

--- a/source/_components/alarm_control_panel.markdown
+++ b/source/_components/alarm_control_panel.markdown
@@ -7,12 +7,9 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Alarm
 ha_release: 0.7.3
 ---
 
-Home Assistant can give you an interface with is similar to a classic alarm system. There are several panels supported:
-
-- [Alarm.com](/components/alarm_control_panel.alarmdotcom/)
-- [Manual](/components/alarm_control_panel.manual/)
-- [MQTT](/components/alarm_control_panel.mqtt/)
-- [Verisure](/components/verisure/)
+Home Assistant can give you an interface with is similar to a classic alarm system.

--- a/source/_components/binary_sensor.markdown
+++ b/source/_components/binary_sensor.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Binary Sensor
+ha_qa_scale: internal
 ha_release: 0.9
 ---
 

--- a/source/_components/binary_sensor.markdown
+++ b/source/_components/binary_sensor.markdown
@@ -7,43 +7,13 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Binary Sensor
 ha_release: 0.9
 ---
 
 Binary sensors gather information about the state of devices which have a "digital" return value (either 1 or 0). These can be switches, contacts, pins, etc. These sensors only have two states: **0/off/low/closed/false** and **1/on/high/open/true**.  Knowing that there are only two states allows Home Assistant to represent these sensors in a better way in the frontend according to their functionality.
 
-### {% linkable_title Device Class %}
-
-The way these sensors are displayed in the frontend can be modified in the [customize section](/getting-started/customizing-devices/). The following device classes are supported for binary sensors:
-
-- **None**: Generic on/off. This is the default and doesn't need to be set.
-- **battery**: `On` means low, `Off` means normal
-- **cold**: `On` means cold, `Off` means normal
-- **connectivity**: `On` means connected, `Off` means disconnected
-- **door**: `On` means open, `Off` means closed
-- **garage_door**: `On` means open, `Off` means closed
-- **gas**: `On` means gas detected, `Off` means no gas (clear)
-- **heat**: `On` means hot, `Off` means normal
-- **light**: `On` means light detected, `Off` means no light
-- **lock**: `On` means open (unlocked), `Off` means closed (locked)
-- **moisture**: `On` means moisture detected (wet), `Off` means no moisture (dry)
-- **motion**: `On` means motion detected, `Off` means no motion (clear)
-- **moving**: `On` means moving, `Off` means not moving (stopped)
-- **occupancy**: `On` means occupied, `Off` means not occupied (clear)
-- **opening**: `On` means open, `Off` means closed
-- **plug**: `On` means device is plugged in, `Off` means device is unplugged
-- **power**: `On` means power detected, `Off` means no power
-- **presence**: `On` means home, `Off` means away
-- **problem**: `On` means problem detected, `Off` means no problem (OK)
-- **safety**: `On` means unsafe, `Off` means safe
-- **smoke**: `On` means smoke detected, `Off` means no smoke (clear)
-- **sound**: `On` means sound detected, `Off` means no sound (clear)
-- **vibration**: `On` means vibration detected, `Off` means no vibration (clear)
-- **window**: `On` means open, `Off` means closed
-
-For analog sensors please check the [component overview](/components/#sensor).
-
 <p class='img'>
 <img src='/images/screenshots/binary_sensor_classes_icons.png' />
-Example of various device classes icons in `On` and `Off` state.
 </p>

--- a/source/_components/camera.markdown
+++ b/source/_components/camera.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Camera
+ha_qa_scale: internal
 ha_release: 0.7
 ---
 

--- a/source/_components/camera.markdown
+++ b/source/_components/camera.markdown
@@ -7,16 +7,50 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Camera
 ha_release: 0.7
 ---
 
-The camera component allows you to use IP cameras with Home Assistant. With a little additional work you could use [USB cameras](/blog/2016/06/23/usb-webcams-and-home-assistant/) as well.
+The camera component allows you to use IP cameras with Home Assistant.
+
+### {% linkable_title Streaming Video %}
+
+If your camera supports it, and the [`stream`](/components/stream) component is setup, you will be able to stream your cameras in the frontend and on supported media players.
+
+This option will keep the stream alive, and preload the feed on Home Assistant startup. This will result in reduced latency when opening the stream in the frontend, as well as when using the `play_stream` service or Google Assistant integration. It does, however, utilize more resources on your machine, so it is recommended to check CPU usage if you plan to use this feature.
+
+<p class='img'>
+  <img src='/images/components/camera/preload-stream.png' alt='Screenshot showing Preload Stream option in Home Assistant front end.'>
+  Example showing the Preload Stream option in the camera dialog.
+</p>
+
 
 ### {% linkable_title Services %}
 
 Once loaded, the `camera` platform will expose services that can be called to perform various actions.
 
 Available services: `turn_on`, `turn_off`, `enable_motion_detection`, `disable_motion_detection`, `snapshot`, and `play_stream`.
+
+#### {% linkable_title Service `play_stream` %}
+
+Play a live stream from a camera to selected media player(s). Requires [`stream`](/components/stream) component to be set up.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |      no  | Name of entity to fetch stream from, e.g., `camera.living_room_camera`. |
+| `media_player`         |      no  | Name of media player to play stream on, e.g., `media_player.living_room_tv`. |
+| `format`               |      yes | Stream format supported by `stream` component and selected `media_player`. Default: `hls` |
+
+For example, the following action in an automation would send an `hls` live stream to your chromecast.
+
+```yaml
+action:
+  service: camera.play_stream
+  data:
+    entity_id: camera.yourcamera
+    media_player: media_player.chromecast
+```
 
 #### {% linkable_title Service `turn_on` %}
 
@@ -100,26 +134,6 @@ action:
 ```
 {% endraw %}
 
-#### {% linkable_title Service `play_stream` %}
-
-Play a live stream from a camera to selected media player(s). Requires [`stream`](/components/stream) component to be set up.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | Name of entity to fetch stream from, e.g., `camera.living_room_camera`. |
-| `media_player`         |      no  | Name of media player to play stream on, e.g., `media_player.living_room_tv`. |
-| `format`               |      yes | Stream format supported by `stream` component and selected `media_player`. Default: `hls` |
-
-For example, the following action in an automation would send an `hls` live stream to your chromecast.
-
-```yaml
-action:
-  service: camera.play_stream
-  data:
-    entity_id: camera.yourcamera
-    media_player: media_player.chromecast
-```
-
 ### {% linkable_title Test if it works %}
 
 A simple way to test if you have set up your `camera` platform correctly, is to use <img src='/images/screenshots/developer-tool-services-icon.png' alt='service developer tool icon' class="no-shadow" height="38" /> **Services** from the **Developer Tools**. Choose your service from the dropdown menu **Service**, enter something like the sample below into the **Service Data** field, and hit **CALL SERVICE**.
@@ -129,12 +143,3 @@ A simple way to test if you have set up your `camera` platform correctly, is to 
   "entity_id": "camera.living_room_camera"
 }
 ```
-
-### {% linkable_title Preload Stream %}
-
-If your camera supports it, and the [`stream`](/components/stream) component is setup, You will notice a "Preload Stream" option in the top right of the dialog when clicking to view the camera stream.  This option will keep the stream alive, and preload the feed on Home Assistant startup.  This will result in reduced latency when opening the stream in the frontend, as well as when using the `play_stream` service or Google Assistant integration.  It does, however, utilize more resources on your machine, so it is recommended to check CPU usage if you plan to use this feature.
-
-<p class='img'>
-  <img src='/images/components/camera/preload-stream.png' alt='Screenshot showing Preload Stream option in Home Assistant front end.'>
-  Example showing the Preload Stream option in the camera dialog.
-</p>

--- a/source/_components/climate.markdown
+++ b/source/_components/climate.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Climate
+ha_qa_scale: internal
 ha_release: 0.19
 ---
 

--- a/source/_components/climate.markdown
+++ b/source/_components/climate.markdown
@@ -7,19 +7,12 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Climate
 ha_release: 0.19
 ---
 
-
 The `climate` component is built for the controlling and monitoring of HVAC (heating, ventilating, and air conditioning) and thermostat devices.
- 
-To enable this component, pick one of the platforms, and add it to your `configuration.yaml`:
-
-```yaml
-# Example configuration.yaml entry
-climate:
-  platform: demo
-```
 
 ## {% linkable_title Services %}
 
@@ -238,13 +231,3 @@ Turn climate device off
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Targets all when omitted.
-
-#### {% linkable_title Customization  %}
-
-The step for the setpoint can be adjusted (default to 0,5 increments) by adding the following line into configuration
-
-```yaml
-customize:
-  - entity_id
-      target_temp_step: 1
-```

--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -7,32 +7,12 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Cover
 ha_release: 0.27
 ---
 
 Home Assistant can give you an interface to control covers such as rollershutters, blinds, and garage doors.
-
-The display style of each entity can be modified in the [customize section](/getting-started/customizing-devices/). Besides the basic ones like `friendly_name` or `hidden`, the following attributes are supported for covers:
- 
-| Attribute | Default | Description |
-| --------- | ------- | ----------- |
-| `device_class` | | see below
-| `assumed_state` | `false` | If set to `true`, cover buttons will always be enabled
-
-### {% linkable_title Device Class %}
-
-The way these sensors are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for covers:
-
-- **None**: Generic cover. This is the default and doesn't need to be set.
-- **awning**: Control of an awning, such as an exterior retractable window, door, or patio cover.
-- **blind**: Control of blinds, which are linked slats that expand or collapse to cover an opening or may be tilted to partially covering an opening, such as window blinds.
-- **curtain**: Control of curtains or drapes, which is often fabric hung above a window or door that can be drawn open.
-- **damper**: Control of a mechanical damper that reduces airflow, sound, or light.
-- **door**: Control of a door or gate that provides access to an area.
-- **garage**: Control of a garage door that provides access to a garage.
-- **shade**: Control of shades, which are a continuous plane of material or connected cells that expanded or collapsed over an opening, such as window shades.
-- **shutter**: Control of shutters, which are linked slats that swing out/in to covering an opening or may be tilted to partially cover an opening, such as indoor or exterior window shutters.
-- **window**: Control of a physical window that opens and closes or may tilt.
 
 ## {% linkable_title Services %}
 

--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Cover
+ha_qa_scale: internal
 ha_release: 0.27
 ---
 

--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Presence Detection
+ha_qa_scale: internal
 ha_release: 0.7
 ---
 

--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -7,14 +7,12 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Presence Detection
 ha_release: 0.7
 ---
 
-Home Assistant can get information from your wireless router or third party services like iCloud or OwnTracks to track which devices are connected and considered "in home". Please check the sidebar for a list of  brands of supported wireless routers and services.
-
-There are also trackers available which use different technologies like [MQTT](/components/mqtt/) or [Nmap](/components/nmap_tracker/) to scan the network for devices.
-
-An [event](/getting-started/automation-trigger/#event-trigger) (`device_tracker_new_device`) will be fired when a device is discovered for the first time.
+The device tracker allows you to track devices in Home Assistant. This can happen by querying your wireless router or by having applications push location info.
 
 ## {% linkable_title Configuring a `device_tracker` platform %}
 
@@ -24,8 +22,8 @@ To get started add the following lines to your `configuration.yaml` (example for
 # Example configuration.yaml entry for Netgear device
 device_tracker:
   - platform: netgear
-    host: 192.168.1.1
-    username: admin
+    host: IP_ADDRESS
+    username: YOUR_USERNAME
     password: YOUR_PASSWORD
     new_device_defaults:
       track_new_devices: true
@@ -54,8 +52,8 @@ The extended example from above would look like the following sample:
 # Example configuration.yaml entry for Netgear device
 device_tracker:
   - platform: netgear
-    host: 192.168.1.1
-    username: admin
+    host: IP_ADDRESS
+    username: YOUR_USERNAME
     interval_seconds: 10
     consider_home: 180
     new_device_defaults:
@@ -93,24 +91,6 @@ devicename:
 | `track`        | [uses platform setting]       | If  `yes`/`on`/`true` then the device will be tracked. Otherwise its location and state will not update. |
 | `hide_if_away` | false                         | If `yes`/`on`/`true` then the device will be hidden if it is not at home.                                |
 | `consider_home` | [uses platform setting]      | Seconds to wait till marking someone as not home after not being seen. Allows you to override the global `consider_home` setting from the platform configuration on a per device level.                                 |
-
-## {% linkable_title Using GPS device trackers with local network device trackers %}
-
-GPS based device trackers (like [OwnTracks](/components/owntracks/), [GPSLogger](/components/gpslogger) and others) can also be used with local network device trackers, such as [Nmap](/components/nmap_tracker/) or [Netgear](/components/netgear/). To do this, fill in the `mac` field to the entry in `known_devices.yaml` with the MAC address of the device you want to track. This way the state of the device will be determined by *the source that reported last*. The naming convention for known device list is `<username>_<device-id>` and could be set in the app configuration.
-
-An example showing the inclusion of the `mac` field for multiple platform tracking. The `mac` field was added to the GPS based device tracker entry and will enable tracking by all platforms that track via the `mac` address.
-
-```yaml
-USERNAME_DEVICE_ID:
-  name: Friendly Name
-  mac: EA:AA:55:E7:C6:94
-  picture: https://www.home-assistant.io/images/favicon-192x192.png
-  gravatar: test@example.com
-  track: true
-  hide_if_away: false
-```
-
-If you want to track whether either your GPS based tracker or your local network tracker, identify you as being at home, use [a group](/components/group/) instead.
 
 ## {% linkable_title Device states %}
 

--- a/source/_components/fan.markdown
+++ b/source/_components/fan.markdown
@@ -7,17 +7,9 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Fan
 ha_release: 0.27
 ---
 
-
-The `fan` component is built for the controlling of fan devices. It can be called the little brother of the [climate](/components/climate/) component.
- 
-To enable this component, pick one of the platforms, and add it to your `configuration.yaml`:
-
-```yaml
-# Example configuration.yaml entry
-climate:
-  platform: fan
-```
-
+The `fan` component is built for the controlling of fan devices.

--- a/source/_components/fan.markdown
+++ b/source/_components/fan.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Fan
+ha_qa_scale: internal
 ha_release: 0.27
 ---
 

--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Light
+ha_qa_scale: internal
 ha_release: pre 0.7
 ---
 

--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -7,14 +7,12 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Light
 ha_release: pre 0.7
 ---
 
-This component allows you to track and control various light bulbs. Read the platform documentation for your particular light hardware to learn how to enable it.
-
-<p class='note'>
-The light component supports multiple entries in <code>configuration.yaml</code> by appending a sequential number to the section: <code>light 2:</code>, <code>light 3:</code> etc.
-</p>
+This component allows you to track and control various light bulbs. Read the integration documentation for your particular light hardware to learn how to enable it.
 
 ### {% linkable_title Default turn-on values %}
 
@@ -26,7 +24,7 @@ The `.default` suffix should be added to the entity identifier of each light to 
 
 Turns one light on or multiple lights on using [groups]({{site_root}}/components/group/).
 
-Most lights do not support all attributes. You can check the platform documentation of your particular light for hints, but in general, you will have to try things out and see what works.
+Most lights do not support all attributes. You can check the integration documentation of your particular light for hints, but in general, you will have to try things out and see what works.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |

--- a/source/_components/lock.markdown
+++ b/source/_components/lock.markdown
@@ -7,6 +7,8 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Lock
 ha_release: 0.9
 ---
 

--- a/source/_components/lock.markdown
+++ b/source/_components/lock.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Lock
+ha_qa_scale: internal
 ha_release: 0.9
 ---
 

--- a/source/_components/media_player.markdown
+++ b/source/_components/media_player.markdown
@@ -7,10 +7,12 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Media Player
 ha_release: 0.7
 ---
 
-Interacts with media players on your network. Please check the right sidebar for a full list of supported devices.
+Interacts with media players on your network.
 
 ## {% linkable_title Services %}
 

--- a/source/_components/media_player.markdown
+++ b/source/_components/media_player.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Media Player
+ha_qa_scale: internal
 ha_release: 0.7
 ---
 

--- a/source/_components/notify.markdown
+++ b/source/_components/notify.markdown
@@ -7,6 +7,8 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Notifications
 ha_release: 0.7
 ---
 
@@ -14,19 +16,7 @@ The `notify` component makes it possible to send notifications to a wide variety
 
 If you want to send notifications to the Home Assistant Web Interface you may use the [Persistent Notification Component](/components/persistent_notification/).
 
-## {% linkable_title Configuration %}
-
-```yaml
-# Example configuration.yaml entry
-notify:
-  - platform: pushbullet
-    name: NOTIFY_NAME
-    api_key: YOUR_API_KEY
-```
-
-The **name** parameter is optional but needed if you want to use multiple platforms. The platform will be exposed as service `notify.<name>`. The name will default to `notify` if not supplied.
-
-### {% linkable_title Service %}
+## {% linkable_title Service %}
 
 Once loaded, the `notify` platform will expose a service that can be called to send notifications.
 

--- a/source/_components/notify.markdown
+++ b/source/_components/notify.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Notifications
+ha_qa_scale: internal
 ha_release: 0.7
 ---
 

--- a/source/_components/pushbullet.markdown
+++ b/source/_components/pushbullet.markdown
@@ -23,6 +23,10 @@ There is currently support for the following device types within Home Assistant:
 - [Sensor](#sensor)
 - [Notifications](#notifications)
 
+<p class='note'>
+The free tier is [limited](https://docs.pushbullet.com/#push-limit) to 500 pushes per month.
+</p>
+
 ### {% linkable_title Sensor %}
 
 The `pushbullet` sensor platform reads messages from [Pushbullet](https://www.pushbullet.com/), a free service to send information between your phones, browsers, and friends. This sensor platform provides sensors that show the properties of the latest received Pushbullet notification mirror.
@@ -83,7 +87,7 @@ All properties will be displayed as attributes. The properties array are just fo
 
 ## {% linkable_title Notifications %}
 
-The `pushbullet` notification platform sends messages to [Pushbullet](https://www.pushbullet.com/), a free service to send information between your phones, browsers, and friends.
+The `pushbullet` notification platform sends messages to [Pushbullet](https://www.pushbullet.com/), a free service to send information between your phones, browsers, and friends. The free tier is [limited](https://docs.pushbullet.com/#push-limit) to 500 pushes per month.
 
 To enable Pushbullet notifications in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Sensor
+ha_qa_scale: internal
 ha_release: 0.7
 ---
 

--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -7,28 +7,15 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Sensor
 ha_release: 0.7
 ---
 
 Sensors are gathering information about states and conditions.
 
-Home Assistant currently supports a wide range of sensors. They are able to display information which are provides by Home Assistant directly, are gathered from web services, and, of course, physical devices. Please check the sidebar for a full list of supported sensor platforms.
-
-## {% linkable_title Device Class %}
-
-The way these sensors are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for sensors:
-
-- **None**: Generic sensor. This is the default and doesn't need to be set.
-- **battery**: Percentage of battery that is left.
-- **humidity**: Percentage of humidity in the air.
-- **illuminance**: The current light level in lx or lm.
-- **signal_strength**: Signal strength in dB or dBm.
-- **temperature**: Temperature in °C or °F.
-- **power**: Power in W or kW.
-- **pressure**: Pressure in hPa or mbar.
-- **timestamp**: Datetime object or timestamp string.
+Home Assistant currently supports a wide range of sensors. They are able to display information which are provides by Home Assistant directly, are gathered from web services, and, of course, physical devices.
 
 <p class='img'>
 <img src='/images/screenshots/sensor_device_classes_icons.png' />
-Example of various device class icons for sensors.
 </p>

--- a/source/_components/switch.markdown
+++ b/source/_components/switch.markdown
@@ -7,6 +7,8 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+ha_category:
+  - Switch
 ha_release: 0.7
 ---
 

--- a/source/_components/switch.markdown
+++ b/source/_components/switch.markdown
@@ -7,8 +7,10 @@ sidebar: true
 comments: false
 sharing: true
 footer: true
+logo: home-assistant.png
 ha_category:
   - Switch
+ha_qa_scale: internal
 ha_release: 0.7
 ---
 

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -106,4 +106,4 @@ In case you want to add Philips Hue bulbs that have previously been added to ano
 
 ## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
 
-On Linux hosts ZHA can fail to start during HA startup or restarts because the HUSBZB-1 device is being claimed by the host's modemmanager service.  To fix this disable the modemmanger on the host system.
+On Linux hosts ZHA can fail to start during HA startup or restarts because the HUSBZB-1 device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -106,4 +106,4 @@ In case you want to add Philips Hue bulbs that have previously been added to ano
 
 ## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
 
-On Linux hosts ZHA can fail to start during HA startup or restarts because the HUSBZB-1 device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.
+On Linux hosts ZHA can fail to start during HA startup or restarts because the zigbee USB device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -102,3 +102,8 @@ enable_quirks:
 To add new devices to the network, call the `permit` service on the `zha` domain. Do this by clicking the Service icon in Developer tools and typing `zha.permit` in the **Service** dropdown box. Next, follow the device instructions for adding, scanning or factory reset.
 
 In case you want to add Philips Hue bulbs that have previously been added to another bridge, have a look at: [https://github.com/vanviegen/hue-thief/](https://github.com/vanviegen/hue-thief/)
+
+
+## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
+
+On Linux hosts ZHA can fail to start during HA startup or restarts because the HUSBZB-1 device is being claimed by the host's modemmanager service.  To fix this disable the modemmanger on the host system.

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -103,12 +103,14 @@ To add new devices to the network, call the `permit` service on the `zha` domain
 
 In case you want to add Philips Hue bulbs that have previously been added to another bridge, have a look at: [https://github.com/vanviegen/hue-thief/](https://github.com/vanviegen/hue-thief/)
 
+## {% linkable_title Troubleshooting %}
 
-## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
+### {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
 
 On Linux hosts ZHA can fail to start during HA startup or restarts because the zigbee USB device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.
 
 To remove modemmanager from an Debian/Ubuntu host run this command:
-```
+
+```bash
 sudo apt-get purge modemmanager
 ```

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -107,3 +107,8 @@ In case you want to add Philips Hue bulbs that have previously been added to ano
 ## {% linkable_title ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts %}
 
 On Linux hosts ZHA can fail to start during HA startup or restarts because the zigbee USB device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.
+
+To remove modemmanager from an Debian/Ubuntu host run this command:
+```
+sudo apt-get purge modemmanager
+```

--- a/source/_cookbook/custom_panel_using_react.markdown
+++ b/source/_cookbook/custom_panel_using_react.markdown
@@ -18,7 +18,7 @@ This is a [React](https://facebook.github.io/react/) implementation of [TodoMVC]
 - It uses the user configuration for the component in the `configuration.yaml` file for rendering.
 - It allows toggling the sidebar.
 
-Download the source [here](https://github.com/home-assistant/example-custom-config/blob/master/panels/react.html). Copy the file to `<config dir>/panels/` (you might have to create the directory if it doesn't exist).
+[Download the source for React Starter Kit here](https://github.com/home-assistant/custom-panel-starter-kit-react). Copy the file to `<config dir>/panels/` (you might have to create the directory if it doesn't exist).
 
 Create an entry for the panel in your `configuration.yaml` file to enable it.
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -130,7 +130,7 @@ automation:
 
 ### {% linkable_title Sun trigger %}
 
-#### Sunset / Sunrise trigger
+#### {% linkable_title Sunset / Sunrise trigger %}
 Triggers when the sun is setting or rising, i.e. when the sun elevation reaches 0°.
 
 An optional time offset can be given to have it trigger a set time before or after the sun event (e.g. 45 minutes before sunset). Since the duration of twilight is different throughout the year, it is recommended to use sun elevation triggers instead of `sunset` or `sunrise` with a time offset to trigger automations at the start of dusk or dawn.
@@ -145,7 +145,7 @@ automation:
     offset: '-00:45:00'
 ```
 
-#### Sun elevation trigger
+#### {% linkable_title Sun elevation trigger %}
 Sometimes you may want more granular control over an automation than simply sunset or sunrise and specify an exact elevation of the sun. This can be used to layer automations to occur as the sun lowers on the horizon or even after it is below the horizon. This is also useful when the "sunset" event is not dark enough outside and you would like the automation to run later at a precise solar angle instead of the time offset such as turning on exterior lighting. For most things intended to trigger during dusk or dawn, a number between 0° and -6° is suitable; -4° is used in this example:
 
 {% raw %}

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -130,9 +130,10 @@ automation:
 
 ### {% linkable_title Sun trigger %}
 
-Triggers when the sun is setting or rising. An optional time offset can be given to have it trigger a set time before or after the sun event (i.e. 45 minutes before sunset, when dusk is setting in).
+#### Sunset / Sunrise trigger
+Triggers when the sun is setting or rising, i.e. when the sun elevation reaches 0°.
 
-Sunrise as a trigger may need special attention as explained in time triggers below. This is due to the date changing at midnight and sunrise is at an earlier time on the following day.
+An optional time offset can be given to have it trigger a set time before or after the sun event (e.g. 45 minutes before sunset). Since the duration of twilight is different throughout the year, it is recommended to use sun elevation triggers instead of `sunset` or `sunrise` with a time offset to trigger automations at the start of dusk or dawn.
 
 ```yaml
 automation:
@@ -140,11 +141,12 @@ automation:
     platform: sun
     # Possible values: sunset, sunrise
     event: sunset
-    # Optional time offset. This example is 45 minutes.
+    # Optional time offset. This example will trigger 45 minutes before sunrise.
     offset: '-00:45:00'
 ```
 
-Sometimes you may want more granular control over an automation based on the elevation of the sun. This can be used to layer automations to occur as the sun lowers on the horizon or even after it is below the horizon. This is also useful when the "sunset" event is not dark enough outside and you would like the automation to run later at a precise solar angle instead of the time offset such as turning on exterior lighting. For most things, a general number like -4 degrees is suitable and is used in this example:
+#### Sun elevation trigger
+Sometimes you may want more granular control over an automation than simply sunset or sunrise and specify an exact elevation of the sun. This can be used to layer automations to occur as the sun lowers on the horizon or even after it is below the horizon. This is also useful when the "sunset" event is not dark enough outside and you would like the automation to run later at a precise solar angle instead of the time offset such as turning on exterior lighting. For most things intended to trigger during dusk or dawn, a number between 0° and -6° is suitable; -4° is used in this example:
 
 {% raw %}
 ```yaml
@@ -162,11 +164,15 @@ automation:
 ```
 {% endraw %}
 
-If you want to get more precise, start with the US Naval Observatory [tool](http://aa.usno.navy.mil/data/docs/AltAz.php) that will help you estimate what the solar angle will be at any specific time. Then from this, you can select from the defined twilight numbers. Although the actual amount of light depends on weather, topography and land cover, they are defined as:
+If you want to get more precise, start with the US Naval Observatory [tool](http://aa.usno.navy.mil/data/docs/AltAz.php) which will help you estimate what the solar elevation will be at any specific time. Then from this, you can select from the defined twilight numbers.
 
-- Civil twilight: Solar angle > -6°
-- Nautical twilight: Solar angle > -12°
-- Astronomical twilight: Solar angle > -18°
+Although the actual amount of light depends on weather, topography and land cover, they are defined as:
+
+- Civil twilight: 0° > Solar angle > -6°
+
+  This is what is meant by twilight for the average person: Under clear weather conditions, civil twilight approximates the limit at which solar illumination suffices for the human eye to clearly distinguish terrestrial objects. Enough illumination renders artificial sources unnecessary for most outdoor activities.
+- Nautical twilight: 6° > Solar angle > -12°
+- Astronomical twilight: 12° > Solar angle > -18°
     
 A very thorough explanation of this is available in the Wikipedia article about the [Twilight](https://en.wikipedia.org/wiki/Twilight).
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -131,6 +131,7 @@ automation:
 ### {% linkable_title Sun trigger %}
 
 #### {% linkable_title Sunset / Sunrise trigger %}
+
 Triggers when the sun is setting or rising, i.e. when the sun elevation reaches 0°.
 
 An optional time offset can be given to have it trigger a set time before or after the sun event (e.g. 45 minutes before sunset).
@@ -152,6 +153,7 @@ automation:
 ```
 
 #### {% linkable_title Sun elevation trigger %}
+
 Sometimes you may want more granular control over an automation than simply sunset or sunrise and specify an exact elevation of the sun. This can be used to layer automations to occur as the sun lowers on the horizon or even after it is below the horizon. This is also useful when the "sunset" event is not dark enough outside and you would like the automation to run later at a precise solar angle instead of the time offset such as turning on exterior lighting. For most things intended to trigger during dusk or dawn, a number between 0° and -6° is suitable; -4° is used in this example:
 
 {% raw %}

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -133,7 +133,13 @@ automation:
 #### {% linkable_title Sunset / Sunrise trigger %}
 Triggers when the sun is setting or rising, i.e. when the sun elevation reaches 0°.
 
-An optional time offset can be given to have it trigger a set time before or after the sun event (e.g. 45 minutes before sunset). Since the duration of twilight is different throughout the year, it is recommended to use sun elevation triggers instead of `sunset` or `sunrise` with a time offset to trigger automations at the start of dusk or dawn.
+An optional time offset can be given to have it trigger a set time before or after the sun event (e.g. 45 minutes before sunset).
+
+<p class='note'>
+Since the duration of twilight is different throughout the year, it is recommended to use [sun elevation triggers][sun_elevation_trigger]  instead of `sunset` or `sunrise` with a time offset to trigger automations during dusk or dawn.
+</p>
+
+[sun_elevation_trigger]: /docs/automation/trigger/#sun-elevation-trigger
 
 ```yaml
 automation:

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -119,10 +119,52 @@ condition:
 ```
 
 ### {% linkable_title Sun condition %}
+#### Sun state condition
+The sun state can be used to test if the sun has set or risen.
 
-The sun condition can test if the sun has already set or risen when a trigger occurs. The `before` and `after` keys can only be set to `sunset` or `sunrise`. They have a corresponding optional offset value (`before_offset`, `after_offset`) that can be added, similar to the [sun trigger][sun_trigger].
+```yaml
+condition:
+    condition: state  # 'day' condition: from sunrise until sunset
+    entity_id: sun.sun
+    state: 'above_horizon'
+```
 
+```yaml
+condition:
+    condition: state  # from sunset until sunrise
+    entity_id: sun.sun
+    state: 'below_horizon'
+```
+
+#### Sun elevation condition
+The sun elevation can be used to test if the sun has set or risen, it is dusk, it is night etc. when a trigger occurs.
+For an in depth explanation of sun elevation see [sun trigger][sun_trigger].
+
+```yaml
+condition:
+    condition: and  # 'twilight' condition: dusk and dawn, in typical locations
+    conditions:
+      - condition: template
+        value_template: '{{ states.sun.sun.attributes.elevation < 0 }}'
+      - condition: template
+        value_template: '{{ states.sun.sun.attributes.elevation > -6 }}'
+```
+
+```yaml
+condition:
+    condition: template  # 'night' condition: from dusk to dawn, in typical locations
+    value_template: '{{ states.sun.sun.attributes.elevation < -6 }}'
+```
+
+#### Sunset/sunrise condition
+The sun condition can also test if the sun has already set or risen when a trigger occurs. The `before` and `after` keys can only be set to `sunset` or `sunrise`. They have a corresponding optional offset value (`before_offset`, `after_offset`) that can be added, similar to the [sun trigger][sun_trigger].
 [sun_trigger]: /docs/automation/trigger/#sun-trigger
+
+<p class='note warning'>
+The sunset/sunrise conditions do not work in locations inside the polar circles, and also not in locations with highly skewed local time zone.
+
+It is advised to use conditions evaluating the solar elevation instead of the before/after sunset/sunrise conditions.
+</p>
 
 ```yaml
 condition:

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -139,6 +139,7 @@ condition:
 #### {% linkable_title Sun elevation condition %}
 The sun elevation can be used to test if the sun has set or risen, it is dusk, it is night etc. when a trigger occurs.
 For an in depth explanation of sun elevation see [sun elevation trigger][sun_elevation_trigger].
+
 [sun_elevation_trigger]: /docs/automation/trigger/#sun-elevation-trigger
 
 ```yaml
@@ -159,6 +160,7 @@ condition:
 
 #### {% linkable_title Sunset/sunrise condition %}
 The sun condition can also test if the sun has already set or risen when a trigger occurs. The `before` and `after` keys can only be set to `sunset` or `sunrise`. They have a corresponding optional offset value (`before_offset`, `after_offset`) that can be added, similar to the [sun trigger][sun_trigger].
+
 [sun_trigger]: /docs/automation/trigger/#sun-trigger
 
 <p class='note warning'>

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -119,7 +119,7 @@ condition:
 ```
 
 ### {% linkable_title Sun condition %}
-#### Sun state condition
+#### {% linkable_title Sun state condition %}
 The sun state can be used to test if the sun has set or risen.
 
 ```yaml
@@ -136,9 +136,10 @@ condition:
     state: 'below_horizon'
 ```
 
-#### Sun elevation condition
+#### {% linkable_title Sun elevation condition %}
 The sun elevation can be used to test if the sun has set or risen, it is dusk, it is night etc. when a trigger occurs.
-For an in depth explanation of sun elevation see [sun trigger][sun_trigger].
+For an in depth explanation of sun elevation see [sun elevation trigger][sun_elevation_trigger].
+[sun_elevation_trigger]: /docs/automation/trigger/#sun-elevation-trigger
 
 ```yaml
 condition:
@@ -156,7 +157,7 @@ condition:
     value_template: {% raw %}'{{ states.sun.sun.attributes.elevation < -6 }}'{% endraw %}
 ```
 
-#### Sunset/sunrise condition
+#### {% linkable_title Sunset/sunrise condition %}
 The sun condition can also test if the sun has already set or risen when a trigger occurs. The `before` and `after` keys can only be set to `sunset` or `sunrise`. They have a corresponding optional offset value (`before_offset`, `after_offset`) that can be added, similar to the [sun trigger][sun_trigger].
 [sun_trigger]: /docs/automation/trigger/#sun-trigger
 

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -145,15 +145,15 @@ condition:
     condition: and  # 'twilight' condition: dusk and dawn, in typical locations
     conditions:
       - condition: template
-        value_template: '{{ states.sun.sun.attributes.elevation < 0 }}'
+        value_template: {% raw %}'{{ states.sun.sun.attributes.elevation < 0 }}'{% endraw %}
       - condition: template
-        value_template: '{{ states.sun.sun.attributes.elevation > -6 }}'
+        value_template: {% raw %}'{{ states.sun.sun.attributes.elevation > -6 }}'{% endraw %}
 ```
 
 ```yaml
 condition:
     condition: template  # 'night' condition: from dusk to dawn, in typical locations
-    value_template: '{{ states.sun.sun.attributes.elevation < -6 }}'
+    value_template: {% raw %}'{{ states.sun.sun.attributes.elevation < -6 }}'{% endraw %}
 ```
 
 #### Sunset/sunrise condition

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -119,7 +119,9 @@ condition:
 ```
 
 ### {% linkable_title Sun condition %}
+
 #### {% linkable_title Sun state condition %}
+
 The sun state can be used to test if the sun has set or risen.
 
 ```yaml
@@ -137,6 +139,7 @@ condition:
 ```
 
 #### {% linkable_title Sun elevation condition %}
+
 The sun elevation can be used to test if the sun has set or risen, it is dusk, it is night etc. when a trigger occurs.
 For an in depth explanation of sun elevation see [sun elevation trigger][sun_elevation_trigger].
 
@@ -159,6 +162,7 @@ condition:
 ```
 
 #### {% linkable_title Sunset/sunrise condition %}
+
 The sun condition can also test if the sun has already set or risen when a trigger occurs. The `before` and `after` keys can only be set to `sunset` or `sunrise`. They have a corresponding optional offset value (`before_offset`, `after_offset`) that can be added, similar to the [sun trigger][sun_trigger].
 
 [sun_trigger]: /docs/automation/trigger/#sun-trigger

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -167,7 +167,7 @@ Some models of the Zooz Toggle switches ship with an instruction manual with inc
 
 ## {% linkable_title Central Scene configuration %}
 
-To provide Central Scene support you need to shut Home Assistant down and modify your `zwcfg_*.xml` file according to the following guides.
+To provide Central Scene support you need to **shut Home Assistant down** and modify your `zwcfg_*.xml` file according to the following guides.
 
 ### {% linkable_title Inovelli Scene Capable On/Off and Dimmer Wall Switches %}
 
@@ -386,7 +386,7 @@ Button four release|4|1
 
 Use the same configuration as for the Aeotec Wallmote.
 
-### {% linkable_title HANK One-key Scene Controller HKZN-SCN01 %}
+### {% linkable_title HANK One-key Scene Controller HKZN-SCN01/HKZW-SCN01 %}
 
 For the HANK One-key Scene Controller, you may need to update the `COMMAND_CLASS_CENTRAL_SCENE` for each node in your `zwcfg` file with the following:
 

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -167,7 +167,7 @@ Some models of the Zooz Toggle switches ship with an instruction manual with inc
 
 ## {% linkable_title Central Scene configuration %}
 
-To provide Central Scene support you need to **shut Home Assistant down** and modify your `zwcfg_*.xml` file according to the following guides.
+To provide Central Scene support you need to **shutdown Home Assistant** and modify your `zwcfg_*.xml` file according to the following guides.
 
 ### {% linkable_title Inovelli Scene Capable On/Off and Dimmer Wall Switches %}
 


### PR DESCRIPTION
**Description:**
In the Nginx config rather than specifying localhost:8123 use 127.0.0.1:8123 so this will ensure incoming IPv6 requests get redirected to Hass on IPv4. "localhost:8123" means Nginx will try to connect to Hass using the same protocol that came in - and Hass doesn't do dual stack at present

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
