### PR TITLE
Add add_torrent service to Transmission

### DIFF
--- a/source/_components/transmission.markdown
+++ b/source/_components/transmission.markdown
@@ -116,3 +116,13 @@ Example of configuration of an automation with completed torrents:
       title: "Torrent completed!"
       message: "{{trigger.event.data.name}}"
 ```
+
+## Services
+
+### Service `add_torrent`
+
+Adds a new torrent to download. It can either be a URL, magnet link or a Base64 encoded .bittorrent file.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `torrent` | no | Torrent to download

--- a/source/_components/transmission.markdown
+++ b/source/_components/transmission.markdown
@@ -121,7 +121,7 @@ Example of configuration of an automation with completed torrents:
 
 ### Service `add_torrent`
 
-Adds a new torrent to download. It can either be a URL, magnet link or a Base64 encoded .bittorrent file.
+Adds a new torrent to download. It can either be a URL (http, https or ftp), magnet link or a local file (make sure that the path is white listed).
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION
**Description:**
Added short description about the new `add_torrent` service in Transmission.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25144

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9854"><img src="https://gitpod.io/api/apps/github/pbs/github.com/postlund/home-assistant.github.io.git/23e6a39e2d537b4ff4a3662b6606872098917543.svg" /></a>

