### PR TITLE
Information about notification

### DIFF
--- a/source/_components/webostv.markdown
+++ b/source/_components/webostv.markdown
@@ -23,7 +23,7 @@ There is currently support for the following device types within Home Assistant:
 
 To begin with enable *LG Connect Apps* feature in *Network* settings of the TV [instructions](http://www.lg.com/uk/support/product-help/CT00008334-1437131798537-others).
 
-Once basic configuration is added to your `configuration.yaml` *Configuration* card should prompt on your Home Assistants's states. Follow the instructions and accept pairing request on your TV.
+Once basic configuration is added to your `configuration.yaml` A notification should be visible in Lovelace, Follow the instructions and accept pairing request on your TV.
 
 Pairing information will be saved to the `filename:` provided in configuration. This process is IP sensitive, in case the IP address of your TV would change in future.
 

--- a/source/_components/webostv.markdown
+++ b/source/_components/webostv.markdown
@@ -23,9 +23,9 @@ There is currently support for the following device types within Home Assistant:
 
 To begin with enable *LG Connect Apps* feature in *Network* settings of the TV [instructions](http://www.lg.com/uk/support/product-help/CT00008334-1437131798537-others).
 
-Once basic configuration is added to your `configuration.yaml` A notification should be visible in Lovelace, Follow the instructions and accept pairing request on your TV.
+Once basic configuration is added to your `configuration.yaml` file. A notification should be visible in the frontend's **Notification** section. Follow the instructions and accept the pairing request on your TV.
 
-Pairing information will be saved to the `filename:` provided in configuration. This process is IP sensitive, in case the IP address of your TV would change in future.
+Pairing information will be saved to the `filename:` provided in the configuration. This process is IP address-sensitive, in case the IP address of your TV would change in future.
 
 ### Configuration
 


### PR DESCRIPTION
The pairing info now appears as a lovelace notification, not a state popupcard.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
