### PR TITLE
Note deprecation of Uber API

### DIFF
--- a/source/_components/uber.markdown
+++ b/source/_components/uber.markdown
@@ -15,6 +15,7 @@ ha_release: 0.16
 redirect_from:
  - /components/sensor.uber/
 ---
+## This component has been deprecated as of June 13, 2019 as Uber closed their public api.
 
 The `uber` sensor will give you time and price estimates for all available [Uber](https://uber.com) products at the given location. The `ATTRIBUTES` are used to provide extra information about products, such as estimated trip duration, distance and vehicle capacity. By default, 2 sensors will be created for each product at the given `start` location, one for pickup time and one for current price. The sensor is powered by the official Uber [API](https://developer.uber.com/).
 


### PR DESCRIPTION
Uber no loner supports the API after June 13, 2019.

**Description:**
Uber no longer is supporting the API. It is noted in breaking changes for the 0.95 release, but the docs are still present. This is to clarify the docs that the component is no longer supported. 

Eventually a deletion of the docs may be necessary, but in the transition, this clarification can help people who find their component no longer working and/or that did not read the breaking changes.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
