### PR TITLE
UniFi - configuration option to not track wired clients

### DIFF
--- a/source/_components/unifi.markdown
+++ b/source/_components/unifi.markdown
@@ -73,6 +73,11 @@ dont_track_devices:
   type: boolean
   required: false
   default: false
+dont_track_wired_clients:
+  description: enable to not allow device tracker to track wired clients.
+  type: boolean
+  required: false
+  default: false
 ssid_filter:
   description: Filter the SSIDs that tracking will occur on.
   type: list


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25669

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10040"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Kane610/home-assistant.github.io.git/2ae3f49fd66520aad924cfb5370c914a790012a3.svg" /></a>

