### PR TITLE
Update mosquitto.markdown

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -104,7 +104,7 @@ acl_file /share/mosquitto/accesscontrollist
 3. Create `/share/mosquitto/accesscontrollist` with the contents:
 ```text
 user [YOUR_MQTT_USER]
-topic #
+topic readwrite #
 ```
 
 The `/share` folder can be accessed via SMB, or on the host filesystem under `/usr/share/hassio/share`.


### PR DESCRIPTION
In my case, user was not able to publish message with "topic #"
I had to add readwrite to it to work
I'm using Mosquitto 5.0

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9796"><img src="https://gitpod.io/api/apps/github/pbs/github.com/berightback-dev/home-assistant.io.git/974b7f177e2e7aaba7d05080fa1130ab694fcf6b.svg" /></a>

