### PR TITLE
Document the 'state_detection_rules' config parameter

### DIFF
--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -132,8 +132,8 @@ media_player:
       'com.hulu.plus':
         - 'media_session_state'
         - 'wake_lock_size':
-            4: 'playing'
-            2: 'paused'
+            4: 'playing'  # this indentation is important!
+            2: 'paused'   # this indentation is important!
 
   # Use the Python ADB implementation with authentication
   # to setup a Fire TV device and don't get the running apps

--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -260,3 +260,5 @@ The `state_detection_rules` configuration parameter allows you to provide your o
 * `'media_session_state'` = try to use the `media_session_state` property to determine the state
 * `'audio_state'` = try to use the `audio_state` property to determine the state
 * `'wake_lock_size'` = if the `wake_lock_size` property is present in this map, then use its corresponding state
+
+To determine what these rules should be, you can use the `androidtv.adb_command` service with the command `GET_PROPERTIES`, as described in the [androidtv.adb_command](#androidtvadb_command) section.

--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -129,11 +129,16 @@ media_player:
         - 'standby'
       'com.netflix.ninja':
         - 'media_session_state'
-      'com.hulu.plus':
-        - 'media_session_state'
-        - 'wake_lock_size':
-            4: 'playing'  # this indentation is important!
-            2: 'paused'   # this indentation is important!
+      'com.ellation.vrv':
+        - 'audio_state'
+      'com.plexapp.android':
+        - 'playing':
+            'media_session_state': 3  # this indentation is important!
+            'wake_lock_size': 3       # this indentation is important!
+        - 'paused':
+            'media_session_state': 3  # this indentation is important!
+            'wake_lock_size': 1       # this indentation is important!
+        - 'standby'
 
   # Use the Python ADB implementation with authentication
   # to setup a Fire TV device and don't get the running apps
@@ -256,9 +261,13 @@ You can also use the command `GET_PROPERTIES` to retrieve the properties used by
 
 The `state_detection_rules` configuration parameter allows you to provide your own rules for state detection.  The keys are app IDs, and the values are lists of rules that are evaluated in order.  Valid rules are:
 
-* `'standby'`, `'playing'`, `'paused'`, `'idle'`, `'stopped'`, or `'off'` = always use the specified state for the state when this app is open
+* `'standby'`, `'playing'`, `'paused'`, `'idle'`, `'stopped'`, or `'off'`
+  * If this is not a map, then this state will always be reported when this app is the current app
+  * If this is a map, then its entries are conditions that will be checked.  If all of the conditions are true, then this state will be reported.  Valid conditions pertain to 3 properties (see the example configuration above):
+    1. ``'media_session_state'``
+    2. ``'audio_state'``
+    3. ``'wake_lock_size'``
 * `'media_session_state'` = try to use the `media_session_state` property to determine the state
 * `'audio_state'` = try to use the `audio_state` property to determine the state
-* `'wake_lock_size'` = if the `wake_lock_size` property is present in this map, then use its corresponding state
 
 To determine what these rules should be, you can use the `androidtv.adb_command` service with the command `GET_PROPERTIES`, as described in the [androidtv.adb_command](#androidtvadb_command) section.


### PR DESCRIPTION
**Description:**

Document the `state_detection_rules` config parameter.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/25647

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10036"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JeffLIrion/home-assistant.io.git/14ba6ac03b286c3db6d5aad944fe76d9fbae70d2.svg" /></a>

