### PR TITLE
Mode `on` is now `heat`

### DIFF
--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -281,7 +281,7 @@ climate:
     name: Study
     modes:
       - "off"
-      - "on"
+      - "heat"
       - "auto"
     mode_command_topic: "study/ac/mode/set"
     mode_state_topic: "study/ac/mode/state"


### PR DESCRIPTION
**Description:**
Mode `on` is now called `heat`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
