### PR TITLE
Add template support to state trigger's for option

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -124,6 +124,27 @@ automation:
     for: '01:10:05'
 ```
 
+You can also use templates in the `for` option.
+
+{% raw %}
+```yaml
+automation:
+  trigger:
+    platform: state
+    entity_id: device_tracker.paulus, device_tracker.anne_therese
+    to: 'home'
+    for:
+      minutes: "{{ states('input_number.lock_min')|int }}"
+      seconds: "{{ states('input_number.lock_sec')|int }}"
+  action:
+    service: lock.lock
+    entity_id: lock.my_place
+```
+{% endraw %}
+
+The `for` template(s) will be evaluated when an entity changes as specified.
+
+
 <p class='note warning'>
   Use quotes around your values for `from` and `to` to avoid the YAML parser interpreting values as booleans.
 </p>


### PR DESCRIPTION
**Description:**
Allow the use of templates with the state trigger's `for` option.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24912

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9762"><img src="https://gitpod.io/api/apps/github/pbs/github.com/pnbruckner/home-assistant.io.git/61bcbcbdf1d84ae2742606520f634cb76bc83a5e.svg" /></a>

