### PR TITLE
Document Lutron Powr Savr occupancy sensor support

### DIFF
--- a/source/_components/lutron.markdown
+++ b/source/_components/lutron.markdown
@@ -77,4 +77,4 @@ After setup, scenes will appear in Home Assistant using the area, keypad and but
 
 ## Occupancy Sensors
 
-Any configured Powr Savr occuancy sensors will be added as occupancy binary_sensors. Lutron reports occupancy for an area, rather than reporting individual sensors. Sensitivity and timeouts are controlled on the sensors themselves, not in software.
+Any configured Powr Savr occuancy sensors will be added as occupancy binary sensors. Lutron reports occupancy for an area, rather than reporting individual sensors. Sensitivity and timeouts are controlled on the sensors themselves, not in software.

--- a/source/_components/lutron.markdown
+++ b/source/_components/lutron.markdown
@@ -75,3 +75,6 @@ The Lutron scene platform allows you to control scenes programmed into your SeeT
 
 After setup, scenes will appear in Home Assistant using the area, keypad and button name.
 
+## Occupancy Sensors
+
+Any configured Powr Savr occuancy sensors will be added as occupancy binary_sensors. Lutron reports occupancy for an area, rather than reporting individual sensors. Sensitivity and timeouts are controlled on the sensors themselves, not in software.


### PR DESCRIPTION
**Description:**

Document support for Lutron occupancy sensors.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25854

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10110"><img src="https://gitpod.io/api/apps/github/pbs/github.com/achatham/home-assistant.io.git/716d36b099cd105a30dfcfcd66cd8dd9311df04c.svg" /></a>

