### PR TITLE
Update installation.markdown

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -160,11 +160,10 @@ On the Raspberry Pi you will need to enable the serial interface in the `raspi-c
 
 #### Linux (except Hassbian)
 
-On Debian Linux platforms there two dependencies you will need to have installed ahead of time (included in `systemd-devel` on Fedora/RHEL systems):
+On Debian Linux platforms there are dependencies you will need to have installed ahead of time (included in `systemd-devel` on Fedora/RHEL systems):
 
 ```bash
 $ sudo apt-get install libudev-dev
-$ sudo apt-get install libopenzwave1.5-dev
 ```
 
 You may also have to install the Python development libraries for your version of Python. For example `libpython3.6-dev`, and possibly `python3.6-dev` if you're using Python 3.6.


### PR DESCRIPTION
**Description:**
Remove instructions to install libopenzwave1.5 on Linux installs. This instruction causes a lot of problems as the installed files interfere with the Python openzwave installation.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9985"><img src="https://gitpod.io/api/apps/github/pbs/github.com/kpine/home-assistant.io.git/39f3f38767ee8f0bde6aae63794547608e86b1dd.svg" /></a>

