### PR TITLE
Remove reference to removed zwave update_config

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -27,7 +27,7 @@ network_key:
   type: string
   default: None
 config_path:
-  description: "The path to the Python OpenZWave configuration files.
+  description: The path to the Python OpenZWave configuration files.
   required: false
   type: string
   default: the 'config' that is installed by python-openzwave

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -27,7 +27,7 @@ network_key:
   type: string
   default: None
 config_path:
-  description: "The path to the Python OpenZWave configuration files. NOTE: there is also the [update_config service](/docs/z-wave/services/) to perform updating the config within python-openzwave automatically."
+  description: "The path to the Python OpenZWave configuration files.
   required: false
   type: string
   default: the 'config' that is installed by python-openzwave


### PR DESCRIPTION
Remove reference to zwave `update_config` service, which has been removed.

**Description:**
An additional doc update to the one made in #10139. Searched the project and didn't find any other references.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#25959
## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10210"><img src="https://gitpod.io/api/apps/github/pbs/github.com/kpine/home-assistant.io.git/3cd2d0af957aecf97b5902067cdb49099e12a558.svg" /></a>

