### PR TITLE
Drop reference to `known_devices.yaml`

### DIFF
--- a/source/_components/gpslogger.markdown
+++ b/source/_components/gpslogger.markdown
@@ -75,4 +75,4 @@ If your battery drains too fast then you can tune the performance of GPSLogger u
   Performance
 </p>
 
-A request can be forced from the app to test if everything is working fine/
+A request can be forced from the app to test if everything is working fine.

--- a/source/_components/gpslogger.markdown
+++ b/source/_components/gpslogger.markdown
@@ -75,4 +75,4 @@ If your battery drains too fast then you can tune the performance of GPSLogger u
   Performance
 </p>
 
-A request can be forced from the app to test if everything is working fine. A successful request will update the `known_devices.yaml` file with the device's serial number.
+A request can be forced from the app to test if everything is working fine/


### PR DESCRIPTION
It no longer uses it, we shouldn't be talking about it here

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
