### PR TITLE
Add note about purge_keep_days

### DIFF
--- a/source/_components/history_stats.markdown
+++ b/source/_components/history_stats.markdown
@@ -119,6 +119,12 @@ duration:
   minutes: 30
 ```
 
+<div class='note'>
+
+  If the duration exceeds the number of days of history stored by the `recorder` component (`purge_keep_days`), the history statistics sensor will not have all the information it needs to look at the entire duration. For example, if `purge_keep_days` is set to 7, a history statistics sensor with a duration of 30 days will only report a value based on the last 7 days of history.
+
+</div>
+
 ### Examples
 
 Here are some examples of periods you could work with, and what to write in your `configuration.yaml`:


### PR DESCRIPTION
The purge_keep_days variable in the recorder component limits the max duration of a history stats sensor. This might not be clear to some users.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10152"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Tediore/home-assistant.io.git/cdc76686fb65b12e1aa5f0fa1775b9fab255a720.svg" /></a>

