### PR TITLE
Update rainbird.markdown

### DIFF
--- a/source/_components/rainbird.markdown
+++ b/source/_components/rainbird.markdown
@@ -106,11 +106,11 @@ friendly_name:
   required: false
   type: string
 trigger_time:
-  description: The default duration to sprinkle the zone.
+  description: The default duration to sprinkle the zone in minutes.
   required: true
   type: integer
 scan_interval:
-  description: How fast to refresh the switch.
+  description: How fast to refresh the switch in minutes.
   required: false
   type: integer
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Clarify the trigger_time, scan_interval durations to include minutes

**Issue in [home-assistant](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io/issues/9594

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
