### PR TITLE
Set camera_image as required

### DIFF
--- a/source/_lovelace/picture-glance.markdown
+++ b/source/_lovelace/picture-glance.markdown
@@ -35,7 +35,7 @@ image:
   description: Background image URL.
   type: string
 camera_image:
-  required: false
+  required: true
   description: Camera entity as Background image.
   type: string
 camera_view:


### PR DESCRIPTION
**Description:**
Without camera_image configuration, picture-glance is invalid.
This is why I'm assuming it's a required field!

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
