### PR TITLE
With hass.io no need for additional packages

### DIFF
--- a/source/_components/fritz.markdown
+++ b/source/_components/fritz.markdown
@@ -15,7 +15,7 @@ The `fritz` platform offers presence detection by looking at connected devices t
 ## Setup
 
 <div class='note warning'>
-It might be necessary to install additional packages: <code>sudo apt-get install python3-lxml libxslt-dev libxml2-dev zlib1g-dev</code>
+If not running Hass.io it might be necessary to install additional packages: <code>sudo apt-get install python3-lxml libxslt-dev libxml2-dev zlib1g-dev</code>
 If you installed Home Assistant in a virtualenv, run the following commands inside it: <code>pip3 install lxml</code>; be patient this will take a while.</div>
 
 ## Configuration


### PR DESCRIPTION
Installed the Fritz!Box device tracker today on Hass.io without the need to install additional packages.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10215"><img src="https://gitpod.io/api/apps/github/pbs/github.com/gerard33/home-assistant.github.io.git/6d146be1e5bd4e5d15e21414031fc3b4a298d7a9.svg" /></a>

