### PR TITLE
Update Geocoding Quickstart link in Google Cloud

### DIFF
--- a/source/_components/google_cloud.markdown
+++ b/source/_components/google_cloud.markdown
@@ -31,7 +31,7 @@ API key obtaining process described in corresponding documentation:
 
 * [Text-to-Speach](https://cloud.google.com/text-to-speech/docs/quickstart-protocol)
 * [Speach-to-Text](https://cloud.google.com/speech-to-text/docs/quickstart-protocol)
-* [Geocoding](https://cloud.google.com/translate/docs/quickstart)
+* [Geocoding](https://developers.google.com/maps/documentation/geocoding/start)
 
 Basic instruction for all APIs:
 


### PR DESCRIPTION
**Description:**
Update Geocoding Quickstart link in Google Cloud
Currently it links to Translate API

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
