### PR TITLE
Change initial HA Release from 0.96 to 0.97 for Rainforest sensor

### DIFF
--- a/source/_components/rainforest_eagle.markdown
+++ b/source/_components/rainforest_eagle.markdown
@@ -5,7 +5,7 @@ logo: rainforest_automation_logo.png
 ha_category:
   - Energy
   - Sensor
-ha_release: 0.96
+ha_release: 0.97
 ha_iot_class: Local Polling
 ---
 


### PR DESCRIPTION
**Description:**
Sensor Integration for the Rainforest Eagle-200 did not make it into 0.96.  The initial release is 0.97.  `Introduced in release` should be changed accordingly.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10078"><img src="https://gitpod.io/api/apps/github/pbs/github.com/gtdiehl/home-assistant.io.git/1d07c974bce747554777e0f530355d2dd58dd451.svg" /></a>

