### PR TITLE
Update watson_tts.markdown

### DIFF
--- a/source/_components/watson_tts.markdown
+++ b/source/_components/watson_tts.markdown
@@ -14,7 +14,7 @@ ha_release: 0.94
 ---
 
 The `watson_tts` text-to-speech platform that works with [IBM Watson Cloud](https://www.ibm.com/watson/services/text-to-speech/) to create the spoken output.
-Polly is a paid service via IBM Cloud but there is a decent [free tier](https://www.ibm.com/cloud/watson-text-to-speech/pricing) which offers 10000 free characters every month.
+Watson is a paid service via IBM Cloud but there is a decent [free tier](https://www.ibm.com/cloud/watson-text-to-speech/pricing) which offers 10000 free characters every month.
 
 ## {% linkable_title Setup %}
 


### PR DESCRIPTION
**Description:**
Small change: Watson documentation noted "Polly" (an AWS service)  instead of "Watson" at one location.

## Checklist:
- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
