### PR TITLE
Fix Markdown link

### DIFF
--- a/source/_components/cast.markdown
+++ b/source/_components/cast.markdown
@@ -11,7 +11,7 @@ redirect_from: /components/media_player.cast/
 ---
 
 Google Cast devices like Android TVs and Chromecasts will be automatically
-discovered if you enable [the discovery integration(/components/discovery/). If
+discovered if you enable [the discovery integration](/components/discovery/). If
 you don't have the discovery integration enabled, you can enable the Cast
 integration by going to the Integrations page inside the config panel.
 


### PR DESCRIPTION
**Description:**

Fixes link in first sentence of [Google Cast docs](https://www.home-assistant.io/components/cast/).

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9959"><img src="https://gitpod.io/api/apps/github/pbs/github.com/AlecRust/home-assistant.io.git/15bfdf0b10b68e70003af7550b6bad55e66f8ad0.svg" /></a>

