### PR TITLE
Incorrect entity_id under data:

### DIFF
--- a/source/_components/input_select.markdown
+++ b/source/_components/input_select.markdown
@@ -101,8 +101,8 @@ automation:
       event_type: MY_CUSTOM_EVENT
     action:
       - service: input_select.select_option
+        entity_id: input_select.who_cooks
         data:
-          entity_id: input_select.who_cooks
           option: Paulus
 ```
 
@@ -117,8 +117,8 @@ automation:
       event_type: MY_CUSTOM_EVENT
     action:
       - service: input_select.set_options
+        entity_id: input_select.who_cooks
         data:
-          entity_id: input_select.who_cooks
           options: ["Item A", "Item B", "Item C"]
 ```
 
@@ -149,9 +149,9 @@ input_select:
    # entity_id: input_select.thermostat_mode
   action:
      service: input_select.select_option
+     entity_id: input_select.thermostat_mode
      data_template:
-      entity_id: input_select.thermostat_mode
-      option: "{{ trigger.payload }}"
+       option: "{{ trigger.payload }}"
 
  # This automation script runs when the thermostat mode selector is changed.
  # It publishes its value to the same MQTT topic it is also subscribed to.


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
