### PR TITLE
add in ring switch docs

### DIFF
--- a/source/_components/ring.markdown
+++ b/source/_components/ring.markdown
@@ -55,7 +55,7 @@ password:
 
 ## Binary Sensor
 
-Once you have enabled the [Ring component](/components/ring), you can start using a binary sensor. Add the following to your `configuration.yaml` file:
+Once you have enabled the [Ring integration](/components/ring), you can start using a binary sensor. Add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -83,7 +83,7 @@ Currently it supports doorbell, external chimes and stickup cameras.
 Please note that downloading and playing Ring video will require a Ring Protect plan.
 </div>
 
-Once you have enabled the [Ring component](/components/ring), you can start using the camera platform. Add the following to your `configuration.yaml` file:
+Once you have enabled the [Ring integration](/components/ring), you can start using the camera platform. Add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -157,7 +157,7 @@ hass.services.call('downloader', 'download_file', data)
 
 ## Sensor
 
-Once you have enabled the [Ring component](/components/ring), you can start using the sensor platform. Add the following to your `configuration.yaml` file:
+Once you have enabled the [Ring integration](/components/ring), you can start using the sensor platform. Add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -191,7 +191,7 @@ Currently it supports doorbell, external chimes and stickup cameras.
 
 ## Switch
 
-Once you have enabled the [Ring component](/components/ring), you can start using the switch platform. Add the following to your `configuration.yaml` file:
+Once you have enabled the [Ring integration](/components/ring), you can start using the switch platform. Add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/ring.markdown
+++ b/source/_components/ring.markdown
@@ -7,21 +7,26 @@ ha_category:
   - Binary Sensor
   - Camera
   - Sensor
+  - Switch
 ha_release: 0.42
 ha_iot_class: Cloud Polling
 redirect_from:
   - /components/binary_sensor.ring/
   - /components/camera.ring/
   - /components/sensor.ring/
+  - /components/switch.ring/
 ---
 
 The `ring` implementation allows you to integrate your [Ring.com](https://ring.com/) devices in Home Assistant.
 
 There is currently support for the following device types within Home Assistant:
 
+- [Configuration](#configuration)
 - [Binary Sensor](#binary-sensor)
-- [Camera](#camera) - downloading and playing Ring video will require a Ring Protect plan.
+- [Camera](#camera)
+- [Saving the videos captured by your Ring Door Bell](#saving-the-videos-captured-by-your-ring-door-bell)
 - [Sensor](#sensor)
+- [Switch](#switch)
 
 Currently only doorbells are supported by this sensor.
 
@@ -186,3 +191,15 @@ monitored_conditions:
 {% endconfiguration %}
 
 Currently it supports doorbell, external chimes and stickup cameras.
+
+## Switch
+
+Once you have enabled the [Ring component](/components/ring), you can start using the switch platform. Add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: ring
+```
+
+This will add a switch for every camera that supports a siren, and for every camera that supports a floodlight. Note the siren will only turn on for 30 seconds before automatically turning off.

--- a/source/_components/ring.markdown
+++ b/source/_components/ring.markdown
@@ -14,7 +14,6 @@ redirect_from:
   - /components/binary_sensor.ring/
   - /components/camera.ring/
   - /components/sensor.ring/
-  - /components/switch.ring/
 ---
 
 The `ring` implementation allows you to integrate your [Ring.com](https://ring.com/) devices in Home Assistant.

--- a/source/_components/ring.markdown
+++ b/source/_components/ring.markdown
@@ -20,10 +20,8 @@ The `ring` implementation allows you to integrate your [Ring.com](https://ring.c
 
 There is currently support for the following device types within Home Assistant:
 
-- [Configuration](#configuration)
 - [Binary Sensor](#binary-sensor)
 - [Camera](#camera)
-- [Saving the videos captured by your Ring Door Bell](#saving-the-videos-captured-by-your-ring-door-bell)
 - [Sensor](#sensor)
 - [Switch](#switch)
 


### PR DESCRIPTION
**Description:**
Add in documentation for the ring switch (support for floodlights and siren)

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25501

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9948"><img src="https://gitpod.io/api/apps/github/pbs/github.com/rossdargan/home-assistant.io.git/85bcf250d04d284900351cddd6299494e219a89f.svg" /></a>

