### PR TITLE
Update discovery.markdown

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -94,7 +94,6 @@ Valid values for ignore are:
  * `openhome`: Linn / Openhome
  * `panasonic_viera`: Panasonic Viera
  * `philips_hue`: Philips Hue
- * `plex_mediaserver`: Plex media server
  * `roku`: Roku media player
  * `sabnzbd`: SABnzbd downloader
  * `samsung_printer`: Samsung SyncThru Printer
@@ -106,6 +105,9 @@ Valid values for ignore are:
  * `yamaha`: Yamaha media player
  * `yeelight`: Yeelight lamps and bulbs (not only Yeelight Sunflower bulb)
  * `xiaomi_gw`: Xiaomi Aqara gateway
+
+Enabled by default:
+ * `plex_mediaserver`: Plex media server
 
 Valid values for enable are:
 


### PR DESCRIPTION
not sure if there are more but i got this warning in my logs:

2019-06-11 17:47:07 WARNING (MainThread) [homeassistant.components.discovery] Please remove plex_mediaserver from your discovery.enable configuration as it is now enabled by default

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
