### PR TITLE
Removes linkable_title occurance

### DIFF
--- a/source/_components/cups.markdown
+++ b/source/_components/cups.markdown
@@ -58,7 +58,7 @@ is_cups_server:
   default: true
 {% endconfiguration %}
 
-## {% linkable_title Examples %}
+## Examples
 
 Default configuration for an IPP printer:
 


### PR DESCRIPTION
**Description:**
Found an `linkable_title` occurrence.

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
