### PR TITLE
Remote rpi gpio: address -> host

### DIFF
--- a/source/_components/remote_rpi_gpio.markdown
+++ b/source/_components/remote_rpi_gpio.markdown
@@ -28,20 +28,20 @@ To use your Remote Raspberry Pi's GPIO in your installation, add the following t
 # Example configuration.yaml entry
 binary_sensor:
   - platform: remote_rpi_gpio
-    address: <address of remote pi>
+    host: <address of remote pi>
     ports:
       11: PIR Office
       12: PIR Bedroom
       
 switch:
   - platform: remote_rpi_gpio
-    address: <address of remote pi>
+    host: <address of remote pi>
     ports:
       4: Garage Relay
 ```
 
 {% configuration %}
-address:
+host:
   description: IP Address of remote Raspberry Pi
   required: true
   type: string
@@ -81,14 +81,14 @@ To use your Remote Raspberry Pi's GPIO in your installation, add the following t
 # Example configuration.yaml entry
 switch:
   - platform: remote_rpi_gpio
-    address: 192.168.0.123
+    host: 192.168.0.123
     ports:
       11: Fan Office
       12: Light Desk
 ```
 
 {% configuration %}
-address:
+host:
   description: IP Address of remote Raspberry Pi
   required: true
   type: string
@@ -121,7 +121,7 @@ For example, if you have a relay connected to pin 11 its GPIO # is 17.
 # Example configuration.yaml entry
 switch:
   - platform: remote_rpi_gpio
-    address: 192.168.0.123
+    host: 192.168.0.123
     ports:
       17: Speaker Relay
 ```


### PR DESCRIPTION
**Description:**
address should be host in the config

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
