### PR TITLE
CoolMaster: Change auto to heat_cool

### DIFF
--- a/source/_components/coolmaster.markdown
+++ b/source/_components/coolmaster.markdown
@@ -44,8 +44,8 @@ supported_modes:
       description: Heat mode.
     cool:
       description: Cool mode.
-    auto:
-      description: Auto mode.
+    heat_cool:
+      description: Heat/Cool mode (CoolMasterNet refers to it as Auto).
     dry:
       description: Dry mode.
     fan_only:


### PR DESCRIPTION
**Description:**

Changing the `auto` mode to a `heat_cool` mode in CoolMaster to better reflect what it does.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26144

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10209"><img src="https://gitpod.io/api/apps/github/pbs/github.com/OnFreund/home-assistant.io.git/8b00d8d9b7aca17c2affdfb28639e0e03e7b6fb0.svg" /></a>

