### PR TITLE
Fixes updater notification template

### DIFF
--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -68,7 +68,7 @@ automation:
       to: 'on'
   action:
     - service: notify.notify
-      data:
+      data_template:
         message: "Home Assistant {{ state_attr('binary_sensor.updater', 'newest_version') }} is available."
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**

Fixes a broken example for the `updater` integration, caused by #10257

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
