### PR TITLE
Update outdated PS4 integration information

### DIFF
--- a/source/_components/ps4.markdown
+++ b/source/_components/ps4.markdown
@@ -5,13 +5,12 @@ logo: ps4.png
 ha_category:
   - Media Player
 ha_release: 0.89
+ha_config_flow: true
 ha_iot_class: Local Polling
 ---
 
 The `ps4` integration allows you to control a
 [Sony PlayStation 4 console](https://www.playstation.com/en-us/explore/ps4/).
-
-- This integration supports controlling a single PlayStation 4 for your instance. Additional consoles may be supported in a future release.
 
 ## Requirements
 
@@ -26,7 +25,7 @@ The `ps4` integration allows you to control a
   Read the section "Granting Port Access" below before continuing.
 </div>
 
-2. Navigate to `Configuration -> Integrations` and select `Configure` for `PlayStation 4`.
+2. Navigate to `Configuration -> Integrations` and press the plus button in the bottom right corner. Select `PlayStation 4` from the list of integrations.
 
 3. Follow instructions displayed to generate user credentials. You will know this step is completed when a form with fields appears.
 
@@ -71,7 +70,7 @@ sudo setcap 'cap_net_bind_service=+ep' /usr/bin/python3.5
 
 To find your system Python path:
 
-- Add the [System Health](/components/system_health/) integration to your `configuration.yaml`. In a web browser access your frontend and navigate to the about/logs page "http://<yourhomeassistanturl>/dev-info). In the System Health box locate the item **python_version** and note the value that is displayed. Then in terminal run:
+- Add the [System Health](/components/system_health/) integration to your `configuration.yaml`. In a web browser access your frontend and navigate to the about/logs page "http://<yourhomeassistanturl>/developer-tools/info). In the System Health box locate the item **python_version** and note the value that is displayed. Then in terminal run:
 
   ```bash
   whereis python<version>


### PR DESCRIPTION
**Description:**
* This removes outdated info about the PS4 integration only supporting a single console. Support for that was added in 0.90 a few months back (PR here: https://github.com/home-assistant/home-assistant/pull/21302).
* Added field to sidebar that it's configurable from UI (that's the *only* way it can be configured in fact - which the docs already mentioned).
* Also tweaks the instructions to reflect design changes that were made to Home Assistant Integrations panel after this doc was first published (must press the + button to add integrations).
* Lastly updated a URL that was changed in the Dev Tools redesign in 0.96 release (`/dev-info` has now become `/developer-tools/info`).

## Checklist:
- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/9999"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SeanPM5/home-assistant.io.git/b842f622433fd91d6767c4693eb99de2f34d239a.svg" /></a>

