### PR TITLE
Fix typo in autostart directions

### DIFF
--- a/source/_docs/autostart/init.d.markdown
+++ b/source/_docs/autostart/init.d.markdown
@@ -14,7 +14,7 @@ Home Assistant can run as a daemon within init.d with the script below.
 
 ### {% linkable_title 1. Copy script %}
 
-Copy either the daemon script or the Python environment scrip at the end of this page to `/etc/init.d/hass-daemon` depending on your installation.
+Copy either the daemon script or the Python environment script at the end of this page to `/etc/init.d/hass-daemon` depending on your installation.
 
 After that, set the script to be executable:
 


### PR DESCRIPTION
**Description:**
"scrip" -> "script"

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
