### PR TITLE
Alert Component Documentation: fix quotes in example code

### DIFF
--- a/source/_components/alert.markdown
+++ b/source/_components/alert.markdown
@@ -153,7 +153,7 @@ binary_sensor:
   - platform: template
     sensors:
       motion_battery_low:
-        value_template: '{{ state_attr('sensor.motion', 'battery') < 15 }}'
+        value_template: "{{ state_attr('sensor.motion', 'battery') < 15 }}"
         friendly_name: 'Motion battery is low'
 
 alert:


### PR DESCRIPTION
**Description:** It's in the Alert Component documentation


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10142"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ebaschiera/home-assistant.io.git/a65fa854091b30c2cdef5d3cc64710c5304bb9f4.svg" /></a>

