### PR TITLE
Clarity edit about `websocket-client`

### DIFF
--- a/source/_components/samsungtv.markdown
+++ b/source/_components/samsungtv.markdown
@@ -33,7 +33,7 @@ host:
   required: true
   type: string
 port:
-  description: The port of the Samsung Smart TV. If set to 8001, the new websocket connection will be used (required for 2016+ TVs).
+  description: The port of the Samsung Smart TV. If set to 8001, the new websocket connection will be used (required for 2016+ TVs) - for installs other than Hass.io or Docker you may need to install a Python package, see below.
   required: false
   type: integer
   default: 55000
@@ -77,23 +77,23 @@ Currently known supported models:
 - K5579 (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 - K5600AK (partially supported, turn on works but state is not updated)
 - K6500AF (port must be set to 8001)
-- KS7005 (port must be set to 8001, and `pip3 install websocket-client` must be executed, MAC address must be provided, On/Off, Volume are OK, no channel change)
-- KS7502 (port must be set to 8001, and `pip3 install websocket-client` must be executed, turn on doesn't work, turn off works fine)
-- KS8000 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KS8005 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KS8500 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KU6020 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KU6100 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- KS7005 (port must be set to 8001, MAC address must be provided, On/Off, Volume are OK, no channel change)
+- KS7502 (port must be set to 8001, turn on doesn't work, turn off works fine)
+- KS8000 (port must be set to 8001)
+- KS8005 (port must be set to 8001)
+- KS8500 (port must be set to 8001)
+- KU6020 (port must be set to 8001)
+- KU6100 (port must be set to 8001)
 - KU6290 (port must be set to 8001)
-- KU6400U (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- KU6400U (port must be set to 8001)
 - KU7000 (port must be set to 8001)
-- M5620 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- MU6170UXZG (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- M5620 (port must be set to 8001)
+- MU6170UXZG (port must be set to 8001)
 - NU7090 (port must be set to 8801, On/Off, MAC must be specified for Power On)
-- NU7400 (port set to 8001 and `pip3 install websocket-client` executed)
+- NU7400 (port set to 8001)
 - NU8000
 - U6000 (port must be set to 8001)
-- U6300 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- U6300 (port must be set to 8001)
 - UE6199UXZG (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 - UE65KS8005 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
 - UE49KU6470 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
@@ -112,7 +112,7 @@ Currently tested but not working models:
 - JU7000 - Unable to see state and unable to control (but port 8001 *is* open)
 - JU7500 - Unable to see state and unable to control
 - MU6125 - Unable to see state and unable to control (Tested on UE58MU6125 on port 8001 and 8801)
-- MU6300 - Port set to 8001, `pip3 install websocket-client` must be executed, turning on works, status not working reliably, turning off is not permanent (it comes back on)
+- MU6300 - Port set to 8001, turning on works, status not working reliably, turning off is not permanent (it comes back on)
 - Q7F - State is always "off" and unable to control via port 8001.
 
 None of the 2014 (H) and 2015 (J) model series (e.g., J5200) will work, since Samsung have used a different (encrypted) type of interface for these.
@@ -134,3 +134,30 @@ with the following payload:
 ```
 
 Currently the ability to select a source is not implemented.
+
+### Hass.io
+
+No additional actions are required
+
+### Docker
+
+No additional actions are required
+
+### Hassbian
+
+You will need to activate the venv and install the websocket library:
+
+```bash
+$ sudo -u homeassistant -H -s
+$ source /srv/homeassistant/bin/activate
+$ pip3 install websocket-client
+```
+### Other install methods
+
+You will need to install the `websocket-client` Python package in your Home Assistant install. This will probably be done with:
+
+```bash
+$ pip3 install websocket-client
+```
+
+Remembering to activate your venv if you're using a venv install.


### PR DESCRIPTION
The constant references to installing the Python package causes confusion for Hass.io and Docker users, breaking these out.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10129"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/c233b9c3e6519e5f8a97735c66526a3c732a1207.svg" /></a>

