### PR TITLE
add HmIP-FCI1, HmIP-BBL, HmIP-FBL to Homematic IP Cloud

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -86,6 +86,7 @@ authtoken:
 
 * homematicip_cloud.binary_sensor
   * Window and door contact (*HmIP-SWDO, -I*)
+  * Contact Interface flush-mount – 1 channel (*HmIP-FCI1*)
   * Window Rotary Handle Sensor (*HmIP-SRH*)
   * Smoke sensor and alarm (*HmIP-SWSD*)
   * Motion Detector with Brightness Sensor - indoor (*HmIP-SMI*)

--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -111,8 +111,10 @@ authtoken:
     * Temperature and humidity Sensor with display (*HmIP-STHD*)
 
 * homematicip_cloud.cover
-  * Shutter actuator brand-mount (*HmIP-BROLL*)
-  * Shutter actuator flush-mount (*HmIP-FROLL*)
+  * Shutter actuator for brand-mount (*HmIP-BROLL*)
+  * Shutter actuator for flush-mount (*HmIP-FROLL*)
+  * Blind Actuator for brand switches (*HmIP-BBL*)
+  * Blind Actuator for flush-mount (*HmIP-FBL*)
 
 * homematicip_cloud.light
   * Switch actuator and meter for brand switches (*HmIP-BSM*)


### PR DESCRIPTION
**Description:**
add HmIP-FCI1, HmIP-BBL, HmIP-FBL to Homematic IP Cloud

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25188

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9873"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SukramJ/home-assistant.io.git/cae5c8a9b79a0418aab7c0ddc90a239562fb3891.svg" /></a>

