### PR TITLE
Indentation of "Full Configuration" was off

### DIFF
--- a/source/_components/wwlln.markdown
+++ b/source/_components/wwlln.markdown
@@ -70,7 +70,7 @@ the standard ones:
 ```yaml
 # Example configuration.yaml entry
 wwlln:
-    radius: 100
-    latitude: 37.39
-    longitude: -5.99
+  radius: 100
+  latitude: 37.39
+  longitude: -5.99
 ```


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10047"><img src="https://gitpod.io/api/apps/github/pbs/github.com/atxbyea/home-assistant.io.git/a293c94f0ca4d06b15e0d8e3a2a9f4910992480b.svg" /></a>

