### PR TITLE
Update google_maps.markdown

### DIFF
--- a/source/_components/google_maps.markdown
+++ b/source/_components/google_maps.markdown
@@ -17,16 +17,9 @@ The `google_maps` platform allows you to detect presence using the unofficial AP
 You first need to create an additional Google account and share your location with that account. This platform will use that account to fetch the location of your device(s). 
 
 1. You have to setup sharing through the Google Maps app on your mobile phone. You can find more information [here](https://support.google.com/accounts?p=location_sharing).
-2. You must use `mapscookiegettercli` to get a cookie file which can be used with this device tracker.  See more information [here](#maps-cookie-getter)
+2. You need to use the cookies from that account after you have properly authenticated which you can retrieve with either [Export cookies](https://addons.mozilla.org/en-US/firefox/addon/export-cookies-txt/?src=search) for firefox (make sure that "Prefix HttpOnly cookies" is unchecked) or [cookies.txt](https://chrome.google.com/webstore/detail/cookiestxt/njabckikapfpffapmjgojcnbfjonfjfg?hl=en-US) for chrome.
 3. Save the cookie file to your Home Assistant configuration directory with the following name: `.google_maps_location_sharing.cookies.` followed by the slugified username of the NEW Google account.
     - For example: if your email was `location.tracker@gmail.com`, the filename would be: `.google_maps_location_sharing.cookies.location_tracker_gmail_com`.
-
-<div class='note warning'>
-
-Since this platform is using an unofficial API with the help of [locationsharinglib](https://github.com/costastf/locationsharinglib), Google seems to block access to your data the first time you've logged in with this platform.
-This issue can be fixed by logging in with your new account and approving your login on the [Device Activity](https://myaccount.google.com/device-activity) page.
-
-</div>
 
 To integrate Google Maps Location Sharing in Home Assistant, add the following section to your `configuration.yaml` file:
 
@@ -52,19 +45,3 @@ scan_interval:
   default: 60
   type: integer
 {% endconfiguration %}
-
-### Maps Cookie Getter
-
-You must run the [`mapscookiegetter`](https://mapscookiegettercli.readthedocs.io/en/latest/) tool to get the cookie file from a computer with a Web Browser.  To install, your computer must have Python 3 and PIP installed:
-
-```shell
-pip3 install mapscookiegettercli
-```
-
-Then run the command:
-
-```shell
-maps-cookie-getter
-```
-
-This will open up a browser window for you to log-in to the NEW Google Account (the one you are sharing the location with, not your normal account). After logging in, the program will save the pickled cookie file `location_sharing.cookies` in the same directory as you ran the command from. Copy this to your Home Assistant configuration directory and rename as described above.


### PR DESCRIPTION
Documentation updated to match change in https://github.com/home-assistant/home-assistant/pull/26361

**Description:** Mentioned PR updates locationsharinglib which now supports text based cookies since mapscookiegettercli is reported blocked from google so pickled cookies cannot be retrieved any more.


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26361

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10279"><img src="https://gitpod.io/api/apps/github/pbs/github.com/costastf/home-assistant.io.git/a7417d5dd3620384e133ff81516d229b51dc19d0.svg" /></a>

