### PR TITLE
updated rainbird component to include the new irrigation service

### DIFF
--- a/source/_components/rainbird.markdown
+++ b/source/_components/rainbird.markdown
@@ -109,3 +109,27 @@ scan_interval:
   required: false
   type: integer
 {% endconfiguration %}
+
+## Services
+
+The Rain Bird switch platform exposes a service to start the irrigation for a given duration. 
+
+| Service | Description |
+| ------- | ----------- |
+| rainbird.start_irrigation | Set a duration state attribute for a switch and turn the irrigation on.|
+
+The service can be used as part of an automation script. For example:
+
+```yaml
+# Example configuration.yaml automation entry
+automation:
+  - alias: Turn irrigation on
+    trigger:
+      platform: time
+      at: '5:30:00'
+    action:
+      service: rainbird.start_irrigation
+      entity_id: switch.sprinkler_1
+      data:
+        duration: 5
+```


### PR DESCRIPTION
**Description:**
It's great that you can turn on your irrigation through home assistant. The annoying part I had with Rain Bird is that you have to set the duration up front within the config. This means that if you want to do a different duration, you have to reload home assistant. With this change, a new service is being added, allowing you to send along the duration.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26404

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10288"><img src="https://gitpod.io/api/apps/github/pbs/github.com/peternijssen/home-assistant.io.git/c33ed8231594a07f0dd9eb0ec6e7a6fc499d0dda.svg" /></a>

