### PR TITLE
Remove update_config service call

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,8 +99,8 @@ social:
 # Home Assistant release details
 current_major_version: 0
 current_minor_version: 97
-current_patch_version: 0
-date_released: 2019-08-07
+current_patch_version: 1
+date_released: 2019-08-09
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/_config.yml
+++ b/_config.yml
@@ -99,8 +99,8 @@ social:
 # Home Assistant release details
 current_major_version: 0
 current_minor_version: 97
-current_patch_version: 1
-date_released: 2019-08-09
+current_patch_version: 2
+date_released: 2019-08-12
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/source/_components/apache_kafka.markdown
+++ b/source/_components/apache_kafka.markdown
@@ -18,7 +18,7 @@ To use the `apache_kafka` integration in your installation, add the following to
 
 ```yaml
 apache_kafka:
-  ip_address: localhost
+  host: localhost
   port: 9092
   topic: home_assistant_1
 ```

--- a/source/_components/binary_sensor.knx.markdown
+++ b/source/_components/binary_sensor.knx.markdown
@@ -5,10 +5,18 @@ logo: knx.png
 ha_category:
   - Binary Sensor
 ha_release: 0.24
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ---
 
+<div class='note'>
+  
+The `knx` integration must be configured correctly to use this integration, see [KNX Integration](/components/knx).
+
+</div>
+
 The `knx` sensor platform allows you to monitor [KNX](http://www.knx.org) binary sensors.
+
+Binary sensors are read-only. To write to the knx-bus configure an exposure [KNX Integration - Expose](/components/knx/#exposing-sensor-values-or-time-to-knx-bus).
 
 ## Configuration
 
@@ -18,11 +26,11 @@ The `knx` integration must be configured correctly, see [KNX Integration](/compo
 # Example configuration.yaml entry
 binary_sensor:
   - platform: knx
-    address: '6/0/2'
+    state_address: '6/0/2'
 ```
 
 {% configuration %}
-address:
+state_address:
   description: KNX group address of the binary sensor.
   required: true
   type: string
@@ -30,6 +38,11 @@ name:
   description: A name for this device used within Home Assistant.
   required: false
   type: string
+sync_state:
+  description: Actively read the value from the bus. If `False` no GroupValueRead telegrams will be sent to the bus.
+  required: false
+  type: boolean
+  default: True
 device_class:
   description: Sets the [class of the device](/components/binary_sensor/), changing the device state and icon that is displayed on the frontend.
   required: false
@@ -54,7 +67,7 @@ You can also attach actions to binary sensors (e.g., to switch on a light when a
 binary_sensor:
   - platform: knx
     name: Livingroom.3Switch3
-    address: '5/0/26'
+    state_address: '5/0/26'
     automation:
       - counter: 1
         hook: 'on'

--- a/source/_components/buienradar.markdown
+++ b/source/_components/buienradar.markdown
@@ -3,6 +3,7 @@ title: "Buienradar"
 description: "Instructions on how to integrate buienradar.nl weather within Home Assistant."
 logo: buienradar.png
 ha_category:
+  - Camera
   - Weather
 ha_release: 0.47
 ha_iot_class: Cloud Polling
@@ -13,6 +14,11 @@ redirect_from:
 The `buienradar` platform uses [buienradar.nl](http://buienradar.nl/) as a source for current meteorological data for your location. The weather forecast is delivered by Buienradar, who provides a web service that provides detailed weather information for users in The Netherlands.
 
 The relevant weather station used will be automatically selected based on the location specified in the Home Assistant configuration (or in the Buienradar weather/sensor component).  A map of all available weather stations can be found [here](https://www.google.com/maps/d/embed?mid=1NivHkTGQUOs0dwQTnTMZi8Uatj0).
+
+Besides the weather platform, there is currently support for the following additional device types:
+
+- [Camera](#camera): Radar map
+- [Sensor](/components/sensor.buienradar/): More customizable
 
 ## Configuration
 
@@ -59,12 +65,55 @@ weather:
     forecast: true
 ```
 
+
 <div class='note'>
 
 This platform is an alternative to the [`buienradar`](/components/sensor.buienradar/) sensor.
 The weather platform is easier to configure but less customizable.
 
 </div>
+
+## Camera
+
+The `buienradar` camera platform uses [buienradar.nl](http://buienradar.nl/) as a source for the last rain radar map. The overview image of the whole of the Netherlands is loaded and shown as a camera in Home Assistant.
+
+Internally this component uses the radar map image as [documented](https://www.buienradar.nl/overbuienradar/gratis-weerdata) on buienradar.nl.
+The downloaded image is cached to prevent Home Assistant from making a new request to buienradar.nl multiple times a minute when Home Assistant checks for new stills from the camera.
+
+To add `buienradar` camera to Home Assistant, add the following section to your
+`configuration.yaml` file:
+```yaml
+# Example configuration.yaml entry
+camera:
+  - platform: buienradar
+```
+
+{% configuration %}
+name:
+  description: You can (optionally) specify the name of the camera. The name
+    will be shown in the user interface below the radar image.
+  required: false
+  type: string
+dimension:
+  description: Size of the image to be loaded from buienradar.nl
+    (120 to 700 pixels)
+  required: false
+  default: 512
+  type: integer
+delta:
+  description: Time interval in seconds between image updates
+  required: false
+  default: 600
+  type: integer
+{% endconfiguration %}
+
+### The `name` Variable
+
+If you specify a name, the camera will get this name as its label. A slugified
+version of the name will be used as the name of the entity.
+
+With the default of "Buienradar loop" the entity name becomes
+`camera.buienradar_loop`.
 
 [Usage statement:](https://www.buienradar.nl/overbuienradar/gratis-weerdata)
 > Buienradar makes free weather data available for use by individuals and businesses (website/intranet). The use of the weather data is allowed for **non-commercial purposes**. Please refer to the full usage statement linked above to confirm your use or to request permission.

--- a/source/_components/climate.knx.markdown
+++ b/source/_components/climate.knx.markdown
@@ -5,12 +5,16 @@ logo: knx.png
 ha_category:
   - Climate
 ha_release: 0.25
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ---
 
-The `knx` climate platform is used as in interface with KNX thermostats.
+<div class='note'>
+  
+The `knx` integration must be configured correctly to use this integration, see [KNX Integration](/components/knx).
 
-The `knx` integration must be configured correctly, see [KNX Integration](/components/knx).
+</div>
+
+The `knx` climate platform is used as an interface to KNX thermostats and room controllers.
 
 To use your KNX thermostats in your installation, add the following lines to your `configuration.yaml` file:
 
@@ -24,6 +28,7 @@ climate:
      setpoint_shift_state_address: '5/1/3'
      target_temperature_state_address: '5/1/4'
      operation_mode_address: '5/1/5'
+     operation_mode_state_address: '5/1/6'
 ```
 
 Alternatively, if your device has dedicated binary group addresses for frost/night/comfort mode:
@@ -40,10 +45,11 @@ climate:
     operation_mode_frost_protection_address: '5/1/5'
     operation_mode_night_address: '5/1/6'
     operation_mode_comfort_address: '5/1/7'
+    operation_mode_state_address: '5/1/8'
 ```
 
 If your device doesn't support setpoint_shift calculations (i.e. if you don't provide a `setpoint_shift_address` value) please set the `min_temp` and `max_temp`
-attributes of the climate device to avoid issues with increasing the temperature in the frontend. Please do also make sure to add the `target_temperature_address`
+attributes of the climate device to avoid issues with exceeding valid temperature values in the frontend. Please do also make sure to add the `target_temperature_address`
 to the config in this case.:
 
 ```yaml
@@ -57,11 +63,13 @@ climate:
     operation_mode_frost_protection_address: '5/1/5'
     operation_mode_night_address: '5/1/6'
     operation_mode_comfort_address: '5/1/7'
+    operation_mode_state_address: '5/1/8'
     min_temp: 7.0
     max_temp: 32.0
 ```
 
 `operation_mode_frost_protection_address` / `operation_mode_night_address` / `operation_mode_comfort_address` are not necessary if `operation_mode_address` is specified.
+If the actor doesn't support explicit state communication objects the *_state_address can be configured with the same group address as the writeable *_address. The Read-Flag for the *_state_address communication object has to be set in ETS to support initial reading eg. when starting home-assistant.
 
 The following values are valid for the `hvac_mode` attribute:
 
@@ -86,27 +94,27 @@ name:
   default: KNX Climate
   type: string
 temperature_address:
-  description: KNX group address for reading current room temperature from KNX bus.
+  description: KNX group address for reading current room temperature from KNX bus. *DPT 9.001*
   required: true
   type: string
 target_temperature_address:
-  description: KNX group address for setting target temperature.
+  description: KNX group address for setting target temperature. *DPT 9.001*
   required: false
   type: string
 target_temperature_state_address:
-  description: KNX group address for reading current target temperature from KNX bus.
+  description: KNX group address for reading current target temperature from KNX bus. *DPT 9.001*
   required: true
   type: string
 setpoint_shift_address:
-  description: KNX address for setpoint_shift.
+  description: KNX address for setpoint_shift. *DPT 6.010*
   required: false
   type: string
 setpoint_shift_state_address:
-  description: Explicit KNX address for reading setpoint_shift.
+  description: KNX address for reading setpoint_shift. *DPT 6.010*
   required: false
   type: string
 setpoint_shift_step:
-  description: Defines for step size in Kelvin for each step of setpoint_shift.
+  description: Defines the step size in Kelvin for each step of setpoint_shift.
   required: false
   default: 0.5
   type: float
@@ -114,18 +122,18 @@ setpoint_shift_min:
   description: Minimum value of setpoint shift.
   required: false
   default: -6
-  type: integer
+  type: float
 setpoint_shift_max:
   description: Maximum value of setpoint shift.
   required: false
   default: 6
-  type: integer
+  type: float
 operation_mode_address:
-  description: KNX address for operation mode (Frost protection/night/comfort).
+  description: KNX address for setting operation mode (Frost protection/night/comfort). *DPT 20.102*
   required: false
   type: string
 operation_mode_state_address:
-  description: Explicit KNX address for reading operation mode.
+  description: KNX address for reading operation mode. *DPT 20.102*
   required: false
   type: string
 controller_status_address:
@@ -133,15 +141,15 @@ controller_status_address:
   required: false
   type: string
 controller_status_state_address:
-  description: Explicit KNX address for reading HVAC controller status.
+  description: KNX address for reading HVAC controller status.
   required: false
   type: string
 controller_mode_address:
-  description: KNX address for handling controller modes.
+  description: KNX address for setting HVAC controller modes. *DPT 20.105*
   required: false
   type: string
 controller_mode_state_address:
-  description: Explicit KNX address for reading HVAC Control Mode.
+  description: KNX address for reading HVAC Control Mode. *DPT 20.105*
   required: false
   type: string
 operation_mode_frost_protection_address:

--- a/source/_components/cover.knx.markdown
+++ b/source/_components/cover.knx.markdown
@@ -5,13 +5,16 @@ logo: knx.png
 ha_category:
   - Cover
 ha_release: 0.48
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ---
 
+<div class='note'>
 
-The `knx` cover platform is used as in interface with KNX covers.
+The `knx` integration must be configured correctly to use this integration, see [KNX Integration](/components/knx).
 
-The `knx` integration must be configured correctly, see [KNX Integration](/components/knx).
+</div>
+
+The `knx` cover platform is used as an interface to KNX covers.
 
 To use your KNX covers in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_components/darksky.markdown
+++ b/source/_components/darksky.markdown
@@ -84,9 +84,9 @@ monitored_conditions:
     summary:
       description: A human-readable text summary.
     icon:
-      description: A machine-readable text summary, suitable for selecting an icon for display. See [Dark Sky API documentation][] for the list of possible values.
+      description: A machine-readable text summary, suitable for selecting an icon for display. See [Dark Sky API documentation](https://darksky.net/dev/docs) for the list of possible values.
     precip_type:
-      description: The type of precipitation occurring at the given time. If `precip_intensity` is zero, then this property will be `unknown`. See [Dark Sky API documentation][] for the list of possible values.
+      description: The type of precipitation occurring at the given time. If `precip_intensity` is zero, then this property will be `unknown`. See [Dark Sky API documentation](https://darksky.net/dev/docs) for the list of possible values.
     precip_intensity:
       description: The intensity of precipitation occurring at the given time. This value is conditional on probability (that is, assuming any precipitation occurs at all).
     precip_probability:
@@ -238,7 +238,4 @@ All language options are described in this table that you can use for the dark s
 While the platform is called "darksky" the sensors will show up in Home Assistant as "dark_sky" (eg: sensor.dark_sky_summary).
 </div>
 
-More details about the API are available in the [Dark Sky API documentation][].
-
-[Dark Sky API documentation]: https://darksky.net/dev/docs
-
+More details about the API are available in the [Dark Sky API documentation](https://darksky.net/dev/docs).

--- a/source/_components/deconz.markdown
+++ b/source/_components/deconz.markdown
@@ -320,6 +320,8 @@ The `entity_id` name will be `binary_sensor.device_name`, where `device_name` is
   - Philips Hue Motion Sensor
   - Xiaomi Motion Sensor
   - Xiaomi Smart Home Aqara Human Body Sensor
+- Water leakage detection
+  - Xiaomi Aqara water leak Sensor
 
 ## Climate
 
@@ -340,7 +342,7 @@ The `entity_id` name will be `climate.device_name`, where `device_name` is defin
 
 Covers are devices like ventilation dampers or smart window covers.
 
-Note that devices in the cover platform identify as lights, so there is a manually curated list that defines which "lights" are covers.
+Note that devices in the cover platform identify as lights, so there is a manually curated list that defines which "lights" are covers. You therefore add a cover device as a light device in deCONZ (phoscon app).
 
 The `entity_id` name will be `cover.device_name`, where `device_name` is defined in deCONZ.
 

--- a/source/_components/environment_canada.markdown
+++ b/source/_components/environment_canada.markdown
@@ -144,7 +144,7 @@ scan_interval:
   default: 600
 {% endconfiguration %}
 
-###Alert TTS Script
+### Alert TTS Script
 
 If you would like to have alerts announced via a text-to-speech service, you can use a script similar to the following:
 

--- a/source/_components/fortigate.markdown
+++ b/source/_components/fortigate.markdown
@@ -43,7 +43,7 @@ Add the following to your `configuration.yaml` file:
 # Example configuration.yaml entry
 fortigate:
   host: HOST_IP
-  username: YPUR_USERNAME
+  username: YOUR_USERNAME
   api_key: YOUR_API_KEY
 ```
 

--- a/source/_components/fortios.markdown
+++ b/source/_components/fortios.markdown
@@ -31,7 +31,7 @@ host:
     required: true
     type: string
 token:
-    description: "See [Fortinet Developer Network](https://fndn.fortinet.com) for how to create an API token. Remember this integration only needs read access to a FortiGate, so configure the API user to only to have limited and read-only access."
+    description: "See [Fortinet Developer Network](https://fndn.fortinet.net) for how to create an API token. Remember this integration only needs read access to a FortiGate, so configure the API user to only to have limited and read-only access."
     required: true
     type: string
 verify_ssl:

--- a/source/_components/frontend.markdown
+++ b/source/_components/frontend.markdown
@@ -86,7 +86,6 @@ Set a theme at the startup of Home Assistant:
 ```yaml
 automation:
   - alias: 'Set theme at startup'
-    initial_state: 'on'
     trigger:
      - platform: homeassistant
        event: start
@@ -101,7 +100,6 @@ To enable "night mode":
 ```yaml
 automation:
   - alias: 'Set dark theme for the night'
-    initial_state: true
     trigger:
       - platform: time
         at: '21:00:00'

--- a/source/_components/garadget.markdown
+++ b/source/_components/garadget.markdown
@@ -89,13 +89,13 @@ sensor:
     sensors:
       garage_door_status:
         friendly_name: 'State of the door'
-        value_template: '{{ states('cover.garage_door') }}'
+        value_template: "{{ states('cover.garage_door') }}"
       garage_door_time_in_state:
         friendly_name: 'Since'
-        value_template: '{{ state_attr('cover.garage_door', 'time_in_state') }}'
+        value_template: "{{ state_attr('cover.garage_door', 'time_in_state') }}"
       garage_door_wifi_signal_strength:
         friendly_name: 'WiFi strength'
-        value_template: '{{ state_attr('cover.garage_door', 'wifi_signal_strength') }}'
+        value_template: "{{ state_attr('cover.garage_door', 'wifi_signal_strength') }}"
         unit_of_measurement: 'dB'
 
 group:

--- a/source/_components/google_assistant.markdown
+++ b/source/_components/google_assistant.markdown
@@ -79,11 +79,12 @@ You need to create an API Key with the [Google Cloud API Console](https://consol
     9. Testing instructions: Enter anything. It doesn't matter since you won't submit this app.
 
     <img src='/images/components/google_assistant/accountlinking.png' alt='Screenshot: Account linking'>
-
-3. Back on the overview page. Click `Simulator` under `TEST`. It will create a new draft version Test App. You don't have to actually test, but you need to generate this draft version Test App.
-4. Add the `google_assistant` integration configuration to your `configuration.yaml` file and restart Home Assistant following the [configuration guide](#configuration) below.
-5. Open the Google Home app and go into `Account > Settings > Assistant > Home Control`.
-6. Click the `+` sign, and near the bottom, you should have `[test] your app name` listed under 'Add new.' Selecting that should lead you to a browser to login your Home Assistant instance, then redirect back to a screen where you can set rooms for your devices or nicknames for your devices.
+3. Under `Build your Action` click `Add Action(s)`.
+    1. Under `Fulfillment` fill in this URL (replace with your actual URL): `https://[YOUR HOME ASSISTANT URL:PORT]/api/google_assistant`.
+4. Back on the overview page. Click `Simulator` under `TEST`. It will create a new draft version Test App. You don't have to actually test, but you need to generate this draft version Test App.
+5. Add the `google_assistant` integration configuration to your `configuration.yaml` file and restart Home Assistant following the [configuration guide](#configuration) below.
+6. Open the Google Home app and go into `Account > Settings > Assistant > Home Control`.
+7. Click the `+` sign, and near the bottom, you should have `[test] your app name` listed under 'Add new.' Selecting that should lead you to a browser to login your Home Assistant instance, then redirect back to a screen where you can set rooms for your devices or nicknames for your devices.
 
 <div class='note'>
 

--- a/source/_components/google_maps.markdown
+++ b/source/_components/google_maps.markdown
@@ -42,10 +42,6 @@ username:
   description: The email address for the Google account that has access to your shared location.
   required: true
   type: string
-password:
-  description: The password for your given username.
-  required: true
-  type: string
 max_gps_accuracy:
    description: Sometimes Google Maps can report GPS locations with a very low accuracy (few kilometers). That can trigger false zoning. Using this parameter, you can filter these false GPS reports. The number has to be in meters. For example, if you put 200 only GPS reports with an accuracy under 200 will be taken into account - Defaults to 100km if not specified.
    required: false

--- a/source/_components/google_translate.markdown
+++ b/source/_components/google_translate.markdown
@@ -55,5 +55,5 @@ If you are using SSL certificate or Docker, you may need to add the `base_url` c
 ```yaml
 #Example configuration.yaml entry
 http:
-  base_url: example.duckdns.org
+  base_url: https://example.duckdns.org
 ```

--- a/source/_components/haveibeenpwned.markdown
+++ b/source/_components/haveibeenpwned.markdown
@@ -12,6 +12,12 @@ redirect_from:
 
 The `haveibeenpwned` sensor platform creates sensors that check for breached email accounts on [haveibeenpwned](https://haveibeenpwned.com).
 
+<div class='note warning'>
+
+  The HaveIBeenPwned API now requires you to pay $3.50 a month in order to query the API. More info can be found [here](https://www.troyhunt.com/authentication-and-the-have-i-been-pwned-api/)
+
+</div>
+
 ## Configuration
 
 To enable this sensor, add the following lines to your `configuration.yaml`, it will list every specified email address as a sensor showing
@@ -24,6 +30,7 @@ sensor:
     email:
       - your_email1@domain.com
       - your_email2@domain.com
+    api_key: API_KEY
 ```
 
 {% configuration %}
@@ -31,6 +38,10 @@ email:
   description: List of email addresses.
   required: true
   type: list
+api_key:
+  description: HaveIBeenPwned API Key
+  required: true
+  type: string
 {% endconfiguration %}
 
 ## Breach meta data

--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -248,7 +248,7 @@ In some cases it might be desirable to check that all entities are available bef
 ```yaml
 # Example checking specific entities to be available before start
 homekit:
-  auto_start: False
+  auto_start: false
 
 automation:
   - alias: 'Start HomeKit'

--- a/source/_components/knx.markdown
+++ b/source/_components/knx.markdown
@@ -5,17 +5,15 @@ logo: knx.png
 ha_category:
   - Hub
 ha_release: 0.24
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ---
 
 The [KNX](https://www.knx.org) integration for Home Assistant allows you to connect to a KNX/IP devices.
 
-The integration requires a local KNX/IP interface like the [Weinzierl 730](https://www.weinzierl.de/index.php/en/all-knx/knx-devices-en/produktarchiv-en/knx-ip-interface-730-en). Through this, it will send and receive commands to and from other devices to the KNX bus.
+The integration requires a local KNX/IP interface or a KNX/IP router. Through this, it will send and receive commands to and from other devices to the KNX bus.
 
-<div class='note warning'>
-
-  Please note, the `knx` platform does not support Windows.
-
+<div class='note'>
+Please note, the `knx` platform does not support Windows.
 </div>
 
 There is currently support for the following device types within Home Assistant:
@@ -69,19 +67,21 @@ knx:
 host:
   description: Host of the KNX/IP tunneling device.
   type: string
+  required: true
 port:
   description: Port of the KNX/IP tunneling device.
   type: integer
+  required: false
 local_ip:
   description: IP of the local interface.
   type: string
+  required: false
 {% endconfiguration %}
 
 Explicit connection to a KNX/IP routing device:
 
 ```yaml
 knx:
-  config_file: '/path/to/xknx.yaml'
   routing:
      local_ip: '192.168.2.109'
 ```
@@ -90,6 +90,7 @@ knx:
 local_ip:
   description: The local IP address of interface (which should be used for multicasting).
   type: string
+  required: true
 {% endconfiguration %}
 
 ```yaml
@@ -117,7 +118,7 @@ state_updater:
 
 ### Services
 
-In order to directly interact with the KNX bus, you can now use the following service:
+In order to directly interact with the KNX bus, you can use the following service:
 
 ```
 Domain: knx
@@ -145,6 +146,12 @@ knx:
     - type: 'temperature'
       entity_id: 'sensor.owm_temperature'
       address: '0/0/2'
+    - type: 'string'
+      address: '0/6/4'
+      entity_id: "sensor.owm_weather"
+    - type: 'binary'
+      entity_id: 'binary_sensor.kitchen_window'
+      address: '0/6/5'
     - type: 'time'
       address: '0/0/1'
     - type: 'datetime'
@@ -153,12 +160,14 @@ knx:
 
 {% configuration %}
 type:
-  description: Type of the exposed value. Either time or datetime or any supported type of [KNX Sensor](/components/sensor.knx/) (e.g., "temperature" or "humidity").
+  description: Type of the exposed value. Either 'binary', 'time', 'date', 'datetime' or any supported type of [KNX Sensor](/components/sensor.knx/) (e.g., "temperature" or "humidity").
   type: string
+  required: true
 entity_id:
-  description: Entity id of the HASS integration to be exposed. Not necessary for types time and datetime.
+  description: Entity id to be exposed. Not needed for types time, date and datetime.
   type: string
 address:
   description: KNX group address.
   type: string
+  required: true
 {% endconfiguration %}

--- a/source/_components/light.knx.markdown
+++ b/source/_components/light.knx.markdown
@@ -5,8 +5,14 @@ logo: knx.png
 ha_category:
   - Light
 ha_release: 0.44
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ---
+
+<div class='note'>
+  
+The `knx` integration must be configured correctly to use this integration, see [KNX Integration](/components/knx).
+
+</div>
 
 The `knx light` integration is used as an interface to control knx actuators for lighting applications such as:
 
@@ -14,8 +20,6 @@ The `knx light` integration is used as an interface to control knx actuators for
 - dimming actuators
 - LED controllers
 - DALI gateways
-
-The `knx` integration must be configured correctly to use this component, see [KNX Component](/components/knx).
 
 ## Configuration
 
@@ -55,6 +59,14 @@ color_address:
   type: string
 color_state_address:
   description: KNX group address for retrieving the RGB color of the light. *DPT 232.600*
+  required: false
+  type: string
+rgbw_address:
+  description: KNX group address for setting the RGBW color of the light. *DPT 251.600*
+  required: false
+  type: string
+rgbw_state_address:
+  description: KNX group address for retrieving the RGBW color of the light. *DPT 251.600*
   required: false
   type: string
 color_temperature_address:

--- a/source/_components/mcp23017.markdown
+++ b/source/_components/mcp23017.markdown
@@ -98,12 +98,12 @@ i2c_address:
   required: false
   type: integer
   default: "`0x20`"
-ports:
+pins:
   description: Array of used pins.
   required: true
   type: list
   keys:
-    port:
+    pin:
       description: The pin numbers (from 0 to 15) and corresponding names.
       required: true
       type: [integer, string]

--- a/source/_components/nest.markdown
+++ b/source/_components/nest.markdown
@@ -313,7 +313,7 @@ The following conditions are available by device:
   - preset\_mode
   - temperature
   - target
-  - hvac\_mode: The currently active state of the HVAC system, `heat`, `cool` or `off` (previously `heating`, `cooling` or `off`).
+  - hvac\_state: The currently active state of the HVAC system, `heat`, `cool` or `off` (previously `heating`, `cooling` or `off`).
 - Nest Protect:
   - co\_status: `Ok`, `Warning` or `Emergency`
   - smoke\_status: `Ok`, `Warning` or `Emergency`

--- a/source/_components/notify.knx.markdown
+++ b/source/_components/notify.knx.markdown
@@ -8,9 +8,13 @@ ha_release: 0.53
 ha_iot_class: Local Push
 ---
 
-The `knx` notify platform allows you to send notifications to [KNX](http://www.knx.org) devices.
+<div class='note'>
+  
+The `knx` integration must be configured correctly to use this integration, see [KNX Integration](/components/knx).
 
-The `knx` integration must be configured correctly, see [KNX Component](/components/knx).
+</div>
+
+The `knx` notify platform allows you to send notifications to [KNX](http://www.knx.org) devices.
 
 ## Configuration
 

--- a/source/_components/person.markdown
+++ b/source/_components/person.markdown
@@ -86,3 +86,15 @@ person:
       - device_tracker.stacey
       - device_tracker.beacon
 ```
+
+### Customizing the picture for a person
+
+By following the instructions on the [customizing entities](/docs/configuration/customizing-devices#entity_picture) page, you can customize the picture used for a person entity in the `customize:` section of your configuration. For example:
+
+```yaml
+customize:
+  person.ada6789:
+    entity_picture: "/local/ada.jpg"
+```
+
+See the documentation about [hosting files](/components/http/#hosting-files) for more information about the `www` folder. 

--- a/source/_components/rainforest_eagle.markdown
+++ b/source/_components/rainforest_eagle.markdown
@@ -5,7 +5,7 @@ logo: rainforest_automation_logo.png
 ha_category:
   - Energy
   - Sensor
-ha_release: 0.96
+ha_release: 0.97
 ha_iot_class: Local Polling
 ---
 

--- a/source/_components/samsungtv.markdown
+++ b/source/_components/samsungtv.markdown
@@ -33,7 +33,7 @@ host:
   required: true
   type: string
 port:
-  description: The port of the Samsung Smart TV. If set to 8001, the new websocket connection will be used (required for 2016+ TVs).
+  description: The port of the Samsung Smart TV. If set to 8001, the new websocket connection will be used (required for 2016+ TVs) - for installs other than Hass.io or Docker you may need to install a Python package, see below.
   required: false
   type: integer
   default: 55000
@@ -77,23 +77,23 @@ Currently known supported models:
 - K5579 (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 - K5600AK (partially supported, turn on works but state is not updated)
 - K6500AF (port must be set to 8001)
-- KS7005 (port must be set to 8001, and `pip3 install websocket-client` must be executed, MAC address must be provided, On/Off, Volume are OK, no channel change)
-- KS7502 (port must be set to 8001, and `pip3 install websocket-client` must be executed, turn on doesn't work, turn off works fine)
-- KS8000 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KS8005 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KS8500 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KU6020 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- KU6100 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- KS7005 (port must be set to 8001, MAC address must be provided, On/Off, Volume are OK, no channel change)
+- KS7502 (port must be set to 8001, turn on doesn't work, turn off works fine)
+- KS8000 (port must be set to 8001)
+- KS8005 (port must be set to 8001)
+- KS8500 (port must be set to 8001)
+- KU6020 (port must be set to 8001)
+- KU6100 (port must be set to 8001)
 - KU6290 (port must be set to 8001)
-- KU6400U (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- KU6400U (port must be set to 8001)
 - KU7000 (port must be set to 8001)
-- M5620 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
-- MU6170UXZG (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- M5620 (port must be set to 8001)
+- MU6170UXZG (port must be set to 8001)
 - NU7090 (port must be set to 8801, On/Off, MAC must be specified for Power On)
-- NU7400 (port set to 8001 and `pip3 install websocket-client` executed)
+- NU7400 (port set to 8001)
 - NU8000
 - U6000 (port must be set to 8001)
-- U6300 (port must be set to 8001, and `pip3 install websocket-client` must be executed)
+- U6300 (port must be set to 8001)
 - UE6199UXZG (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 - UE65KS8005 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
 - UE49KU6470 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
@@ -112,7 +112,7 @@ Currently tested but not working models:
 - JU7000 - Unable to see state and unable to control (but port 8001 *is* open)
 - JU7500 - Unable to see state and unable to control
 - MU6125 - Unable to see state and unable to control (Tested on UE58MU6125 on port 8001 and 8801)
-- MU6300 - Port set to 8001, `pip3 install websocket-client` must be executed, turning on works, status not working reliably, turning off is not permanent (it comes back on)
+- MU6300 - Port set to 8001, turning on works, status not working reliably, turning off is not permanent (it comes back on)
 - Q7F - State is always "off" and unable to control via port 8001.
 
 None of the 2014 (H) and 2015 (J) model series (e.g., J5200) will work, since Samsung have used a different (encrypted) type of interface for these.
@@ -134,3 +134,30 @@ with the following payload:
 ```
 
 Currently the ability to select a source is not implemented.
+
+### Hass.io
+
+No additional actions are required
+
+### Docker
+
+No additional actions are required
+
+### Hassbian
+
+You will need to activate the venv and install the websocket library:
+
+```bash
+$ sudo -u homeassistant -H -s
+$ source /srv/homeassistant/bin/activate
+$ pip3 install websocket-client
+```
+### Other install methods
+
+You will need to install the `websocket-client` Python package in your Home Assistant install. This will probably be done with:
+
+```bash
+$ pip3 install websocket-client
+```
+
+Remembering to activate your venv if you're using a venv install.

--- a/source/_components/scene.knx.markdown
+++ b/source/_components/scene.knx.markdown
@@ -7,9 +7,13 @@ ha_category:
 ha_release: 0.63
 ---
 
-The `knx` scenes platform allows you to trigger [KNX](http://www.knx.org) scenes.
+<div class='note'>
+  
+The `knx` integration must be configured correctly to use this integration, see [KNX Integration](/components/knx).
 
-The `knx` integration must be configured correctly, see [KNX Component](/components/knx).
+</div>
+
+The `knx` scenes platform allows you to trigger [KNX](http://www.knx.org) scenes.
 
 ## Configuration
 
@@ -26,11 +30,11 @@ scene:
 
 {% configuration %}
 address:
-  description: KNX group address of the binary sensor.
+  description: KNX group address for the scene.
   required: true
   type: string
 scene_number:
-  description: Zero-indexed KNX scene number to be activated.
+  description: KNX scene number to be activated. ( 1 ... 64 )
   required: true
   type: integer
 name:

--- a/source/_components/sensor.knx.markdown
+++ b/source/_components/sensor.knx.markdown
@@ -1,6 +1,6 @@
 ---
 title: "KNX Sensor"
-description: "Instructions on how to use the KNX Sensor with Home Assistant."
+description: "Instructions on how to use a KNX Sensor with Home Assistant."
 logo: knx.png
 ha_category:
   - Sensor
@@ -8,9 +8,16 @@ ha_release: 0.29
 ha_iot_class: Local Push
 ---
 
-The `knx` sensor platform allows you to monitor [KNX](http://www.knx.org) sensors.
+<div class='note'>
+  
+The `knx` integration must be configured correctly to use this integration, see [KNX Integration](/components/knx).
 
-The `knx` integration must be configured correctly, see [KNX Component](/components/knx).
+</div>
+
+The `knx` sensor platform allows you to monitor [KNX](http://www.knx.org) sensors. 
+
+Sensors are read-only. To write to the knx-bus configure an exposure [KNX Integration - Expose](/components/knx/#exposing-sensor-values-or-time-to-knx-bus).
+
 
 ## Configuration
 
@@ -33,44 +40,68 @@ name:
   description: A name for this device used within Home Assistant.
   required: false
   type: string
-type:
-  description: A type from the following table can be defined. The DPT of the group address should match the expected KNX DPT to be parsed correctly.
+sync_state:
+  description: Actively read the value from the bus. If `False` no GroupValueRead telegrams will be sent to the bus.
   required: false
+  type: boolean
+  default: True
+type:
+  description: A type from the following table must be defined. The DPT of the group address should match the expected KNX DPT to be parsed correctly.
+  required: true
   type: string
 {% endconfiguration %}
 
-| type               | unit | expected KNX DPT |
-|--------------------|------|------------------|
-| percent            | %    | 5.001            |
-| pulse              |      | 5.010            |
-| temperature        | °C   | 9.001            |
-| humidity           | %    | 9.007            |
-| illuminance        | lx   | 9.004            |
-| brightness         | lx   | 7.013            |
-| speed_ms           | m/s  | 9.005            |
-| current            | mA   | 7.012            |
-| voltage            | mV   | 9.020            |
-| power              | W    | 14.056           |
-| electric_current   | A    | 14.019           |
-| electric_potential | V    | 14.027           |
-| energy             | J    | 14.031           |
-| frequency          | Hz   | 14.033           |
-| heatflowrate       | W    | 14.036           |
-| phaseanglerad      | rad  | 14.054           |
-| phaseangledeg      | °    | 14.055           |
-| powerfactor        |      | 14.057           |
-| speed              | m/s  | 14.065           |
-| enthalpy           | H    | 9.*              |
-| ppm                | ppm  | 9.008            |
-| DPT-7              |      | 7.*              |
-| 2byte_unsigned     |      | 7.*              |
-| DPT-9              |      | 9.*              |
-| DPT-12             |      | 12.*             |
-| 4byte_unsigned     |      | 12.*             |
-| DPT-13             |      | 13.*             |
-| 4byte_signed       |      | 13.*             |
-| DPT-14             |      | 14.*             |
-| 4byte_float        |      | 14.*             |
+| KNX DPT | type               | size in byte | unit           |
+|--------:|--------------------|-------------:|----------------|
+| 5.001   | percent            | 1            | %              |
+| 5.003   | angle              | 1            | °              |
+| 5.004   | percentU8          | 1            | %              |
+| 5.010   | pulse              | 1            |                |
+| 5.010   | DPT-5              | 1            |                |
+| 5.010   | 1byte_unsigned     | 1            |                |
+| 6.001   | percentV8          | 1            | %              |
+| 6.010   | counter_pulses     | 1            | counter pulses |
+| 7.***   | DPT-7              | 2            |                |
+| 7.001   | 2byte_unsigned     | 2            | pulses         |
+| 7.012   | current            | 2            | mA             |
+| 7.013   | brightness         | 2            | lx             |
+| 7.600   | color_temperature  | 2            | K              |
+| 8.***   | DPT-8              | 2            |                |
+| 8.001   | 2byte_signed       | 2            | pulses         |
+| 8.002   | delta_time_ms      | 2            | ms             |
+| 8.005   | delta_time_sec     | 2            | s              |
+| 8.006   | delta_time_min     | 2            | min            |
+| 8.007   | delta_time_hrs     | 2            | h              |
+| 8.010   | percentV16         | 2            | %              |
+| 8.011   | rotation_angle     | 2            | °              |
+| 9.*     | enthalpy           | 2            | H              |
+| 9.***   | DPT-9              | 2            |                |
+| 9.001   | temperature        | 2            | °C             |
+| 9.004   | illuminance        | 2            | lx             |
+| 9.005   | speed_ms           | 2            | m/s            |
+| 9.007   | humidity           | 2            | %              |
+| 9.008   | ppm                | 2            | ppm            |
+| 9.020   | voltage            | 2            | mV             |
+| 12.***  | DPT-12             | 4            |                |
+| 12.***  | 4byte_unsigned     | 4            |                |
+| 13.***  | DPT-13             | 4            |                |
+| 13.***  | 4byte_signed       | 4            |                |
+| 14.***  | DPT-14             | 4            |                |
+| 14.***  | 4byte_float        | 4            |                |
+| 14.019  | electric_current   | 4            | A              |
+| 14.027  | electric_potential | 4            | V              |
+| 14.031  | energy             | 4            | J              |
+| 14.033  | frequency          | 4            | Hz             |
+| 14.036  | heatflowrate       | 4            | W              |
+| 14.042  | luminous_flux      | 4            | lm             |
+| 14.054  | phaseanglerad      | 4            | rad            |
+| 14.055  | phaseangledeg      | 4            | °              |
+| 14.056  | power              | 4            | W              |
+| 14.057  | powerfactor        | 4            |                |
+| 14.058  | pressure           | 4            | Pa             |
+| 14.065  | speed              | 4            | m/s            |
+| 16.000  | string             | 14           |                |
+| 17.001  | scene_number       | 1            |                |
 
 ## Full example
 
@@ -84,5 +115,6 @@ sensor:
   - platform: knx
     name: Kitchen.Temperature
     state_address: '6/2/1'
+    sync_state: False
     type: 'temperature'
 ```

--- a/source/_components/sensor.knx.markdown
+++ b/source/_components/sensor.knx.markdown
@@ -21,11 +21,11 @@ To use your KNX sensor in your installation, add the following lines to your `co
 sensor:
   - platform: knx
     name: Heating.Valve1
-    address: '2/0/0'
+    state_address: '2/0/0'
 ```
 
 {% configuration %}
-address:
+state_address:
   description: KNX group address of the sensor.
   required: true
   type: string
@@ -79,10 +79,10 @@ type:
 sensor:
   - platform: knx
     name: Heating.Valve1
-    address: '2/0/0'
+    state_address: '2/0/0'
     type: 'percent'
   - platform: knx
     name: Kitchen.Temperature
-    address: '6/2/1'
+    state_address: '6/2/1'
     type: 'temperature'
 ```

--- a/source/_components/switch.knx.markdown
+++ b/source/_components/switch.knx.markdown
@@ -5,12 +5,16 @@ logo: knx.png
 ha_category:
   - Switch
 ha_release: 0.24
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ---
 
-The `knx` switch integration is used as in interface to switching actuators.
+<div class='note'>
+  
+The `knx` integration must be configured correctly to use this integration, see [KNX Integration](/components/knx).
 
-The `knx` integration must be configured correctly, see [KNX Component](/components/knx).
+</div>
+
+The `knx` switch platform is used as an interface to switching actuators.
 
 ## Configuration
 

--- a/source/_components/syncthru.markdown
+++ b/source/_components/syncthru.markdown
@@ -44,3 +44,7 @@ The following information is displayed in separate sensors, if it is available:
  - Black, cyan, magenta and yellow drum state
  - First to fifth paper input tray state
  - First to sixth paper output tray state
+
+<div class="note warning">
+Note that this component or parts thereof may not work if the language of your printer is not configured to be English.
+</div>

--- a/source/_components/twitter.markdown
+++ b/source/_components/twitter.markdown
@@ -14,7 +14,7 @@ The `twitter` notification platform uses [Twitter](https://twitter.com) to deliv
 
 ## Setup
 
-Go to [Twitter Apps](https://apps.twitter.com/app/new) and create an application. Visit "Keys and Access Tokens" of the application to get the details (Consumer Key, Consumer Secret, Access Token and Access Token Secret which needs to be generated).
+Make sure you have a developer account registered with Twitter, then go to [Twitter Apps](https://apps.twitter.com/app/new) and create an application. If you don't have a developer account you need to apply for one, it can take some time to get approved. Visit "Keys and Access Tokens" of the application to get the details (Consumer Key, Consumer Secret, Access Token and Access Token Secret which needs to be generated). 
 
 ## Configuration
 

--- a/source/_components/webhooks.markdown
+++ b/source/_components/webhooks.markdown
@@ -63,7 +63,7 @@ trusted_networks:
   description: Telegram server access ACL as list.
   required: false
   type: string
-  default: 149.154.167.197-233
+  default: 149.154.160.0/20, 91.108.4.0/22
 {% endconfiguration %}
 
 To get your `chat_id` and `api_key` follow the instructions [here](/components/notify.telegram). As well as authorizing the chat, if you have added your bot to a group you will also need to authorize any user that will be interacting with the webhook. When an unauthorized user tries to interact with the webhook Home Assistant will raise an error ("Incoming message is not allowed"), you can easily obtain the users id by looking in the "from" section of this error message.
@@ -81,12 +81,8 @@ telegram_bot:
   - platform: webhooks
     api_key: YOUR_API_KEY
     trusted_networks:
-      - 149.154.167.197/32
-      - 149.154.167.198/31
-      - 149.154.167.200/29
-      - 149.154.167.208/28
-      - 149.154.167.224/29
-      - 149.154.167.232/31
+      - 149.154.160.0/20
+      - 91.108.4.0/22
     allowed_chat_ids:
       - 12345
       - 67890

--- a/source/_components/zha.markdown
+++ b/source/_components/zha.markdown
@@ -59,8 +59,9 @@ The custom quirks implementations for zigpy implemented as ZHA Device Handlers f
 
 ## Configuration
 
-To configure the component, a `zha` section must be present in the `configuration.yaml`,
-and the path to the serial device for the radio and path to the database which will persist your network data is required.
+To configure the component, select ZHA on the Integrations page and provide the path to your Zigbee USB stick.
+
+Or, you can manually confiure `zha` section in `configuration.yaml`. The path to the database which will persist your network data is required.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_components/zwave.markdown
+++ b/source/_components/zwave.markdown
@@ -83,10 +83,10 @@ automation:
       - platform: time
         at: "20:00:00"
     action:
-      - service: climate.set_operation_mode
+      - service: climate.set_hvac_mode
         data:
           entity_id: climate.remotec_zxt120_heating_1_id
-          operation_mode: Heat
+          hvac_mode: Heat
       - service: climate.set_temperature
         data:
           entity_id: climate.remotec_zxt120_heating_1_39
@@ -102,10 +102,10 @@ automation:
       - platform: time
         at: "21:00:00"
     action:
-      - service: climate.set_operation_mode
+      - service: climate.set_hvac_mode
         data:
           entity_id: climate.remotec_zxt120_heating_1_id
-          operation_mode: 'Off'
+          hvac_mode: 'Off'
 ```
 
 **Note:** In the example above, the word `Off` is encased in single quotes to be valid YAML.
@@ -117,7 +117,7 @@ A simple way to test if your Z-Wave climate device is working is to use <img src
 ```json
 {
   "entity_id": "climate.remotec_zxt120_heating_1_id",
-  "operation_mode": "Heat"
+  "hvac_mode": "Heat"
 }
 ```
 

--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -20,7 +20,9 @@ If you have incorrect entries in your configuration files you can use the [`chec
 
 One of the most common problems with Home Assistant is an invalid `configuration.yaml` file. 
  
- - You can test your configuration using the command line with: `hass --script check_config`. On Hass.io you can use the [hassio command](/hassio/commandline/#home-assistant): `hassio homeassistant check`.
+ - You can test your configuration using the command line with: `hass --script check_config`.
+   - On Hass.io you can use the [hassio command](/hassio/commandline/#home-assistant): `hassio homeassistant check`.
+   - On Docker you can use `docker exec home-assistant python -m homeassistant --script check_config --config /config` - where `homeassistant` is the name of the container.
  - You can verify your configuration's yaml structure using [this online YAML parser](http://yaml-online-parser.appspot.com/) or [YAML Lint](http://www.yamllint.com/).
  - To learn more about the quirks of YAML, read [YAML IDIOSYNCRASIES](https://docs.saltstack.com/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html) by SaltStack (the examples there are specific to SaltStack, but do explain YAML issues well).
 

--- a/source/_docs/installation.markdown
+++ b/source/_docs/installation.markdown
@@ -119,7 +119,7 @@ These guides are provided as-is. Some of these install methods are more limited 
     </div>
     <div class='title'>FreeNAS</div>
   </a>
-  <a class='option-card' href='/hassio/installation/#alternative-install-on-generic-linux-server'>
+  <a class='option-card' href='/hassio/installation/#alternative-install-on-a-generic-linux-host'>
     <div class='img-container'>
       <img src='/images/supported_brands/home-assistant.png' />
     </div>

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -197,7 +197,8 @@ As the docker command becomes more complex, switching to `docker-compose` can be
       image: homeassistant/home-assistant
       volumes:
         - /PATH_TO_YOUR_CONFIG:/config
-        - /etc/localtime:/etc/localtime:ro
+      environment:
+        - TZ=America/New_York
       restart: always
       network_mode: host
 ```
@@ -220,7 +221,7 @@ In order to use Z-Wave, Zigbee or other integrations that require access to devi
 
 ```bash
 $ docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config \
-   -v /etc/localtime:/etc/localtime:ro --device /dev/ttyUSB0:/dev/ttyUSB0 \
+   -e TZ=Australia/Melbourne --device /dev/ttyUSB0:/dev/ttyUSB0 \
    --net=host homeassistant/home-assistant
 ```
 
@@ -234,7 +235,6 @@ or in a `docker-compose.yml` file:
       image: homeassistant/home-assistant
       volumes:
         - /PATH_TO_YOUR_CONFIG:/config
-        - /etc/localtime:/etc/localtime:ro
       devices:
         - /dev/ttyUSB0:/dev/ttyUSB0
         - /dev/ttyUSB1:/dev/ttyUSB1

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -11,19 +11,19 @@ Installation with Docker is straightforward. Adjust the following command so tha
 ### Linux
 
 ```bash
-$ docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant
+$ docker run --init -d --name="home-assistant" -e "TZ=America/New_York" -v /PATH_TO_YOUR_CONFIG:/config --net=host homeassistant/home-assistant
 ```
 
 ### Raspberry Pi 3 (Raspbian)
 
 ```bash
-$ docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/raspberrypi3-homeassistant
+$ docker run --init -d --name="home-assistant" -e "TZ=America/New_York" -v /PATH_TO_YOUR_CONFIG:/config --net=host homeassistant/raspberrypi3-homeassistant
 ```
 
 You need to replace `/PATH_TO_YOUR_CONFIG` with your path to the configuration, for example if you choose your configuration path to be `/home/pi/homeassistant`, then command would be:
  
 ```bash
-$ docker run --init -d --name="home-assistant" -v /home/pi/homeassistant:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/raspberrypi3-homeassistant
+$ docker run --init -d --name="home-assistant" -e "TZ=America/New_York" -v /home/pi/homeassistant:/config --net=host homeassistant/raspberrypi3-homeassistant
 ```
 
 ### macOS
@@ -33,7 +33,7 @@ When using `docker-ce` (or `boot2docker`) on macOS, you are unable to map the lo
 If you wish to browse directly to `http://localhost:8123` from your macOS host, meaning forward ports directly to the container, replace the `--net=host` switch with `-p 8123:8123`. More detail can be found in [the docker forums](https://forums.docker.com/t/should-docker-run-net-host-work/14215/10).
 
 ```bash
-$ docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -e "TZ=America/Los_Angeles" -p 8123:8123 homeassistant/home-assistant
+$ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v /PATH_TO_YOUR_CONFIG:/config -p 8123:8123 homeassistant/home-assistant
 ```
 
 Alternatively, `docker-compose` works with any recent release of `docker-ce` on macOS. Note that (further down this page) we provide an example `docker-compose.yml` however it differs from the `docker run` example above. To make the .yml directives match, you would need to make _two_ changes: first add the equivalent `ports:` directive, then _remove_ the `network_mode: host` section. This is because `Port mapping is incompatible with network_mode: host:`. More details can be found at [Docker networking docs](https://docs.docker.com/engine/userguide/networking/#default-networks). Note also the `/dev/tty*` device name used by your Arduino etc. devices will differ from the Linux example, so the compose `mount:` may require updates.
@@ -41,7 +41,7 @@ Alternatively, `docker-compose` works with any recent release of `docker-ce` on 
 ### Windows
 
 ```powershell
-$ docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -e "TZ=America/Los_Angeles" --net=host homeassistant/home-assistant
+$ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v /PATH_TO_YOUR_CONFIG:/config --net=host homeassistant/home-assistant
 ```
 
 When running Home Assistant in Docker on Windows, you may have some difficulty getting ports to map for routing (since the `--net=host` switch actually applies to the hypervisor's network interface). To get around this, you will need to add port proxy ipv4 rules to your local Windows machine, like so (Replacing '192.168.1.10' with whatever your Windows IP is, and '10.0.50.2' with whatever your Docker container's IP is):
@@ -239,6 +239,8 @@ or in a `docker-compose.yml` file:
         - /dev/ttyUSB0:/dev/ttyUSB0
         - /dev/ttyUSB1:/dev/ttyUSB1
         - /dev/ttyACM0:/dev/ttyACM0
+      environment:
+        - TZ=America/New_York
       restart: always
       network_mode: host
 ```

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -221,7 +221,7 @@ In order to use Z-Wave, Zigbee or other integrations that require access to devi
 
 ```bash
 $ docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config \
-   -e TZ=Australia/Melbourne --device /dev/ttyUSB0:/dev/ttyUSB0 \
+   -e "TZ=Australia/Melbourne" --device /dev/ttyUSB0:/dev/ttyUSB0 \
    --net=host homeassistant/home-assistant
 ```
 

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -191,6 +191,161 @@ Triple tap on|2|4
 5x tap off|1|6
 5x tap on|2|6
 
+### Zooz Scene Capable On/Off and Dimmer Wall Switches (Zen26 & Zen27 - Firmware 2.0+)
+
+Many Zooz Zen26/27 switches that have been sold do not have firmware 2.0+. Contact Zooz to obtain the over the air firmware update instructions and new user manual for the switches.
+
+Once the firmware is updated, the the new configuration paramters will have to be added to the `zwcfg` file. Replace the existing `COMMAND_CLASS_CONFIGURATION` with the one of the following options (depending on your model of switch):
+
+Zen26 (On/Off Switch):
+```xml
+<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1" request_flags="4" innif="true">
+	<Instance index="1" />
+	<Value type="list" genre="config" instance="1" index="1" label="Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+		<Help>Normal mode: Upper paddle turns the light on, lower paddle turns the light off. Reverse will reverse those functions. Any will toggle the light regardless of which button is pushed.</Help>
+		<Item label="Normal" value="0" />
+		<Item label="Reverse" value="1" />
+		<Item label="Any" value="2" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="2" label="LED Indication Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="0" size="1">
+		<Help>LED Indication light function. Normal has the LED Indication on when the switch is off, off when the switch is on.</Help>
+		<Item label="Normal" value="0" />
+		<Item label="Reverse" value="1" />
+		<Item label="Always Off" value="2" />
+		<Item label="Always On" value="3" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="3" label="Enable Turn-Off Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Help>Enable or disable the auto turn-off timer function.</Help>
+		<Item label="Disabled (Default)" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+	<Value type="int" genre="config" instance="1" index="4" label="Turn-Off Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="1">
+		<Help>Time, in seconds, for auto-off timer delay. 60 (default).</Help>
+	</Value>
+	<Value type="list" genre="config" instance="1" index="5" label="Enable Turn-On Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Help>Enable or disable the auto turn-on timer function.</Help>
+		<Item label="Disabled (Default)" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+	<Value type="int" genre="config" instance="1" index="6" label="Turn-On Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="55">
+		<Help>Time, in minutes, for auto-on timer delay. 60 (default).</Help>
+	</Value>
+	<Value type="list" genre="config" instance="1" index="8" label="On Off Status After Power Failure" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="2" size="1">
+		<Help>Status after power on after power failure. OFF will always turn light off. ON will always turn light on. Restore will remember the latest state and restore that state.</Help>
+		<Item label="OFF" value="0" />
+		<Item label="ON" value="1" />
+		<Item label="Restore" value="2" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="10" label="Scene Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Help>Enable or disable scene control functionality for quick double tap triggers.</Help>
+		<Item label="Disabled (Default)" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="11" label="Enable/Disable Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+		<Help>Enable or disable local on/off control. If enabled, you&apos;ll only be able to control the connected light via Z-Wave.</Help>
+		<Item label="Disabled" value="0" />
+		<Item label="Enabled (Default)" value="1" />
+	</Value>
+</CommandClass>
+```
+
+Zen27 (Dimmer):
+```xml
+<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1" request_flags="4" innif="true">
+	<Instance index="1" />
+	<Value type="list" genre="config" instance="1" index="1" label="Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+		<Help>Normal mode: Upper paddle turns the light on, lower paddle turns the light off. Reverse will reverse those functions. Any will toggle the light regardless of which button is pushed.</Help>
+		<Item label="Normal" value="0" />
+		<Item label="Reverse" value="1" />
+		<Item label="Any" value="2" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="2" label="LED Indication Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="0" size="1">
+		<Help>LED Indication light function. Normal has the LED Indication on when the switch is off, off when the switch is on.</Help>
+		<Item label="Normal" value="0" />
+		<Item label="Reverse" value="1" />
+		<Item label="Always Off" value="2" />
+		<Item label="Always On" value="3" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="3" label="Enable Auto Turn-Off Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Item label="Disabled" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+	<Value type="int" genre="config" instance="1" index="4" label="Auto Turn-Off Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+		<Help>Time, in minutes, for auto-off timer delay.</Help>
+	</Value>
+	<Value type="list" genre="config" instance="1" index="5" label="Enable Auto Turn-On Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Item label="Disabled" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+	<Value type="int" genre="config" instance="1" index="6" label="Auto Turn-On Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+		<Help>Time, in minutes, for auto-off timer delay.</Help>
+	</Value>
+	<Value type="list" genre="config" instance="1" index="8" label="On Off Status After Power Failure" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="2" size="1">
+		<Help>Status after power on after power failure. OFF will always turn light off. ON will always turn light on. Restore will remember the latest state and restore that state.</Help>
+		<Item label="OFF" value="0" />
+		<Item label="ON" value="1" />
+		<Item label="Restore" value="2" />
+	</Value>
+	<Value type="byte" genre="config" instance="1" index="9" label="Ramp Rate Control" units="seconds" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="3">
+		<Help>Adjust the ramp rate for your dimmer (fade-in / fade-out effect for on / off operation). Values correspond to the number of seconds it take for the dimmer to reach full brightness or turn off when operated manually.</Help>
+	</Value>
+	<Value type="byte" genre="config" instance="1" index="10" label="Minimum Brightness" units="%" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="99">
+		<Help>Set the minimum brightness level for your dimmer. You won&apos;t be able to dim the light below the set value.</Help>
+	</Value>
+	<Value type="byte" genre="config" instance="1" index="11" label="Maximum Brightness" units="%" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="99">
+		<Help>Set the maximum brightness level for your dimmer. You won&apos;t be able to add brightness to the light beyond the set value. Note: if Parameter 12 is set to value &quot;Full&quot;, Parameter 11 is automatically disabled.</Help>
+	</Value>
+	<Value type="list" genre="config" instance="1" index="12" label="Double Tap Function Brightness" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Help>Double Tap action. When set to Full, turns light on to 100%. If set to Maximum Level, turns light on to % set in Parameter 11.</Help>
+		<Item label="Full" value="0" />
+		<Item label="Maximum Level" value="1" />
+	</Value>				
+	<Value type="list" genre="config" instance="1" index="13" label="Scene Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+		<Help>Enable or disable scene control functionality for quick double tap triggers.</Help>
+		<Item label="Disabled" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="14" label="Enable Double Tap Function" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+		<Help>Enable the double tap or disable the double tap function and assign brightness level to single tap.</Help>
+		<Item label="Enabled" value="0" />
+		<Item label="Disabled - Single Tap To Last Brightness" value="1" />
+		<Item label="Disabled - Single Tap To Max Brightness" value="2" />
+	</Value>
+	<Value type="list" genre="config" instance="1" index="15" label="Enable/Disable Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+		<Help>Enable or disable local on/off control. If enabled, light will only be able to be controlled via Z-Wave.</Help>
+		<Item label="Disabled" value="0" />
+		<Item label="Enabled" value="1" />
+	</Value>
+</CommandClass>
+```
+
+For Zooz switches, you'll need to update (or possibly add) the `COMMAND_CLASS_CENTRAL_SCENE` for each node in your `zwcfg` file with the following:
+```xml
+<CommandClass id="91" name="COMMAND_CLASS_CENTRAL_SCENE" version="1" request_flags="4" innif="true" scenecount="0">
+	<Instance index="1" />
+	<Value type="int" genre="system" instance="1" index="0" label="Scene Count" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="2" />
+	<Value type="int" genre="user" instance="1" index="1" label="Bottom Button Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
+	<Value type="int" genre="user" instance="1" index="2" label="Top Button Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
+</CommandClass>
+```
+
+Go to the Z-Wave Network Management section in the Home Assistant Configuration, select the node which has just been updated and enable the scene support configuration paramter.
+
+Once this is complete, you should see the following `zwave.scene_activated` events:
+
+**Action**|**scene\_id**|**scene\_data**
+:-----:|:-----:|:-----:
+Single tap off|1|7680
+Single tap on|2|7680
+Double tap off|1|7860
+Double tap on|2|7860
+Triple tap off|1|7920
+Triple tap on|2|7920
+4x tap off|1|7980
+4x tap on|2|7980
+5x tap off|1|8040
+5x tap on|2|8040
+
 ### HomeSeer Switches
 
 For the HomeSeer devices specifically, you may need to update the `COMMAND_CLASS_CENTRAL_SCENE` for each node in your `zwcfg` file with the following:

--- a/source/_docs/z-wave/services.markdown
+++ b/source/_docs/z-wave/services.markdown
@@ -31,7 +31,6 @@ The `zwave` integration exposes multiple services to help maintain the network. 
 | stop_network           | Stops the Z-Wave network.                                                                                                                    |
 | test_network           | Tells the controller to send no-op commands to each node and measure the time for a response. In theory, this can also bring back nodes which have been marked "presumed dead."             |
 | test_node              | Tells the controller to send no-op command(s) to a specific node. Requires `node_id` field. You can specify amount of test_messages to send by specifying it with `messages` field. In theory, this could bring back nodes marked as "presumed dead"
-| update_config          | Attempt to update OZW configuration files from git to support newer devices. After you run this, wait a few minutes then stop Home Assistant. You can now back up your `zwcfg_*.xml` file, then delete the relevant entries from your `zwcfg_*.xml` (between and including `<Node id="?">` and `</Node>`), and finally start Home Assistant. |
 
 The `soft_reset` and `heal_network` commands can be used to help keep a Z-Wave network running reliably. This is a configuration option for the `zwave` component. The option defaults to `false` but can be enabled by setting `autoheal` to true. This, however, is bad practice since it introduces overhead that can be avoided since you only need to do a `heal_network` whenever one of the following actions are done:
 

--- a/source/_posts/2019-08-07-release-97.markdown
+++ b/source/_posts/2019-08-07-release-97.markdown
@@ -101,6 +101,38 @@ A new breaking change was introduced with 0.97.1 to accomodate for the HaveIBeen
 [haveibeenpwned docs]: /components/haveibeenpwned/
 [unifi docs]: /components/unifi/
 
+## Release 0.97.2 - August 11
+
+- Fix eco preset for Wink Air Conditioner ([@cameronrmorris] - [#25763]) ([wink docs])
+- Update pyvera to 0.3.3 ([@brandond] - [#25820]) ([vera docs])
+- Fix Netatmo climate issue ([@cgtobi] - [#25830]) ([netatmo docs])
+- Fix KNX Climate mode change callback ([@tombbo] - [#25851]) ([knx docs])
+- Always populate hvac_modes in SmartThings climate platform ([@andrewsayre] - [#25859]) ([smartthings docs])
+- UniFi - Use state to know if device is online ([@Kane610] - [#25876]) ([unifi docs])
+- Fix issue with nuki new available state ([@pvizeli] - [#25881]) ([nuki docs])
+
+[#25763]: https://github.com/home-assistant/home-assistant/pull/25763
+[#25820]: https://github.com/home-assistant/home-assistant/pull/25820
+[#25830]: https://github.com/home-assistant/home-assistant/pull/25830
+[#25851]: https://github.com/home-assistant/home-assistant/pull/25851
+[#25859]: https://github.com/home-assistant/home-assistant/pull/25859
+[#25876]: https://github.com/home-assistant/home-assistant/pull/25876
+[#25881]: https://github.com/home-assistant/home-assistant/pull/25881
+[@Kane610]: https://github.com/Kane610
+[@andrewsayre]: https://github.com/andrewsayre
+[@brandond]: https://github.com/brandond
+[@cameronrmorris]: https://github.com/cameronrmorris
+[@cgtobi]: https://github.com/cgtobi
+[@pvizeli]: https://github.com/pvizeli
+[@tombbo]: https://github.com/tombbo
+[knx docs]: /components/knx/
+[netatmo docs]: /components/netatmo/
+[nuki docs]: /components/nuki/
+[smartthings docs]: /components/smartthings/
+[unifi docs]: /components/unifi/
+[vera docs]: /components/vera/
+[wink docs]: /components/wink/
+
 ## If you need help...
 
 ...don't hesitate to use our very active [forums](https://community.home-assistant.io/) or join us for a little [chat](https://discord.gg/c5DvZ4e).

--- a/source/_posts/2019-08-07-release-97.markdown
+++ b/source/_posts/2019-08-07-release-97.markdown
@@ -79,6 +79,28 @@ We wrote about how we use Azure DevOps to automate the development of Home Assis
 - Add De Lijn (Flemish Public Transport) component ([@bollewolle] - [#24265]) ([delijn docs]) (new-integration) (new-platform)
 - Add Support for VeSync Devices - Outlets and Switches ([@webdjoe] - [#24953]) ([vesync docs]) (new-platform)
 
+## Release 0.97.1 - August 9
+
+A new breaking change was introduced with 0.97.1 to accomodate for the HaveIBeenPwned shutting down v2 of their API on August 18. The integration has been migrated to using v3.
+
+- Update HIBP sensor to use API v3 and API Key ([@aetaric] - [#25699]) ([haveibeenpwned docs]) (breaking change)
+- Update Cisco Mobility Express module version ([@fbradyirl] - [#25770]) ([cisco_mobility_express docs])
+- Don't track unstable attributes ([@jjlawren] - [#25787]) ([unifi docs]) (breaking change)
+- Fix deconz allow_clip_sensor and allow_deconz_groups options ([@Anonym-tsk] - [#25811]) ([deconz docs])
+
+[#25699]: https://github.com/home-assistant/home-assistant/pull/25699
+[#25770]: https://github.com/home-assistant/home-assistant/pull/25770
+[#25787]: https://github.com/home-assistant/home-assistant/pull/25787
+[#25811]: https://github.com/home-assistant/home-assistant/pull/25811
+[@Anonym-tsk]: https://github.com/Anonym-tsk
+[@aetaric]: https://github.com/aetaric
+[@fbradyirl]: https://github.com/fbradyirl
+[@jjlawren]: https://github.com/jjlawren
+[cisco_mobility_express docs]: /components/cisco_mobility_express/
+[deconz docs]: /components/deconz/
+[haveibeenpwned docs]: /components/haveibeenpwned/
+[unifi docs]: /components/unifi/
+
 ## If you need help...
 
 ...don't hesitate to use our very active [forums](https://community.home-assistant.io/) or join us for a little [chat](https://discord.gg/c5DvZ4e).
@@ -145,6 +167,8 @@ Experiencing issues introduced by this release? Please report them in our [issue
   - Direction -> direction
   - Due in -> due_in
   - Due at -> due_at
+
+- **haveibeenpwned** - the v2 API is now replaced with the v3 API, which requires an API key. v2 of the API will stop working on August 18.
 
 ## Beta Fixes
 

--- a/source/_posts/2019-08-07-release-97.markdown
+++ b/source/_posts/2019-08-07-release-97.markdown
@@ -95,7 +95,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - **Z-Wave** - Improve handling of Z-Wave config entry vs yaml config. If a Z-Wave `network_key` is specified in configuration.yaml it will override a `network_key` specified in the Z-Wave config entry. ([@cgarwood] - [#25112]) ([zwave docs])
 - **Unifi** - Unifi Device tracker is now part of config entry. After initial import the unifi device tracker configuration is no longer needed. If configuring SSID filter or detection time you will need to use the new configuration from UniFi. See UniFi component documentation for details. ([@Kane610] - [#24367]) ([unifi docs])
 - **Ecobee** - Ecobee presets now represent the different Ecobee comfort settings. Selectable by name instead of unknown ID. ([@balloob] - PR link todo)
-- **Calendar** - Rewrite calendar component - The calendar integration has been rewritten to follow our current standards and is mostly non breaking. The reset (clean up) of state attributes upon an event time passing has been removed, though. Attributes are no longer set to an arbitrary default value, and will now keep the attributes representing the last event. With this change, automations that rely on state attributes getting reset will need to be updated. All platforms have been converted. - ([@MartinHjelmare] - [#24950]) ([caldav docs]) ([calendar docs]) ([demo docs]) ([google docs]) ([todoist docs])
+- **Calendar** - Rewrite calendar component - The calendar integration has been rewritten to follow our current standards and is mostly non breaking. The reset (clean up) of state attributes upon an event time passing has been removed, though. Attributes are no longer set to an arbitrary default value, and will now keep the attributes representing the last event. With this change, automations that rely on state attributes getting reset will need to be updated. All platforms have been converted. - ([@MartinHjelmare] - [#24950]) ([caldav docs]) ([calendar docs]) ([demo docs]) ([google cal docs]) ([todoist docs])
 - **SyncThru** - The monitored_conditions configuration option has been removed. All available monitored conditions will be used by default. Users that have been using the monitored_conditions option need to remove it from the syncthru section in configuration.yaml. ([@nielstron] - [#25052]) ([syncthru docs])
 - **KNX** - Updates the knx component to use xknx 0.11.1 . This introduces several new features and bugfixes. For a complete list see: https://github.com/XKNX/xknx/releases/tag/0.11.0  ([@farmio] - [#24738]) ([knx docs])
   - `scene:` `scene_number` is now 1 indexed according to KNX standards. Previously it was 0 based. Please add 1 to your already configured scene numbers (`scene_number: 5` becomes `scene_number: 6`).
@@ -695,7 +695,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [fortigate docs]: /components/fortigate/
 [fortios docs]: /components/fortios/
 [geniushub docs]: /components/geniushub/
-[google docs]: /components/google/
+[google cal docs]: /components/calendar.google/
 [google_assistant docs]: /components/google_assistant/
 [google_maps docs]: /components/google_maps/
 [google_travel_time docs]: /components/google_travel_time/


### PR DESCRIPTION
**Description:**
Remove `zwave.update_config` service call from Z-Wave service documentation. This corresponds to the reference pull request where the service call code has been removed.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10138"><img src="https://gitpod.io/api/apps/github/pbs/github.com/kpine/home-assistant.io.git/0acaf3106811c7c7cdaa59b734f7baba4cc491b6.svg" /></a>

