### PR TITLE
Add mikrotik login_method config option

### DIFF
--- a/source/_components/airvisual.markdown
+++ b/source/_components/airvisual.markdown
@@ -35,44 +35,44 @@ sensor:
 {% configuration %}
 api_key:
   description: Your AirVisual API key.
-  required: required
+  required: true
   type: string
 monitored_conditions:
   description: "The air quality standard(s) to use (`us` for U.S., `cn` for Chinese)."
-  required: required
+  required: true
   type: list
   default: ['us', 'cn']
 show_on_map:
   description: "Whether to show a marker on the map at the specified location."
-  required: optional
+  required: false
   type: boolean
   default: true
 scan_interval:
   description: "The rate in seconds at which AirVisual should be polled for new data."
-  required: optional
+  required: false
   type: integer
   default: 600
 latitude:
   description: The latitude of the location to monitor.
-  required: optional
+  required: false
   type: string
   default: "The latitude defined under the `homeassistant` key in `configuration.yaml`."
 longitude:
   description: The longitude of the location to monitor.
-  required: optional
+  required: false
   type: string
   default: "The longitude defined under the `homeassistant` key in `configuration.yaml`."
 city:
   description: The city to monitor.
-  required: optional
+  required: false
   type: string
 state:
   description: The state the city belongs to.
-  required: optional
+  required: false
   type: string
 country:
   description: The country the state belongs to.
-  required: optional
+  required: false
   type: string
 {% endconfiguration %}
 

--- a/source/_components/alarm_control_panel.mqtt.markdown
+++ b/source/_components/alarm_control_panel.mqtt.markdown
@@ -129,7 +129,7 @@ device:
     identifiers:
       description: 'A list of IDs that uniquely identify the device. For example a serial number.'
       required: false
-      type: list, string
+      type: [list, string]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false

--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -64,7 +64,7 @@ repeat:
     Number of minutes before the notification should be repeated.
     Can be either a number or a list of numbers.
   required: true
-  type: [int, list]
+  type: [integer, list]
 can_acknowledge:
   description: Allows the alert to be unacknowledgeable.
   required: false

--- a/source/_components/alpha_vantage.markdown
+++ b/source/_components/alpha_vantage.markdown
@@ -51,7 +51,7 @@ symbols:
       default: USD
     symbol:
       description: The stock market symbol for the given company.
-      required: required
+      required: true
       type: string
 foreign_exchange:
   description: List of currencies.
@@ -64,11 +64,11 @@ foreign_exchange:
       type: string
     from:
       description: The source currency.
-      required: required
+      required: true
       type: string
     to:
       description: The target currency.
-      required: required
+      required: true
       type: string
 {% endconfiguration %}
 

--- a/source/_components/amazon_polly.markdown
+++ b/source/_components/amazon_polly.markdown
@@ -46,7 +46,7 @@ profile_name:
 region_name:
   description: The region identifier to connect to.
   required: false
-  type: string or list
+  type: [string, list]
   default: us-east-1
 name:
   description: "Setting the optional parameter `name` allows multiple notifiers to be created. The default value is `notify`. The notifier will bind to the service `notify.NOTIFIER_NAME`."

--- a/source/_components/ambient_station.markdown
+++ b/source/_components/ambient_station.markdown
@@ -42,7 +42,7 @@ app_key:
   type: string
 monitored_conditions:
   description: Weather conditions to track.
-  required: optional
+  required: false
   type: list
   keys:
     24hourrainin:

--- a/source/_components/android_ip_webcam.markdown
+++ b/source/_components/android_ip_webcam.markdown
@@ -122,6 +122,7 @@ motion_sensor:
   description: Activate motion sensor if `auto_discovery` is disabled.
   required: false
   type: boolean
+  default: false
 {% endconfiguration %}
 
 <div class='note'>

--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -76,7 +76,7 @@ adb_server_port:
   description: The port for the ADB server.
   required: false
   default: 5037
-  type: port
+  type: integer
 get_sources:
   description: Whether or not to retrieve the running apps as the list of sources for Fire TV devices; not used for Android TV devices.
   required: false
@@ -86,7 +86,7 @@ apps:
   description: A dictionary where the keys are app IDs and the values are app names that will be displayed in the UI; see example below.
   required: false
   default: {}
-  type: dict
+  type: map
 device_class:
   description: "The type of device: `auto` (detect whether it is an Android TV or Fire TV device), `androidtv`, or `firetv`."
   required: false

--- a/source/_components/apple_tv.markdown
+++ b/source/_components/apple_tv.markdown
@@ -66,6 +66,7 @@ start_off:
   description: Set to true if the device should start in fake standby.
   required: false
   type: boolean
+  default: false
 credentials:
   description: Credentials used for AirPlay playback.
   required: false

--- a/source/_components/aqualogic.markdown
+++ b/source/_components/aqualogic.markdown
@@ -39,7 +39,7 @@ host:
 port:
   description: The port provided by the RS-485 to Ethernet adapter.
   required: true
-  type: int
+  type: integer
 {% endconfiguration %}
 
 ## Sensor

--- a/source/_components/aquostv.markdown
+++ b/source/_components/aquostv.markdown
@@ -32,7 +32,7 @@ port:
   description: The port of the Sharp Aquos TV.
   required: false
   default: 10002
-  type: int
+  type: integer
 username:
   description: The username of the Sharp Aquos TV.
   required: false

--- a/source/_components/arduino.markdown
+++ b/source/_components/arduino.markdown
@@ -92,7 +92,7 @@ pins:
       type: map
       keys:
         name:
-          default: Name that will be used in the frontend for the pin.
+          description: Name that will be used in the frontend for the pin.
           type: string
 {% endconfiguration %}
 
@@ -129,16 +129,16 @@ pins:
       type: map
       keys:
         name:
-          default: Name that will be used in the frontend for the pin.
+          description: Name that will be used in the frontend for the pin.
           type: string
           required: false
         initial:
-          default: The initial value for this port.
+          description: The initial value for this port.
           type: boolean
           required: false
           default: false
         negate:
-          default: If this pin should be inverted.
+          description: If this pin should be inverted.
           type: boolean
           required: false
           default: false

--- a/source/_components/arest.markdown
+++ b/source/_components/arest.markdown
@@ -214,7 +214,7 @@ resource:
   type: string
 name:
   description: Let you overwrite the name of the device. By default *name* from the device is used.
-  required: optional
+  required: false
   type: string
 pins:
   description: An array with all used pins.

--- a/source/_components/aws.markdown
+++ b/source/_components/aws.markdown
@@ -42,12 +42,12 @@ name:
   required: true
   type: string
 aws_access_key_id:
-  description: Your AWS Access Key ID. If provided, you must also provide an `aws_secret_access_key` and must **not** provide a `profile_name`.
-  required: Required if aws_secret_access_key is provided
+  description: Your AWS Access Key ID. If provided, you must also provide an `aws_secret_access_key` and must **not** provide a `profile_name`. Required if `aws_secret_access_key` is provided.
+  required: false
   type: string
 aws_secret_access_key:
-  description: Your AWS Secret Access Key. If provided, you must also provide an `aws_access_key_id` and must **not** provide a `profile_name`.
-  required: Required if aws_access_key_id is provided
+  description: Your AWS Secret Access Key. If provided, you must also provide an `aws_access_key_id` and must **not** provide a `profile_name`. Required if `aws_access_key_id` is provided.
+  required: false
   type: string
 profile_name:
   description: A credentials profile name.
@@ -80,8 +80,8 @@ aws_access_key_id:
   required: false
   type: string
 aws_secret_access_key:
-  description: Your AWS Secret Access Key. If provided, you must also provide an `aws_access_key_id`.
-  required: Required if aws_access_key_id is provided
+  description: Your AWS Secret Access Key. If provided, you must also provide an `aws_access_key_id`. Required if aws_access_key_id is provided.
+  required: false
   type: string
 profile_name:
   description: A credentials profile name.

--- a/source/_components/bayesian.markdown
+++ b/source/_components/bayesian.markdown
@@ -62,12 +62,12 @@ observations:
       required: true
       type: string
     entity_id:
-      description: Name of the entity to monitor.
-      required: true (for `state` and `numeric_state`)
+      description: Name of the entity to monitor. Required for `state` and `numeric_state`.
+      required: false
       type: string
     value_template:
-      description: Defines the template to be used.
-      required: true (for `template`)
+      description: Defines the template to be used. Required for `template`.
+      required: false
       type: template
     prob_given_true:
       description: The probability of the observation occurring, given the event is `true`.
@@ -79,8 +79,8 @@ observations:
       type: float
       default: "`1 - prob_given_true` if `prob_given_false` is not set"
     to_state:
-      description: The target state.
-      required: true (for `state`)
+      description: The target state. Required (for `state`).
+      required: false
       type: string
 {% endconfiguration %}
 

--- a/source/_components/binary_sensor.mqtt.markdown
+++ b/source/_components/binary_sensor.mqtt.markdown
@@ -105,11 +105,11 @@ device:
     identifiers:
       description: A list of IDs that uniquely identify the device. For example a serial number.
       required: false
-      type: list, string
+      type: [list, string]
     connections:
       description: "A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `'connections': ['mac', '02:5b:26:a8:dc:12']`."
       required: false
-      type: list, tuple
+      type: [list, map]
     manufacturer:
       description: The manufacturer of the device.
       required: false

--- a/source/_components/binary_sensor.rest.markdown
+++ b/source/_components/binary_sensor.rest.markdown
@@ -88,7 +88,7 @@ verify_ssl:
 timeout:
   description: Defines max time to wait data from the endpoint.
   required: false
-  type: positive integer
+  type: integer
   default: 10
 authentication:
   description: "Type of the HTTP authentication. `basic` or `digest`."
@@ -105,7 +105,7 @@ password:
 headers:
   description: The headers for the requests.
   required: false
-  type: list, string
+  type: [list, string]
 {% endconfiguration %}
 
 <div class='note warning'>

--- a/source/_components/binary_sensor.rflink.markdown
+++ b/source/_components/binary_sensor.rflink.markdown
@@ -55,7 +55,7 @@ devices:
         off_delay:
           description: For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
           required: false
-          type: int
+          type: integer
         force_update:
           description: Sends update events even if the value has not changed. Useful for sensors that only sends `On`.
           required: false

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -48,7 +48,7 @@ sensors:
         entity_id:
           description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
           required: false
-          type: string, list
+          type: [string, list]
         device_class:
           description: Sets the [class of the device](/components/binary_sensor/), changing the device state and icon that is displayed on the frontend.
           required: false

--- a/source/_components/bitcoin.markdown
+++ b/source/_components/bitcoin.markdown
@@ -33,7 +33,7 @@ currency:
 display_options:
   description: Options to display in the frontend.
   required: true
-  type: map
+  type: list
   keys:
     exchangerate:
       description: Exchange rate of 1 BTC

--- a/source/_components/blackbird.markdown
+++ b/source/_components/blackbird.markdown
@@ -39,17 +39,19 @@ host:
 zones:
   description: This is the list of zones available. Valid zones are 1, 2, 3, 4, 5, 6, 7, 8. Each zone must have a name assigned to it.
   required: true
-  type: integer
+  type: map
   keys:
-    name:
+    ZONE_NUMBER:
       description: The name of the zone.
+      type: string
 sources:
   description: The list of sources available. Valid source numbers are 1, 2, 3, 4, 5, 6, 7, 8. Each source number corresponds to the input number on the Blackbird matrix switch. Similar to zones, each source must have a name assigned to it.
   required: true
-  type: integer
+  type: map
   keys:
-    name:
+    ZONE_NUMBER:
       description: The name of the source.
+      type: string
 {% endconfiguration %}
 
 ### Service `media_player.blackbird_set_all_zones`

--- a/source/_components/blockchain.markdown
+++ b/source/_components/blockchain.markdown
@@ -28,6 +28,6 @@ sensor:
 addresses:
   description: List of bitcoin wallet addresses to watch.
   required: true
-  type: string, list
+  type: [string, list]
 {% endconfiguration %}
 

--- a/source/_components/bom.markdown
+++ b/source/_components/bom.markdown
@@ -33,11 +33,11 @@ weather:
 {% configuration %}
 name:
   description:  The name you would like to give to the weather station.
-  required: optional
+  required: false
   type: string
 station:
   description: "The station ID string. See the [`sensor.bom` docs](#sensor) for details on how to find the ID of a station."
-  required: optional
+  required: false
   type: string
   default: The closest station
 {% endconfiguration %}

--- a/source/_components/broadlink.markdown
+++ b/source/_components/broadlink.markdown
@@ -46,7 +46,7 @@ name:
   description: Sensor name.
   required: false
   default: Broadlink sensor
-  type: String
+  type: string
 scan_interval:
   description: Time in seconds to fetch data from sensors.
   required: false
@@ -155,12 +155,12 @@ friendly_name:
   type: string
 type:
   description: "Switch type. Choose one from: `rm`, `rm2`, `rm_mini`, `rm_pro_phicomm`, `rm2_home_plus`, `rm2_home_plus_gdt`, `rm2_pro_plus`, `rm2_pro_plus2`, `rm2_pro_plus_bl`, `rm_mini_shate`, `sp1`, `sp2`, `honeywell_sp2`, `sp3`, `spmini2`, `spminiplus` or `mp1`. `SC1` devices can be registered as `sp2`."
-  required: true/false
+  required: true
   type: string
 switches:
   description: The array that contains all switches.
   required: false
-  type: array
+  type: map
   keys:
     identifier:
       description: Name of the command switch as slug. Multiple entries are possible.
@@ -182,7 +182,7 @@ switches:
 slots:
   description: Friendly names of 4 slots of MP1 power strip. If not configured, slot name will be `switch's friendly_name + 'slot {slot_index}'`. e.g 'MP1 slot 1'
   required: false
-  type: array
+  type: map
   keys:
     slot_1:
       description: Friendly names of slot 1

--- a/source/_components/brottsplatskartan.markdown
+++ b/source/_components/brottsplatskartan.markdown
@@ -34,10 +34,12 @@ area:
 latitude:
   description: Latitude for sensor.
   required: false
+  type: float
   default: Your home zone latitude defined in your configuration.
 longitude:
   description: Longitude for sensor.
   required: false
+  type: float
   default: Your home zone longitude defined in your configuration.
 {% endconfiguration %}
 

--- a/source/_components/calendar.google.markdown
+++ b/source/_components/calendar.google.markdown
@@ -121,6 +121,7 @@ entities:
       description: "Should we create a sensor `true` or ignore it `false`?"
       required: true
       type: boolean
+      default: true
     search:
       description: If set will only trigger for matched events.
       required: false
@@ -141,7 +142,7 @@ entities:
     max_results:
       description: "Max number of entries to retrieve"
       required: false
-      type: int
+      type: integer
       default: 5
 {% endconfiguration %}
 

--- a/source/_components/camera.mqtt.markdown
+++ b/source/_components/camera.mqtt.markdown
@@ -44,7 +44,7 @@ device:
     identifiers:
       description: 'A list of IDs that uniquely identify the device. For example a serial number.'
       required: false
-      type: list, string
+      type: [list, string]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": ["mac", "02:5b:26:a8:dc:12"]`.'
       required: false

--- a/source/_components/clicksend.markdown
+++ b/source/_components/clicksend.markdown
@@ -9,7 +9,6 @@ redirect_from:
  - /components/notify.clicksend/
 ---
 
-
 The `clicksend` platform uses [ClickSend](https://clicksend.com) to deliver notifications from Home Assistant.
 
 ## Prerequisites
@@ -54,7 +53,7 @@ api_key:
 recipient:
   description: "A single or multiple phone numbers. This is where you want to send your SMS notification messages, e.g., `09171234567` or `[09171234567, 09177654321]`."
   required: true
-  type: string or list
+  type: [string, list]
 sender:
   description: The name or number of the sender.
   required: false

--- a/source/_components/climate.knx.markdown
+++ b/source/_components/climate.knx.markdown
@@ -157,7 +157,7 @@ operation_mode_comfort_address:
 operation_modes:
   description: Overrides the supported operation modes.
   required: false
-  type: array
+  type: list
 on_off_address:
   description: KNX address for switching the climate device on/off.
   required: false

--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -52,7 +52,7 @@ send_if_off:
 initial:
   description: Set the initial target temperature.
   required: false
-  type: number
+  type: integer
   default: 21
 payload_on:
   description: The payload that represents enabled state.
@@ -214,15 +214,15 @@ aux_state_template:
   type: template
 min_temp:
   description: Minimum set point available.
-  type: number
+  type: float
   required: false
 max_temp:
   description: Maximum set point available.
-  type: number
+  type: float
   required: false
 temp_step:
   description: Step size for temperature set point.
-  type: number
+  type: float
   required: false
   default: 1
 json_attributes_topic:
@@ -241,7 +241,7 @@ device:
     identifiers:
       description: 'A list of IDs that uniquely identify the device. For example a serial number.'
       required: false
-      type: list, string
+      type: [list, string]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false

--- a/source/_components/cover.group.markdown
+++ b/source/_components/cover.group.markdown
@@ -31,7 +31,7 @@ cover:
   entities:
     description: List of all cover entities you want to control.
     required: true
-    type: [string | list]
+    type: [string, list]
 {% endconfiguration %}
 
 ## Functionality

--- a/source/_components/cover.mqtt.markdown
+++ b/source/_components/cover.mqtt.markdown
@@ -196,7 +196,7 @@ device:
     identifiers:
       description: 'A list of IDs that uniquely identify the device. For example a serial number.'
       required: false
-      type: list, string
+      type: [list, string]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": ["mac", "02:5b:26:a8:dc:12"]`.'
       required: false

--- a/source/_components/crimereports.markdown
+++ b/source/_components/crimereports.markdown
@@ -35,10 +35,12 @@ radius:
 latitude:
   description: Latitude for sensor.
   required: false
+  type: float
   default: Your home zone latitude defined in your configuration.
 longitude:
   description: Longitude for sensor.
   required: false
+  type: float
   default: Your home zone longitude defined in your configuration.
 include:
   description: List of incident types to include. See below for a list of valid incidents.

--- a/source/_components/currencylayer.markdown
+++ b/source/_components/currencylayer.markdown
@@ -36,7 +36,7 @@ api_key:
 quote:
   description: The symbol(s) of the quote or target currencies.
   required: false
-  type: string, list
+  type: [string, list]
   default: Exchange rate
 base:
   description: The symbol of the base currency.
@@ -44,4 +44,3 @@ base:
   type: string
   default: USD
 {% endconfiguration %}
-

--- a/source/_components/epsonworkforce.markdown
+++ b/source/_components/epsonworkforce.markdown
@@ -35,7 +35,7 @@ host:
 monitored_conditions:
   description: The cartridge colours to monitor. 
   required: true
-  type: map
+  type: list
   keys:
     black:
       description: The black ink cartridge

--- a/source/_components/evohome.markdown
+++ b/source/_components/evohome.markdown
@@ -56,12 +56,12 @@ password:
 location_idx:
   description: Used to select which location to use, if your login has access to more than one location. Multiple locations at one time are not supported.
   required: false
-  type: int
+  type: integer
   default: 0
 scan_interval:
   description: How often updates are retrieved from Honeywell's web servers. The minimum value is 60 seconds.
   required: false
-  type: int
+  type: integer
   default: 300
 {% endconfiguration %}
 

--- a/source/_components/fan.mqtt.markdown
+++ b/source/_components/fan.mqtt.markdown
@@ -122,7 +122,7 @@ speed_value_template:
 speeds:
   description: "List of speeds this fan is capable of running at. Valid entries are `off`, `low`, `medium` and `high`."
   required: false
-  type: string list
+  type: [string, list]
 availability_topic:
   description: The MQTT topic subscribed to receive availability (online/offline) updates.
   required: false
@@ -157,11 +157,11 @@ device:
     identifiers:
       description: A list of IDs that uniquely identify the device. For example a serial number.
       required: false
-      type: list, string
+      type: [string, list]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false
-      type: list, tuple
+      type: [list, map]
     manufacturer:
       description: The manufacturer of the device.
       required: false

--- a/source/_components/fan.template.markdown
+++ b/source/_components/fan.template.markdown
@@ -100,6 +100,6 @@ fan:
       speeds:
         description: List of speeds the fan is capable of running at.
         required: false
-        type: string list
+        type: [string, list]
         default: ['low', 'medium', 'high']
 {% endconfiguration %}

--- a/source/_components/feedreader.markdown
+++ b/source/_components/feedreader.markdown
@@ -29,7 +29,7 @@ feedreader:
     description: Defines the update interval of the feeds.
     required: false
     default: 1 hour
-    type: interval
+    type: time
   max_entries:
     description: The maximum number of entries to extract from each feed.
     required: false

--- a/source/_components/fibaro.markdown
+++ b/source/_components/fibaro.markdown
@@ -64,7 +64,7 @@ gateways:
 url:
   description: The URL for your Fibaro HomeCenter device.
   required: true
-  type: url
+  type: string
 username:
   description: The username for your Fibaro account.
   required: true
@@ -76,7 +76,7 @@ password:
 plugins:
   description: Whether to import plugin-generated devices from Fibaro HomeCenter, such as Netatmo and Sonos devices, etc.
   required: false
-  type: bool
+  type: boolean
   default: false
 device_config:
   description: Lists device specific parameter or behaviour overrides.

--- a/source/_components/filesize.markdown
+++ b/source/_components/filesize.markdown
@@ -27,5 +27,5 @@ sensor:
 file_paths:
   description: The absolute path to the file.
   required: true
-  type: list of strings
+  type: list
 {% endconfiguration %}

--- a/source/_components/filter.markdown
+++ b/source/_components/filter.markdown
@@ -73,7 +73,7 @@ filters:
     window_size:
       description: Size of the window of previous states. Time based filters such as `time_simple_moving_average` will require a time period (size in time), while other filters such as `outlier` will require an integer (size in number of states)
       required: false
-      type: [int, time]
+      type: [integer, time]
       default: 1
     precision:
       description: See [_lowpass_](#low-pass) filter. Defines the precision of the filtered state, through the argument of round().

--- a/source/_components/flunearyou.markdown
+++ b/source/_components/flunearyou.markdown
@@ -33,13 +33,13 @@ monitored_conditions:
   default: ['cdc_report', 'user_report']
 latitude:
   description: The latitude of the location to monitor.
-  required: optional
-  type: string
+  required: false
+  type: float
   default: The latitude defined under the `homeassistant` key in `configuration.yaml`.
 longitude:
   description: The longitude of the location to monitor.
-  required: optional
-  type: string
+  required: false
+  type: float
   default: The longitude defined under the `homeassistant` key in `configuration.yaml`.
 {% endconfiguration %}
 

--- a/source/_components/flux.markdown
+++ b/source/_components/flux.markdown
@@ -72,6 +72,7 @@ disable_brightness_adjust:
   description: If true, brightness will not be adjusted besides color temperature.
   required: false
   type: boolean
+  default: false
 mode:
   description: Select how color temperature is passed to lights. Valid values are `xy`, `mired` and `rgb`.
   required: false

--- a/source/_components/freedns.markdown
+++ b/source/_components/freedns.markdown
@@ -42,6 +42,6 @@ freedns:
   scan_interval:
     description: How often to call the update service.
     required: false
-    type: time period
+    type: time
     default: 10 minutes
 {% endconfiguration %}

--- a/source/_components/generic_thermostat.markdown
+++ b/source/_components/generic_thermostat.markdown
@@ -53,6 +53,7 @@ ac_mode:
   description: Set the switch specified in the *heater* option to be treated as a cooling device instead of a heating device.
   required: false
   type: boolean
+  default: false
 min_cycle_duration:
   description: Set a minimum amount of time that the switch specified in the *heater* option must be in its current state prior to being switched either off or on.
   required: false

--- a/source/_components/glances.markdown
+++ b/source/_components/glances.markdown
@@ -91,7 +91,7 @@ version:
 resources:
   description: Entries to monitor.
   required: false
-  type: map
+  type: list
   default: disk_use
   keys:
     disk_use_percent:

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -170,6 +170,7 @@ entity_config:
           description: Force an entity to be exposed/excluded.
           required: false
           type: boolean
+          default: true
         aliases:
           description: Aliases that can also be used to refer to this entity
           required: false

--- a/source/_components/google_domains.markdown
+++ b/source/_components/google_domains.markdown
@@ -37,6 +37,6 @@ google_domains:
   timeout:
     description: Timeout (in seconds) for the API calls.
     required: false
-    type: number
+    type: integer
     default: 10
 {% endconfiguration %}

--- a/source/_components/google_wifi.markdown
+++ b/source/_components/google_wifi.markdown
@@ -37,7 +37,7 @@ name:
 monitored_conditions:
   description: Defines the data to monitor as sensors. Defaults to all of the listed options below.
   required: false
-  type: map
+  type: list
   keys:
     current_version:
       description: Current firmware version of the router.

--- a/source/_components/greeneye_monitor.markdown
+++ b/source/_components/greeneye_monitor.markdown
@@ -70,7 +70,7 @@ monitors:
         net_metering:
           description: Set to `true` if the channel is configured for net metering in the GEM, otherwise `false`.
           required: false
-          type: bool
+          type: boolean
           default: false
     temperature_sensors:
       description: Configuration for temperature sensors

--- a/source/_components/group.markdown
+++ b/source/_components/group.markdown
@@ -44,6 +44,7 @@ all:
   description: Set this to `true` if the group state should only turn *on* if **all** grouped entities are *on*.
   required: false
   type: boolean
+  default: false
 icon:
   description: The icon that shows in the front end. **The rest of this only applies to the deprecated UI `/states`**. If the group is a view, this icon will show at the top in the frontend instead of the name. If the group is a view and both name and icon have been specified, the icon will appear at the top of the frontend and the name will be displayed as the mouse-over text. 
   required: false
@@ -52,6 +53,7 @@ view:
   description: "**Only applies to the deprecated UI `/states`**. If yes then the entry will be shown as a view (tab) at the top. Groups that are set to `view: true` cannot be used as entities in other views. *Does not apply to Lovelace.*"
   required: false
   type: boolean
+  default: false
 control:
   description: "**Only applies to the deprecated UI `/states`**. Set value to `hidden`. If hidden then the group switch will be hidden. *Does not apply to Lovelace.*"
   required: false

--- a/source/_components/harmony.markdown
+++ b/source/_components/harmony.markdown
@@ -66,6 +66,7 @@ delay_secs:
 hold_secs:
   description: Default duration in seconds between sending the "press" command and sending the "release" command.
   required: false
+  type: integer
   default: 0
 {% endconfiguration %}
 

--- a/source/_components/hikvision.markdown
+++ b/source/_components/hikvision.markdown
@@ -99,6 +99,7 @@ ssl:
   description: "`true` if you want to connect with https. Be sure to set the port also."
   required: false
   type: boolean
+  default: false
 customize:
   description: >
     This attribute contains sensor-specific override values.
@@ -112,6 +113,7 @@ customize:
         the Web Interface and no events are generated for it.
       required: false
       type: boolean
+      default: false
     delay:
       description: >
         Specify the delay to wait after a sensor event ends before notifying

--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -37,12 +37,6 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor (HomeKit motion sensors)
 - Sensor (HomeKit humidity, temperature, and light level sensors)
 
-The integration will be automatically configured if the [`discovery:`](/components/discovery/) integration is enabled and an enable entry added for HomeKit:
-
-```yaml
-discovery:
-  enable:
-    - homekit
-```
+The integration will be automatically configured if the [`discovery`](/components/discovery/) integration is enabled.
 
 For each detected HomeKit accessory, a configuration prompt will appear in the web front end. Use this to provide the HomeKit PIN. Note that HomeKit accessories can only be paired to one device at once. If your device is currently paired with Siri, you will need to reset it in order to pair it with Home Assistant. Once Home Assistant is configured to work with the device, you can export it back to Siri with the [`HomeKit`](/components/homekit/) component.

--- a/source/_components/homeworks.markdown
+++ b/source/_components/homeworks.markdown
@@ -49,7 +49,7 @@ host:
 port:
   description: The port of the ethernet to serial adapter.
   required: true
-  type: port
+  type: integer
 dimmers:
   description: List of dimmers.
   required: false

--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -67,7 +67,7 @@ ssl_key:
 cors_allowed_origins:
   description: "A list of origin domain names to allow [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) requests from. Enabling this will set the `Access-Control-Allow-Origin` header to the Origin header if it is found in the list, and the `Access-Control-Allow-Headers` header to `Origin, Accept, X-Requested-With, Content-type, Authorization`. You must provide the exact Origin, i.e. `https://www.home-assistant.io` will allow requests from `https://www.home-assistant.io` but __not__ `http://www.home-assistant.io`."
   required: false
-  type: string, list
+  type: [string, list]
 use_x_forwarded_for:
   description: "Enable parsing of the `X-Forwarded-For` header, passing on the client's correct IP address in proxied setups. You **must** also whitelist trusted proxies using the `trusted_proxies` setting for this to work. Non-whitelisted requests with this header will be considered IP spoofing attacks, and the header will, therefore, be ignored."
   required: false
@@ -76,11 +76,11 @@ use_x_forwarded_for:
 trusted_proxies:
   description: "List of trusted proxies, consisting of IP addresses or networks, that are allowed to set the `X-Forwarded-For` header.  This is required when using `use_x_forwarded_for` because all requests to Home Assistant, regardless of source, will arrive from the reverse proxy IP address. Therefore in a reverse proxy scenario, this option should be set with extreme care."
   required: false
-  type: string, list
+  type: [string, list]
 trusted_networks:
   description: "**Deprecated since 0.89 release. Configuration moved to [Trusted Networks auth provider](/docs/authentication/providers/#trusted-networks).** List of trusted networks, consisting of IP addresses or networks, that are allowed to bypass password protection when accessing Home Assistant.  If using a reverse proxy with the `use_x_forwarded_for` and `trusted_proxies` options enabled, requests proxied to Home Assistant with a trusted `X-Forwarded-For` header will appear to come from the IP given in that header instead of the proxy IP."
   required: false
-  type: string, list
+  type: [string, list]
 ip_ban_enabled:
   description: Flag indicating whether additional IP filtering is enabled.
   required: false

--- a/source/_components/huawei_lte.markdown
+++ b/source/_components/huawei_lte.markdown
@@ -42,7 +42,7 @@ huawei_lte:
 url:
   description: URL of the router web interface.
   required: true
-  type: url
+  type: string
 username:
   description: The username used for the router web interface.
   required: true
@@ -93,7 +93,7 @@ notify:
 recipient:
   description: The phone number of a default recipient or a list with multiple recipients.
   required: true
-  type: string, list
+  type: [string, list]
 name:
   description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
   required: false
@@ -102,7 +102,7 @@ name:
 url:
   description: The router to use. Not needed if you only have one.
   required: false
-  type: url
+  type: string
 {% endconfiguration %}
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).

--- a/source/_components/hue.markdown
+++ b/source/_components/hue.markdown
@@ -44,6 +44,7 @@ allow_unreachable:
   description: This will allow unreachable bulbs to report their state correctly.
   required: false
   type: boolean
+  default: false
 filename:
   description: Make this unique if specifying multiple Hue hubs.
   required: false
@@ -52,6 +53,7 @@ allow_hue_groups:
   description: Disable this to stop Home Assistant from importing the groups defined on the Hue bridge.
   required: false
   type: boolean
+  default: true
 {% endconfiguration %}
 
 ## Examples

--- a/source/_components/hyperion.markdown
+++ b/source/_components/hyperion.markdown
@@ -31,7 +31,7 @@ light:
   port:
     description: The port used to communicate with the Hyperion service.
     required: false
-    type: int
+    type: integer
     default: 19444
   name:
     description: The name of the device used in the frontend.
@@ -40,12 +40,12 @@ light:
   priority:
     description: The priority of the Hyperion instance make sure this is higher then the system prio in hyperion itself.
     required: false
-    type: int
+    type: integer
     default: 128
   hdmi_priority:
     description: The priority of the HDMI grabber of this Hyperion instance, note that this priority must be higher than all other priorities used for correct behavior.
     required: false
-    type: int
+    type: integer
     default: 880
   default_color:
     description: The color of the light.

--- a/source/_components/idteck_prox.markdown
+++ b/source/_components/idteck_prox.markdown
@@ -33,7 +33,7 @@ host:
 port:
   description: The port of the ethernet to serial adapter
   required: true
-  type: port
+  type: integer
 name:
   description: The name of the prox card reader
   required: true

--- a/source/_components/ihc.markdown
+++ b/source/_components/ihc.markdown
@@ -61,6 +61,7 @@ info:
   description: Shows the IHC "name", "note" and "position" attributes of each component. This will make it easier to identify the IHC products within Home Assistant.
   required: false
   type: boolean
+  default: true
 {% endconfiguration %}
 
 ## Auto setup of IHC products

--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -101,19 +101,19 @@ include:
   required: false
   keys:
     entities:
-      type: string, list
+      type: [string, list]
       description:  The list of entity ids to be included in recording to InfluxDB.
       required: false    
     domains:
-      type: string, list
+      type: [string, list]
       description:  The list of domains to be included in recording to InfluxDB.
       required: false
 tags:
-  type: string, list
+  type: [string, list]
   description: Tags to mark the data.
   default: 0
 tags_attributes:
-  type: string, list
+  type: [string, list]
   description: The list of attribute names which should be reported as tags and not fields to InfluxDB. For example, if set to `friendly_name`, it will be possible to group by entities' friendly names as well, in addition to their ids.
   required: false
   default: 0

--- a/source/_components/input_boolean.markdown
+++ b/source/_components/input_boolean.markdown
@@ -30,7 +30,7 @@ input_boolean:
       name:
         description: Friendly name of the input.
         required: false
-        type: String
+        type: string
       initial:
         description: Initial value when Home Assistant starts.
         required: false

--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -39,7 +39,7 @@ input_datetime:
       name:
         description: Friendly name of the datetime input.
         required: false
-        type: String
+        type: string
       has_time:
         description: Set to `true` if the input should have a time. At least one `has_time` or `has_date` must be defined.
         required: false
@@ -53,7 +53,7 @@ input_datetime:
       initial:
         description: Set the initial value of this input, depending on `has_time` and `has_date`.
         required: false
-        type: datetime | time | date
+        type: [datetime, time, date]
         default: 1970-01-01 00:00 | 1970-01-01 | 00:00
 {% endconfiguration %}
 

--- a/source/_components/input_number.markdown
+++ b/source/_components/input_number.markdown
@@ -68,7 +68,7 @@ input_number:
       mode:
         description: Can specify `box` or `slider`.
         required: false
-        type: box | slider
+        type: string
         default: slider
       unit_of_measurement:
         description: Unit of measurement in which the value of the slider is expressed in.

--- a/source/_components/input_text.markdown
+++ b/source/_components/input_text.markdown
@@ -37,7 +37,7 @@ input_text:
       name:
         description: Friendly name of the text input.
         required: false
-        type: String
+        type: string
       min:
         description: Minimum length for the text value.
         required: false
@@ -51,17 +51,17 @@ input_text:
       initial:
         description: Initial value when Home Assistant starts.
         required: false
-        type: String
+        type: string
         default: empty
       pattern:
         description: Regex pattern for client side validation.
         required: false
-        type: String
+        type: string
         default: empty
       mode:
         description: Can specify `text` or `password`. Elements of type "password" provide a way for the user to securely enter a value.
         required: false
-        type: String
+        type: string
         default: text
 {% endconfiguration %}
 

--- a/source/_components/insteon.markdown
+++ b/source/_components/insteon.markdown
@@ -95,28 +95,28 @@ insteon:
 
 {% configuration %}
 port:
-  description: The serial or USB port for your device, e.g., `/dev/ttyUSB0` or `COM3`.
-  required: Required for PLM setup
+  description: The serial or USB port for your device, e.g., `/dev/ttyUSB0` or `COM3`. Required for PLM setup.
+  required: false
   type: string
 host:
-  description: The host name or IP address of the Hub.
-  required: Required for Hub setup
+  description: The host name or IP address of the Hub. Required with Hub.
+  required: false
   type: string
 ip_port:
-  description: The IP port number of the Hub. For Hub model [2245] (i.e. Hub version 2) the default port is 25105. For the Hub model [2242] (i.e. Hub version 1) the default port is 9761. Use the Insteon app to find the port number for your specific Hub.
-  required: Optional for Hub setup
+  description: The IP port number of the Hub. For Hub model [2245] (i.e. Hub version 2) the default port is 25105. For the Hub model [2242] (i.e. Hub version 1) the default port is 9761. Use the Insteon app to find the port number for your specific Hub. Optional with Hub.
+  required: true
   type: integer
 username:
-  description: The username to login in to the local Hub. You can find your Hub username on the bottom of the Hub or you can use the Insteon app.
-  required: Required for Hub version 2 setup
+  description: The username to login in to the local Hub. You can find your Hub username on the bottom of the Hub or you can use the Insteon app. Required for Hub version 2 setup.
+  required: false
   type: string
 password:
-  description: The password to login in to the local Hub. You can find your Hub password on the bottom of the Hub or you can use the Insteon app.
-  required: Required for Hub version 2 setup
+  description: The password to login in to the local Hub. You can find your Hub password on the bottom of the Hub or you can use the Insteon app. Required for Hub version 2 setup.
+  required: false
   type: string
 hub_version:
-  description: The Hub version number where model [2242] is Hub version 1 and model [2245] is Hub version 2.
-  required: Required for Hub version 1 setup
+  description: The Hub version number where model [2242] is Hub version 1 and model [2245] is Hub version 2. Required for Hub version 1 setup.
+  required: false
   default: 2
   type: integer
 device_override:

--- a/source/_components/integration.markdown
+++ b/source/_components/integration.markdown
@@ -44,12 +44,12 @@ unit_prefix:
   description: Metric unit to prefix the integration result. Available units are k, M, G, T.
   required: false
   default: None
-  type: unit
+  type: string
 unit_time:
   description: SI unit of time to integrate over. Available units are s, min, h, d.
   required: false
   default: h
-  type: unit
+  type: string
 unit:
   description: Unit of Measurement to be used for the integration.
   required: false
@@ -57,6 +57,7 @@ unit:
 method:
   description: Riemann sum method to be used. Available methods are trapezoidal, left, right.
   required: false
+  type: string
   default: trapezoidal
 {% endconfiguration %}
 

--- a/source/_components/iss.markdown
+++ b/source/_components/iss.markdown
@@ -37,7 +37,7 @@ name:
   default: ISS
 show_on_map:
   description: Option to show the position of the ISS on the map.
-  required: optional
+  required: false
   type: boolean
   default: false
 {% endconfiguration %}

--- a/source/_components/jewish_calendar.markdown
+++ b/source/_components/jewish_calendar.markdown
@@ -53,9 +53,10 @@ havdalah_minutes_after_sunset:
   default: 0
   type: integer
 sensors:
+  description: List of available sensors.
   required: false
   default: date
-  description: List of available sensors.
+  type: list
   keys:
     date:
       description: Show the hebrew date for today.

--- a/source/_components/knx.markdown
+++ b/source/_components/knx.markdown
@@ -103,6 +103,7 @@ fire_event:
   description: If set to True, platform will write all received KNX messages to event bus
   required: inclusive
   type: boolean
+  default: false
 fire_event_filter:
   description: If `fire_event` is set `fire_event_filter` has to be specified. `fire_event_filter` defines a list of patterns for filtering KNX addresses. Only telegrams which match this pattern are sent to the HOme Assistant event bus.
   required: inclusive

--- a/source/_components/kodi.markdown
+++ b/source/_components/kodi.markdown
@@ -370,6 +370,7 @@ message:
   required: true
   type: string
 data:
+  description: Configure message properties
   required: false
   type: map
   keys:

--- a/source/_components/konnected.markdown
+++ b/source/_components/konnected.markdown
@@ -62,7 +62,7 @@ access_token:
 api_host:
   description: Override the IP address/host (and port number) of Home Assistant that the Konnected device(s) will use to communicate sensor state updates. If omitted, this is defaulted to the value of `base_url` in the `http` component. If you've set `base_url` to an external hostname, then you'll want to set this value back to your _local_ IP address and port (e.g., `http://192.168.1.101:8123`).
   required: false
-  type: url
+  type: string
   default: value of `base_url`
 devices:
   description: A list of Konnected devices that you have on your network.

--- a/source/_components/lacrosse.markdown
+++ b/source/_components/lacrosse.markdown
@@ -54,6 +54,7 @@ sensor:
     description: Activate or deactivate the Jeelink LED.
     required: false
     type: boolean
+    default: false
   frequency:
     description: Initial frequency in 5kHz steps.
     required: false

--- a/source/_components/lastfm.markdown
+++ b/source/_components/lastfm.markdown
@@ -38,7 +38,7 @@ api_key:
 users:
   description: List of users.
   required: true
-  type: map
+  type: list
   keys:
     username:
       description: Username of the user to monitor.

--- a/source/_components/lcn.markdown
+++ b/source/_components/lcn.markdown
@@ -199,7 +199,7 @@ climates:
     lockable:
       description: "Climate control can be locked."
       required: false
-      type: bool
+      type: boolean
       default: false
 
 covers:
@@ -240,12 +240,12 @@ lights:
     dimmable:
       description: Enable the dimming feature for this light.
       required: false
-      type: bool
+      type: boolean
       default: false
     transition:
       description: Transition (ramp) time in seconds.
       required: false
-      type: int
+      type: integer
       default: 0
 
 scenes:
@@ -264,11 +264,11 @@ scenes:
     register:
       description: Number of scene register (0..9).
       required: true
-      type: int
+      type: integer
     scene:
       description: Number of scene (0..9).
       required: true
-      type: int
+      type: integer
     outputs:
       description: "List of ports ([OUTPUT_PORT](#ports), [RELAY_PORT](#ports))."
       required: false
@@ -276,7 +276,7 @@ scenes:
     transition:
       description: Transition (ramp) time in seconds.
       required: false
-      type: int
+      type: integer
       default: None
 
 sensors:

--- a/source/_components/lifx.markdown
+++ b/source/_components/lifx.markdown
@@ -125,7 +125,7 @@ server:
 port:
   description: The UDP port for discovery. Will listen on a random port if omitted.
   required: false
-  type: port
+  type: integer
 broadcast:
   description: The broadcast address for discovering lights. Can also set this to the IP address of a bulb to skip discovery.
   required: false

--- a/source/_components/light.group.markdown
+++ b/source/_components/light.group.markdown
@@ -33,7 +33,7 @@ light:
   entities:
     description: A list of entities to be included in the light group.
     required: true
-    type: string list
+    type: [string, list]
 {% endconfiguration %}
 
 <p class='img'>

--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -237,7 +237,7 @@ device:
     identifiers:
       description: 'A list of IDs that uniquely identify the device. For example a serial number.'
       required: false
-      type: list, string
+      type: [string, list]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false
@@ -501,7 +501,7 @@ device:
     identifiers:
       description: 'A list of IDs that uniquely identify the device. For example a serial number.'
       required: false
-      type: list, string
+      type: [string, list]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false
@@ -779,7 +779,7 @@ device:
     identifiers:
       description: 'A list of IDs that uniquely identify the device. For example a serial number.'
       required: false
-      type: list, string
+      type: [string, list]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false

--- a/source/_components/lock.mqtt.markdown
+++ b/source/_components/lock.mqtt.markdown
@@ -104,7 +104,7 @@ device:
     identifiers:
       description: 'A list of IDs that uniquely identify the device. For example a serial number.'
       required: false
-      type: list, string
+      type: [string, list]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false

--- a/source/_components/luftdaten.markdown
+++ b/source/_components/luftdaten.markdown
@@ -44,7 +44,7 @@ sensor_id:
   type: string
 show_on_map:
   description: Option to show the position of the sensor on the map.
-  required: optional
+  required: false
   default: false
   type: boolean
 scan_interval:

--- a/source/_components/manual_mqtt.markdown
+++ b/source/_components/manual_mqtt.markdown
@@ -123,7 +123,7 @@ command_topic:
 qos:
   description: The maximum QoS level for subscribing and publishing to MQTT messages.
   required: false
-  type: int
+  type: integer
   default: 0
 payload_disarm:
   description: The payload to disarm this Alarm Panel.

--- a/source/_components/mikrotik.markdown
+++ b/source/_components/mikrotik.markdown
@@ -75,6 +75,13 @@ method:
   type: string
 {% endconfiguration %}
 
+<div class='note info'>
+  As of version 6.43 of RouterOS Mikrotik introduced a new login method (plain) in addition to the old login method (token). With Version 6.45.1 the old token login method got deprecated.
+  In order to support both login mechanisms the new config option `login_method` has been introduced. If this option is not set, the component will try to login with the plan method first and the token method if that fails.
+  That can cause log entries on the router like `login failure for user homeassistant from 192.168.23.10 via api` but doesn't keep the component from working. 
+  To get rid of these entries, simply set the `login_method` to `plain` for Routers with OS versions > 6.43 or `token` for routers with OS versions < 6.43.
+</div>
+
 ## Use a certificate
 
 To use SSL to connect to the API (via `api-ssl` instead of `api` service) further configuration is required at RouterOS side. You have to upload or generate a certificate and configure `api-ssl` service to use it. Here is an example of a self-signed certificate:

--- a/source/_components/mikrotik.markdown
+++ b/source/_components/mikrotik.markdown
@@ -53,6 +53,12 @@ password:
   description: The password of the given user account on the MikroTik device.
   required: true
   type: string
+login_method:
+  description: The login method to use on the MikroTik device. The `plain` method is used by default, if you have an older RouterOS Version than 6.43, use `token` as login method.
+  required: false
+  type: string
+  options: plain, token
+  default: plain
 port:
   description: RouterOS API port.
   required: false

--- a/source/_components/mitemp_bt.markdown
+++ b/source/_components/mitemp_bt.markdown
@@ -81,10 +81,12 @@ name:
 force_update:
   description: Sends update events even if the value hasn't changed.
   required: false
+  default: false
   type: boolean
 median:
   description: "Sometimes the sensor measurements show spikes. Using this parameter, the poller will report the median of the last 3 (you can also use larger values) measurements. This filters out single spikes. Median: 5 will also filter double spikes. If you never have problems with spikes, `median: 1` will work fine."
   required: false
+  default: 3
   type: integer
 timeout:
   description: Define the timeout value in seconds when polling.
@@ -121,7 +123,8 @@ sensor:
   - platform: mitemp_bt
     mac: 'xx:xx:xx:xx:xx:xx'
     name: Kids Room Temp
-    force_up    median: 3
+    force_update: true
+    median: 1
     monitored_conditions:
       - temperature
       - humidity

--- a/source/_components/netgear_lte.markdown
+++ b/source/_components/netgear_lte.markdown
@@ -63,7 +63,7 @@ notify:
     recipient:
       description: The phone number of a default recipient or a list with multiple recipients.
       required: false
-      type: string, list
+      type: [string, list]
     name:
       description: The name of the notification service.
       required: false

--- a/source/_components/nuheat.markdown
+++ b/source/_components/nuheat.markdown
@@ -48,7 +48,7 @@ password:
 devices:
   description: The serial number/ID of each thermostat you would like to integrate.
   required: true
-  type: [string, int]
+  type: [string, integer]
 {% endconfiguration %}
 
 ## Concepts

--- a/source/_components/oasa_telematics.markdown
+++ b/source/_components/oasa_telematics.markdown
@@ -41,7 +41,7 @@ Next, get the `stop_id` from this link:
 route_id:
   description: The id of the public transport route.
   required: true
-  type: int
+  type: integer
 stop_id:
   description: The id of the public transport stop.
   required: true

--- a/source/_components/pencom.markdown
+++ b/source/_components/pencom.markdown
@@ -41,7 +41,7 @@ host:
 port:
   description: The port of the ethernet to serial adapter.
   required: true
-  type: port (positive integer between 1-65535)
+  type: integer (positive integer between 1-65535)
 boards:
   description: Number of boards daisy-chained together (default is 1).
   required: false
@@ -58,7 +58,7 @@ relays:
     addr:
       description: The relay on the board starting with 0.
       required: true
-      type: int
+      type: integer
     board:
       description: The board number (defaults to 1).
       required: false

--- a/source/_components/person.markdown
+++ b/source/_components/person.markdown
@@ -67,7 +67,7 @@ person:
   device_trackers:
     description: A list of device tracker entity ids to track. These will represent the state of the person.
     required: false
-    type: list, string
+    type: [string, list]
 {% endconfiguration %}
 
 An extended example would look like the following sample:

--- a/source/_components/ptvsd.markdown
+++ b/source/_components/ptvsd.markdown
@@ -30,7 +30,7 @@ port:
   description: Port to listen on.
   required: false
   default: 5678
-  type: port
+  type: integer
 wait:
   description: If true, wait for the debugger to connect before starting up home assistant.
   required: false

--- a/source/_components/qwikswitch.markdown
+++ b/source/_components/qwikswitch.markdown
@@ -78,7 +78,7 @@ sensors:
       description: The channel of interest. Refer to type above.
       required: false
       default: 1
-      type: int
+      type: integer
     invert:
       description: Invert the open/close state. Only applicable to binary_sensors
       required: false

--- a/source/_components/rainmachine.markdown
+++ b/source/_components/rainmachine.markdown
@@ -52,7 +52,7 @@ rainmachine:
 {% configuration %}
 ip_address:
   description: The IP address or hostname of your RainMachine unit.
-  required: optional
+  required: false
   type: string
 password:
   description: Your RainMachine password.

--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -30,7 +30,7 @@ recorder:
     db_url:
       description: The URL that points to your database.
       required: false
-      type: URL
+      type: string
     purge_keep_days:
       description: Specify the number of history days to keep in recorder database after a purge.
       required: false

--- a/source/_components/rest.markdown
+++ b/source/_components/rest.markdown
@@ -89,11 +89,11 @@ password:
 headers:
   description: The headers for the requests.
   required: false
-  type: list, string
+  type: [string, list]
 json_attributes:
   description: A list of keys to extract values from a JSON dictionary result and then set as sensor attributes.
   reqired: false
-  type: list, string
+  type: [string, list]
 force_update:
   description: Sends update events even if the value hasn't changed. Useful if you want to have meaningful value graphs in history.
   reqired: false

--- a/source/_components/rmvtransport.markdown
+++ b/source/_components/rmvtransport.markdown
@@ -59,7 +59,7 @@ next_departure:
     lines:
       description: "One or more line numbers, e.g., `'S8'` or `['S8', 'RB33', '41']`"
       required: false
-      type: [string, int]
+      type: [string, integer]
     products:
       description: "One or more modes of transport `['U-Bahn', 'Tram', 'Bus', 'S-Bahn', 'RB', 'RE', 'EC', 'IC', 'ICE']`."
       required: false

--- a/source/_components/route53.markdown
+++ b/source/_components/route53.markdown
@@ -98,6 +98,6 @@ records:
 ttl:
   description: The TTL value for the DNS records.
   required: false
-  type: int
+  type: integer
   default: 300
 {% endconfiguration %}

--- a/source/_components/sensor.command_line.markdown
+++ b/source/_components/sensor.command_line.markdown
@@ -52,7 +52,7 @@ command_timeout:
 json_attributes:
   description: Defines a list of keys to extract values from a JSON dictionary result and then set as sensor attributes.
   required: false
-  type: string, list
+  type: [string, list]
 {% endconfiguration %}
 
 ## Examples

--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -82,7 +82,7 @@ json_attributes_template:
 json_attributes:
   description: (Deprecated, replaced by json_attributes_topic) A list of keys to extract values from a JSON dictionary payload and then set as sensor attributes.
   required: false
-  type: list, string
+  type: [string, list]
 unique_id:
   description: "An ID that uniquely identifies this sensor. If two sensors have the same unique ID, Home Assistant will raise an exception."
   required: false
@@ -100,7 +100,7 @@ device:
     identifiers:
       description: A list of IDs that uniquely identify the device. For example a serial number.
       required: false
-      type: list, string
+      type: [string, list]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false

--- a/source/_components/snmp.markdown
+++ b/source/_components/snmp.markdown
@@ -32,19 +32,19 @@ This device tracker needs SNMP to be enabled on the router. It could be that you
 The following OID examples pull the current MAC Address table from a router. This reflects all recent devices seen on the network. However, since devices are not removed until they time out, this is less effective for [device tracker integration page](/components/device_tracker/) than desirable. It is recommended to use [Ping](/components/device_tracker.ping/) or [Nmap](/components/device_tracker.nmap_tracker/) instead.
 
 | Brand | Device/Firmware | OID |
-|---|---|---|---|
+| --- | --- | --- |
 | Aerohive | AP230 | `1.3.6.1.4.1.26928.1.1.1.2.1.2.1.1` |
-| Apple | Airport Express (2nd gen.) 7.6.9 |  `1.3.6.1.2.1.3.1.1.2` or `1.3.6.1.2.1.4.22.1.2`|
+| Apple | Airport Express (2nd gen.) 7.6.9 | `1.3.6.1.2.1.3.1.1.2` or `1.3.6.1.2.1.4.22.1.2`|
 | Aruba | IAP325 on AOS 6.5.4.8 | `1.3.6.1.4.1.14823.2.3.3.1.2.4.1.1` |
 | BiPAC | 7800DXL Firmware 2.32e | `1.3.6.1.2.1.17.7.1.2.2.1.1` |
-| DD-WRT | unknown version/model |  `1.3.6.1.2.1.4.22.1.2` |
+| DD-WRT | unknown version/model | `1.3.6.1.2.1.4.22.1.2` |
 | Mikrotik | unknown RouterOS version/model | `1.3.6.1.4.1.14988.1.1.1.2.1.1` |
 | Mikrotik | RouterOS 6.x on RB2011 | `1.3.6.1.2.1.4.22.1.2` |
 | OpenWrt | Chaos Calmer 15.05 | `1.3.6.1.2.1.4.22.1.2` |
-| OPNSense | 19.1  | `1.3.6.1.2.1.4.22.1.2` |
-| pfSense | 2.2.4  | `1.3.6.1.2.1.4.22.1.2` |
+| OPNSense | 19.1 | `1.3.6.1.2.1.4.22.1.2` |
+| pfSense | 2.2.4 | `1.3.6.1.2.1.4.22.1.2` |
 | Ruckus | ZoneDirector 9.13.3 | `1.3.6.1.4.1.25053.1.2.2.1.1.3.1.1.1.6` |
-| TP-Link | Archer VR2600v |  `1.3.6.1.2.1.3.1.1.2.19.1` |
+| TP-Link | Archer VR2600v | `1.3.6.1.2.1.3.1.1.2.19.1` |
 | TP-Link | Archer VR600 | `1.3.6.1.2.1.3.1.1.2` |
 | Ubiquiti | Edgerouter Lite v1.9.0 | `1.3.6.1.2.1.4.22.1.2` |
 

--- a/source/_components/socialblade.markdown
+++ b/source/_components/socialblade.markdown
@@ -10,11 +10,11 @@ redirect_from:
  - /components/sensor.socialblade/
 ---
 
-The `socialblade` sensor platform allows you get updates on a Youtube channel using your social blade channel ID. The sensor gets the subscribers and total views count from [Social Blade Website](https://socialblade.com).
+The `socialblade` sensor platform allows you to monitor a YouTube channels subscriber count and total views count. The sensor retrieves data from the [Social Blade website](https://socialblade.com).
 
 ## Setup
 
-To get the channel ID you can go to [Social Blade Website](https://socialblade.com) and search for Youtube channel by username, then select the channel and grab the ID from the URL. The channel ID will be the last part of the URL: `https://socialblade.com/youtube/channel/{channel_id}`
+To get the YouTube channel ID, search for and select the channel on the [Social Blade website](https://socialblade.com). The channel ID will be at the end of the Social Blade URL: `https://socialblade.com/youtube/channel/{channel_id}`
 
 ## Configuration
 
@@ -24,14 +24,12 @@ To enable the sensor, add the following lines to your `configuration.yaml` file:
 # Example configuration.yaml entry
 sensor:
   - platform: socialblade
-    channel_id: YOUR_CHANNEL_NUMBER
+    channel_id: YOUTUBE_CHANNEL_ID
 ```
 
 {% configuration %}
 channel_id:
-  description: Channel id number optained from the URL when you access Social Blade web client.
+  description: YouTube channel ID.
   required: true
   type: string
 {% endconfiguration %}
-
-All the data will be fetch from  [Social Blade]( https://socialblade.com/).

--- a/source/_components/spaceapi.markdown
+++ b/source/_components/spaceapi.markdown
@@ -37,11 +37,11 @@ space:
 logo:
   description: URL which is publicly accessible of the logo.
   required: true
-  type: URL
+  type: string
 logo:
   description: URL of the hackerspace's web site.
   required: true
-  type: URL
+  type: string
 location:
   description: Location of the Hackerspace.
   required: true
@@ -50,7 +50,7 @@ location:
     address:
       description: The physical address of the Hackerspace.
       required: true
-      type: String
+      type: string
 contact:
   description: Contact information of the Hackerspace.
   required: true
@@ -59,19 +59,19 @@ contact:
     email:
       description: The email address of the Hackerspace.
       required: true
-      type: String
+      type: string
     irc:
       description: The IRC channel of the Hackerspace
       required: false
-      type: String
+      type: string
     mailing_list:
       description: The mailing list of the Hackerspace.
       required: false
-      type: String
+      type: string
     twitter:
       description: The Twitter account of the Hackerspace.
       required: false
-      type: String
+      type: string
 issue_report_channels:
   description: "The reporting channel for issues. Pick an entity from `contact:`."
   required: true
@@ -88,11 +88,11 @@ state:
     icon_open:
       description: The URL which is publicly accessible of the icon for the open Hackerspace.
       required: false
-      type: URL
+      type: string
     icon_closed:
       description: The URL which is publicly accessible of the icon for the closed Hackerspace.
       required: false
-      type: URL
+      type: string
 sensors:
   description: List of sensors to expose.
   required: false

--- a/source/_components/switch.mqtt.markdown
+++ b/source/_components/switch.mqtt.markdown
@@ -114,7 +114,7 @@ device:
     identifiers:
       description: A list of IDs that uniquely identify the device. For example a serial number.
       required: false
-      type: list, string
+      type: [string, list]
     connections:
       description: 'A list of connections of the device to the outside world as a list of tuples `[connection_type, connection_identifier]`. For example the MAC address of a network interface: `"connections": [["mac", "02:5b:26:a8:dc:12"]]`.'
       required: false

--- a/source/_components/switch.rest.markdown
+++ b/source/_components/switch.rest.markdown
@@ -66,7 +66,7 @@ password:
 headers:
   description: The headers for the request.
   required: false
-  type: list, string
+  type: [string, list]
 verify_ssl:
   description: Verify the SSL certificate of the endpoint.
   required: false

--- a/source/_components/syncthru.markdown
+++ b/source/_components/syncthru.markdown
@@ -30,7 +30,7 @@ sensor:
     description: The address for connecting to the printer. Equal to the SyncThru Webservice address.
     required: true
     default: false
-    type: url
+    type: string
   name:
     description: A user specified name for the printer. Defaults to "Samsung Printer" and the friendly name will be the name of the printer model.
     required: false

--- a/source/_components/synology_srm.markdown
+++ b/source/_components/synology_srm.markdown
@@ -32,7 +32,7 @@ port:
   description: The port to connect to the Synology SRM router.
   required: false
   default: 8001
-  type: int
+  type: integer
 username:
   description: The username of a user with administrative privileges.
   required: false

--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -50,7 +50,7 @@ sensor:
       entity_id:
         description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
         required: false
-        type: string, list
+        type: [string, list]
       unit_of_measurement:
         description: "Defines the units of measurement of the sensor, if any. This will also influence the graphical presentation in the history visualization as a continuous value. Sensors with missing `unit_of_measurement` are showing as discrete values."
         required: false

--- a/source/_components/tplink_lte.markdown
+++ b/source/_components/tplink_lte.markdown
@@ -48,7 +48,7 @@ notify:
     target:
       description: The phone number of a default recipient or a list with multiple recipients.
       required: true
-      type: string, list
+      type: [string, list]
     name:
       description: The name of the notification service.
       required: false

--- a/source/_components/yale_smart_alarm.markdown
+++ b/source/_components/yale_smart_alarm.markdown
@@ -42,7 +42,7 @@ password:
 area_id:
   description: Area ID of the device when talking to Yale's API if required.
   required: false
-  type: int
+  type: integer
   default: 1
 {% endconfiguration %}
 

--- a/source/_cookbook/configuration_yaml_by_fredsmith.markdown
+++ b/source/_cookbook/configuration_yaml_by_fredsmith.markdown
@@ -1,7 +1,0 @@
----
-title: "Configuration.yaml by fredsmith"
-description: ""
-ha_category: Example configuration.yaml
-ha_external_link: https://git.smith.bz/derf/homeautomation
----
-

--- a/source/_cookbook/configuration_yaml_by_mf_social.markdown
+++ b/source/_cookbook/configuration_yaml_by_mf_social.markdown
@@ -1,6 +1,0 @@
----
-title: "Configuration.yaml by mf_social"
-description: ""
-ha_category: Example configuration.yaml
-ha_external_link: https://github.com/mf-social/Home-Assistant
----

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -226,6 +226,7 @@ The following software has built-in support for MQTT discovery:
 - [Arilux AL-LC0X LED controllers](https://github.com/mertenats/Arilux_AL-LC0X)
 - [room-assistant](https://github.com/mKeRix/room-assistant) (starting with 1.1.0)
 - [Zigbee2mqtt](https://github.com/koenkk/zigbee2mqtt)
+- [Zwave2Mqtt](https://github.com/OpenZWave/Zwave2Mqtt) (starting with 2.0.1)
 
 ### Examples
 

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -49,7 +49,7 @@ autoheal:
 device_config / device_config_domain / device_config_glob:
   description: "This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the following options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format."
   required: false
-  type: string, list
+  type: [string, list]
   keys:
     ignored:
       description: Ignore this entity completely. It won't be shown in the Web Interface and no events are generated for it.


### PR DESCRIPTION
**Description:**
Mikrotik changed the used login method with version 6.43 of their RouterOS and disabled the old token login method with version 6.45.1. Therefore the mikrotik component was no longer able to login and use the API.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#25194

## Checklist:

- [ x ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9877"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Bouni/home-assistant.io.git/1ebc8884c4a7e050d01859124def1dd659315330.svg" /></a>

