### PR TITLE
Fix opentherm_gw reverted updates

### DIFF
--- a/source/_components/opentherm_gw.markdown
+++ b/source/_components/opentherm_gw.markdown
@@ -73,10 +73,6 @@ climate:
       default: false
 {% endconfiguration %}
 
-## Supported Variables
-
-The list above contains all supported variables. Note that not all boilers and thermostats properly support all variables, so the fact that a variable is listed here and published by your system does not necessarily mean that you will get useful data out of it. To see which variables are published in your situation, enable debug logging for the `opentherm_gw` integration and look for the status updates.
-
 ## Services
 
 ### Service `opentherm_gw.reset_gateway`

--- a/source/_components/opentherm_gw.markdown
+++ b/source/_components/opentherm_gw.markdown
@@ -23,7 +23,7 @@ redirect_from:
 
 The `opentherm_gw` integration is used to control the [OpenTherm Gateway](http://otgw.tclcode.com/) from Home Assistant.
 
-There is currently support for the following device types within Home Assistant:
+The following device types are currently supported within Home Assistant:
 
 - Binary Sensor
 - Climate
@@ -377,7 +377,7 @@ Not all boilers and thermostats properly support all OpenTherm features, so not 
   Solar storage unit temperature.
 
 
-## {% linkable_title Binary Sensors %}
+## Binary Sensors
 
 The following `binary_sensor` entities will be created for each configured gateway. The `entity_id` of every sensor will have a suffix containing the `gateway_id` of the gateway to which it belongs.
 <p class='note'>


### PR DESCRIPTION
**Description:**
af37b00 reverted some recent changes that were made after an update of the `opentherm_gw` integration (see #9176). This PR reinstates the changes that were reverted and fixes content in conflict areas - it's basically a rebase of the `opentherm_gw` update on next as it is now.
This PR is filed against next as the changes did not make it into current yet.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9821"><img src="https://gitpod.io/api/apps/github/pbs/github.com/mvn23/home-assistant.io.git/369f44fc9872735008f019162c28d9efd99d70e2.svg" /></a>

