### PR TITLE
Add path option to SABnzbd component docs

### DIFF
--- a/source/_components/sabnzbd.markdown
+++ b/source/_components/sabnzbd.markdown
@@ -39,6 +39,10 @@ host:
   required: false
   default: localhost
   type: string
+path:
+  description: Path to your SABnzbd instance corresponding to its `url_base` setting, e.g., `/sabnzbd`.
+  required: false
+  type: string
 name:
   description: The name of your SABnzbd instance (this will be the prefix for all created sensors).
   required: false
@@ -81,6 +85,7 @@ Available sensors are:
 sabnzbd:
   api_key: YOUR_SABNZBD_API_KEY
   host: 192.168.1.32
+  path: /sabnzbd
   name: sab
   port: 9090
   ssl: true


### PR DESCRIPTION
**Description:**

Adds an optional `path` setting to the SABnzbd component. This allows support for SABnzbd installs that use a different `url_base` (typically a reverse proxied configuration; see https://sabnzbd.org/wiki/configuration/2.3/special).

Replaces #9444 which was reviewed/approved by @frenck 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25908

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10124"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cj-thornton/home-assistant.io.git/2235af8572312e62430b34fe98bc72fa28fbef6b.svg" /></a>

