### PR TITLE
Fix configuration example for input date time

### DIFF
--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -21,13 +21,16 @@ add the following lines to your `configuration.yaml`:
 input_datetime:
   both_date_and_time:
     name: Input with both date and time
-    has_    has_time: true
+    has_date: true
+    has_time: true
   only_date:
     name: Input with only date
-    has_    has_time: false
+    has_date: true
+    has_time: false
   only_time:
     name: Input with only time
-    has_    has_time: true
+    has_date: false
+    has_time: true
 ```
 
 {% configuration %}


### PR DESCRIPTION
**Description:**
example was screwed up, due to new yaml rendering ? :)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9911"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SNoof85/home-assistant.io.git/7268df7e29ee02525bfef9447c164621a10951a3.svg" /></a>

