### PR TITLE
Updated wording

### DIFF
--- a/source/_cookbook/ifttt.manything.markdown
+++ b/source/_cookbook/ifttt.manything.markdown
@@ -9,9 +9,9 @@ redirect_from:
 
 [Manything](https://manything.com) is a smart app that turns your Android device, iPhone, iPod, or iPad into a WiFi camera for monitoring your home, your pets, anything! Comes with live streaming, motion activated alerts, cloud video recording, and more.
 
-To get manything support, HA will use IFTTT's [Maker Channel](https://ifttt.com/maker) and the [ManyThing Channel](https://ifttt.com/manything). Use the [IFTTT Setup instructions](/components/ifttt/) to activate the IFTTT Platform.
+To get manything support, HA will use IFTTT's [Webhooks Service](https://ifttt.com/maker_webhooks) and the [ManyThing Service](https://ifttt.com/manything). Use the [IFTTT Setup instructions](/components/ifttt/) to activate the IFTTT Platform.
 
-After setting up IFTTT, Maker Channel and ManyThing Channel, you can use the following examples to configure Home Assistant.
+After setting up IFTTT, Maker Service and ManyThing Service, you can use the following examples to configure Home Assistant.
 
 ```yaml
 # Example configuration.yaml entry
@@ -57,7 +57,7 @@ For ManyThing support, you need to set up an `on` and `off` event.
 
 ### Testing your trigger
 
-You can use the developer tools to test your [Maker Channel](https://ifttt.com/maker) trigger. To do this, open the Home Assistant UI, open the sidebar, click on the first icon in the developer tools. This should get you to the 'Call Service' screen. Fill in the following values:
+You can use the developer tools to test your [Maker Service](https://ifttt.com/maker_webhooks) trigger. To do this, open the Home Assistant UI, open the sidebar, click on the first icon in the developer tools. This should get you to the 'Call Service' screen. Fill in the following values:
 
 Field | Value
 ----- | -----


### PR DESCRIPTION
**Description:**

The Maker Channel is now the Webhooks Service and channels were renamed to services. Fixed a 404 link from #9774

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10030"><img src="https://gitpod.io/api/apps/github/pbs/github.com/pattyland/home-assistant.io.git/bd3c161d1650e358642c59b4a8c205240a068733.svg" /></a>

