### PR TITLE
Add raw tags to netgear_lte example

### DIFF
--- a/source/_components/netgear_lte.markdown
+++ b/source/_components/netgear_lte.markdown
@@ -171,6 +171,7 @@ This service can set modem configuration options (otherwise available in the mod
 
 The following automation example processes incoming SMS messages with the [Conversation](/components/conversation/) integration and then deletes the message from the inbox.
 
+{% raw %}
 ```yaml
 automation:
   - alias: SMS conversation
@@ -186,3 +187,4 @@ automation:
           host: '{{ trigger.event.data.host }}'
           sms_id: '{{ trigger.event.data.sms_id }}'
 ```
+{% endraw %}


### PR DESCRIPTION
**Description:**

I noticed that templates are missing in this example: https://www.home-assistant.io/components/netgear_lte/#examples

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9989"><img src="https://gitpod.io/api/apps/github/pbs/github.com/amelchio/home-assistant.github.io.git/c77fe8cda7d432bba9aa911a62fd18b04459dcb3.svg" /></a>

