### PR TITLE
Fix logger examples (great migration)

### DIFF
--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -33,8 +33,7 @@ components:
 logger:
   default: info
   logs:
-    homeassistant.components.device_tracker: critical
-    homeassistant.components.camera: critical
+    homeassistant.components.yamaha: critical
     custom_components.my_integration: critical
 ```
 
@@ -48,9 +47,8 @@ logger:
   logs:
     homeassistant.components: info
     homeassistant.components.rfxtrx: debug
-    homeassistant.components.device_tracker: critical
-    homeassistant.components.camera: critical
-    homeassistant.components.yamaha.media_player: debug
+    homeassistant.components.lifx: warning
+    homeassistant.components.yamaha: debug
     custom_components.my_integration: debug
 ```
 
@@ -109,7 +107,7 @@ An example call might look like this:
 service: logger.set_level
 data:
   homeassistant.components: warning
-  homeassistant.components.yamaha.media_player: debug
+  homeassistant.components.yamaha: debug
   custom_components.my_integration: debug
 ```
 

--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -45,11 +45,17 @@ components:
 logger:
   default: critical
   logs:
-    homeassistant.components: info
-    homeassistant.components.rfxtrx: debug
-    homeassistant.components.lifx: warning
-    homeassistant.components.yamaha: debug
+    # log level for HA core
+    homeassistant.core: fatal
+    
+    # log level for SmartThings lights
+    homeassistant.components.smartthings.light: info
+
+    # log level for a custom component
     custom_components.my_integration: debug
+
+    # log level for the `aiohttp` Python package
+    aiohttp: critical
 ```
 
 {% configuration %}
@@ -106,9 +112,10 @@ An example call might look like this:
 ```yaml
 service: logger.set_level
 data:
-  homeassistant.components: warning
-  homeassistant.components.yamaha: debug
+  homeassistant.core: fatal
+  homeassistant.components.smartthings.light: info
   custom_components.my_integration: debug
+  aiohttp: critical
 ```
 
 The log information are stored in the

--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -48,6 +48,9 @@ logger:
     # log level for HA core
     homeassistant.core: fatal
     
+    # log level for MQTT integration
+    homeassistant.components.mqtt: warning
+    
     # log level for SmartThings lights
     homeassistant.components.smartthings.light: info
 
@@ -55,7 +58,7 @@ logger:
     custom_components.my_integration: debug
 
     # log level for the `aiohttp` Python package
-    aiohttp: critical
+    aiohttp: error
 ```
 
 {% configuration %}
@@ -113,9 +116,10 @@ An example call might look like this:
 service: logger.set_level
 data:
   homeassistant.core: fatal
+  homeassistant.components.mqtt: warning
   homeassistant.components.smartthings.light: info
   custom_components.my_integration: debug
-  aiohttp: critical
+  aiohttp: error
 ```
 
 The log information are stored in the

--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -50,6 +50,7 @@ logger:
     homeassistant.components.rfxtrx: debug
     homeassistant.components.device_tracker: critical
     homeassistant.components.camera: critical
+    homeassistant.components.yamaha.media_player: debug
     custom_components.my_integration: debug
 ```
 
@@ -108,7 +109,7 @@ An example call might look like this:
 service: logger.set_level
 data:
   homeassistant.components: warning
-  homeassistant.components.media_player.yamaha: debug
+  homeassistant.components.yamaha.media_player: debug
   custom_components.my_integration: debug
 ```
 


### PR DESCRIPTION
**Description:**

Fix and improve examples for the logger component. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

Generated documentation: https://deploy-preview-9567--home-assistant-docs.netlify.com/components/logger/

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html