### PR TITLE
Update to required

### DIFF
--- a/source/_components/roku.markdown
+++ b/source/_components/roku.markdown
@@ -30,8 +30,8 @@ roku:
 
 {% configuration %}
 host:
-  description: Set the IP address of the Roku device. Use only if you don't want to autodiscover devices.
-  required: false
+  description: Set the IP address of the Roku device.
+  required: true
   type: string
 {% endconfiguration %}
 


### PR DESCRIPTION
If you don't have this you get:

```
Invalid config for [roku]: required key not provided @ data['roku'][0]['host']. Got None. (See ?, line ?). Please check the docs at https://home-assistant.io/components/roku/
```

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10174"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ptarjan/home-assistant.io.git/89876bc976a26df6d306f746036552bc6943af41.svg" /></a>

