### PR TITLE
Minor clarification on Telegram bot setup

### DIFF
--- a/source/_components/telegram.markdown
+++ b/source/_components/telegram.markdown
@@ -20,8 +20,6 @@ The requirements are:
 - You need to configure a [Telegram bot in Home Assistant](/components/telegram_bot) and define there your API key and the allowed chat ids to interact with.
 - The `chat_id` of an allowed user.
 
-To retrieve your `chat_id`, contact any of the Telegram bots created for this purpose (@myidbot, @get_id_bot)
-
 The quickest way to retrieve your `chat_id` is visiting [https://api.telegram.org/botYOUR_API_TOKEN/getUpdates](https://api.telegram.org/botYOUR_API_TOKEN/getUpdates) or to use `$ curl -X GET https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` **after** you have sent the bot a message. Replace `YOUR_API_TOKEN` with your actual token.
 
 The result set will include your chat ID as `id` in the `chat` section:

--- a/source/_components/telegram.markdown
+++ b/source/_components/telegram.markdown
@@ -22,7 +22,7 @@ The requirements are:
 
 To retrieve your `chat_id`, contact any of the Telegram bots created for this purpose (@myidbot, @get_id_bot)
 
-The quickest way to retrieve your `chat_id` is visiting [https://api.telegram.org/botYOUR_API_TOKEN/getUpdates](https://api.telegram.org/botYOUR_API_TOKEN/getUpdates) or to use `$ curl -X GET https://api.telegram.org/botYOUR_API_TOKEN/getUpdates`. Replace `YOUR_API_TOKEN` with your actual token.
+The quickest way to retrieve your `chat_id` is visiting [https://api.telegram.org/botYOUR_API_TOKEN/getUpdates](https://api.telegram.org/botYOUR_API_TOKEN/getUpdates) or to use `$ curl -X GET https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` **after** you have sent the bot a message. Replace `YOUR_API_TOKEN` with your actual token.
 
 The result set will include your chat ID as `id` in the `chat` section:
 


### PR DESCRIPTION
Spent a long time getting a near-empty JSON because I didn't realize I had to send the message before calling the URL, so I attempted to clarify the phrasing a little bit.

Also removed the previous paragrah, which didn't make much sense on the context for me.

PR-ed against `current` for this being useful immediately, can switch to `next` if desired.

Thank you for maintaining this software!

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9988"><img src="https://gitpod.io/api/apps/github/pbs/github.com/chesterbr/home-assistant.io.git/5b81ab52cb02d7123791e13a61fc48a5e6b1446d.svg" /></a>

