### PR TITLE
Deprecates linksys_ap integration (ADR-0004)

### DIFF
--- a/source/_components/linksys_ap.markdown
+++ b/source/_components/linksys_ap.markdown
@@ -9,6 +9,14 @@ redirect_from:
  - /components/device_tracker.linksys_ap/
 ---
 
+<div class="note warning">
+
+This integration is deprecated and will be removed in Home Assistant 0.100.0.
+
+For more information see [Architecture Decision Record: 0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md).
+
+</div>
+
 The `linksys_ap` platform offers presence detection by looking at connected devices to a Linksys based access point.
 
 It was tested with a LAPAC1750 AC1750 Dual Band Access Point.


### PR DESCRIPTION
**Description:**

This PR adds a deprecation for the Linksys Access Points integration since it relies on web scraping to function.
As per [ADR-0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md) this is no longer allowed. The integration should now be deprecated for 2 releases before permanent removal.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25804

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10092"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/8d292a47f969b505cad67d776e7922438ab73aad.svg" /></a>

