### PR TITLE
Correct service call

### DIFF
--- a/source/_docs/mqtt/testing.markdown
+++ b/source/_docs/mqtt/testing.markdown
@@ -16,7 +16,7 @@ If you are using the embedded MQTT broker, the command looks a little different 
 $ mosquitto_pub -V mqttv311 -u homeassistant -P <broker password> -t "hello" -m world
 ```
 
-Another way to send MQTT messages by hand is to use the "Developer Tools" in the Frontend. Choose "Call Service" and then `mqtt/mqtt_send` under "Available Services". Enter something similar to the example below into the "Service Data" field.
+Another way to send MQTT messages by hand is to use the "Developer Tools" in the Frontend. Choose "Call Service" and then `mqtt.publish` under "Available Services". Enter something similar to the example below into the "Service Data" field.
 
 ```json
 {


### PR DESCRIPTION
Updating reference from `mqtt/mqtt_send` to use `mqtt.publish`.

**Description:**
It looks like this document is referencing an outdated service so I've updated it to use the proper service name.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10013"><img src="https://gitpod.io/api/apps/github/pbs/github.com/apop880/home-assistant.io.git/78615b2344090692e7bf7c0def92bf0ff9de8304.svg" /></a>

