### PR TITLE
Fixes type links in configuration blocks

### DIFF
--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -37,7 +37,7 @@ module Jekyll
       type.strip!
       if TYPE_LINKS.include? type.downcase
         url = TYPE_LINKS[type.downcase] % {component: component}
-        "[%s](%s)" % [type, url]
+        "<a href=\"%s\">%s</a>" % [url, type]
       else
         type
       end


### PR DESCRIPTION
**Description:**

Fixes an issue with configuration blocks that have certain variable types that are linked to other parts of the documentation.

Those links were created using Markdown, while this was not needed (and resulting in invalid Markdown).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9968"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/496a0f39066ec1fa4a347cf79d4f23559a0ce93c.svg" /></a>

