### PR TITLE
config example incorrect

### DIFF
--- a/source/_components/apache_kafka.markdown
+++ b/source/_components/apache_kafka.markdown
@@ -18,7 +18,7 @@ To use the `apache_kafka` integration in your installation, add the following to
 
 ```yaml
 apache_kafka:
-  ip_address: localhost
+  host: localhost
   port: 9092
   topic: home_assistant_1
 ```


### PR DESCRIPTION
changed ip_address to host as in docs below

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10083"><img src="https://gitpod.io/api/apps/github/pbs/github.com/atomicpapa/home-assistant.github.io.git/90f84946b58de824d3f88b6255862e2c9992b461.svg" /></a>

