### PR TITLE
Update counter.markdown

### DIFF
--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -24,7 +24,7 @@ counter:
 
 {% configuration %}
 "[alias]":
-  description: Alias for the counter. Multiple entries are allowed. 'alias' should be replaced by the user for their actual value.
+  description: Alias for the counter. Multiple entries are allowed. `alias` should be replaced by the user for their actual value.
   required: true
   type: map
   keys:

--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -120,3 +120,35 @@ Select <img src='/images/screenshots/developer-tool-services-icon.png' alt='serv
   "entity_id": "counter.my_custom_counter"
 }
 ```
+
+### Counting Home Assistant errors
+
+To use a counter to count errors as caught by Home Assistant, you need to add `fire_event: true` to your `configuration.yaml`, like so:
+
+```yaml
+# Example configuration.yaml entry
+system_log:
+  fire_event: true
+```
+
+### Error counting - example configuration
+
+```yaml
+# Example configuration.yaml entry
+automation:
+- id: 'errorcounterautomation'
+  alias: Error Counting Automation
+  trigger:
+    platform: event
+    event_type: system_log_event
+    event_data:
+      level: ERROR
+  action:
+    service: counter.increment
+    entity_id: counter.error_counter
+    
+counter:
+  error_counter:
+    name: Errors
+    icon: mdi:alert  
+```

--- a/source/_components/counter.markdown
+++ b/source/_components/counter.markdown
@@ -23,9 +23,8 @@ counter:
 ```
 
 {% configuration %}
-# 'alias' should be replaced by the user for their actual value.
 "[alias]":
-  description: Alias for the counter. Multiple entries are allowed.
+  description: Alias for the counter. Multiple entries are allowed. 'alias' should be replaced by the user for their actual value.
   required: true
   type: map
   keys:
@@ -120,6 +119,8 @@ Select <img src='/images/screenshots/developer-tool-services-icon.png' alt='serv
   "entity_id": "counter.my_custom_counter"
 }
 ```
+
+## Examples
 
 ### Counting Home Assistant errors
 


### PR DESCRIPTION
Added details for getting counters to work when counting errors, with example configuration.

**Description:**

- Added details for getting counters to work when counting errors, with example configuration.
- This is to avoid more users landing on [this thread](https://community.home-assistant.io/t/counter-warning-error-issue/85490).

This is my first ever pull request to anything. Hope it's useful! Please give feedback if anything can be done differently or better. Have a great day! //Storm

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
