### PR TITLE
Added Reference Link for BCM Numbering of pins

### DIFF
--- a/source/_components/rpi_gpio.markdown
+++ b/source/_components/rpi_gpio.markdown
@@ -41,7 +41,7 @@ ports:
   type: map
   keys:
     "port: name":
-      description: The port numbers (BCM mode pin numbers) and corresponding names.
+      description: The port numbers ([BCM mode pin numbers](https://pinout.xyz/resources/raspberry-pi-pinout.png)) and corresponding names.
       required: true
       type: string
 bouncetime:


### PR DESCRIPTION
I spent like 2 hours trying to figure out what I was doing wrong in my wiring, only to eventually find this graphic and realized the pin numbers I were using were wrong. I feel like this link will help others.

**Description:**
I just added a link to a graphic to show users which pins correspond to which BCM pin numbers. This graphic specifically, https://pinout.xyz/resources/raspberry-pi-pinout.png

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
