### PR TITLE
Prometheus - Fix the documentation of filters on Prometheus

### DIFF
--- a/source/_components/prometheus.markdown
+++ b/source/_components/prometheus.markdown
@@ -26,32 +26,22 @@ filter:
   required: false
   type: list
   keys:
-    exclude:
-      description: Excluded from recording.
+    exclude_entities:
+      description: The list of entity ids to be excluded from recording.
       required: false
       type: list
-      keys:
-        entities:
-          description: The list of entity ids to be excluded from recording.
-          required: false
-          type: list
-        domains:
-          description: The list of domains to be excluded from recording.
-          required: false
-          type: list
-    include:
-      description: Included in recordings. If set, all other entities will not be recorded. Values set by the **exclude** option will prevail.
+    exclude_domains:
+      description: The list of domains to be excluded from recording.
       required: false
       type: list
-      keys:
-        entities:
-          description: The list of entity ids to be included from recordings.
-          required: false
-          type: list
-        domains:
-          description: The list of domains to be included from recordings.
-          required: false
-          type: list
+    include_entities:
+      description: The list of entity ids to be included from recordings. If set, all other entities will not be recorded. Values set by the **exclude_*** option will prevail.
+      required: false
+      type: list
+    include_domains:
+      description: The list of domains to be included from recordings. If set, all other entities will not be recorded. Values set by the **exclude_*** option will prevail.
+      required: false
+      type: list
 {% endconfiguration %}
 
 You can then configure Prometheus to fetch metrics from Home Assistant by adding to its `scrape_configs` configuration.


### PR DESCRIPTION
**Description:**

The description for the filter object for the prometheus component is incorrect. This updates the documentation to match what the component expects.

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10035"><img src="https://gitpod.io/api/apps/github/pbs/github.com/btobolaski/home-assistant.io.git/903c0f59823221f5fc5d41c21a6d0d3a9e25d785.svg" /></a>

