### PR TITLE
Fix incorrect timing statement on WWLLN docs

### DIFF
--- a/source/_components/wwlln.markdown
+++ b/source/_components/wwlln.markdown
@@ -21,7 +21,7 @@ is available as the state of each entity.
   <img src='{{site_root}}/images/screenshots/wwlln-feed-map.png' />
 </p>
 
-New data is returned every 5 minutes.
+New data is returned every 10 minutes.
 
 ## Configuration
 


### PR DESCRIPTION
**Description:**

This PR fixes an incorrect statement on the WWLLN docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9929"><img src="https://gitpod.io/api/apps/github/pbs/github.com/bachya/home-assistant.github.io.git/717e9b4bfaadff7a82d1851cec8d868f1ba32b89.svg" /></a>

