### PR TITLE
Add template support to numeric_state trigger's for option

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -118,6 +118,7 @@ The following tables show the available trigger data per platform.
 | `trigger.above` | The above threshold, if any.
 | `trigger.from_state` | The previous [state object] of the entity.
 | `trigger.to_state` | The new [state object] that triggered trigger.
+| `trigger.for` | Timedelta object how long state has met above/below criteria, if any.
 
 ### state
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -106,6 +106,30 @@ automation:
 ```
 {% endraw %}
 
+You can also use templates in the `for` option.
+
+{% raw %}
+```yaml
+automation:
+  trigger:
+    platform: numeric_state
+    entity_id:
+      - sensor.temperature_1
+      - sensor.temperature_2
+    above: 80
+    for:
+      minutes: "{{ states('input_number.high_temp_min')|int }}"
+      seconds: "{{ states('input_number.high_temp_sec')|int }}"
+  action:
+    service: persistent_notification.create
+    data_template:
+      message: >
+        {{ trigger.to_state.name }} too high for {{ trigger.for }}!
+```
+{% endraw %}
+
+The `for` template(s) will be evaluated when an entity changes as specified.
+
 ### State trigger
 
 Triggers when the state of a given entity changes. If only `entity_id` is given trigger will activate for all state changes, even if only state attributes change.


### PR DESCRIPTION
**Description:**
Allow the use of templates with the numeric_state trigger's `for` option.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24955

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9781"><img src="https://gitpod.io/api/apps/github/pbs/github.com/pnbruckner/home-assistant.io.git/14dc46cb201d8f78e2922297562b260bc489ba31.svg" /></a>

