### PR TITLE
Add zigate support to zha

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -57,7 +57,7 @@ The custom quirks implementations for zigpy implemented as ZHA Device Handlers f
   - [ConBee USB adapter from Dresden-Elektronik](https://www.dresden-elektronik.de/conbee/)
   - [RaspBee Raspberry Pi Shield from Dresden-Elektronik](https://www.dresden-elektronik.de/raspbee/)
 - ZiGate based radios (via the [zigpy-zigate](https://github.com/doudz/zigpy-zigate) library for zigpy)
-  - ZiGate USB modules
+  - ZiGate USB modules (require firmware 3.1a or later)
 
 ## Configuration
 

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -56,6 +56,8 @@ The custom quirks implementations for zigpy implemented as ZHA Device Handlers f
   - [ConBee II (a.k.a. ConBee 2) USB adapter from Dresden-Elektronik](https://shop.dresden-elektronik.de/conbee-2.html)
   - [ConBee USB adapter from Dresden-Elektronik](https://www.dresden-elektronik.de/conbee/)
   - [RaspBee Raspberry Pi Shield from Dresden-Elektronik](https://www.dresden-elektronik.de/raspbee/)
+- ZiGate based radios (via the [zigpy-zigate](https://github.com/doudz/zigpy-zigate) library for zigpy)
+  - ZiGate USB modules
 
 ## Configuration
 


### PR DESCRIPTION
**Description:**

Add zigate support to zha component

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25552

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9990"><img src="https://gitpod.io/api/apps/github/pbs/github.com/doudz/home-assistant.io.git/9d72d6fcacbee7712f42c0895f570a3635fe5c14.svg" /></a>

