### PR TITLE
Adding bug warning

### DIFF
--- a/source/_components/shell_command.markdown
+++ b/source/_components/shell_command.markdown
@@ -11,6 +11,12 @@ ha_release: 0.7.6
 This integration can expose regular shell commands as services. Services can be called from a [script] or in [automation].
 Shell commands aren't allowed for a camel-case naming, please use lowercase naming only and separate the names with underscores.
 
+<div class='note warning'>
+
+If you are also using the [stream component](/components/stream) there is currently a [bug in the library](https://github.com/home-assistant/home-assistant/issues/22999) used for `stream` that causes shell commands to crash Home Assistant.
+
+</div>
+
 [script]: /components/script/
 [automation]: /getting-started/automation/
 


### PR DESCRIPTION
Added bug warning about crashing

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10101"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/8836ceb465625aa9249d934ae56fac7832e49ba3.svg" /></a>

