### PR TITLE
Add docs for new SimpliSafe PIN services

### DIFF
--- a/source/_components/simplisafe.markdown
+++ b/source/_components/simplisafe.markdown
@@ -15,6 +15,8 @@ There is currently support for the following device types within Home Assistant:
 
 - Alarm
 
+## Configuration
+
 To enable this component, add the following lines to your `configuration.yaml`:
 
 ```yaml
@@ -39,3 +41,28 @@ code:
   required: false
   type: string
 {% endconfiguration %}
+
+## Services
+
+Note that the `system_id` parameter required by the below service calls can be discovered
+by looking at the device state attributes for the integration's `alarm_control_panel`
+entity.
+
+### `simplisafe.remove_pin`
+
+Remove a SimpliSafe PIN (by label or PIN value).
+
+| Service Data Attribute    | Optional | Description                                 |
+|---------------------------|----------|---------------------------------------------|
+| `system_id`                |      no  | The ID of the system to remove the PIN from |
+| `label_or_pin`              |      no  | The PIN label or value to remove            |
+
+### `simplisafe.set_pin`
+
+Set a SimpliSafe PIN.
+
+| Service Data Attribute    | Optional | Description                                 |
+|---------------------------|----------|---------------------------------------------|
+| `system_id`                |      no  | The ID of the system to remove the PIN from |
+| `label`                     |      no  | The label to show in the SimpliSafe UI      |
+| `pin`                       |      no  | The PIN value to use                        |


### PR DESCRIPTION
**Description:**

This PR adds docs for the forthcoming PIN-related SimpliSafe services.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/25207

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9887"><img src="https://gitpod.io/api/apps/github/pbs/github.com/bachya/home-assistant.github.io.git/3e0edfce74aa8c05843fdf6828da053a3b6a4349.svg" /></a>

