### PR TITLE
Add omer_count docs to jewish_calendar

### DIFF
--- a/source/_components/jewish_calendar.markdown
+++ b/source/_components/jewish_calendar.markdown
@@ -91,6 +91,8 @@ sensors:
       description: The time of havdalah for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the havdalah for Rosh Hashana on Wednesday night. To always get the Shabbat times, use the upcoming_shabbat_havdalah sensor.
     issur_melacha_in_effect:
       description: A boolean sensor indicating if melacha is currently not permitted. The value is true when it is currently Shabbat or Yom Tov and false otherwise.
+    omer_count:
+      description: An integer sensor indicating the day of the Omer (1-49) or 0 if it is not currently the Omer.
 
 {% endconfiguration %}
 


### PR DESCRIPTION
**Description:**
Adds documentation for new sensor for the day of the omer to jewish_calendar.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24958

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9814"><img src="https://gitpod.io/api/apps/github/pbs/github.com/arigilder/home-assistant.io.git/d64f897302475469d0d19fd80bb268bcdb1b499a.svg" /></a>

