### PR TITLE
⏪ Put the device classes back

### DIFF
--- a/source/_components/binary_sensor.markdown
+++ b/source/_components/binary_sensor.markdown
@@ -14,8 +14,40 @@ ha_qa_scale: internal
 ha_release: 0.9
 ---
 
-Binary sensors gather information about the state of devices which have a "digital" return value (either 1 or 0). These can be switches, contacts, pins, etc. These sensors only have two states: **0/off/low/closed/false** and **1/on/high/open/true**.  Knowing that there are only two states allows Home Assistant to represent these sensors in a better way in the frontend according to their functionality.
+Binary sensors gather information about the state of devices which have a "digital" return value (either 1 or 0). These can be switches, contacts, pins, etc. These sensors only have two states: **0/off/low/closed/false** and **1/on/high/open/true**. Knowing that there are only two states allows Home Assistant to represent these sensors in a better way in the frontend according to their functionality.
+
+### {% linkable_title Device Class %}
+
+The way these sensors are displayed in the frontend can be modified in the [customize section](/getting-started/customizing-devices/). The following device classes are supported for binary sensors:
+
+- **None**: Generic on/off. This is the default and doesn't need to be set.
+- **battery**: `On` means low, `Off` means normal
+- **cold**: `On` means cold, `Off` means normal
+- **connectivity**: `On` means connected, `Off` means disconnected
+- **door**: `On` means open, `Off` means closed
+- **garage_door**: `On` means open, `Off` means closed
+- **gas**: `On` means gas detected, `Off` means no gas (clear)
+- **heat**: `On` means hot, `Off` means normal
+- **light**: `On` means light detected, `Off` means no light
+- **lock**: `On` means open (unlocked), `Off` means closed (locked)
+- **moisture**: `On` means moisture detected (wet), `Off` means no moisture (dry)
+- **motion**: `On` means motion detected, `Off` means no motion (clear)
+- **moving**: `On` means moving, `Off` means not moving (stopped)
+- **occupancy**: `On` means occupied, `Off` means not occupied (clear)
+- **opening**: `On` means open, `Off` means closed
+- **plug**: `On` means device is plugged in, `Off` means device is unplugged
+- **power**: `On` means power detected, `Off` means no power
+- **presence**: `On` means home, `Off` means away
+- **problem**: `On` means problem detected, `Off` means no problem (OK)
+- **safety**: `On` means unsafe, `Off` means safe
+- **smoke**: `On` means smoke detected, `Off` means no smoke (clear)
+- **sound**: `On` means sound detected, `Off` means no sound (clear)
+- **vibration**: `On` means vibration detected, `Off` means no vibration (clear)
+- **window**: `On` means open, `Off` means closed
+
+For analog sensors please check the [component overview](/components/#sensor).
 
 <p class='img'>
 <img src='/images/screenshots/binary_sensor_classes_icons.png' />
+Example of various device classes icons in `On` and `Off` state.
 </p>

--- a/source/_components/cover.markdown
+++ b/source/_components/cover.markdown
@@ -16,6 +16,21 @@ ha_release: 0.27
 
 Home Assistant can give you an interface to control covers such as rollershutters, blinds, and garage doors.
 
+## {% linkable_title Device Class %}
+
+The way these sensors are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for covers:
+
+- **None**: Generic cover. This is the default and doesn't need to be set.
+- **awning**: Control of an awning, such as an exterior retractable window, door, or patio cover.
+- **blind**: Control of blinds, which are linked slats that expand or collapse to cover an opening or may be tilted to partially covering an opening, such as window blinds.
+- **curtain**: Control of curtains or drapes, which is often fabric hung above a window or door that can be drawn open.
+- **damper**: Control of a mechanical damper that reduces airflow, sound, or light.
+- **door**: Control of a door or gate that provides access to an area.
+- **garage**: Control of a garage door that provides access to a garage.
+- **shade**: Control of shades, which are a continuous plane of material or connected cells that expanded or collapsed over an opening, such as window shades.
+- **shutter**: Control of shutters, which are linked slats that swing out/in to covering an opening or may be tilted to partially cover an opening, such as indoor or exterior window shutters.
+- **window**: Control of a physical window that opens and closes or may tilt.
+
 ## {% linkable_title Services %}
 
 ### {% linkable_title Cover control services %}

--- a/source/_components/sensor.markdown
+++ b/source/_components/sensor.markdown
@@ -18,6 +18,21 @@ Sensors are gathering information about states and conditions.
 
 Home Assistant currently supports a wide range of sensors. They are able to display information which are provides by Home Assistant directly, are gathered from web services, and, of course, physical devices.
 
+## {% linkable_title Device Class %}
+
+The way these sensors are displayed in the frontend can be modified in the [customize section](/docs/configuration/customizing-devices/). The following device classes are supported for sensors:
+
+- **None**: Generic sensor. This is the default and doesn't need to be set.
+- **battery**: Percentage of battery that is left.
+- **humidity**: Percentage of humidity in the air.
+- **illuminance**: The current light level in lx or lm.
+- **signal_strength**: Signal strength in dB or dBm.
+- **temperature**: Temperature in °C or °F.
+- **power**: Power in W or kW.
+- **pressure**: Pressure in hPa or mbar.
+- **timestamp**: Datetime object or timestamp string.
+
 <p class='img'>
 <img src='/images/screenshots/sensor_device_classes_icons.png' />
+Example of various device class icons for sensors.
 </p>


### PR DESCRIPTION
**Description:**
This PR cancels the removal of the device classes.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
