### PR TITLE
Add switcher kis auto off service

### DIFF
--- a/source/_components/switcher_kis.markdown
+++ b/source/_components/switcher_kis.markdown
@@ -42,17 +42,17 @@ switcher_kis:
 
 {% configuration %}
 phone_id:
-description: The device's phone id.
-required: true
-type: string
+  description: The device's phone id.
+  required: true
+  type: string
 device_id:
-description: The device's id.
-required: true
-type: string
+  description: The device's id.
+  required: true
+  type: string
 device_password:
-description: The device's password.
-required: true
-type: string
+  description: The device's password.
+  required: true
+  type: string
 {% endconfiguration %}
 
 ## {% linkable_title Switch State Attributes %}
@@ -68,3 +68,16 @@ type: string
 <p class='note warning'>
   Please note, the following attributes are not eligible when the device is off and therefore will not appear as state attributes: `remaining_time`, `electric_current`, `current_power_w`.
 </p>
+
+## {% linkable_title Services %}
+
+### {% linkable_title Service: `switcher_kis.set_auto_off` %}
+
+You can use the `switcher_kis.set_auto_off` service to set the auto-off configuration setting for the device.
+
+Meaning the device will turn itself off when reaching the auto-off configuration limit.
+
+| Service Field | Mandatory | Description                                                                            | Example                    |
+| ------------- | --------- | -------------------------------------------------------------------------------------- | -------------------------- |
+| `entity_id`   | Yes       | Name of the entity id associated with the integration, used for permission validation. | switch.switcher_kis_boiler |
+| `auto_off`    | Yes       | Time period string containing hours and minutes.                                       | "02:30"                    |

--- a/source/_components/switcher_kis.markdown
+++ b/source/_components/switcher_kis.markdown
@@ -42,28 +42,28 @@ switcher_kis:
 
 {% configuration %}
 phone_id:
-  description: The device's phone id.
-  required: true
-  type: string
+description: The device's phone id.
+required: true
+type: string
 device_id:
-  description: The device's id.
-  required: true
-  type: string
+description: The device's id.
+required: true
+type: string
 device_password:
-  description: The device's password.
-  required: true
-  type: string
+description: The device's password.
+required: true
+type: string
 {% endconfiguration %}
 
 ## {% linkable_title Switch State Attributes %}
 
-| Attribute | Type | Description | Example |
-| --------- | ---- | ----------- | ------- |
-| `friendly_name` | string | Defaults to the device's configured name. | "Switcher Boiler" |
-| `auto_off_set` | string | The auto shutdown time limit configured on the device. | "01:30:00" |
-| `remaining_time` | string | Time remaining to shutdown (auto or timer). | "01:29:41" |
-| `electric_current` | float | The electric current in amps. | 12.5 |
-| `current_power_w` | integer | The current power used in watts. | 2756 |
+| Attribute          | Type    | Description                                            | Example           |
+| ------------------ | ------- | ------------------------------------------------------ | ----------------- |
+| `friendly_name`    | string  | Defaults to the device's configured name.              | "Switcher Boiler" |
+| `auto_off_set`     | string  | The auto shutdown time limit configured on the device. | "01:30:00"        |
+| `remaining_time`   | string  | Time remaining to shutdown (auto or timer).            | "01:29:41"        |
+| `electric_current` | float   | The electric current in amps.                          | 12.5              |
+| `current_power_w`  | integer | The current power used in watts.                       | 2756              |
 
 <p class='note warning'>
   Please note, the following attributes are not eligible when the device is off and therefore will not appear as state attributes: `remaining_time`, `electric_current`, `current_power_w`.


### PR DESCRIPTION
**Description:**
Added `switcher_kis.set_auto_off` service documentation.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23477

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html