### PR TITLE
honeywell - Fix issue 18932 & clean up the mess

### DIFF
--- a/source/_components/honeywell.markdown
+++ b/source/_components/honeywell.markdown
@@ -16,13 +16,9 @@ redirect_from:
  - /components/climate.honeywell/
 ---
 
-<p class='note'>
-There is a great deal of confusion over this integration. Please take the time to fully understand the causes of this confusion before you raise an issue, or submit a PR.
-</p>
-
 The `honeywell` climate platform lets you control Honeywell TCC (Total Connect Comfort) climate systems from Home Assistant. It does not integrate with Honeywell TCC alarm systems.
 
-Unfortunately, this integration is incorrectly implemented as a combination of two _distinct_ climate systems, one being US-based, the other is EU-based; they are _not_ interchangeable. Before you proceed, please be clear which client library is appropriate to your system.
+There is some potential confusion over this integration because it is currently implemented as a combination of two _distinct_ climate systems, one being US-based, the other is EU-based. Importantly, these two regions are _not_ interchangeable, so you must clear which applies to your climate system.
 
 ## {% linkable_title US-based Systems %}
 
@@ -30,23 +26,17 @@ These systems are based in North America, and temperatures are usually in Fahren
 
 If your system is US-based, then you can access your system via [https://mytotalconnectcomfort.com/portal/](https://mytotalconnectcomfort.com/portal/) (note the `/portal/`).
 
-<p class='note'>
-For historical reasons, this is not the default region, and so you _must_ have `region: us` in your **configuration.yaml** file for US-based systems (this requirement may be relaxed in future, see below).
-</p>
-
 ## {% linkable_title EU-based Systems %}
 
 These systems are based in Europe (including the UK & Ireland), and temperatures are usually in Celsius. They would likely be heating-only systems. They use the [evohome-client](https://github.com/watchforstock/evohome-client) client library. In this integration, this is called the `eu` region.
 
 If your system is US-based, then you can access it via [https://international.mytotalconnectcomfort.com/](https://international.mytotalconnectcomfort.com/) (note the `international`).
 
-<p class='note'>
-The `eu` region is being deprecated, as there is better support available via the [evohome](/components/evohome/) integration. Unfortunately, **evohome** does not yet have support for DHW, but will do so before this region is fully deprecated (a PR for this has been submitted).
-</p>
+The `eu` region is being deprecated, and ongoing support for such systems is available via the [evohome](/components/evohome/) integration.
 
 ## {% linkable_title Configuration %}
 
-To set up this integration, first confirm your region (i.e. which website is a good start), then add the following information to your **configuration.yaml** file (the below example is for US-based systems):
+To set up this integration, first confirm your region, then add the following information to your **configuration.yaml** file (the below example is for US-based systems):
 
 ```yaml
 climate:

--- a/source/_components/honeywell.markdown
+++ b/source/_components/honeywell.markdown
@@ -16,54 +16,72 @@ redirect_from:
  - /components/climate.honeywell/
 ---
 
+<p class='note'>
+There is a great deal of confusion over this integration. Please take the time to fully understand the causes of this confusion before you raise an issue, or submit a PR.
+</p>
 
-The `honeywell` climate platform let you control Honeywell Connected thermostats from Home Assistant.
+The `honeywell` climate platform lets you control Honeywell TCC (Total Connect Comfort) climate systems from Home Assistant. It does not integrate with Honeywell TCC alarm systems.
 
-To set it up, add the following information to your `configuration.yaml` file:
+Unfortunately, this integration is incorrectly implemented as a combination of two _distinct_ climate systems, one being US-based, the other is EU-based; they are _not_ interchangeable. Before you proceed, please be clear which client library is appropriate to your system.
+
+## {% linkable_title US-based Systems %}
+
+These systems are based in North America, and temperatures are usually in Fahrenheit. They would likely be HVAC systems. They use the [somecomfort](https://github.com/kk7ds/somecomfort) client library. In this integration, this is called the `us` region.
+
+If your system is US-based, then you can access your system via [https://mytotalconnectcomfort.com/portal/](https://mytotalconnectcomfort.com/portal/) (note the `/portal/`).
+
+<p class='note'>
+For historical reasons, this is not the default region, and so you _must_ have `region: us` in your **configuration.yaml** file for US-based systems (this requirement may be relaxed in future, see below).
+</p>
+
+## {% linkable_title EU-based Systems %}
+
+These systems are based in Europe (including the UK & Ireland), and temperatures are usually in Celsius. They would likely be heating-only systems. They use the [evohome-client](https://github.com/watchforstock/evohome-client) client library. In this integration, this is called the `eu` region.
+
+If your system is US-based, then you can access it via [https://international.mytotalconnectcomfort.com/](https://international.mytotalconnectcomfort.com/) (note the `international`).
+
+<p class='note'>
+The `eu` region is being deprecated, as there is better support available via the [evohome](/components/evohome/) integration. Unfortunately, **evohome** does not yet have support for DHW, but will do so before this region is fully deprecated (a PR for this has been submitted).
+</p>
+
+## {% linkable_title Configuration %}
+
+To set up this integration, first confirm your region (i.e. which website is a good start), then add the following information to your **configuration.yaml** file (the below example is for US-based systems):
 
 ```yaml
 climate:
   - platform: honeywell
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
-    scan_interval: 600
+    region: us
 ```
-<p class='note'>
-Scan interval is expressed in seconds. Omitting or mis-configuring `scan_interval` may result in too-frequent polling and cause you to be rate-limited by Honeywell.
-</p>
-
 {% configuration %}
 username:
-  description: The username of an user with access.
+  description: Email address of an account with access the the TCC website for your region.
   required: true
   type: string
 password:
-  description: The password for your given admin account.
+  description: Password for the account.
   required: true
   type: string
 region:
-  description: Region identifier (either 'eu' or 'us').  Use the `somecomfort` client library for `us`, and evohome-client for `eu`.
+  description: Region identifier, either 'eu' or 'us'.
   required: false
   default: eu
   type: string
-scan_interval:
-  description: Scan interval is expressed in seconds. Recommended value of 600 seconds. Omitting scan_interval may result in too-frequent polling and cause you to rate-limited by Honeywell.
-  required: false
-  default: 120
-  type: integer
 away_temperature:
-  description: "(*only for eu region*) Heating setpoint when away mode is on, in deg C."
+  description: "(*only for the eu region*) Heating setpoint when away mode is on, in degrees Celsius."
   required: false
   default: 16.0
   type: float
 away_cool_temperature:
-  description: "(*only for us region*) Cooling setpoint when away mode is on, in deg C."
+  description: "(*only for the us region*) Cooling setpoint when away mode is on, in degrees Fahrenheit."
   required: false
-  default: 30.0
-  type: float
+  default: 88
+  type: int
 away_heat_temperature:
-  description: "(*only for us region*) Heating setpoint when away mode is on, in deg C."
+  description: "(*only for the us region*) Heating setpoint when away mode is on, in degrees Fahrenheit."
   required: false
-  default: 16.0
-  type: float
+  default: 61
+  type: int
 {% endconfiguration %}

--- a/source/_components/honeywell.markdown
+++ b/source/_components/honeywell.markdown
@@ -18,21 +18,25 @@ redirect_from:
 
 The `honeywell` climate platform lets you control Honeywell TCC (Total Connect Comfort) climate systems from Home Assistant. It does not integrate with Honeywell TCC alarm systems.
 
-There is some potential confusion over this integration because it is currently implemented as a combination of two _distinct_ climate systems, one being US-based, the other is EU-based. Importantly, these two regions are _not_ interchangeable, so you must clear which applies to your climate system.
+<p class='note'>
+There is some potential confusion over this integration because it is currently implemented as a combination of two _distinct_ climate systems, one being US-based, the other is EU-based.
+
+These two regions are _not_ interchangeable, so you must clear which applies to your climate system.
+</p>
 
 ## {% linkable_title US-based Systems %}
 
-These systems are based in North America, and temperatures are usually in Fahrenheit. They would likely be HVAC systems. They use the [somecomfort](https://github.com/kk7ds/somecomfort) client library. In this integration, this is called the `us` region.
+These systems are based in North America, and temperatures are usually in Fahrenheit. They would likely be HVAC systems. They always use the [somecomfort](https://github.com/kk7ds/somecomfort) client library. In this integration, this is called the `us` region.
 
 If your system is US-based, then you can access your system via [https://mytotalconnectcomfort.com/portal/](https://mytotalconnectcomfort.com/portal/) (note the `/portal/`).
 
 ## {% linkable_title EU-based Systems %}
 
-These systems are based in Europe (including the UK & Ireland), and temperatures are usually in Celsius. They would likely be heating-only systems. They use the [evohome-client](https://github.com/watchforstock/evohome-client) client library. In this integration, this is called the `eu` region.
+These systems are based in Europe (including the UK & Ireland), and temperatures are usually in Celsius. They would likely be heating-only systems. They always use the [evohome-client](https://github.com/watchforstock/evohome-client) client library. In this integration, this is called the `eu` region.
 
 If your system is US-based, then you can access it via [https://international.mytotalconnectcomfort.com/](https://international.mytotalconnectcomfort.com/) (note the `international`).
 
-The `eu` region is being deprecated, and ongoing support for such systems is available via the [evohome](/components/evohome/) integration.
+The `eu` region is soon to be deprecated, and ongoing support for such systems is available via the [evohome](/components/evohome/) integration.
 
 ## {% linkable_title Configuration %}
 

--- a/source/_components/honeywell.markdown
+++ b/source/_components/honeywell.markdown
@@ -21,7 +21,7 @@ The `honeywell` climate platform lets you control Honeywell TCC (Total Connect C
 <p class='note'>
 There is some potential confusion over this integration because it is currently implemented as a combination of two _distinct_ climate systems, one being US-based, the other is EU-based.
 
-These two regions are _not_ interchangeable, so you must clear which applies to your climate system.
+These two regions are _not_ interchangeable, so you must be clear which applies to your climate system.
 </p>
 
 ## {% linkable_title US-based Systems %}
@@ -49,9 +49,10 @@ climate:
     password: YOUR_PASSWORD
     region: us
 ```
+
 {% configuration %}
 username:
-  description: Email address of an account with access the the TCC website for your region.
+  description: Email address of an account with access the TCC website for your region.
   required: true
   type: string
 password:
@@ -64,17 +65,17 @@ region:
   default: eu
   type: string
 away_temperature:
-  description: "(*only for the eu region*) Heating setpoint when away mode is on, in degrees Celsius."
+  description: "(*only for the EU region*) Heating setpoint when away mode is on, in degrees Celsius."
   required: false
   default: 16.0
   type: float
 away_cool_temperature:
-  description: "(*only for the us region*) Cooling setpoint when away mode is on, in degrees Fahrenheit."
+  description: "(*only for the US region*) Cooling setpoint when away mode is on, in degrees Fahrenheit."
   required: false
   default: 88
   type: int
 away_heat_temperature:
-  description: "(*only for the us region*) Heating setpoint when away mode is on, in degrees Fahrenheit."
+  description: "(*only for the US region*) Heating setpoint when away mode is on, in degrees Fahrenheit."
   required: false
   default: 61
   type: int

--- a/source/_components/honeywell.markdown
+++ b/source/_components/honeywell.markdown
@@ -73,10 +73,10 @@ away_cool_temperature:
   description: "(*only for the US region*) Cooling setpoint when away mode is on, in degrees Fahrenheit."
   required: false
   default: 88
-  type: int
+  type: integer
 away_heat_temperature:
   description: "(*only for the US region*) Heating setpoint when away mode is on, in degrees Fahrenheit."
   required: false
   default: 61
-  type: int
+  type: integer
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Unfortunately, this integration is incorrectly implemented as a combination of two _distinct_ climate systems, one being US-based, the other is EU-based; they are _not_ interchangeable.  The EU half is being deprecated soon home-assistant/home-assistant#23469, in favour of **evohome**.

Several issues & PRs have been raised unnecessarily (e.g. #9447) because this hasn't been clearly understood. In addition, reverts of PRs by different mods has contributed to the confusion.

In short, this docs page is now a mess. I have completely re-written it, and this PR should clear all of that up.

It also addresses https://github.com/home-assistant/home-assistant/issues/18932, and paves the way for PR home-assistant/home-assistant#24257 (part of `climate-1.0`).

I would recommend merging this PR with the `current` branch.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24402

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
