### PR TITLE
Add datetime option to input_datetime.set_datetime service

### DIFF
--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -87,12 +87,15 @@ Assistant stopping as long as your entity does **not** have a set value for
 
 ### Services
 
-This integration provides a service to modify the state of the `input_datetime`.
+Available service: `input_datetime.set_datetime`.
 
-| Service | Data | Description |
-| ----- | ----- | ----- |
-| `set_datetime` | `time` | This can be used to dynamically set the time.
-| `set_datetime` | `date` | This can be used to dynamically set the date.
+Service data attribute | Format String | Description
+-|-|-
+`date` | `%Y-%m-%d` | This can be used to dynamically set the date.
+`time` | `%H:%M:%S` | This can be used to dynamically set the time.
+`datetime` | `%Y-%m-%d %H:%M:%S` | This can be used to dynamically set both the date & time.
+
+To set both the date and time in the same call, use `date` and `time` together, or use `datetime` by itself. Using `datetime` has the advantage that both can be set using one template.
 
 ## Automation Examples
 
@@ -115,8 +118,8 @@ automation:
 {% endraw %}
 
 To dynamically set the `input_datetime` you can call
-`input_datetime.set_datetime`. The values for `date` and `time` must be in a certain format for the call to be successful.
-You can use either `strftime("%Y-%m-%d")`/`strftime("%H:%M:%S")` or `timestamp_custom("%Y-%m-%d", true)`/`timestamp_custom("%H:%M:%S", true)` filter respectively.
+`input_datetime.set_datetime`. The values for `date` and `time` must be in a certain format for the call to be successful. (See service description above.)
+If you have a `datetime` object you can use its `strftime` method. Of if you have a timestamp you can use the `timestamp_custom` filter.
 The following example can be used in an automation rule:
 
 {% raw %}
@@ -136,17 +139,14 @@ automation:
   - service: input_datetime.set_datetime
     entity_id: input_datetime.another_time
     data_template:
-      time: '{{ now().strftime("%H:%M:%S") }}'
+      time: "{{ now().strftime('%H:%M:%S') }}"
   - service: input_datetime.set_datetime
     entity_id: input_datetime.another_date
     data_template:
-      date: '{{ now().strftime("%Y-%m-%d") }}'
+      date: "{{ as_timestamp(now())|timestamp_custom('%Y-%m-%d') }}"
   - service: input_datetime.set_datetime
+    entity_id: input_datetime.date_and_time
     data_template:
-     entity_id: input_datetime.date_and_time
-      date: >
-        {{ now().timestamp() | timestamp_custom("%Y-%m-%d", true) }}
-      time: >
-        {{ now().timestamp() | timestamp_custom("%H:%M:%S", true) }}
+      datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**
Document new `input_datetime.set_datetime` service data option `datetime`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24975

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9791"><img src="https://gitpod.io/api/apps/github/pbs/github.com/pnbruckner/home-assistant.io.git/89a968232418074faffd3f7ff0a67bfea62d0c6c.svg" /></a>

