### PR TITLE
Adjust stalebot to ignore 'Help wanted'

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,7 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - has-parent
+  - Help wanted
 # Label to use when marking an issue as stale
 staleLabel: Stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
**Description:**

Closes #9710

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9738"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/6b6d26eeaf907673e020c4a735b1d856416dee36.svg" /></a>

