### PR TITLE
added Testing section

### DIFF
--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -60,3 +60,19 @@ automation:
   trigger:
   ...
 ```
+
+### {% linkable_title Testing your automation %}
+
+It is generally a difficult task to test an automation, especially if it includes several triggers and some conditions.
+Please note that if you click on an automation name in your frontend and click Trigger, **only `action` part is executed** by Home Assistant.
+That means you **cannot** test your trigger or condition part that way.
+It also means that if your automation uses some data from triggers, it won't work properly as well just because `trigger` is not defined in this scenario.
+All this makes that Trigger feature pretty limited and nearly useless for debugging purposes so you need to find another way.
+Make sure you check and adapt to your circumstances appropriate examples from Automation Trigger, Conditions and Actions.
+It is also useful to go to Configuration -> General and click on Check Config button in Configuration validation section to make sure there are no syntax errors before restarting Home Assistant.
+If your automation uses templates in any part, you can do the following to make sure it works as expected:
+Copy your template in Developer tools -> Templates.
+Make sure you have created all necessary variables (sources) before code of your template as described at the end of [this](https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data) paragraph.
+Then change your sources' value and check if the template works as you want and does not generate any errors.
+ 
+

--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -67,12 +67,13 @@ It is generally a difficult task to test an automation, especially if it include
 Please note that if you click on an automation name in your frontend and click Trigger, **only `action` part is executed** by Home Assistant.
 That means you **cannot** test your trigger or condition part that way.
 It also means that if your automation uses some data from triggers, it won't work properly as well just because `trigger` is not defined in this scenario.
+
 All this makes that Trigger feature pretty limited and nearly useless for debugging purposes so you need to find another way.
 Make sure you check and adapt to your circumstances appropriate examples from Automation Trigger, Conditions and Actions.
 It is also useful to go to Configuration -> General and click on Check Config button in Configuration validation section to make sure there are no syntax errors before restarting Home Assistant.
-If your automation uses templates in any part, you can do the following to make sure it works as expected:
-Copy your template in Developer tools -> Templates.
-Make sure you have created all necessary variables (sources) before code of your template as described at the end of [this](https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data) paragraph.
-Then change your sources' value and check if the template works as you want and does not generate any errors.
- 
 
+If your automation uses templates in any part, you can do the following to make sure it works as expected:
+1. Go to Developer tools -> Templates
+2. Create all variables (sources) required for your template as described at the end of [this](https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data) paragraph.
+3. Copy your template code and paste it in Template editor straight after your variables.
+4. If necessary, change your sources' value and check if the template works as you want and does not generate any errors.

--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -60,20 +60,3 @@ automation:
   trigger:
   ...
 ```
-
-### {% linkable_title Testing your automation %}
-
-It is generally a difficult task to test an automation, especially if it includes several triggers and some conditions.
-Please note that if you click on an automation name in your frontend and click Trigger, **only `action` part is executed** by Home Assistant.
-That means you **cannot** test your trigger or condition part that way.
-It also means that if your automation uses some data from triggers, it won't work properly as well just because `trigger` is not defined in this scenario.
-
-All this makes that Trigger feature pretty limited and nearly useless for debugging purposes so you need to find another way.
-Make sure you check and adapt to your circumstances appropriate examples from Automation Trigger, Conditions and Actions.
-It is also useful to go to Configuration -> General and click on Check Config button in Configuration validation section to make sure there are no syntax errors before restarting Home Assistant.
-
-If your automation uses templates in any part, you can do the following to make sure it works as expected:
-1. Go to Developer tools -> Templates
-2. Create all variables (sources) required for your template as described at the end of [this](https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data) paragraph.
-3. Copy your template code and paste it in Template editor straight after your variables.
-4. If necessary, change your sources' value and check if the template works as you want and does not generate any errors.

--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -28,16 +28,17 @@ The Logbook integration will show a line entry when an automation is triggered. 
 ### {% linkable_title Testing your automation %}
 
 It is generally a difficult task to test an automation, especially if it includes several triggers and some conditions.
-Please note that if you click on an automation name in your frontend and click Trigger, **only `action` part is executed** by Home Assistant.  
-That means you **cannot** test your trigger or condition part that way.
-It also means that if your automation uses some data from triggers, it won't work properly as well just because `trigger` is not defined in this scenario.  
+
+Please note that if you click on **Trigger** of an automation in the frontend, **only the `action` part will be executed** by Home Assistant. That means you **can't** test your trigger or condition part that way. It also means that if your automation uses some data from triggers, it won't work properly as well just because `trigger` is not defined in this scenario.
 
 All this makes that Trigger feature pretty limited and nearly useless for debugging purposes so you need to find another way.
 Make sure you check and adapt to your circumstances appropriate examples from Automation Trigger, Conditions and Actions.
-It is also useful to go to Configuration -> General and click on Check Config button in Configuration validation section to make sure there are no syntax errors before restarting Home Assistant.  
+
+It is also useful to go to **Configuration** -> **Server Control** and click on **Check Config** button in Configuration validation section to make sure there are no syntax errors before restarting Home Assistant.
 
 If your automation uses templates in any part, you can do the following to make sure it works as expected:
-1. Go to Developer tools -> Templates
+
+1. Go to **Developer tools** -> **Template** tab.
 2. Create all variables (sources) required for your template as described at the end of [this](https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data) paragraph.
 3. Copy your template code and paste it in Template editor straight after your variables.
 4. If necessary, change your sources' value and check if the template works as you want and does not generate any errors.

--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -25,7 +25,7 @@ The Logbook integration will show a line entry when an automation is triggered. 
 
 [template]: /topics/templating/
 
-### {% linkable_title Testing your automation %}
+### Testing your automation
 
 It is generally a difficult task to test an automation, especially if it includes several triggers and some conditions.
 

--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -24,3 +24,20 @@ The Logbook integration will show a line entry when an automation is triggered. 
 ![Logbook example](/images/components/automation/logbook.png)
 
 [template]: /topics/templating/
+
+### {% linkable_title Testing your automation %}
+
+It is generally a difficult task to test an automation, especially if it includes several triggers and some conditions.
+Please note that if you click on an automation name in your frontend and click Trigger, **only `action` part is executed** by Home Assistant.  
+That means you **cannot** test your trigger or condition part that way.
+It also means that if your automation uses some data from triggers, it won't work properly as well just because `trigger` is not defined in this scenario.  
+
+All this makes that Trigger feature pretty limited and nearly useless for debugging purposes so you need to find another way.
+Make sure you check and adapt to your circumstances appropriate examples from Automation Trigger, Conditions and Actions.
+It is also useful to go to Configuration -> General and click on Check Config button in Configuration validation section to make sure there are no syntax errors before restarting Home Assistant.  
+
+If your automation uses templates in any part, you can do the following to make sure it works as expected:
+1. Go to Developer tools -> Templates
+2. Create all variables (sources) required for your template as described at the end of [this](https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data) paragraph.
+3. Copy your template code and paste it in Template editor straight after your variables.
+4. If necessary, change your sources' value and check if the template works as you want and does not generate any errors.


### PR DESCRIPTION
I saw no such thing in docs and it constantly causes topics like this - https://community.home-assistant.io/t/condition-problems/124222.
Hope this addition is useful.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9767"><img src="https://gitpod.io/api/apps/github/pbs/github.com/akasma74/home-assistant.io.git/b20b4c5142d11341a0ae10e3ecff3c2fba8afec5.svg" /></a>

