### PR TITLE
Removes self referencing git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "_deploy"]
-	path = _deploy
-	url = https://github.com/home-assistant/home-assistant.github.io.git


### PR DESCRIPTION
**Description:**

This is a leftover from the time we where deploying to GitHub pages.
🔥 All the git submodules!

Part of issue #9718

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9743"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/e2eeeb501fc1b91b920e53bd695463cfa34c4025.svg" /></a>

