### PR TITLE
Adds support for Gitpod.io

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,3 @@
+FROM gitpod/workspace-full:latest
+RUN gem install bundler -v 2.0.1
+RUN bundle install

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,3 +1,0 @@
-FROM gitpod/workspace-full:latest
-RUN gem install bundler -v 2.0.1
-RUN bundle install

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,3 +6,13 @@ tasks:
 ports:
   - port: 4000
     onOpen: open-browser
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+    addComment: false
+    addBadge: true
+    addLabel: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: gem install bundler -v 2.0.1
+  - init: bundle install
+ports:
+  - port: 4000
+    onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,3 @@
-image:
-  file: .gitpod.dockerfile
 tasks:
   - init: gem install bundler -v 2.0.1
   - init: bundle install

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,5 @@
+image:
+  file: .gitpod.dockerfile
 tasks:
   - init: gem install bundler -v 2.0.1
   - init: bundle install

--- a/.theia/tasks.json
+++ b/.theia/tasks.json
@@ -1,0 +1,30 @@
+{
+    "tasks": [
+        {
+            "label": "Generate",
+            "type": "shell",
+            "command": "bundle",
+            "args": [
+                "exec",
+                "rake",
+                "generate"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}",
+            }        
+        },
+        {
+            "label": "Preview",
+            "type": "shell",
+            "command": "bundle",
+            "args": [
+                "exec",
+                "rake",
+                "preview"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}",
+            }        
+        },
+    ]
+}

--- a/.theia/tasks.json
+++ b/.theia/tasks.json
@@ -10,7 +10,7 @@
                 "generate"
             ],
             "options": {
-                "cwd": "${workspaceFolder}",
+                "cwd": "${workspaceFolder}"
             }        
         },
         {
@@ -23,8 +23,8 @@
                 "preview"
             ],
             "options": {
-                "cwd": "${workspaceFolder}",
+                "cwd": "${workspaceFolder}"
             }        
-        },
+        }
     ]
 }


### PR DESCRIPTION
**Description:**

This PR adds support for using Gitpod.io with the Home Assistant documentation.

This PR can be reviewed using Gitpod as well 😉 

[![image](https://user-images.githubusercontent.com/195327/60383709-cac06100-9a74-11e9-92dd-74f156c0f9a4.png)](https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9727)

<https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9727>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
