### PR TITLE
Add note on Advanced mode toggle

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -19,7 +19,7 @@ By default, all of your devices will be visible and have a default icon determin
 
 ### Customization using the UI
 
-Under the *Configuration* menu you'll find the *Customization* menu. When you select an entity to customize, you'll see all the existing attributes listed and you can customize those, or select an additional supported attribute ([see below](/docs/configuration/customizing-devices/#possible-values)).
+Under the *Configuration* menu you'll find the *Customization* menu. If this menu item is not visible, enable advanced mode on your [profile page](/docs/authentication/#your-account-profile) first. When you select an entity to customize, you'll see all the existing attributes listed and you can customize those, or select an additional supported attribute ([see below](/docs/configuration/customizing-devices/#possible-values)).
 
 #### Possible values
 


### PR DESCRIPTION
**Description:**
Customization menu will be hidden by default starting in 0.96, unless the user toggles on Advanced mode first.

## Checklist:
- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10001"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SeanPM5/home-assistant.io.git/9799a22427d193aeb1953abdfdf7d75be3e40938.svg" /></a>

