### PR TITLE
Add documentation of new login_method config option

### DIFF
--- a/source/_components/mikrotik.markdown
+++ b/source/_components/mikrotik.markdown
@@ -54,7 +54,7 @@ password:
   required: true
   type: string
 login_method:
-  description: The login method to use on the MikroTik device. The `plain` method is used by default, if you have an older RouterOS Version than 6.43, use `token` as login method.
+  description: The login method to use on the MikroTik device. The `plain` method is used by default, if you have an older RouterOS Version than 6.43, use `token` as the login method.
   required: false
   type: string
   options: plain, token
@@ -76,10 +76,12 @@ method:
 {% endconfiguration %}
 
 <div class='note info'>
+  
   As of version 6.43 of RouterOS Mikrotik introduced a new login method (plain) in addition to the old login method (token). With Version 6.45.1 the old token login method got deprecated.
-  In order to support both login mechanisms the new config option `login_method` has been introduced. If this option is not set, the component will try to login with the plan method first and the token method if that fails.
+  In order to support both login mechanisms, the new config option `login_method` has been introduced. If this option is not set, the component will try to login with the plain method first and the token method if that fails.
   That can cause log entries on the router like `login failure for user homeassistant from 192.168.23.10 via api` but doesn't keep the component from working. 
-  To get rid of these entries, simply set the `login_method` to `plain` for Routers with OS versions > 6.43 or `token` for routers with OS versions < 6.43.
+  To get rid of these entries, set the `login_method` to `plain` for Routers with OS versions > 6.43 or `token` for routers with OS versions < 6.43.
+
 </div>
 
 ## Use a certificate

--- a/source/_components/mikrotik.markdown
+++ b/source/_components/mikrotik.markdown
@@ -53,6 +53,12 @@ password:
   description: The password of the given user account on the MikroTik device.
   required: true
   type: string
+login_method:
+  description: The login method to use on the MikroTik device. The `plain` method is used by default, if you have an older RouterOS Version than 6.43, use `token` as login method.
+  required: false
+  type: string
+  options: plain, token
+  default: plain
 port:
   description: RouterOS API port.
   required: false
@@ -68,6 +74,13 @@ method:
   required: false
   type: string
 {% endconfiguration %}
+
+<div class='note info'>
+  As of version 6.43 of RouterOS Mikrotik introduced a new login method (plain) in addition to the old login method (token). With Version 6.45.1 the old token login method got deprecated.
+  In order to support both login mechanisms the new config option `login_method` has been introduced. If this option is not set, the component will try to login with the plan method first and the token method if that fails.
+  That can cause log entries on the router like `login failure for user homeassistant from 192.168.23.10 via api` but doesn't keep the component from working. 
+  To get rid of these entries, simply set the `login_method` to `plain` for Routers with OS versions > 6.43 or `token` for routers with OS versions < 6.43.
+</div>
 
 ## Use a certificate
 


### PR DESCRIPTION
**Description:**
Mikrotik changed the used login method with version 6.43 of their RouterOS and disabled the old token login method with version 6.45.1. Therefore the mikrotik component was no longer able to login and use the API.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#25194

## Checklist:

- [ x ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9881"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Bouni/home-assistant.io.git/51d60049ee3093c67fb88ae4bec8966018d07d6e.svg" /></a>

