### PR TITLE
Update hvac_mode attributes

### DIFF
--- a/source/_components/climate.knx.markdown
+++ b/source/_components/climate.knx.markdown
@@ -72,9 +72,11 @@ climate:
 The following values are valid for the `hvac_mode` attribute:
 
 - Off (maps internally to HVAC_MODE_OFF within Home Assistant)
+- Auto (maps internally to HVAC_MODE_AUTO within Home Assistant)
 - Heat (maps internally to HVAC_MDOE_HEAT within Home Assistant)
+- Cool (maps internally to HVAC_MDOE_COOL within Home Assistant)
 - Fan only (maps internally to HVAC_MODE_FAN_ONLY within Home Assistant)
-- Dehumidification (maps internally to HVAC_MODE_DRY within Home Assistant)
+- Dry (maps internally to HVAC_MODE_DRY within Home Assistant)
 
 The following presets are valid for the `preset_mode` attribute:
 


### PR DESCRIPTION
Added missing attributes according to commit https://github.com/home-assistant/home-assistant/pull/25069/commits/abe62039882bed6ac8ae9b5087733cad90cc0228
I think we must add explanation for `hvac_mode` and `preset_mode` attributes, because it is unclear what these paragraphs mean and what those attributes stands for in the first place. If I am correct first are used for `controller_mode_address` and second for `operation_mode_address` variables in config. Maybe it needs to be mentioned?

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9869"><img src="https://gitpod.io/api/apps/github/pbs/github.com/monte-monte/home-assistant.io.git/accbcd56d126c274c8656b356ae2b2a175ebda48.svg" /></a>

