### PR TITLE
Correct incorrect YAML in Discord example

### DIFF
--- a/source/_components/discord.markdown
+++ b/source/_components/discord.markdown
@@ -71,9 +71,9 @@ This channel ID has to be used as the target when calling the notification servi
 ```yaml
 - service: notify.discord
   data:
-    message from Home Assistant",
-    target: "1234567890", "0987654321"
-    data: 
+    message: "A message from Home Assistant"
+    target: ["1234567890", "0987654321"]
+    data:
       images: "/tmp/garage_cam"
 ```
 


### PR DESCRIPTION
**Description:**

Correct an incorrect YAML example (with invalid YAML syntax) for the Discord integration.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9936"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/ab31a2f4ed98abe5e713fe7336961d82b9a46759.svg" /></a>

