### PR TITLE
Autoconf is required for some integrations

### DIFF
--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -41,7 +41,7 @@ $ sudo apt-get upgrade -y
 Install the dependencies.
 
 ```bash
-$ sudo apt-get install python3 python3-venv python3-pip libffi-dev libssl-dev
+$ sudo apt-get install python3 python3-venv python3-pip libffi-dev libssl-dev autoconf
 ```
 
 Add an account for Home Assistant called `homeassistant`.


### PR DESCRIPTION
Autoconf is required for Ikea Tradfri and will not install without this

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10056"><img src="https://gitpod.io/api/apps/github/pbs/github.com/will-h/home-assistant.io.git/5fa69f6940ae08d922df4001c92865d68f5883b6.svg" /></a>

