### PR TITLE
Correct typo in service call for Spot Cleaning

### DIFF
--- a/source/_components/neato.markdown
+++ b/source/_components/neato.markdown
@@ -64,7 +64,7 @@ Currently supported services are:
 - `stop`
 - `return_to_base`
 - `locate`
-- `spot_clean`
+- `clean_spot`
 
 And a specific Platform Service:
 


### PR DESCRIPTION
**Description:**

Noticed that the service call listed is incorrect.  Updated it so it reflects the correct name

https://www.home-assistant.io/components/vacuum/#service-vacuumclean_spot
https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/neato/vacuum.py#L320

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10160"><img src="https://gitpod.io/api/apps/github/pbs/github.com/dshokouhi/home-assistant.github.io.git/e72ec551f41788a164468bb7353cbe63e46dca56.svg" /></a>

