### PR TITLE
Fixed typos

### DIFF
--- a/source/_components/google_cloud.markdown
+++ b/source/_components/google_cloud.markdown
@@ -29,8 +29,8 @@ tts:
 
 API key obtaining process described in corresponding documentation:
 
-* [Text-to-Speach](https://cloud.google.com/text-to-speech/docs/quickstart-protocol)
-* [Speach-to-Text](https://cloud.google.com/speech-to-text/docs/quickstart-protocol)
+* [Text-to-Speech](https://cloud.google.com/text-to-speech/docs/quickstart-protocol)
+* [Speech-to-Text](https://cloud.google.com/speech-to-text/docs/quickstart-protocol)
 * [Geocoding](https://developers.google.com/maps/documentation/geocoding/start)
 
 Basic instruction for all APIs:


### PR DESCRIPTION
Corrected instances where 'speech' was spelt as 'speach'. It's not all (s)peachy now ;)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
