### PR TITLE
Remove monitored conditions config

### DIFF
--- a/source/_components/netatmo.markdown
+++ b/source/_components/netatmo.markdown
@@ -318,14 +318,7 @@ climate:
 The `netatmo` sensor platform is consuming the information provided by a [Netatmo Weather Station](https://www.netatmo.com/en-us/weather/weatherstation), a
 [Netatmo Home Coach](https://www.netatmo.com/en-us/aircare/homecoach) [Netatmo](https://www.netatmo.com) device or the public sensors of others available via the [Netatmo API](https://weathermap.netatmo.com/) even if you don't own a Netatmo device.
 
-Public sensors have to be set up manually. Currently the following conditions are supported for the public sensors:
-
-* temperature
-* pressure
-* humidity
-* rain
-* windstrength
-* guststrength
+Public sensors have to be set up manually.
 
 ## Advanced sensor configuration
 
@@ -338,11 +331,8 @@ sensor:
   - platform: netatmo
     station: STATION_NAME
     modules:
-      module_name1:
-        - temperature
-      module_name2:
-        - temperature
-        - battery_vp
+      - module_name1
+      - module_name2
 
   # Public sensor
   - platform: netatmo
@@ -351,13 +341,6 @@ sensor:
         lon_ne: -73.735
         lat_sw: 40.552
         lon_sw: -74.105
-        monitored_conditions:
-          - temperature
-          - pressure
-          - humidity
-          - rain
-          - windstrength
-          - guststrength
 ```
 
 {% configuration %}
@@ -374,45 +357,6 @@ modules:
       type: list
       required: true
       description: Name of the module.
-      keys:
-        temperature:
-          description: Current temperature.
-        co2:
-          description: CO2 concentration in ppm.
-        pressure:
-          description: Pressure in mbar.
-        noise:
-          description: Noise level in dB.
-        humidity:
-          description: "Humidity in %."
-        health_idx:
-          description: "Air health as one of the values Healthy, Fine, Fair, Poor, Unhealthy."
-        rain:
-          description: Estimated rainfall for today in mm.
-        sum_rain_1:
-          description: Rainfall in the last hour in mm.
-        sum_rain_24:
-          description: "Rainfall in mm from 00:00am - 23:59pm."
-        windangle:
-          description: Wind angle
-        windstrength:
-          description: Wind strength
-        gustangle:
-          description: Wind gust angle
-        guststrength:
-          description: Wind gust strength
-        min_temp:
-          description: Min temperature for today
-        max_temp:
-          description: Max temperature for today
-        rf_status:
-          description: "Current radio status per module. (90=low, 60=highest)"
-        wifi_status:
-          description: Wifi status per Base station
-        battery_vp:
-          description: Current battery status per module.
-        battery_percent:
-          description: Percentage of battery remaining per module.
 areas:
   description: The list contains one or more areas to add as sensors.
   required: false
@@ -434,10 +378,6 @@ areas:
       description: Longitude of south-western corner of area.
       required: true
       type: string
-    monitored_conditions:
-      description: List of environment conditions to monitor.
-      required: true
-      type: list
     name:
       description: Name of the sensor.
       required: false


### PR DESCRIPTION
In ADR0003 monitored conditions and equal configuration options have to be removed. This was implemented in #24944.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24944

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9789"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/45d67b945803e0d659c3ccecb4570a336ef8e37d.svg" /></a>

