### PR TITLE
link on tahoma does not work

### DIFF
--- a/source/_components/somfy.markdown
+++ b/source/_components/somfy.markdown
@@ -53,7 +53,7 @@ client_secret:
 
 ### {% linkable_title Potential duplicate with the Tahoma integration %}
 
-If you use the [tahoma](/component/tahoma) component, you will have to exclude the covers added by this one. Otherwise, they will be added twice.
+If you use the [tahoma](/components/tahoma) component, you will have to exclude the covers added by this one. Otherwise, they will be added twice.
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
link on tahoma does not work, needed s in componets

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9773"><img src="https://gitpod.io/api/apps/github/pbs/github.com/DKAutomater/home-assistant.io.git/9849e081d74fa6247bd0e47a302be906c73228c0.svg" /></a>

