### PR TITLE
Darksky doc : Missing web links

### DIFF
--- a/source/_components/darksky.markdown
+++ b/source/_components/darksky.markdown
@@ -84,9 +84,9 @@ monitored_conditions:
     summary:
       description: A human-readable text summary.
     icon:
-      description: A machine-readable text summary, suitable for selecting an icon for display. See [Dark Sky API documentation][] for the list of possible values.
+      description: A machine-readable text summary, suitable for selecting an icon for display. See [Dark Sky API documentation](https://darksky.net/dev/docs) for the list of possible values.
     precip_type:
-      description: The type of precipitation occurring at the given time. If `precip_intensity` is zero, then this property will be `unknown`. See [Dark Sky API documentation][] for the list of possible values.
+      description: The type of precipitation occurring at the given time. If `precip_intensity` is zero, then this property will be `unknown`. See [Dark Sky API documentation](https://darksky.net/dev/docs) for the list of possible values.
     precip_intensity:
       description: The intensity of precipitation occurring at the given time. This value is conditional on probability (that is, assuming any precipitation occurs at all).
     precip_probability:
@@ -236,7 +236,4 @@ All language options are described in this table that you can use for the dark s
 While the platform is called "darksky" the sensors will show up in Home Assistant as "dark_sky" (eg: sensor.dark_sky_summary).
 </div>
 
-More details about the API are available in the [Dark Sky API documentation][].
-
-[Dark Sky API documentation]: https://darksky.net/dev/docs
-
+More details about the API are available in the [Dark Sky API documentation](https://darksky.net/dev/docs).


### PR DESCRIPTION
**Description:**
There was few missing links in this page.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10063"><img src="https://gitpod.io/api/apps/github/pbs/github.com/SNoof85/home-assistant.io.git/60e6229d77675a9c7f5fca9b95b5f165ba99b871.svg" /></a>

