### PR TITLE
Mention integration in ZHA docs

### DIFF
--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -59,8 +59,9 @@ The custom quirks implementations for zigpy implemented as ZHA Device Handlers f
 
 ## Configuration
 
-To configure the component, a `zha` section must be present in the `configuration.yaml`,
-and the path to the serial device for the radio and path to the database which will persist your network data is required.
+To configure the component, select ZHA on the Integrations page and provide the path to your Zigbee USB stick.
+
+Or, you can manually confiure `zha` section in `configuration.yaml`. The path to the database which will persist your network data is required.
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
Due to the previous wording of this I thought a `zha` entry was necessary in `configuration.yaml`, which wasn't working for me on Hass.io. Adding ZHA from the Integrations page did work, but this isn't mentioned in the docs.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10108"><img src="https://gitpod.io/api/apps/github/pbs/github.com/AlecRust/home-assistant.io.git/5e2b2cff2d1b970ebbf7cb5b060b3eaa48ecb4c0.svg" /></a>

