### PR TITLE
Remove some no longer needed Python 3.5 info

### DIFF
--- a/source/_components/discovery.markdown
+++ b/source/_components/discovery.markdown
@@ -118,10 +118,6 @@ If running Home Assistant in a [Docker container](/docs/installation/docker/) us
 #### 64-bit Python
 There is currently a <a href='https://bitbucket.org/al45tair/netifaces/issues/17/dll-fails-to-load-windows-81-64bit'>known issue</a> with running this integration on a 64-bit version of Python and Windows.
 
-#### Python 3.5
-
-If you are on Windows and you're using Python 3.5, download the [Netifaces](http://www.lfd.uci.edu/~gohlke/pythonlibs/#netifaces) dependency.
-
 ### could not install dependency netdisco
 
 If you see `Not initializing discovery because could not install dependency netdisco==0.6.1` in the logs, you will need to install the `python3-dev` or `python3-devel` package on your system manually (eg. `sudo apt-get install python3-dev` or `sudo dnf -y install python3-devel`). On the next restart of Home Assistant, the discovery should work. If you still get an error, check if you have a compiler (`gcc`) available on your system.

--- a/source/_components/knx.markdown
+++ b/source/_components/knx.markdown
@@ -14,7 +14,7 @@ The integration requires a local KNX/IP interface like the [Weinzierl 730](https
 
 <div class='note warning'>
 
-  Please note, the `knx` platform does not support Windows and needs at least python version 3.5.
+  Please note, the `knx` platform does not support Windows.
 
 </div>
 
@@ -162,7 +162,3 @@ address:
   description: KNX group address.
   type: string
 {% endconfiguration %}
-
-### Known issues
-
-Due to lame multicast support the routing abstraction and the gateway scanner only work with Python >=3.5.

--- a/source/_docs/installation/armbian.markdown
+++ b/source/_docs/installation/armbian.markdown
@@ -5,8 +5,6 @@ description: "Instructions to install Home Assistant on an Armbian-powered syste
 
 [armbian](https://www.armbian.com) runs on a wide-variety of [ARM development boards](https://www.armbian.com/download/). Currently there are around 50 boards supported inclusive the OrangePi family, Cubieboard, Pine64, and Odroid.
 
-Python 3.5.3 or later is required.
-
 Setup Python and `pip`:
 
 ```bash


### PR DESCRIPTION
**Description:**

Subject says it all.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10039"><img src="https://gitpod.io/api/apps/github/pbs/github.com/scop/home-assistant.io.git/f1bbc3dd210a4c43d22d8c8854e162dda5ebc47d.svg" /></a>

