### PR TITLE
Quick removal of links to setting the password

### DIFF
--- a/source/_docs/ecosystem/certificates/lets_encrypt.markdown
+++ b/source/_docs/ecosystem/certificates/lets_encrypt.markdown
@@ -13,16 +13,11 @@ footer: true
 If you are using Hass.io or Hassbian, do not use this guide. Instead, use the [DuckDNS add-on](/addons/duckdns/) for Hass.io or the [DuckDNS suite](https://github.com/home-assistant/hassbian-scripts/blob/master/docs/suites/duckdns.md) for Hassbian to automatically maintain a subdomain including HTTPS certificates via Let's Encrypt.
 </p>
 
-<p class='note warning'>
-Before exposing your Home Assistant instance to the outside world it is ESSENTIAL that you have set a password following the advice on the [http](/components/http/) page.
-</p>
-
-
 This guide was added by mf_social on 16/03/2017 and was valid at the time of writing. This guide makes the following assumptions:
 
  * You can access your Home Assistant instance across your local network, and access the device that it is on via SSH from your local network.
  * You know the internal IP address of your router and can access your router's configuration pages.
- * You have already set up a password for your Home Assistant instance, following the advice on this page: [http](/docs/configuration/basic/)
+ * You have already secured your Home Assistant instance, following the advice on [this page](/docs/configuration/securing/)
  * You want to access your Home Assistant instance when you are away from home (ie, not connected to your local network) and secure it with a TLS/SSL certificate.
  * You have a basic understanding of the phrases I have used so far.
  * You are not currently running anything on port 80 on your network (you'd know if you were).


### PR DESCRIPTION
API password is dead, we shouldn't be talking about it any more

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9795"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/98d109e1696bdb0a331e37c017b6511130716897.svg" /></a>

