### PR TITLE
Fix atom.xml Issue #9861

### DIFF
--- a/source/atom.xml
+++ b/source/atom.xml
@@ -1,4 +1,5 @@
 ---
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
This fixes the invalid element name error that is described in issue #9861

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9867"><img src="https://gitpod.io/api/apps/github/pbs/github.com/bradleywehmeier/home-assistant.io.git/d457c8df467c6b4293710471b49e72b67a53425c.svg" /></a>

