### PR TITLE
Add inverted RFLink cover description

### DIFF
--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -67,6 +67,7 @@ cover:
       bofumotor_455201_0f: {}
 ```
 
+
 {% configuration %}
 device_defaults:
   description: The defaults for the devices.
@@ -124,7 +125,13 @@ devices:
           description: The `aliases` which do not respond to group commands.
           required: false
           type: [list, string]
+        type:
+          description: Set to 'standard' or 'inverted'. 'inverted' will invert the on/off commands sent to the RFLink device, 'standard' will not invert the on/off commands sent to the RFLink device. When omitted, the commands to the RFLink device will be inverted if the ID of the device starts with 'newkaku'.
+          required: false
+          default: 
+          type: string
 {% endconfiguration %}
+
 
 ### Setting up a KAKU ASUN-650 device
 

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -163,6 +163,7 @@ cover:
       nonkaku_yyyyyyyy_z:
         name: non_kaku_not_inverted_by_default
 ```
+
 The configuration above shows that the `type` property may be omitted. When the ID starts with `newkaku`, the component will make sure that the on and off commands are inverted. When the ID does not start with `newkaku`, the on and off commands are not inverted. 
 
 ### Device support

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -124,7 +124,7 @@ devices:
           required: false
           type: [list, string]
         type:
-          description: Set to `standard` or `inverted`. `inverted` will invert the on/off commands sent to the RFLink device, `standard` will not invert the on/off commands sent to the RFLink device. When omitted, the commands to the RFLink device will be inverted if the ID of the device starts with 'newkaku'.
+          description: Set to `inverted` to invert the on/off command and set to `standard` to not invert the on/off command sent to the RFLink device.
           required: false
           default: 
           type: string

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -7,7 +7,6 @@ ha_category:
 ha_release: 0.55
 ---
 
-
 The `rflink` integration supports devices that use [RFLink gateway firmware](http://www.nemcon.nl/blog2/), for example the [Nodo RFLink Gateway](https://www.nodo-shop.nl/nl/21-rflink-gateway). RFLink gateway is an Arduino firmware that allows two-way communication with a multitude of RF wireless devices using cheap hardware (Arduino + transceiver).
 
 First, you have to set up your [RFLink hub](/components/rflink/).
@@ -66,7 +65,6 @@ cover:
       RTS_0100F2_0: {}
       bofumotor_455201_0f: {}
 ```
-
 
 {% configuration %}
 device_defaults:
@@ -131,7 +129,6 @@ devices:
           default: 
           type: string
 {% endconfiguration %}
-
 
 ### Setting up a KAKU ASUN-650 device
 

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -124,7 +124,7 @@ devices:
           required: false
           type: [list, string]
         type:
-          description: Set to 'standard' or 'inverted'. 'inverted' will invert the on/off commands sent to the RFLink device, 'standard' will not invert the on/off commands sent to the RFLink device. When omitted, the commands to the RFLink device will be inverted if the ID of the device starts with 'newkaku'.
+          description: Set to `standard` or `inverted`. `inverted` will invert the on/off commands sent to the RFLink device, `standard` will not invert the on/off commands sent to the RFLink device. When omitted, the commands to the RFLink device will be inverted if the ID of the device starts with 'newkaku'.
           required: false
           default: 
           type: string
@@ -135,6 +135,7 @@ devices:
 In RFLink, the ON and DOWN command are used to close the cover and the OFF and UP command are used to open the cover. The KAKU (COCO) ASUN-650 works the other way around, it uses the ON command to open the cover and the OFF command to close the cover.
 
 The RFLink cover device has a property named `type` that takes 2 values:
+
 - standard: Do not invert the on/off commands sent to the RFLink device.
 - inverted: Invert the on/off commands sent to the RFLink device.
 

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -136,8 +136,8 @@ In RFLink, the ON and DOWN command are used to close the cover and the OFF and U
 
 The RFLink cover device has a property named `type` that takes 2 values:
 
-- standard: Do not invert the on/off commands sent to the RFLink device.
-- inverted: Invert the on/off commands sent to the RFLink device.
+- `standard`: Do not invert the on/off commands sent to the RFLink device.
+- `inverted`: Invert the on/off commands sent to the RFLink device.
 
 The following configuration example shows how to use the `type` property:
 

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -124,7 +124,7 @@ devices:
           required: false
           type: [list, string]
         type:
-          description: Set to `inverted` to invert the on/off command and set to `standard` to not invert the on/off command sent to the RFLink device.
+          description: The option to invert (`inverted`) on/off commands sent to the RFLink device or not (`standard`).
           required: false
           default: 
           type: string

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -137,7 +137,7 @@ The following configuration example shows how to use the `type` property:
 ```yaml
 # Example configuration.yaml entry that shows how to
 # use the type property.
-cover rflink:
+cover:
   - platform: rflink
     device_defaults:
       fire_event: false

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -128,7 +128,9 @@ devices:
 
 ### Setting up a KAKU ASUN-650 device
 
-In RFLink, the ON and DOWN command are used to close the cover and the OFF and UP command are used to open the cover. The KAKU (COCO) ASUN-650 works the other way around, it uses the ON command to open the cover and the OFF command to close the cover. The RFLink cover component has an extra property named `type` that takes 2 values:
+In RFLink, the ON and DOWN command are used to close the cover and the OFF and UP command are used to open the cover. The KAKU (COCO) ASUN-650 works the other way around, it uses the ON command to open the cover and the OFF command to close the cover.
+
+The RFLink cover device has a property named `type` that takes 2 values:
 - standard: Do not invert the on/off commands sent to the RFLink device.
 - inverted: Invert the on/off commands sent to the RFLink device.
 
@@ -139,8 +141,6 @@ The following configuration example shows how to use the `type` property:
 # use the type property.
 cover:
   - platform: rflink
-    device_defaults:
-      fire_event: false
     devices:
       newkaku_xxxxxxxx_x:
         name: kaku_inverted_by_type

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -1,6 +1,6 @@
 ---
 title: "RFLink Cover"
-description: "Instructions on how to integrate RFLink Somfy RTS Cover into Home Assistant."
+description: "Instructions on how to integrate RFLink Somfy RTS and KAKU ASUN-650 covers into Home Assistant."
 logo: rflink.png
 ha_category:
   - Cover
@@ -125,6 +125,41 @@ devices:
           required: false
           type: [list, string]
 {% endconfiguration %}
+
+### Setting up a KAKU ASUN-650 device
+
+In RFLink, the ON and DOWN command are used to close the cover and the OFF and UP command are used to open the cover. The KAKU (COCO) ASUN-650 works the other way around, it uses the ON command to open the cover and the OFF command to close the cover. The RFLink cover component has an extra property named `type` that takes 2 values:
+- standard: Do not invert the on/off commands sent to the RFLink device.
+- inverted: Invert the on/off commands sent to the RFLink device.
+
+The following configuration example shows how to use the `type` property:
+
+```yaml
+# Example configuration.yaml entry that shows how to
+# use the type property.
+cover rflink:
+  - platform: rflink
+    device_defaults:
+      fire_event: false
+    devices:
+      newkaku_xxxxxxxx_x:
+        name: kaku_inverted_by_type
+        type: inverted
+      newkaku_xxxxxxxx_y:
+        name: kaku_not_inverted_by_type
+        type: standard
+      newkaku_xxxxxxxx_z:
+        name: kaku_inverted_by_default
+      nonkaku_yyyyyyyy_x:
+        name: non_kaku_inverted_by_type
+        type: inverted
+      nonkaku_yyyyyyyy_y:
+        name: non_kaku_not_inverted_by_type
+        type: standard
+      nonkaku_yyyyyyyy_z:
+        name: non_kaku_not_inverted_by_default
+```
+The configuration above shows that the `type` property may be omitted. When the ID starts with `newkaku`, the component will make sure that the on and off commands are inverted. When the ID does not start with `newkaku`, the on and off commands are not inverted. 
 
 ### Device support
 

--- a/source/_components/cover.rflink.markdown
+++ b/source/_components/cover.rflink.markdown
@@ -126,7 +126,6 @@ devices:
         type:
           description: The option to invert (`inverted`) on/off commands sent to the RFLink device or not (`standard`).
           required: false
-          default: 
           type: string
 {% endconfiguration %}
 


### PR DESCRIPTION
This documentation is required when PR #26038 is merged.

**Description:**
Added a section about the KAKU ASUN-650 (an 'inverted' RFLink cover) to the documentation.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26038

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10177"><img src="https://gitpod.io/api/apps/github/pbs/github.com/fmartens/home-assistant.io.git/1c4258c35d38ec319d9e19736ab5ebd764ec36e0.svg" /></a>

