### PR TITLE
remove password from configuration options

### DIFF
--- a/source/_components/google_maps.markdown
+++ b/source/_components/google_maps.markdown
@@ -42,10 +42,6 @@ username:
   description: The email address for the Google account that has access to your shared location.
   required: true
   type: string
-password:
-  description: The password for your given username.
-  required: true
-  type: string
 max_gps_accuracy:
    description: Sometimes Google Maps can report GPS locations with a very low accuracy (few kilometers). That can trigger false zoning. Using this parameter, you can filter these false GPS reports. The number has to be in meters. For example, if you put 200 only GPS reports with an accuracy under 200 will be taken into account - Defaults to 100km if not specified.
    required: false


### PR DESCRIPTION
Update documentation to reflect the recent change in 0.97.0 release

**Description:**
Documentation update to include the latest 0.97.0 changes to remove the option for the password in favour of the new cookie generation method.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10076"><img src="https://gitpod.io/api/apps/github/pbs/github.com/bigwoof/home-assistant.github.io.git/946652a24f6037c417eb161b290e0f4edf3b2072.svg" /></a>

