### PR TITLE
Update nest.markdown

### DIFF
--- a/source/_components/nest.markdown
+++ b/source/_components/nest.markdown
@@ -35,6 +35,10 @@ There is currently support for the following device types within Home Assistant:
 
 ### {% linkable_title Setting up developer account %}
 
+<p class='note warning'>
+  New users are not currently able to set up a Works With Nest Developer account due to the change announced by Google. We will reach out to Nest to see if we can become a partner so that users joining Home Assistant after August can still use Nest. In the future we will add documentation on how to setup a Works With Google account and configure your Nest integration.
+</p>
+
 1. Visit [Nest Developers](https://developers.nest.com/), and sign in. Create an account if you don't have one already.
 2. Fill in account details:
   * The "Company Information" can be anything. We recommend using your name.


### PR DESCRIPTION
I added a warning alerting new users that Works With Nest Developer accounts can no longer be created, and they need a Works With Google account to setup a custom integration for Nest products.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9757"><img src="https://gitpod.io/api/apps/github/pbs/github.com/danner26/home-assistant.io.git/a3048f565c2f7ed9a1986436b4e6d1719dd83639.svg" /></a>

