### PR TITLE
Fix typo in Glances doc

### DIFF
--- a/source/_components/glances.markdown
+++ b/source/_components/glances.markdown
@@ -32,7 +32,7 @@ $ curl -X GET http://IP_ADDRESS:61208/api/2/mem/free
 {"free": 203943936}
 ```
 
-If this doesn't work, try changing the `2` for `3`, if you have installed the latest verison of Glances.
+If this doesn't work, try changing the `2` for `3`, if you have installed the latest version of Glances.
 
 For details about auto-starting `glances`, please refer to [Start Glances through Systemd](https://github.com/nicolargo/glances/wiki/Start-Glances-through-Systemd).
 


### PR DESCRIPTION
**Description:**
Fix typo


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9865"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SNoof85/home-assistant.io.git/a720cc06e01533c60c7758c252275f3cfc485c10.svg" /></a>

