### PR TITLE
Add documentation for new service sonos.play_queue

### DIFF
--- a/source/_components/sonos.markdown
+++ b/source/_components/sonos.markdown
@@ -123,6 +123,7 @@ Force start playing the queue, allows switching from another stream to playing t
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of `entity_id`s that will start playing. It must be the coordinator if targeting a group.
+| `queue_position` | yes | Position of the song in the queue to start playing from, starts at 0.
 
 ## Advanced use
 

--- a/source/_components/sonos.markdown
+++ b/source/_components/sonos.markdown
@@ -118,7 +118,7 @@ Night Sound and Speech Enhancement modes are only supported when playing from th
 
 Starts playing the Sonos queue.
 
-Force start playing the queue, allows switching from another stream to playing the queue.
+Force start playing the queue, allows switching from another stream (such as radio) to playing the queue.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |

--- a/source/_components/sonos.markdown
+++ b/source/_components/sonos.markdown
@@ -114,6 +114,16 @@ Night Sound and Speech Enhancement modes are only supported when playing from th
 | `night_sound` | yes | Boolean to control Night Sound mode.
 | `speech_enhance` | yes | Boolean to control Speech Enhancement mode.
 
+### Service `sonos.play_queue`
+
+Starts playing the Sonos queue.
+
+Force start playing the queue, allows switching from another stream to playing the queue.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of `entity_id`s that will start playing. It must be the coordinator if targeting a group.
+
 ## Advanced use
 
 For advanced uses, there are some manual configuration options available.


### PR DESCRIPTION
**Description:**

Documentation for new service sonos.play_queue

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24974

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9790"><img src="https://gitpod.io/api/apps/github/pbs/github.com/apeeters/home-assistant.github.io.git/9643c1da27c9fe271bbf700717be87ac200fa7c5.svg" /></a>

