### PR TITLE
"off" mode missing in initial_hvac_mode:

### DIFF
--- a/source/_components/generic_thermostat.markdown
+++ b/source/_components/generic_thermostat.markdown
@@ -73,7 +73,7 @@ keep_alive:
   required: false
   type: [time, integer]
 initial_hvac_mode:
-  description: Set the initial HVAC mode. Valid values are `heat`, `cool` or `auto`. Value has to be double quoted. If this parameter is not set, it is preferable to set a *keep_alive* value. This is helpful to align any discrepancies between *generic_thermostat* and *heater* state.
+  description: Set the initial HVAC mode. Valid values are `off`, `heat`, `cool` or `auto`. Value has to be double quoted. If this parameter is not set, it is preferable to set a *keep_alive* value. This is helpful to align any discrepancies between *generic_thermostat* and *heater* state.
   required: false
   type: string
 away_temp:

--- a/source/_components/generic_thermostat.markdown
+++ b/source/_components/generic_thermostat.markdown
@@ -73,7 +73,7 @@ keep_alive:
   required: false
   type: [time, integer]
 initial_hvac_mode:
-  description: Set the initial HVAC mode. Valid values are `off`, `heat`, `cool` or `auto`. Value has to be double quoted. If this parameter is not set, it is preferable to set a *keep_alive* value. This is helpful to align any discrepancies between *generic_thermostat* and *heater* state.
+  description: Set the initial HVAC mode. Valid values are `off`, `heat` or `cool`. Value has to be double quoted. If this parameter is not set, it is preferable to set a *keep_alive* value. This is helpful to align any discrepancies between *generic_thermostat* and *heater* state.
   required: false
   type: string
 away_temp:


### PR DESCRIPTION
added "off" mode to initial_hvac_mode:

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9910"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Destix/home-assistant.io.git/b614980f2e2671baa1d58d0fdc13eb74d050d6b2.svg" /></a>

