### PR TITLE
Add info about concurrent use of data and data_template

### DIFF
--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -77,6 +77,16 @@ data_template:
   temperature: {% raw %}{{ 22 - distance(states.device_tracker.paulus) }}{% endraw %}
 ```
 
+It is even possible to use `data` and `data_template` concurrently but be aware that `data_template` will overwrite attributes that are provided in both.
+
+```yaml
+service: thermostat.set_temperature
+data:
+  entity_id: thermostat.upstairs
+data_template:
+  temperature: {% raw %}{{ 22 - distance(states.device_tracker.paulus) }}{% endraw %}
+```
+
 ### `homeassistant` services
 
 There are four `homeassistant` services that aren't tied to any single domain, these are:


### PR DESCRIPTION
**Description:**
In service calls `data` and `data_template` can be used in the same service call concurrently. It has to be noted that attributes can be overwritten.

See also #9890

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9889"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/eca777d7c781aaaf62fdd1b4a31269a6f8a7bb26.svg" /></a>

