### PR TITLE
Documents rest_command header templates usage

### DIFF
--- a/source/_integrations/rest_command.markdown
+++ b/source/_integrations/rest_command.markdown
@@ -31,7 +31,7 @@ service_name:
     url:
       description: The URL (supports template) for sending request.
       required: true
-      type: [string, template]
+      type: template
     method:
       description: HTTP method to use (get, patch, post, put, or delete).
       required: false
@@ -44,7 +44,7 @@ service_name:
     payload:
       description: A string/template to send with request.
       required: false
-      type: [string, template]
+      type: template
     username:
       description: The username for HTTP authentication.
       required: false
@@ -83,6 +83,7 @@ rest_command:
     headers:
       authorization: !secret rest_headers_secret
       accept: 'application/json, text/html'
+      user-agent: 'Mozilla/5.0 {{ useragent }}'
     payload: '{"profile":{"status_text": "{{ status }}","status_emoji": "{{ emoji }}"}}'
     content_type:  'application/json; charset=utf-8'
     verify_ssl: true


### PR DESCRIPTION
**Description:**
Adds example for templates usage in rest_command headers.

**Pull request in home-assistant:** home-assistant/home-assistant#26099

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10213"><img src="https://gitpod.io/api/apps/github/pbs/github.com/PedroLamas/home-assistant.io.git/15ab03ffdb71470b6588f33df7efae724340cbea.svg" /></a>

