### PR TITLE
Update REST Sensors to allow json_attributes_template for state attributes

### DIFF
--- a/source/_components/binary_sensor.rest.markdown
+++ b/source/_components/binary_sensor.rest.markdown
@@ -112,6 +112,19 @@ headers:
   description: The headers for the requests.
   required: false
   type: list, string
+json_attributes:
+  description: A list of keys to extract values from a JSON dictionary result and then set as sensor attributes.
+  reqired: false
+  type: list, string
+json_attributes_template:
+  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the JSON dictionary from the response. Can be used in conjuction with `json_attributes` to filter a nested response object. Usage example can be found in [MQTT sensor](/components/sensor.mqtt/#json-attributes-template-configuration) documentation."
+  required: false
+  type: template
+force_update:
+  description: Sends update events even if the value hasn't changed. Useful if you want to have meaningful value graphs in history.
+  reqired: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 <p class='note warning'>

--- a/source/_components/rest.markdown
+++ b/source/_components/rest.markdown
@@ -100,6 +100,10 @@ json_attributes:
   description: A list of keys to extract values from a JSON dictionary result and then set as sensor attributes.
   reqired: false
   type: list, string
+json_attributes_template:
+  description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract the JSON dictionary from the response. Can be used in conjuction with `json_attributes` to filter a nested response object. Usage example can be found in [MQTT sensor](/components/sensor.mqtt/#json-attributes-template-configuration) documentation."
+  required: false
+  type: template
 force_update:
   description: Sends update events even if the value hasn't changed. Useful if you want to have meaningful value graphs in history.
   reqired: false
@@ -340,5 +344,22 @@ sensor:
         value_template: '{{ states.sensor.room_sensors.attributes["bedroom2"]["temperature"] }}'
         device_class: temperature
         unit_of_measurement: '°C'
+```
+{% endraw %}
+
+
+Using the same example above, if you were only interested in Bedroom 1's temperature and wanted to keep the humidity and battery info as a state attribute, you could use the `json_attributes_template`:
+
+{% raw %}
+```yaml
+sensor:
+  - platform: rest
+    name: room_sensors
+    resource: http://<address_to_rest_service>
+    json_attributes:
+      - humidity
+      - battery
+    value_template: "{{ value_json[bedroom1][temperature] }}"
+    json_attributes_template: "{{ value_json[bedroom1] | tojson }}"
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**
1) Add `json_attributes` and  `force_update` options to the `rest` platform's `binary_sensor` platform (already exist in `sensor`)
2) Update the `rest` `sensor` and `binary_sensor` devices to allow MQTT-style `json_attribute_template` options to break out the JSON response into state attributes.  Currently only first-level JSON dict values can be handled as device state attributes, this allows you to add a nested JSON response object as state values and then (coupled with `json_attributes`) filter *that* object further. [MQTT Documentation](https://www.home-assistant.io/components/sensor.mqtt/#json-attributes-template-configuration) for reference. 


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24820

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
