### PR TITLE
Fix typo in Fortinet Developer Network URL

### DIFF
--- a/source/_components/fortios.markdown
+++ b/source/_components/fortios.markdown
@@ -31,7 +31,7 @@ host:
     required: true
     type: string
 token:
-    description: "See [Fortinet Developer Network](https://fndn.fortinet.com) for how to create an API token. Remember this integration only needs read access to a FortiGate, so configure the API user to only to have limited and read-only access."
+    description: "See [Fortinet Developer Network](https://fndn.fortinet.net) for how to create an API token. Remember this integration only needs read access to a FortiGate, so configure the API user to only to have limited and read-only access."
     required: true
     type: string
 verify_ssl:


### PR DESCRIPTION
**Description:**
Fixes typo in Fortinet Developer Network URL

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10073"><img src="https://gitpod.io/api/apps/github/pbs/github.com/patrickeasters/home-assistant.github.io.git/f59bf47f2573c6c408e8fe2c87868a1e57dcd25c.svg" /></a>

