### PR TITLE
Add documentation for arcus trigonometry functions

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -268,6 +268,10 @@ Some of these functions can also be used in a [filter](http://jinja.pocoo.org/do
 - `sin(value)` will return the sine of the input. Can be used as a filter.
 - `cos(value)` will return the cosine of the input. Can be used as a filter.
 - `tan(value)` will return the tangent of the input. Can be used as a filter.
+- `asin(value)` will return the arcus sine of the input. Can be used as a filter.
+- `acos(value)` will return the arcus cosine of the input. Can be used as a filter.
+- `atan(value)` will return the arcus tangent of the input. Can be used as a filter.
+- `atan2(y, x)` will return the four quadrant arcus tangent of y / x. Can be used as a filter.
 - `sqrt(value)` will return the square root of the input. Can be used as a filter.
 - `e` mathematical constant, approximately 2.71828.
 - `pi` mathematical constant, approximately 3.14159.


### PR DESCRIPTION
**Description:**

This PR adds documentation for arcus trigonometry functions asin, acos, atan and atan2.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25510

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9982"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tomilehto/home-assistant.io.git/aabf8e19453b634992e46bfede9acee3ba2673e7.svg" /></a>

