### PR TITLE
Add note on conditions not working without forecast

### DIFF
--- a/source/_components/darksky.markdown
+++ b/source/_components/darksky.markdown
@@ -160,7 +160,7 @@ scan_interval:
 {% endconfiguration %}
 
 <p class='note'>
-Please note that some monitored conditions, such as `temperature_high` or `temperature_high`, may only work when setting the `forecast` attribute to at least `0` (current day).
+Please note that some monitored conditions, such as `temperature_high` or `temperature_low`, may only work when setting the `forecast` attribute to at least `0` (current day).
 </p>
 
 #### {% linkable_title Time period dictionary example %}

--- a/source/_components/darksky.markdown
+++ b/source/_components/darksky.markdown
@@ -159,6 +159,10 @@ scan_interval:
   type: time
 {% endconfiguration %}
 
+<p class='note'>
+Please note that some monitored conditions, such as `temperature_high` or `temperature_high`, may only work when setting the `forecast` attribute to at least `0` (current day).
+</p>
+
 #### {% linkable_title Time period dictionary example %}
 
 ```yaml


### PR DESCRIPTION
It tripped me off that some monitored conditions only work with the forecast attribute set, as they require a forecast to be made. This will add a note that explains this behaviour.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
