### PR TITLE
Clarify device blocking functionality

### DIFF
--- a/source/_components/unifi.markdown
+++ b/source/_components/unifi.markdown
@@ -54,7 +54,7 @@ site:
   required: true
   default: None
 block_client:
-  description: Clients that can be blocked from the network
+  description: A list of Clients MAC Addresses that can be blocked from the network
   type: list
   required: false
   default: None
@@ -96,7 +96,7 @@ If Home Assistant and the UniFi controller are running on separate machines or V
 
 ### Block network access for clients
 
-Allow control of network access to clients configured in `configuration.yaml`
+Allow control of network access to clients configured in `configuration.yaml` by adding a list of the MAC addresses. Items in this list will have a Home Assistant Switch created, using the Unifi Device name, allowing for blocking and unblocking.
 
 ### Control clients powered by POE
 

--- a/source/_components/unifi.markdown
+++ b/source/_components/unifi.markdown
@@ -44,17 +44,17 @@ unifi:
 
 {% configuration %}
 host:
-  description: Same address as relevant config entry, needed to identify config entry
+  description: Same address as relevant config entry, needed to identify config entry.
   type: string
   required: true
   default: None
 site:
-  description: Same site as relevant config entry, needed to identify config entry
+  description: Same site as relevant config entry, needed to identify config entry.
   type: string
   required: true
   default: None
 block_client:
-  description: A list of Clients MAC Addresses that can be blocked from the network
+  description: A list of Clients MAC Addresses that can be blocked from the network.
   type: list
   required: false
   default: None
@@ -96,7 +96,7 @@ If Home Assistant and the UniFi controller are running on separate machines or V
 
 ### Block network access for clients
 
-Allow control of network access to clients configured in `configuration.yaml` by adding a list of the MAC addresses. Items in this list will have a Home Assistant Switch created, using the Unifi Device name, allowing for blocking and unblocking.
+Allow control of network access to clients configured in the `configuration.yaml` file by adding a list of the MAC addresses. Items in this list will have a Home Assistant switch created, using the Unifi Device name, allowing for blocking and unblocking.
 
 ### Control clients powered by POE
 


### PR DESCRIPTION
The Unifi Device Tracker documentation did not clearly explain that you had to use MAC addresses to allow for blocking/unblocking clients.

## Checklist:

- [ X ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ X ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10217"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Lopton/home-assistant.io.git/10a5495b8e3989a9a346a7e7a53398e357e424f4.svg" /></a>

