### PR TITLE
Fix a typo

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -48,7 +48,7 @@ debug:
   type: boolean
   default: false
 autoheal:
-  description: Allows enabling auto Z-Wave heal at midnight. Warning, this is in efficient and [should not be used](https://github.com/home-assistant/architecture/issues/81#issuecomment-478444085).
+  description: Allows enabling auto Z-Wave heal at midnight. Warning, this is inefficient and [should not be used](https://github.com/home-assistant/architecture/issues/81#issuecomment-478444085).
   required: false
   type: boolean
   default: false


### PR DESCRIPTION
**Description:**

"in efficient" -> "inefficient"

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
