### PR TITLE
Add HmIP-SCI to Homematic IP Cloud

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -87,6 +87,7 @@ authtoken:
 * homematicip_cloud.binary_sensor
   * Window and door contact (*HmIP-SWDO, -I*)
   * Contact Interface flush-mount – 1 channel (*HmIP-FCI1*)
+  * Contact Interface (*HmIP-SCI*)
   * Window Rotary Handle Sensor (*HmIP-SRH*)
   * Smoke sensor and alarm (*HmIP-SWSD*)
   * Motion Detector with Brightness Sensor - indoor (*HmIP-SMI*)


### PR DESCRIPTION
**Description:**
Add HmIP-SCI to Homematic IP Cloud

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25639

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10033"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SukramJ/home-assistant.io.git/b659b9bf7ad8326c06f3983775aa93ad3d18b711.svg" /></a>

