### PR TITLE
serial_sensor Added splitting string example,  fixed Arduino ex

### DIFF
--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -61,9 +61,9 @@ value_template:
 
 ## Examples
 
-### Arduino with .json over serial
+### Arduino
 
-For controllers of the Arduino family, a possible sketch to read the temperature and the humidity could look like the sample below.  The returned data is in json format and can be split into the individual sensor values using a [template](/docs/configuration/templating/#processing-incoming-data).
+For controllers of the Arduino family, a possible sketch to read the temperature and the humidity could look like the sample below.The returned data is in JSON format and can be split into the individual sensor values using a [template](/docs/configuration/templating/#processing-incoming-data).
 
 ```c
 #include <ArduinoJson.h>
@@ -87,14 +87,14 @@ void loop() {
 
 ### Devices returning multiple sensors as a text string
 
-For devices that return multiple sensors as a concatenated string of values with a delimiter, (i.e., the returned string is not json formatted) you can make several template sensors, all using the same serial response.  For example, a stream from the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800) includes temperature, humidity and barometric pressure within it returned text string.  Sample returned data:
+For devices that return multiple sensors as a concatenated string of values with a delimiter, (i.e., the returned string is not JSON formatted) you can make several template sensors, all using the same serial response. For example, a stream from the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800) includes temperature, humidity and barometric pressure within it returned text string. Sample returned data:
 
 ```c
 $,24.1,50,12.9,1029.83,0.0,0.00,*
 $,24.3,51,12.8,1029.76,0.0,0.00,*
 ```
 
-To parse this into individual sensors, split using the comma delimiter, and then create a template sensor for each item of interest.
+To parse this into individual sensors, split using the comma delimiter and then create a template sensor for each item of interest.
 
 {% raw %}
 ```yaml

--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -87,7 +87,14 @@ void loop() {
 
 ### Devices returning multiple sensors as a text string
 
-For devices that return multiple sensors as a concatenated string of values with comma delimiting, (i.e., the returned string is not json formatted) you can make several template sensors, all using the same serial response.  First, the serial_sensor response is split using the comma delimiter, and then an item in the array is used.  This is useful for devices such as the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800).
+For devices that return multiple sensors as a concatenated string of values with a delimiter, (i.e., the returned string is not json formatted) you can make several template sensors, all using the same serial response.  For example, a stream from the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800) includes temperature, humidity and barometric pressure within it returned text string.  Sample returned data:
+
+```c
+$,24.1,50,12.9,1029.83,0.0,0.00,*
+$,24.3,51,12.8,1029.76,0.0,0.00,*
+```
+
+To parse this into individual sensors, split using the comma delimiter, and then create a template sensor for each item of interest.
 
 {% raw %}
 ```yaml

--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -53,9 +53,11 @@ value_template:
 
 ### TMP36
 
+{% raw %}
 ```yaml
-"{% raw %}{{ (((states('sensor.serial_sensor') | float * 5 / 1024 ) - 0.5) * 100) | round(1) }}{% endraw %}"
+"{{ (((states('sensor.serial_sensor') | float * 5 / 1024 ) - 0.5) * 100) | round(1) }}"
 ```
+{% endraw %}
 
 ## Examples
 
@@ -87,6 +89,7 @@ void loop() {
 
 For devices that return multiple sensors as a concatenated string of values with comma delimiting, (i.e., the returned string is not json formatted) you can make several template sensors, all using the same serial response.  First, the serial_sensor response is split using the comma delimiter, and then an item in the array is used.  This is useful for devices such as the [Sparkfun USB Weather Board](https://www.sparkfun.com/products/retired/9800).
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 sensor:
@@ -99,16 +102,17 @@ sensor:
       my_temperature_sensor:
         friendly_name: Temperature
         unit_of_measurement: "°C"
-        value_template: "{% raw %}{{ states('sensor.serial_sensor').split(',')[1] | float }}{% endraw %}"
+        value_template: "{{ states('sensor.serial_sensor').split(',')[1] | float }}"
       my_humidity_sensor:
         friendly_name: Humidity
         unit_of_measurement: "%"
-        value_template: "{% raw %}{{ states('sensor.serial_sensor').split(',')[2] | float }}{% endraw %}"
+        value_template: "{{ states('sensor.serial_sensor').split(',')[2] | float }}"
       my_barometer:
         friendly_name: Barometer
         unit_of_measurement: "mbar"
-        value_template: "{% raw %}{{ states('sensor.serial_sensor').split(',')[4] | float }}{% endraw %}"
+        value_template: "{{ states('sensor.serial_sensor').split(',')[4] | float }}"
 ```
+{% endraw %}
 
 ### Digispark USB Development Board
 

--- a/source/_components/serial.markdown
+++ b/source/_components/serial.markdown
@@ -22,7 +22,6 @@ sudo minicom -D /dev/ttyACM0
 
 To setup a serial sensor to your installation, add the following to your `configuration.yaml` file:
 
-
 ```yaml
 # Example configuration.yaml entry
 sensor:
@@ -54,11 +53,9 @@ value_template:
 
 ### TMP36
 
-{% raw %}
 ```yaml
-"{{ (((states('sensor.serial_sensor') | float * 5 / 1024 ) - 0.5) * 100) | round(1) }}"
+"{% raw %}{{ (((states('sensor.serial_sensor') | float * 5 / 1024 ) - 0.5) * 100) | round(1) }}{% endraw %}"
 ```
-{% endraw %}
 
 ## Examples
 
@@ -96,21 +93,21 @@ sensor:
   - platform: serial
     serial_port: /dev/ttyUSB0
     baudrate: 9600
- 
+
   - platform: template
     sensors:
       my_temperature_sensor:
         friendly_name: Temperature
         unit_of_measurement: "°C"
-        value_template: "{{ states('sensor.serial_sensor').split(',')[1] | float }}"
+        value_template: "{% raw %}{{ states('sensor.serial_sensor').split(',')[1] | float }}{% endraw %}"
       my_humidity_sensor:
         friendly_name: Humidity
         unit_of_measurement: "%"
-        value_template: "{{ states('sensor.serial_sensor').split(',')[2] | float }}"
+        value_template: "{% raw %}{{ states('sensor.serial_sensor').split(',')[2] | float }}{% endraw %}"
       my_barometer:
         friendly_name: Barometer
         unit_of_measurement: "mbar"
-        value_template: "{{ states('sensor.serial_sensor').split(',')[4] | float }}"
+        value_template: "{% raw %}{{ states('sensor.serial_sensor').split(',')[4] | float }}{% endraw %}"
 ```
 
 ### Digispark USB Development Board


### PR DESCRIPTION
**Description:**

Added example of splitting a string response to an array, and creating multiple template sensors from it.
Fixed the arduino example to work with the latest ArduinoJson V6

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9845"><img src="https://gitpod.io/api/apps/github/pbs/github.com/surlymatt/home-assistant.io.git/e621c60c7ca731f227219911091d53d75e006f96.svg" /></a>

