### PR TITLE
Add MQTT climate precision

### DIFF
--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -143,7 +143,7 @@ precision:
   description: The desired precision for this device. Can be used to match your actual thermostat's precision. Supported values are `0.1`, `0.5` and `1.0`.
   required: false
   type: float
-  default: `0.1` for Celsius and `1.0` for Fahrenheit.
+  default: 0.1 for Celsius and 1.0 for Fahrenheit.
 fan_mode_command_topic:
   description: The MQTT topic to publish commands to change the fan mode.
   required: false

--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -323,4 +323,5 @@ climate:
     temperature_command_topic: "study/ac/temperature/set"
     fan_mode_command_topic: "study/ac/fan/set"
     swing_mode_command_topic: "study/ac/swing/set"
+    precision: 1.0
 ```

--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -143,6 +143,7 @@ precision:
   description: The desired precision for this device. Can be used to match your actual thermostat's precision. Supported values are `0.1`, `0.5` and `1.0`.
   required: false
   type: float
+  default: `0.1` for Celsius and `1.0` for Fahrenheit.
 fan_mode_command_topic:
   description: The MQTT topic to publish commands to change the fan mode.
   required: false

--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -139,6 +139,10 @@ temperature_high_state_topic:
   description: The MQTT topic to subscribe for changes in the target high temperature. If this is not set, the target high temperature works in optimistic mode (see below).
   required: false
   type: string
+precision:
+  description: The desired precision for this device. Can be used to match your actual thermostat's precision. Supported values are `0.1`, `0.5` and `1.0`.
+  required: false
+  type: float
 fan_mode_command_topic:
   description: The MQTT topic to publish commands to change the fan mode.
   required: false


### PR DESCRIPTION
**Description:**
Document MQTT climate precision configuration.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25265

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9896"><img src="https://gitpod.io/api/apps/github/pbs/github.com/PhilRW/home-assistant.github.io.git/42cf446aa41db0af39b23a5c01da7e7e7bb1c38a.svg" /></a>

