### PR TITLE
Update Arch Linux instructions to install from 'community' repo

### DIFF
--- a/source/_docs/installation/archlinux.markdown
+++ b/source/_docs/installation/archlinux.markdown
@@ -5,7 +5,27 @@ description: "Installation of Home Assistant on your Arch Linux computer."
 
 [Arch Linux](https://www.archlinux.org/) is a lightweight and flexible Linux distribution for x86_64.
 
-Install the needed Python packages.
+### Official Repositories
+
+Home Assistant is provided in Arch's official `community` repository. Install using pacman.
+
+```bash
+# pacman -S home-assistant
+```
+
+Enable and start `home-assistant.service`.
+
+```bash
+# systemctl enable home-assistant
+# systemctl start home-assistant
+```
+
+Configurations and data are stored at `/var/lib/hass`
+
+
+### PyPI
+
+Alternatively, install directly using the PyPI repository. Install the needed Python packages.
 
 ```bash
 $ sudo pacman -S python
@@ -16,10 +36,4 @@ and Home Assistant itself.
 
 ```bash
 $ pip3 install --user homeassistant
-```
-
-Home Assistant is part of the [AUR](https://aur.archlinux.org/packages/home-assistant/). This means that it can be installed with `pacaur`. This package is often broken or outdated:
-
-```bash
-$ pacaur -S home-assistant
 ```


### PR DESCRIPTION
**Description:** Arch Linux's Home Assistant package has recently been added to the official 'community' repository. This commit updates the instructions for Arch to reflect this change.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9904"><img src="https://gitpod.io/api/apps/github/pbs/github.com/etskinner/home-assistant.io.git/62b4e57ad71e6a2e282bb0e2ad5cdc0eaeac48e1.svg" /></a>

