### PR TITLE
Add show_on_map config

### DIFF
--- a/source/_components/rmvtransport.markdown
+++ b/source/_components/rmvtransport.markdown
@@ -75,6 +75,11 @@ next_departure:
       required: false
       default: 5
       type: integer
+    show_on_map:
+      description: Enable/Disable to display the station on the map.
+      required: false
+      default: false
+      type: boolean
 {% endconfiguration %}
 
 ## Examples


### PR DESCRIPTION
**Description:**

The sensors can now also be shown on the map.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25674

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10052"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/bab003c3d2ab08ed5c44bf8201d75186ca02e70b.svg" /></a>

