### PR TITLE
prefix HTTP scheme in example base_url

### DIFF
--- a/source/_components/google_translate.markdown
+++ b/source/_components/google_translate.markdown
@@ -55,5 +55,5 @@ If you are using SSL certificate or Docker, you may need to add the `base_url` c
 ```yaml
 #Example configuration.yaml entry
 http:
-  base_url: http(s)://example.duckdns.org
+  base_url: https://example.duckdns.org
 ```

--- a/source/_components/google_translate.markdown
+++ b/source/_components/google_translate.markdown
@@ -55,5 +55,5 @@ If you are using SSL certificate or Docker, you may need to add the `base_url` c
 ```yaml
 #Example configuration.yaml entry
 http:
-  base_url: example.duckdns.org
+  base_url: http(s)://example.duckdns.org
 ```


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10118"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ogarling/home-assistant.io.git/bf8daa85b438e9fb1d50e0b0dfe14f82a47bda01.svg" /></a>

