### PR TITLE
Update homematicip_cloud.markdown

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -116,7 +116,6 @@ authtoken:
     * Temperature and humidity Sensor with display (*HmIP-STHD*)
     
 * homematicip_cloud.cover
-  * Blind actuator for brand switches (*HmIP-BBL*)
   * Shutter actuator brand-mount (*HmIP-BROLL*)
   * Shutter actuator flush-mount (*HmIP-FROLL*)    
 


### PR DESCRIPTION
HmIP-BBL is delted from docu because not supported yet and needs to be added first

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
