### PR TITLE
Disclaimer for existing users on migrating to Integrations

### DIFF
--- a/source/_components/unifi.markdown
+++ b/source/_components/unifi.markdown
@@ -22,6 +22,14 @@ There is currently support for the following device types within Home Assistant:
 - [Switch](#switch)
 
 ## Configuration
+<div class='note warning'>
+
+As of 0.94 `known_devices.yaml` has being phased out, and no longer used by all trackers.
+If you have previously configured UniFi in your `configuration.yaml` file, it is recommended to remove it from your `configuration.yaml` file and setup again within **Integrations**
+Your existing `known_devices.yaml` will be imported into the new configuration area. However, it is recommend reviewing and updating within **Configuration** -> **Integrations** -> **UniFi Controller**. Once the new configuration is in place, you can delete your existing `known_devices.yaml` file.
+
+For more information, see release notes [here](https://www.home-assistant.io/blog/2019/06/05/release-94/#modernizing-the-device-tracker)
+</div>
 
 Home Assistant offers UniFi integration through **Configuration** -> **Integrations** -> **UniFi Controller**. For legacy support old device_tracker configurations are imported and set up as new integrations.
 


### PR DESCRIPTION
Warning disclaimer for existing users with UniFi configured with configuration.yaml on how to migration to UniFi via integrations and what to do with tracking and known_devices.yaml

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10173"><img src="https://gitpod.io/api/apps/github/pbs/github.com/rosscullen/home-assistant.io.git/272106dcbd944af72dd757fdb857037c2bec56db.svg" /></a>

