### PR TITLE
Document user-provided services.yaml file

### DIFF
--- a/source/_components/python_script.markdown
+++ b/source/_components/python_script.markdown
@@ -46,7 +46,6 @@ The following example shows how to call a service from `python_script`. This scr
 
 ```python
 # turn_on_light.py
-
 entity_id = data.get('entity_id')
 rgb_color = data.get('rgb_color', [255, 255, 255])
 if entity_id is not None:
@@ -65,7 +64,6 @@ You can add descriptions for your Python scripts that will be shown in the Call 
 
 ```yaml
 # services.yaml
-
 turn_on_light:
   description: Turn on a light and set its color. 
   fields:

--- a/source/_components/python_script.markdown
+++ b/source/_components/python_script.markdown
@@ -45,6 +45,8 @@ hass.bus.fire(name, { "wow": "from a Python script!" })
 The following example shows how to call a service from `python_script`. This script takes two parameters: `entity_id` (required), `rgb_color` (optional) and calls `light.turn_on` service by setting the brightness value to `255`.
 
 ```python
+# turn_on_light.py
+
 entity_id = data.get('entity_id')
 rgb_color = data.get('rgb_color', [255, 255, 255])
 if entity_id is not None:
@@ -55,6 +57,24 @@ The above `python_script` can be called using the following JSON as an input.
 
 ```json
 {"entity_id": "light.bedroom", "rgb_color": [255, 0, 0] }
+```
+
+## Documenting your Python scripts
+
+You can add descriptions for your Python scripts that will be shown in the Call Services tab of the Developer Options page. To do so, simply create a `services.yaml` file in your `<config>/python_scripts` folder. Using the above Python script as an example, the `services.yaml` file would look like:
+
+```yaml
+# services.yaml
+
+turn_on_light:
+  description: Turn on a light and set its color. 
+  fields:
+    entity_id:
+      description: The light that will be turned on.
+      example: light.bedroom
+    rgb_color:
+      description: The color to which the light will be set.
+      example: [255, 0, 0]
 ```
 
 For more examples, visit the [Scripts section](https://community.home-assistant.io/c/projects/scripts) in our forum.


### PR DESCRIPTION
**Description:**

Provide an example of a user-provided services.yaml file that documents a `python_script`. 

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/26069

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10186"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JeffLIrion/home-assistant.io.git/2f34504c5b15be21b6ff65db624bfb142b5d59a6.svg" /></a>

