### PR TITLE
small typo

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -248,7 +248,7 @@ In some cases it might be desirable to check that all entities are available bef
 ```yaml
 # Example checking specific entities to be available before start
 homekit:
-  auto_start: False
+  auto_start: false
 
 automation:
   - alias: 'Start HomeKit'


### PR DESCRIPTION
**Description:**
lowercase `F` for `false`



**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10132"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jonathanweinberg/home-assistant.io.git/1122be1c3450a0d8f91fca5f40162fa1c6b6a280.svg" /></a>

