### PR TITLE
Update to the macOS guide

### DIFF
--- a/source/_docs/installation/macos.markdown
+++ b/source/_docs/installation/macos.markdown
@@ -11,13 +11,12 @@ footer: true
 
 [macOS](http://www.apple.com/macos/) is available by default on Apple computer. If you run a different operating system, please refer to the other section of the documentation.
 
-To run Home Assistant on macOS you need to install Python first. Download Python 3.6 or later (at this time we recommend Python 3.7) from [https://www.python.org/downloads/mac-osx/](https://www.python.org/downloads/mac-osx/) and follow the instructions of the installer.
+To run Home Assistant on macOS, you need to install Python first. Download Python 3.6 or later (at this time, we recommend Python 3.7) from [https://www.python.org/downloads/mac-osx/](https://www.python.org/downloads/mac-osx/) and follow the instructions of the installer.
 
 Open a terminal and install Home Assistant in a virtual environment:
 
 ```bash
-$ pip3 install venv
-$ virtualenv homeassistant
+$ python3 -m venv homeassistant
 $ source homeassistant/bin/activate
 $ pip3 install homeassistant
 ```

--- a/source/_docs/installation/macos.markdown
+++ b/source/_docs/installation/macos.markdown
@@ -21,4 +21,4 @@ $ source homeassistant/bin/activate
 $ pip3 install homeassistant
 ```
 
-You can then configure Home Assistant to autostart by following [this guide](/docs/autostart/macos/)
+You can then configure Home Assistant to autostart by following [this guide](/docs/autostart/macos/).

--- a/source/_docs/installation/macos.markdown
+++ b/source/_docs/installation/macos.markdown
@@ -16,7 +16,7 @@ To run Home Assistant on macOS you need to install Python first. Download Python
 Open a terminal and install Home Assistant in a virtual environment:
 
 ```bash
-$ pip3 install virtualenv
+$ pip3 install venv
 $ virtualenv homeassistant
 $ source homeassistant/bin/activate
 $ pip3 install homeassistant

--- a/source/_docs/installation/macos.markdown
+++ b/source/_docs/installation/macos.markdown
@@ -11,12 +11,15 @@ footer: true
 
 [macOS](http://www.apple.com/macos/) is available by default on Apple computer. If you run a different operating system, please refer to the other section of the documentation.
 
-To run Home Assistant on macOS you need to install Python first. Download Python 3.5.3 or later from [https://www.python.org/downloads/mac-osx/](https://www.python.org/downloads/mac-osx/) and follow the instructions of the installer.
+To run Home Assistant on macOS you need to install Python first. Download Python 3.6 or later (at this time we recommend Python 3.7) from [https://www.python.org/downloads/mac-osx/](https://www.python.org/downloads/mac-osx/) and follow the instructions of the installer.
 
-Open a terminal and install Home Assistant.
+Open a terminal and install Home Assistant in a virtual environment:
 
 ```bash
+$ pip3 install virtualenv
+$ virtualenv homeassistant
+$ source homeassistant/bin/activate
 $ pip3 install homeassistant
 ```
 
-Check this [video](https://www.youtube.com/watch?v=hej6ipN86ls) for the installation on macOS.
+You can then configure Home Assistant to autostart by following [this guide](/docs/autostart/macos/)


### PR DESCRIPTION
1. Updated the Python version
2. Changed it to a venv install to avoid people breaking things by accident
3. Linked to the auto-start guide
4. Removed link to the outdated video

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
