### PR TITLE
Add note about language issues with syncthru

### DIFF
--- a/source/_components/syncthru.markdown
+++ b/source/_components/syncthru.markdown
@@ -45,4 +45,6 @@ The following information is displayed in separate sensors, if it is available:
  - First to fifth paper input tray state
  - First to sixth paper output tray state
 
-Note that this component or parts thereof may not work if your printers language is not configured to be English.
+<div class="note warning">
+Note that this component or parts thereof may not work if the language of your printer is not configured to be English.
+</div>

--- a/source/_components/syncthru.markdown
+++ b/source/_components/syncthru.markdown
@@ -44,3 +44,5 @@ The following information is displayed in separate sensors, if it is available:
  - Black, cyan, magenta and yellow drum state
  - First to fifth paper input tray state
  - First to sixth paper output tray state
+
+Note that this component or parts thereof may not work if your printers language is not configured to be English.


### PR DESCRIPTION
**Description:**
As was correctly pointed out [by KOliver4 on the underlying library](https://github.com/nielstron/pysyncthru/pull/16), the component may partially or completely not work if the printers language is not English.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):**  None

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`. (This is a fix for something that was updated in the current next branch)
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10109"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nielstron/home-assistant.github.io.git/5fdcb8b2e7f2e39cc5a5786cb42cd7b91db59d48.svg" /></a>

