### PR TITLE
Update attribute of input_datetime with icon:

### DIFF
--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -54,7 +54,7 @@ input_datetime:
         type: boolean
         default: false
       icon:
-        description: Icon to display for the component.
+        description: Icon to display in the frontend.
         required: false
         type: icon
       initial:
@@ -75,6 +75,7 @@ automations and templates.
 | `has_date` | `true` if this entity has a date.
 | `year`<br>`month`<br>`day` | The year, month and day of the date.<br>(only available if `has_| `hour`<br>`minute`<br>`second` | The hour, minute and second of the time.<br>(only available if `has_time: true`)
 | `timestamp` | A timestamp representing the time held in the input.<br>If `has_
+
 ### Restore State
 
 This integration will automatically restore the state it had prior to Home

--- a/source/_components/input_datetime.markdown
+++ b/source/_components/input_datetime.markdown
@@ -53,6 +53,10 @@ input_datetime:
         required: false
         type: boolean
         default: false
+      icon:
+        description: Icon to display for the component.
+        required: false
+        type: icon
       initial:
         description: Set the initial value of this input, depending on `has_time` and `has_date`.
         required: false


### PR DESCRIPTION
It's possible to set an icon for input_datetime, but it's not mentioned in the documentation.

**Description:**

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9967"><img src="https://gitpod.io/api/apps/github/pbs/github.com/mvandek/home-assistant.io.git/68b5d727311ca3e3daf61e2e5962ea318ece2741.svg" /></a>

