### PR TITLE
Add incomfort climate, sensor and binary_sensor

### DIFF
--- a/source/_components/incomfort.markdown
+++ b/source/_components/incomfort.markdown
@@ -28,6 +28,8 @@ Any room thermostats (there can be 0, 1 or 2) are represented as **Climate** dev
 In addition, there is a **Sensor** for CV pressure, CV temperature, and Tap temperature, and a **Binary Sensor** that will be `on` if there is a fault with the boiler (the fault code will be a state attribute).
 
 To send an alert if the CV pressure is too low or too high, consider the following automation:
+
+{% raw %}
 ```yaml
 - alias: Low CV Pressure Alert
   trigger:
@@ -42,6 +44,7 @@ To send an alert if the CV pressure is too low or too high, consider the followi
         {{ trigger.to_state.attributes.friendly_name }}
         is low, {{ trigger.to_state.state }} bar.
 ```
+{% endraw %}
 
 Other properties are available via each device's attributes.
 

--- a/source/_components/incomfort.markdown
+++ b/source/_components/incomfort.markdown
@@ -21,9 +21,27 @@ The `incomfort` integration links Home Assistant with your Intergas Lan2RF gatew
 
 The boiler is represented as a **Water Heater** device. It will report the boiler's `state` and `temperature` (current temperature). The gateway does not expose any means to directly control the boiler or change its configuration.
 
+Note that the `temperature` will switch between the CV and Tap temperatures according to the current operating mode of the boiler.  If the boiler is neither pumping nor tapping, it will be reported as the higher of the two.
+
 Any room thermostats (there can be 0, 1 or 2) are represented as **Climate** devices. They will report the thermostat's `target_temperature` (setpoint) and `current_temperature` and the setpoint can be changed.
 
 In addition, there is a **Sensor** for CV pressure, CV temperature, and Tap temperature, and a **Binary Sensor** that will be `True` if there is a fault with the boiler.
+
+To send an alert if the CV pressure is too low or too high, consider the following automation:
+```yaml
+- alias: Low CV Pressure Alert
+  trigger:
+    platform: numeric_state
+    entity_id: sensor.cv_pressure
+    below: 1.0
+  action:
+  - service: notify.pushbullet_notifier
+    data_template:
+      title: "Warning: Low CH Pressure"
+      message: >-
+        {{ trigger.to_state.attributes.friendly_name }}
+        is low, {{ trigger.to_state.state }} bar.
+```
 
 Other properties are available via each device's attributes.
 
@@ -31,13 +49,14 @@ Other properties are available via each device's attributes.
 
 To add your Lan2RF gateway into your Home Assistant installation, add one of the following to your `configuration.yaml` file.
 
-Older gateways do not require user authentication::
+Older gateways do not require user authentication:
 
 ```yaml
 # Example configuration.yaml entry, older firmware with no user credentials
 incomfort:
   host: IP_ADDRESS
 ```
+
 Alternatively, if a **username** & **password** is printed on the back of the gateway:
 
 ```yaml

--- a/source/_components/incomfort.markdown
+++ b/source/_components/incomfort.markdown
@@ -25,7 +25,7 @@ Note that the `temperature` will switch between the CV and Tap temperatures acco
 
 Any room thermostats (there can be 0, 1 or 2) are represented as **Climate** devices. They will report the thermostat's `target_temperature` (setpoint) and `current_temperature` and the setpoint can be changed.
 
-In addition, there is a **Sensor** for CV pressure, CV temperature, and Tap temperature, and a **Binary Sensor** that will be `True` if there is a fault with the boiler.
+In addition, there is a **Sensor** for CV pressure, CV temperature, and Tap temperature, and a **Binary Sensor** that will be `on` if there is a fault with the boiler (the fault code will be a state attribute).
 
 To send an alert if the CV pressure is too low or too high, consider the following automation:
 ```yaml

--- a/source/_components/incomfort.markdown
+++ b/source/_components/incomfort.markdown
@@ -10,19 +10,30 @@ footer: true
 logo: incomfort.png
 ha_category:
   - Water heater
+  - Climate
+  - Sensor
+  - Binary sensor
 ha_release: 0.93
 ha_iot_class: Local Polling
 ---
 
-The `incomfort` integration links Home Assistant with your Intergas Lan2RF gateway for controlling water_heater devices (the hub does not have to be in the same network as HA).
+The `incomfort` integration links Home Assistant with your Intergas Lan2RF gateway for integrating the boiler and any room thermostats attached to it.
 
-The **Water Heater** device will report back the `state` and `temperature`. Other properties are available via the device's attributes.
+The boiler is represented as a **Water Heater** device. It will report the boiler's `state` and `temperature` (current temperature). The gateway does not expose any means to directly control the boiler or change its configuration.
 
-In the future, other entities will be added to this integration (e.g. a **Sensor** for CV pressure, and a **Climate** device for room temperature).
+Any room thermostats (there can be 0, 1 or 2) are represented as **Climate** devices. They will report the thermostat's `target_temperature` (setpoint) and `current_temperature` and the setpoint can be changed.
+
+In addition, there is a **Sensor** for CV pressure, CV temperature, and Tap temperature, and a **Binary Sensor** that will be `True` if there is a fault with the boiler.
+
+Other properties are available via each device's attributes.
 
 ### {% linkable_title Configuration %}
 
 To add your Lan2RF gateway into your Home Assistant installation, add one of the following to your `configuration.yaml` file.
+
+The hub does not have to be in the same network as HA.
+
+Older gateways do not require user authentication::
 
 ```yaml
 # Example configuration.yaml entry, older firmware with no user credentials
@@ -41,15 +52,15 @@ incomfort:
 
 {% configuration %}
 host:
-  description: The hostname/IP address of the Lan2RF gateway
+  description: The hostname/IP address of the Lan2RF gateway.
   required: true
   type: string
 username:
-  description: The username of the Lan2RF gateway
+  description: The username of the Lan2RF gateway, if any.
   required: inclusive
   type: string
 password:
-  description: The password of the Lan2RF gateway
+  description: The password of the Lan2RF gateway, if any.
   required: inclusive
   type: string
 {% endconfiguration %}

--- a/source/_components/incomfort.markdown
+++ b/source/_components/incomfort.markdown
@@ -31,8 +31,6 @@ Other properties are available via each device's attributes.
 
 To add your Lan2RF gateway into your Home Assistant installation, add one of the following to your `configuration.yaml` file.
 
-The hub does not have to be in the same network as HA.
-
 Older gateways do not require user authentication::
 
 ```yaml
@@ -49,6 +47,8 @@ incomfort:
   username: USERNAME
   password: PASSWORD
 ```
+
+The hub does not have to be in the same network as HA.
 
 {% configuration %}
 host:


### PR DESCRIPTION
**Description:**
Adds Room thermostats & Sensors to the **incomfort** integration.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):**
home-assistant/home-assistant#23812
home-assistant/home-assistant#23830

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
