### PR TITLE
Note that System Health is part of default_config

### DIFF
--- a/source/_components/system_health.markdown
+++ b/source/_components/system_health.markdown
@@ -11,6 +11,7 @@ ha_release: 0.87
 The System Health integration provides an API to offer information on the system and its components. It also allows to run diagnostic tools to diagnose problems.
 
 System health is included as part of the [default config](https://www.home-assistant.io/components/default_config/) starting with Home Assistant 0.88. If you do not wish to use the default config, you can add the following to your configuration.yaml file.
+
 ```yaml
 system_health:
 ```

--- a/source/_components/system_health.markdown
+++ b/source/_components/system_health.markdown
@@ -1,6 +1,6 @@
 ---
 title: "System Health"
-description: "Systeam Health integration will report system info and allow to run system diagnostics."
+description: "System Health integration will report system info and allow to run system diagnostics."
 logo: home-assistant.png
 ha_category:
   - "Other"
@@ -10,9 +10,9 @@ ha_release: 0.87
 
 The System Health integration provides an API to offer information on the system and its components. It also allows to run diagnostic tools to diagnose problems.
 
-Add the following to your configuration.yaml file.
+System health is included as part of the [default config](https://www.home-assistant.io/components/default_config/) starting with Home Assistant 0.88. If you do not wish to use the default config, you can add the following to your configuration.yaml file.
 ```yaml
 system_health:
 ```
 
-Once added the system health integration data can be viewed in the developer tools under <img src='/images/screenshots/developer-tool-about-icon.png' alt='service developer tool icon' class="no-shadow" height="38">.
+System Health integration data can be viewed in Developer Tools on the "Info" tab.


### PR DESCRIPTION
Added information on system health being part of default config, and updated instructions for Developer Tools UI changes that came in 0.96. Fixed a minor typo too.

On a side note, I don't believe the introductory paragraph is correct - it seems to be purely informational rather than having diagnostic tools - but I didn't touch that part at all.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10058"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SeanPM5/home-assistant.io.git/ff1ecaf16dcac3021567dfd4c4d04d9857e0b1b0.svg" /></a>

