### PR TITLE
add default values and icon option to horizon component

### DIFF
--- a/source/_components/horizon.markdown
+++ b/source/_components/horizon.markdown
@@ -30,10 +30,17 @@ media_player:
     description: The port of the device to connect to.
     required: false
     type: integer
+    default: 5900
   name:
     description: The name of the device used in the frontend.
     required: false
     type: string
+    default: Horizon
+  icon:
+    description: The icon of the device used in the frontend.
+    required: false
+    type: string
+    default: mdi:television-box
 {% endconfiguration %}
 
 


### PR DESCRIPTION
**Description:**
add icon option to horizon component

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25198

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9879"><img src="https://gitpod.io/api/apps/github/pbs/github.com/benleb/home-assistant.io.git/00e72eb7c59f590c30a98608da68ff4f928a950b.svg" /></a>

