### PR TITLE
several changes to Manual Alarm panel doc

### DIFF
--- a/source/_components/manual.markdown
+++ b/source/_components/manual.markdown
@@ -214,59 +214,61 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
 {% raw %}
 ```yaml
 - alias: 'Send notification when alarm is Disarmed'
-  initial_state: 'on'
+  #initial_state: 'on'
   trigger:
     - platform: state
       entity_id: alarm_control_panel.home_alarm
       to: 'disarmed'
   action:
     - service: notify.notify
-      data:
-        message: "ALARM! The alarm is Disarmed at {{ states('sensor.date__time') }}"
+      data_template:
+        message: "ALARM! The alarm is Disarmed at {{ states('sensor.date_time') }}"
 ```
 {% endraw %}
 
 {% raw %}
 ```yaml
 - alias: 'Send notification when alarm is in pending status'
-  initial_state: 'on'
+  #initial_state: 'on'
   trigger:
     - platform: state
       entity_id: alarm_control_panel.home_alarm
       to: 'pending'
   action:
     - service: notify.notify
-      data:
-        message: "ALARM! The alarm is in pending status at {{ states('sensor.date__time') }}"
+      data_template:
+        message: "ALARM! The alarm is in pending status at {{ states('sensor.date_time') }}"
 ```
 {% endraw %}
 
 {% raw %}
 ```yaml
 - alias: 'Send notification when alarm is Armed in Away mode'
-  initial_state: 'on'
+  #initial_state: 'on'
   trigger:
     - platform: state
       entity_id: alarm_control_panel.home_alarm
       to: 'armed_away'
   action:
     - service: notify.notify
-      data:
-        message: "ALARM! The alarm is armed in Away mode {{ states('sensor.date__time') }}"
+      data_template:
+        message: "ALARM! The alarm is armed in Away mode {{ states('sensor.date_time') }}"
 ```
 {% endraw %}
 
 {% raw %}
 ```yaml
 - alias: 'Send notification when alarm is Armed in Home mode'
-  initial_state: 'on'
+  #initial_state: 'on'
   trigger:
     - platform: state
       entity_id: alarm_control_panel.home_alarm
       to: 'armed_home'
   action:
     - service: notify.notify
-      data:
-        message: "ALARM! The alarm is armed in Home mode {{ states('sensor.date__time') }}"
+      data_template:
+        # using multi-line notation, allows for easier quoting
+        message: >
+          ALARM! The alarm is armed in Home mode {{ states('sensor.date_time') }}
 ```
 {% endraw %}

--- a/source/_components/manual.markdown
+++ b/source/_components/manual.markdown
@@ -214,7 +214,6 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
 {% raw %}
 ```yaml
 - alias: 'Send notification when alarm is Disarmed'
-  #initial_state: 'on'
   trigger:
     - platform: state
       entity_id: alarm_control_panel.home_alarm
@@ -229,7 +228,6 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
 {% raw %}
 ```yaml
 - alias: 'Send notification when alarm is in pending status'
-  #initial_state: 'on'
   trigger:
     - platform: state
       entity_id: alarm_control_panel.home_alarm
@@ -244,7 +242,6 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
 {% raw %}
 ```yaml
 - alias: 'Send notification when alarm is Armed in Away mode'
-  #initial_state: 'on'
   trigger:
     - platform: state
       entity_id: alarm_control_panel.home_alarm
@@ -259,7 +256,6 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
 {% raw %}
 ```yaml
 - alias: 'Send notification when alarm is Armed in Home mode'
-  #initial_state: 'on'
   trigger:
     - platform: state
       entity_id: alarm_control_panel.home_alarm
@@ -267,7 +263,7 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
   action:
     - service: notify.notify
       data_template:
-        # using multi-line notation, allows for easier quoting
+        # Using multi-line notation allows for easier quoting
         message: >
           ALARM! The alarm is armed in Home mode {{ states('sensor.date_time') }}
 ```


### PR DESCRIPTION
took out the double underscores in the sensor.date_time templates
changed the data field to data_template field where applicable (since the messages use the template)
commented out the initial_state: 'on', since that is no longer required
provided 1 example using multi-line notation

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9969"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Mariusthvdb/home-assistant.github.io.git/88b17518ce01492d45e00256d5e91a4fa678105a.svg" /></a>

