### PR TITLE
Add ctags file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ source/.jekyll-metadata
 !.vscode/extensions.json
 !.vscode/tasks.json
 *.suo
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ source/.jekyll-metadata
 !.vscode/extensions.json
 !.vscode/tasks.json
 *.suo
-tags
+tags*


### PR DESCRIPTION
**Description:**

This PR adds ctags files to `.gitignore`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9930"><img src="https://gitpod.io/api/apps/github/pbs/github.com/bachya/home-assistant.github.io.git/f261f4acfd81c547b406ffde72397961d6cc9d69.svg" /></a>

