### PR TITLE
✏️ Fix broken link in configurator component

### DIFF
--- a/source/_components/configurator.markdown
+++ b/source/_components/configurator.markdown
@@ -24,6 +24,6 @@ The configurator component allows components to request information from the use
 - Input fields can be defined with a description, and optional type
 - It will trigger a callback when the button is pressed
 
-The Hue component in [the demo](/demo) and Plex are implemented using the configurator. See [the source of the demo component](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/demo.py#L132) for a simple example.
+The Hue component in [the demo](/demo) and Plex are implemented using the configurator. See [the source of the demo component](https://github.com/home-assistant/home-assistant/tree/dev/homeassistant/components/demo) for a simple example.
 
-See [the source](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/configurator.py#L39) for more details on how to use the configurator component.
+See [the source](https://github.com/home-assistant/home-assistant/tree/dev/homeassistant/components/configurator) for more details on how to use the configurator component.


### PR DESCRIPTION
**Description:**
Current link provided a 404

related issue: #9428 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
