### PR TITLE
Add enable_x10 flag

### DIFF
--- a/source/_components/isy994.markdown
+++ b/source/_components/isy994.markdown
@@ -78,6 +78,11 @@ enable_climate:
   required: false
   type: string
   default: true
+enable_x10:
+  description: When enabled, legacy X10 devices in the ISY994 will show up in Home Assistant as switches.
+  required: false
+  type: boolean
+  default: false
 tls:
   description: This entry should reflect the version of TLS that the ISY controller is using for HTTPS encryption. This value can be either 1.1 or 1.2. If this value is not set, it is assumed to be version 1.1. This is the default for most users. ISY994 Pro users may likely be using 1.2. When using HTTPS in the host entry, it is best practice to set this value.
   required: false


### PR DESCRIPTION
**Description:**
See other PR for full details.
**Pull request in home-assistant:** home-assistant/home-assistant#26342

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10271"><img src="https://gitpod.io/api/apps/github/pbs/github.com/taylorsilva/home-assistant.io.git/b9a211f1f03c205f0e1e9904690119bb73ad4280.svg" /></a>

