### PR TITLE
Add info about concurrent use of data and data_template

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -72,6 +72,8 @@ There are a few very important rules to remember when writing automation templat
 
 Remembering these simple rules will help save you from many headaches and endless hours of frustration when using automation templates.
 
+It is possible to use `data` and `data_template` concurrently but be aware that `data_template` will overwrite attributes that are provided in both.
+
 ## Trigger State Object
 
 Knowing how to access the [state object](/docs/configuration/state_object/) of a trigger entity could be one of the more common questions. Here are a few ways for the [`state`](#state), [`numeric_state`](#numeric_state) and [`template`](#template) triggers:


### PR DESCRIPTION
**Description:**
In automations `data` and `data_template` can be used in the same service call concurrently. It has to be noted that attributes can be overwritten.

See also #9889

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9890"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/c5b65b0a8aa7d70ce9af02609bebfbe0a9742f83.svg" /></a>

