### PR TITLE
Add info about nightlight switch

### DIFF
--- a/source/_components/yeelight.markdown
+++ b/source/_components/yeelight.markdown
@@ -74,7 +74,7 @@ devices:
           type: boolean
           default: false
         nightlight_switch_type:
-          description: Adds another entity, to control nightlight mode (for models that supports it). Currently only `light` is supported. It will create 2 light entities, one for normal light mode and second for nightlight mode. They are mutually exclusive.
+          description: Adds another entity, to control nightlight mode (for models that supports it). Currently, only `light` is supported. It will create 2 light entities, one for normal light mode and second for nightlight mode. They are mutually exclusive.
           required: false
           type: string
         model:

--- a/source/_components/yeelight.markdown
+++ b/source/_components/yeelight.markdown
@@ -73,6 +73,10 @@ devices:
           required: false
           type: boolean
           default: false
+        nightlight_switch_type:
+          description: Adds another entity, to control nightlight mode (for models that supports it). Currently only `light` is supported. It will create 2 light entities, one for normal light mode and second for nightlight mode. They are mutually exclusive.
+          required: false
+          type: string
         model:
           description: "Yeelight model. Possible values are `mono1`, `color1`, `color2`, `strip1`, `bslamp1`, `ceiling1`, `ceiling2`, `ceiling3`, `ceiling4`. The setting is used to enable model specific features f.e. a particular color temperature range."
           required: false


### PR DESCRIPTION
**Description:**
Add info yeelight about nightlight_switch_type option.

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/26224

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10242"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zewelor/home-assistant.io.git/88b9c3b736a7d20cad701e5ed92af47cce635a22.svg" /></a>

