### PR TITLE
Documentation for serial_sensor updated with more examples

### DIFF
--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -22,12 +22,14 @@ sudo minicom -D /dev/ttyACM0
 
 To setup a serial sensor to your installation, add the following to your `configuration.yaml` file:
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 sensor:
   - platform: serial
     serial_port: /dev/ttyACM0
 ```
+{% endraw %}
 
 {% configuration %}
 serial_port:
@@ -67,7 +69,7 @@ For controllers of the Arduino family, a possible sketch to read the temperature
 #include <ArduinoJson.h>
 
 void setup() {
-  Serial.begin(9600);
+  Serial.begin(115200);
 }
 
 void loop() {

--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -22,14 +22,13 @@ sudo minicom -D /dev/ttyACM0
 
 To setup a serial sensor to your installation, add the following to your `configuration.yaml` file:
 
-{% raw %}
+
 ```yaml
 # Example configuration.yaml entry
 sensor:
   - platform: serial
     serial_port: /dev/ttyACM0
 ```
-{% endraw %}
 
 {% configuration %}
 serial_port:
@@ -55,9 +54,11 @@ value_template:
 
 ### TMP36
 
+{% raw %}
 ```yaml
 "{{ (((states('sensor.serial_sensor') | float * 5 / 1024 ) - 0.5) * 100) | round(1) }}"
 ```
+{% endraw %}
 
 ## Examples
 

--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -94,22 +94,19 @@ For controllers of the Arduino family a possible sketch to read the temperature 
 #include <ArduinoJson.h>
 
 void setup() {
-  Serial.begin(115200);
+  Serial.begin(9600);
 }
 
 void loop() {
-  StaticJsonBuffer<100> jsonBuffer;
-  JsonObject& json = prepareResponse(jsonBuffer);
-  json.printTo(Serial);
-  Serial.println();
-  delay(2000);
-}
+  StaticJsonDocument<100> jsonBuffer;
 
-JsonObject& prepareResponse(JsonBuffer& jsonBuffer) {
-  JsonObject& root = jsonBuffer.createObject();
-  root["temperature"] = analogRead(A0);
-  root["humidity"] = analogRead(A1);
-  return root;
+  jsonBuffer["temperature"] = analogRead(A0);
+  jsonBuffer["humidity"] = analogRead(A1);
+
+  serializeJson(jsonBuffer, Serial);
+  Serial.println();
+  
+  delay(1000);
 }
 ```
 

--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -53,23 +53,23 @@ value_template:
 
 ### TMP36
 
-{% raw %}
 ```yaml
 "{{ (((states('sensor.serial_sensor') | float * 5 / 1024 ) - 0.5) * 100) | round(1) }}"
 ```
-{% endraw %}
+
+## Examples
 
 ### Devices returning multiple sensors as a single string
 
-For devices that return multiple sensors as a concatenated string of values, but are not json formatted you can split the string into an array of items, then make each item in the array a separate sensor using templates.  This is useful for devices such as the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800).
+For devices that return multiple sensors as a concatenated string of values, (but are not json formatted) you can split the string into an array of items, then make each item in the array a separate sensor using templates.  This is useful for devices such as the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800).
 
-configuration.yaml can be set up as shown:
-{% raw %}
 ```yaml
+# Example configuration.yaml entry
+sensor:
   - platform: serial
     serial_port: /dev/ttyUSB0
     baudrate: 9600
-
+ 
   - platform: template
     sensors:
       my_temperature_sensor:
@@ -85,9 +85,6 @@ configuration.yaml can be set up as shown:
         unit_of_measurement: "mbar"
         value_template: "{{ states('sensor.serial_sensor').split(',')[4] | float }}"
 ```
-{% endraw %}
-
-## Examples
 
 ### Arduino
 

--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -59,9 +59,33 @@ value_template:
 
 ## Examples
 
-### Devices returning multiple sensors as a single string
+### Arduino with .json over serial
 
-For devices that return multiple sensors as a concatenated string of values, (but are not json formatted) you can split the string into an array of items, then make each item in the array a separate sensor using templates.  This is useful for devices such as the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800).
+For controllers of the Arduino family, a possible sketch to read the temperature and the humidity could look like the sample below.  The returned data is in json format and can be split into the individual sensor values using a [template](/docs/configuration/templating/#processing-incoming-data).
+
+```c
+#include <ArduinoJson.h>
+
+void setup() {
+  Serial.begin(9600);
+}
+
+void loop() {
+  StaticJsonDocument<100> jsonBuffer;
+
+  jsonBuffer["temperature"] = analogRead(A0);
+  jsonBuffer["humidity"] = analogRead(A1);
+
+  serializeJson(jsonBuffer, Serial);
+  Serial.println();
+  
+  delay(1000);
+}
+```
+
+### Devices returning multiple sensors as a text string
+
+For devices that return multiple sensors as a concatenated string of values with comma delimiting, (i.e., the returned string is not json formatted) you can make several template sensors, all using the same serial response.  First, the serial_sensor response is split using the comma delimiter, and then an item in the array is used.  This is useful for devices such as the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800).
 
 ```yaml
 # Example configuration.yaml entry
@@ -84,30 +108,6 @@ sensor:
         friendly_name: Barometer
         unit_of_measurement: "mbar"
         value_template: "{{ states('sensor.serial_sensor').split(',')[4] | float }}"
-```
-
-### Arduino
-
-For controllers of the Arduino family a possible sketch to read the temperature and the humidity could look like the sample below.
-
-```c
-#include <ArduinoJson.h>
-
-void setup() {
-  Serial.begin(9600);
-}
-
-void loop() {
-  StaticJsonDocument<100> jsonBuffer;
-
-  jsonBuffer["temperature"] = analogRead(A0);
-  jsonBuffer["humidity"] = analogRead(A1);
-
-  serializeJson(jsonBuffer, Serial);
-  Serial.println();
-  
-  delay(1000);
-}
 ```
 
 ### Digispark USB Development Board

--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -59,6 +59,34 @@ value_template:
 ```
 {% endraw %}
 
+### Devices returning multiple sensors as a single string
+
+For devices that return multiple sensors as a concatenated string of values, but are not json formatted you can split the string into an array of items, then make each item in the array a separate sensor using templates.  This is useful for devices such as the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800).
+
+configuration.yaml can be set up as shown:
+{% raw %}
+```yaml
+  - platform: serial
+    serial_port: /dev/ttyUSB0
+    baudrate: 9600
+
+  - platform: template
+    sensors:
+      my_temperature_sensor:
+        friendly_name: Temperature
+        unit_of_measurement: "°C"
+        value_template: "{{ states('sensor.serial_sensor').split(',')[1] | float }}"
+      my_humidity_sensor:
+        friendly_name: Humidity
+        unit_of_measurement: "%"
+        value_template: "{{ states('sensor.serial_sensor').split(',')[2] | float }}"
+      my_barometer:
+        friendly_name: Barometer
+        unit_of_measurement: "mbar"
+        value_template: "{{ states('sensor.serial_sensor').split(',')[4] | float }}"
+```
+{% endraw %}
+
 ## Examples
 
 ### Arduino


### PR DESCRIPTION
**Description:**
Arduino example fixed to match v6 of ArduinoJson.
Added example of a serial string and using .split to convert 1 serail string to multiple sensors.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9844"><img src="https://gitpod.io/api/apps/github/pbs/github.com/surlymatt/home-assistant.io.git/c9c55cc82c9add65c75fc60cfaa3504329a0bb82.svg" /></a>

