### PR TITLE
Add documentation for custom spotify service play_playlist

### DIFF
--- a/source/_components/spotify.markdown
+++ b/source/_components/spotify.markdown
@@ -123,6 +123,18 @@ which are part of the
 service. You can test this from the services
 control panel in the Home Assistant frontend.
 
+## Services
+Extra services besides the default ones in component [Media Player component](/components/media_player/).
+
+### Service `play_playlist_random_music`
+
+Starts playing a Spotify playlist starting on random music from playlist.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `media_content_id`     | no       | Spotify URI of playlist. Must be playlist kind of URI.
+
+
 The above playlist example is a URI link to the "Reggae Infusions" playlist.
 [This support document from Spotify](https://support.spotify.com/us/article/sharing-music/)
 explains how to get this URI value to use for playlists in the Spotify component.

--- a/source/_components/spotify.markdown
+++ b/source/_components/spotify.markdown
@@ -126,13 +126,14 @@ control panel in the Home Assistant frontend.
 ## Services
 Extra services besides the default ones in component [Media Player component](/components/media_player/).
 
-### Service `play_playlist_random_music`
+### Service `play_playlist`
 
-Starts playing a Spotify playlist starting on random music from playlist.
+Play a Spotify playlist, with some extra features from generic service `"media_player.media_play"`.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `media_content_id`     | no       | Spotify URI of playlist. Must be playlist kind of URI.
+| `random_song`          | yes      | True to select random song at start, False to start from beginning.
 
 
 The above playlist example is a URI link to the "Reggae Infusions" playlist.

--- a/source/_components/spotify.markdown
+++ b/source/_components/spotify.markdown
@@ -128,7 +128,7 @@ Extra services besides the default ones in component [Media Player component](/c
 
 ### Service `play_playlist`
 
-Play a Spotify playlist, with some extra features from generic service `"media_player.media_play"`.
+Play a Spotify playlist with an option to start on a random position of the playlist.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION
**Description:**

Adding documentation for new custom service `play_playlist` that allows to start playing a Spotify playlist with extra parameter `random_song` to allow start from a random position.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#24991

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9798"><img src="https://gitpod.io/api/apps/github/pbs/github.com/lealoureiro/home-assistant.io.git/bde06e3ce13b7758cfc2d193fd18716ff46d2b0d.svg" /></a>

