### PR TITLE
Update switch.rest for new configuration option

### DIFF
--- a/source/_components/switch.rest.markdown
+++ b/source/_components/switch.rest.markdown
@@ -51,6 +51,11 @@ body_off:
   required: false
   type: string
   default: OFF
+body_state:
+  description: "For poor IOT implementations of a REST API that don't return any data when querying the API endpoint without any body data, this option allows to send data in the body of the GET request when state of the switch is queried.  This value can also be a [template](/topics/templating/)."
+  required: false
+  type: string
+  default: None
 is_on_template:
   description: "A [template](/docs/configuration/templating/#processing-incoming-data) that determines the state of the switch from the value returned by the GET request on the resource URL. This template should compute to a boolean (True or False). If the value is valid JSON, it will be available in the template as the variable `value_json`. Default is equivalent to `'{% raw %}{{ value_json == body_on }}{% endraw %}'`. This means that by default, the state of the switch is on if and only if the response to the GET request matches."
   required: false


### PR DESCRIPTION
**Description:**
Update the doc to indicate new option of body_state to allow sending of data in the body of the GET request.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):**
home-assistant/home-assistant#25831
## Checklist:

- [X ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10096"><img src="https://gitpod.io/api/apps/github/pbs/github.com/quielb/home-assistant.io.git/be8f2abb293c6ac6865bfcdd1e2a58ef508a1c17.svg" /></a>

