### PR TITLE
Update event prefixes

### DIFF
--- a/source/_components/doorbird.markdown
+++ b/source/_components/doorbird.markdown
@@ -112,7 +112,7 @@ Events can be defined for each configured DoorBird device independently. These e
 
 See [Schedules](#schedules) section below for details on how to configure schedules.
 
-Event names will be prefixed by `doorbird_`. For example, the example event `somebody_pressed_the_button` will be seen in Home Assistant as `doorbird_somebody_pressed_the_button`. This is to prevent conflicts with other events.
+Event names will be prefixed by `doorbird_devicename`. For example, the example event `somebody_pressed_the_button` for the device 'Driveway Gate' will be seen in Home Assistant as `doorbird_driveway_gate_somebody_pressed_the_button`. This is to prevent conflicts with other events.
 
 See [Automation Example](#automation_example) section below for details on how to use the event names in an automation.
 

--- a/source/_components/doorbird.markdown
+++ b/source/_components/doorbird.markdown
@@ -167,7 +167,7 @@ Remember to complete the schedule assignment steps above for each event type tha
 - alias: Doorbird Ring
   trigger:
     platform: event
-    event_type: doorbird_somebody_pressed_the_button
+    event_type: doorbird_driveway_gate_somebody_pressed_the_button
   action:
     service: light.turn_on
       entity_id: light.side_entry_porch


### PR DESCRIPTION
Changed the event name prefixes and the explanation how they will be seen in Home Assistant.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
