### PR TITLE
Update deconz.markdown

### DIFF
--- a/source/_components/deconz.markdown
+++ b/source/_components/deconz.markdown
@@ -371,6 +371,7 @@ The `entity_id` names will be `light.device_name`, where `device_name` is define
 - Philips Hue White Ambiance A19
 - Philips Hue Hue White ambiance Milliskin (recessed spotlight) LTW013
 - Busch Jaeger ZigBee Light Link univ. relai (6711 U) with ZigBee Light Link control element 6735-84
+- Xiaomi Aqara Smart Led Bulb (white) E27 ZNLDP12LM 
 
 ## Scene
 


### PR DESCRIPTION
Xiaomi Aqara Smart Led Bulb (white) E27 ZNLDP12LM supported

**Description:**
Added support for xiaomi aqara ZNLDP12LM, got it works as expected

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9810"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Viktor45/home-assistant.io.git/39e53673bcadb0ca44fe81e7a84da81fac1d9458.svg" /></a>

