### PR TITLE
🚧 Add remove warning for edp_redy integration

### DIFF
--- a/source/_components/edp_redy.markdown
+++ b/source/_components/edp_redy.markdown
@@ -13,6 +13,12 @@ redirect_from:
   - /components/switch.edp_redy/
 ---
 
+<div class='note warning'>
+
+  The API of this integration has been stopped and will therefore be removed in a future release. See also [this pull request](https://github.com/home-assistant/home-assistant/pull/25971)
+
+</div>
+
 [EDP re:dy](https://www.edp.pt/particulares/servicos/redy/) is a Home Automation platform from Portuguese energy provider EDP, that allows control of appliances and other devices, as well as monitoring power consumption. This integration allows integrating EDP re:dy into Home Assistant.
 
 ## Configuration


### PR DESCRIPTION
**Description:**
Given this [PR](https://github.com/home-assistant/home-assistant/pull/25971), the integration will be removed in release 0.98, which is why I now include a warning note.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10178"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/c156f02a9955ce40d256cc43827d4cf0b75c3a02.svg" /></a>

