### PR TITLE
Fix mixed single quotes in automation example

### DIFF
--- a/source/_components/meteoalarm.markdown
+++ b/source/_components/meteoalarm.markdown
@@ -99,7 +99,7 @@ automation:
     action:
       - service: notify.notify
         data_template:
-          title: '{{state_attr('binary_sensor.meteoalarm', 'headline')}}'
+          title: "{{state_attr('binary_sensor.meteoalarm', 'headline')}}"
           message: "{{state_attr('binary_sensor.meteoalarm', 'description')}} is effective on {{state_attr('binary_sensor.meteoalarm', 'effective')}}"
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
