### PR TITLE
Updated release cycle information

### DIFF
--- a/source/_faq/release.markdown
+++ b/source/_faq/release.markdown
@@ -10,5 +10,8 @@ footer: true
 ha_category: Common
 ---
 
-The usual release cycle is two weeks. Every other weekend will a new release of Home Assistant be available. There is no fix day or time when the release will happen because that depends on the person who is finishing the release. It can already be Monday at your location. If there was no announcement made in the previous release notes or on another communication channel then the release will happen.
+The current release cycle is three weeks. This allows for two weeks of development time and 1 week of beta testing and fixing. Releases usually occur on a Wednesday. There is no fixed time of day when the release will happen because that depends on the person who is finishing the release, it could therefore be Tuesday or Thursday depending on your timezone when its available for you. If there was no announcement made in the previous release notes or on another communication channel then the release will happen.
+
+Beta's are normally released on the 2nd Wednesday after the last major release. Please subscribe to the Beta Channel on the [Home Assistant Discord server](https://discord.gg/RMC8WkX) for help running beta versions.
+When a beta release is in progress the the release notes for it can be found here [Beta Release Notes](https://rc.home-assistant.io/latest-release-notes/).
   

--- a/source/_faq/release.markdown
+++ b/source/_faq/release.markdown
@@ -14,4 +14,6 @@ The current release cycle is three weeks. This allows for two weeks of developme
 
 Beta's are normally released on the 2nd Wednesday after the last major release. Please subscribe to the Beta Channel on the [Home Assistant Discord server](https://discord.gg/RMC8WkX) for help running beta versions.
 When a beta release is in progress the the release notes for it can be found here [Beta Release Notes](https://rc.home-assistant.io/latest-release-notes/).
+
+The release schedule is published in the upcoming events calender on the [Home Assistant Developers](https://developers.home-assistant.io/) website.
   


### PR DESCRIPTION
Updated FAQ release cycle information from 2 to  3 week release  schedule and added notes about betas.



- [x ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9784"><img src="https://gitpod.io/api/apps/github/pbs/github.com/aidbish/home-assistant.io.git/934c8003606be5abc2493eb302fb7bd3b3de37e8.svg" /></a>

