### PR TITLE
Add multi-server support to CUPS

### DIFF
--- a/source/_components/cups.markdown
+++ b/source/_components/cups.markdown
@@ -53,7 +53,7 @@ servers:
       type: string
       default: 127.0.0.1
     port:
-      description: Port of the CUPS print server.
+      description: The port number of the CUPS print server.
       required: false
       type: integer
       default: 631

--- a/source/_components/cups.markdown
+++ b/source/_components/cups.markdown
@@ -30,27 +30,37 @@ To enable the CUPS sensor, add the following lines to your `configuration.yaml`:
 ```yaml
 # Example configuration.yaml entry
 sensor:
-  - platform: cups
-    printers:
-      - C410
-      - C430
+  - platform: cups      
+  - servers:
+      - printers:
+          - C410
+          - C430
+      - host: 192.168.1.50
+        port: 631
+        printers:
+          - C450
 ```
 
 {% configuration %}
-printers:
-  description: List of printers to add.
+servers:
+  description: List of CUPS servers to add.
   required: true
   type: list
-host:
-  description: IP address of the CUPS print server.
-  required: false
-  type: string
-  default: 127.0.0.1
-port:
-  description: Port of the CUPS print server.
-  required: false
-  type: integer
-  default: 631
+  keys:
+    printers:
+      description: List of printers to add.
+      required: true
+      type: list
+    host:
+      description: IP address of the CUPS print server.
+      required: false
+      type: string
+      default: 127.0.0.1
+    port:
+      description: Port of the CUPS print server.
+      required: false
+      type: integer
+      default: 631
 {% endconfiguration %}
 
 <p class='note'>

--- a/source/_components/cups.markdown
+++ b/source/_components/cups.markdown
@@ -48,7 +48,7 @@ servers:
       required: true
       type: list
     host:
-      description: IP address of the CUPS print server.
+      description: The IP address of the CUPS print server.
       required: false
       type: string
       default: 127.0.0.1

--- a/source/_components/cups.markdown
+++ b/source/_components/cups.markdown
@@ -35,10 +35,6 @@ sensor:
       - printers:
           - C410
           - C430
-      - host: 192.168.1.50
-        port: 631
-        printers:
-          - C450
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:** Updated documentation for CUPS about multi-server support


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24651

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html