### PR TITLE
Minor tweaks to notify page

### DIFF
--- a/source/_components/notify.markdown
+++ b/source/_components/notify.markdown
@@ -10,7 +10,7 @@ ha_release: 0.7
 
 The `notify` integration makes it possible to send notifications to a wide variety of platforms. Please check the sidebar for a full list of platforms that are supported.
 
-If you want to send notifications to the Home Assistant Web Interface you may use the [Persistent Notification Component](/components/persistent_notification/).
+If you want to send notifications to the Home Assistant web interface, you may use the [Persistent Notification integration](/components/persistent_notification/).
 
 ## Service
 
@@ -19,11 +19,11 @@ Once loaded, the `notify` platform will expose a service that can be called to s
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `message`              |       no | Body of the notification.
-| `title`                |      yes | Title of the notification. Default is `Home Assistant`.
-| `target`               |      yes | Some platforms will allow specifying a recipient that will receive the notification. See your platform page if it is supported.
+| `title`                |      yes | Title of the notification.
+| `target`               |      yes | Some platforms allow specifying a recipient that will receive the notification. See your platform page if it is supported.
 | `data`                 |      yes | On platforms who have extended functionality. See your platform page if it is supported.
 
-The notification integration supports specifying [templates](/topics/templating/) with `data_template`. This will allow you to use the current state of Home Assistant in your notifications.
+The notify integration supports specifying [templates](/topics/templating/) with `data_template`. This will allow you to use the current state of Home Assistant in your notifications.
 
 In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this with a customized subject.
 
@@ -37,7 +37,7 @@ action:
 
 ### Test if it works
 
-A simple way to test if you have set up your notify platform correctly, is to use <img src='/images/screenshots/developer-tool-services-icon.png' alt='service developer tool icon' class="no-shadow" height="38" /> **Services** from the **Developer Tools**. Choose your service from the dropdown menu **Service**, enter something like the sample below into the **Service Data** field, and hit **CALL SERVICE**.
+A simple way to test if you have set up your notify platform correctly, is to open **Developer Tools** from the sidebar and then select the  **Services** tab. Choose your service from the **Service** dropdown menu, enter the sample below into the **Service Data** field, and press the **CALL SERVICE** button.
 
 ```json
 {


### PR DESCRIPTION
This mostly fixes instructions to be up to date with developer tools changes in 0.96, renames component to integration, case changes, other very minor tweaks.

## Checklist:
- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9964"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SeanPM5/home-assistant.io.git/e1e6b8f45c8b8f7688a271b0b6eb2ec2c6933313.svg" /></a>

