### PR TITLE
Add co2 sensor to homekit_controller docs

### DIFF
--- a/source/_components/homekit_controller.markdown
+++ b/source/_components/homekit_controller.markdown
@@ -35,7 +35,7 @@ There is currently support for the following device types within Home Assistant:
 - Lock (HomeKit lock)
 - Switch (HomeKit switches)
 - Binary Sensor (HomeKit motion sensors and contact sensors)
-- Sensor (HomeKit humidity, temperature, and light level sensors)
+- Sensor (HomeKit humidity, temperature, co2 and light level sensors)
 
 The integration will be automatically configured if the [`discovery`](/components/discovery/) integration is enabled.
 


### PR DESCRIPTION
**Description:**
Update docs to include co2 sensors in homekit_controller docs.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25603

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10037"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tleegaard/home-assistant.github.io.git/6500c9426a690129da1fdb7651b086e26478cac2.svg" /></a>

