### PR TITLE
Update climate.knx.markdown

### DIFF
--- a/source/_integrations/climate.knx.markdown
+++ b/source/_integrations/climate.knx.markdown
@@ -176,6 +176,10 @@ on_off_state_address:
   description: KNX address for gathering the current state (on/off) of the climate device.
   required: false
   type: string
+on_off_inverted:
+  description: Value for switching the climate device on/off is inverted.
+  required: false
+  type: boolean
 min_temp:
   description: Override the minimum temperature.
   required: false

--- a/source/_integrations/climate.knx.markdown
+++ b/source/_integrations/climate.knx.markdown
@@ -172,7 +172,7 @@ on_off_address:
   description: KNX address for switching the climate device on/off.
   required: false
   type: string
-on_off_inverted:
+on_off_invert:
   description: Value for switching the climate device on/off is inverted.
   required: false
   default: false

--- a/source/_integrations/climate.knx.markdown
+++ b/source/_integrations/climate.knx.markdown
@@ -172,14 +172,15 @@ on_off_address:
   description: KNX address for switching the climate device on/off.
   required: false
   type: string
+on_off_inverted:
+  description: Value for switching the climate device on/off is inverted.
+  required: false
+  default: false
+  type: boolean
 on_off_state_address:
   description: KNX address for gathering the current state (on/off) of the climate device.
   required: false
   type: string
-on_off_inverted:
-  description: Value for switching the climate device on/off is inverted.
-  required: false
-  type: boolean
 min_temp:
   description: Override the minimum temperature.
   required: false


### PR DESCRIPTION
Some KNX Room controllers (RCD 20xx, 2178) have inverted power ON/OFF value. ON means disable controller, OFF means enable controller.

**Description:**

Added a new configuration boolean parameter on_off_inverted to KNX Climate component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25900

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10126"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tombbo/home-assistant.io.git/64f5b07e9d07f6479c91f16bc5e40a68f8ba455b.svg" /></a>

