### PR TITLE
add details on usb-stick

### DIFF
--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -57,12 +57,13 @@ We will need a few things to get started with installing Home Assistant. The lat
    - Create a folder named `network` in the root of the newly formatted USB-stick.
    - Within that folder create a file named `my-network` without extension.
    - Copy one of [the examples] to the `my-network` file and adjust accordingly.
-   - Plug the USB-stick into the Raspberry Pi 3. (The USB-stick needs to be inserted to the device during the following setup process only and can be disconnected afterwards.)
+   - Plug the USB-stick into the Raspberry Pi 3.
 
 1. Insert the SD card into your Raspberry Pi 3. If you are going to use an Ethernet cable, connect that too.
 1. Connect your Raspberry Pi to the power supply, so it turns on.
 1. The Raspberry Pi will now boot up, connect to the Internet and download the latest version of Home Assistant, which will take about 20 minutes.
 1. Home Assistant will be available at [http://hassio.local:8123][local]. If you are running an older Windows or have stricter network configuration, you might need to access Home Assistant at [http://hassio:8123][host].
+1. If you have used a USB-stick for configuring the network, it can now be removed.
 
 [local]: http://hassio.local:8123
 [host]: http://hassio:8123

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -57,7 +57,7 @@ We will need a few things to get started with installing Home Assistant. The lat
    - Create a folder named `network` in the root of the newly formatted USB-stick.
    - Within that folder create a file named `my-network` without extension.
    - Copy one of [the examples] to the `my-network` file and adjust accordingly.
-   - Plug the USB-stick into the Raspberry Pi 3.
+   - Plug the USB-stick into the Raspberry Pi 3. (The USB-stick needs to be inserted to the device during the following setup process only and can be disconnected afterwards.)
 
 1. Insert the SD card into your Raspberry Pi 3. If you are going to use an Ethernet cable, connect that too.
 1. Connect your Raspberry Pi to the power supply, so it turns on.


### PR DESCRIPTION
A question I asked myself and that got asked frequently in the forums is weather the usb stick used for configuration needs to stay within the device. So I just added one line to make this more precise.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9971"><img src="https://gitpod.io/api/apps/github/pbs/github.com/capstan1/home-assistant.io.git/6b3e2baa913be11d0041351cb3eec8ee9e0378dd.svg" /></a>

