### PR TITLE
Added note about `known_devices.yaml`

### DIFF
--- a/source/_components/device_tracker.markdown
+++ b/source/_components/device_tracker.markdown
@@ -66,6 +66,10 @@ Multiple device trackers can be used in parallel, such as [Owntracks](/component
 
 ## {% linkable_title `known_devices.yaml` %}
 
+<p class='note warning'>
+As of 0.94 `known_devices.yaml` is being phased out, and no longer used by all trackers. Depending on the component you use this section may no longer apply. This includes the mobile app, OwnTracks, GeoFency, GPSLogger, and Locative.
+</p>
+
 Once `device_tracker` is enabled, a file will be created in your config dir named `known_devices.yaml`. Edit this file to adjust which devices to be tracked.
 
 Here's an example configuration for a single device:


### PR DESCRIPTION
Given that this is being phased out, adding a warning about it here to reduce confusion.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
