### PR TITLE
Fix wrong example in `sensor.miflora`

### DIFF
--- a/source/_components/miflora.markdown
+++ b/source/_components/miflora.markdown
@@ -119,7 +119,8 @@ sensor:
   - platform: miflora
     mac: 'xx:xx:xx:xx:xx:xx'
     name: Flower 1
-    force_up    median: 3
+    force_update: true    
+    median: 3
     monitored_conditions:
       - moisture
       - light


### PR DESCRIPTION
Fixes: #9908

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9909"><img src="https://gitpod.io/api/apps/github/pbs/github.com/AlexxIT/home-assistant.github.io.git/560f79511c550368391d7c85c387e85f75cb0f88.svg" /></a>

