### PR TITLE
Corrected an example

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -74,7 +74,7 @@ The next two statements result in the same value if the state exists. The second
 {% raw %}
 ```text
 {{ states('device_tracker.paulus') }}
-{{ states('device_tracker.paulus') }}
+{{ states.device_tracker.paulus }}
 ```
 {% endraw %}
 


### PR DESCRIPTION
This example is trying to draw a distinction but has two identical lines.  I suspect this came from a search and replace to switch to the newer states('') notation.

**Description:**
Use new notation on first line, old notation on second line.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10005"><img src="https://gitpod.io/api/apps/github/pbs/github.com/gjbadros/home-assistant.io.git/7a01c6afd7a1f90ace2e41e1cb0805d068cbf8d8.svg" /></a>

