### PR TITLE
Update history-graph.markdown

### DIFF
--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -27,7 +27,7 @@ entities:
   type: list
 hours_to_show:
   required: false
-  description: Hours to show. Minimum is 1 hours, maximum of 80 hours.
+  description: Hours to show. Minimum is 1 hour, maximum of 80 hours.
   type: integer
   default: 24
 refresh_interval:

--- a/source/_lovelace/history-graph.markdown
+++ b/source/_lovelace/history-graph.markdown
@@ -27,7 +27,7 @@ entities:
   type: list
 hours_to_show:
   required: false
-  description: Hours to show. Minimum is 10 hours, maximum of 80 hours.
+  description: Hours to show. Minimum is 1 hours, maximum of 80 hours.
   type: integer
   default: 24
 refresh_interval:


### PR DESCRIPTION
Changed minimum time_to_show from 10 to 1

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9978"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ambarkhuizen/home-assistant.io.git/d60a8121eaed7e52e1e95aa26690bfacbdb00771.svg" /></a>

