### PR TITLE
Adds config validation to configuration plugin

### DIFF
--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -7,6 +7,11 @@ module Jekyll
       'icon'         => '/docs/configuration/customizing-devices/#icon',
     }
 
+    TYPES = [
+      'action', 'boolean', 'string', 'integer', 'float', 'time', 'template',
+      'device_class', 'icon', 'map', 'list', 'date', 'datetime'
+    ]
+
     def initialize(tag_name, text, tokens)
       super
       @component, @platform = text.strip.split('.', 2)
@@ -48,7 +53,7 @@ module Jekyll
       end
     end
 
-    def render_config_vars(vars:, component:, platform:, classes: nil)
+    def render_config_vars(vars:, component:, platform:, converter:, classes: nil, parent_type: nil)
       result = Array.new
       result << "<dl class='#{classes}'>"
 
@@ -57,20 +62,56 @@ module Jekyll
         markup << "<dt><a class='title-link' name='#{slug(key)}' href='\##{slug(key)}'></a> #{key}</dt>"
         markup << "<dd>"
         markup << "<p class='desc'>"
+
         if attr.key? 'type'
+
+          # Check if the type (or list of types) are valid
+          if attr['type'].kind_of? Array
+            attr['type'].each do |type|
+              raise ArgumentError, "Configuration type '#{type}' for key '#{key}' is not a valid type in the documentation."\
+              " See: https://developers.home-assistant.io/docs/en/documentation_create_page.html#configuration" unless \
+                TYPES.include? type
+            end
+          else          
+            raise ArgumentError, "Configuration type '#{attr['type']}' for key '#{key}' is not a valid type in the documentation."\
+            " See: https://developers.home-assistant.io/docs/en/documentation_create_page.html#configuration" unless \
+              TYPES.include? attr['type']
+          end
+
           markup << "<span class='type'>(<span class='#{type_class(attr['type'])}'>"
           markup << "#{type_link(attr['type'], component: component)}</span>)</span>"
+        else
+          # Type is missing, which is required (unless we are in a list or template)
+          raise ArgumentError, "Configuration key '#{key}' is missing a type definition" \
+            unless ['list', 'template'].include? parent_type
         end
+
+        
         if attr.key? 'required'
+          # Check if required is a valid value
+          raise ArgumentError, "Configuration key '#{key}' required field must be specified as: "\
+            "true, false, inclusive or exclusive."\
+            unless [true, false, 'inclusive', 'exclusive'].include? attr['required']
+
           markup << "<span class='required'>(#{required_value(attr['required'])})</span>"
         end
+
         if attr.key? 'description'
-          markup << "<span class='description'>#{attr['description']}</span>"
+          markup << "<span class='description'>#{converter.convert(attr['description'].to_s)}</span>"
+        else
+          # Description is missing
+          raise ArgumentError, "Configuration key '#{key}' is missing a description."
         end
         markup << "</p>"
-        if attr.key? 'default'
-          markup << "<p class='default'>Default value: #{attr['default']}</p>"
+
+        if attr.key? 'default' and not attr['default'].to_s.empty?
+          markup << "<p class='default'>\nDefault value: #{converter.convert(attr['default'].to_s)}</p>"
+        elsif attr['type'].to_s.include? 'boolean'
+          # Is the type is a boolean, a default key is required
+          raise ArgumentError, "Configuration key '#{key}' is a boolean type and"\
+            " therefore, requires a default."
         end
+
         markup << "</dd>"
 
         # Check for nested configuration variables
@@ -78,7 +119,8 @@ module Jekyll
           markup << "<dd>"
           markup << render_config_vars(
             vars: attr['keys'], component: component,
-            platform: platform, classes: 'nested')
+            platform: platform, converter: converter,
+            classes: 'nested', parent_type: attr['type'])
           markup << "</dd>"
         end
 
@@ -100,12 +142,20 @@ module Jekyll
       component = Liquid::Template.parse(@component).render context
       platform  = Liquid::Template.parse(@platform).render context
 
+      site = context.registers[:site]
+      converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+
       vars = SafeYAML.load(contents)
 
       <<~MARKUP
         <div class="config-vars">
           <h3><a class="title-link" name="configuration-variables" href="#configuration-variables"></a> Configuration Variables</h3>
-          #{render_config_vars(vars: vars, component: component, platform: platform)}
+          #{render_config_vars(
+            vars: vars,
+            component: component,
+            platform: platform,
+            converter: converter
+          )}
         </div>
       MARKUP
     end


### PR DESCRIPTION
**Description:**

This updates our Jekyll configuration plugin (responsible for rendering the configuration blocks).

## Markdown in config values

It adds support for rendering config values as Markdown by parsing the values. This broken when we switched Markdown parser. The output wasn't actually Markdown, but mixed HTML/Markdown. By Markdown parsing values separately, this becomes just HTML as output.

## Configuration validation

Secondly, it adds a bunch of check to the configuration, basically adding config validation.
If the configuration block contains invalid values/syntax/types/ect the site build will fail with a proper error message.

All current configuration blocks are corrected using this check: #9884 and #9874.


⚠️ **This PR cannot be merged until we have done a release**. Merging this in right now, will work, but will cause issues with merging in the `rc` branch (aka release).

📆 The plan: 
- [x] Wait for release, manual check and correct everything again, correct if needed.
- [x] Merge `current` -> `next`
- [x] Run on `next` manually and correct if needed.
- [x] Merge this PR on `current`
- [ ] Merge `current` -> `next`


## Screenshots of build errors

![image](https://user-images.githubusercontent.com/195327/61403728-3bb9a280-a8d6-11e9-8eb7-31abc3754318.png)

![image](https://user-images.githubusercontent.com/195327/61403749-45430a80-a8d6-11e9-9a97-9420ae7ffcf9.png)

![image](https://user-images.githubusercontent.com/195327/61403772-4d9b4580-a8d6-11e9-83a9-a57775fc26f5.png)

![image](https://user-images.githubusercontent.com/195327/61403782-5429bd00-a8d6-11e9-9455-7b086150a3cf.png)



**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9886"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/d6ad12ec44b3b90448fa84eba0e45f8e1f947abd.svg" /></a>

