### PR TITLE
Updated phrasing of warning note

### DIFF
--- a/source/_components/googlehome.markdown
+++ b/source/_components/googlehome.markdown
@@ -14,7 +14,7 @@ redirect_from:
 
 <div class='note warning'>
 
-  For a couple of weeks / months this integration is broken, therefore it will be removed in the future according to [this pull request](https://github.com/home-assistant/home-assistant/pull/26035).
+  This integration is currently broken and will be removed in a future version of home assistant. See [this pull request](https://github.com/home-assistant/home-assistant/pull/26035) for more information. As an alternative to the device tracking features of this component check out [this thread in the home assistant community forums](https://community.home-assistant.io/t/monitor-reliable-multi-user-distributed-bluetooth-occupancy-presence-detection/68505). No alternatives for the alarm tracking features of this component are known at this time.
 
 </div>
 


### PR DESCRIPTION
Made the phrasing of the warning note more clear of exactly what is happening, and added link to alternative options to user.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
