### PR TITLE
Fix deprecated link

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -178,7 +178,7 @@ A detailed guide about running Hass.io as a virtual machine is available in the 
 [vmdk]: https://github.com/home-assistant/hassos/releases/download/2.12/hassos_ova-2.12.vmdk.gz
 [vhdx]: https://github.com/home-assistant/hassos/releases/download/2.12/hassos_ova-2.12.vhdx.gz
 [vdi]: https://github.com/home-assistant/hassos/releases/download/2.12/hassos_ova-2.12.vdi.gz
-[linux]: https://github.com/home-assistant/hassio-build/tree/master/install#install-hassio
+[linux]: https://github.com/home-assistant/hassio-installer
 [local]: http://hassio.local:8123
 [samba]: /addons/samba/
 [ssh]: /addons/ssh/


### PR DESCRIPTION
Updated the link to hassio installation instructions on linux/vm.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9938"><img src="https://gitpod.io/api/apps/github/pbs/github.com/magnusoverli/home-assistant.io.git/565ace7d41727be610c9d1a52933467c87fe5204.svg" /></a>

