### PR TITLE
Update docs for new alarmdecoder keypress feature

### DIFF
--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -138,7 +138,7 @@ The Alarm Decoder integration gives you access to several services for you to co
 - `alarm_arm_home`: Arms the alarm in stay mode; faults to the doors or windows will trigger the alarm.
 - `alarm_arm_night`: Arms the alarm in instant mode; all faults will trigger the alarm. Additionally, the entry delay is turned off on the doors.
 - `alarm_disarm`: Disarms the alarm from any state. Also clears a `check_zone` flag after an alarm was triggered.
-- `alarmdecoder_alarm_keypress`: Sends a string of characters to the alarm, as if you had touched those keys on a keypad.
+- `alarmdecoder.alarm_keypress`: Sends a string of characters to the alarm, as if you had touched those keys on a keypad.
 - `alarmdecoder_alarm_toggle_chime`: Toggles the alarm's chime state.
 
 <div class='note'>

--- a/source/_components/alarmdecoder.markdown
+++ b/source/_components/alarmdecoder.markdown
@@ -138,6 +138,7 @@ The Alarm Decoder integration gives you access to several services for you to co
 - `alarm_arm_home`: Arms the alarm in stay mode; faults to the doors or windows will trigger the alarm.
 - `alarm_arm_night`: Arms the alarm in instant mode; all faults will trigger the alarm. Additionally, the entry delay is turned off on the doors.
 - `alarm_disarm`: Disarms the alarm from any state. Also clears a `check_zone` flag after an alarm was triggered.
+- `alarmdecoder_alarm_keypress`: Sends a string of characters to the alarm, as if you had touched those keys on a keypad.
 - `alarmdecoder_alarm_toggle_chime`: Toggles the alarm's chime state.
 
 <div class='note'>


### PR DESCRIPTION
**Description:**
Straightforward doc update for adding a new service to the `alarmdecoder` component. Docs are modeled after the docs for the equivalent service on the `envisalink` component, though this one (to my knowledge) does not have a character limit.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26100

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10195"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jkeljo/home-assistant.github.io.git/7056a833cb670deaf0853de0c9593a8f50941587.svg" /></a>

