### PR TITLE
Remove 'stopped' as a valid state for 'state_detection_rules'

### DIFF
--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -261,7 +261,7 @@ You can also use the command `GET_PROPERTIES` to retrieve the properties used by
 
 The `state_detection_rules` configuration parameter allows you to provide your own rules for state detection.  The keys are app IDs, and the values are lists of rules that are evaluated in order.  Valid rules are:
 
-* `'standby'`, `'playing'`, `'paused'`, `'idle'`, `'stopped'`, or `'off'`
+* `'standby'`, `'playing'`, `'paused'`, `'idle'`, or `'off'`
   * If this is not a map, then this state will always be reported when this app is the current app
   * If this is a map, then its entries are conditions that will be checked.  If all of the conditions are true, then this state will be reported.  Valid conditions pertain to 3 properties (see the example configuration above):
     1. ``'media_session_state'``

--- a/source/_components/python_script.markdown
+++ b/source/_components/python_script.markdown
@@ -45,6 +45,7 @@ hass.bus.fire(name, { "wow": "from a Python script!" })
 The following example shows how to call a service from `python_script`. This script takes two parameters: `entity_id` (required), `rgb_color` (optional) and calls `light.turn_on` service by setting the brightness value to `255`.
 
 ```python
+# turn_on_light.py
 entity_id = data.get('entity_id')
 rgb_color = data.get('rgb_color', [255, 255, 255])
 if entity_id is not None:
@@ -55,6 +56,23 @@ The above `python_script` can be called using the following JSON as an input.
 
 ```json
 {"entity_id": "light.bedroom", "rgb_color": [255, 0, 0] }
+```
+
+## Documenting your Python scripts
+
+You can add descriptions for your Python scripts that will be shown in the Call Services tab of the Developer Options page. To do so, simply create a `services.yaml` file in your `<config>/python_scripts` folder. Using the above Python script as an example, the `services.yaml` file would look like:
+
+```yaml
+# services.yaml
+turn_on_light:
+  description: Turn on a light and set its color. 
+  fields:
+    entity_id:
+      description: The light that will be turned on.
+      example: light.bedroom
+    rgb_color:
+      description: The color to which the light will be set.
+      example: [255, 0, 0]
 ```
 
 For more examples, visit the [Scripts section](https://community.home-assistant.io/c/projects/scripts) in our forum.


### PR DESCRIPTION
**Description:**

Removes `'stopped'` as a valid state for `'state_detection_rules'`.

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/26158

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10212"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JeffLIrion/home-assistant.io.git/9b9d946d5d8f4adb3259e868101d2c3e9b185367.svg" /></a>

