### PR TITLE
Get stale bot of the PRs that have parents

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,9 +3,8 @@ daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
-#exemptLabels:
-#  - pinned
-#  - security
+exemptLabels:
+  - has-parent
 # Label to use when marking an issue as stale
 staleLabel: Stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
**Description:**

Stale bot is marking PR's that have a parent as stale. This sometimes leads to PR's being closed, while the parent is still open and sometimes even get merged.

Currently, we bump a comment in the PR to prevent closing, ideally, the stale bot should not touch those PR's at all.

This PR addressed this by adding an exempt for PR's with the `has-parent` label.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
