### PR TITLE
🔨 Fix broken Github user links

### DIFF
--- a/source/_posts/2019-07-17-release-96.markdown
+++ b/source/_posts/2019-07-17-release-96.markdown
@@ -67,7 +67,7 @@ Huge thanks to [@pvizeli] who drove the core implementation and to the following
 [@marvin-w]: https://github.com/marvin-w
 [@OnFreund]: https://github.com/OnFreund
 [@SukramJ]: https://github.com/SukramJ
-[@teachingbirds]: https://github.com/teachingbirds
+[@isabellaalstrom]: https://github.com/isabellaalstrom
 
 ## Advanced mode
 
@@ -87,7 +87,7 @@ The [Home Assistant code repository on GitHub](https://github.com/home-assistant
 
 The Home Assistant Podcast has published [episode 53](https://hasspodcast.io/ha053/) to discuss all the ins and outs of this new release.
 
-[@teachingbirds] has redone her Lovelace UI and it is looking fabulous!
+[@isabellaalstrom] has redone her Lovelace UI and it is looking fabulous!
 
 <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Redid my whole layout for the <a href="https://twitter.com/home_assistant?ref_src=twsrc%5Etfw">@home_assistant</a> dashboard yesterday on a whim. &quot;Nest hub inspired&quot;, I call it. 😄 I like it a lot! Feels put together and less messy. <a href="https://t.co/8pmA5CWKev">pic.twitter.com/8pmA5CWKev</a></p>&mdash; Isa (@teachingbirds) <a href="https://twitter.com/teachingbirds/status/1151113630391427072?ref_src=twsrc%5Etfw">July 16, 2019</a>
 </blockquote>

--- a/source/developers/credits.markdown
+++ b/source/developers/credits.markdown
@@ -2113,7 +2113,7 @@ This page contains a list of people who have contributed in one way or another t
 3 commits to open-zwave
 3 commits to home-assistant.io
 ")
-- [Collin Allen (@commandtab)](https://github.com/commandtab "1 total commits to the Home Assistant orga:
+- [Collin Allen (@command-tab)](https://github.com/command-tab "1 total commits to the Home Assistant orga:
 1 commit to home-assistant.io
 ")
 - [Comic Chang (@comicchang)](https://github.com/comicchang "1 total commits to the Home Assistant orga:
@@ -2728,7 +2728,7 @@ This page contains a list of people who have contributed in one way or another t
 - [dennisaion (@dennisaion)](https://github.com/dennisaion "1 total commits to the Home Assistant orga:
 1 commit to home-assistant.io
 ")
-- [Denver P (@DrTexxOfficial)](https://github.com/DrTexxOfficial "1 total commits to the Home Assistant orga:
+- [Denver P (@DrTexx)](https://github.com/DrTexx "1 total commits to the Home Assistant orga:
 1 commit to home-assistant.io
 ")
 - [Department G33k (@department-g33k)](https://github.com/department-g33k "1 total commits to the Home Assistant orga:
@@ -3076,7 +3076,7 @@ This page contains a list of people who have contributed in one way or another t
 25 commits to home-assistant
 6 commits to home-assistant.io
 ")
-- [eltoro81 (@eltoro81)](https://github.com/eltoro81 "1 total commits to the Home Assistant orga:
+- [mvjt (@mvjt)](https://github.com/mvjt "1 total commits to the Home Assistant orga:
 1 commit to home-assistant.io
 ")
 - [Elvis (@mu3)](https://github.com/mu3 "1 total commits to the Home Assistant orga:
@@ -3374,7 +3374,7 @@ This page contains a list of people who have contributed in one way or another t
 2 commits to home-assistant.io
 1 commit to home-assistant
 ")
-- [fedor1210 (@fedor1210)](https://github.com/fedor1210 "3 total commits to the Home Assistant orga:
+- [augustdipierro (@augustdipierro)](https://github.com/augustdipierro "3 total commits to the Home Assistant orga:
 3 commits to home-assistant.io
 ")
 - [Felipe Cypriano (@fcy)](https://github.com/fcy "1 total commits to the Home Assistant orga:


### PR DESCRIPTION
**Description:**
This PR will fix some dead github user links.

Related to: #9774 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10015"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/13cd14d978caa60116e39210ca3961212b9736a5.svg" /></a>

