### PR TITLE
Changes explained for new default configuration

### DIFF
--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -96,3 +96,9 @@ It is possible to [customize entities](/docs/configuration/customizing-devices/)
 homeassistant:
   customize:
 ```
+In newer versions of Home Assistant the homeassistant: configuration has been moved and default_config: is now at the top of your configuration.yaml. The new enteries should look like this.
+
+```yaml
+default_config:
+  packages:
+```


### PR DESCRIPTION
Home assistant moved alot of the main configuration to the UI and now uses default_config: in the configuration.yaml

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10161"><img src="https://gitpod.io/api/apps/github/pbs/github.com/IxsharpxI/home-assistant.io.git/7ba17cb6187b5c2ab7ed04d3f3009fdca08685b6.svg" /></a>

