### PR TITLE
Small site adjustments (look and feel)

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -8,6 +8,21 @@ $primary-color: #049cdb;
   .site-title {
     font-weight: normal;
   }
+
+  a {
+    color: $white;
+    text-decoration: none;
+    &:visited {
+      color: darken($white, 10%);
+    }
+    .menu & {
+      color: $white;
+    }
+  }
+}
+
+footer {
+  background-color: $white;
 }
 
 .search-container {
@@ -16,7 +31,7 @@ $primary-color: #049cdb;
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: white;
+  background-color: $header-background;
   padding-top: 19px;
   padding-right: 15%;
 
@@ -31,10 +46,16 @@ $primary-color: #049cdb;
       margin: 0 10px;
     }
 
+    i {
+      color: $white;
+    }
+
     input {
       border: 0;
       width: 100%;
       outline: none;
+      background-color: $header-background;
+      color: $white;
     }
   }
 }
@@ -50,6 +71,7 @@ $primary-color: #049cdb;
 .hero {
   background-color: #038FC7;
   padding-bottom: 0;
+  padding-top: 20px;
 
   .lead {
     margin-bottom: 16px;

--- a/sass/oscailte/_variables.scss
+++ b/sass/oscailte/_variables.scss
@@ -19,7 +19,7 @@ $white:             #fff !default;
 
 // Accent colors
 // -------------------------
-$blue:              #049cdb !default;
+$blue:              #038fc7 !default;
 $blueDark:          #0064cd !default;
 $green:             #46a546 !default;
 $red:               #9d261d !default;
@@ -53,9 +53,9 @@ $footer-height: 100px;
 $primary-color:     $blue;
 $secondary-color:   $green;
 // -------------------------
-$site-background:   #F5F5F5;
-$header-background: $white;
-$footer-background: $header-background;
+$site-background:   $white;
+$header-background: $blue;
+$footer-background: #F5F5F5;
 $text-color:        $grayDarker;
 $title-color:       $primary-color;
 $link-color:        $primary-color;


### PR DESCRIPTION
**Description:**

- Made background less dirty (white instead of smug)
- Made header more distinctive
- Header now looks like one with hero unit on the frontpage
- Hero unit is closer to the header

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9745"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/2c9e12fa96351abf64eb97e6e1ea98b32475da14.svg" /></a>

