### PR TITLE
Added info on supported Ubuntu versions

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -137,7 +137,7 @@ You also need to have Docker-CE installed. There are well-documented procedures 
   Some distributions, like Ubuntu, have a `docker.io` package available. Using that packages will cause issues!
   Be sure to install the official Docker-CE from the above listed URL.
   
-  Currently, Docker has not yet released a version that supports Ubuntu 19.04. The latest Ubuntu version supported by Docker is Ubuntu 18.10 (Cosmic Cuttlefish).
+  Docker is not always ready with a release when a new Ubuntu version is out. Check if your version of Ubuntu is supported by docker [here](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
 
 </div>
 

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -136,6 +136,8 @@ You also need to have Docker-CE installed. There are well-documented procedures 
 
   Some distributions, like Ubuntu, have a `docker.io` package available. Using that packages will cause issues!
   Be sure to install the official Docker-CE from the above listed URL.
+  
+  Currently, Docker has not yet released a version that supports Ubuntu 19.04. The latest Ubuntu version supported by Docker is Ubuntu 18.10 (Cosmic Cuttlefish).
 
 </div>
 


### PR DESCRIPTION
Adding a note on the latest docker-supported version of Ubuntu.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9940"><img src="https://gitpod.io/api/apps/github/pbs/github.com/magnusoverli/home-assistant.io.git/b4799e0cb218952a64485ee63c0a222f7373b090.svg" /></a>

