### PR TITLE
Corrected template examples

### DIFF
--- a/source/_components/garadget.markdown
+++ b/source/_components/garadget.markdown
@@ -89,13 +89,13 @@ sensor:
     sensors:
       garage_door_status:
         friendly_name: 'State of the door'
-        value_template: '{{ states('cover.garage_door') }}'
+        value_template: "{{ states('cover.garage_door') }}"
       garage_door_time_in_state:
         friendly_name: 'Since'
-        value_template: '{{ state_attr('cover.garage_door', 'time_in_state') }}'
+        value_template: "{{ state_attr('cover.garage_door', 'time_in_state') }}"
       garage_door_wifi_signal_strength:
         friendly_name: 'WiFi strength'
-        value_template: '{{ state_attr('cover.garage_door', 'wifi_signal_strength') }}'
+        value_template: "{{ state_attr('cover.garage_door', 'wifi_signal_strength') }}"
         unit_of_measurement: 'dB'
 
 group:


### PR DESCRIPTION
**Description:**
Template examples were incorrectly quoted.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10114"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tomlut/home-assistant.io.git/38a7bb96bea9c5c64519c3edcacc65e7b96f91da.svg" /></a>

