### PR TITLE
Remove reference to 'device_class'

### DIFF
--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -68,10 +68,6 @@ cover:
         description: Defines a template to specify which icon to use.
         required: false
         type: template
-      device_class:
-        description: Sets the [class of the device](/components/cover/), changing the device state and icon that is displayed on the frontend.
-        required: false
-        type: string
       open_cover:
         description: Defines an action to run when the cover is opened. If [`open_cover`](#open_cover) is specified, [`close_cover`](#close_cover) must also be specified. At least one of [`open_cover`](#open_cover) and [`set_cover_position`](#set_cover_position) must be specified.
         required: inclusive


### PR DESCRIPTION
It does not seem to be supported (anymore?) according to this configuration validation error: 
"Invalid config for [cover.template]: [device_class] is an invalid option for [cover.template]."

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9794"><img src="https://gitpod.io/api/apps/github/pbs/github.com/rschuiling/home-assistant.io.git/057f7fa6a3bf384f5850c11af0650d7c62c32a66.svg" /></a>

