### PR TITLE
Typo in local URL

### DIFF
--- a/source/_lovelace/markdown.markdown
+++ b/source/_lovelace/markdown.markdown
@@ -18,7 +18,7 @@ type:
   type: string
 content:
   required: true
-  description: "Content to render as [markdown](http://commonmark.org/help/). May contain [templates](/configuration/templating/)."
+  description: "Content to render as [markdown](http://commonmark.org/help/). May contain [templates](/docs/configuration/templating/)."
   type: string
 title:
   required: false


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
