### PR TITLE
Update emulated_hue.markdown

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -49,7 +49,7 @@ emulated_hue:
 ```yaml
 # Amazon Echo example configuration.yaml entry
 emulated_hue:
-# Required for Echo Dot 3
+# Required if there is no older Echo device (Like an Echo Dot 1 or 2) in the same network
   host_ip: YOUR.HASSIO.IP.ADDRESS
   listen_port: 80
 ```


### PR DESCRIPTION
**Description:**

The current documentation states that port 80 is required for "Echo Dot 3". First of all this is unspecific because it counts for all new devices like e.g. Echo (2nd Gen.) and is not needed as long as an older device like a 2nd generation Dot remains active in the network.
Maybe an Info Block, which describes both ways briefly, makes sense?

## Checklist:

- [ x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9824"><img src="https://gitpod.io/api/apps/github/pbs/github.com/pattyland/home-assistant.io.git/f43a0d8b9729cc8b3e571758b3d946aac9bf23ec.svg" /></a>

