### PR TITLE
Update freenas.markdown

### DIFF
--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -57,7 +57,7 @@ Install Home Assistant itself:
 % exit
 ```
 
-Create an `rc.d` script for the system-level service that enables Home Assistant to start when the jail starts. Create a file at `/usr/local/etc/rc.d/homeassistant` with the following contents:
+Create an `rc.d` script for the system-level service that enables Home Assistant to start when the jail starts. Create a file at `/usr/local/etc/rc.d/homeassistant` (create the directory with `mkdir -p /usr/local/etc/rc.d` if necessary) with the following contents:
 
 ```bash
 #!/bin/sh

--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -27,6 +27,8 @@ Install the necessary Python packages:
 # pkg upgrade
 # pkg install -y python37 py37-sqlite3 ca_root_nss
 # python3.7 -m ensurepip
+# pip3 install --upgrade pip
+# pip3 install --upgrade virtualenv
 ```
 
 Create the configuration directory:
@@ -48,8 +50,8 @@ Install Home Assistant itself:
 ```bash
 # su homeassistant
 % cd /usr/local/share/homeassistant
-% source ./bin/activate.csh
 % virtualenv -p python3.7 .
+% source ./bin/activate.csh
 % pip3 install homeassistant
 % deactivate
 % exit


### PR DESCRIPTION
source and virtualenv commands were around the wrong way (lines 51/52) - can't run the source command until the virtualenv command has been run:
```
root@homeassistant_1:~ # su homeassistant
homeassistant@homeassistant_1:/root % cd /usr/local/share/homeassistant/
homeassistant@homeassistant_1:/usr/local/share/homeassistant % source ./bin/acti
./bin/ not found

homeassistant@homeassistant_1:/usr/local/share/homeassistant % source ./bin/activ
./bin/ not found

homeassistant@homeassistant_1:/usr/local/share/homeassistant % source ./bin/activate.csh
./bin/activate.csh: No such file or directory.
```


In addition, I also found I had to install virtualenv, output below was what I received trying to run that command.
```
homeassistant@homeassistant_1:/usr/local/share/homeassistant % virtualenv -p python3.7 .
virtualenv: Command not found.
```

Added pip3 install commands for both ensuring pip is upgraded, and installing virtualenv to the script. Allows the virtualenv command to run successfully, and then the source command works:
```
root@homeassistant_1:~ # su homeassistant
homeassistant@homeassistant_1:/root % cd /usr/local/share/homeassistant/
homeassistant@homeassistant_1:/usr/local/share/homeassistant % virtualenv -p python3.7 .
Already using interpreter /usr/local/bin/python3.7
Using base prefix '/usr/local'
New python executable in /usr/local/share/homeassistant/bin/python3.7
Also creating executable in /usr/local/share/homeassistant/bin/python
Installing setuptools, pip, wheel...
done.
homeassistant@homeassistant_1:/usr/local/share/homeassistant % source ./bin/activate.
activate.csh   activate.fish  activate.ps1   activate.xsh
homeassistant@homeassistant_1:/usr/local/share/homeassistant % source ./bin/activate.csh
(homeassistant) homeassistant@homeassistant_1:/usr/local/share/homeassistant %

```


All based on the content found here:
https://community.home-assistant.io/t/my-almost-complete-quick-start-to-installing-home-assistant-on-freenas-11-2-including-appdaemon-ha-dashboard-hass-configurator-mosquitto-and-tasmoadmin/71882

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
