### PR TITLE
Minor - Clarify Services

### DIFF
--- a/source/_components/ecobee.markdown
+++ b/source/_components/ecobee.markdown
@@ -141,6 +141,7 @@ modes that the Ecobee thermostat provides: heat, auxHeatOnly, cool,
 auto, and off.
 
 ## Services
+Ecobee integration as of version 0.96.0 uses standard Home Assistant [Climate](https://www.home-assistant.io/components/climate/) Services.
 
 The following extra services are provided by the Ecobee Thermostat: `resume_program`.
 

--- a/source/_components/ecobee.markdown
+++ b/source/_components/ecobee.markdown
@@ -141,9 +141,8 @@ modes that the Ecobee thermostat provides: heat, auxHeatOnly, cool,
 auto, and off.
 
 ## Services
-Ecobee integration as of version 0.96.0 uses standard Home Assistant [Climate](https://www.home-assistant.io/components/climate/) Services.
 
-The following extra services are provided by the Ecobee Thermostat: `resume_program`.
+Besides the standard services provided by the Home Assistant [Climate](https://www.home-assistant.io/components/climate/) integration, the following extra service is provided by the Ecobee Thermostat: `resume_program`.
 
 ### Service `resume_program`
 


### PR DESCRIPTION
Minor update to Services to point users to the standard HA Climate page and note the change occurred in 0.96.0.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9905"><img src="https://gitpod.io/api/apps/github/pbs/github.com/rrubin0/home-assistant.github.io.git/e94d93c36ecee0a63910d0b61f40b598050f2dbf.svg" /></a>

