### PR TITLE
add icon_template to configuration options

### DIFF
--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -67,6 +67,10 @@ light:
         required: false
         type: template
         default: optimistic
+      icon_template:
+        description: Defines a template for an icon or picture, e.g. showing a different icon for different states.
+        required: false
+        type: template        
       turn_on:
         description: Defines an action to run when the light is turned on.
         required: true


### PR DESCRIPTION
It wasn't listed in the list of config options, only as examples.

**Description:**
The icon_template configuration option was missing from the list of configuration options.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
