### PR TITLE
🌱 Correct misspelled install (#9565)

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -144,7 +144,7 @@ $ sudo -i
 # curl -fsSL get.docker.com | sh
 ```
 
-And to intall Hass.io the one below. That one is used also for other distributions.
+And to install Hass.io the one below. That one is used also for other distributions.
 
 ```bash
 # curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/master/hassio_install.sh" | bash -s


### PR DESCRIPTION
**Description:**
My mistake, I had performed a merge too quickly, so that the PR had now come into next.

Original PR: #9565 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
