### PR TITLE
Fix title in Aftership docs page

### DIFF
--- a/source/_components/aftership.markdown
+++ b/source/_components/aftership.markdown
@@ -60,7 +60,7 @@ api_key:
 | `slug` | `False` | string | Carrier e.g. `fedex`
 | `title` | `False` | string | Friendly name of package
 
- ## {% linkable_title Service `remove_tracking` %}
+## {% linkable_title Service `remove_tracking` %}
 
  You can use the service `aftership.remove_tracking` to remove trackings from Aftership.
 


### PR DESCRIPTION
**Description:**
The space in front causes a misformatting in the rendering.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
