### PR TITLE
Update uptimerobot.markdown

### DIFF
--- a/source/_components/uptimerobot.markdown
+++ b/source/_components/uptimerobot.markdown
@@ -20,7 +20,7 @@ To enable the sensor, add the following lines to your `configuration.yaml`:
 # Example configuration.yaml entry
 binary_sensor:
   - platform: uptimerobot
-    api_key: YOUR_API_KEY
+      api_key: YOUR_API_KEY
 ```
 
 {% configuration %}


### PR DESCRIPTION
Corrected indentation of ` api_key`

**Description:**
There is a typo in the example yaml configuration. ` api_key` should be indented.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10117"><img src="https://gitpod.io/api/apps/github/pbs/github.com/garethhowell/home-assistant.io.git/467fb3cf23c365ee9a5b901bc3af6fd4577bf407.svg" /></a>

