### PR TITLE
Add Twilio SMS media_url docs

### DIFF
--- a/source/_components/twilio_sms.markdown
+++ b/source/_components/twilio_sms.markdown
@@ -45,6 +45,12 @@ name:
 
 Twilio is a notify platform and thus can be controlled by calling the notify service [as described here](/components/notify/). It will send a notification to all E.164 phone numbers in the notification **target**. See the notes above regarding the `from_number` configuration variable for information about formatting phone numbers.
 
+Media can be included with messages by setting the optional `media_url` variable.
+[Per the Twilio documentation, only `.gif`, `.png`, or `.jpeg` content is supported,
+and this feature is only suported in the US and Canada.][mms]
+
+[mms]: https://www.twilio.com/docs/sms/send-messages#include-media-in-your-messages
+
 ```yaml
 # Example automation notification entry
 automation:
@@ -59,4 +65,6 @@ automation:
         target:
           - '+14151234567'
           - '+15105555555'
+        data:
+          - media_url: 'https://www.home-assistant.io/images/supported_brands/home-assistant.png'
 ```

--- a/source/_components/twilio_sms.markdown
+++ b/source/_components/twilio_sms.markdown
@@ -46,8 +46,8 @@ name:
 Twilio is a notify platform and thus can be controlled by calling the notify service [as described here](/components/notify/). It will send a notification to all E.164 phone numbers in the notification **target**. See the notes above regarding the `from_number` configuration variable for information about formatting phone numbers.
 
 Media can be included with messages by setting the optional `media_url` variable.
-[Per the Twilio documentation, only `.gif`, `.png`, or `.jpeg` content is supported,
-and this feature is only suported in the US and Canada.][mms]
+Per the Twilio documentation, only `.gif`, `.png`, or `.jpeg` content is supported,
+and this feature is [only suported in the US and Canada.][mms]
 
 [mms]: https://www.twilio.com/docs/sms/send-messages#include-media-in-your-messages
 

--- a/source/_components/twilio_sms.markdown
+++ b/source/_components/twilio_sms.markdown
@@ -45,9 +45,7 @@ name:
 
 Twilio is a notify platform and thus can be controlled by calling the notify service [as described here](/components/notify/). It will send a notification to all E.164 phone numbers in the notification **target**. See the notes above regarding the `from_number` configuration variable for information about formatting phone numbers.
 
-Media can be included with messages by setting the optional `media_url` variable.
-Per the Twilio documentation, only `.gif`, `.png`, or `.jpeg` content is supported,
-and this feature is [only suported in the US and Canada.][mms]
+Media can be included with messages by setting the optional `media_url` variable. Only `.gif`, `.png`, or `.jpeg` content are supported, according to the Twilio documentation and this feature is [only supported in the US and Canada.][mms]
 
 [mms]: https://www.twilio.com/docs/sms/send-messages#include-media-in-your-messages
 


### PR DESCRIPTION
**Description:**

Adds docs for the `media_url` setting for the Twilio SMS notify component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24971

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9792"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Chris-Johnston/home-assistant.io.git/afeec7a0ae8eb57692a2e94c32164c85b1266f45.svg" /></a>

