### PR TITLE
Allow more universal media_player attributes to be overridden by the user

### DIFF
--- a/source/_components/universal.markdown
+++ b/source/_components/universal.markdown
@@ -63,7 +63,7 @@ commands:
   required: false
   type: string
 attributes:
-  description: "Attributes that can be overwritten. Possible entries are `is_volume_muted`, `state`, `source`, `source_list` and `volume_level`. The values should be an entity ID and state attribute separated by a pipe character (|). If the entity ID's state should be used, then only the entity id should be provided."
+  description: "Attributes that can be overwritten. Possible entries are `is_volume_muted`, `state`, `source`, `source_list`, `volume_level`, `media_content_id`, `media_content_type`, `media_duration`, `media_image_url`, `media_title`, `media_artist`, `media_album_name`, `media_album_artist`, `media_track`, `media_series_title`, `media_season`, `media_episode`, `media_channel`, `media_playlist`, `app_id`, `app_name`, `media_position`, and `media_position_updated_at`. The values should be an entity ID and state attribute separated by a pipe character (|). If the entity ID's state should be used, then only the entity id should be provided."
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_components/universal.markdown
+++ b/source/_components/universal.markdown
@@ -63,7 +63,7 @@ commands:
   required: false
   type: string
 attributes:
-  description: "Attributes that can be overwritten. Possible entries are `is_volume_muted`, `state`, `source`, `source_list`, `volume_level`, `media_content_id`, `media_content_type`, `media_duration`, `media_image_url`, `media_title`, `media_artist`, `media_album_name`, `media_album_artist`, `media_track`, `media_series_title`, `media_season`, `media_episode`, `media_channel`, `media_playlist`, `app_id`, `app_name`, `media_position`, and `media_position_updated_at`. The values should be an entity ID and state attribute separated by a pipe character (|). If the entity ID's state should be used, then only the entity id should be provided."
+  description: "Attributes that can be overwritten. Possible entries are `is_volume_muted`, `state`, `source`, `source_list`, `volume_level`, `media_content_id`, `media_content_type`, `media_duration`, `media_image_url`, `media_title`, `media_artist`, `media_album_name`, `media_album_artist`, `media_track`, `media_series_title`, `media_season`, `media_episode`, `media_channel`, `media_playlist`, `app_id`, `app_name`, `media_position` and `media_position_updated_at`. The values should be an entity ID and state attribute separated by a pipe character (|). If the entity ID's state should be used, then only the entity id should be provided."
   required: false
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**
Currently, the universal media_player only allows for the is_volume_muted, state, source, source_list and volume_level attributes to be overridden in the attributes: section of the config.

This PR allows media_content_id, media_content_type, media_duration, media_image_url (and thereby entity_picture), media_title, media_artist, media_album_name, media_album_artist, media_track, media_series_title, media_season, media_episode, media_channel, media_playlist, app_id, app_name, media_position, and media_position_updated_at to be overridden in the same way.

Rationale: I needed to override app_name so that the custom Lovelace card mini-media-player would show my chosen source instead of passing through to the Assistant speaker's app_name that reports "Default Media Receiver". Because the other attributes listed above are just as easy to allow to be overridden as app_name, I included them in this PR instead of leaving them alone with the arbitrary restriction that they must take their value from the active child. 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#24903

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9871"><img src="https://gitpod.io/api/apps/github/pbs/github.com/babichjacob/home-assistant.io.git/025e56e86d947d146732fb0dfe395d680f862169.svg" /></a>

