### PR TITLE
Adding a big warning

### DIFF
--- a/source/_posts/2017-05-01-home-assistant-on-raspberry-pi-zero-in-30-minutes.markdown
+++ b/source/_posts/2017-05-01-home-assistant-on-raspberry-pi-zero-in-30-minutes.markdown
@@ -15,6 +15,10 @@ og_image: /images/blog/2017-05-hassbian-pi-zero/home_assistant_plus_rpi_600x315.
   <img src="/images/blog/2017-05-hassbian-pi-zero/home_assistant_plus_rpi_600x315.png" />
 </p>
 
+<p class='note warning'>
+  ***This article is very outdated*** guide. If you follow it you will be installing a very outdated version of Hassbian, on a hardware platform only suitable for testing.  ***We strongly recommend you do not follow this article***.
+</p>
+
 Saw the [announcement](/blog/2017/04/30/hassbian-1.21-its-about-time/) yesterday for HASSbian 1.21 and got super excited?
 
 Today we'll flash the latest HASSbian to a [Raspberry Pi Zero W](https://www.raspberrypi.org/products/pi-zero/).


### PR DESCRIPTION
Because people are following this, and installing a massively outdated version of HA, on hardware only fit for testing

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
