### PR TITLE
Update dyson.markdown for the HP04 (new device) 

### DIFF
--- a/source/_components/dyson.markdown
+++ b/source/_components/dyson.markdown
@@ -178,6 +178,3 @@ Note: currently only the 2018 dyson fans are supported(TP04 and DP04).
 - Pure Cool link (desk and tower)
 - Pure Hot+cool link (see climate part) for thermal control
 - Pure Cool 2018 Models (TP04 and DP04)
-
-### Almost supported fan devices
-- Pure Hot+cool HP04 purifying heater + fan (see this [pull request](https://github.com/etheralm/libpurecool/pull/5))

--- a/source/_components/dyson.markdown
+++ b/source/_components/dyson.markdown
@@ -178,3 +178,6 @@ Note: currently only the 2018 dyson fans are supported(TP04 and DP04).
 - Pure Cool link (desk and tower)
 - Pure Hot+cool link (see climate part) for thermal control
 - Pure Cool 2018 Models (TP04 and DP04)
+
+### Almost supported fan devices
+- Pure Hot+cool HP04 purifying heater + fan (see this [pull request](https://github.com/etheralm/libpurecool/pull/5))


### PR DESCRIPTION
Add description explaining the Pure Hot+cool HP04 purifying heater + fan (dyson device nr 527) is under review for the dyson lib used by home-assistant

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9830"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jongep86/home-assistant.io.git/d8c4ef8647dc70f2c7a485b7aa1dcde281acb710.svg" /></a>

