### PR TITLE
add retry option description for broadlink

### DIFF
--- a/source/_components/broadlink.markdown
+++ b/source/_components/broadlink.markdown
@@ -150,9 +150,10 @@ timeout:
   required: false
   type: integer
 retry:
-  description: Retry times for fetch data if failed. The default value is 2.
+  description: Retry times for fetch data if failed.
   required: false
   type: integer
+  default: 2
 friendly_name:
   description: The name used to display the switch in the frontend.
   required: false

--- a/source/_components/broadlink.markdown
+++ b/source/_components/broadlink.markdown
@@ -149,6 +149,10 @@ timeout:
   description: Timeout in seconds for the connection to the device.
   required: false
   type: integer
+retry:
+  description: Retry times for fetch data if failed. The default value is 2.
+  required: false
+  type: integer
 friendly_name:
   description: The name used to display the switch in the frontend.
   required: false
@@ -216,6 +220,7 @@ switch:
     host: 192.168.1.2
     mac: 'B4:43:0D:CC:0F:58'
     timeout: 15
+    retry: 5
     switches:
       # Will work on most Phillips TVs:
       tv_phillips:
@@ -263,6 +268,7 @@ switch:
     host: IP_ADDRESS
     mac: 'MAC_ADDRESS'
     type:  sp2
+    retry: 5
     friendly_name: 'Humidifier'
 ```
 


### PR DESCRIPTION
**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10150"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zhumuht/home-assistant.io.git/b14d23b043dc85eb6635704ce8f56178f6e4d4e5.svg" /></a>

