### PR TITLE
Add list of supported languages.

### DIFF
--- a/source/_components/microsoft.markdown
+++ b/source/_components/microsoft.markdown
@@ -35,7 +35,7 @@ api_key:
   required: true
   type: string
 language:
-  description: The language to use. Note that if you set the language to anything other than the default, you will need to specify a matching voice type as well. For a list of supported languages please check here [Supported Languages](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/microsoft/tts.py#L20)
+  description: The language to use. Note that if you set the language to anything other than the default, you will need to specify a matching voice type as well. For the supported languages check the list of [available languages](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/microsoft/tts.py#L20).
   required: false
   type: string
   default: "`en-us`"

--- a/source/_components/microsoft.markdown
+++ b/source/_components/microsoft.markdown
@@ -35,7 +35,7 @@ api_key:
   required: true
   type: string
 language:
-  description: The language to use. Note that if you set the language to anything other than the default, you will need to specify a matching voice type as well. For a list of supported languages please check here https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/microsoft/tts.py#L20
+  description: The language to use. Note that if you set the language to anything other than the default, you will need to specify a matching voice type as well. For a list of supported languages please check here [Supported Languages](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/microsoft/tts.py#L20)
   required: false
   type: string
   default: "`en-us`"

--- a/source/_components/microsoft.markdown
+++ b/source/_components/microsoft.markdown
@@ -35,7 +35,7 @@ api_key:
   required: true
   type: string
 language:
-  description: The language to use. Accepted values are listed below. Note that if you set the language to anything other than the default, you will need to specify a matching voice type as well.
+  description: The language to use. Note that if you set the language to anything other than the default, you will need to specify a matching voice type as well. For a list of supported languages please check here https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/microsoft/tts.py#L20
   required: false
   type: string
   default: "`en-us`"
@@ -70,13 +70,6 @@ contour:
   type: string
 {% endconfiguration %}
 
-Languages supported by this integration.
-  'ar-eg', 'ar-sa', 'ca-es', 'cs-cz', 'da-dk', 'de-at', 'de-ch', 'de-de',
-  'el-gr', 'en-au', 'en-ca', 'en-gb', 'en-ie', 'en-in', 'en-us', 'es-es',
-  'es-mx', 'fi-fi', 'fr-ca', 'fr-ch', 'fr-fr', 'he-il', 'hi-in', 'hu-hu',
-  'id-id', 'it-it', 'ja-jp', 'ko-kr', 'nb-no', 'nl-nl', 'pl-pl', 'pt-br',
-  'pt-pt', 'ro-ro', 'ru-ru', 'sk-sk', 'sv-se', 'th-th', 'tr-tr', 'zh-cn',
-  'zh-hk', 'zh-tw'
   
 ## {% linkable_title Full configuration example %}
 

--- a/source/_components/microsoft.markdown
+++ b/source/_components/microsoft.markdown
@@ -35,7 +35,7 @@ api_key:
   required: true
   type: string
 language:
-  description: The language to use. Accepted values are listed in the documentation mentioned below. Note that if you set the language to anything other than the default, you will need to specify a matching voice type as well.
+  description: The language to use. Accepted values are listed below. Note that if you set the language to anything other than the default, you will need to specify a matching voice type as well.
   required: false
   type: string
   default: "`en-us`"
@@ -70,6 +70,14 @@ contour:
   type: string
 {% endconfiguration %}
 
+Languages supported by this integration.
+  'ar-eg', 'ar-sa', 'ca-es', 'cs-cz', 'da-dk', 'de-at', 'de-ch', 'de-de',
+  'el-gr', 'en-au', 'en-ca', 'en-gb', 'en-ie', 'en-in', 'en-us', 'es-es',
+  'es-mx', 'fi-fi', 'fr-ca', 'fr-ch', 'fr-fr', 'he-il', 'hi-in', 'hu-hu',
+  'id-id', 'it-it', 'ja-jp', 'ko-kr', 'nb-no', 'nl-nl', 'pl-pl', 'pt-br',
+  'pt-pt', 'ro-ro', 'ru-ru', 'sk-sk', 'sv-se', 'th-th', 'tr-tr', 'zh-cn',
+  'zh-hk', 'zh-tw'
+  
 ## {% linkable_title Full configuration example %}
 
 A full configuration sample including optional variables:


### PR DESCRIPTION
The integration does not list the languages that it supports.
Some languages are missing from the integration itself compared to the Microsoft documentation, adding the languages it supports should prevent users trying to add an non-supported language

https://github.com/home-assistant/home-assistant.io/issues/9637



