### PR TITLE
Add logo & category to the weather info page, remove side bar hint

### DIFF
--- a/source/_components/weather.markdown
+++ b/source/_components/weather.markdown
@@ -1,12 +1,16 @@
 ---
 title: "Weather"
 description: "Instructions on how to setup your Weather platforms with Home Assistant."
+logo: home-assistant.png
+ha_category:
+  - Weather
+ha_qa_scale: internal
 ha_release: 0.32
 ---
 
-The `weather` platforms are gathering meteorological information from web services and display the conditions and other details about the weather at the given location.
+The `weather` platforms are gathering meteorological information from web services and display the conditions and other details about the weather at the given location. Read the integration documentation for your particular weather provider to learn how to set it up.
 
-Home Assistant currently supports free web services and such which require a registration. Please check the sidebar for a full list of supported `weather` platforms.
+Home Assistant currently supports free web services and such which require a registration.
 
 ## Condition mapping
 


### PR DESCRIPTION
Since there is no real sidebar anymore, we should link to the component category instead.

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10006"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Maxr1998/home-assistant.io.git/5bb3befb364e2eed056d79dcf4b5ed5859544487.svg" /></a>

