### PR TITLE
Removes archlinux package instructions

### DIFF
--- a/source/_docs/installation/archlinux.markdown
+++ b/source/_docs/installation/archlinux.markdown
@@ -8,18 +8,9 @@ description: "Installation of Home Assistant on your Arch Linux computer."
 Install the needed Python packages.
 
 ```bash
-$ sudo pacman -S python
-$ sudo pacman -S python-pip
+sudo pacman -S python
+sudo pacman -S python-pip
 ```
 
-and Home Assistant itself.
-
-```bash
-$ pip3 install --user homeassistant
-```
-
-Home Assistant is part of the [AUR](https://aur.archlinux.org/packages/home-assistant/). This means that it can be installed with `pacaur`. This package is often broken or outdated:
-
-```bash
-$ pacaur -S home-assistant
-```
+From here on, we recommend you to follow the
+[virtualenv](https://www.home-assistant.io/docs/installation/virtualenv/) guide.


### PR DESCRIPTION
**Description:**

This removes the part of the archlinux instructions where the user is instructed to install a community package.

We are trying to reduce the number of community created installation methods in our documentation, because they have concerns about people considering it an official supported method by us, which is not the case.

Secondly, there is no way we can control it, keep it up 2 dates or in sync with our current releases (at the time of writing this comment, the package is already 2 minor releases behind).

The currently place to display this community effort would be our community forum.

More info:
https://github.com/home-assistant/home-assistant.io/pull/9904#issuecomment-513453994

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9934"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/bc783292ec579aecaefe156271483e5dd5f65f96.svg" /></a>

