### PR TITLE
[Utility Meter] Add template sensors to DSMR example

### DIFF
--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -184,3 +184,23 @@ utility_meter:
     source: sensor.gas_consumption
     cycle: monthly
 ```
+
+Additionally, you can add template sensors to compute daily and monthly total usage. 
+
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      daily_power:
+        friendly_name: Daily Power
+        icon: mdi:counter
+        unit_of_measurement: kWh
+        value_template: >-
+          {{ states('sensor.daily_power_offpeak')|float + states('sensor.daily_power_peak')|float }}
+      monthly_power:
+        friendly_name: Monthly Power
+        icon: mdi:counter
+        unit_of_measurement: kWh
+        value_template: >-
+          {{ states('sensor.monthly_power_offpeak')|float + states('sensor.monthly_power_peak')|float }}
+```

--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -187,6 +187,7 @@ utility_meter:
 
 Additionally, you can add template sensors to compute daily and monthly total usage. 
 
+{% raw %}
 ```yaml
 sensor:
   - platform: template
@@ -202,3 +203,4 @@ sensor:
         unit_of_measurement: kWh
         value_template: {{ states('sensor.monthly_power_offpeak')|float + states('sensor.monthly_power_peak')|float }}
 ```
+{% endraw %}

--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -195,12 +195,10 @@ sensor:
         friendly_name: Daily Power
         icon: mdi:counter
         unit_of_measurement: kWh
-        value_template: >-
-          {{ states('sensor.daily_power_offpeak')|float + states('sensor.daily_power_peak')|float }}
+        value_template: {{ states('sensor.daily_power_offpeak')|float + states('sensor.daily_power_peak')|float }}
       monthly_power:
         friendly_name: Monthly Power
         icon: mdi:counter
         unit_of_measurement: kWh
-        value_template: >-
-          {{ states('sensor.monthly_power_offpeak')|float + states('sensor.monthly_power_peak')|float }}
+        value_template: {{ states('sensor.monthly_power_offpeak')|float + states('sensor.monthly_power_peak')|float }}
 ```


### PR DESCRIPTION
Add a daily and monthly template sensor to DSMR example that sum peak and off peak usage

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
