### PR TITLE
Remove GitPod badge from PR's

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,5 +11,5 @@ github:
     pullRequestsFromForks: true
     addCheck: true
     addComment: false
-    addBadge: true
+    addBadge: false
     addLabel: false


### PR DESCRIPTION
**Description:**

Removed the GitPod badge that gets added to every single PR.
The build status remains.

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
