### PR TITLE
Clarify weblink differences under States & Lovelace

### DIFF
--- a/source/_components/weblink.markdown
+++ b/source/_components/weblink.markdown
@@ -10,6 +10,10 @@ ha_qa_scale: internal
 
 The `weblink` integration allows you to display links in the Home Assistant frontend.
 
+<div class='note'>
+The below documentation applies to the classic "States" user interface. Starting with Home Assistant 0.86, Lovelace is the new default interface. For information on configuring weblinks in Lovelace please follow [these instructions](/lovelace/entities/#weblink) instead.
+</div>
+
 ## Configuration
 
 To use this integration in your installation, add something like the following to your `configuration.yaml` file:


### PR DESCRIPTION
Notice at top of weblink page mentioning that it applies to only States UI, and that Lovelace configuration is different. Includes a link for how to configure weblinks in Lovelace.

Fixes https://github.com/home-assistant/home-assistant-polymer/issues/3322

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9924"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SeanPM5/home-assistant.io.git/bb4ac6e1df070d77a579842701f79de00fba2b74.svg" /></a>

