### PR TITLE
Update for new max volume

### DIFF
--- a/source/_components/onkyo.markdown
+++ b/source/_components/onkyo.markdown
@@ -39,7 +39,7 @@ name:
   required: false
   type: string
 max_volume:
-  description: Maximum volume. Defaults to 80.
+  description: Maximum volume. Defaults to 200. Set to 80 for older Onkyo receivers.
   required: false
   type: integer
 sources:


### PR DESCRIPTION

**Description:**
New max volume of 200, advises owners of older receivers to set to 80.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26341

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10269"><img src="https://gitpod.io/api/apps/github/pbs/github.com/libots/home-assistant.io.git/c0ad84ac3d515bf872be7182ae28a56e44430a95.svg" /></a>

