### PR TITLE
Added bug warning about crashing

### DIFF
--- a/source/_components/stream.markdown
+++ b/source/_components/stream.markdown
@@ -11,6 +11,12 @@ ha_qa_scale: internal
 
 The `stream` integration provides a way to proxy live streams through Home Assistant. The integration currently only supports proxying H.264 source streams to the HLS format and requires at least FFmpeg >= 3.2.
 
+<div class='note warning'>
+
+If you are also using the [shell_command component](/components/shell_command) there is currently a [bug in the library](https://github.com/home-assistant/home-assistant/issues/22999) used for `stream` that causes shell commands to crash Home Assistant.
+
+</div>
+
 ## Configuration
 
 To enable this component, add the following lines to your `configuration.yaml` file:


### PR DESCRIPTION
Added bug warning about crashing when using stream and shell_command

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10102"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/2667ca113a466fe424c7afc35370cbbeda461286.svg" /></a>



<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10102"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/2667ca113a466fe424c7afc35370cbbeda461286.svg" /></a>



<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10102"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/2667ca113a466fe424c7afc35370cbbeda461286.svg" /></a>



<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10102"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/2667ca113a466fe424c7afc35370cbbeda461286.svg" /></a>

