### PR TITLE
add contact sensor to homekit_controller docs

### DIFF
--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -34,7 +34,7 @@ There is currently support for the following device types within Home Assistant:
 - Light (HomeKit lights)
 - Lock (HomeKit lock)
 - Switch (HomeKit switches)
-- Binary Sensor (HomeKit motion sensors)
+- Binary Sensor (HomeKit motion sensors and contact sensors)
 - Sensor (HomeKit humidity, temperature, and light level sensors)
 
 The integration will be automatically configured if the [`discovery`](/components/discovery/) integration is enabled.


### PR DESCRIPTION
**Description:**
Update docs to include contact sensors in homekit_controller docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25355

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9931"><img src="https://gitpod.io/api/apps/github/pbs/github.com/dwradcliffe/home-assistant.io.git/9efe0fbcaa605bde0f283bad573eac9199c75947.svg" /></a>

