### PR TITLE
shorten network instruction and add link

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -33,10 +33,7 @@ The following will take you through the steps required to install Hass.io.
    - Flash the downloaded image to an SD card using [balenaEtcher][balenaEtcher]. If using a Pi we recommend at least a 32 GB SD card to avoid running out of space. On Virtual machine platforms, provide at least 32 GB of disk space for the VM.
    - Load the appliance image into your virtual machine software. Choose 64-bit Linux and UEFI boot.
 
-3. Optional - set up the WiFi or static IP. There are two possible places for that: 
-- On a blank USB stick with Fat32 partition (partition label: "CONFIG"), while in / directory, create `network/my-network` file 
-- or on Hassio SD card first, bootable partition (might not be auto mounted in Linux) create `CONFIG/network/my-network` file 
-For the content of this file follow the [HassOS howto][hassos-network].
+3. Optional - set up the WiFi or static IP. Configuration of your network is detailed in [HassOS howto][hassos-network].
 
 4. For image-based installs insert the SD card (and optional USB stick) into the device.
 


### PR DESCRIPTION
There already exists a very detailed instructions on how to set up network wifi in https://github.com/home-assistant/hassos/blob/dev/Documentation/network.md and https://github.com/home-assistant/hassos/blob/dev/Documentation/configuration.md

The shorter version without any details here does not help the user to solve his problem, he has to got to the other pages either way. When information are scattered throughout various pages this might confuse the user.
Also, the link to the to HassOS HowTo (with the configuration files) was only present in the second option, so the person using usbstick might not click it.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9970"><img src="https://gitpod.io/api/apps/github/pbs/github.com/capstan1/home-assistant.io.git/c72db46b3442af634c16b28471d9215c6e97b88e.svg" /></a>

