### PR TITLE
typo in persistent_notification.markdown

### DIFF
--- a/source/_components/persistent_notification.markdown
+++ b/source/_components/persistent_notification.markdown
@@ -8,7 +8,7 @@ ha_release: 0.23
 ha_qa_scale: internal
 ---
 
-The `persistent_notification` integration can be used to show a notfication on the frontend that has to be dismissed by the user.
+The `persistent_notification` integration can be used to show a notification on the frontend that has to be dismissed by the user.
 
 <p class='img'>
   <img src='/images/screenshots/persistent-notification.png' />


### PR DESCRIPTION
## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
