### PR TITLE
Specify text language on some code blocks

### DIFF
--- a/source/_docs/autostart/init.d.markdown
+++ b/source/_docs/autostart/init.d.markdown
@@ -36,6 +36,9 @@ This logrotate script at `/etc/logrotate.d/homeassistant` will create an outage 
 
 ```
 /var/log/homeassistant/home-assistant.log
+```
+
+```text
 {
         rotate 7
         daily

--- a/source/_docs/autostart/init.d.markdown
+++ b/source/_docs/autostart/init.d.markdown
@@ -34,9 +34,7 @@ $ sudo service hass-daemon install
 
 This logrotate script at `/etc/logrotate.d/homeassistant` will create an outage of a few seconds every week at night. If you do not want this add `--log-rotate-days 7` to the `FLAGS` variable in the init script.
 
-```
-/var/log/homeassistant/home-assistant.log
-```
+File `/var/log/homeassistant/home-assistant.log`:
 
 ```text
 {

--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -19,7 +19,7 @@ A service file is needed to control Home Assistant with `systemd`. The template 
 - If unfamiliar with command-line text editors, `sudo nano -w [filename]` can be used with `[filename]` replaced with the full path to the file.  Ex. `sudo nano -w /etc/systemd/system/home-assistant@YOUR_USER.service`.  After text entered, press CTRL-X then press Y to save and exit.
 - If you're running Home Assistant in a Python virtual environment or a Docker container, please skip to the appropriate template listed below.
 
-```
+```text
 [Unit]
 Description=Home Assistant
 After=network-online.target
@@ -37,7 +37,7 @@ WantedBy=multi-user.target
 
 If you've setup Home Assistant in `virtualenv` following our [Python installation guide](/getting-started/installation-virtualenv/) or [manual installation guide for Raspberry Pi](/getting-started/installation-raspberry-pi/), the following template should work for you. If Home Assistant install is not located at `/srv/homeassistant`, please modify the `ExecStart=` line appropriately. `YOUR_USER` should be replaced by the user account that Home Assistant will run as (e.g `homeassistant`).
 
-```
+```text
 [Unit]
 Description=Home Assistant
 After=network-online.target
@@ -55,7 +55,7 @@ WantedBy=multi-user.target
 
 If you want to use Docker, the following template should work for you.
 
-```
+```text
 [Unit]
 Description=Home Assistant
 Requires=docker.service
@@ -132,7 +132,7 @@ $ sudo systemctl restart home-assistant@YOUR_USER && sudo journalctl -f -u home-
 
 If you want to restart the Home Assistant service automatically after a crash, add the following lines to the `[Service]` section of your unit file:
 
-```
+```text
 Restart=on-failure
 RestartSec=5s
 ```

--- a/source/_docs/ecosystem/caddy.markdown
+++ b/source/_docs/ecosystem/caddy.markdown
@@ -26,7 +26,7 @@ Forward ports 443 and 80 to your server on your router. Do not forward port 8123
 
 Use this as your Caddyfile, change the domain name to match yours.
 
-```
+```text
 example.com {
     proxy / localhost:8123 {
         websocket

--- a/source/_docs/ecosystem/scenegen.markdown
+++ b/source/_docs/ecosystem/scenegen.markdown
@@ -33,7 +33,7 @@ You should now be ready to run `scenegen`
 
 ## Basic Operation
 
-```
+```text
 usage: scenegen [-h] [-k KEY] [-s SCENENAME] [-m MAPFILE] [-f FILTER]
                 [-c {xy_color,rgb_color,color_temp,color_name}] [-t TYPES]
                 url
@@ -60,7 +60,7 @@ optional arguments:
 
 For basic operation just supply the url and optionally the api key (using the --key option) on the command line and scenegen will output a list of all lights and switches with their attributes. Optionally use the `--scenename` flag to explicitly set the scenename.
 
-```
+```text
 $ ./scenegen.py https://<some url> -k <some api key>
 name: My New Scene
 entities:
@@ -126,7 +126,7 @@ This will make more sense as and when more types are added.
 
 Maps allow you to specify and label various subsets of devices that you want to work on together. A mapfile is specified using the `--mapfile` option and is a `.ini` style file consisting of section headers and entries. The section headers specify a region or zone or otherwise organized selection of entities you want to filter on, and it is mandatory to have at least one. If you create a map file like this:
 
-```
+```text
 [entities]
 light.living_room:
 light.dining_room:
@@ -136,7 +136,7 @@ The trailing colons are necessary to prevent parsing errors for including just k
 
 If you run scenegen with the `--mapfile` argument pointing to that file you will only get output for the listed entities (the name of the section is irrelevant if not using the `--filter` option). A more complex mapfile might look like this:
 
-```
+```text
 [Outside]
 light.porch:
 switch.path_lights:

--- a/source/_docs/ecosystem/scenegen.markdown
+++ b/source/_docs/ecosystem/scenegen.markdown
@@ -11,14 +11,14 @@ Scenegen is a scene generation tool for [Home Assistant](/) home automation soft
 ### Clone the Repository
 Clone the [**scenegen**](https://github.com/home-assistant/scenegen) repository to the current local directory on your machine.
 
-``` bash
-$ git clone https://github.com/home-assistant/scenegen.git
+```bash
+git clone https://github.com/home-assistant/scenegen.git
 ```
 
 Change your working directory to the repository root. Moving forward, we will be working from this directory.
 
-``` bash
-$ cd scenegen
+```bash
+cd scenegen
 ```
 
 ## Install Prerequisites
@@ -26,7 +26,7 @@ $ cd scenegen
 Before running `SceneGen` you will need to add some python prerequisites:
 
 ```bash
-$ sudo pip3 install configparser
+sudo pip3 install configparser
 ```
 
 You should now be ready to run `scenegen`
@@ -60,7 +60,7 @@ optional arguments:
 
 For basic operation just supply the url and optionally the api key (using the --key option) on the command line and scenegen will output a list of all lights and switches with their attributes. Optionally use the `--scenename` flag to explicitly set the scenename.
 
-```text
+```bash
 $ ./scenegen.py https://<some url> -k <some api key>
 name: My New Scene
 entities:
@@ -90,14 +90,14 @@ Note that depending on the type of light there may be a delay in actually settin
 
 For a more advanced way to use the output try the following. In configuration.yaml add the following line:
 
-```
+```yaml
 scene: !include_dir_list scenes
 ```
 
 This will tell Home Assistant to look in the subdirectory `scenes` for yaml files containing scene information. Each file will be named for the scene it will create and should contain information formatted as above. Then simply run Scenegen and redirect its output to the scenes subdirectory:
 
-```
-$ ./scenegen.py https://<some url> -k <some api key> > scenes/my_new_scene.yaml
+```bash
+./scenegen.py https://<some url> -k <some api key> > scenes/my_new_scene.yaml
 ```
 
 This will create a new scene called `my_new_scene` which will automatically be picked up by Home Assistant on the next restart.
@@ -110,13 +110,13 @@ Scenegen allows colors to be captured, and in fact Home Assistant light entities
 
 By default, Scenegen will list all lights and switches. To restrict the device type use the `--types` option and supply a comma separated list (no spaces) of types to output. e.g.:
 
-```
+```bash
 ./scenegen.py https://<some url> -k <some api key> --types light,switch
 ```
 
 or:
 
-```
+```bash
 ./scenegen.py https://<some url> -k <some api key> --types light
 ```
 
@@ -149,7 +149,7 @@ light.bedside:
 
 Again, if you run with that map file it will output all of the entities listed, however you now have the possibility of restricting output devices based on the sections they are in, using the `--filter` option and supplying a comma separated list of sections you want to include, for instance:
 
-```
+```bash
 ./scenegen.py https://<some url> -k <some api key> --mapfile map.cfg --filter "Outside,Living Room"
 ```
 
@@ -159,6 +159,6 @@ The intended use of the mapfile and filter is that you create a map of all your 
 To update SceneGen after a new version is released, just run the following command to update your copy:
 
 ```bash
-$ git pull
+git pull
 ```
 

--- a/source/_docs/ecosystem/synology.markdown
+++ b/source/_docs/ecosystem/synology.markdown
@@ -22,7 +22,7 @@ To allow WebSocket by default for all service exposed by NGINX, you can enable i
 
 Open `/usr/syno/share/nginx/Portal.mustache` and add the followings in the `Location` section:
 
-```
+```text
         proxy_set_header        Upgrade             $http_upgrade;
         proxy_set_header        Connection          "upgrade";
         proxy_read_timeout      86400;
@@ -43,7 +43,7 @@ You can find more information [here](https://github.com/orobardet/dsm-reverse-pr
 - Copy the Home Assistant specific Reverse Proxy settings from the existing `/etc/nginx/app.d/server.ReverseProxy.conf` file to `/usr/local/etc/nginx/conf.d/http.HomeAssistant.conf`.
 - Include these lines in the location declaration:
 
-```
+```text
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
 ```


### PR DESCRIPTION
**Description:** There were some text blocks, generally containing things like config file data, which did not specify a "language" for the text block. This made the text appear like a single-line quoted string, but across multiple lines. Jekyll formats these differently than Github, so it appears to have been an oversight.

I may have missed some instances of this, but I tried to find them all.

I did not make changes to some areas where I was not sure if it would be the intended style. An example of this is in the ``source/_docs/z-wave/installation.markdown`` file in the ``Random Failures`` section. This section gives an example of an error message with this same formatting. Could I get confirmation on if instances like these should be modified?

There were a few cases I was not sure about the preferred style. I will make comments on these changes for review.

If this formatting is desired, it may be worth specifying it in the documentation standards.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10031"><img src="https://gitpod.io/api/apps/github/pbs/github.com/agsimmons/home-assistant.io.git/3764ca2a819b0922e094486ae7712eb9bdae567c.svg" /></a>

