### PR TITLE
Changed heading to be a link

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -143,7 +143,7 @@ You also need to have Docker-CE installed. There are well-documented procedures 
 
 </div>
 
-To prepare your machine for the Hass.io installation, run the following commands:
+### To prepare your machine for the Hass.io installation, run the following commands:
 
 ```bash
 sudo -i

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -143,7 +143,9 @@ You also need to have Docker-CE installed. There are well-documented procedures 
 
 </div>
 
-### To prepare your machine for the Hass.io installation, run the following commands:
+### Preparation
+
+To prepare your machine for the Hass.io installation, run the following commands:
 
 ```bash
 sudo -i


### PR DESCRIPTION
Changed "To prepare your machine for the Hass.io installation, run the following commands:" to a linkable heading so it can be shared more easily

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
