### PR TITLE
Replace operating_mode with hvac_mode

### DIFF
--- a/source/_components/zwave.markdown
+++ b/source/_components/zwave.markdown
@@ -83,10 +83,10 @@ automation:
       - platform: time
         at: "20:00:00"
     action:
-      - service: climate.set_operation_mode
+      - service: climate.set_hvac_mode
         data:
           entity_id: climate.remotec_zxt120_heating_1_id
-          operation_mode: Heat
+          hvac_mode: Heat
       - service: climate.set_temperature
         data:
           entity_id: climate.remotec_zxt120_heating_1_39
@@ -102,10 +102,10 @@ automation:
       - platform: time
         at: "21:00:00"
     action:
-      - service: climate.set_operation_mode
+      - service: climate.set_hvac_mode
         data:
           entity_id: climate.remotec_zxt120_heating_1_id
-          operation_mode: 'Off'
+          hvac_mode: 'Off'
 ```
 
 **Note:** In the example above, the word `Off` is encased in single quotes to be valid YAML.
@@ -117,7 +117,7 @@ A simple way to test if your Z-Wave climate device is working is to use <img src
 ```json
 {
   "entity_id": "climate.remotec_zxt120_heating_1_id",
-  "operation_mode": "Heat"
+  "hvac_mode": "Heat"
 }
 ```
 


### PR DESCRIPTION
**Description:**
Update zwave climate examples. Replace all occurrences of `operation_mode` with `hvac_mode`.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#23899

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10075"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Santobert/home-assistant.io.git/0149d45bded0eee736242fe47ae85120dea4f50d.svg" /></a>

