### PR TITLE
Linked to Shopping List component

### DIFF
--- a/source/_addons/snips.markdown
+++ b/source/_addons/snips.markdown
@@ -17,7 +17,7 @@ The Snips add-on depends on the Mosquitto add on to bridge to Home Assistant, so
 
 Home Assistant comes with certain Intents builtin to handle common tasks. A complete list of Intents can be found in this wiki [Hass Snips Bundle](https://github.com/tschmidty69/hass-snips-bundle-intents/wiki).
 
-The Snips add-on by default comes with an assistant that allows you to turn on lights or switches, open covers, or add and list items to a [Shopping List](https://www.home-assistant.io/components/shopping_list/) if that integration is enabled.
+The Snips add-on by default comes with an assistant that allows you to turn on lights or switches, open covers, or add and list items to a [Shopping List](/components/shopping_list/) if that integration is enabled.
 
 If using a USB microphone and speakers plugged into the Raspberry Pi output, Snips will work without any change to the configuration. Trying saying things like:
 

--- a/source/_addons/snips.markdown
+++ b/source/_addons/snips.markdown
@@ -17,7 +17,7 @@ The Snips add-on depends on the Mosquitto add on to bridge to Home Assistant, so
 
 Home Assistant comes with certain Intents builtin to handle common tasks. A complete list of Intents can be found in this wiki [Hass Snips Bundle](https://github.com/tschmidty69/hass-snips-bundle-intents/wiki).
 
-The Snips add-on by default comes with an assistant that allows you to turn on lights or switches, open covers, or add and list items to a shopping list if that integration is enabled.
+The Snips add-on by default comes with an assistant that allows you to turn on lights or switches, open covers, or add and list items to a [Shopping List](https://www.home-assistant.io/components/shopping_list/) if that integration is enabled.
 
 If using a USB microphone and speakers plugged into the Raspberry Pi output, Snips will work without any change to the configuration. Trying saying things like:
 


### PR DESCRIPTION
What: Converted existing text to a link to the HA ShoppingList component page.
Why: As a new user of HA, I was not even aware of the ShoppingList component until I read this page.
It would simply be useful to link relevant info since after reading this page I was wanting to try Snips on a "shopping list", but had no idea where it was.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9769"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SonicMagna/home-assistant.io.git/9fd77bebcc4ac40f515b8e38996f68e8f2aa7579.svg" /></a>

