### PR TITLE
Update utility_meter.markdown

### DIFF
--- a/source/_components/utility_meter.markdown
+++ b/source/_components/utility_meter.markdown
@@ -188,13 +188,11 @@ sensor:
     sensors:
       daily_power:
         friendly_name: Daily Power
-        icon: mdi:counter
         unit_of_measurement: kWh
-        value_template: {{ states('sensor.daily_power_offpeak')|float + states('sensor.daily_power_peak')|float }}
+        value_template: "{{ states('sensor.daily_power_offpeak')|float + states('sensor.daily_power_peak')|float }}"
       monthly_power:
         friendly_name: Monthly Power
-        icon: mdi:counter
         unit_of_measurement: kWh
-        value_template: {{ states('sensor.monthly_power_offpeak')|float + states('sensor.monthly_power_peak')|float }}
+        value_template: "{{ states('sensor.monthly_power_offpeak')|float + states('sensor.monthly_power_peak')|float }}"
 ```
 {% endraw %}


### PR DESCRIPTION
Hi, 

I was adding the last part of this page to my Home Assistant installation. 
Icon was not allowed, and the value must between quotes.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10175"><img src="https://gitpod.io/api/apps/github/pbs/github.com/pdeelen/home-assistant.io.git/2c385d2c19dde0b4604ed3287430dd8be72d4d51.svg" /></a>

