### PR TITLE
Add OTGW domestic hot water enable option as service

### DIFF
--- a/source/_components/opentherm_gw.markdown
+++ b/source/_components/opentherm_gw.markdown
@@ -108,6 +108,19 @@ Please read [this information](http://otgw.tclcode.com/standalone.html) from the
 
 </div>
 
+### Service `opentherm_gw.set_hot_water_ovrd`
+
+Set the domestic hot water enable option on the OpenTherm Gateway.
+Control the domestic hot water enable option. If the boiler has
+been configured to let the room unit control when to keep a
+small amount of water preheated, this command can influence
+that.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `gateway_id` | no | The `gateway_id` as specified in `configuration.yaml`.
+| `dhw_override` | no | The domestic hot water override state. Value should be 0 or 1 to enable the override in off or on state, or "A" to disable the override.
+
 ### Service `opentherm_gw.set_gpio_mode`
 
 Configure the GPIO behavior on the OpenTherm Gateway.


### PR DESCRIPTION
**Description:**
This PR adds the documentation for the service to OTGW to override and restore domestic hot water enabling/disabling

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** https://github.com/home-assistant/home-assistant/pull/25849

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10105"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tcoenraad/home-assistant.io.git/496f6d22dd369332fae651d90e998affb7562a8c.svg" /></a>

