### PR TITLE
Highlight that live view isn't possible.

### DIFF
--- a/source/_components/ring.markdown
+++ b/source/_components/ring.markdown
@@ -25,6 +25,10 @@ There is currently support for the following device types within Home Assistant:
 
 Currently only doorbells are supported by this sensor.
 
+<p class='note'>
+This component does NOT allow for live viewing of your Ring camera within Home Assistant.
+</p>
+
 ## Configuration
 
 To enable device linked in your [Ring.com](https://ring.com/) account, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**
Highlight that Ring integration in HA will not provide a live view


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9862"><img src="https://gitpod.io/api/apps/github/pbs/github.com/KaiboshOz/home-assistant.github.io.git/4dbea9755e332f0519fb339348a607e80c573b33.svg" /></a>

