### PR TITLE
state trigger - entity_id details

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -102,7 +102,7 @@ automation:
 
 ### State trigger
 
-Triggers when the state of a given entity changes. If only `entity_id` is given trigger will activate for all state changes, even if only state attributes change.
+Triggers when the state of any of given entities changes (mapping can be used as explained [here](/docs/configuration/yaml/)). If only `entity_id` is given trigger will activate for all state changes, even if only state attributes change.
 
 ```yaml
 automation:

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -102,7 +102,7 @@ automation:
 
 ### State trigger
 
-Triggers when the state of any of given entities changes (mapping can be used as explained [here](/docs/configuration/yaml/)). If only `entity_id` is given trigger will activate for all state changes, even if only state attributes change.
+Triggers when the state of any of given entities changes. If only `entity_id` is given trigger will activate for all state changes, even if only state attributes change.
 
 ```yaml
 automation:


### PR DESCRIPTION
I think it would be beneficial to underline in text that it is possible to use multiple entities in entity_id.
Not sure if it is applicable to any other triggers that accept entity_id (like numeric_state)

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9850"><img src="https://gitpod.io/api/apps/github/pbs/github.com/akasma74/home-assistant.io.git/9f36f7967435bfc4fa165db3f34fe14a1212f0f6.svg" /></a>

