### PR TITLE
Add option type for entities

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -129,6 +129,7 @@ The following are attributes that can be applied in the `entities` section:
 
 - **name** (*Optional*): The name that the emulated Hue will use. The default for this is the entity's friendly name.
 - **hidden** (*Optional*): Whether or not the emulated Hue bridge should expose the entity. Adding `hidden: false` will expose the entity to Alexa. The default value for this attribute is controlled by the `expose_by_default` option.
+- **type** (*Optional*): The type from the exposed entity. Possible Values are `Dimmable light` and `On/off light` The default for this is `Dimmable light`.
 
 <p class='note'>
 These attributes used to be found under the `customize` section of `homeassistant`, however, they have now been moved to `entities`. Emulated Hue configuration under `homeassistant.customize` will be deprecated in the near future.


### PR DESCRIPTION
**Description:**
Add option type for entities possible values are "Dimmable light" and "On/off light".

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) :** home-assistant/home-assistant#24467

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
