### PR TITLE
Documentation for home-assistant/home-assistant#24675

### DIFF
--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -45,8 +45,12 @@ frontend:
     description: "List of additional [resources](/developers/frontend_creating_custom_ui/) to load in `latest` javascript mode."
     required: false
     type: list
-  extra_html_url_es5:
-    description: "List of additional [resources](/developers/frontend_creating_custom_ui/) to load in `es5` javascript mode."
+  extra_module_url:
+    description: "List of additional javascript modules to load."
+    required: false
+    type: list
+  extra_js_url_es5:
+    description: "List of additional javascript code to load in `es5` javascript mode."
     required: false
     type: list
   development_repo:


### PR DESCRIPTION
**Description:**
Documentation for new frontend options. Also removed `extra_html_url_es5` which hasn't done anything for a while.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24675 and home-assistant/home-assistant-polymer#3288

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
