### PR TITLE
Correct evohome typos, add example templates

### DIFF
--- a/source/_components/evohome.markdown
+++ b/source/_components/evohome.markdown
@@ -12,8 +12,9 @@ redirect_from:
 ---
 
 The `evohome` integration links Home Assistant with all _non-US_ [Honeywell Total Connect Comfort (TCC)](https://international.mytotalconnectcomfort.com/Account/Login) CH/DHW systems, such as:
- * the Honeywell evohome CH/DHW system, and
- * the Honeywell Round Thermostat
+
+- The Honeywell evohome CH/DHW system, and
+- The Honeywell Round Thermostat
 
 It does not support the home security functionality of TCC.
 
@@ -23,15 +24,15 @@ Honeywell removed support for higher-precision temperatures from the v2 API, and
 
 ### evohome
 
-evohome is a multi-zone system. Each Zone is represented as a **Climate** device: it will expose the Zone's operating mode, temperature and setpoint.
+evohome is a multi-zone system. Each zone is represented as a **Climate** device: it will expose the zone's operating mode, temperature and setpoint.
 
-The Controller/Location is also represented as a **Climate** device: it will expose the location's operating mode (see below for details). Note that the Controller's current temperature is calculated as an average of all the Zones.
+The controller/location is also represented as a **Climate** device: it will expose the location's operating mode (see below for details). Note that the controller's current temperature is calculated as an average of all the Zones.
 
 The DHW controller is represented as a **WaterHeater** device: It will report its current temperature (but not target temperature), and it can be turned on or off.
 
 ### Round Thermostat
 
-Although Round Thermostat is, strictly speaking, a Controller and a single Zone, they are merged into a single **Climate** device.
+Although Round Thermostat is, strictly speaking, a Controller and a single zone, they are merged into a single **Climate** device.
 
 ## Configuration
 
@@ -67,29 +68,30 @@ scan_interval:
 
 This is an IoT cloud-polling device, and the recommended `scan_interval` is 180 seconds. Testing has indicated that this is a safe interval that - by itself - shouldn't cause you to be rate-limited by Honeywell.
 
-## Operating modes, and Inheritance
+## Operating modes, and inheritance
 
 Zones support only three setpoint modes: **FollowSchedule**, **TemporaryOverride**, and **PermanentOverride**.
 
-Mostly, the Zone 'inherits' its functional operating mode from the controller (the actual algorithm for this is a little complicated).
+Mostly, the zone 'inherits' its functional operating mode from the controller (the actual algorithm for this is a little complicated).
 
-The evohome Controller supports seven distinct system modes: **Auto**, **AutoWithEco**, **Away**, **DayOff**, **HeatingOff**, and **Custom**; **AutoWithReset** is a hidden mode that will revert all Zones to **FollowSchedule** mode.
+The evohome controller supports seven distinct system modes: **Auto**, **AutoWithEco**, **Away**, **DayOff**, **HeatingOff**, and **Custom**; **AutoWithReset** is a hidden mode that will revert all zones to **FollowSchedule** mode.
 
 If the zone is in **FollowSchedule** mode, its `temperature` (target temperature) is a function of its scheduled temperature and its functional mode - for example, **AutoWithEco** is scheduled temperature less 3C.
 
-If the Controller is set to **HeatingOff** (target temperature to minimum) or **Away** (target temperature to 12C), then the Zones will inherit that mode regardless of their own setpoint mode.
+If the controller is set to **HeatingOff** (target temperature to a minimum) or **Away** (target temperature to 12C), then the zones will inherit that mode regardless of their own setpoint mode.
 
-If the Zone's temperature is changed, then it will be a **TemporaryOverride** that will revert to **FollowSchedule** at the next scheduled setpoint. Once this is done, the Zone can be switched to **PermanentOverride** mode.
+If the zone's temperature is changed, then it will be a **TemporaryOverride** that will revert to **FollowSchedule** at the next scheduled setpoint. Once this is done, the zone can be switched to **PermanentOverride** mode.
 
 In Home Assistant, all this is done via `HVAC_MODE` and `PRESET_MODE` (but also see `systemModeStatus`, `setpointStatus`, below).
 
 ## Useful Jinja Templates
 
-The actual operating mode of evohome entities can be tracked via their state attributes, which includes a JSON data structure for current state called `status`.
+The actual operating mode of evohome entities can be tracked via their state attributes, which includes a JSON data structure for the current state called `status`.
 
 For the Controller, see `systemModeStatus`:
+
 {% raw %}
-```
+```text
 {% if state_attr('climate.my_home', 'status').systemModeStatus.mode == "Away" %}
   The system is in Away mode
 {% else %}
@@ -99,22 +101,25 @@ For the Controller, see `systemModeStatus`:
 {% endraw %}
 
 For the Zones, it is `setpointStatus`:
+
 {% raw %}
-```
+```text
 {{ state_attr('climate.kitchen', 'status').setpointStatus.setpointMode }}
 ```
 {% endraw %}
 
 The Zones will expose the current/upcoming scheduled `setpoints`:
+
 {% raw %}
-```
+```text
 {{ state_attr('climate.kitchen', 'status').setpoints.next.temperature }}
 ```
 {% endraw %}
 
 All evohome entities may have faults, and these can be turned into sensors, or:
+
 {% raw %}
-```
+```text
 {% if state_attr('climate.bedroom', 'status').activeFaults %}
   {% if state_attr('climate.bedroom', 'status').activeFaults[0].faultType == 'TempZoneActuatorLowBattery' %}
     There is a low battery
@@ -125,4 +130,3 @@ All evohome entities may have faults, and these can be turned into sensors, or:
 {% endif %}
 ```
 {% endraw %}
-

--- a/source/_components/evohome.markdown
+++ b/source/_components/evohome.markdown
@@ -19,7 +19,7 @@ It does not support the home security functionality of TCC.
 
 It uses v2 of the [evohome-client](https://github.com/watchforstock/evohome-client) client library.
 
-Honeywell removed support for higher-precision temperatures from the v2 API, and reported temperatures are rounded up to the nearest 0.5C.
+Honeywell removed support for higher-precision temperatures from the v2 API, and thus reported temperatures are rounded up to the nearest 0.5C.
 
 ### evohome
 
@@ -31,7 +31,7 @@ The DHW controller is represented as a **WaterHeater** device: It will report it
 
 ### Round Thermostat
 
-Although Round Thermostat is, strictly speaking, a single zone system (i.e. a Controller and a single Zone), it is implemented as a single **Climate** device.
+Although Round Thermostat is, strictly speaking, a single zone system (i.e. a Controller and a single Zone), they are merged into a single **Climate** device.
 
 ## Configuration
 
@@ -81,7 +81,7 @@ If the Controller is set to **HeatingOff** (target temperature to minimum) or **
 
 If the Zone's temperature is changed, then it will be a **TemporaryOverride** that will revert to **FollowSchedule** at the next scheduled setpoint. Once this is done, the Zone can be switched to **PermanentOverride** mode.
 
-In Home Assistant, all this is done via `HVAC_MODE` and `PRESET_MODE`.
+In Home Assistant, all this is done via `HVAC_MODE` and `PRESET_MODE` (but also see `systemModeStatus`, `setpointStatus`, below).
 
 ## Useful Jinja Templates
 

--- a/source/_components/evohome.markdown
+++ b/source/_components/evohome.markdown
@@ -31,7 +31,7 @@ The DHW controller is represented as a **WaterHeater** device: It will report it
 
 ### Round Thermostat
 
-Although Round Thermostat is, strictly speaking, a single zone system (i.e. a Controller and a single Zone), they are merged into a single **Climate** device.
+Although Round Thermostat is, strictly speaking, a Controller and a single Zone, they are merged into a single **Climate** device.
 
 ## Configuration
 

--- a/source/_components/evohome.markdown
+++ b/source/_components/evohome.markdown
@@ -19,19 +19,19 @@ It does not support the home security functionality of TCC.
 
 It uses v2 of the [evohome-client](https://github.com/watchforstock/evohome-client) client library.
 
-Honeywell removed support for higher-precision temperatures from the v2 API, so temperatures are reported to the nearest 0.5C.
+Honeywell removed support for higher-precision temperatures from the v2 API, and reported temperatures are rounded up to the nearest 0.5C.
 
 ### evohome
 
 evohome is a multi-zone system. Each Zone is represented as a **Climate** device: it will expose the Zone's operating mode, temperature and setpoint.
 
-The Controller/Location is also represented as a **Climate** device: it will expose the location's operating mode (see below for details). Note that the Controller's temperatures are calculated as an average of all the Zones.
+The Controller/Location is also represented as a **Climate** device: it will expose the location's operating mode (see below for details). Note that the Controller's current temperature is calculated as an average of all the Zones.
 
 The DHW controller is represented as a **WaterHeater** device: It will report its current temperature (but not target temperature), and it can be turned on or off.
 
 ### Round Thermostat
 
-Round Thermostat is a single zone system. It is currently implemented as two **Climate** devices, as if a single zone evohome system.
+Although Round Thermostat is, strictly speaking, a single zone system (i.e. a Controller and a single Zone), it is implemented as a single **Climate** device.
 
 ## Configuration
 
@@ -115,8 +115,8 @@ The Zones will expose the current/upcoming scheduled `setpoints`:
 All evohome entities may have faults, and these can be turned into sensors, or:
 {% raw %}
 ```
-{% if state_attr('climate.main_room', 'status').activeFaults %}
-  {% if state_attr('climate.main_room', 'status').activeFaults[0].faultType == 'TempZoneActuatorLowBattery' %}
+{% if state_attr('climate.bedroom', 'status').activeFaults %}
+  {% if state_attr('climate.bedroom', 'status').activeFaults[0].faultType == 'TempZoneActuatorLowBattery' %}
     There is a low battery
   {% endif %}
     There is a Fault!

--- a/source/_components/evohome.markdown
+++ b/source/_components/evohome.markdown
@@ -83,7 +83,7 @@ If the Zone's temperature is changed, then it will be a **TemporaryOverride** th
 
 In Home Assistant, all this is done via `HVAC_MODE` and `PRESET_MODE`.
 
-## Useful Templates
+## Useful Jinja Templates
 
 The actual operating mode of evohome entities can be tracked via their state attributes, which includes a JSON data structure for current state called `status`.
 

--- a/source/_components/evohome.markdown
+++ b/source/_components/evohome.markdown
@@ -79,20 +79,50 @@ If the zone is in **FollowSchedule** mode, its `temperature` (target temperature
 
 If the Controller is set to **HeatingOff** (target temperature to minimum) or **Away** (target temperature to 12C), then the Zones will inherit that mode regardless of their own setpoint mode.
 
-If the Zone's temperature is changed, then it will be a **TemporaryOverride** that will revert to **FollowSchedule** at the next scheduled setpoint. Once this is done, the ZOne can be switched to **PermanentOverride** mode.
+If the Zone's temperature is changed, then it will be a **TemporaryOverride** that will revert to **FollowSchedule** at the next scheduled setpoint. Once this is done, the Zone can be switched to **PermanentOverride** mode.
 
-In Home Assistant, all this is done via `HVAC_MODE` and `PRESET_MODE`. However, the actual operating mode of these devices can be tracked via its state attributes, which includes a JSON data structure for current state called `status`.
+In Home Assistant, all this is done via `HVAC_MODE` and `PRESET_MODE`.
 
-For the Controller:
+## Useful Templates
+
+The actual operating mode of evohome entities can be tracked via their state attributes, which includes a JSON data structure for current state called `status`.
+
+For the Controller, see `systemModeStatus`:
 {% raw %}
 ```
-value_template: "{{ state_attr('climate.main_room', 'status').systemModeStatus.mode }}"
+{% if state_attr('climate.my_home', 'status').systemModeStatus.mode == "Away" %}
+  The system is in Away mode
+{% else %}
+  The system is not in Away mode
+{% endif %}
 ```
 {% endraw %}
 
-For the Zones:
+For the Zones, it is `setpointStatus`:
 {% raw %}
 ```
-value_template: "{{ state_attr('climate.my_house', 'status').setpointStatus.setpointMode }}"
+{{ state_attr('climate.kitchen', 'status').setpointStatus.setpointMode }}
 ```
 {% endraw %}
+
+The Zones will expose the current/upcoming scheduled `setpoints`:
+{% raw %}
+```
+{{ state_attr('climate.kitchen', 'status').setpoints.next.temperature }}
+```
+{% endraw %}
+
+All evohome entities may have faults, and these can be turned into sensors, or:
+{% raw %}
+```
+{% if state_attr('climate.main_room', 'status').activeFaults %}
+  {% if state_attr('climate.main_room', 'status').activeFaults[0].faultType == 'TempZoneActuatorLowBattery' %}
+    There is a low battery
+  {% endif %}
+    There is a Fault!
+{% else %}
+  Yay, everything is OK :)
+{% endif %}
+```
+{% endraw %}
+


### PR DESCRIPTION
**Description:**
Fix typos, add example templates

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10016"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zxdavb/home-assistant.io.git/57bc94e96b9feee6e788fc6615b6467befcfba88.svg" /></a>

