### PR TITLE
Restore "away" function config options

### DIFF
--- a/source/_components/radiotherm.markdown
+++ b/source/_components/radiotherm.markdown
@@ -42,12 +42,24 @@ host:
   description: List of your Radiotherm thermostats. If not provided the thermostats will be auto-detected.
   required: false
   type: list
+away_temperature_heat:
+  description: Target heating temperature in Fahrenheit for away mode. This is separate from away mode in the app.
+  required: false
+  default: 60
+  type: float
+away_temperature_cool:
+  description: Target cooling temperature in Fahrenheit for away mode. This is separate from away mode in the app.
+  required: false
+  default: 85
+  type: float
 hold_temp:
   description: Boolean to control if Home Assistant temperature adjustments hold (`true`) or are temporary (`false`).
   required: false
   default: false
   type: boolean
 {% endconfiguration %}
+
+The "away" preset mode functions similarly to the away mode feature of the website and apps, but cannot detect if you set away mode outside of Home Assistant.
 
 Set `hold_temp: true` if you want temperature settings from Home Assistant to override a thermostat schedule on the thermostat itself. Otherwise Home Assistant will perform temporary temperature changes.
 


### PR DESCRIPTION
**Description:**

Restore "away" function config options

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#25912

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10131"><img src="https://gitpod.io/api/apps/github/pbs/github.com/dieselrabbit/home-assistant.io.git/e64a0ecb3cea05c0582065257c559f43b8348a8e.svg" /></a>

