### PR TITLE
Add precip_yesterday to Environment Canada sensors

### DIFF
--- a/source/_components/environment_canada.markdown
+++ b/source/_components/environment_canada.markdown
@@ -101,6 +101,7 @@ sensor:
     - `uv_index` - The next forecast UV index.
     - `pop` - The next forecast probability of precipitation, in %.
     - `text_summary` - A textual description of the next forecast period, e.g. "Tonight. Mainly cloudy. Low -12."
+    - `precip_yesterday` - The total amount of precipitation that fell the previous day.
     - `warnings` - Current warning alerts.
     - `watches` - Current watch alerts.
     - `advisories` - Current advisory alerts.


### PR DESCRIPTION
**Description:**

Adds `precip_yesterday` to the list of sensors created by the Environment Canada sensor component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25594

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10014"><img src="https://gitpod.io/api/apps/github/pbs/github.com/michaeldavie/home-assistant.github.io.git/fd3691d7b6b31b0e2fc5044be42319e18ae3680b.svg" /></a>

