### PR TITLE
Update Homekit Docs

### DIFF
--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -37,12 +37,6 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor (HomeKit motion sensors)
 - Sensor (HomeKit humidity, temperature, and light level sensors)
 
-The integration will be automatically configured if the [`discovery:`](/components/discovery/) integration is enabled and an enable entry added for HomeKit:
-
-```yaml
-discovery:
-  enable:
-    - homekit
-```
+The integration will be automatically configured if the [`discovery:`](/components/discovery/) integration is enabled
 
 For each detected HomeKit accessory, a configuration prompt will appear in the web front end. Use this to provide the HomeKit PIN. Note that HomeKit accessories can only be paired to one device at once. If your device is currently paired with Siri, you will need to reset it in order to pair it with Home Assistant. Once Home Assistant is configured to work with the device, you can export it back to Siri with the [`HomeKit`](/components/homekit/) component.

--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -37,6 +37,6 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor (HomeKit motion sensors)
 - Sensor (HomeKit humidity, temperature, and light level sensors)
 
-The integration will be automatically configured if the [`discovery:`](/components/discovery/) integration is enabled
+The integration will be automatically configured if the [`discovery`](/components/discovery/) integration is enabled.
 
 For each detected HomeKit accessory, a configuration prompt will appear in the web front end. Use this to provide the HomeKit PIN. Note that HomeKit accessories can only be paired to one device at once. If your device is currently paired with Siri, you will need to reset it in order to pair it with Home Assistant. Once Home Assistant is configured to work with the device, you can export it back to Siri with the [`HomeKit`](/components/homekit/) component.


### PR DESCRIPTION
**Description:**

Homeassistant 0.95.x throws warning "Please remove homekit from your discovery.enable configuration as it is now enabled by default" if enable homekit is added to discovery component

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9858"><img src="https://gitpod.io/api/apps/github/pbs/github.com/J3n50m4t/home-assistant.io.git/20087e519d0f5709cf714eacebfd951a0521f87d.svg" /></a>

