### PR TITLE
Add media data services to PS4

### DIFF
--- a/source/_components/ps4.markdown
+++ b/source/_components/ps4.markdown
@@ -124,7 +124,6 @@ Some titles will have different SKUs in the PlayStation Store database depending
 | Slovakia, Slovenia, South Africa, Spain, Sweden, Switzerland, Taiwan,       |                            |
 | Thailand, Turkey, United Arab Emirates, United Kingdom, United States       |                            |
 
-
 <p class='note'>
   The regions which are unavailable have no database or have formatting in the database which can not be used by the component.
 </p>
@@ -172,90 +171,72 @@ Full list of supported commands.
 
 Manually add media data to source list. Media data will be locked and not be updated automatically.
 
-| Service data attribute | Optional | Example                                 | Description                                    |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
-|                        |          |                                         | ID of the title. Must be specified if          |
-|                        |          |                                         | 'entity_id' is not specified.                  |
-| `media_title`          | No       | `A Title: The Name`                     | The name for the media title.                  |
-| `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an          |
-|                        |          |                                         | image that will be  displayed. You may         |
-|                        |          |                                         | use images in the local (/config/www/) folder. |
-| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'.    |
-|                        |          |                                         | Defaults to 'game'.                            |
+| Service data attribute | Optional | Example                                 | Description                                                                                                                 |
+| ---------------------- | -------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. Must be specified if 'entity_id' is not specified.                     |
+| `media_title`          | No       | `A Title: The Name`                     | The name for the media title.                                                                                               |
+| `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an image that will be  displayed. You may use images in the local (/config/www/) folder. |
+| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'. Defaults to 'game'.                                                             |
 
 ### Service `remove_media`
 
 Remove media data from source list.
 
-| Service data attribute | Optional | Example                                 | Description                                    |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
-|                        |          |                                         | ID of the title.                               |
+| Service data attribute | Optional | Example                                 | Description                                          |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. |
 
 ### Service `lock_media`
 
 Lock media data attributes to prevent automatic updates to media data. Media data will no longer be updated automatically.
 
-| Service data attribute | Optional | Example                                 | Description                                    |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
-|                        |          |                                         | ID of the title.                               |
+| Service data attribute | Optional | Example                                 | Description                                          |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. |                               |
 
 ### Service `lock_current_media`
 
 Lock the attributes of the media which is currently playing. Media data will no longer be updated automatically.
 
-| Service data attribute | Optional | Example                                 | Description                                    |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
-| `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media.              |
+| Service data attribute | Optional | Example                                 | Description                       |
+| ---------------------- | -------- | --------------------------------------- | --------------------------------- |
+| `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media. |
 
 ### Service `unlock_media`
 
 Unlock the attributes of the media which is currently playing. Media data will be updated automatically.
 
-| Service data attribute | Optional | Example                                 | Description                                    |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
-|                        |          |                                         | ID of the title.                               |
+| Service data attribute | Optional | Example                                 | Description                                          |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. | 
 
 ### Service `unlock_current_media`
 
 Unlock the attributes of the media which is currently playing. Media data will be updated automatically.
 
-| Service data attribute | Optional | Example                                 | Description                                    |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
-| `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media.              |
+| Service data attribute | Optional | Example                                 | Description                       |
+| ---------------------- | -------- | --------------------------------------- | --------------------------------- |
+| `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media. |
 
 ### Service `edit_media`
 
 Edit or correct media data attributes. Media data will be locked.
 
-| Service data attribute | Optional | Example                                 | Description                                    |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
-|                        |          |                                         | ID of the title. Must be specified if          |
-|                        |          |                                         | 'entity_id' is not specified.                  |
-| `media_title`          | Yes      | `A Title: The Name`                     | The name for the media title.                  |
-| `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an          |
-|                        |          |                                         | image that will be  displayed. You may         |
-|                        |          |                                         | use images in the local (/config/www/) folder. |
-| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'.    |
-|                        |          |                                         | Defaults to 'game'.                            |
+| Service data attribute | Optional | Example                                 | Description                                                                                                                 |
+| ---------------------- | -------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. Must be specified if 'entity_id' is not specified.                     |
+| `media_title`          | Yes      | `A Title: The Name`                     | The name for the media title.                                                                                               |
+| `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an image that will be  displayed. You may use images in the local (/config/www/) folder. |
+| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'. Defaults to 'game'.     
 
 ### Service `edit_current_media`
 
-Edit or correct media data attributes of the media which is currently playing. Media data will be locked.
-
-| Service data attribute | Optional | Example                                 | Description                                    |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
-| `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media.              |
-| `media_title`          | Yes      | `A Title: The Name`                     | The name for the media title.                  |
-| `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an          |
-|                        |          |                                         | image that will be  displayed. You may         |
-|                        |          |                                         | use images in the local (/config/www/) folder. |
-| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'.    |
-|                        |          |                                         | Defaults to 'game'.                            |
+| Service data attribute | Optional | Example                                 | Description                                                                                                                 |
+| ---------------------- | -------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media.                                                                                           |
+| `media_title`          | Yes      | `A Title: The Name`                     | The name for the media title.                                                                                               |
+| `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an image that will be  displayed. You may use images in the local (/config/www/) folder. |
+| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'. Defaults to 'game'.     
 
 ## Troubleshooting
 

--- a/source/_components/ps4.markdown
+++ b/source/_components/ps4.markdown
@@ -240,6 +240,58 @@ Edit or correct the attributes of the media which is currently playing. Media da
 | `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an image that will be  displayed. You may use images in the local (/config/www/) folder. |
 | `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'. Defaults to 'game'.                                                             |
 
+## Media Data
+Media data is stored when your PlayStation 4 console is playing a game or an app. The integration will automatically add the media to the source list for your PS4 entities when a new media is playing on your console. Data that is stored includes the PlayStation Store ID of the media, the title, and a url to the cover art of the media. Occasionally, the integration will not be able to retrieve the media data from the PlayStation Store. You may edit data that is incorrect by using services, or manually with a text editor.
+
+To edit data with a text editor:
+
+1. Backup a copy of the file if you don't want to lose your sources.
+2. Open the file in your configuration directory: `config/.ps4.games.json`
+
+3. Edit an entry. Example of an unedited file:
+```json
+{
+    "CUSA00129": {
+        "locked": false,
+        "media_content_type": "game",
+        "media_image_url": "https://google.com/image.jpg",
+        "media_title": "Netflix"
+    },
+    "CUSA00123": {
+        "locked": false,
+        "media_content_type": "game",
+        "media_image_url": null,
+        "media_title": "Something"
+    }
+}
+```
+Here we want to edit the entry with the "Netflix" title. We want to correct the "media_content_type" as it is not a game but actually an app.
+Also the image is not correct, so we will edit the "media_image_url". You can specify an image file saved in your `config/www/` directory as well as any valid remote url. To use a saved image file type in `"your/HA/IP/Address:yourport/local/thefile"`. See the example below if you need help.
+
+Make sure to not deviate from the format of these entries.
+To have the PS4 integration load your edited entry you must changed the "locked" value from "false" to "true". Example:
+
+```json
+{
+    "CUSA00129": {
+        "locked": true,
+        "media_content_type": "app",
+        "media_image_url": "http://localhost:8123/local/image.jpg",
+        "media_title": "Netflix"
+    },
+    "CUSA00123": {
+        "locked": false,
+        "media_content_type": "game",
+        "media_image_url": null,
+        "media_title": "Something"
+    }
+}
+```
+
+4. Restart your Home Assistant
+
+If issues arise you may delete the file but your entities will have no sources available until they are added again by the integration.
+
 ## Troubleshooting
 
 ### Cover Art Issues

--- a/source/_components/ps4.markdown
+++ b/source/_components/ps4.markdown
@@ -155,6 +155,108 @@ Full list of supported commands.
 | `left`   | Swipe Left       |
 | `right`  | Swipe Right      |
 
+## Media Data Services
+
+  The following services are provided to correct/edit the data for games and apps which the PS4 Integration displays/retrieves 
+  incorrectly or can not find.
+  
+  Each media title will have an attribute named `locked` with a value of `True` or `False` associated to it. If locked is True the data 
+  will not change automatically. You can set locked to True if you confirm that the details/attributes of the media title are correct.
+  Using services which edit the data of a media title, automatically set the locked  attribute to True. If locked is set to False, the
+  Integration will attempt to get the current media information from the PlayStation Store. 
+  
+  Items in the Playstation Store are continually changing. Games are often re-released which results in a slight modification to the
+  Title in addition to new cover art. Often the original game is replaced by the re-released version.
+
+### Service `add_media`
+
+Manually add media data to source list. Media data will be locked and not be updated automatically.
+
+| Service data attribute | Optional | Example                                 | Description                                    |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
+|                        |          |                                         | ID of the title. Must be specified if          |
+|                        |          |                                         | 'entity_id' is not specified.                  |
+| `media_title`          | No       | `A Title: The Name`                     | The name for the media title.                  |
+| `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an          |
+|                        |          |                                         | image that will be  displayed. You may         |
+|                        |          |                                         | use images in the local (/config/www/) folder. |
+| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'.    |
+|                        |          |                                         | Defaults to 'game'.                            |
+
+### Service `remove_media`
+
+Remove media data from source list.
+
+| Service data attribute | Optional | Example                                 | Description                                    |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
+|                        |          |                                         | ID of the title.                               |
+
+### Service `lock_media`
+
+Lock media data attributes to prevent automatic updates to media data. Media data will no longer be updated automatically.
+
+| Service data attribute | Optional | Example                                 | Description                                    |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
+|                        |          |                                         | ID of the title.                               |
+
+### Service `lock_current_media`
+
+Lock the attributes of the media which is currently playing. Media data will no longer be updated automatically.
+
+| Service data attribute | Optional | Example                                 | Description                                    |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
+| `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media.              |
+
+### Service `unlock_media`
+
+Unlock the attributes of the media which is currently playing. Media data will be updated automatically.
+
+| Service data attribute | Optional | Example                                 | Description                                    |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
+|                        |          |                                         | ID of the title.                               |
+
+### Service `unlock_current_media`
+
+Unlock the attributes of the media which is currently playing. Media data will be updated automatically.
+
+| Service data attribute | Optional | Example                                 | Description                                    |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
+| `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media.              |
+
+### Service `edit_media`
+
+Edit or correct media data attributes. Media data will be locked.
+
+| Service data attribute | Optional | Example                                 | Description                                    |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU            |
+|                        |          |                                         | ID of the title. Must be specified if          |
+|                        |          |                                         | 'entity_id' is not specified.                  |
+| `media_title`          | Yes      | `A Title: The Name`                     | The name for the media title.                  |
+| `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an          |
+|                        |          |                                         | image that will be  displayed. You may         |
+|                        |          |                                         | use images in the local (/config/www/) folder. |
+| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'.    |
+|                        |          |                                         | Defaults to 'game'.                            |
+
+### Service `edit_current_media`
+
+Edit or correct media data attributes of the media which is currently playing. Media data will be locked.
+
+| Service data attribute | Optional | Example                                 | Description                                    |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------- |
+| `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media.              |
+| `media_title`          | Yes      | `A Title: The Name`                     | The name for the media title.                  |
+| `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an          |
+|                        |          |                                         | image that will be  displayed. You may         |
+|                        |          |                                         | use images in the local (/config/www/) folder. |
+| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'.    |
+|                        |          |                                         | Defaults to 'game'.                            |
+
 ## Troubleshooting
 
 ### Cover Art Issues

--- a/source/_components/ps4.markdown
+++ b/source/_components/ps4.markdown
@@ -173,7 +173,7 @@ Manually add media data to source list. Media data will be locked and not be upd
 
 | Service data attribute | Optional | Example                                 | Description                                                                                                                 |
 | ---------------------- | -------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. Must be specified if 'entity_id' is not specified.                     |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title.                                                                        |
 | `media_title`          | No       | `A Title: The Name`                     | The name for the media title.                                                                                               |
 | `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an image that will be  displayed. You may use images in the local (/config/www/) folder. |
 | `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'. Defaults to 'game'.                                                             |
@@ -182,17 +182,17 @@ Manually add media data to source list. Media data will be locked and not be upd
 
 Remove media data from source list.
 
-| Service data attribute | Optional | Example                                 | Description                                          |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. |
+| Service data attribute | Optional | Example                                 | Description                                                                  |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. Must be in source list. |
 
 ### Service `lock_media`
 
 Lock media data attributes to prevent automatic updates to media data. Media data will no longer be updated automatically.
 
-| Service data attribute | Optional | Example                                 | Description                                          |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. |                               |
+| Service data attribute | Optional | Example                                 | Description                                                                  |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. Must be in source list. |
 
 ### Service `lock_current_media`
 
@@ -206,9 +206,9 @@ Lock the attributes of the media which is currently playing. Media data will no 
 
 Unlock the attributes of the media which is currently playing. Media data will be updated automatically.
 
-| Service data attribute | Optional | Example                                 | Description                                          |
-| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. | 
+| Service data attribute | Optional | Example                                 | Description                                                                  |
+| ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------------------------------- |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. Must be in source list. | 
 
 ### Service `unlock_current_media`
 
@@ -224,7 +224,7 @@ Edit or correct media data attributes. Media data will be locked.
 
 | Service data attribute | Optional | Example                                 | Description                                                                                                                 |
 | ---------------------- | -------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. Must be specified if 'entity_id' is not specified.                     |
+| `media_content_id`     | No       | `CUSA00123`                             | The ID or the PlayStation Store SKU ID of the title. Must be in source list.                                                |
 | `media_title`          | Yes      | `A Title: The Name`                     | The name for the media title.                                                                                               |
 | `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an image that will be  displayed. You may use images in the local (/config/www/) folder. |
 | `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'. Defaults to 'game'.     
@@ -236,7 +236,7 @@ Edit or correct media data attributes. Media data will be locked.
 | `entity_id`            | No       | `media_player.playstation_4`            | The entity that is playing media.                                                                                           |
 | `media_title`          | Yes      | `A Title: The Name`                     | The name for the media title.                                                                                               |
 | `media_image_url`      | Yes      | `http://localhost:8123/local/image.jpg` | A remote or local URL directing to an image that will be  displayed. You may use images in the local (/config/www/) folder. |
-| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'. Defaults to 'game'.     
+| `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'. Defaults to 'game'.                                                             |
 
 ## Troubleshooting
 

--- a/source/_components/ps4.markdown
+++ b/source/_components/ps4.markdown
@@ -188,7 +188,7 @@ Remove media data from source list.
 
 ### Service `lock_media`
 
-Lock media data attributes to prevent automatic updates to media data. Media data will no longer be updated automatically.
+Lock media data attributes to prevent automatic updates to media data. Media data will be locked and not be updated automatically.
 
 | Service data attribute | Optional | Example                                 | Description                                                                  |
 | ---------------------- | -------- | --------------------------------------- | ---------------------------------------------------------------------------- |
@@ -196,7 +196,7 @@ Lock media data attributes to prevent automatic updates to media data. Media dat
 
 ### Service `lock_current_media`
 
-Lock the attributes of the media which is currently playing. Media data will no longer be updated automatically.
+Lock the attributes of the media which is currently playing. Media data will be locked and not be updated automatically.
 
 | Service data attribute | Optional | Example                                 | Description                       |
 | ---------------------- | -------- | --------------------------------------- | --------------------------------- |
@@ -220,7 +220,7 @@ Unlock the attributes of the media which is currently playing. Media data will b
 
 ### Service `edit_media`
 
-Edit or correct media data attributes. Media data will be locked.
+Edit or correct media data attributes. Media data will be locked and not be updated automatically.
 
 | Service data attribute | Optional | Example                                 | Description                                                                                                                 |
 | ---------------------- | -------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
@@ -230,6 +230,8 @@ Edit or correct media data attributes. Media data will be locked.
 | `media_content_type`   | Yes      | `Game`                                  | The type of media. Must be 'game' or 'app'. Defaults to 'game'.     
 
 ### Service `edit_current_media`
+
+Edit or correct the attributes of the media which is currently playing. Media data will be locked and not be updated automatically.
 
 | Service data attribute | Optional | Example                                 | Description                                                                                                                 |
 | ---------------------- | -------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
**Description:**
Add documentation for media data services.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25084

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9840"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ktnrg45/home-assistant.io.git/0dbbe7a3daa9fb38b5f02a2e328cc91d9d02d6e6.svg" /></a>

