### PR TITLE
Add support for turn_on/off, add note on Away mode

### DIFF
--- a/source/_components/daikin.markdown
+++ b/source/_components/daikin.markdown
@@ -57,15 +57,27 @@ The `daikin` climate platform integrates Daikin air conditioning systems into Ho
 
 - [**set_hvac_mode**](/components/climate/#service-climateset_hvac_mode) (off, heat, cool, auto, or fan only)
 - [**target temperature**](https://www.home-assistant.io/components/climate#service-climateset_temperature)
+- [**turn on/off**](https://www.home-assistant.io/components/climate#service-climateturn_on)
 - [**fan mode**](https://www.home-assistant.io/components/climate#service-climateset_fan_mode) (speed)
 - [**swing mode**](https://www.home-assistant.io/components/climate#service-climateset_swing_mode)
-- [**set_preset_mode**](https://www.home-assistant.io/components/climate#service-climateset_away_mode) (away, home)
+- [**set_preset_mode**](https://www.home-assistant.io/components/climate#service-climateset_away_mode) (away, none)
 
 Current inside temperature is displayed.
 
 <div class='note'>
 
 Some models do not support setting of **fan speed** or **swing mode**.
+
+</div>
+
+<div class='note'>
+
+Preset mode **away** translates to Daikin's *Holiday Mode*:<br/>
+"*Holiday mode* is used when you want to turn off your units when you leave you home for a longer time.<br/>
+
+When *Holiday mode* is enabled, the following action take place:
+- All connected units are turned OFF.
+- All schedule timers are disabled."
 
 </div>
 

--- a/source/_components/daikin.markdown
+++ b/source/_components/daikin.markdown
@@ -60,7 +60,7 @@ The `daikin` climate platform integrates Daikin air conditioning systems into Ho
 - [**turn on/off**](https://www.home-assistant.io/components/climate#service-climateturn_on)
 - [**fan mode**](https://www.home-assistant.io/components/climate#service-climateset_fan_mode) (speed)
 - [**swing mode**](https://www.home-assistant.io/components/climate#service-climateset_swing_mode)
-- [**set_preset_mode**](https://www.home-assistant.io/components/climate#service-climateset_away_mode) (away, none)
+- [**set_preset_mode**](https://www.home-assistant.io/components/climate#service-climateset_preset_mode) (away, none)
 
 Current inside temperature is displayed.
 
@@ -74,7 +74,7 @@ Some models do not support setting of **fan speed** or **swing mode**.
 
 Preset mode **away** translates to Daikin's *Holiday Mode*:<br/>
 "*Holiday mode* is used when you want to turn off your units when you leave you home for a longer time.<br/>
-
+<br/>
 When *Holiday mode* is enabled, the following action take place:
 - All connected units are turned OFF.
 - All schedule timers are disabled."

--- a/source/_components/daikin.markdown
+++ b/source/_components/daikin.markdown
@@ -73,7 +73,7 @@ Some models do not support setting of **fan speed** or **swing mode**.
 <div class='note'>
 
 Preset mode **away** translates to Daikin's *Holiday Mode*:<br/>
-"*Holiday mode* is used when you want to turn off your units when you leave you home for a longer time.<br/>
+*Holiday mode* is used when you want to turn off your units when you leave you home for a longer time.<br/>
 <br/>
 When *Holiday mode* is enabled, the following action take place:
 - All connected units are turned OFF.


### PR DESCRIPTION
**Description:**

home-assistant/home-assistant#25332 re-added service **turn_on/off** but the documentation was never updated.

home-assistant/home-assistant#25395 renamed **preset_mode** **home** to **none**.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25332, home-assistant/home-assistant#25395

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9965"><img src="https://gitpod.io/api/apps/github/pbs/github.com/fredrike/home-assistant.github.io.git/58c21482e17d49baed31eca8fce1dba0dd7ae968.svg" /></a>

