### PR TITLE
✨ Troubleshooting automation page back in menu

### DIFF
--- a/source/_includes/asides/docs_navigation.html
+++ b/source/_includes/asides/docs_navigation.html
@@ -61,6 +61,7 @@
           <li>{% active_link /docs/automation/condition/ Conditions %}</li>
           <li>{% active_link /docs/automation/action/ Actions %}</li>
           <li>{% active_link /docs/automation/templating/ Templates %}</li>
+          <li>{% active_link /docs/automation/troubleshooting/ Troubleshooting %}</li>
         </ul>
       </li>
       <li>


### PR DESCRIPTION
**Description:**
The automation troubleshooting file has been around for a long time, but for unknown reason the file path was no longer present in the index of the menu, therefore added again.

PR that will add more info: #9767 

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10185"><img src="https://gitpod.io/api/apps/github/pbs/github.com/home-assistant/home-assistant.io.git/64f29186b7a19a8a49f5142a7cc0bee18f0e584d.svg" /></a>

