### PR TITLE
Remove monitored conditions in syncthru component

### DIFF
--- a/source/_components/syncthru.markdown
+++ b/source/_components/syncthru.markdown
@@ -29,9 +29,6 @@ sensor:
   - platform: syncthru
     resource: http://my-printer.address
     name: My Awesome Printer
-    monitored_conditions:
-        - toner_black
-        - output_tray_0
 ```
 
 {% configuration %}
@@ -45,48 +42,11 @@ sensor:
     required: false
     default: Samsung Printer
     type: string
-  monitored_conditions:
-    description: Conditions to display in the frontend.
-    required: false
-    default: all values
-    type: list
-    keys:
-      toner_black:
-        description: Black toner fill level
-      toner_cyan:
-        description: Cyan toner fill level
-      toner_magenta:
-        description: Magenta toner fill level
-      toner_yellow:
-        description: Yellow toner fill level
-      drum_black:
-        description: Black drum state
-      drum_cyan:
-        description: Cyan drum state
-      drum_magenta:
-        description: Magenta drum state
-      drum_yellow:
-        description: Yellow drum state
-      tray_1:
-        description: First paper input tray state
-      tray_2:
-        description: Second paper input tray state
-      tray_3:
-        description: Third paper input tray state
-      tray_4:
-        description: Fourth paper input tray state
-      tray_5:
-        description: Fifth paper input tray state
-      output_tray_0:
-        description: First paper output tray state
-      output_tray_1:
-        description: Second paper output tray state
-      output_tray_2:
-        description: Third paper output tray state
-      output_tray_3:
-        description: Fourth paper output tray state
-      output_tray_4:
-        description: Fifth paper output tray state
-      output_tray_5:
-        description: Sixth paper output tray state
 {% endconfiguration %}
+
+The following information is displayed in separate sensors, if it is available:
+
+ - Black, cyan, magenta and yellow toner fill level
+ - Black, cyan, magenta and yellow drum state
+ - First to fifth paper input tray state
+ - First to sixth paper output tray state


### PR DESCRIPTION
**Description:**
As noted in [this comment on my last PR](https://github.com/home-assistant/home-assistant/pull/24961#pullrequestreview-258305105) monitored conditions are to be successively removed from home-assistant. Thus, now it is forbidden to use them anymore.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25052

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9825"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nielstron/home-assistant.github.io.git/d8dd644465e372fc78687bc4e438e29064b380fb.svg" /></a>

