### PR TITLE
Fixed Hassbian 404 URLs

### DIFF
--- a/source/_docs/installation/hassbian/customization.markdown
+++ b/source/_docs/installation/hassbian/customization.markdown
@@ -16,26 +16,26 @@ The tool is available by running `hassbian-config`.
 ### Install scripts
 To view the available suites run `hassbian-config show` or have a look at the [hassbian-scripts repository][hassbian-repo].  
 These are some of the available suites:  
- - [AppDaemon](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/appdaemon.md)
- - [Duck DNS](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/duckdns.md) _This can also be configured to generate Let's Encrypt SSL certificates_
- - [Homebridge](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/homebridge.md)
- - [Mosquitto](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/mosquitto.md)
- - [Samba](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/samba.md)
- - [Webterminal](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/webterminal.md)
+ - [AppDaemon](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/appdaemon.md)
+ - [Duck DNS](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/duckdns.md) _This can also be configured to generate Let's Encrypt SSL certificates_
+ - [Homebridge](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/homebridge.md)
+ - [Mosquitto](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/mosquitto.md)
+ - [Samba](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/samba.md)
+ - [Webterminal](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/docs/webterminal.md)
  - Various database engines.
-   - [MariaDB](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/mariadb.md)
-   - [PostgreSQL](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/postgresql.md)
-   - [MS SQL](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/mssql.md)
+   - [MariaDB](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/mariadb.md)
+   - [PostgreSQL](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/postgresql.md)
+   - [MS SQL](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/mssql.md)
 
  To install any of them simply run `sudo hassbian-config install SUITE`.
 
 ### Upgrade scripts
 To view the available suites run `hassbian-config show` or have a look at the [hassbian-scripts repository][hassbian-repo].  
 These are some of the available suites:  
-- [AppDaemon](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/appdaemon.md)
-- [Hassbian](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/hassbian.md)
-- [Home Assistant](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/homeassistant.md)
-- [hassbian-config (hassbian-scripts)](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/hassbian_config.md)
+- [AppDaemon](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/appdaemon.md)
+- [Hassbian](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/hassbian.md)
+- [Home Assistant](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/homeassistant.md)
+- [hassbian-config (hassbian-scripts)](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/hassbian_config.md)
 
 To upgrade any of them simply run `sudo hassbian-config upgrade SUITE`.
 

--- a/source/_docs/installation/hassbian/customization.markdown
+++ b/source/_docs/installation/hassbian/customization.markdown
@@ -16,26 +16,38 @@ The tool is available by running `hassbian-config`.
 ### Install scripts
 To view the available suites run `hassbian-config show` or have a look at the [hassbian-scripts repository][hassbian-repo].  
 These are some of the available suites:  
- - [AppDaemon](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/appdaemon.md)
- - [Duck DNS](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/duckdns.md) _This can also be configured to generate Let's Encrypt SSL certificates_
- - [Homebridge](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/homebridge.md)
- - [Mosquitto](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/mosquitto.md)
- - [Samba](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/samba.md)
- - [Webterminal](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/docs/webterminal.md)
+ - [AppDaemon](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/appdaemon.md)
+ - [Cloud9](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/cloud9.md)
+ - [Custom Component Store](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/custom-component-store.md)
+ - [Fail2Ban](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/fail2ban.md) **This suite can't be installed on Raspberry Pi Zero**
+ - [Duck DNS](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/duckdns.md) _This can also be configured to generate Let's Encrypt SSL certificates_
+ - [Hue](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/hue.md)
+ - [Hassbian Manager](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/manager.md) is a web UI tool that can help you manage your suites.
+ - [Mosquitto](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/mosquitto.md)
+ - [Pi-hole](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/pihole.md)
+ - [Razberry](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/razberry.md)
+ - [Samba](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/samba.md)
+ - [Trådfri](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/tradfri.md)
+ - [Webterminal](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/webterminal.md)
+ - [Zigbee2mqtt](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/zigbee2mqtt.md)
  - Various database engines.
-   - [MariaDB](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/mariadb.md)
-   - [PostgreSQL](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/postgresql.md)
-   - [MS SQL](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/mssql.md)
+   - [MariaDB](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/mariadb.md)
+   - [PostgreSQL](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/postgresql.md)
+   - [MS SQL](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/mssql.md)
 
  To install any of them simply run `sudo hassbian-config install SUITE`.
 
 ### Upgrade scripts
 To view the available suites run `hassbian-config show` or have a look at the [hassbian-scripts repository][hassbian-repo].  
 These are some of the available suites:  
-- [AppDaemon](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/appdaemon.md)
-- [Hassbian](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/hassbian.md)
-- [Home Assistant](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/homeassistant.md)
-- [hassbian-config (hassbian-scripts)](https://github.com/home-assistant/hassbian-scripts/tree/dev/docs/suites/hassbian_config.md)
+- [AppDaemon](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/appdaemon.md)
+- [Cloud9](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/cloud9.md)
+- [Custom Component Store](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/custom-component-store.md)
+- [Hassbian](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/hassbian.md)
+- [Hassbian Manager](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/manager.md)
+- [Home Assistant](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/homeassistant.md)
+- [hassbian-config (hassbian-scripts)](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/hassbian_config.md)
+- [Python](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/python.md)
 
 To upgrade any of them simply run `sudo hassbian-config upgrade SUITE`.
 


### PR DESCRIPTION
.md were moved from 'hassbian-scripts/blob/master/docs' to 'hassbian-scripts/tree/dev/docs/suites'

**Description:**

Fixes: #9700

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9755"><img src="https://gitpod.io/api/apps/github/pbs/github.com/leytpapas/home-assistant.io.git/3afffb1592d05e32b2fad812ffde3e4456461905.svg" /></a>

