### PR TITLE
Add broadcast parameter to samsungtv component

### DIFF
--- a/source/_components/samsungtv.markdown
+++ b/source/_components/samsungtv.markdown
@@ -56,6 +56,10 @@ mac:
   description: "The MAC address of the Samsung Smart TV, e.g., `00:11:22:33:44:55:66`. Required for power on support via wake on lan."
   required: false
   type: string
+broadcast:
+  description: "The IP address of the host to send the magic packet to for wake on lan, e.g. `192.168.255.255`."
+  required: false
+  type: string
 {% endconfiguration %}
 
 Currently known supported models:


### PR DESCRIPTION
**Description:**

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24731

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
