### PR TITLE
Added pushover image attachment functionality

### DIFF
--- a/source/_components/pushover.markdown
+++ b/source/_components/pushover.markdown
@@ -59,9 +59,12 @@ Example Automation:
           url: "https://www.home-assistant.io/"
           sound: pianobar
           priority: 0
+          attachment: "http://example.com/image.png"
 ```
 
 Component specific values in the nested `data` section are optional.
+
+Image attachments can be added using the `attachment` parameter, which can either be a valid URL for an image (ex: `http://example.com/image.png`) or a local file reference (ex: `/tmp/image.png`).
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
 
@@ -86,6 +89,7 @@ alexa:
             sound: falling
             device: pixel
             url: "https://www.home-assistant.io/"
+            attachment: "/tmp/image.png"
 ```
 
 {% endraw %}


### PR DESCRIPTION
**Description:**
A new feature adds the ability to send attachments in pushover notifications. Documentation updated to reflect changes to the data section, added "attachment" parameter.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24806

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
