### PR TITLE
Document 'name' config parameter in rejseplanen

### DIFF
--- a/source/_components/rejseplanen.markdown
+++ b/source/_components/rejseplanen.markdown
@@ -54,7 +54,7 @@ stop_id:
   required: true
   type: string
 name:
-  description: The name of the sensor. Entity ID for the sensor will be created based on this name. Example - Glostrup St becomes sensor.glostrup_st. It is optional but recommended if you define more than one sensor
+  description: The name of the sensor. Entity ID for the sensor will be created based on this name. Example - Glostrup St becomes sensor.glostrup_st. It's optional but recommended if you define more than one sensor.
   required: false
   type: string
   default: next_departure

--- a/source/_components/rejseplanen.markdown
+++ b/source/_components/rejseplanen.markdown
@@ -54,10 +54,10 @@ stop_id:
   required: true
   type: string
 name:
-  description: The name of the sensor. Entity ID for the sensor will be created based on this name. Example - Glostrup St becomes sensor.glostrup_st. It's optional but recommended if you define more than one sensor.
+  description: "The name of the sensor. Entity ID for the sensor will be created based on this name. E.g., Glostrup St becomes `sensor.glostrup_st`. It's optional but recommended if you define more than one sensor."
   required: false
   type: string
-  default: next_departure
+  default: "Next departure"
 route:
   description: List of route names.
   required: false

--- a/source/_components/rejseplanen.markdown
+++ b/source/_components/rejseplanen.markdown
@@ -45,6 +45,7 @@ Add a sensor to your `configuration.yaml` file as shown in the example:
 # Example configuration.yaml entry
 sensor:
   - platform: rejseplanen
+    name: 'Bus Stop Name'
     stop_id: 'YOUR_STOP_ID'
 ```
 
@@ -53,6 +54,11 @@ stop_id:
   description: The ID of the public transport stop.
   required: true
   type: string
+name:
+  description: The name of the sensor. Entity ID for the sensor will be created based on this name. Example - Glostrup St becomes sensor.glostrup_st. It is optional but recommended if you define more than one sensor
+  required: false
+  type: string
+  default: next_departure
 route:
   description: List of route names.
   required: false
@@ -105,6 +111,7 @@ A more extensive example on how to use this sensor:
 # Example configuration.yaml entry
 sensor:
   - platform: rejseplanen
+    name:'Elmegade 350S'
     stop_id: '000045740'
     route: 'Bus 350S'
     direction:

--- a/source/_components/rejseplanen.markdown
+++ b/source/_components/rejseplanen.markdown
@@ -45,7 +45,6 @@ Add a sensor to your `configuration.yaml` file as shown in the example:
 # Example configuration.yaml entry
 sensor:
   - platform: rejseplanen
-    name: 'Bus Stop Name'
     stop_id: 'YOUR_STOP_ID'
 ```
 

--- a/source/_components/rejseplanen.markdown
+++ b/source/_components/rejseplanen.markdown
@@ -110,7 +110,7 @@ A more extensive example on how to use this sensor:
 # Example configuration.yaml entry
 sensor:
   - platform: rejseplanen
-    name:'Elmegade 350S'
+    name: 'Elmegade 350S'
     stop_id: '000045740'
     route: 'Bus 350S'
     direction:


### PR DESCRIPTION
Document the undocumented but fully working name config. This is an optional config but essential to know to define more than one instance of the rejseplanen sensor and getting a predictable result. Otherwise the sensor name defaults to sensor.next_departure_# and the numbers can swap around after an HA restart

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
