### PR TITLE
replace address with state_address

### DIFF
--- a/source/_components/sensor.knx.markdown
+++ b/source/_components/sensor.knx.markdown
@@ -21,11 +21,11 @@ To use your KNX sensor in your installation, add the following lines to your `co
 sensor:
   - platform: knx
     name: Heating.Valve1
-    address: '2/0/0'
+    state_address: '2/0/0'
 ```
 
 {% configuration %}
-address:
+state_address:
   description: KNX group address of the sensor.
   required: true
   type: string
@@ -79,10 +79,10 @@ type:
 sensor:
   - platform: knx
     name: Heating.Valve1
-    address: '2/0/0'
+    state_address: '2/0/0'
     type: 'percent'
   - platform: knx
     name: Kitchen.Temperature
-    address: '6/2/1'
+    state_address: '6/2/1'
     type: 'temperature'
 ```


### PR DESCRIPTION
as per 0.97 release notes xKNX climate now uses : state_address instead of address

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10084"><img src="https://gitpod.io/api/apps/github/pbs/github.com/adonno/home-assistant.io.git/efd1b89dcfbbbff2fae4b21a4e7c52825ae28f37.svg" /></a>

