### PR TITLE
Add WWLLN to list of geolocation triggers

### DIFF
--- a/source/_components/geo_location.markdown
+++ b/source/_components/geo_location.markdown
@@ -20,7 +20,7 @@ The [Geolocation trigger](/docs/automation/trigger/#geolocation-trigger) can be 
 | NSW Rural Fire Service Incidents                  | `nsw_rural_fire_service_feed`   |
 | Queensland Bushfire Alert                         | `qld_bushfire`                  |
 | U.S. Geological Survey Earthquake Hazards Program | `usgs_earthquakes_feed`         |
-| The World Wide Lightning Location Network         | `wwlln                `         |
+| The World Wide Lightning Location Network         | `wwlln`                         |
 
 Conditions can be used to further filter entities, for example by inspecting their state attributes.
 

--- a/source/_components/geo_location.markdown
+++ b/source/_components/geo_location.markdown
@@ -15,11 +15,12 @@ The [Geolocation trigger](/docs/automation/trigger/#geolocation-trigger) can be 
 
 | Platform                                          | Source                        |
 |---------------------------------------------------|-------------------------------|
-| GeoJSON Events                                    | `geo_json_events`             |
-| IGN Sismología                                    | `ign_sismologia`              |
-| NSW Rural Fire Service Incidents                  | `nsw_rural_fire_service_feed` |
-| Queensland Bushfire Alert                         | `qld_bushfire`                |
-| U.S. Geological Survey Earthquake Hazards Program | `usgs_earthquakes_feed`       |
+| GeoJSON Events                                    | `geo_json_events`               |
+| IGN Sismología                                    | `ign_sismologia`                |
+| NSW Rural Fire Service Incidents                  | `nsw_rural_fire_service_feed`   |
+| Queensland Bushfire Alert                         | `qld_bushfire`                  |
+| U.S. Geological Survey Earthquake Hazards Program | `usgs_earthquakes_feed`         |
+| The World Wide Lightning Location Network         | `wwlln                `         |
 
 Conditions can be used to further filter entities, for example by inspecting their state attributes.
 


### PR DESCRIPTION
**Description:**

This PR adds `wwlln` to the list of `geo_location` triggers.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9921"><img src="https://gitpod.io/api/apps/github/pbs/github.com/bachya/home-assistant.github.io.git/cf7d0b7060ec4a68f43f2a3dc88308a17d8eb375.svg" /></a>

