### PR TITLE
Added link to add-on configuration doc

### DIFF
--- a/source/hassio/external_storage.markdown
+++ b/source/hassio/external_storage.markdown
@@ -11,7 +11,7 @@ footer: true
 
 ### {% linkable_title ResinOS / Generic %}
 
-Map the USB drive into add-on with `devices` options. If you need it on multiple add-ons, you can use the `/share` folder which is accessible from various add-ons.
+Map the USB drive into add-on with `devices` options (see [Add-On Configuration doc][Add-On Configuration doc] for more details). If you need it on multiple add-ons, you can use the `/share` folder which is accessible from various add-ons.
 It is also possible to create an add-on that only mounts stuff to `share`.
 
 You can format the USB device with multiple volumes and map it to a specific add-on.
@@ -19,3 +19,5 @@ You can format the USB device with multiple volumes and map it to a specific add
 ### {% linkable_title Generic %}
 
 The `share` defaults to `/usr/share/hassio/share` so you can mount your volumes into this folder.
+
+[Add-On Configuration doc]: https://developers.home-assistant.io/docs/en/hassio_addon_config.html


### PR DESCRIPTION
**Description:**
Added link to add-on configuration doc but I think this part of the doc needs to be reworked, with example, as there are a lot of concepts that are taken for granted... I certainly could not set this up without a lot of trial and error...

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** not applicable

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html