### PR TITLE
correct the quotes in continue_on_timeout: 'false'

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -132,7 +132,7 @@ You can also get the script to abort after the timeout by using `continue_on_tim
 # Wait until a valve is < 10 or abort after 1 minute.
 - wait_template: "{{ state_attr('climate.kitchen', 'valve')|int < 10 }}"
   timeout: '00:01:00'
-  continue_on_timeout: 'false'
+  continue_on_timeout: false
 ```
 {% endraw %}
 


### PR DESCRIPTION
[docs ](https://www.home-assistant.io/docs/scripts/#wait) show` continue_on_timeout: 'false'` while this doesn't stop the script from continuing. using `continue_on_timeout: false` does work correctly, so the quotes should be taken out on the false.
haven't tested this on the continue_on_timeout: 'true', but figure that to be the same. (I won't PR that just yet, just to be 100% sure)

posted on this in the community on https://community.home-assistant.io/t/script-help-wait-template-and-proceed-after-x-minute/56158/12?u=mariusthvdb

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html