### PR TITLE
added i2c group to homeassistant user

### DIFF
--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -52,7 +52,7 @@ Add an account for Home Assistant called `homeassistant`.
 Since this account is only for running Home Assistant the extra arguments of `-rm` is added to create a system account and create a home directory. The arguments `-G dialout,gpio` adds the user to the `dialout` and the `gpio` group. The first is required for using Z-Wave and Zigbee controllers, while the second is required to communicate with Raspberry's GPIO.
 
 ```bash
-$ sudo useradd -rm homeassistant -G dialout,gpio
+$ sudo useradd -rm homeassistant -G dialout,gpio,i2c
 ```
 
 Next we will create a directory for the installation of Home Assistant and change the owner to the `homeassistant` account.

--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -49,7 +49,7 @@ $ sudo apt-get install python3 python3-venv python3-pip libffi-dev libssl-dev
 ```
 
 Add an account for Home Assistant called `homeassistant`.
-Since this account is only for running Home Assistant the extra arguments of `-rm` is added to create a system account and create a home directory. The arguments `-G dialout,gpio` adds the user to the `dialout` and the `gpio` group. The first is required for using Z-Wave and Zigbee controllers, while the second is required to communicate with Raspberry's GPIO.
+Since this account is only for running Home Assistant the extra arguments of `-rm` is added to create a system account and create a home directory. The arguments `-G dialout,gpio,i2c` adds the user to the `dialout`, `gpio` and the `i2c` group. The first is required for using Z-Wave and Zigbee controllers, while the second is required to communicate with Raspberry's GPIO.
 
 ```bash
 $ sudo useradd -rm homeassistant -G dialout,gpio,i2c


### PR DESCRIPTION
this change should ease user experience

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch:  `current`
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
