### PR TITLE
Removing integration instead of .tradfri_psk.conf

### DIFF
--- a/source/_components/tradfri.markdown
+++ b/source/_components/tradfri.markdown
@@ -56,7 +56,11 @@ allow_tradfri_groups:
 
 ### {% linkable_title Firmware updates %}
 
-After updating the firmware of your IKEA Trådfri Gateway it might be necessary to repeat the configuration process. If you encounter problems, delete the `.tradfri_psk.conf` file in your `.homeassistant` directory, restart Home Assistant, when prompted enter the security key and click configure, just like during initial setup. Possible errors: `Fatal DTLS error: code 115`.
+After updating the firmware of your IKEA Trådfri Gateway it might be necessary to repeat the configuration process. Possible errors: `Fatal DTLS error: code 115`. If you encounter problems:
+- when configured using the integration: remove the integration through Settings > Integrations > Tradfri > delete using trash can icon;
+- with manual configuration: delete the `.tradfri_psk.conf` file in your `.homeassistant` directory;
+
+Then restart Home Assistant, when prompted enter the security key and click configure, just like during initial setup.
 
 ### {% linkable_title Compilation issues %}
 


### PR DESCRIPTION
When using the integration, you can simply remove the integration after a Tradfri firmware update. Everything will get rediscovered after a restart. This was not yet mentioned in the docs.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
