### PR TITLE
Revert "Notification of non working status"

### DIFF
--- a/source/_components/googlehome.markdown
+++ b/source/_components/googlehome.markdown
@@ -12,12 +12,6 @@ redirect_from:
   - /components/device_tracker.googlehome/
 ---
 
-<div class='note warning'>
-
-  This integration is currently not working as Google have disabled access to their unofficial API. A workaround may be in progress, but for now, this integration should not be included in your setup.
-
-</div>
-
 The `googlehome` integration allows you to connect to your Google Home device using an [unofficial Google Home API][googlehomeapi].
 
 This integration will provide:


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#10155

We should not add temporary manual stuff to our documentation.
This causes a maintenance burden and most likely to stick around whenever it gets fixed.

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10158"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/b7072edc5fd08f200083265487607abf9370981e.svg" /></a>

