### PR TITLE
Document mandatory emulated_hue port setting

### DIFF
--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -55,6 +55,9 @@ emulated_hue:
 ```yaml
 # Amazon Echo example configuration.yaml entry
 emulated_hue:
+# listen_port set to 80 is required since 2019-08 when new Firmware for Echo and Echo Dot v1 was pushed out by Amazon
+# See note below about "setcap" as port 80 is not available to non-root users under Linux/Unix.
+# host_ip is optional
   host_ip: YOUR.HASSIO.IP.ADDRESS
   listen_port: 80
   # Alexa stopped working on different ports. Search for "Philipps Hue Bridge V1 (round)" in the Alexa App to discover devices.

--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -70,7 +70,7 @@ host_ip:
   required: false
   type: string
 listen_port:
-  description: "The port the Hue bridge API web server will run on. This can be any free port on your system. However, all new Alexa devices require listen_port: 80. See "setcap" note below if this is set below 1024 when Home Assistant is ran as a non-root user."
+  description: "The port the Hue bridge API web server will run on. This can be any free port on your system. However, all new Alexa devices require listen_port: 80. See `setcap` note below if this is set below `1024` when Home Assistant is ran as a non-root user."
   required: false
   type: integer
   default: 8300

--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -55,12 +55,8 @@ emulated_hue:
 ```yaml
 # Amazon Echo example configuration.yaml entry
 emulated_hue:
-# listen_port set to 80 is required since 2019-08 when new Firmware for Echo and Echo Dot v1 was pushed out by Amazon
-# See note below about "setcap" as port 80 is not available to non-root users under Linux/Unix.
-# host_ip is optional
-  host_ip: YOUR.HASSIO.IP.ADDRESS
   listen_port: 80
-  # Alexa stopped working on different ports. Search for "Philipps Hue Bridge V1 (round)" in the Alexa App to discover devices.
+  # Amazon Echo/Alexa stopped working on different ports. Search for "Philips Hue Bridge V1 (round)" in the Alexa App to discover devices.
 ```
 
 {% configuration %}
@@ -74,7 +70,7 @@ host_ip:
   required: false
   type: string
 listen_port:
-  description: "The port the Hue bridge API web server will run on. This can be any free port on your system. However, all new Alexa devices require listen_port: 80." 
+  description: "The port the Hue bridge API web server will run on. This can be any free port on your system. However, all new Alexa devices require listen_port: 80. See "setcap" note below if this is set below 1024 when Home Assistant is ran as a non-root user."
   required: false
   type: integer
   default: 8300
@@ -149,16 +145,19 @@ These attributes used to be found under the `customize` section of `homeassistan
 
 You can verify that the `emulated_hue` integration has been loaded and is responding by pointing a local browser to the following URL:
 
- - `http://<HA IP Address>:8300/description.xml` - This URL should return a descriptor file in the form of an XML file.
- - `http://<HA IP Address>:8300/api/pi/lights` - This will return a list of devices, lights, scenes, groups, etc.. that `emulated_hue` is exposing to Alexa.
+- `http://<HA IP Address>:8300/description.xml` - This URL should return a descriptor file in the form of an XML file.
+- `http://<HA IP Address>:8300/api/pi/lights` - This will return a list of devices, lights, scenes, groups, etc.. that `emulated_hue` is exposing to Alexa.
 
 For Google Home, verify that the URLs above are using port 80, rather than port 8300 (i.e. `http://<HA IP Address>:80/description.xml`).
+
+For Amazon Alexa/Echo, verify that the URLs above are using port 80, rather than port 8300 (i.e. `http://<HA IP Address>:80/description.xml`). Since 2019-08 Amazon Echo firmware, Alexa no longer works with port 8300.
 
 An additional step is required to run Home Assistant as a non-root user and use port 80 when using the AiO script.  Execute the following command to allow `emulated_hue` to use port 80 as a non-root user.
 
 ```bash
 sudo setcap 'cap_net_bind_service=+ep' /srv/homeassistant/homeassistant_venv/bin/python3
 ```
+
 Please note that your path may be different depending on your installation method. For example, if you followed the [Virtualenv instructions](/docs/installation/virtualenv/), your path will be `/srv/homeassistant/bin/python3`.
 
 ### License


### PR DESCRIPTION
Since 2019 August/September firmware updates for Echo and Echo Dot v1.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
