### PR TITLE
Fix typo

### DIFF
--- a/source/_components/switch.markdown
+++ b/source/_components/switch.markdown
@@ -24,7 +24,7 @@ Keeps track which switches are in your environment, their state and allows you t
 In the frontend open the sidebar. At the bottom, under **Developer Tools**, click **Services**. From the Service dropdown menu choose `switch.turn_on` or `switch.turn_off` from the list of available services. In the Entity dropdown menu choose or enter the entity ID you want to work with. This will enter something like the sample below into the **Service Data** field. Now hit **CALL SERVICE**.
 
 ```json
-{"entity_id":"livingroom_pin2"}
+{"entity_id":"switch.livingroom_pin2"}
 ```
 
 | Service data attribute | Optional | Description |


### PR DESCRIPTION
The entity in the example is missing the domain 🤦‍♂

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9735"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/f1521295496f6fe9fa7cfc265c428d1dccf4a3b4.svg" /></a>

