### PR TITLE
Update apcupsd.markdown

### DIFF
--- a/source/_components/apcupsd.markdown
+++ b/source/_components/apcupsd.markdown
@@ -26,7 +26,7 @@ There is currently support for the following device types within Home Assistant:
 - [Binary Sensor](#binary-sensor)
 - [Sensor](#sensor)
 
-## {% Hass.io Installation %}
+## {% linkable_title Hass.io Installation %}
 
 Install this [unofficial add-on](https://github.com/korylprince/hassio-apcupsd/) to use this integration with Hass.io. Keep in mind that we can't give you support for this add-on. 
 

--- a/source/_components/apcupsd.markdown
+++ b/source/_components/apcupsd.markdown
@@ -27,12 +27,10 @@ There is currently support for the following device types within Home Assistant:
 - [Sensor](#sensor)
 
 ## {% Hass.io Installation %}
-Install this unofficial plugin to use this component with Hass.io:
-https://github.com/korylprince/hassio-apcupsd/
 
-After installation, follow the instructions on the github page to configure the plugin.
-Then continue to follow the component configurations below.
+Install this [unofficial add-on](https://github.com/korylprince/hassio-apcupsd/) to use this integration with Hass.io. Keep in mind that we can't give you support for this add-on. 
 
+After installation, follow the instructions on the Github page to configure the plugin. Then continue to follow the integration configurations below.
 
 ## {% linkable_title Configuration %}
 

--- a/source/_components/apcupsd.markdown
+++ b/source/_components/apcupsd.markdown
@@ -26,6 +26,14 @@ There is currently support for the following device types within Home Assistant:
 - [Binary Sensor](#binary-sensor)
 - [Sensor](#sensor)
 
+## {% Hass.io Installation %}
+Install this unofficial plugin to use this component with Hass.io:
+https://github.com/korylprince/hassio-apcupsd/
+
+After installation, follow the instructions on the github page to configure the plugin.
+Then continue to follow the component configurations below.
+
+
 ## {% linkable_title Configuration %}
 
 To enable this sensor, add the following lines to your `configuration.yaml`:
@@ -127,13 +135,33 @@ OUTPUTV  : 218.4 Volts
 [...]
 ```
 
-Use the (case insensitive) values from the left hand column:
+Use the values from the left hand column (lower case required).
+
+Full Example Configuration:
 
 ```yaml
 sensor:
   - platform: apcupsd
     resources:
+      - apc
+      - date
+      - hostname
+      - version
+      - upsname
+      - cable
+      - driver
+      - upsmode
+      - starttime
+      - model
+      - status
       - linev
       - loadpct
+      - bcharge
       - timeleft
+      - mbattchg
+      - mintimel
+      - maxtime
+      - maxlinev
+      - minlinev
+      - outputv
 ```


### PR DESCRIPTION
Three Changes:
1. I added a link to the unofficial hass.io plugin which is required to use this component with hass.io. (maybe we can add it to the community repository?) 
2. I copied the values as-is (in all caps) and it caused a configuration error. This is just a quick edit to clarify the instructions and state that the listed resources should be lower case.
3. I also added a full example configuration that users can just copy & paste.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
