### PR TITLE
Allow csv string for rgb_color, hs_color & xy_color in light.turn_on service

### DIFF
--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -34,8 +34,8 @@ Most lights do not support all attributes. You can check the integration documen
 | `transition` | yes | Number that represents the time (in seconds) the light should take to transition to the new state.
 | `profile` | yes | String with the name of one of the [built-in profiles](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/light/light_profiles.csv) (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory.  Light profiles define an xy color and a brightness. If a profile is given and a brightness then the profile brightness will be overwritten.
 | `hs_color` | yes | A list containing two floats representing the hue and saturation of the color you want the light to be. Hue is scaled 0-360, and saturation is scaled 0-100.
-| `xy_color` | yes | A list containing two floats representing the xy color you want the light to be. Two comma-separated floats that represent the color in XY. You can find a great chart here: [Hue Color Chart](https://developers.meethue.com/documentation/core-concepts#color_gets_more_complicated).
-| `rgb_color` | yes | A list containing three integers between 0 and 255 representing the RGB color you want the light to be. Three comma-separated integers that represent the color in RGB, within square brackets. Note that the specified RGB value will not change the light brightness, only the color.
+| `xy_color` | yes | A list containing two floats representing the xy color you want the light to be. You can find a great chart here: [Hue Color Chart](https://developers.meethue.com/documentation/core-concepts#color_gets_more_complicated).
+| `rgb_color` | yes | A list containing three integers between 0 and 255 representing the RGB color you want the light to be. Note that the specified RGB value will not change the light brightness, only the color.
 | `white_value` | yes | Integer between 0 and 255 for how bright a dedicated white LED should be.
 | `color_temp` | yes | An integer in mireds representing the color temperature you want the light to be.
 | `kelvin` | yes | Alternatively, you can specify the color temperature in Kelvin.
@@ -47,6 +47,10 @@ Most lights do not support all attributes. You can check the integration documen
 
 <p class='note'>
 In order to apply attributes to an entity, you will need to add `data:` to the configuration. See example below
+</p>
+
+<p class='note'>
+`hs_color`, `xy_color` & `rgb_color` can also accept a string containing a comma separated list of numbers, which can be helpful when using templates. See example below
 </p>
 
 ```yaml
@@ -79,6 +83,26 @@ automation:
         brightness: 130
         rgb_color: [255,0,0]
 ```
+{% raw %}
+```yaml
+script:
+  rotate_rgb:
+    sequence:
+      - service: light.turn_on
+        data_template:
+          entity_id: "{{ entity_id }}"
+          brightness: "{{ brightness }}"
+          rgb_color: >
+            {% set r,g,b = state_attr(entity_id, 'rgb_color') %}
+            {% if r == 255 %}
+              0, 255, 0
+            {% elif g == 255 %}
+              0, 0, 255
+            {% else %}
+              255, 0, 0
+            {% endif %}
+```
+{% endraw %}
 
 ### Service `light.turn_off`
 


### PR DESCRIPTION
**Description:**
Allow string containing comma separated values for `light.turn_on` service's `rgb_color`, `hs_color` & `xy_color` attributes to make it easier to use templates.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25065

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9828"><img src="https://gitpod.io/api/apps/github/pbs/github.com/pnbruckner/home-assistant.io.git/7c74b8056518258670efa847b9b74e1c84c6b680.svg" /></a>

