### PR TITLE
Added info on how to launch specific Roku channel via automation.

### DIFF
--- a/source/_components/roku.markdown
+++ b/source/_components/roku.markdown
@@ -97,7 +97,7 @@ data:
 
 ## {% linkable_title Media Player %}
 
-When the Home Assistant Roku integration is enabled and has found a Roku device, in the Home Assistant GUI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will aatempt to launch the channel on your Roku device. This action can also be automated, but it requires you to acquire an extra piece of information; the ```appID``` for the channel specific to your Roku. Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
+When the Home Assistant Roku integration is enabled and has found a Roku device, in the Home Assistant GUI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will attempt to launch the channel on your Roku device. This action can also be automated, but it requires you to acquire an extra piece of information; the ```appID``` for the channel specific to your Roku. Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
 The api calls are like this:
 ```
 GET http:// ROKU_IP:8060/query/apps

--- a/source/_components/roku.markdown
+++ b/source/_components/roku.markdown
@@ -94,3 +94,23 @@ data:
     - left
     - select
 ```
+
+## {% linkable_title Media Player %}
+
+When the Home Assistant Roku integration is enabled and has found a Roku device, in the Home Assistant GUI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will aatempt to launch the channel on your Roku device. This action can also be automated, but it requires you to acquire an extra piece of information; the ```appID``` for the channel specific to your Roku. Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
+The api calls are like this:
+```
+GET http:// ROKU_IP:8060/query/apps
+POST http://ROKU_IP:8060/launch/APP_ID
+```
+More details can be found on the [Roku dev pages](https://developer.roku.com/docs/developer-program/discovery/external-control-api.md)
+
+To use this in Home Assistant, for instance in an automation, the format is as follows. Note that ```source: ``` is the appID you discovered in the API call:
+
+```
+  action:
+  - data:
+      entity_id: media_player.roku
+      source: 20197
+    service: media_player.select_source
+```

--- a/source/_components/roku.markdown
+++ b/source/_components/roku.markdown
@@ -41,13 +41,13 @@ host:
   type: string
 {% endconfiguration %}
 
-## {% linkable_title Services %}
+## Services
 
-### {% linkable_title Service `roku_scan` %}
+### Service `roku_scan`
 
 Scans the local network for Rokus. All found devices are presented as a persistent notification.
 
-## {% linkable_title Remote %}
+## Remote
 
 The `roku` remote platform allows you to send remote control buttons to a Roku device. It is automatically set up when a Roku is configured.
 
@@ -95,14 +95,17 @@ data:
     - select
 ```
 
-## {% linkable_title Media Player %}
+## Media Player
 
 When the Home Assistant Roku integration is enabled and has found a Roku device, in the Home Assistant GUI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will attempt to launch the channel on your Roku device. This action can also be automated, but it requires you to acquire an extra piece of information; the ```appID``` for the channel specific to your Roku. Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
+
 The api calls are like this:
+
 ```
 GET http:// ROKU_IP:8060/query/apps
 POST http://ROKU_IP:8060/launch/APP_ID
 ```
+
 More details can be found on the [Roku dev pages](https://developer.roku.com/docs/developer-program/discovery/external-control-api.md)
 
 To use this in Home Assistant, for instance in an automation, the format is as follows. Note that ```source: ``` is the appID you discovered in the API call:


### PR DESCRIPTION
**Description:**
Added information how an end user can discover their Roku channel ID and use this in an HA automation. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9804"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SonicMagna/home-assistant.io.git/fa0976237fedbe39ea49c4887fe46e16b787f6b4.svg" /></a>

