### PR TITLE
fix typo on Google Assistant page

### DIFF
--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -29,7 +29,7 @@ To use Google Assistant, your Home Assistant configuration has to be [externally
 ## Migrate to release 0.80 and above
 <div class='note'>
 
-If this is the first time setting up your Google Assistant integration, you can skip this section and continue with the [maual setup instructions](#first-time-setup) below.
+If this is the first time setting up your Google Assistant integration, you can skip this section and continue with the [manual setup instructions](#first-time-setup) below.
 
 </div>
 


### PR DESCRIPTION
fixes one typo

maual = manual


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9923"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SeanPM5/home-assistant.io.git/93542eddfeb4451ab9c445f9a9ca31c3f6038967.svg" /></a>

