### PR TITLE
Fix formatting of installation commands

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -83,7 +83,7 @@ Best practice for updating a Hass.io installation:
 SSH to your Hass.io system, or connect to the console, and run:
 
 ```bash
-$ hassio ha update --version=0.XX.X
+hassio ha update --version=0.XX.X
 ```
 
 ## Run the beta version on Hass.io
@@ -140,18 +140,18 @@ You also need to have Docker-CE installed. There are well-documented procedures 
 To perform the Hass.io installation on Ubuntu, run the following commands:
 
 ```bash
-$ sudo -i
-$ apt-get install software-properties-common
-$ add-apt-repository universe
-$ apt-get update
-$ apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
-$ curl -fsSL get.docker.com | sh
+sudo -i
+apt-get install software-properties-common
+add-apt-repository universe
+apt-get update
+apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
+curl -fsSL get.docker.com | sh
 ```
 
 And to install Hass.io the one below. That one is used also for other distributions.
 
 ```bash
-$ curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/master/hassio_install.sh" | bash -s
+curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/master/hassio_install.sh" | bash -s
 ```
 
 <p class='note'>

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -82,8 +82,8 @@ Best practice for updating a Hass.io installation:
 
 SSH to your Hass.io system, or connect to the console, and run:
 
-```
-hassio ha update --version=0.XX.X
+```bash
+$ hassio ha update --version=0.XX.X
 ```
 
 ## Run the beta version on Hass.io
@@ -141,17 +141,17 @@ To perform the Hass.io installation on Ubuntu, run the following commands:
 
 ```bash
 $ sudo -i
-# apt-get install software-properties-common
-# add-apt-repository universe
-# apt-get update
-# apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
-# curl -fsSL get.docker.com | sh
+$ apt-get install software-properties-common
+$ add-apt-repository universe
+$ apt-get update
+$ apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
+$ curl -fsSL get.docker.com | sh
 ```
 
 And to install Hass.io the one below. That one is used also for other distributions.
 
 ```bash
-# curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/master/hassio_install.sh" | bash -s
+$ curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/master/hassio_install.sh" | bash -s
 ```
 
 <p class='note'>


### PR DESCRIPTION
**Description:**

This change fixes the formatting of the generic linux host installation commands so that they all begin with `$`. This ensures that they are rendered correctly in the documentation.

Previously, the commands under `$ sudo -i` all began with `#` (to indicate that the shell was running as root). While this is correct, the markdown formatting thinks that they are comments, so they are rendered in a light gray color. I think that it's better that they are shown as commands and not comments.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9803"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Chris-Johnston/home-assistant.io.git/f87c92c1dcffffd32c33aaef971cf49b29b41f98.svg" /></a>

