### PR TITLE
Add deprecation warning to MQTT page for embedded broker

### DIFF
--- a/source/_components/mqtt.markdown
+++ b/source/_components/mqtt.markdown
@@ -31,6 +31,10 @@ mqtt:
 
 You can also use the [embedded MQTT broker](/docs/mqtt/broker#embedded-broker). A separate broker is advised for more stability.
 
+<p class='note warning'>
+As of release 0.92, the embedded broker has been marked as deprecated. This means bugs may not be fixed, and the functionality may be removed in a future release.
+</p>
+
 ```yaml
 # Example configuration.yaml entry
 mqtt:

--- a/source/_components/mqtt.markdown
+++ b/source/_components/mqtt.markdown
@@ -32,7 +32,7 @@ mqtt:
 You can also use the [embedded MQTT broker](/docs/mqtt/broker#embedded-broker). A separate broker is advised for more stability.
 
 <p class='note warning'>
-As of release 0.92, the embedded broker has been marked as deprecated. This means bugs may not be fixed, and the functionality may be removed in a future release.
+As of release 0.92, the embedded broker has been marked as deprecated. This means bugs may not be fixed, and the broker functionality will be removed in a future release.
 </p>
 
 ```yaml


### PR DESCRIPTION
**Description:**
As of release 0.92 the embedded MQTT broker has been marked deprecated.
On the MQTT components page this isn't clear. This is the first page you'll find when navigating the components page search for MQTT.

Added the deprecated warning to this page for the embedded broker.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9750"><img src="https://gitpod.io/api/apps/github/pbs/github.com/mlakerveld/home-assistant.io.git/0a0e47a2cfccb04b5df6a146d7894a132e7e9ba8.svg" /></a>

