### PR TITLE
Deprecates fedex integration (ADR-0004)

### DIFF
--- a/source/_components/fedex.markdown
+++ b/source/_components/fedex.markdown
@@ -10,6 +10,14 @@ redirect_from:
  - /components/sensor.fedex/
 ---
 
+<div class="note warning">
+
+This integration is deprecated and will be removed in Home Assistant 0.100.0.
+
+For more information see [Architecture Decision Record: 0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md).
+
+</div>
+
 The `fedex` platform allows one to track deliveries by [FedEx](http://www.fedex.com/). To use this sensor, you need a [FedEx Delivery Manager](https://www.fedex.com/us/delivery/) account.
 
 ## Configuration


### PR DESCRIPTION
**Description:**

This PR adds a deprecation for the FedEx integration since it relies on web scraping to function.
As per [ADR-0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md) this is no longer allowed. The integration should now be deprecated for 2 releases before permanent removal.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25745

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html



<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10070"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/68dce308d18d6f52be16beef557990cd43341162.svg" /></a>

