### PR TITLE
Include HA version in update available example

### DIFF
--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -68,5 +68,5 @@ automation:
   action:
     - service: notify.notify
       data:
-        message: 'Update for Home Assistant is available.'
+        message: "Home Assistant {{ state_attr('binary_sensor.updater', 'newest_version') }} is available."
 ```

--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -56,6 +56,7 @@ It is possible to report the integrations that you are using to the Home Assista
 
 For an added bonus, an automation integration can be created to send a message with a notifier when that state of this component's entity changes.
 
+{% raw %}
 ```yaml
 # Example configuration.yaml entry
 automation:
@@ -70,3 +71,4 @@ automation:
       data:
         message: "Home Assistant {{ state_attr('binary_sensor.updater', 'newest_version') }} is available."
 ```
+{% endraw %}


### PR DESCRIPTION
**Description:**

Improves the "update available" example automation in the Updater component docs to include the new version number that's available.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
