### PR TITLE
add support docs for yeelight: Yeelight Serene Eye-Friendly Desk Lamp

### DIFF
--- a/source/_components/yeelight.markdown
+++ b/source/_components/yeelight.markdown
@@ -142,6 +142,7 @@ This integration is tested to work with the following models. If you have a diff
 | ?, may be `ceiling3` | YLXD04YL     | Yeelight Ceiling Light (Jiaoyue 450)   |
 | `ceiling3` | YLXD05YL     | Yeelight Ceiling Light (Jiaoyue 480)             |
 | `ceiling4` | YLXD02YL     | Yeelight Ceiling Light (Jiaoyue 650)             |
+| `mono`     | YLTD03YL     | Yeelight Serene Eye-Friendly Desk Lamp           |
 
 
 ## Platform Services


### PR DESCRIPTION
add support for yeelight: Yeelight Serene Eye-Friendly Desk Lamp (YLTD03YL) . product url: https://www.yeelight.com/en_US/product/muse
it is can use model 'mono', tested pass.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10157"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zhumuht/home-assistant.io.git/8fae08d939a3385e901309127cd4eacdea2653d0.svg" /></a>

