### PR TITLE
Update neato configuration to include vendor support

### DIFF
--- a/source/_components/neato.markdown
+++ b/source/_components/neato.markdown
@@ -33,6 +33,10 @@ password:
   description: Password for the Neato account.
   required: true
   type: string
+vendor:
+  description: Support for additional vendors. Set to `vorwerk` for Vorwerk robots. Defaults to `neato`.
+  required: false
+  type: string
 {% endconfiguration %}
 
 <div class='note'>

--- a/source/_components/neato.markdown
+++ b/source/_components/neato.markdown
@@ -34,9 +34,10 @@ password:
   required: true
   type: string
 vendor:
-  description: Support for additional vendors. Set to `vorwerk` for Vorwerk robots. Defaults to `neato`.
+  description: Support for additional vendors. Set to `vorwerk` for Vorwerk robots.
   required: false
   type: string
+  default: neato
 {% endconfiguration %}
 
 <div class='note'>


### PR DESCRIPTION
**Description:**

The neato integration is being updated to include vendor support

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25200

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9882"><img src="https://gitpod.io/api/apps/github/pbs/github.com/dshokouhi/home-assistant.github.io.git/837c07185d6cca1c7368ba7f9b5a22a72a9b98bf.svg" /></a>

