### PR TITLE
Added infos about the windows parameter

### DIFF
--- a/source/_components/wwlln.markdown
+++ b/source/_components/wwlln.markdown
@@ -46,9 +46,10 @@ radius:
   required: false
   type: integer
 window:
-  description: The amount of time before now for which strikes should be considered "active" and shown in the UI. Defaults to 10 minutes.
+  description: The amount of time before now for which strikes should be considered "active" and shown in the UI.
   required: false
   type: time
+  default: 10 minutes
 {% endconfiguration %}
 
 ## State Attributes

--- a/source/_components/wwlln.markdown
+++ b/source/_components/wwlln.markdown
@@ -46,7 +46,7 @@ radius:
   required: false
   type: integer
 window:
-  description: The amount of time before now for which strikes should be considered "active" and shown in the UI.
+  description: The amount of time before now for which strikes should be considered "active" and shown in the UI. Defaults to 10 minutes.
   required: false
   type: time
 {% endconfiguration %}


### PR DESCRIPTION
Default value 10 minutes

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9926"><img src="https://gitpod.io/api/apps/github/pbs/github.com/lubeda/home-assistant.io.git/4625f3431f957e4c624fb4230cc2822292d0132c.svg" /></a>

