### PR TITLE
Fix ipv6 issue with Nginx not redirecting to ipv4 instance of Hass

### DIFF
--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -145,7 +145,7 @@ server {
     proxy_buffering off;
 
     location / {
-        proxy_pass http://localhost:8123;
+        proxy_pass http://127.0.0.1:8123;
         proxy_set_header Host $host;
         proxy_redirect http:// https://;
         proxy_http_version 1.1;


### PR DESCRIPTION
In the Nginx config rather than specifying localhost:8123 use 127.0.0.1:8123 so this will ensure incoming IPv6 requests get redirected to Hass on IPv4. "localhost:8123" means Nginx will try to connect to Hass using the same protocol that came in - and Hass doesn't do dual stack at present

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
