### PR TITLE
Fix broken anchor in installation guides list

### DIFF
--- a/source/_docs/installation.markdown
+++ b/source/_docs/installation.markdown
@@ -119,7 +119,7 @@ These guides are provided as-is. Some of these install methods are more limited 
     </div>
     <div class='title'>FreeNAS</div>
   </a>
-  <a class='option-card' href='/hassio/installation/#alternative-install-on-generic-linux-server'>
+  <a class='option-card' href='/hassio/installation/#alternative-install-on-a-generic-linux-host'>
     <div class='img-container'>
       <img src='/images/supported_brands/home-assistant.png' />
     </div>


### PR DESCRIPTION
**Description:**
As in title

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10091"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jack1142/home-assistant.io.git/e68d12b64c94dd8baa740f9d13843547dd64d419.svg" /></a>

