### PR TITLE
Thermostat sensor changed from hvac_mode to hvac_state

### DIFF
--- a/source/_components/nest.markdown
+++ b/source/_components/nest.markdown
@@ -313,7 +313,7 @@ The following conditions are available by device:
   - preset\_mode
   - temperature
   - target
-  - hvac\_mode: The currently active state of the HVAC system, `heat`, `cool` or `off` (previously `heating`, `cooling` or `off`).
+  - hvac\_state: The currently active state of the HVAC system, `heat`, `cool` or `off` (previously `heating`, `cooling` or `off`).
 - Nest Protect:
   - co\_status: `Ok`, `Warning` or `Emergency`
   - smoke\_status: `Ok`, `Warning` or `Emergency`


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10133"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jbrody17/home-assistant.io.git/dfda6e27792bb3e1c3e9f4c233cd74c1f5967a3d.svg" /></a>

