### PR TITLE
Add marker sensor to CUPS

### DIFF
--- a/source/_components/cups.markdown
+++ b/source/_components/cups.markdown
@@ -17,7 +17,7 @@ redirect_from:
 ---
 
 
-The `cups` sensor platform is using the open source printing system [CUPS](https://www.cups.org/) to show details about your printers. It can obtain the informations using a CUPS server or communicating directly with the printer with the Internet Printing Protocol.
+The `cups` sensor platform is using the open source printing system [CUPS](https://www.cups.org/) to show details about your printers, including the ink levels. It can obtain the informations using a CUPS server or communicating directly with the printer with the Internet Printing Protocol.
 
 If you want to use an existing CUPS server the "Queue Name" of the printer is needed. The fastest way to get it, is to visit the CUPS web interface at "http://[IP ADDRESS PRINT SERVER]:631" and go to "Printers".
 


### PR DESCRIPTION
**Description:**

Added marker sensor to CUPS integration. This sensor represent the percentage of ink / toner of configured printers.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25037

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9820"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Matte23/home-assistant.io.git/5ab23f3e1139d41836ad01cea83119e376060e5f.svg" /></a>

