### PR TITLE
Zooz Zen26 Switch Scene Support

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -231,6 +231,87 @@ Hold Button|7740
 5x Tap|8040
 
 
+### Zooz Zen26 Switch
+
+Firmware on Zooz switch must be 2.0 or higher for scenes to work. For OTA firmware updates for the switch, reach out to Zooz. You may need to update the `COMMAND_CLASS_CENTRAL_SCENE` for each node in your `zwcfg` file with the following:
+
+```xml
+<CommandClass id="91" name="COMMAND_CLASS_CENTRAL_SCENE" version="1" request_flags="4" innif="true" scenecount="0">
+  <Instance index="1" />
+  <Value type="int" genre="system" instance="1" index="0" label="Scene Count" units="" read_only="true" write_only="false"   verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="2" />
+  <Value type="int" genre="user" instance="1" index="1" label="Top Button Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+  <Value type="int" genre="user" instance="1" index="2" label="Bottom Button Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+</CommandClass>
+```
+
+You will also need to ensure your `zwcfg` file has the updated configuration paramters for the version 2.0 firmware.  Replace the existing `COMMAND_CLASS_CONFIGURATION` with the following:
+```xml
+<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1" request_flags="4" innif="true">
+	<Instance index="1" />
+	<Value type="list" genre="config" instance="1" index="1" label="Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+		<Help>Normal mode: Upper paddle turns the light on, lower paddle turns the light off. Reverse will reverse those functions. Any will toggle the light regardless of which button is pushed.</Help>
+		<Item label="Normal" value="0" />
+		<Item label="Reverse" value="1" />
+		<Item label="Any" value="2" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="2" label="LED Indication Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="0" size="1">
+		<Help>LED Indication light function. Normal has the LED Indication on when the switch is off, off when the switch is on.</Help>
+		<Item label="Normal" value="0" />
+		<Item label="Reverse" value="1" />
+		<Item label="Always Off" value="2" />
+		<Item label="Always On" value="3" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="3" label="Auto Turn-Off Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Help>Enable or disable the auto turn-off timer function.</Help>
+		<Item label="Disabled (Default)" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+	<Value type="short" genre="config" instance="1" index="4" label="Auto Turn-Off Timer Time" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="65535" value="60">
+		<Help>Time, in seconds, for auto-off timer delay. 60 (default).</Help>
+	</Value>
+	<Value type="list" genre="config" instance="1" index="5" label="Auto Turn-On Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Help>Enable or disable the auto turn-on timer function.</Help>
+		<Item label="Disabled (Default)" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+	<Value type="short" genre="config" instance="1" index="6" label="Auto Turn-On Timer Time" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="65535" value="60">
+		<Help>Time, in minutes, for auto-on timer delay. 60 (default).</Help>
+	</Value>
+	<Value type="list" genre="config" instance="1" index="8" label="On Off Status After Power Failure" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="2" size="1">
+		<Help>Status after power on after power failure. OFF will always turn light off. ON will always turn light on. Restore will remember the latest state and restore that state.</Help>
+		<Item label="OFF" value="0" />
+		<Item label="ON" value="1" />
+		<Item label="Restore" value="2" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="10" label="Scene Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Help>Enable or disable scene control functionality for quick double tap triggers.</Help>
+		<Item label="Disabled (Default)" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="11" label="Enable/Disable Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+		<Help>Enable or disable local on/off control. If disabled, you&apos;ll only be able to control the connected light via Z-Wave.</Help>
+		<Item label="Disabled" value="0" />
+		<Item label="Enabled (Default)" value="1" />
+	</Value>
+</CommandClass>
+```
+
+Below is a table of the action/scenes for the Zooz Zen26 device:
+
+**Action**|**scene\_id**|**scene\_data**
+:-----:|:-----:|:-----:
+Single tap on|2|7680
+Single tap off|1|7680
+Double tap on|2|7860
+Double tap off|1|7860
+Triple tap on|2|7920
+Triple tap off|1|7920
+4x tap on|2|7980
+4x tap off|1|7980
+5x tap on|2|8040
+5x tap off|1|8040
+
+
 ### Fibaro Button FGPB-101-6 v3.2
 
 <!-- from https://hastebin.com/esodiweduq.cs -->


### PR DESCRIPTION
Add information on how to enable scene support on a Zooz Zen26 Switch.

**Description:** Zooz Zen26 Z-Wave Scene Support


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10066"><img src="https://gitpod.io/api/apps/github/pbs/github.com/DaveCo1701/home-assistant.io.git/2925e130be7c100c4d548ddd3a62ccabec725455.svg" /></a>

