### PR TITLE
Update references to away mode in generic_thermostat documentation

### DIFF
--- a/source/_components/generic_thermostat.markdown
+++ b/source/_components/generic_thermostat.markdown
@@ -77,7 +77,7 @@ initial_hvac_mode:
   required: false
   type: string
 away_temp:
-  description: Set the temperature used by "away_mode". If this is not specified, away_mode feature will not get activated.
+  description: Set the temperature used by `preset_mode: away`. If this is not specified, the preset mode feature will not be available.
   required: false
   type: float
 precision:
@@ -91,7 +91,7 @@ A full configuration example looks like the one below. `min_cycle_duration` and 
 
 Currently the `generic_thermostat` climate platform supports 'heat', 'cool' and 'off' hvac modes. You can force your `generic_thermostat` to avoid starting by setting HVAC mode to 'off'.
 
-Please note that changing Away Mode you will force a target temperature change as well that will get restored once the Away Mode is turned off.
+Please note that when changing the preset mode to away, you will force a target temperature change as well that will get restored once the preset mode is set to none again.
 
 ```yaml
 # Full example configuration.yaml entry

--- a/source/_components/generic_thermostat.markdown
+++ b/source/_components/generic_thermostat.markdown
@@ -77,7 +77,7 @@ initial_hvac_mode:
   required: false
   type: string
 away_temp:
-  description: Set the temperature used by `preset_mode: away`. If this is not specified, the preset mode feature will not be available.
+  description: "Set the temperature used by `preset_mode: away`. If this is not specified, the preset mode feature will not be available."
   required: false
   type: float
 precision:


### PR DESCRIPTION
**Description:** this PR updates the generic_thermostat description to remove references to "away_mode" left over after the Climate cleanup in 0.96

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10171"><img src="https://gitpod.io/api/apps/github/pbs/github.com/mickdekkers/home-assistant.io.git/a9590b3bc1e4d1145dc7675b3c25899841c33a54.svg" /></a>

