### PR TITLE
Automations: Corrects documentation to match codebase

### DIFF
--- a/source/_components/automation.markdown
+++ b/source/_components/automation.markdown
@@ -26,6 +26,7 @@ Starting with 0.28 your automation rules can be controlled with the frontend.
 This allows one to reload the automation without restarting Home Assistant
 itself. If you don't want to see the automation rule in your frontend use
 `hide_entity: true` to hide it.
+
 You can also use `initial_state: 'false'` so that the automation
 is not automatically turned on after a Home Assistant reboot.
 
@@ -33,7 +34,7 @@ is not automatically turned on after a Home Assistant reboot.
 automation:
   - alias: Door alarm
     hide_entity: true
-    initial_state: 'true'
+    initial_state: true
     trigger:
       - platform: state
   ...

--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -49,14 +49,14 @@ Actions are all about calling services. To explore the available services open t
 
 ### {% linkable_title Automation initial state %}
 
-When you create a new automation, it will be disabled (and therefore won't trigger) unless you explicitly add `initial_state: true` to it or turn it on manually via UI/another automation/developer tools.
+When you create a new automation, it will be enabled unless you explicitly add `initial_state: false` to it or turn it off manually via UI/another automation/developer tools. In case automations need to be always enabled or disabled upon Home Assistant start, then you can set the `initial_state` in your automations. Otherwise, the previous state will be restored.
 
-In case automations need to be enabled or disabled upon Home Assistant restart, then you have to set the `initial_state` in your automations. Otherwise, the previous state will be restored. Please note that if for some reason Home Assistant cannot restore the previous state, e.g., because of an interrupted or failed startup, it will result in the automation being disabled on the next Home Assistant startup.
+Please note that if for some reason Home Assistant cannot restore the previous state, it will result in the automation being enabled.
 
 ```text
 automation:
 - alias: Automation Name
-  initial_state: true
+  initial_state: false
   trigger:
   ...
 ```

--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -49,7 +49,7 @@ Actions are all about calling services. To explore the available services open t
 
 ### {% linkable_title Automation initial state %}
 
-When you create a new automation, it will be enabled unless you explicitly add `initial_state: false` to it or turn it off manually via UI/another automation/developer tools. In case automations need to be always enabled or disabled upon Home Assistant start, then you can set the `initial_state` in your automations. Otherwise, the previous state will be restored.
+When you create a new automation, it will be enabled unless you explicitly add `initial_state: false` to it or turn it off manually via UI/another automation/developer tools. In case automations need to be always enabled or disabled when Home Assistant starts, then you can set the `initial_state` in your automations. Otherwise, the previous state will be restored.
 
 Please note that if for some reason Home Assistant cannot restore the previous state, it will result in the automation being enabled.
 


### PR DESCRIPTION
**Description:**

There was a lot of things going on with automations lately, which even reflected the documentation to become not true anymore.

This was caused, mainly, by unexpected behavior/bugs in our codebase, which have been fixed in `0.94.1` (already shipped).

This PR correct the documentation (partially) back the original documentation, making it true again.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24390

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
