### PR TITLE
Add template support to template trigger's for option

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -201,6 +201,21 @@ automation:
 ```
 {% endraw %}
 
+You can also use templates in the `for` option.
+
+{% raw %}
+```yaml
+automation:
+  trigger:
+    platform: template
+    value_template: "{{ is_state('device_tracker.paulus', 'home') }}"
+    for:
+      minutes: "{{ states('input_number.minutes')|int(0) }}"
+```
+{% endraw %}
+
+The `for` template(s) will be evaluated when the `value_template` becomes `true`.
+
 <p class='note warning'>
 Rendering templates with time (`now()`) is dangerous as trigger templates only update based on entity state changes.
 </p>


### PR DESCRIPTION
**Description:**
Allow the use of templates with the template trigger's for option.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24810

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
