### PR TITLE
Set default payloads in quotes because the docs show true/false

### DIFF
--- a/source/_components/command_line.markdown
+++ b/source/_components/command_line.markdown
@@ -47,12 +47,12 @@ payload_on:
   description: The payload that represents enabled state.
   required: false
   type: string
-  default: ON
+  default: 'ON'
 payload_off:
   description: The payload that represents disabled state.
   required: false
   type: string
-  default: OFF
+  default: 'OFF'
 value_template:
   description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the payload.
   required: false


### PR DESCRIPTION
https://github.com/home-assistant/home-assistant/blob/a90ec88e5c7098e11fbcf8212c8bc9dcae713a60/homeassistant/components/command_line/binary_sensor.py#L19-L20
https://community.home-assistant.io/t/command-line-binary-sensor-never-switches-to-on/128840?u=vdrainer

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10002"><img src="https://gitpod.io/api/apps/github/pbs/github.com/VDRainer/home-assistant.io.git/8ec32f90969f9df3e92c91de8df26beca8fee9f6.svg" /></a>

