### PR TITLE
Fix Google Assistant docs horizontal scroll

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -202,8 +202,7 @@ By default these cannot be opened by Google Assistant unless a `secure_devices_p
 ### Media Player Sources
 
 Media Player sources are sent via the Modes trait in Google Assistant.
-There is currently a limitation with this feature that requires a hard-coded set of settings. Because of this, the only sources that will be usable by this feature are listed here:
-https://developers.google.com/actions/reference/smarthome/traits/modes
+There is currently a limitation with this feature that requires a hard-coded set of settings. Because of this, the only sources that will be usable by this feature [are listed here](https://developers.google.com/actions/reference/smarthome/traits/modes).
 
 #### Example Command:
 


### PR DESCRIPTION
**Description:**

Fixes [Google Assistant docs](https://www.home-assistant.io/components/google_assistant/) horizontal scroll on iOS Mobile Safari.

**Before:**
![before screenshot](https://i.imgur.com/nzVOgVz.png)

**After:**
![after screenshot](https://i.imgur.com/4Z9rte8.png)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
