### PR TITLE
Add offset option (#24600)

### DIFF
--- a/source/_components/deutsche_bahn.markdown
+++ b/source/_components/deutsche_bahn.markdown
@@ -37,6 +37,11 @@ to:
   description: The name of the end/destination station.
   required: true
   type: string
+offset:
+  description: 
+  required: false
+  type: time
+  default: 00:00
 only_direct:
   description: Only show direct connections.
   required: false

--- a/source/_components/deutsche_bahn.markdown
+++ b/source/_components/deutsche_bahn.markdown
@@ -38,7 +38,7 @@ to:
   required: true
   type: string
 offset:
-  description: 
+  description: Do not display departures leaving sooner than this number of minutes. Useful if you are a couple of minutes away from the stop.
   required: false
   type: time
   default: 00:00


### PR DESCRIPTION
Add documentation to new option 'offset' to search for upcoming connections in the future.
Handy if you need a few minutes to get to the train station and need to add that to the queried departure time.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24600

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
