### PR TITLE
Fixes running Jekyll preview in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Use Bash as the default shell
 ENV SHELL=/bin/bash 
 
+# Set an environment variable to be able to detect we are in dev container
+ENV DEVCONTAINER=true
+
 # Locale env vars
 ENV \
     LANG=en_US.UTF-8 \

--- a/Rakefile
+++ b/Rakefile
@@ -89,6 +89,7 @@ end
 desc "preview the site in a web browser"
 task :preview, :listen do |t, args|
   listen_addr = args[:listen] || '127.0.0.1'
+  listen_addr = '0.0.0.0' unless ENV['DEVCONTAINER'].nil?
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "Starting to watch source with Jekyll and Compass. Starting Rack on port #{server_port}"
   system "compass compile --css-dir #{source_dir}/stylesheets" unless File.exist?("#{source_dir}/stylesheets/screen.css")


### PR DESCRIPTION
**Description:**

Fixes the use of the preview mode when using the devcontainer provided by this repository in Visual Studio Code.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9920"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/c171deff295e94fedbb17907c4ebf299e16d1975.svg" /></a>

