### PR TITLE
Add descriptive fields to script documentation

### DIFF
--- a/source/_components/script.markdown
+++ b/source/_components/script.markdown
@@ -34,6 +34,7 @@ script: 
   # Turns on the bedroom lights and then the living room lights 1 minute later
   wakeup:
     alias: Wake Up
+    description: 'Turns on the bedroom lights and then the living room lights 1 minute later'
     sequence:
       # This is Home Assistant Script Syntax
       - event: LOGBOOK_ENTRY
@@ -102,6 +103,14 @@ Using the variables in the script requires the use of `data_template`:
 # Example configuration.yaml entry
 script:
   notify_pushover:
+    description: 'Send a pushover notification'
+    fields:
+      title:
+        description: 'The title of the notification'
+        example: 'State change'
+      message:
+        description: 'The message content'
+        example: 'The light is on!'
     sequence:
       - condition: state
         entity_id: switch.pushover_notifications

--- a/source/_components/script.markdown
+++ b/source/_components/script.markdown
@@ -53,7 +53,10 @@ fields:
       keys:
         description:
           description: A description of PARAMETER_NAME.
-          example: An example value for PARAMETER_NAME.      
+          type: string
+        example:
+          description: An example value for PARAMETER_NAME.
+          type: string
 sequence:
   description: The sequence of actions to be performed in the script.
   required: true

--- a/source/_components/script.markdown
+++ b/source/_components/script.markdown
@@ -31,7 +31,6 @@ Script names (e.g., `message_temperature` in the example above) are not allowed 
 
 ```yaml
 script: 
-  # Turns on the bedroom lights and then the living room lights 1 minute later
   wakeup:
     alias: Wake Up
     description: 'Turns on the bedroom lights and then the living room lights 1 minute later'

--- a/source/_components/script.markdown
+++ b/source/_components/script.markdown
@@ -10,6 +10,8 @@ ha_release: 0.7
 
 The `script` integration allows users to specify a sequence of actions to be executed by Home Assistant when turned on. The script integration will create an entity for each script and allow them to be controlled via services.
 
+## Configuration
+
 The sequence of actions is specified using the [Home Assistant Script Syntax](/getting-started/scripts/).
 
 ```yaml
@@ -29,11 +31,46 @@ Script names (e.g., `message_temperature` in the example above) are not allowed 
 
 </div>
 
+{% configuration %}
+alias:
+  description: Friendly name for the script.
+  required: false
+  type: string
+description:
+  description: A description of the script that will be displayed in the Services tab under Developer Tools.
+  required: false
+  default: ''
+  type: string
+fields:
+  description: Information about the parameters that the script uses; see the [Passing variables to scripts](#passing-variables-to-scripts) section below.
+  required: false
+  default: {}
+  type: map
+  keys:
+    PARAMETER_NAME:
+      description: A parameter used by this script.
+      type: map
+      keys:
+        description:
+          description: A description of PARAMETER_NAME.
+          example: An example value for PARAMETER_NAME.      
+sequence:
+  description: The sequence of actions to be performed in the script.
+  required: true
+  type: list
+{% endconfiguration %}
+
+### Full Configuration
+
 ```yaml
 script: 
   wakeup:
     alias: Wake Up
-    description: 'Turns on the bedroom lights and then the living room lights 1 minute later'
+    description: 'Turns on the bedroom lights and then the living room lights after a delay'
+    fields:
+      minutes:
+        description: 'The amount of time to wait before turning on the living room lights'
+        example: 1
     sequence:
       # This is Home Assistant Script Syntax
       - event: LOGBOOK_ENTRY
@@ -49,7 +86,7 @@ script: 
           brightness: 100
       - delay:
           # supports seconds, milliseconds, minutes, hours
-          minutes: 1
+          minutes: {{ minutes }}
       - alias: Living room lights on
         service: light.turn_on
         data:


### PR DESCRIPTION
**Description:**

Add descriptive fields to script documentation

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/26056

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10180"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JeffLIrion/home-assistant.io.git/f9c0c51c13da8381ebe6cb899ccf9f043e503679.svg" /></a>

