### PR TITLE
Add scan interval config item to Environment Canada sensor

### DIFF
--- a/source/_components/environment_canada.markdown
+++ b/source/_components/environment_canada.markdown
@@ -129,10 +129,10 @@ language:
   type: string
   default: english
 scan_interval:
-  description: The time between updates in minutes.
+  description: The time between updates in seconds.
   required: false
-  type: int
-  default: 10
+  type: integer
+  default: 600
 {% endconfiguration %}
 
 ###Alert TTS Script

--- a/source/_components/environment_canada.markdown
+++ b/source/_components/environment_canada.markdown
@@ -105,7 +105,6 @@ sensor:
     - `advisories` - Current advisory alerts.
     - `statements` - Current special weather statements.
     - `endings` - Alerts that have recently ended.
-- The platform refreshes the data every minute (primarily to update alerts), and the source data is typically updated hourly within 10 minutes after the hour.
 - The platform automatically determines which weather station to use based on the system's latitude/longitude settings. For greater precision, it is also possible to specify either:
     - A specific station code of the form `AB/s0000123` based on those listed in [this CSV file](http://dd.weatheroffice.ec.gc.ca/citypage_weather/docs/site_list_towns_en.csv), or
     - A specific latitude/longitude
@@ -129,6 +128,11 @@ language:
   required: false
   type: string
   default: english
+scan_interval:
+  description: The time between updates in minutes.
+  required: false
+  type: int
+  default: 10
 {% endconfiguration %}
 
 ###Alert TTS Script


### PR DESCRIPTION
**Description:**

Adds a config item to configure the refresh rate for the Environment Canada sensor.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25414

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9950"><img src="https://gitpod.io/api/apps/github/pbs/github.com/michaeldavie/home-assistant.github.io.git/1cfa71bf1cd8b00c46dfe033fe944186b9fbe1ff.svg" /></a>

