### PR TITLE
fix for using custom keys

### DIFF
--- a/source/_components/sma.markdown
+++ b/source/_components/sma.markdown
@@ -133,7 +133,7 @@ Example:
 ```yaml
    custom:
       yesterday_consumption:
-         key: 6400_00543A01
+         key: '6400_00543A01'
          unit: kWh
          factor: 1000
 ```


### PR DESCRIPTION
Custom keys must be quoted, or else the parser will try to interpret them as numbers.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10045"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Human/home-assistant.github.io.git/8e1bdd36c3f7afbeedd6b7e839af41440778fc1a.svg" /></a>

