### PR TITLE
Update mitemp_bt component documentation

### DIFF
--- a/source/_components/mitemp_bt.markdown
+++ b/source/_components/mitemp_bt.markdown
@@ -81,7 +81,7 @@ name:
 force_update:
   description: Sends update events even if the value hasn't changed.
   required: false
-  default: False
+  default: false
   type: boolean
 median:
   description: "Sometimes the sensor measurements show spikes. Using this parameter, the poller will report the median of the last 3 (you can also use larger values) measurements. This filters out single spikes. Median: 5 will also filter double spikes. If you never have problems with spikes, `median: 1` will work fine."

--- a/source/_components/mitemp_bt.markdown
+++ b/source/_components/mitemp_bt.markdown
@@ -81,10 +81,12 @@ name:
 force_update:
   description: Sends update events even if the value hasn't changed.
   required: false
+  default: False
   type: boolean
 median:
   description: "Sometimes the sensor measurements show spikes. Using this parameter, the poller will report the median of the last 3 (you can also use larger values) measurements. This filters out single spikes. Median: 5 will also filter double spikes. If you never have problems with spikes, `median: 1` will work fine."
   required: false
+  default: 3
   type: integer
 timeout:
   description: Define the timeout value in seconds when polling.
@@ -121,7 +123,8 @@ sensor:
   - platform: mitemp_bt
     mac: 'xx:xx:xx:xx:xx:xx'
     name: Kids Room Temp
-    force_up    median: 3
+    force_update: true
+    median: 1
     monitored_conditions:
       - temperature
       - humidity


### PR DESCRIPTION
**Description:**
Fixed the full example and added the default values for `force_update` and `median`.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9859"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ferdinand/home-assistant.io.git/50162d436da4ecf9efdedc3c5f2e96af75359bbf.svg" /></a>

