### PR TITLE
Fix dead link

### DIFF
--- a/source/_docs/ecosystem/notebooks/database.markdown
+++ b/source/_docs/ecosystem/notebooks/database.markdown
@@ -4,4 +4,4 @@ description: "Accessing the Home-Assistant database from a Jupyter notebook."
 redirect_from: /ecosystem/notebooks/database/
 ---
 
-You can directly access the Home-Assistant database from Jupyter notebooks. The [Database example](http://nbviewer.jupyter.org/github/home-assistant/home-assistant-notebooks/blob/master/database-examples.ipynb) shows you how you can work with stored database values.
+You can directly access the Home-Assistant database from Jupyter notebooks. The [Database example](https://nbviewer.jupyter.org/github/home-assistant/home-assistant-notebooks/blob/master/other/database-examples.ipynb) shows you how you can work with stored database values.


### PR DESCRIPTION
**Description:**

Link to `nbviewer.jupyter.org` was dead after an apparent refactoring effort on the repository.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
