### PR TITLE
Add DD-WRT device tracker wireless_only option

### DIFF
--- a/source/_components/ddwrt.markdown
+++ b/source/_components/ddwrt.markdown
@@ -51,6 +51,11 @@ verify_ssl:
   required: false
   type: boolean
   default: true
+wireless_only:
+  description: Whether to only list devices that are connected directly to the router via WiFi or include those connected via Ethernet or other networked access points as well.
+  required: false
+  type: boolean
+  default: true
 {% endconfiguration %}
 
 By default Home Assistant pulls information about connected devices from DD-WRT every 5 seconds.


### PR DESCRIPTION
**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24259

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
