### PR TITLE
Add HmIP-PCBS, HmIP-PCBS2, HmIP-PCBS-Bat to Homematic IP Cloud

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -140,7 +140,7 @@ authtoken:
   * Multi IO Box - 2x (*HmIP-MIOB*)
   * Switch Circuit Board - 1x channels (*HmIP-PCBS*)
   * Switch Circuit Board - 2x channels (*HmIP-PCBS2*)
-  * Printed Circuit Board Switch Batter (*HmIP-PCBS-BAT*)
+  * Printed Circuit Board Switch Battery (*HmIP-PCBS-BAT*)
 
 * homematicip_cloud.weather
   * Weather Sensor – basic (*HmIP-SWO-B*)

--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -138,6 +138,9 @@ authtoken:
   * Switch Actuator and Meter – flush-mount (*HmIP-FSM, -FSM16*)
   * Open Collector Module Receiver - 8x (*HmIP-MOD-OC8*)
   * Multi IO Box - 2x (*HmIP-MIOB*)
+  * Switch Circuit Board - 1x channels (*HmIP-PCBS*)
+  * Switch Circuit Board - 2x channels (*HmIP-PCBS2*)
+  * Printed Circuit Board Switch Batter (*HmIP-PCBS-BAT*)
 
 * homematicip_cloud.weather
   * Weather Sensor – basic (*HmIP-SWO-B*)


### PR DESCRIPTION
**Description:**
Add HmIP-PCBS, HmIP-PCBS2, HmIP-PCBS-Bat to Homematic IP Cloud

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25201

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9883"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SukramJ/home-assistant.io.git/b562b1f41ef3af58f9d579ceb5357ab2953de4c1.svg" /></a>

