### PR TITLE
Removes outdated example configs

### DIFF
--- a/source/_cookbook/configuration_yaml_by_fredsmith.markdown
+++ b/source/_cookbook/configuration_yaml_by_fredsmith.markdown
@@ -1,7 +1,0 @@
----
-title: "Configuration.yaml by fredsmith"
-description: ""
-ha_category: Example configuration.yaml
-ha_external_link: https://git.smith.bz/derf/homeautomation
----
-

--- a/source/_cookbook/configuration_yaml_by_mf_social.markdown
+++ b/source/_cookbook/configuration_yaml_by_mf_social.markdown
@@ -1,6 +1,0 @@
----
-title: "Configuration.yaml by mf_social"
-description: ""
-ha_category: Example configuration.yaml
-ha_external_link: https://github.com/mf-social/Home-Assistant
----


### PR DESCRIPTION
**Description:**

Removed config of:

- `fredsmith` not updated in 7 months
- `mf_social` archived.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9868"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/abe65a9fe0278632607240d22f6927fe831e47a8.svg" /></a>

