### PR TITLE
Small fix + grammar improvement

### DIFF
--- a/source/getting-started/automation.markdown
+++ b/source/getting-started/automation.markdown
@@ -34,7 +34,7 @@ In the trigger section, click on the dropdown and change trigger type to "Sun". 
 A new automation with a sun trigger filled in.
 </p>
 
-Once we have defined our trigger, scroll down to the action section. Make sure trigger type is set to "Call Service" and change the service to `light.turn_on`. For this automation we're going to turn on all lights, so let's change the service data to `{ "entity_id": "all" }`.
+Once we have defined our trigger, scroll down to the action section. Make sure the action type is set to "Call Service" and change the service to `light.turn_on`. For this automation we're going to turn on all lights, so let's change the service data to `{ "entity_id": "all" }`.
 
 <p class='img'>
 <img src='/images/getting-started/automation-new-action.png'>


### PR DESCRIPTION
**Description:**

This text is referring to a field called "action type", not "trigger type".

Adding "the" also feels more natural.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
