### PR TITLE
Document homematic default local IP

### DIFF
--- a/source/_components/homematic.markdown
+++ b/source/_components/homematic.markdown
@@ -70,6 +70,7 @@ local_ip:
   description: IP of device running Home Assistant. Override auto-detected value for exotic network setups.
   required: false
   type: string
+  default: 0.0.0.0
 local_port:
   description: Port for connection with Home Assistant. By default it is randomly assigned.
   required: false


### PR DESCRIPTION
**Description:**

TItle says it all.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10170"><img src="https://gitpod.io/api/apps/github/pbs/github.com/scop/home-assistant.io.git/8c3f524bde7ecbc139dca1d0f410b4aad605b766.svg" /></a>

