### PR TITLE
Add documentation related to new sources configuration option in pioneer component

### DIFF
--- a/source/_components/pioneer.markdown
+++ b/source/_components/pioneer.markdown
@@ -19,10 +19,6 @@ To add a Pioneer receiver to your installation, add the following to your `confi
 media_player:
   - platform: pioneer
     host: 192.168.0.10
-    sources:
-      SAT: '06'
-      TV: '05'
-      Game: '49'
 ```
 
 {% configuration %}

--- a/source/_components/pioneer.markdown
+++ b/source/_components/pioneer.markdown
@@ -45,9 +45,9 @@ timeout:
   required: false
   type: float
 sources:
-  description: A list of mappings from source friendly name to source code (e.g. `TV:'05'`). Valid source codes depend on the receiver (some known codes can be found below). Codes must be defined as strings (between single or double quotation marks), so that `05` is not implicitly transformed to `5`, which wouldn't be a valid source code.
+  description: A list of mappings from source friendly name to the source code (e.g. `TV:'05'`). Valid source codes depend on the receiver (some known codes can be found below). Codes must be defined as strings (between single or double quotation marks) so that `05` is not implicitly transformed to `5`, which wouldn't be valid source code.
   required: false
-  default: Empty list (i.e. no soruce selection will be possible)
+  default: Empty list (i.e. no source selection will be possible)
   type: list
 {% endconfiguration %}
 
@@ -56,14 +56,14 @@ Notes:
 - Some Pioneer AVRs use the port 23 default and some are reported to use 8102.
 - `timeout` is a socket level option and should only be configured if you know what you are doing.
 
-
 ### Source codes
 
-Under these lines you can find some sample `sources` lists per receiver model. Here we use the source names as shown on the remote as key for each code. However these are for display purposes only, so you could rename inputs to better match your set-up (e.g. `HDMI: '19'` to `Kodi: '19'`.
+Under these lines, you can find some sample `sources` lists per receiver model. Here we use the source names as shown on the remote as key for each code. However these are for display purposes only, so you could rename inputs to better match your set-up (e.g. `HDMI: '19'` to `Kodi: '19'`.
 
-Codes must be defined as strings (between single or double quotation marks), so that `05` is not implicitly transformed to `5`, which wouldn't be a valid source code.
+Codes must be defined as strings (between single or double quotation marks) so that `05` is not implicitly transformed to `5`, which wouldn't be valid source code.
 
 #### VSX-921
+
 ```yaml
 sources:
   'PHONO': '00'
@@ -86,6 +86,7 @@ sources:
 ```
 
 #### VSX-822-K
+
 ```yaml
 sources:
   'CD': '01'
@@ -106,6 +107,7 @@ sources:
 ```
 
 #### VSX-824
+
 ```yaml
 sources:
   'CD': '01'

--- a/source/_components/pioneer.markdown
+++ b/source/_components/pioneer.markdown
@@ -19,6 +19,10 @@ To add a Pioneer receiver to your installation, add the following to your `confi
 media_player:
   - platform: pioneer
     host: 192.168.0.10
+    sources:
+      SAT: '06'
+      TV: '05'
+      Game: '49'
 ```
 
 {% configuration %}
@@ -40,9 +44,84 @@ timeout:
   description: Number of seconds (float) to wait for blocking operations like connect, write and read.
   required: false
   type: float
+sources:
+  description: A list of mappings from source friendly name to source code (e.g. `TV:'05'`). Valid source codes depend on the receiver (some known codes can be found below). Codes must be defined as strings (between single or double quotation marks), so that `05` is not implicitly transformed to `5`, which wouldn't be a valid source code.
+  required: false
+  default: Empty list (i.e. no soruce selection will be possible)
+  type: list
 {% endconfiguration %}
 
 Notes:
 
 - Some Pioneer AVRs use the port 23 default and some are reported to use 8102.
 - `timeout` is a socket level option and should only be configured if you know what you are doing.
+
+
+### Source codes
+
+Under these lines you can find some sample `sources` lists per receiver model. Here we use the source names as shown on the remote as key for each code. However these are for display purposes only, so you could rename inputs to better match your set-up (e.g. `HDMI: '19'` to `Kodi: '19'`.
+
+Codes must be defined as strings (between single or double quotation marks), so that `05` is not implicitly transformed to `5`, which wouldn't be a valid source code.
+
+#### VSX-921
+```yaml
+sources:
+  'PHONO': '00'
+  'CD': '01'
+  'CD-R/TAPE': '03'
+  'DVD': '04'
+  'TV/SAT': '05'
+  'VIDEO 1(VIDEO)': '10'
+  'VIDEO 2': '14'
+  'DVR/BDR': '15'
+  'iPod/USB': '17'
+  'HDMI1': '19'
+  'HDMI2': '20'
+  'HDMI3': '21'
+  'HDMI4': '22'
+  'HDMI5': '23'
+  'HDMI6': '24'
+  'BD': '25'
+  'HOME MEDIA GALLERY(Internet Radio)': '26'
+```
+
+#### VSX-822-K
+```yaml
+sources:
+  'CD': '01'
+  'Tuner': '02'
+  'DVD': '04'
+  'TV': '05'
+  'Sat/Cbl': '06'
+  'Video': '10'
+  'DVR/BDR': '15'
+  'iPod/USB': '17'
+  'BD': '25'
+  'Adapter': '33'
+  'Netradio': '38'
+  'Pandora': '41'
+  'Media Server': '44'
+  'Favorites': '45'
+  'Game': '49'
+```
+
+#### VSX-824
+```yaml
+sources:
+  'CD': '01'
+  'Tuner': '02'
+  'DVD': '04'
+  'TV': '05'
+  'Sat/Cbl': '06'
+  'Video': '10'
+  'DVR/BDR': '15'
+  'iPod/USB': '17'
+  'HDMI': '19'
+  'BD': '25'
+  'Adapter': '33'
+  'Netradio': '38'
+  'Media Server': '44'
+  'Favorites': '45'
+  'MHL': '48'
+  'Game': '49'
+```


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#25305

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9937"><img src="https://gitpod.io/api/apps/github/pbs/github.com/plafue/home-assistant.io.git/7c6d8b301dec12b4e30dbbbb14c4eba8d3befc11.svg" /></a>

