### PR TITLE
Clarify modes is limited to a specific set.

### DIFF
--- a/source/_components/climate.mqtt.markdown
+++ b/source/_components/climate.mqtt.markdown
@@ -107,7 +107,7 @@ mode_state_template:
   required: false
   type: template
 modes:
-  description: A list of supported modes.
+  description: A list of supported modes. Needs to be a subset of the default values.
   required: false
   default: ['auto', 'off', 'cool', 'heat', 'dry', 'fan_only']
   type: list


### PR DESCRIPTION
**Description:**
Clarify that MQTT climate the modes need to be part of our set of supported HVAC modes.

Fixes https://github.com/home-assistant/home-assistant/issues/25217

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9897"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/6650be30827a84278d0fa04b8ac4f8467438acb7.svg" /></a>

