### PR TITLE
Adjust Gitpod to run Jekyll generate in pre-build

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,5 @@
 tasks:
-  - init: gem install bundler -v 2.0.1
-  - init: bundle install
-  - init: bundle exec rake generate
+  - init: gem install bundler -v 2.0.1 && bundle install && bundle exec rake generate
 ports:
   - port: 4000
     onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,7 @@
 tasks:
   - init: gem install bundler -v 2.0.1
   - init: bundle install
+  - init: bundle exec rake generate
 ports:
   - port: 4000
     onOpen: open-browser


### PR DESCRIPTION
**Description:**

Adjustment for the Gitpod file.
Gitpod does pre-build PR's now but doesn't run the Jekyll generate as part of the pre-build.
This PR addresses that, giving you an instant environment to work in / preview with.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9739"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/491a37e27ad1bf84a8f40907776fc1be08ae406b.svg" /></a>

