### PR TITLE
Adding a big warning

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -115,6 +115,10 @@ The packages you need to have available on your system that will run Hass.io may
  - socat
  - software-properties-common
 
+<p class='note warning'>
+   The `modemmanager` package will interfere with any Z-Wave or Zigbee stick and should be removed or disabled. Failure to do so will result in random failures of those components.
+</p>
+
 ### {% linkable_title Arch Linux %}
 
  - apparmor

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -116,7 +116,7 @@ The packages you need to have available on your system that will run Hass.io may
  - software-properties-common
 
 <p class='note warning'>
-   The `modemmanager` package will interfere with any Z-Wave or Zigbee stick and should be removed or disabled. Failure to do so will result in random failures of those components.
+   The `modemmanager` package will interfere with any Z-Wave or Zigbee stick and should be removed or disabled. Failure to do so will result in random failures of those components. For example you can disable with `sudo systemctl disable ModemManager` and remove with `sudo apt-get purge modemmanager`
 </p>
 
 ### {% linkable_title Arch Linux %}


### PR DESCRIPTION
Multiple people have independently identified `modemmanager` as the source of Z-Wave and Zigbee related issues, and confirmed that disabling it resolves those problems. Adding a great big warning here.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
