### PR TITLE
Remove link from Logbook introduction

### DIFF
--- a/source/_components/logbook.markdown
+++ b/source/_components/logbook.markdown
@@ -11,7 +11,7 @@ ha_release: 0.7
 
 The logbook integration provides a different perspective on the history of your
 house by showing all the changes that happened to your house in reverse
-chronological order. [See the demo for a live example](/demo/). It depends on
+chronological order. It depends on
 the `recorder` integration for storing the data. This means that if the
 [`recorder`](/components/recorder/) integration is set up to use e.g., MySQL or
 PostgreSQL as data store, the `logbook` integration does not use the default


### PR DESCRIPTION
The Home Assistant demo website doesn't have Logbook, so there's no "live example" that can be seen anymore. Better to remove this link rather than causing readers confusion.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9952"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SeanPM5/home-assistant.io.git/17564eae2afdcc62ebfe50c4e11a0e056d821cf8.svg" /></a>

