### PR TITLE
Edit updater component to match PR #25418

### DIFF
--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -61,12 +61,12 @@ For an added bonus, an automation integration can be created to send a message w
 automation:
   alias: Update Available Notification
   trigger:
-  - platform: state
-    entity_id: binary_sensor.updater
-    from: 'off'
-    to: 'on'
+    - platform: state
+      entity_id: binary_sensor.updater
+      from: 'off'
+      to: 'on'
   action:
-  - service: notify.notify
-    data:
-      message: 'Update for Home Assistant is available.'
+    - service: notify.notify
+      data:
+        message: 'Update for Home Assistant is available.'
 ```

--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -3,14 +3,14 @@ title: "Updater"
 description: "Detecting when Home Assistant updates are available."
 logo: home-assistant.png
 ha_category:
-  - Other
+  - binary_sensor
 ha_qa_scale: internal
 ha_release: 0.8
 ---
 
-The `updater` integration will check daily for new releases. The state will be "on" when an update is available. Otherwise the state will be "off". The newer version as well as the link to the release notes are attributes of the updater component. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this integration on Hass.io.
+The `updater` binary sensor will check daily for new releases. The state will be "on" when an update is available. Otherwise the state will be "off". The newer version as well as the link to the release notes are attributes of the updater. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this binary sensor on Hass.io.
 
-The updater integration will also collect basic information about the running Home Assistant instance and its environment. The information includes the current Home Assistant version, the time zone, Python version and operating system information. No identifiable information (i.e., IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/updater.py#L91).
+The updater will also collect basic information about the running Home Assistant instance and its environment. The information includes the current Home Assistant version, the time zone, Python version and operating system information. No identifiable information (i.e., IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/updater.py#L91).
 
 ## Configuration
 
@@ -62,7 +62,7 @@ automation:
   alias: Update Available Notification
   trigger:
   - platform: state
-    entity_id: updater.updater
+    entity_id: binary_sensor.updater
     from: 'off'
     to: 'on'
   action:

--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -8,7 +8,7 @@ ha_qa_scale: internal
 ha_release: 0.8
 ---
 
-The `updater` integration will check daily for new releases. It will show a badge in the frontend if a new version is found. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this integration on Hass.io.
+The `updater` integration will check daily for new releases. The state will be "on" when an update is available. Otherwise the state will be "off". The newer version as well as the link to the release notes are attributes of the updater component. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this integration on Hass.io.
 
 The updater integration will also collect basic information about the running Home Assistant instance and its environment. The information includes the current Home Assistant version, the time zone, Python version and operating system information. No identifiable information (i.e., IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/updater.py#L91).
 
@@ -59,12 +59,14 @@ For an added bonus, an automation integration can be created to send a message w
 ```yaml
 # Example configuration.yaml entry
 automation:
-  alias: 'Update Available Notifications'
+  alias: Update Available Notification
   trigger:
-    platform: state
+  - platform: state
     entity_id: updater.updater
+    from: 'off'
+    to: 'on'
   action:
-    service: notify.notify
+  - service: notify.notify
     data:
       message: 'Update for Home Assistant is available.'
 ```

--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -8,7 +8,7 @@ ha_qa_scale: internal
 ha_release: 0.8
 ---
 
-The `updater` binary sensor will check daily for new releases. The state will be "on" when an update is available. Otherwise the state will be "off". The newer version as well as the link to the release notes are attributes of the updater. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this binary sensor on Hass.io.
+The `updater` binary sensor will check daily for new releases. The state will be "on" when an update is available. Otherwise, the state will be "off". The newer version, as well as the link to the release notes, are attributes of the updater. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this binary sensor on Hass.io.
 
 The updater will also collect basic information about the running Home Assistant instance and its environment. The information includes the current Home Assistant version, the time zone, Python version and operating system information. No identifiable information (i.e., IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/updater.py#L91).
 


### PR DESCRIPTION
**Description:**
Edit the documentation of the updater component to match the new behavior of [PR 25418](https://github.com/home-assistant/home-assistant/pull/25418). In addition, the automation example is now up to date.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25418

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9957"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Santobert/home-assistant.io.git/45555cb611267a5fd2cb35048948e02176310ffc.svg" /></a>

