### PR TITLE
Deprecates srp_energy integration (ADR-0004)

### DIFF
--- a/source/_components/srp_energy.markdown
+++ b/source/_components/srp_energy.markdown
@@ -9,6 +9,14 @@ redirect_from:
  - /components/sensor.srp_energy/
 ---
 
+<div class="note warning">
+
+ This integration is deprecated and will be removed in Home Assistant 0.100.0.
+
+ For more information see [Architecture Decision Record: 0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md).
+
+ </div>
+
 The `srp_energy` integration shows information from Srp hourly energy usage report for their customers. The srpenergy module fetches the data found on the website.
 
 You need a Username, Password, and AccountId which you can create at [Srp](https://www.srpnet.com).


### PR DESCRIPTION
**Description:**

This PR adds a deprecation for the SRP Energy integration since it relies on web scraping to function.
As per [ADR-0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md) this is no longer allowed. The integration should now be deprecated for 2 releases before permanent removal.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25754

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10072"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/55efe7d166fb51e09829efd191dc04a698332295.svg" /></a>

