### PR TITLE
Remove initial_state attributes from the examples

### DIFF
--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -86,7 +86,6 @@ Set a theme at the startup of Home Assistant:
 ```yaml
 automation:
   - alias: 'Set theme at startup'
-    initial_state: 'on'
     trigger:
      - platform: homeassistant
        event: start
@@ -101,7 +100,6 @@ To enable "night mode":
 ```yaml
 automation:
   - alias: 'Set dark theme for the night'
-    initial_state: true
     trigger:
       - platform: time
         at: '21:00:00'


### PR DESCRIPTION
Recently I had an extensive discussion about the pros and cons of using the `initial_state` attribute in automations and in the end I had to admit, that there are good arguments against using it unless absolutely necessary and only if one really knows what he or she is doing.

In the examples above I can't see a good reason for using `initial_state` and thus I'd propose to delete it from both examples.

...and they were inkonsistent in both examples anyways.  ;-) One of them used 'on' and the other used true.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10119"><img src="https://gitpod.io/api/apps/github/pbs/github.com/derandiunddasbo/home-assistant.io.git/1b46293db69efeb447f1f0904d65777470fdc672.svg" /></a>

