### PR TITLE
Added ES5700

### DIFF
--- a/source/_components/samsungtv.markdown
+++ b/source/_components/samsungtv.markdown
@@ -70,6 +70,7 @@ Currently known supported models:
 - EH5300
 - EH5600
 - ES5500
+- ES5700
 - ES6300
 - ES6800
 - F4580


### PR DESCRIPTION
Added ES5700 to the list of tested and working models

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
