### PR TITLE
Add homekit reset accessory

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -110,11 +110,11 @@ homekit:
             type: map
             keys:
               name:
-                description: Name of the entity to show in HomeKit. HomeKit will cache the name on the first run so a device must be removed and then re-added for any change to take effect.
+                description: Name of the entity to show in HomeKit. HomeKit will cache the name on the first run so the accessory must be [reset](#resetting-accessories) for any change to take effect.
                 required: false
                 type: string
               linked_battery_sensor:
-                description: The `entity_id` of a `sensor` entity to use as the battery of the accessory. HomeKit will cache an accessory's feature set on the first run so a device must be removed and then re-added for any change to take effect.
+                description: The `entity_id` of a `sensor` entity to use as the battery of the accessory. HomeKit will cache an accessory's feature set on the first run so a device must be [reset](#resetting-accessories) for any change to take effect.
                 required: false
                 type: string
               low_battery_threshold:
@@ -137,7 +137,7 @@ homekit:
                     required: true
                     type: string
               type:
-                description: Only for `switch` entities. Type of accessory to be created within HomeKit. Valid types are `faucet`, `outlet`, `shower`, `sprinkler`, `switch` and `valve`. HomeKit will cache the type on the first run so a device must be removed and then re-added for any change to take effect.
+                description: Only for `switch` entities. Type of accessory to be created within HomeKit. Valid types are `faucet`, `outlet`, `shower`, `sprinkler`, `switch` and `valve`. HomeKit will cache the type on the first run so a device must be [reset](#resetting-accessories) for any change to take effect.
                 required: false
                 type: string
                 default: '`switch`'
@@ -452,12 +452,20 @@ To fix this, you need to unpair the `Home Assistant Bridge`, delete the `.homeki
 
 #### The linked battery sensor isn't recognized
 
-Try removing the entity from HomeKit and then adding it again. If you are adding this config option to an existing entity in HomeKit, any changes you make to this entity's config options won't appear until the accessory is removed from HomeKit and then re-added.
+Try removing the entity from HomeKit and then adding it again. If you are adding this config option to an existing entity in HomeKit, any changes you make to this entity's config options won't appear until the accessory is removed from HomeKit and then re-added. See [resetting accessories](#resetting-accessories).
 
 #### My media player is not showing up as a television accessory
 
-Media Player entities with `device_class: tv` will show up as Television accessories on  devices running iOS 12.2/macOS 10.14.4 or later. If needed, try removing the entity from HomeKit and then adding it again, especially if the `media_player` was previously exposed as a series of switches. Any changes, including changed supported features, made to an existing accessory won't appear until the accessory is removed from HomeKit and then re-added.
+Media Player entities with `device_class: tv` will show up as Television accessories on  devices running iOS 12.2/macOS 10.14.4 or later. If needed, try removing the entity from HomeKit and then adding it again, especially if the `media_player` was previously exposed as a series of switches. Any changes, including changed supported features, made to an existing accessory won't appear until the accessory is removed from HomeKit and then re-added. See [resetting accessories](#resetting-accessories).
 
 #### Can't control volume of your TV media player?
 
 The volume and play/pause controls will show up on the Remote app or Control Center. If your TV supports volume control through Home Assistant, you will be able to control the volume using the side volume buttons on the device while having the remote selected on screen.
+
+#### {% linkable_title Resetting accessories %}
+
+On Home Assistant `0.97.x` or later, you may use the service `homekit.reset_accessory` with one or more entity_ids to reset accessories whose configuration may have changed. This can be useful when changing a media_player's device class to `tv`, linking a battery, or whenever HomeAssistant add supports for new HomeKit features to existing entities.
+
+On earlier versions of Home Assistant, you can reset accessories by removing the entity from HomeKit (via [filter](#configure-filter)) and then re-adding the accessory.
+
+With either strategy, the accessory will behave as if it's the first time the accessory has been setup, so you will need to restore name, group, room, scene, and/or automation settings.

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -462,7 +462,7 @@ Media Player entities with `device_class: tv` will show up as Television accesso
 
 The volume and play/pause controls will show up on the Remote app or Control Center. If your TV supports volume control through Home Assistant, you will be able to control the volume using the side volume buttons on the device while having the remote selected on screen.
 
-#### {% linkable_title Resetting accessories %}
+#### Resetting accessories
 
 On Home Assistant `0.97.x` or later, you may use the service `homekit.reset_accessory` with one or more entity_ids to reset accessories whose configuration may have changed. This can be useful when changing a media_player's device class to `tv`, linking a battery, or whenever HomeAssistant add supports for new HomeKit features to existing entities.
 

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -468,4 +468,4 @@ On Home Assistant `0.97.x` or later, you may use the service `homekit.reset_acce
 
 On earlier versions of Home Assistant, you can reset accessories by removing the entity from HomeKit (via [filter](#configure-filter)) and then re-adding the accessory.
 
-With either strategy, the accessory will behave as if it's the first time the accessory has been setup, so you will need to restore name, group, room, scene, and/or automation settings.
+With either strategy, the accessory will behave as if it's the first time the accessory has been set up, so you will need to restore the name, group, room, scene, and/or automation settings.


### PR DESCRIPTION
**Description:**

One pain point currently when changing an accessory's services. Currently, the flow looks like this:

Start HomeAssistant with the newly added capability, such as device_class:tv, an entity_config change, or any other services that may change in the future due to HA changes.
Sadly realize the accessory has to be reset.
Exclude the device in the HomeKit filter.
Restart HA.
Include the device in the HomeKit filter.
Restart HA.
With this PR, this flow changes to this:

Start HomeAssistant with the newly added capability, such as device_class:tv, an entity_config change, or any other services that may change in the future due to HA changes.
Issue service call homekit.reset_accessory with the list of entity ids of accessories to be reset.
This should make the docs a bit simpler too, since we can add a section about resetting accessories and then reference that section throughout.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25158

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9860"><img src="https://gitpod.io/api/apps/github/pbs/github.com/adrum/home-assistant.io.git/50891c2d04b6a61a7f36c309b6bffad983596c19.svg" /></a>

