### PR TITLE
Add note about manual config and discovery

### DIFF
--- a/source/_components/netatmo.markdown
+++ b/source/_components/netatmo.markdown
@@ -60,7 +60,7 @@ password:
   required: true
   type: string
 discovery:
-  description: Whether to discover Netatmo devices. Set it to False, if you want to choose which Netatmo device you want to add.
+  description: Whether to discover Netatmo devices automatically. Set it to False, if you want to choose which Netatmo device you want to add. Do not use discovery and manual configuration at the same time.
   required: false
   type: boolean
   default: true


### PR DESCRIPTION
**Description:**
Add note about not using manual configuration and discovery, as it will lead to errors.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9945"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/f9b3ae21b01205e0a084db7335f86f2aacf3c56b.svg" /></a>

