### PR TITLE
Change component to integration

### DIFF
--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -24,7 +24,7 @@ redirect_from:
   - /components/sensor.homekit_controller/
 ---
 
-[HomeKit](https://developer.apple.com/homekit/) controller integration for Home Assistant allows you to connect HomeKit accessories to Home Assistant. This integration should not be confused with the [HomeKit](/components/homekit/) component, which allows you to control Home Assistant devices via HomeKit.
+[HomeKit](https://developer.apple.com/homekit/) controller integration for Home Assistant allows you to connect HomeKit accessories to Home Assistant. This integration should not be confused with the [HomeKit](/components/homekit/) integration, which allows you to control Home Assistant devices via HomeKit.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -39,4 +39,4 @@ There is currently support for the following device types within Home Assistant:
 
 The integration will be automatically configured if the [`discovery`](/components/discovery/) integration is enabled.
 
-For each detected HomeKit accessory, a configuration prompt will appear in the web front end. Use this to provide the HomeKit PIN. Note that HomeKit accessories can only be paired to one device at once. If your device is currently paired with Siri, you will need to reset it in order to pair it with Home Assistant. Once Home Assistant is configured to work with the device, you can export it back to Siri with the [`HomeKit`](/components/homekit/) component.
+For each detected HomeKit accessory, a configuration prompt will appear in the web front end. Use this to provide the HomeKit PIN. Note that HomeKit accessories can only be paired to one device at once. If your device is currently paired with Siri, you will need to reset it in order to pair it with Home Assistant. Once Home Assistant is configured to work with the device, you can export it back to Siri with the [`HomeKit`](/components/homekit/) integration.


### PR DESCRIPTION
Changing stray mentions of "component" to "integration"

**Description:**
Changing stray mentions of "component" to "integration"

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9946"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/7757e5cde0a1a4b109dae9ca1782f1048306060f.svg" /></a>

