### PR TITLE
Update Switchbot doc to match PR #25474

### DIFF
--- a/source/_components/switchbot.markdown
+++ b/source/_components/switchbot.markdown
@@ -32,3 +32,10 @@ name:
   required: false
   type: string
 {% endconfiguration %}
+
+## Switchbot Entity
+
+There are two attributes available on the Switchbot entity to give you more information about your device.
+
+- `last_run_success`: Set to `true` if the last action sent to the switchbot succeeded.  This attribute is useful for error trapping when bluetooth connecitivity is intermittent.   If `false`, see home-assistant.log for specific error messgages.
+- `assumed_state`: Always `true`.  If the state of the switchbot entity cannot be determined, it is assumed to be `on`.

--- a/source/_components/switchbot.markdown
+++ b/source/_components/switchbot.markdown
@@ -37,5 +37,5 @@ name:
 
 There are two attributes available on the Switchbot entity to give you more information about your device.
 
-- `last_run_success`: Set to `true` if the last action sent to the switchbot succeeded.  This attribute is useful for error trapping when bluetooth connecitivity is intermittent.   If `false`, see home-assistant.log for specific error messgages.
-- `assumed_state`: Always `true`.  If the state of the switchbot entity cannot be determined, it is assumed to be `on`.
+- `last_run_success`: If `true` if the last action sent to the Switchbot succeeded. This attribute is useful for error trapping when Bluetooth connectivity is intermittent. If `false`, see home-assistant.log for specific error messgages.
+- `assumed_state`: Always `true`. If the state of the Switchbot entity cannot be determined, it is assumed to be `on`.


### PR DESCRIPTION
**Description:**
Add details on existing assumed_state attribute as well as the for the new last_run_success attribute

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25474

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9976"><img src="https://gitpod.io/api/apps/github/pbs/github.com/manonstreet/home-assistant.io.git/9e7c0e3f73023bda6b8f57507d827799ce9f1f54.svg" /></a>

