### PR TITLE
Deprecates usps integration (ADR-0004)

### DIFF
--- a/source/_components/usps.markdown
+++ b/source/_components/usps.markdown
@@ -13,6 +13,14 @@ redirect_from:
   - /components/sensor.usps/
 ---
 
+<div class="note warning">
+
+ This integration is deprecated and will be removed in Home Assistant 0.100.0.
+
+ For more information see [Architecture Decision Record: 0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md).
+
+ </div>
+
 The `usps` platform allows one to track deliveries and inbound mail from the [US Postal Service (USPS)](https://www.usps.com/).
 In addition to having a USPS account, you will need to complete the "Opt-In" process for packages by clicking "Get Started Now" on [this page](https://my.usps.com/mobileWeb/pages/intro/start.action). You must also "Opt-In" to [Informed Delivery](https://informeddelivery.usps.com/box/pages/intro/start.action) to see inbound mail.
 


### PR DESCRIPTION
**Description:**

This PR adds a deprecation for the USPS integration since it relies on web scraping to function.
As per [ADR-0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md) this is no longer allowed. The integration should now be deprecated for 2 releases before permanent removal.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25743

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10069"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/c145d020e31da823a78a9a8746fdfe80d6162114.svg" /></a>

