### PR TITLE
Correct service calls on persistent_notification page

### DIFF
--- a/source/_components/persistent_notification.markdown
+++ b/source/_components/persistent_notification.markdown
@@ -8,7 +8,7 @@ ha_release: 0.23
 ha_qa_scale: internal
 ---
 
-The `persistent_notification` can be used to show a message on the frontend that has to be dismissed by the user.
+The `persistent_notification` integration can be used to show a notfication on the frontend that has to be dismissed by the user.
 
 <p class='img'>
   <img src='/images/screenshots/persistent-notification.png' />
@@ -16,7 +16,7 @@ The `persistent_notification` can be used to show a message on the frontend that
 
 ### Service
 
-The service `persistent_notification/create` takes in `message`, `title`, and `notification_id`.
+The service `persistent_notification.create` takes in `message`, `title`, and `notification_id`.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -36,7 +36,7 @@ action:
     title: "Custom subject"
 ```
 
-The service `persistent_notification/dismiss` requires a `notification_id`.
+The service `persistent_notification.dismiss` requires a `notification_id`.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -97,7 +97,7 @@ The message attribute supports the [Markdown formatting syntax](https://daringfi
 
 ### Create a persistent notification
 
-Choose <img src='/images/screenshots/developer-tool-services-icon.png' alt='service developer tool icon' class="no-shadow" height="38" /> **Services** from the **Developer Tools** to call the `persistent_notification` service. Select `persistent_notification/create` from the list of **Available services:** and enter something like the sample below into the **Service Data** field and hit **CALL SERVICE**.
+Choose the **Services** tab from the **Developer Tools** sidebar item, then select the `persistent_notification.create` service from the "Service" dropdown. Enter something like the sample below into the **Service Data** field and press the **CALL SERVICE** button.
 
 ```json
 {


### PR DESCRIPTION

I updated the service calls to correct ones (they had a / instead of a .) and also removed the Services icon image since it's gone with the redesigned Dev Tools in 0.96.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9954"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SeanPM5/home-assistant.io.git/1647e2495832ae81e33b84ee1cdb0cc51dab588e.svg" /></a>

