### PR TITLE
a space to many corrupted the equilibrium

### DIFF
--- a/source/_components/google_cloud.markdown
+++ b/source/_components/google_cloud.markdown
@@ -112,7 +112,7 @@ gain:
   type: float
   default: 0.0
 profiles:
-  description: "An identifier which selects 'audio effects' profiles that are applied on (post synthesized) text to speech. Effects are applied on top of each other in the order they are given. Supported profile ids listed [here](https: //cloud.google.com/text-to-speech/docs/audio-profiles)."
+  description: "An identifier which selects 'audio effects' profiles that are applied on (post synthesized) text to speech. Effects are applied on top of each other in the order they are given. Supported profile ids listed [here](https://cloud.google.com/text-to-speech/docs/audio-profiles)."
   required: false
   type: list
   default: "[]"


### PR DESCRIPTION
fixed error in link/url

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
