### PR TITLE
Include note about OpenWRT unreliability

### DIFF
--- a/source/_components/snmp.markdown
+++ b/source/_components/snmp.markdown
@@ -24,13 +24,7 @@ There is currently support for the following device types within Home Assistant:
 - [Switch](#switch)
 
 <div class='note warning'>
-  This device tracker needs SNMP to be enabled on the router. It could be that you need to install the SNMP support manually.
-  This can somewhat be mitigated with by installing fping on the device and performing a broadcast ping periodically.
-  
-  ```
-  opkg update; opkg install fping
-  echo "$(echo '*/5 * * * * /usr/bin/fping 172.24.32.0/24' ; crontab -l)" | crontab -
-  ```
+This device tracker needs SNMP to be enabled on the router. It could be that you need to install the SNMP support manually.
 </div>
 
 ## Presence Detection
@@ -56,6 +50,13 @@ The following OID examples pull the current MAC Address table from a router. Thi
 
 <div class='note warning'>
 OpenWRT will only return information regarding clients that it has an ARP entry for - not associated stations. If it is an access point operating in dumb mode, ie. bridging from wired to wireless, and the internal DHCP is disabled, data regarding clients may not be present or reliable.
+  
+This can somewhat be mitigated with by installing fping on the device and performing a broadcast ping periodically.
+
+```
+opkg update; opkg install fping
+echo "$(echo '*/5 * * * * /usr/bin/fping 172.24.32.0/24' ; crontab -l)" | crontab -
+```
 </div>
 
 To use the SNMP version 1 or 2c platform in your installation, add the following to your `configuration.yaml` file:

--- a/source/_components/snmp.markdown
+++ b/source/_components/snmp.markdown
@@ -24,7 +24,13 @@ There is currently support for the following device types within Home Assistant:
 - [Switch](#switch)
 
 <div class='note warning'>
-This device tracker needs SNMP to be enabled on the router. It could be that you need to install the SNMP support manually.
+  This device tracker needs SNMP to be enabled on the router. It could be that you need to install the SNMP support manually.
+  This can somewhat be mitigated with by installing fping on the device and performing a broadcast ping periodically.
+  
+  ```
+  opkg update; opkg install fping
+  echo "$(echo '*/5 * * * * /usr/bin/fping 172.24.32.0/24' ; crontab -l)" | crontab -
+  ```
 </div>
 
 ## Presence Detection

--- a/source/_components/snmp.markdown
+++ b/source/_components/snmp.markdown
@@ -50,9 +50,9 @@ The following OID examples pull the current MAC Address table from a router. Thi
 
 <div class='note warning'>
 OpenWRT will only return information regarding clients that it has an ARP entry for - not associated stations. If it is an access point operating in dumb mode, ie. bridging from wired to wireless, and the internal DHCP is disabled, data regarding clients may not be present or reliable.
-<br>  
+
 This can somewhat be mitigated with by installing fping on the device and performing a broadcast ping periodically.
-<br>
+
 ```
 opkg update; opkg install fping
 echo "$(echo '*/5 * * * * /usr/bin/fping 172.24.32.0/24' ; crontab -l)" | crontab -

--- a/source/_components/snmp.markdown
+++ b/source/_components/snmp.markdown
@@ -50,9 +50,9 @@ The following OID examples pull the current MAC Address table from a router. Thi
 
 <div class='note warning'>
 OpenWRT will only return information regarding clients that it has an ARP entry for - not associated stations. If it is an access point operating in dumb mode, ie. bridging from wired to wireless, and the internal DHCP is disabled, data regarding clients may not be present or reliable.
-  
+<br>  
 This can somewhat be mitigated with by installing fping on the device and performing a broadcast ping periodically.
-
+<br>
 ```
 opkg update; opkg install fping
 echo "$(echo '*/5 * * * * /usr/bin/fping 172.24.32.0/24' ; crontab -l)" | crontab -

--- a/source/_components/snmp.markdown
+++ b/source/_components/snmp.markdown
@@ -48,6 +48,10 @@ The following OID examples pull the current MAC Address table from a router. Thi
 | TP-Link | Archer VR600 | `1.3.6.1.2.1.3.1.1.2` |
 | Ubiquiti | Edgerouter Lite v1.9.0 | `1.3.6.1.2.1.4.22.1.2` |
 
+<div class='note warning'>
+OpenWRT will only return information regarding clients that it has an ARP entry for - not associated stations. If it is an access point operating in dumb mode, ie. bridging from wired to wireless, and the internal DHCP is disabled, data regarding clients may not be present or reliable.
+</div>
+
 To use the SNMP version 1 or 2c platform in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
OpenWRT SNMP only returns data from the ARP table - not all associated stations.

**Description:**

OpenWRT presence detection can be unreliable if using dumb AP mode. SNMP only returns data from the ARP table - not the associated stations list.

## Checklist:

- [current] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9984"><img src="https://gitpod.io/api/apps/github/pbs/github.com/kylegordon/home-assistant.io.git/605a58978ccb2decdc2c40a96530c4dd060fa2c9.svg" /></a>

