### PR TITLE
Remove incorrect statement about more-info dialog

### DIFF
--- a/source/_lovelace/light.markdown
+++ b/source/_lovelace/light.markdown
@@ -11,7 +11,6 @@ footer: true
 ---
 
 The Light card allows you to change the brightness of the light.
-Note: Long-press on the bulb to bring up the `more-info` dialog.
 
 <p class='img'>
 <img src='/images/lovelace/lovelace_light_card.png' alt='Screenshot of the Light card'>


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
