### PR TITLE
Introducing the rpi_pfio2 component to add multi board support for PiFace Digital2 cards.

### DIFF
--- a/source/_components/rpi_pfio2.markdown
+++ b/source/_components/rpi_pfio2.markdown
@@ -1,0 +1,149 @@
+---
+layout: page
+title: "PiFace Digital2 I/O"
+description: "Instructions on how to integrate the PiFace Digital2 I/O module into Home Assistant."
+date: 2016-06-19 15:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: raspberry-pi.png
+ha_category:
+  - DIY
+  - Binary Sensor
+  - Switch
+ha_release: 0.95
+ha_iot_class: Local Push
+redirect_from:
+  - /components/binary_sensor.rpi_pfio2/
+  - /components/switch.rpi_pfio2/
+---
+
+The `rpi_pfio2` component is the base for all related [PiFace Digital2 I/O (PFIO)](http://www.piface.org.uk/) platforms in Home Assistant. There is no setup needed for the component itself; for the platforms, please check their corresponding pages.
+
+There is currently support for the following device types within Home Assistant:
+
+- [Binary Sensor](#binary-sensor)
+- [Switch](#switch)
+
+Set the jumpers on the PiFace board for a specific address (JP1: 1-2, JP2: 1-2). This address will be the hardware address for the board.
+
+## {% linkable_title Use with HassOS %}
+
+Note that the PiFace Digital 2 uses the Raspberry Pi SPI port, which is disabled by default when using [HassOS](https://github.com/home-assistant/hassos). When using HassOS, you must mount the SD card on another computer and access the boot partition on the card. Edit the `config.txt` file and add the line `dtparam=spi=on` to the end. This should enable SPI when HassOS is booted and allow Home Assistant to access the PiFace Digital 2 board.
+
+## {% linkable_title Binary Sensor %}
+
+The `rpi_pfio2` binary sensor platform allows you to read sensor values of the [PiFace Digital2 I/O](http://www.piface.org.uk/products/piface_digital_2/ .
+
+To use your PiFace Digital2 I/O module in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+  - platform: rpi_pfio2
+    boards:
+      0:
+        ports:
+          0:
+            name: PIR Office
+            invert_logic: true
+          1:
+            name: Doorbell
+            settle_time: 50
+```
+
+{% configuration %}
+boards:
+  description: The hardware address of the board (from 0 to 3).
+  required: true
+  type: map
+  keys:
+    num:
+      description: The hardware address number.
+      required: true
+      type: map
+      keys:
+        ports:
+          description: List of used ports.
+          required: true
+          type: map
+          keys:
+            num:
+              description: The port number.
+              required: true
+              type: map
+              keys:
+                name:
+                  description: The port name.
+                  required: true
+                  type: string
+                settle_time:
+                  description: The time in milliseconds for port debouncing.
+                  required: false
+                  type: integer
+                  default: 20
+                invert_logic:
+                  description: If `true`, inverts the output logic to ACTIVE LOW.
+                  required: false
+                  type: boolean
+                  default: "`false` (ACTIVE HIGH)"
+{% endconfiguration %}
+
+## {% linkable_title Switch %}
+
+The `rpi_pfio` switch platform allows you to control the [PiFace Digital I/O](http://www.piface.org.uk/products/piface_digital/) module.
+
+To use your PiFace Digital I/O module in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: rpi_pfio2
+    boards:
+      0:
+        ports:
+          0:
+            name: Doorlock
+            invert_logic: true
+            initial_state: off
+          1:
+            name: Light Desk
+```
+
+{% configuration %}
+boards:
+  description: The hardware address of the board (from 0 to 3).
+  required: true
+  type: map
+  keys:
+    num:
+      description: The hardware address number.
+      required: true
+      type: map
+      keys:
+        ports:
+          description: Array of used ports.
+          required: true
+          type: list
+          keys:
+            num:
+              description: Port number.
+              required: true
+              type: list
+              keys:
+                name:
+                  description: Port name.
+                  required: true
+                  type: string
+                invert_logic:
+                  description: If true, inverts the output logic to ACTIVE LOW.
+                  required: false
+                  default: false
+                  type: boolean
+                initial_state:
+                  description: The initial state of the switch.
+                  required: false
+                  default: false
+                  type: boolean
+{% endconfiguration %}

--- a/source/_components/rpi_pfio2.markdown
+++ b/source/_components/rpi_pfio2.markdown
@@ -14,9 +14,6 @@ ha_category:
   - Switch
 ha_release: 0.95
 ha_iot_class: Local Push
-redirect_from:
-  - /components/binary_sensor.rpi_pfio2/
-  - /components/switch.rpi_pfio2/
 ---
 
 The `rpi_pfio2` component is the base for all related [PiFace Digital2 I/O (PFIO)](http://www.piface.org.uk/) platforms in Home Assistant. There is no setup needed for the component itself; for the platforms, please check their corresponding pages.


### PR DESCRIPTION
**Description:**

Introducing the rpi_pfio2 component to add multi board support for PiFace Digital2 cards.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24615

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
