### PR TITLE
Correct ' and " in the sun template example

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -144,15 +144,15 @@ condition:
     condition: and  # 'twilight' condition: dusk and dawn, in typical locations
     conditions:
       - condition: template
-        value_template: {% raw %}'{{ state_attr('sun.sun', 'elevation') < 0 }}'{% endraw %}
+        value_template: {% raw %}'{{ state_attr("sun.sun", "elevation") < 0 }}'{% endraw %}
       - condition: template
-        value_template: {% raw %}'{{ state_attr('sun.sun', 'elevation') > -6 }}'{% endraw %}
+        value_template: {% raw %}'{{ state_attr("sun.sun", "elevation") > -6 }}'{% endraw %}
 ```
 
 ```yaml
 condition:
     condition: template  # 'night' condition: from dusk to dawn, in typical locations
-    value_template: {% raw %}'{{ state_attr('sun.sun', 'elevation') < -6 }}'{% endraw %}
+    value_template: {% raw %}'{{ state_attr("sun.sun", "elevation") < -6 }}'{% endraw %}
 ```
 
 #### Sunset/sunrise condition


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9846"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Molodax/home-assistant.github.io.git/75d78c110ae1582a2e9deb968b5156ed86586210.svg" /></a>

