### PR TITLE
Update arp_ping default value

### DIFF
--- a/source/_components/mikrotik.markdown
+++ b/source/_components/mikrotik.markdown
@@ -18,7 +18,7 @@ There is currently support for the following device types within Home Assistant:
 
 ## Configuring `mikrotik` hub
 
-You have to enable accessing the RouterOS API on your router to use this platform.
+As of version 0.98 the Mikrotik component uses a Hub component. To use you have to enable accessing the RouterOS API on your router to use this platform.
 
 Terminal:
 
@@ -80,7 +80,7 @@ method:
 arp_ping:
   description: Use ARP ping with DHCP method for device scanning.
   required: false
-  default: false
+  default: true
   type: boolean
 {% endconfiguration %}
 


### PR DESCRIPTION
**Description:**

Fix arp_ping default value to true. Add HA version 0.98 info.


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
