### PR TITLE
Document the default for with_group option

### DIFF
--- a/source/_components/sonos.markdown
+++ b/source/_components/sonos.markdown
@@ -35,7 +35,7 @@ The queue is not snapshotted and must be left untouched until the restore. Using
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | The speakers to snapshot.
-| `with_group` | yes | Should we also snapshot the group layout and the state of other speakers in the group.
+| `with_group` | yes (Default: True)| Should we also snapshot the group layout and the state of other speakers in the group.
 
 
 ### {% linkable_title Service `sonos.restore` %}
@@ -53,7 +53,7 @@ A cloud queue cannot be restarted. This includes queues started from within Spot
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of `entity_id`s that should have their snapshot restored.
-| `with_group` | yes | Should we also restore the group layout and the state of other speakers in the group.
+| `with_group` | yes (Default: True)| Should we also restore the group layout and the state of other speakers in the group.
 
 ### {% linkable_title Service `sonos.join` %}
 

--- a/source/_components/sonos.markdown
+++ b/source/_components/sonos.markdown
@@ -35,7 +35,7 @@ The queue is not snapshotted and must be left untouched until the restore. Using
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | The speakers to snapshot.
-| `with_group` | yes (Default: True)| Should we also snapshot the group layout and the state of other speakers in the group.
+| `with_group` | yes | Should we also snapshot the group layout and the state of other speakers in the group, defaults to true.
 
 
 ### {% linkable_title Service `sonos.restore` %}
@@ -53,7 +53,7 @@ A cloud queue cannot be restarted. This includes queues started from within Spot
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of `entity_id`s that should have their snapshot restored.
-| `with_group` | yes (Default: True)| Should we also restore the group layout and the state of other speakers in the group.
+| `with_group` | yes | Should we also restore the group layout and the state of other speakers in the group, defaults to true.
 
 ### {% linkable_title Service `sonos.join` %}
 


### PR DESCRIPTION
**Description:**
Just a small addition to indicate the default for `with_group`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
