### PR TITLE
Rewrites states.xxx -> states('xxx') (and similar)

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -159,7 +159,7 @@ binary_sensor:
   - platform: template
     sensors:
       motion_battery_low:
-        value_template: '{{ states.sensor.motion.attributes.battery < 15 }}'
+        value_template: '{{ state_attr('sensor.motion', 'battery') < 15 }}'
         friendly_name: 'Motion battery is low'
 
 alert:

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -32,7 +32,7 @@ binary_sensor:
       sun_up:
         friendly_name: "Sun is up"
         value_template: >-
-          {{ states.sun.sun.attributes.elevation|float > 0 }}
+          {{ state_attr('sun.sun', 'elevation')|float > 0 }}
 ```
 {% endraw %}
 
@@ -91,7 +91,7 @@ Template Binary Sensor may get an `unknown` state during startup. This results
 in error messages in your log file until that platform has completed loading.
 If you use `is_state()` function in your template, you can avoid this situation.
 For example, you would replace
-{% raw %}`{{ states.switch.source.state == 'on' }}`{% endraw %}
+{% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
 with this equivalent that returns `true`/`false` and never gives an unknown
 result:
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}

--- a/source/_components/binary_sensor.xiaomi_aqara.markdown
+++ b/source/_components/binary_sensor.xiaomi_aqara.markdown
@@ -141,7 +141,7 @@ The requirement is that you have setup the [`xiaomi aqara` component](/component
     - service: notify.html5
       data_template:
         title: Gas alarm!
-        message: 'Gas with a density of {% raw %}{{ states.binary_sensor.natgas_sensor_158dxxxxxxxxxx.attributes.density }}{% endraw %} detected.'
+        message: 'Gas with a density of {% raw %}{{ state_attr('binary_sensor.natgas_sensor_158dxxxxxxxxxx', 'density') }}{% endraw %} detected.'
 ```
 
 #### {% linkable_title Xiaomi Wireless Button %}
@@ -268,11 +268,11 @@ The Aqara Wireless Switch is available as single-key and double-key version. Eac
     entity_id: light.gateway_light_34xxxxxxxx13
     data_template:
       brightness: {% raw %}>-
-        {% if states.light.gateway_light_34xxxxxxxx13.attributes.brightness %}
-          {% if states.light.gateway_light_34xxxxxxxx13.attributes.brightness - 60 >= 10 %}
-            {{states.light.gateway_light_34xxxxxxxx13.attributes.brightness - 60}}
+        {% if state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') %}
+          {% if state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') - 60 >= 10 %}
+            {{state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') - 60}}
           {% else %}
-            {{states.light.gateway_light_34xxxxxxxx13.attributes.brightness}}
+            {{state_attr('light.gateway_light_34xxxxxxxx13', 'brightness')}}
           {% endif %}
         {% else %}
           10
@@ -290,11 +290,11 @@ The Aqara Wireless Switch is available as single-key and double-key version. Eac
     entity_id: light.gateway_light_34xxxxxxxx13
     data_template:
       brightness: {% raw %}>-
-        {% if states.light.gateway_light_34xxxxxxxx13.attributes.brightness %}
-          {% if states.light.gateway_light_34xxxxxxxx13.attributes.brightness + 60 <= 255 %}
-            {{states.light.gateway_light_34xxxxxxxx13.attributes.brightness + 60}}
+        {% if state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') %}
+          {% if state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') + 60 <= 255 %}
+            {{state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') + 60}}
           {% else %}
-            {{states.light.gateway_light_34xxxxxxxx13.attributes.brightness}}
+            {{state_attr('light.gateway_light_34xxxxxxxx13', 'brightness')}}
           {% endif %}
         {% else %}
           10

--- a/source/_components/calendar.google.markdown
+++ b/source/_components/calendar.google.markdown
@@ -215,6 +215,6 @@ For example, the actions following this condition will only be executed for even
 ```yaml
     condition:
         condition: template
-        value_template: "{{states.calendar.calendar_name.attributes.message == 'vacation' }}"
+        value_template: "{{is_state_attr('calendar.calendar_name', 'message', 'vacation') }}"
 ```
 {% endraw %}

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -115,7 +115,7 @@ Template Cover may get an `unknown` state during startup. This results in error
 messages in your log file until that platform has completed loading.
 If you use `is_state()` function in your template, you can avoid this situation.
 For example, you would replace
-{% raw %}`{{ states.switch.source.state == 'on' }}`{% endraw %}
+{% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
 with this equivalent that returns `true`/`false` and never gives an unknown
 result:
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}

--- a/source/_components/deconz.markdown
+++ b/source/_components/deconz.markdown
@@ -155,7 +155,7 @@ automation:
         data_template:
           entity_id: light.lamp
           brightness: >
-            {% set bri = states.light.lamp.attributes.brightness | int %}
+            {% set bri = state_attr('light.lamp', 'brightness') | int %}
             {{ [bri+30, 249] | min }}
 
   - alias: 'Decrease brightness of lamp from dimmer'
@@ -171,7 +171,7 @@ automation:
         data_template:
           entity_id: light.lamp
           brightness: >
-            {% set bri = states.light.lamp.attributes.brightness | int %}
+            {% set bri = state_attr('light.lamp', 'brightness') | int %}
             {{ [bri-30, 0] | max }}
 ```
 

--- a/source/_components/deutsche_bahn.markdown
+++ b/source/_components/deutsche_bahn.markdown
@@ -52,7 +52,7 @@ sensor:
   platform: template
   sensors:
     next_departure:
-      value_template: '{% raw %}{{ states.sensor.munich_to_ulm.attributes.next }}{% endraw %}'
+      value_template: '{% raw %}{{ state_attr('sensor.munich_to_ulm', 'next') }}{% endraw %}'
       friendly_name: 'Next departure'
 ```
 

--- a/source/_components/fritzbox_callmonitor.markdown
+++ b/source/_components/fritzbox_callmonitor.markdown
@@ -124,11 +124,11 @@ automation:
             {% if is_state("sensor.phone", "idle") %}
               Phone is idle
             {% elif is_state("sensor.phone", "dialing") %}
-              Calling {{ states.sensor.phone.attributes.to_name }} ({{ states.sensor.phone.attributes.to }})
+              Calling {{ state_attr('sensor.phone', 'to_name') }} ({{ state_attr('sensor.phone', 'to') }})
             {% elif is_state("sensor.phone", "ringing") %}
-              Incoming call from {{ states.sensor.phone.attributes.from_name }} ({{ states.sensor.phone.attributes.from }})
+              Incoming call from {{ state_attr('sensor.phone', 'from_name') }} ({{ state_attr('sensor.phone', 'from') }})
             {% else %}
-              Talking to {{ states.sensor.phone.attributes.with_name }} ({{ states.sensor.phone.attributes.with }})
+              Talking to {{ state_attr('sensor.phone', 'with_name') }} ({{ state_attr('sensor.phone', 'with') }})
             {% endif %}
 ```
 {% endraw %}

--- a/source/_components/garadget.markdown
+++ b/source/_components/garadget.markdown
@@ -95,13 +95,13 @@ sensor:
     sensors:
       garage_door_status:
         friendly_name: 'State of the door'
-        value_template: '{{ states.cover.garage_door.state }}'
+        value_template: '{{ states('cover.garage_door') }}'
       garage_door_time_in_state:
         friendly_name: 'Since'
-        value_template: '{{ states.cover.garage_door.attributes.time_in_state }}'
+        value_template: '{{ state_attr('cover.garage_door', 'time_in_state') }}'
       garage_door_wifi_signal_strength:
         friendly_name: 'WiFi strength'
-        value_template: '{{ states.cover.garage_door.attributes.wifi_signal_strength }}'
+        value_template: '{{ state_attr('cover.garage_door', 'wifi_signal_strength') }}'
         unit_of_measurement: 'dB'
 
 group:

--- a/source/_components/hangouts.markdown
+++ b/source/_components/hangouts.markdown
@@ -155,7 +155,7 @@ hangouts:
 intent_script:
   Ping:
     speech:
-      text: I know {{ states.hangouts.conversations.state }} conversations
+      text: I know {{ states('hangouts.conversations') }} conversations
 ```
 
 {% endraw %}

--- a/source/_components/harmony.markdown
+++ b/source/_components/harmony.markdown
@@ -225,10 +225,10 @@ sensor:
   - platform: template
     sensors:
       family_room:
-        value_template: '{{ states.remote.family_room.attributes.current_activity }}'
+        value_template: '{{ state_attr('remote.family_room', 'current_activity') }}'
         friendly_name: 'Family Room'
       bedroom:
-        value_template: '{{ states.remote.bedroom.attributes.current_activity }}'
+        value_template: '{{ state_attr('remote.bedroom', 'current_activity') }}'
         friendly_name: 'bedroom'
 ```
 {% endraw %}

--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -210,7 +210,7 @@ sensor:
 - platform: template
   sensors:
     bedroom_valve:
-      value_template: '{% raw %}{{ states.climate.leq123456.attributes.Valve }}{% endraw %}'
+      value_template: '{% raw %}{{ state_attr('climate.leq123456', 'Valve') }}{% endraw %}'
       entity_id: climate.leq123456
       friendly_name: 'Bedroom valve'
 ```

--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -107,7 +107,7 @@ automation (note that you will need a
 automation:
   trigger:
     platform: template
-    value_template: "{{ states('sensor.time') == (states.input_datetime.bedroom_alarm_clock_time.attributes.timestamp | int | timestamp_custom('%H:%M', False)) }}"
+    value_template: "{{ states('sensor.time') == (state_attr('input_datetime.bedroom_alarm_clock_time', 'timestamp') | int | timestamp_custom('%H:%M', False)) }}"
   action:
     service: light.turn_on
     entity_id: light.bedroom

--- a/source/_components/input_number.markdown
+++ b/source/_components/input_number.markdown
@@ -225,7 +225,7 @@ automation:
      entity_id: switch.something
      to: 'on'
    action:
-     - delay: '00:{{ states.input_number.minutes.state | int }}:{{ states.input_number.seconds.state | int }}'
+     - delay: '00:{{ states('input_number.minutes') | int }}:{{ states('input_number.seconds') | int }}'
      - service: switch.turn_off
        entity_id: switch.something
 ```

--- a/source/_components/iss.markdown
+++ b/source/_components/iss.markdown
@@ -64,7 +64,7 @@ the possibility to show the location of the ISS on OpenStreetMap.
 camera:
   - platform: generic
     name: ISS
-    still_image_url: http://staticmap.openstreetmap.de/staticmap.php?center={{ states.binary_sensor.iss.attributes.lat }},{{ states.binary_sensor.iss.attributes.long }}&zoom=4&size=865x512&maptype=mapnik&markers={{ states.binary_sensor.iss.attributes.lat }},{{ states.binary_sensor.iss.attributes.long }},lightblue
+    still_image_url: http://staticmap.openstreetmap.de/staticmap.php?center={{ state_attr('binary_sensor.iss', 'lat') }},{{ state_attr('binary_sensor.iss', 'long') }}&zoom=4&size=865x512&maptype=mapnik&markers={{ state_attr('binary_sensor.iss', 'lat') }},{{ state_attr('binary_sensor.iss', 'long') }},lightblue
      limit_refetch_to_url_change: true
 ```
 {% endraw %}

--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -92,7 +92,7 @@ Template Light may get an `unknown` state during startup. This results
 in error messages in your log file until that platform has completed loading.
 If you use `is_state()` function in your template, you can avoid this situation.
 For example, you would replace
-{% raw %}`{{ states.switch.source.state == 'on' }}`{% endraw %}
+{% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
 with this equivalent that returns `true`/`false` and never gives an unknown
 result:
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
@@ -118,7 +118,7 @@ light:
         friendly_name: "Receiver Volume"
         value_template: >-
           {% if is_state('media_player.receiver', 'on') %}
-            {% if states.media_player.receiver.attributes.is_volume_muted %}
+            {% if state_attr('media_player.receiver', 'is_volume_muted') %}
               off
             {% else %}
               on
@@ -143,7 +143,7 @@ light:
             volume_level: "{{ (brightness / 255 * 100)|int / 100 }}"
         level_template: >-
           {% if is_state('media_player.receiver', 'on') %}
-            {{ (states.media_player.receiver.attributes.volume_level|float * 255)|int }}
+            {{ (state_attr('media_player.receiver', 'volume_level')|float * 255)|int }}
           {% else %}
             0
           {% endif %}
@@ -163,7 +163,7 @@ light:
         friendly_name: "Receiver Volume"
         value_template: >-
           {% if is_state('media_player.receiver', 'on') %}
-            {% if states.media_player.receiver.attributes.is_volume_muted %}
+            {% if state_attr('media_player.receiver', 'is_volume_muted') %}
               off
             {% else %}
               on
@@ -173,7 +173,7 @@ light:
           {% endif %}
         icon_template: >-
           {% if is_state('media_player.receiver', 'on') %}
-            {% if states.media_player.receiver.attributes.is_volume_muted %}
+            {% if state_attr('media_player.receiver', 'is_volume_muted') %}
               mdi:lightbulb-off
             {% else %}
               mdi:lightbulb-on
@@ -207,7 +207,7 @@ light:
         friendly_name: "Receiver Volume"
         value_template: >-
           {% if is_state('media_player.receiver', 'on') %}
-            {% if states.media_player.receiver.attributes.is_volume_muted %}
+            {% if state_attr('media_player.receiver', 'is_volume_muted') %}
               off
             {% else %}
               on
@@ -217,7 +217,7 @@ light:
           {% endif %}
         icon_template: >-
           {% if is_state('media_player.receiver', 'on') %}
-            {% if states.media_player.receiver.attributes.is_volume_muted %}
+            {% if state_attr('media_player.receiver', 'is_volume_muted') %}
               /local/lightbulb-off.png
             {% else %}
               /local/lightbulb-on.png

--- a/source/_components/lock.template.markdown
+++ b/source/_components/lock.template.markdown
@@ -72,7 +72,7 @@ lock:
 
 ## {% linkable_title Considerations %}
 
-If you are using the state of a platform that takes extra time to load, the Template Lock may get an `unknown` state during startup. This results in error messages in your log file until that platform has completed loading. If you use `is_state()` function in your template, you can avoid this situation. For example, you would replace {% raw %}`{{ states.switch.source.state == 'on' }}`{% endraw %} with this equivalent that returns `true`/`false` and never gives an unknown result: {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
+If you are using the state of a platform that takes extra time to load, the Template Lock may get an `unknown` state during startup. This results in error messages in your log file until that platform has completed loading. If you use `is_state()` function in your template, you can avoid this situation. For example, you would replace {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %} with this equivalent that returns `true`/`false` and never gives an unknown result: {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
 
 ## {% linkable_title Examples %}
 

--- a/source/_components/london_air.markdown
+++ b/source/_components/london_air.markdown
@@ -72,11 +72,11 @@ To explore the data available within the `data` attribute of a sensor use the `d
   sensors:
     updated:
       friendly_name: 'Updated'
-      value_template: {% raw %}'{{states.sensor.merton.attributes.updated}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.merton', 'updated')}}'{% endraw %}
     merton_pm10:
       friendly_name: 'Merton PM10'
-      value_template: {% raw %}'{{states.sensor.merton.attributes.data[0].pollutants[0].summary}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.merton', 'data')[0].pollutants[0].summary}}'{% endraw %}
     westminster_s02:
       friendly_name: 'Westminster S02'
-      value_template: {% raw %}'{{states.sensor.westminster.attributes.data[0].pollutants[3].summary}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.westminster', 'data')[0].pollutants[3].summary}}'{% endraw %}
 ```

--- a/source/_components/min_max.markdown
+++ b/source/_components/min_max.markdown
@@ -23,9 +23,9 @@ This sensor is an alternative to the [template sensor](/components/sensor.templa
 
 {% raw %}
 ```yaml
-{{ ((float(states.sensor.kitchen_temperature.state) +
-     float(states.sensor.living_room_temperature.state) +
-     float(states.sensor.office_temperature.state)) / 3) | round(2)
+{{ ((float(states('sensor.kitchen_temperature')) +
+     float(states('sensor.living_room_temperature')) +
+     float(states('sensor.office_temperature'))) / 3) | round(2)
 }}
 ```
 {% endraw %}

--- a/source/_components/modem_callerid.markdown
+++ b/source/_components/modem_callerid.markdown
@@ -83,7 +83,7 @@ automation:
     action:
       service: notify.notify
       data:
-        message: 'Call from {{ states.sensor.modem_callerid.attributes.cid_name }} at {{ states.sensor.modem_callerid.attributes.cid_number }} '
+        message: 'Call from {{ state_attr('sensor.modem_callerid', 'cid_name') }} at {{ state_attr('sensor.modem_callerid', 'cid_number') }} '
   - alias: Notify CallerID webui
     trigger:
       platform: state
@@ -93,7 +93,7 @@ automation:
       service: persistent_notification.create
       data:
         title: "Call from"
-        message: '{{ states.sensor.modem_callerid.attributes.cid_time.strftime("%I:%M %p") }} {{ states.sensor.modem_callerid.attributes.cid_name }}  {{ states.sensor.modem_callerid.attributes.cid_number }} '
+        message: '{{ state_attr('sensor.modem_callerid', 'cid_time').strftime("%I:%M %p") }} {{ state_attr('sensor.modem_callerid', 'cid_name') }}  {{ state_attr('sensor.modem_callerid', 'cid_number') }} '
   - alias: Say CallerID
     trigger:
       platform: state
@@ -102,6 +102,6 @@ automation:
     action:
       service: tts.google_say
       data_template:
-        message: 'Call from {{ states.sensor.modem_callerid.attributes.cid_name }}'
+        message: 'Call from {{ state_attr('sensor.modem_callerid', 'cid_name') }}'
 ```
 {% endraw %}

--- a/source/_components/mvglive.markdown
+++ b/source/_components/mvglive.markdown
@@ -93,5 +93,5 @@ sensor:
 ```
 
 The first sensor will return S-Bahn departures to Munich Airport or Markt Schwaben that are at least 2 minutes away.
-The second sensor returns U2 and U8 departures from Sendlinger Tor and stores a total of 5 departures in attributes. To retrieve the time until the second departure, you would use states.sensor.ENTITY_NAME.attributes.departures[1].time.
+The second sensor returns U2 and U8 departures from Sendlinger Tor and stores a total of 5 departures in attributes. To retrieve the time until the second departure, you would use state_attr('sensor.ENTITY_NAME', 'departures')[1].time.
 The third sensor returns all south-bound U-Bahn trains from Scheidplatz.

--- a/source/_components/mystrom.markdown
+++ b/source/_components/mystrom.markdown
@@ -218,6 +218,6 @@ sensor:
       power:
         friendly_name: "Current Power"
         unit_of_measurement: "W"
-        value_template: "{{ states.switch.office.attributes.current_power_w }}"
+        value_template: "{{ state_attr('switch.office', 'current_power_w') }}"
 ```
 {% endraw %}

--- a/source/_components/opengarage.markdown
+++ b/source/_components/opengarage.markdown
@@ -105,7 +105,7 @@ sensor:
     garage_car_present:
       friendly_name: 'Honda in Garage'
       value_template: {% raw %}'{% if states.cover.honda %}
-          {% if states.cover.honda.state == "open" %}
+          {% if is_state('cover.honda', 'open') %}
             n/a
           {% elif ((states.cover.honda.attributes["distance_sensor"] > 40) and (states.cover.honda.attributes["distance_sensor"] < 100)) %}
             Yes

--- a/source/_components/pvoutput.markdown
+++ b/source/_components/pvoutput.markdown
@@ -60,19 +60,19 @@ sensor:
   - platform: template
     sensors:
       power_consumption:
-        value_template: {% raw %}'{% if is_state_attr("sensor.pvoutput", "power_consumption", "NaN") %}0{% else %}{{ states.sensor.pvoutput.attributes.power_consumption }}{% endif %}'{% endraw %}
+        value_template: {% raw %}'{% if is_state_attr("sensor.pvoutput", "power_consumption", "NaN") %}0{% else %}{{ state_attr('sensor.pvoutput', 'power_consumption') }}{% endif %}'{% endraw %}
         friendly_name: 'Using'
         unit_of_measurement: 'Watt'
       energy_consumption:
-        value_template: {% raw %}'{{ "%0.1f"|format(states.sensor.pvoutput.attributes.energy_consumption|float/1000) }}'{% endraw %}
+        value_template: {% raw %}'{{ "%0.1f"|format(state_attr('sensor.pvoutput', 'energy_consumption')|float/1000) }}'{% endraw %}
         friendly_name: 'Used'
         unit_of_measurement: 'kWh'
       power_generation:
-        value_template: {% raw %}'{% if is_state_attr("sensor.pvoutput", "power_generation", "NaN") %}0{% else %}{{ states.sensor.pvoutput.attributes.power_generation }}{% endif %}'{% endraw %}
+        value_template: {% raw %}'{% if is_state_attr("sensor.pvoutput", "power_generation", "NaN") %}0{% else %}{{ state_attr('sensor.pvoutput', 'power_generation') }}{% endif %}'{% endraw %}
         friendly_name: 'Generating'
         unit_of_measurement: 'Watt'
       energy_generation:
-        value_template: {% raw %}'{% if is_state_attr("sensor.pvoutput", "energy_generation", "NaN") %}0{% else %}{{ "%0.2f"|format(states.sensor.pvoutput.attributes.energy_generation|float/1000) }}{% endif %}'{% endraw %}
+        value_template: {% raw %}'{% if is_state_attr("sensor.pvoutput", "energy_generation", "NaN") %}0{% else %}{{ "%0.2f"|format(state_attr('sensor.pvoutput', 'energy_generation')|float/1000) }}{% endif %}'{% endraw %}
         friendly_name: 'Generated'
         unit_of_measurement: 'kWh'
 ```

--- a/source/_components/rest.markdown
+++ b/source/_components/rest.markdown
@@ -263,22 +263,22 @@ sensor:
   - platform: template
     sensors:
       owm_weather:
-        value_template: '{{ states.sensor.owm_report.attributes.weather[0]["description"].title() }}'
-        entity_picture_template: '{{ "http://openweathermap.org/img/w/"+states.sensor.owm_report.attributes.weather[0]["icon"].lower()+".png" }}'
+        value_template: '{{ state_attr('sensor.owm_report', 'weather')[0]["description"].title() }}'
+        entity_picture_template: '{{ "http://openweathermap.org/img/w/"+state_attr('sensor.owm_report', 'weather')[0]["icon"].lower()+".png" }}'
         entity_id: sensor.owm_report
       owm_temp:
         friendly_name: 'Outside temp'
-        value_template: '{{ states.sensor.owm_report.attributes.main["temp"]-273.15 }}'
+        value_template: '{{ state_attr('sensor.owm_report', 'main')["temp"]-273.15 }}'
         unit_of_measurement: "°C"
         entity_id: sensor.owm_report
       owm_pressure:
         friendly_name: 'Outside pressure'
-        value_template: '{{ states.sensor.owm_report.attributes.main["pressure"] }}'
+        value_template: '{{ state_attr('sensor.owm_report', 'main')["pressure"] }}'
         unit_of_measurement: "hP"
         entity_id: sensor.owm_report
       owm_humidity:
         friendly_name: 'Outside humidity'
-        value_template: '{{ states.sensor.owm_report.attributes.main["humidity"] }}'
+        value_template: '{{ state_attr('sensor.owm_report', 'main')["humidity"] }}'
         unit_of_measurement: "%"
         entity_id: sensor.owm_report
 ```

--- a/source/_components/ring.markdown
+++ b/source/_components/ring.markdown
@@ -122,9 +122,9 @@ Then you can use the following `action` in your automation (this will save the v
 action:
   - service: downloader.download_file
     data_template:
-      url: "{{ states.camera.front_door.attributes.video_url }}"
-      subdir: "{{states.camera.front_door.attributes.friendly_name}}"
-      filename: "{{states.camera.front_door.attributes.friendly_name}}"
+      url: "{{ state_attr('camera.front_door', 'video_url') }}"
+      subdir: "{{state_attr('camera.front_door', 'friendly_name')}}"
+      filename: "{{state_attr('camera.front_door', 'friendly_name')}}"
 ```
 
 If you want to use `python_script`, enable it your `configuration.yaml` file first:

--- a/source/_components/ring.markdown
+++ b/source/_components/ring.markdown
@@ -118,6 +118,7 @@ downloader:
 
 Then you can use the following `action` in your automation (this will save the video file under `<config>/downloads/ring_<camera_name>/`):
 
+{% raw %}
 ```yaml
 action:
   - service: downloader.download_file
@@ -126,6 +127,7 @@ action:
       subdir: "{{state_attr('camera.front_door', 'friendly_name')}}"
       filename: "{{state_attr('camera.front_door', 'friendly_name')}}"
 ```
+{% endraw %}
 
 If you want to use `python_script`, enable it your `configuration.yaml` file first:
 

--- a/source/_components/rmvtransport.markdown
+++ b/source/_components/rmvtransport.markdown
@@ -118,6 +118,6 @@ sensor:
 
 The first sensor will return S-Bahn, bus, RB and RE trains departures from Frankfurt Hauptbahnhof to Frankfurt Airport or Stadium that are at least 5 minutes away.
 
-The second sensor returns bus departures from Wiesbaden Hauptbahnhof going to Dernsches Gelände and Mainz Hauptbahnhof. To retrieve the time of the second departure, you would use `states.sensor.ENTITY_NAME.attributes.departures[1].time`.
+The second sensor returns bus departures from Wiesbaden Hauptbahnhof going to Dernsches Gelände and Mainz Hauptbahnhof. To retrieve the time of the second departure, you would use `state_attr('sensor.ENTITY_NAME', 'departures')[1].time`.
 
 The third sensor returns all S-Bahn trains from Mainz Hauptbahnhof for line S8.

--- a/source/_components/rova.markdown
+++ b/source/_components/rova.markdown
@@ -98,9 +98,9 @@ automation:
         at: '19:00:00'
     condition:
       - condition: template
-        value_template: "{% if (as_timestamp(states.sensor.rova_garbage_gft.state) - as_timestamp(now())) < 43200 %}true{% endif %}"
+        value_template: "{% if (as_timestamp(states('sensor.rova_garbage_gft')) - as_timestamp(now())) < 43200 %}true{% endif %}"
       - condition: template
-        value_template: "{% if (as_timestamp(states.sensor.rova_garbage_gft.state) - as_timestamp(now())) > 0 %}true{% endif %}"
+        value_template: "{% if (as_timestamp(states('sensor.rova_garbage_gft')) - as_timestamp(now())) > 0 %}true{% endif %}"
     action:
       - service: NOTIFICATION_SERVICE
         data:

--- a/source/_components/rss_feed_template.markdown
+++ b/source/_components/rss_feed_template.markdown
@@ -28,7 +28,7 @@ rss_feed_template:
     title: "Garden {% raw %}{{ as_timestamp(now())|timestamp_custom('%H:%M', True) }}{% endraw %}"
     items:
     - title: "Outside temperature"
-      description: "{% raw %}{% if is_state('sensor.temp_outside','unknown') %}---{% else %}{{states.sensor.temp_outside.state}} °C{% endif %}{% endraw %}"
+      description: "{% raw %}{% if is_state('sensor.temp_outside','unknown') %}---{% else %}{{states('sensor.temp_outside')}} °C{% endif %}{% endraw %}"
 ```
 
 {% configuration %}

--- a/source/_components/script.markdown
+++ b/source/_components/script.markdown
@@ -26,7 +26,7 @@ script:
       # This is Home Assistant Script Syntax
       - service: notify.notify
         data_template:
-          message: Current temperature is {% raw %}{{ states.sensor.temperature.state }}{% endraw %}
+          message: Current temperature is {% raw %}{{ states('sensor.temperature') }}{% endraw %}
 ```
 <p class='note'>
 Script names (e.g., `message_temperature` in the example above) are not allowed to contain capital letters, or dash (minus) characters, i.e. `-`. The preferred way to separate words for better readability is to use underscore (`_`) characters. 

--- a/source/_components/sensehat.markdown
+++ b/source/_components/sensehat.markdown
@@ -96,13 +96,13 @@ sensor:
   - platform: template
     sensors:
       sensehat_temperature:
-        value_template: '{{ states.sensor.temperature.state | round(1) }}'
+        value_template: '{{ states('sensor.temperature') | round(1) }}'
         unit_of_measurement: '°C'
       sensehat_pressure:
-        value_template: '{{ states.sensor.pressure.state | round(1) }}'
+        value_template: '{{ states('sensor.pressure') | round(1) }}'
         unit_of_measurement: 'mb'
       sensehat_humidity:
-        value_template: '{{ states.sensor.humidity.state | round(1) }}'
+        value_template: '{{ states('sensor.humidity') | round(1) }}'
         unit_of_measurement: '%'
 ```
 

--- a/source/_components/sensor.command_line.markdown
+++ b/source/_components/sensor.command_line.markdown
@@ -185,7 +185,7 @@ sensor:
 sensor:
   - platform: command_line
     name: wind direction
-    command: 'sh /home/pi/.homeassistant/scripts/wind_direction.sh {{ states.sensor.wind_direction.state }}'
+    command: 'sh /home/pi/.homeassistant/scripts/wind_direction.sh {{ states('sensor.wind_direction') }}'
     unit_of_measurement: "Direction"
 ```
 {% endraw %}

--- a/source/_components/seven_segments.markdown
+++ b/source/_components/seven_segments.markdown
@@ -146,7 +146,7 @@ sensor:
   - platform: template
     sensors:
       power_meter:
-        value_template: '{{ states.image_processing.sevensegment_ocr_seven_segments.state }}'
+        value_template: '{{ states('image_processing.sevensegment_ocr_seven_segments') }}'
         friendly_name: 'Ampere'
         unit_of_measurement: 'A'
 ```

--- a/source/_components/shell_command.markdown
+++ b/source/_components/shell_command.markdown
@@ -61,6 +61,6 @@ input_number:
 
 {% raw %}
 shell_command:
-  set_ac_to_slider: 'irsend SEND_ONCE DELONGHI AC_{{ states.input_number.ac_temperature.state }}_AUTO'
+  set_ac_to_slider: 'irsend SEND_ONCE DELONGHI AC_{{ states('input_number.ac_temperature') }}_AUTO'
 {% endraw %}
 ```

--- a/source/_components/solaredge.markdown
+++ b/source/_components/solaredge.markdown
@@ -131,6 +131,6 @@ sensors:
   platform: template
   sensors:
     solaredge_energy_this_year_template:
-      value_template: '{{(states.sensor.solaredge_energy_this_year.state | float / 1000) | round(2)}}'
+      value_template: '{{(states('sensor.solaredge_energy_this_year') | float / 1000) | round(2)}}'
 ```
 {% endraw %}

--- a/source/_components/solaredge_local.markdown
+++ b/source/_components/solaredge_local.markdown
@@ -69,6 +69,6 @@ sensors:
   platform: template
   sensors:
     solaredge_energy_this_year_template:
-      value_template: '{{(states.sensor.solaredge_energy_this_year.state | float / 1000) | round(2)}}'
+      value_template: '{{(states('sensor.solaredge_energy_this_year') | float / 1000) | round(2)}}'
 ```
 {% endraw %}

--- a/source/_components/switch.rest.markdown
+++ b/source/_components/switch.rest.markdown
@@ -108,4 +108,4 @@ switch:
 ```
 {% endraw %}
 
-`body_on` and `body_off` can also depend on the state of the system. For example, to enable a remote temperature sensor tracking on a radio thermostat, one has to send the current value of the remote temperature sensor. This can be achieved by using the template `{% raw %}'{"rem_temp":{{states.sensor.bedroom_temp.state}}}'{% endraw %}`.
+`body_on` and `body_off` can also depend on the state of the system. For example, to enable a remote temperature sensor tracking on a radio thermostat, one has to send the current value of the remote temperature sensor. This can be achieved by using the template `{% raw %}'{"rem_temp":{{states('sensor.bedroom_temp')}}}'{% endraw %}`.

--- a/source/_components/switch.template.markdown
+++ b/source/_components/switch.template.markdown
@@ -82,7 +82,7 @@ switch:
 
 ## {% linkable_title Considerations %}
 
-If you are using the state of a platform that takes extra time to load, the Template Switch may get an `unknown` state during startup. This results in error messages in your log file until that platform has completed loading. If you use `is_state()` function in your template, you can avoid this situation. For example, you would replace {% raw %}`{{ states.switch.source.state == 'on' }}`{% endraw %} with this equivalent that returns `true`/`false` and never gives an unknown result: {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
+If you are using the state of a platform that takes extra time to load, the Template Switch may get an `unknown` state during startup. This results in error messages in your log file until that platform has completed loading. If you use `is_state()` function in your template, you can avoid this situation. For example, you would replace {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %} with this equivalent that returns `true`/`false` and never gives an unknown result: {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
 
 ## {% linkable_title Examples %}
 

--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -85,7 +85,7 @@ sensor:
 
 ### {% linkable_title Startup %}
 
-If you are using the state of a platform that takes extra time to load, the Template Sensor may get an `unknown` state during startup. To avoid this (and the resulting error messages in your log file), you can use `is_state()` function in your template. For example, you would replace {% raw %}`{{ states.switch.source.state == 'on' }}`{% endraw %} with this equivalent that returns `true`/`false` and never gives an `unknown` result:
+If you are using the state of a platform that takes extra time to load, the Template Sensor may get an `unknown` state during startup. To avoid this (and the resulting error messages in your log file), you can use `is_state()` function in your template. For example, you would replace {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %} with this equivalent that returns `true`/`false` and never gives an `unknown` result:
 
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
 

--- a/source/_components/threshold.markdown
+++ b/source/_components/threshold.markdown
@@ -25,7 +25,7 @@ It's an alternative to the template binary sensor's `value_template:` to get the
 
 {% raw %}
 ```yaml
-{{ states.sensor.furnace.state > 2.5 }}
+{{ states('sensor.furnace') > 2.5 }}
 ```
 {% endraw %}
 

--- a/source/_components/tibber.markdown
+++ b/source/_components/tibber.markdown
@@ -90,13 +90,13 @@ The electricity price can be used to make automations. The sensor has a `max_pri
     minutes: 1
   condition:
     condition: template
-    value_template: '{{ float(states.sensor.electricity_price_hamretunet_10.state) > 0.9 * float(states.sensor.electricity_price_hamretunet_10.attributes.max_price) }}'
+    value_template: '{{ float(states('sensor.electricity_price_hamretunet_10')) > 0.9 * float(state_attr('sensor.electricity_price_hamretunet_10', 'max_price')) }}'
   action:
    - service: notify.pushbullet
      data:
        title: "Electricity price"
        target: "device/daniel_telefon_cat"
-       message: "The electricity price is now {{ states.sensor.electricity_price_hamretunet_10.state }}"
+       message: "The electricity price is now {{ states('sensor.electricity_price_hamretunet_10') }}"
 ```
 
 {% endraw %}

--- a/source/_components/transport_nsw.markdown
+++ b/source/_components/transport_nsw.markdown
@@ -100,7 +100,7 @@ The sensor returns n/a if no stop event is found within the next 24h. A `templat
         {% if is_state_attr('sensor.bus', 'due', 'n/a') %}
           No schedule found
         {% else %}
-          {{ states.sensor.bus.attributes.route }} in {{ states.sensor.bus.attributes.due }}m ({{ states.sensor.bus.attributes.delay }})
+          {{ state_attr('sensor.bus', 'route') }} in {{ state_attr('sensor.bus', 'due') }}m ({{ state_attr('sensor.bus', 'delay') }})
         {% endif %}
 ```
 {% endraw %}

--- a/source/_components/uk_transport.markdown
+++ b/source/_components/uk_transport.markdown
@@ -90,19 +90,19 @@ Attributes can be accessed using the [template sensor](/components/sensor.templa
   sensors:
     next_train_status:
       friendly_name: 'Next train status'
-      value_template: {% raw %}'{{states.sensor.next_train_to_wat.attributes.next_trains[0].status}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.next_train_to_wat', 'next_trains')[0].status}}'{% endraw %}
     next_trains_origin:
       friendly_name: 'Next train origin'
-      value_template: {% raw %}'{{states.sensor.next_train_to_wat.attributes.next_trains[0].origin_name}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.next_train_to_wat', 'next_trains')[0].origin_name}}'{% endraw %}
     next_trains_estimated:
       friendly_name: 'Next train estimated'
-      value_template: {% raw %}'{{states.sensor.next_train_to_wat.attributes.next_trains[0].estimated}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.next_train_to_wat', 'next_trains')[0].estimated}}'{% endraw %}
     next_trains_scheduled:
       friendly_name: 'Next train scheduled'
-      value_template: {% raw %}'{{states.sensor.next_train_to_wat.attributes.next_trains[0].scheduled}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.next_train_to_wat', 'next_trains')[0].scheduled}}'{% endraw %}
     next_trains_platform:
       friendly_name: 'Next train platform'
-      value_template: {% raw %}'{{states.sensor.next_train_to_wat.attributes.next_trains[0].platform}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.next_train_to_wat', 'next_trains')[0].platform}}'{% endraw %}
 ```
 
 Bus sensors require as their `origin` a bus stop ATCO code which can be found by browsing OpenStreetMap data as
@@ -138,16 +138,16 @@ And the template sensor for viewing the next bus attributes.
   sensors:
     next_bus_route:
       friendly_name: 'Next bus route'
-      value_template: {% raw %}'{{states.sensor.next_bus_to_wantage.attributes.next_buses[0].route}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.next_bus_to_wantage', 'next_buses')[0].route}}'{% endraw %}
     next_bus_direction:
       friendly_name: 'Next bus direction'
-      value_template: {% raw %}'{{states.sensor.next_bus_to_wantage.attributes.next_buses[0].direction}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.next_bus_to_wantage', 'next_buses')[0].direction}}'{% endraw %}
     next_bus_scheduled:
       friendly_name: 'Next bus scheduled'
-      value_template: {% raw %}'{{states.sensor.next_bus_to_wantage.attributes.next_buses[0].scheduled}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.next_bus_to_wantage', 'next_buses')[0].scheduled}}'{% endraw %}
     next_bus_estimated:
       friendly_name: 'Next bus estimated'
-      value_template: {% raw %}'{{states.sensor.next_bus_to_wantage.attributes.next_buses[0].estimated}}'{% endraw %}
+      value_template: {% raw %}'{{state_attr('sensor.next_bus_to_wantage', 'next_buses')[0].estimated}}'{% endraw %}
 ```
 
 ## {% linkable_title Managing API requests %}

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -130,7 +130,7 @@ automation:
     - service: vacuum.xiaomi_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
-        repeats: '{{states.input_number.vacuum_passes.state|int}}'
+        repeats: '{{states('input_number.vacuum_passes')|int}}'
         zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]
 ```
 Array with inline zone:
@@ -145,7 +145,7 @@ automation:
     - service: vacuum.xiaomi_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
-        repeats: '{{states.input_number.vacuum_passes.state|int}}'
+        repeats: '{{states('input_number.vacuum_passes')|int}}'
         zone:
         - [30914,26007,35514,28807]
         - [20232,22496,26032,26496]

--- a/source/_components/vacuum.xiaomi_miio.markdown
+++ b/source/_components/vacuum.xiaomi_miio.markdown
@@ -119,6 +119,7 @@ Start the cleaning operation in the areas selected for the number of repeats ind
 Example of `vacuum.xiaomi_clean_zone` use:
 
 Inline array:
+{% raw %}
 ```yaml
 automation:
   - alias: Test vacuum zone3
@@ -133,7 +134,10 @@ automation:
         repeats: '{{states('input_number.vacuum_passes')|int}}'
         zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]
 ```
+{% endraw %}
+
 Array with inline zone:
+{% raw %}
 ```yaml
 automation:
   - alias: Test vacuum zone3
@@ -150,6 +154,8 @@ automation:
         - [30914,26007,35514,28807]
         - [20232,22496,26032,26496]
 ```
+{% endraw %}
+
 Array mode:
 ```yaml
 automation:

--- a/source/_components/webostv.markdown
+++ b/source/_components/webostv.markdown
@@ -213,7 +213,7 @@ automation:
     action:
       service: notify.livingroom_tv
       data:
-        message: "You should open a window! (Livingroom Co2: {{ states.sensor.netatmo_livingroom_co2.state }}ppm)"
+        message: "You should open a window! (Livingroom Co2: {{ states('sensor.netatmo_livingroom_co2') }}ppm)"
 ```
 
 The icon can be overridden for individual notifications by providing a path to an alternative icon image to use:

--- a/source/_components/webostv.markdown
+++ b/source/_components/webostv.markdown
@@ -202,6 +202,7 @@ icon:
 
 A possible automation could be:
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 automation:
@@ -215,6 +216,7 @@ automation:
       data:
         message: "You should open a window! (Livingroom Co2: {{ states('sensor.netatmo_livingroom_co2') }}ppm)"
 ```
+{% endraw %}
 
 The icon can be overridden for individual notifications by providing a path to an alternative icon image to use:
 

--- a/source/_cookbook/automation_first_light.markdown
+++ b/source/_cookbook/automation_first_light.markdown
@@ -73,16 +73,16 @@ automation:
           - condition: numeric_state
             entity_id: light.livingroom_ec
             # if light is off, force a 0, otherwise use the brightness value
-            value_template: {% raw %}'{% if states.light.livingroom_ec.state == "on"  %}{{ states.light.livingroom_ec.attributes.brightness }}{% else %}0{% endif %}'{% endraw %}
+            value_template: {% raw %}'{% if is_state('light.livingroom_ec', 'on')  %}{{ state_attr('light.livingroom_ec', 'brightness') }}{% else %}0{% endif %}'{% endraw %}
             # brightness below 50% (255 = 100%)
             below: 128
           - condition: numeric_state
             entity_id: light.kitchen_bar
-            value_template: {% raw %}'{% if states.light.kitchen_bar.state == "on"  %}{{ states.light.kitchen_bar.attributes.brightness }}{% else %}0{% endif %}'{% endraw %}
+            value_template: {% raw %}'{% if is_state('light.kitchen_bar', 'on')  %}{{ state_attr('light.kitchen_bar', 'brightness') }}{% else %}0{% endif %}'{% endraw %}
             below: 128
           - condition: numeric_state
             entity_id: light.kitchen_ceiling
-            value_template: {% raw %}'{% if states.light.kitchen_ceiling.state == "on"  %}{{ states.light.kitchen_ceiling.attributes.brightness }}{% else %}0{% endif %}'{% endraw %}
+            value_template: {% raw %}'{% if is_state('light.kitchen_ceiling', 'on')  %}{{ state_attr('light.kitchen_ceiling', 'brightness') }}{% else %}0{% endif %}'{% endraw %}
             below: 128
 
       # Trigger a scene

--- a/source/_cookbook/dim_and_brighten_lights.markdown
+++ b/source/_cookbook/dim_and_brighten_lights.markdown
@@ -115,7 +115,7 @@ script:
           data_template:
             entity_id: light.YOUR_LIGHT
             brightness: >-
-              {% raw %}{% set current = states.light.YOUR_LIGHT.attributes.brightness|default(0)|int %}
+              {% raw %}{% set current = state_attr('light.YOUR_LIGHT', 'brightness')|default(0)|int %}
               {% set step = states('input_number.light_step')|int %}
               {% set next = current + step %}
               {% if next > states('input_number.light_maximum')|int %}
@@ -124,7 +124,7 @@ script:
               {{ next }}{% endraw %}
 
         - service_template: >
-            {% raw %}{% if states.light.YOUR_LIGHT.attributes.brightness|default(0)|int < states('input_number.light_maximum')|int %}
+            {% raw %}{% if state_attr('light.YOUR_LIGHT', 'brightness')|default(0)|int < states('input_number.light_maximum')|int %}
               script.turn_on
             {% else %}
               script.turn_off
@@ -146,7 +146,7 @@ script:
           data_template:
             entity_id: light.YOUR_LIGHT
             brightness: >-
-              {% raw %}{% set current = states.light.YOUR_LIGHT.attributes.brightness|default(0)|int %}
+              {% raw %}{% set current = state_attr('light.YOUR_LIGHT', 'brightness')|default(0)|int %}
               {% set step = states('input_number.light_step')|int %}
               {% set next = current - step %}
               {% if next < states('input_number.light_minimum')|int %}
@@ -155,7 +155,7 @@ script:
               {{ next }}{% endraw %}
 
         - service_template: >
-            {% raw %}{% if states.light.YOUR_LIGHT.attributes.brightness|default(0)|int > states('input_number.light_minimum')|int %}
+            {% raw %}{% if state_attr('light.YOUR_LIGHT', 'brightness')|default(0)|int > states('input_number.light_minimum')|int %}
               script.turn_on
             {% else %}
               script.turn_off

--- a/source/_cookbook/google_maps_card.markdown
+++ b/source/_cookbook/google_maps_card.markdown
@@ -22,7 +22,7 @@ It also leverages the `limit_refetch_to_url_change` option to ensure that we do 
 camera:
   name: Paulus
   platform: generic
-  still_image_url: {% raw %}https://maps.googleapis.com/maps/api/staticmap?center={{ states.device_tracker.demo_paulus.attributes.latitude }},{{ states.device_tracker.demo_paulus.attributes.longitude }}&zoom=13&size=500x500&maptype=roadmap&markers=color:blue%7Clabel:P%7C{{ states.device_tracker.demo_paulus.attributes.latitude }},{{ states.device_tracker.demo_paulus.attributes.longitude }}{% endraw %}&key=YOUR_API_KEY
+  still_image_url: {% raw %}https://maps.googleapis.com/maps/api/staticmap?center={{ state_attr('device_tracker.demo_paulus', 'latitude') }},{{ state_attr('device_tracker.demo_paulus', 'longitude') }}&zoom=13&size=500x500&maptype=roadmap&markers=color:blue%7Clabel:P%7C{{ state_attr('device_tracker.demo_paulus', 'latitude') }},{{ state_attr('device_tracker.demo_paulus', 'longitude') }}{% endraw %}&key=YOUR_API_KEY
   limit_refetch_to_url_change: true
 ```
 

--- a/source/_cookbook/notify_if__new_ha_release.markdown
+++ b/source/_cookbook/notify_if__new_ha_release.markdown
@@ -49,6 +49,6 @@ automation:
     data_template: 
       title: 'New Home Assistant Release'
       target: 'YOUR_TARGET_HERE' #See Pushbullet integration for usage
-      message: "Home Assistant {% raw %} {{ states.updater.updater.state }} {% endraw %} is now available."
+      message: "Home Assistant {% raw %} {{ states('updater.updater') }} {% endraw %} is now available."
 ```
 

--- a/source/_cookbook/notify_if_over_threshold.markdown
+++ b/source/_cookbook/notify_if_over_threshold.markdown
@@ -29,7 +29,7 @@ automation:
       service: notify.mypushbullet
       data_template:
         title: "Furnace fan is running"
-        message: "Fan running because current is {% raw %}{{ states.sensor.furnace.state }}{% endraw %} amps"
+        message: "Fan running because current is {% raw %}{{ states('sensor.furnace') }}{% endraw %} amps"
 ```
 
 If you also want a notification when it drops back down below that limit, you could add this as well:
@@ -44,5 +44,5 @@ If you also want a notification when it drops back down below that limit, you co
       service: notify.mypushbullet
       data_template:
         title: "Furnace fan is stopped"
-        message: "Fan stopped because current is {% raw %}{{ states.sensor.furnace.state }}{% endraw %} amps"
+        message: "Fan stopped because current is {% raw %}{{ states('sensor.furnace') }}{% endraw %} amps"
 ```

--- a/source/_cookbook/track_battery_level.markdown
+++ b/source/_cookbook/track_battery_level.markdown
@@ -23,10 +23,10 @@ sensor:
         friendly_name: iPhone Battery
         unit_of_measurement: '%'
         value_template: >-
-            {%- if states.device_tracker.iphone.attributes.battery %}
-                {{ states.device_tracker.iphone.attributes.battery|round }}
+            {%- if state_attr('device_tracker.iphone', 'battery') %}
+                {{ state_attr('device_tracker.iphone', 'battery')|round }}
             {% else %}
-                {{ states.sensor.battery_iphone.state }}
+                {{ states('sensor.battery_iphone') }}
             {%- endif %}
         device_class: battery
 ```

--- a/source/_docs/automation/action.markdown
+++ b/source/_docs/automation/action.markdown
@@ -61,9 +61,9 @@ automation:
     - condition: or
       conditions:
         - condition: template
-          value_template: '{% raw %}{{ states.sun.sun.attributes.elevation < 4 }}{% endraw %}'
+          value_template: '{% raw %}{{ state_attr('sun.sun', 'elevation') < 4 }}{% endraw %}'
         - condition: template
-          value_template: '{% raw %}{{ states.sensor.sensorluz_7_0.state < 10 }}{% endraw %}'
+          value_template: '{% raw %}{{ states('sensor.sensorluz_7_0') < 10 }}{% endraw %}'
     - service: scene.turn_on
       entity_id: scene.DespiertaDespacho
 ```

--- a/source/_docs/automation/condition.markdown
+++ b/source/_docs/automation/condition.markdown
@@ -27,9 +27,9 @@ automation:
     condition: or
     conditions:
       - condition: template
-        value_template: '{% raw %}{{ states.sun.sun.attributes.elevation < 4 }}{% endraw %}'
+        value_template: '{% raw %}{{ state_attr('sun.sun', 'elevation') < 4 }}{% endraw %}'
       - condition: template
-        value_template: '{% raw %}{{ states.sensor.sensorluz_7_0.state < 10 }}{% endraw %}'
+        value_template: '{% raw %}{{ states('sensor.sensorluz_7_0') < 10 }}{% endraw %}'
   action:
     - service: scene.turn_on
       entity_id: scene.DespiertaDespacho

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -80,7 +80,7 @@ The next two statements result in the same value if the state exists. The second
 {% raw %}
 ```text
 {{ states('device_tracker.paulus') }}
-{{ states.device_tracker.paulus.state }}
+{{ states('device_tracker.paulus') }}
 ```
 {% endraw %}
 

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -136,7 +136,7 @@ You can also get the script to abort after the timeout by using `continue_on_tim
 {% raw %}
 ```yaml
 # Wait until a valve is < 10 or abort after 1 minute.
-- wait_template: "{{ states.climate.kitchen.attributes.valve|int < 10 }}"
+- wait_template: "{{ state_attr('climate.kitchen', 'valve')|int < 10 }}"
   timeout: '00:01:00'
   continue_on_timeout: 'false'
 ```

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -150,15 +150,15 @@ condition:
     condition: and  # 'twilight' condition: dusk and dawn, in typical locations
     conditions:
       - condition: template
-        value_template: {% raw %}'{{ states.sun.sun.attributes.elevation < 0 }}'{% endraw %}
+        value_template: {% raw %}'{{ state_attr('sun.sun', 'elevation') < 0 }}'{% endraw %}
       - condition: template
-        value_template: {% raw %}'{{ states.sun.sun.attributes.elevation > -6 }}'{% endraw %}
+        value_template: {% raw %}'{{ state_attr('sun.sun', 'elevation') > -6 }}'{% endraw %}
 ```
 
 ```yaml
 condition:
     condition: template  # 'night' condition: from dusk to dawn, in typical locations
-    value_template: {% raw %}'{{ states.sun.sun.attributes.elevation < -6 }}'{% endraw %}
+    value_template: {% raw %}'{{ state_attr('sun.sun', 'elevation') < -6 }}'{% endraw %}
 ```
 
 #### {% linkable_title Sunset/sunrise condition %}

--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -49,7 +49,7 @@ You can use [templating] support to dynamically choose which service to call. Fo
 
 ```yaml
 service_template: >
-  {% raw %}{% if states.sensor.temperature.state | float > 15 %}
+  {% raw %}{% if states('sensor.temperature') | float > 15 %}
     switch.turn_on
   {% else %}
     switch.turn_off


### PR DESCRIPTION
**Description:**

We should encourage the use of the `states()`, `is_state()`, `state_attr` and `is_state_attr()`.

This PR updates all the documentation to match that.

Closes #9711

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9736"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/09334e67f5b16bbe5a51e2a6dd431844c5aed692.svg" /></a>

