### PR TITLE
Update mqtt_room markdown

### DIFF
--- a/source/_components/mqtt_room.markdown
+++ b/source/_components/mqtt_room.markdown
@@ -72,5 +72,6 @@ Example JSON that should be published to the room topics:
 This component works with any software that is sending data in the given format. Each client should post the discovered devices in its own subtopic of the configured topic.
 Instead of developing your own application, you can also use any of these already existing clients:
 
-- [**room-assistant**](https://github.com/mKeRix/room-assistant): looks for Bluetooth LE beacons, based on Node.js
+- [**room-assistant**](https://github.com/mKeRix/room-assistant): runs on a raspberry pi, and looks for Bluetooth LE beacons, based on Node.js
 - [**Happy Bubbles Presence Server**](https://github.com/happy-bubbles/presence): presence detection server for Happy Bubbles BLE-scanning devices, based on Go
+- [**ESP32-MQTT-room**](https://jptrsn.github.io/ESP32-mqtt-room/): runs on an ESP32, and looks for Bluetooth LE devices, based on C++/Arduino

--- a/source/_components/mqtt_room.markdown
+++ b/source/_components/mqtt_room.markdown
@@ -72,6 +72,6 @@ Example JSON that should be published to the room topics:
 This component works with any software that is sending data in the given format. Each client should post the discovered devices in its own subtopic of the configured topic.
 Instead of developing your own application, you can also use any of these already existing clients:
 
-- [**room-assistant**](https://github.com/mKeRix/room-assistant): runs on a raspberry pi, and looks for Bluetooth LE beacons, based on Node.js
+- [**room-assistant**](https://github.com/mKeRix/room-assistant): looks for Bluetooth LE beacons, based on Node.js
 - [**Happy Bubbles Presence Server**](https://github.com/happy-bubbles/presence): presence detection server for Happy Bubbles BLE-scanning devices, based on Go
 - [**ESP32-MQTT-room**](https://jptrsn.github.io/ESP32-mqtt-room/): runs on an ESP32, and looks for Bluetooth LE devices, based on C++/Arduino


### PR DESCRIPTION
**Description:**
Updated list of applications that work with mqtt room component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
