### PR TITLE
Added warning for integration getting removed

### DIFF
--- a/source/_components/googlehome.markdown
+++ b/source/_components/googlehome.markdown
@@ -12,9 +12,13 @@ redirect_from:
   - /components/device_tracker.googlehome/
 ---
 
-The `googlehome` integration allows you to connect to your Google Home device using an [unofficial Google Home API][googlehomeapi].
+<div class='note warning'>
 
-## Warning: This integration is probably getting removed according to [this pull](https://github.com/home-assistant/home-assistant/pull/26035)
+  For a couple of weeks / months this integration is broken, therefore it will be removed in the future according to [this pull request](https://github.com/home-assistant/home-assistant/pull/26035).
+
+</div>
+
+The `googlehome` integration allows you to connect to your Google Home device using an [unofficial Google Home API][googlehomeapi].
 
 This integration will provide:
 - [device_tracker](/components/device_tracker/) platform to track nearby bluetooth devices;

--- a/source/_components/googlehome.markdown
+++ b/source/_components/googlehome.markdown
@@ -14,6 +14,8 @@ redirect_from:
 
 The `googlehome` integration allows you to connect to your Google Home device using an [unofficial Google Home API][googlehomeapi].
 
+## Warning: This integration is probably getting removed according to [this pull](https://github.com/home-assistant/home-assistant/pull/26035)
+
 This integration will provide:
 - [device_tracker](/components/device_tracker/) platform to track nearby bluetooth devices;
 - [sensor](/components/sensor/) platform to track the alarms and the timers.


### PR DESCRIPTION
**Description:**
The googlehome integration is getting removed so letting users know when they wish to setup they know it's going away according to this pull: https://github.com/home-assistant/home-assistant/pull/26035

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26035

## Checklist:

- [Unsure] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [Yes] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10168"><img src="https://gitpod.io/api/apps/github/pbs/github.com/TychoWerner/home-assistant.io.git/27dc0a8009a9a782e2cf669ef98baa69d997ca6c.svg" /></a>

