### PR TITLE
Add missing trigger.for variable to template trigger

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -145,6 +145,7 @@ The following tables show the available trigger data per platform.
 | `trigger.entity_id` | Entity ID that caused change.
 | `trigger.from_state` | Previous [state object] of entity that caused change.
 | `trigger.to_state` | New [state object] of entity that caused template to change.
+| `trigger.for` | Timedelta object how long state has been to state, if any.
 
 ### {% linkable_title time %}
 


### PR DESCRIPTION
**Description:**
When support was added to the template trigger to allow the use of a `for:` option  I overlooked the fact that the `trigger` variable should include the value of the `for:` option, as is the case with the state trigger. This adds it.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24893

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9752"><img src="https://gitpod.io/api/apps/github/pbs/github.com/pnbruckner/home-assistant.io.git/bc42e9a5f86f214c7f8c3c44b54d69c1d0f13555.svg" /></a>

