### PR TITLE
Disable autoplay for Twitch clip

### DIFF
--- a/source/_posts/2019-05-16-release-93.markdown
+++ b/source/_posts/2019-05-16-release-93.markdown
@@ -17,7 +17,7 @@ It's time for our 0.93 release and it is a whopping cool one. It's a day later t
 
 <div class='videoWrapper'>
   <iframe
-      src="https://clips.twitch.tv/embed?clip=DifferentEnjoyableCormorantEagleEye"
+      src="https://clips.twitch.tv/embed?clip=DifferentEnjoyableCormorantEagleEye&autoplay=false"
       width="560" height="315"
       frameborder="0" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
**Description:**

Disables the autoplay feature that apparently is default for twitch clips.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9754"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/fc14553fe9d0e09d3055b88b4bede2804fe4d17c.svg" /></a>

