### PR TITLE
notes on using states(xxx) vs states.xxx

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -59,7 +59,7 @@ script:
 ### {% linkable_title States %}
 - Iterating `states` will yield each state sorted alphabetically by entity ID.
 - Iterating `states.domain` will yield each state of that domain sorted alphabetically by entity ID.
-- `states.sensor.temperature` returns the state object for `sensor.temperature`.
+- `states.sensor.temperature` returns the state object for `sensor.temperature` if `sensor.temperature` exists, and `unknown` otherwise (for example, during Home Assistant startup for [template sensor](https://www.home-assistant.io/components/template/#considerations) *producing error messages in log file*. Use one of the functions below to avoid this:
 - `states('device_tracker.paulus')` will return the state string (not the object) of the given entity or `unknown` if it doesn't exist.
 - `is_state('device_tracker.paulus', 'home')` will test if the given entity is the specified state.
 - `state_attr('device_tracker.paulus', 'battery')` will return the value of the attribute or None if it doesn't exist.

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -57,18 +57,24 @@ script:
  Extensions allow templates to access all of the Home Assistant specific states and adds other convenience functions and filters.
 
 ### {% linkable_title States %}
+
 - Iterating `states` will yield each state sorted alphabetically by entity ID.
 - Iterating `states.domain` will yield each state of that domain sorted alphabetically by entity ID.
-- `states.sensor.temperature` returns the state object for `sensor.temperature` if `sensor.temperature` exists, and `unknown` otherwise (for example, during Home Assistant startup for [template sensor](https://www.home-assistant.io/components/template/#considerations) *producing error messages in log file*. Use one of the functions below to avoid this:
+- `states.sensor.temperature` returns the state object for `sensor.temperature` (avoid when possible, see note below).
 - `states('device_tracker.paulus')` will return the state string (not the object) of the given entity or `unknown` if it doesn't exist.
 - `is_state('device_tracker.paulus', 'home')` will test if the given entity is the specified state.
 - `state_attr('device_tracker.paulus', 'battery')` will return the value of the attribute or None if it doesn't exist.
 - `is_state_attr('device_tracker.paulus', 'battery', 40)` will test if the given entity attribute is the specified state (in this case, a numeric value).
 
+<p class='note warning'>
+  Avoid using `states.sensor.temperature`, instead use `states('sensor.temperature')`. It is strongly advised to use the `states()`, `is_state()`, `state_attr()` and `is_state_attr()` as much as possible, using these avoid errors and error message when the entity isn't ready yet (e.g., during Home Assistant startup).
+</p>
+
 Besides the normal [state object methods and properties](/topics/state_object/), `states.sensor.temperature.state_with_unit` will print the state of the entity and, if available, the unit.
 
 
 #### {% linkable_title States examples %}
+
 The next two statements result in the same value if the state exists. The second one will result in an error if the state does not exist.
 
 {% raw %}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -67,7 +67,7 @@ script:
 - `is_state_attr('device_tracker.paulus', 'battery', 40)` will test if the given entity attribute is the specified state (in this case, a numeric value).
 
 <p class='note warning'>
-  Avoid using `states.sensor.temperature`, instead use `states('sensor.temperature')`. It is strongly advised to use the `states()`, `is_state()`, `state_attr()` and `is_state_attr()` as much as possible, using these avoid errors and error message when the entity isn't ready yet (e.g., during Home Assistant startup).
+  Avoid using `states.sensor.temperature`, instead use `states('sensor.temperature')`. It is strongly advised to use the `states()`, `is_state()`, `state_attr()` and `is_state_attr()` as much as possible, to avoid errors and error message when the entity isn't ready yet (e.g., during Home Assistant startup).
 </p>
 
 Besides the normal [state object methods and properties](/topics/state_object/), `states.sensor.temperature.state_with_unit` will print the state of the entity and, if available, the unit.


### PR DESCRIPTION
as per this discussion - https://community.home-assistant.io/t/using-better-templates-with-state/122912/14

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
