### PR TITLE
Plex remove username/password/servername

### DIFF
--- a/source/_components/plex.markdown
+++ b/source/_components/plex.markdown
@@ -50,25 +50,71 @@ media_player:
   - platform: plex
 ```
 
+In the event that [discovery](/components/discovery/) does not work (GDM disabled or non-local Plex server), you can manually create a `plex.conf` file manually and place it in your [configuration directory ](/docs/configuration/) or `/config/` if you are running Hass.io. The following is an example of `plex.conf`:
+
+```json
+{"IP_ADDRESS:PORT": {"token": "TOKEN", "ssl": false, "verify": true}}
+```
+
+{% configuration %}
+IP_ADDRESS:
+  description: IP address of the Plex Media Server.
+  required: true
+  type: string
+PORT:
+  description: Port where Plex is listening.
+  required: true
+  default: 32400
+  type: integer
+TOKEN:
+  description: Only if authentication is required. Set to `null` (without quotes) otherwise.
+  required: false
+  type: string
+ssl:
+  description: Whether to use SSL/TLS or not.
+  required: false
+  default: "`false`"
+  type: boolean
+verify:
+  description: Perform a verification of the certificate. To allow invalid or self-signed SSL certificates set it to `false`.
+  required: false
+  default: "`true`"
+  type: boolean
+{% endconfiguration %}
+
 ### Customization
 
 You can customize the Plex integration by adding any of the variables below to your configuration:
 
+```yaml
+# Example configuration.yaml entry
+media_player:
+  - platform: plex
+    show_all_controls: false
+    use_episode_art: true
+    remove_unavailable_clients: true
+    client_remove_interval: 600
+```
+
 {% configuration %}
-use_episode_art:
-  description: Display TV episode art instead of TV show art.
-  default: false
-  type: boolean
 show_all_controls:
   description: Forces all controls to display. Ignores dynamic controls (ex. show volume controls for client A but not for client B) based on detected client capabilities. This option allows you to override this detection if you suspect it to be incorrect.
+  required: false
+  default: false
+  type: boolean
+use_episode_art:
+  description: Display TV episode art instead of TV show art.
+  required: false
   default: false
   type: boolean
 remove_unavailable_clients:
   description: Remove stale Plex clients from UI after interval.
+  required: false
   default: true
   type: boolean
 client_remove_interval:
-  description: How long a client is to be unavailable for before it is removed. Measured in seconds.
+  description: How long a client is to be unavailable for before it is cleaned up in seconds.
+  required: false
   default: 600
   type: integer
 {% endconfiguration %}

--- a/source/_components/plex.markdown
+++ b/source/_components/plex.markdown
@@ -26,13 +26,33 @@ If your Plex server has been claimed by a Plex account via the [claim interface]
 
 ## Media Player
 
+The preferred way to setup the Plex platform is by enabling the [discovery component](/components/discovery/) which requires GDM enabled on your Plex server. This can be found on your Plex Web App under Settings > (server Name) > settings > Network and choose "Enable local network discovery (GDM)".
+
+If your Plex server has local authentication enabled or multiple users defined, Home Assistant requires an authentication token to be entered in the frontend. Press "CONFIGURE" to do it.
+
+<p class='img'>
+  <img src='{{site_root}}/images/screenshots/plex-configure.png' />
+</p>
+
+To authorize your device, you'll first need to [click here to claim a token](https://plex.tv/claim).
+
+If your server enforces SSL connections, write "`on`" or "`true`" in the _"Use SSL"_ field. If it does not have a valid SSL certificate available but you still want to use it, write "`on`" or "`true`" in the _"Do not verify SSL"_ field as well.
+
+<p class='img'>
+  <img src='{{site_root}}/images/screenshots/plex-token.png' />
+</p>
+
+You can also enable the plex platform directly by adding the following lines to your `configuration.yaml`:
+
 ```yaml
 # Example configuration.yaml entry
 media_player:
   - platform: plex
 ```
 
-In the event that [discovery](/components/discovery/) does not work (GDM disabled or non-local Plex server), you can manually set the configuration options as shown below.
+### Customization
+
+You can customize the Plex integration by adding any of the variables below to your configuration:
 
 {% configuration %}
 use_episode_art:

--- a/source/_components/plex.markdown
+++ b/source/_components/plex.markdown
@@ -14,32 +14,17 @@ redirect_from:
 ---
 
 
-The `plex` platform allows you to connect to a [Plex Media Server](https://plex.tv). Once connected, [Plex Clients](https://www.plex.tv/apps-devices/) playing media from the connected Plex Media Server will show up as [Media Players](/components/media_player/) in Home Assistant. It will allow you to control media playback and see the current playing item.
+The `plex` platform allows you to connect to a [Plex Media Server](https://plex.tv). Once connected, [Plex Clients](https://www.plex.tv/apps-devices/) playing media from the connected Plex Media Server will show up as [Media Players](/components/media_player/) or report playback status via a [Sensor](/components/sensor/) in Home Assistant. The Media Players will allow you to control media playback and see the current playing item.
 
 There is currently support for the following device types within Home Assistant:
 
-- [Media Player](#setup---media-player)
+- [Media Player](#media-player)
 - [Sensor](#sensor)
 
-## Setup - Media Player
+If your Plex server has been claimed by a Plex account via the [claim interface](https://plex.tv/claim), Home Assistant will require an authentication token to connect. If you don't know your token, see [Finding your account token / X-Plex-Token](https://support.plex.tv/hc/en-us/articles/204059436).
 
-The preferred way to setup the Plex platform is by enabling the [discovery component](/components/discovery/) which requires GDM enabled on your Plex server. This can be found on your Plex Web App under Settings > (server Name) > settings > Network and choose "Enable local network discovery (GDM)".
 
-If your Plex server has local authentication enabled or multiple users defined, Home Assistant requires an authentication token to be entered in the frontend. Press "CONFIGURE" to do it.
-
-<p class='img'>
-  <img src='{{site_root}}/images/screenshots/plex-configure.png' />
-</p>
-
-To authorize your device, you'll first need to [click here to claim a token](https://plex.tv/claim).
-
-If your server enforces SSL connections, write "`on`" or "`true`" in the _"Use SSL"_ field. If it does not have a valid SSL certificate available but you still want to use it, write "`on`" or "`true`" in the _"Do not verify SSL"_ field as well.
-
-<p class='img'>
-  <img src='{{site_root}}/images/screenshots/plex-token.png' />
-</p>
-
-You can also enable the plex platform directly by adding the following lines to your `configuration.yaml`:
+## Media Player
 
 ```yaml
 # Example configuration.yaml entry
@@ -47,71 +32,23 @@ media_player:
   - platform: plex
 ```
 
-In the event that [discovery](/components/discovery/) does not work (GDM disabled or non-local Plex server), you can manually create a `plex.conf` file manually and place it in your [configuration directory ](/docs/configuration/) or `/config/` if you are running Hass.io. The following is an example of `plex.conf`:
-
-```json
-{"IP_ADDRESS:PORT": {"token": "TOKEN", "ssl": false, "verify": true}}
-```
+In the event that [discovery](/components/discovery/) does not work (GDM disabled or non-local Plex server), you can manually set the configuration options as shown below.
 
 {% configuration %}
-IP_ADDRESS:
-  description: IP address of the Plex Media Server.
-  required: true
-  type: string
-PORT:
-  description: Port where Plex is listening.
-  required: true
-  default: 32400
-  type: integer
-TOKEN:
-  description: Only if authentication is required. Set to `null` (without quotes) otherwise.
-  required: false
-  type: string
-ssl:
-  description: Whether to use SSL/TLS or not.
-  required: false
-  default: "`false`"
-  type: boolean
-verify:
-  description: Perform a verification of the certificate. To allow invalid or self-signed SSL certificates set it to `false`.
-  required: false
-  default: "`true`"
-  type: boolean
-{% endconfiguration %}
-
-### Customization
-
-You can customize the Plex integration by adding any of the variables below to your configuration:
-
-```yaml
-# Example configuration.yaml entry
-media_player:
-  - platform: plex
-    show_all_controls: false
-    use_episode_art: true
-    remove_unavailable_clients: true
-    client_remove_interval: 600
-```
-
-{% configuration %}
-show_all_controls:
-  description: "Forces all controls to display. Ignores dynamic controls (ex. show volume controls for client A but not for client B) based on detected client capabilities. This option allows you to override this detection if you suspect it to be incorrect."
-  required: false
-  default: false
-  type: boolean
 use_episode_art:
   description: Display TV episode art instead of TV show art.
-  required: false
+  default: false
+  type: boolean
+show_all_controls:
+  description: Forces all controls to display. Ignores dynamic controls (ex. show volume controls for client A but not for client B) based on detected client capabilities. This option allows you to override this detection if you suspect it to be incorrect.
   default: false
   type: boolean
 remove_unavailable_clients:
-  description: Remove stale plex clients from UI after interval.
-  required: false
+  description: Remove stale Plex clients from UI after interval.
   default: true
   type: boolean
 client_remove_interval:
-  description: How long a client is to be unavailable for before it is cleaned up in seconds.
-  required: false
+  description: How long a client is to be unavailable for before it is removed. Measured in seconds.
   default: 600
   type: integer
 {% endconfiguration %}
@@ -175,14 +112,12 @@ Plays a song, playlist, TV episode, or video on a connected client.
   INFO:homeassistant.components.media_player.plex:No server found at: http://192.168.1.10:32400
   ```
 
-  If this occurs, check the setting `Server`>`Network`>`Secure connections` on your Plex Media Server: if it is set to `Preferred` or `Required`, you may need to manually set the `ssl` and `verify` booleans in the `plex.conf` file to, respectively, `true` and `false`. See the **"Setup"** section above for details.
+  If this occurs, check the setting `Server`>`Network`>`Secure connections` on your Plex Media Server: if it is set to `Preferred` or `Required`, you may need to manually set the `ssl` and `verify` booleans to, respectively, `true` and `false`.
 * Movies must be located under 'Movies' section in the Plex library to properly get 'playing' state.
 
 ## Sensor
 
 The `plex` sensor platform will monitor activity on a given [Plex Media Server](https://plex.tv/). It will create a sensor that shows the number of currently watching users as the state. If you click the sensor for more details it will show you who is watching what.
-
-If your Plex server is on the same local network as Home Assistant, all you need to provide in the `configuration.yaml` is the host or IP address. If you want to access a remote Plex server, you must provide the Plex username, password, and optionally the server name of the remote Plex server. If no server name is given it will use the first server listed. If you use the username and password, all servers in that account are monitored.
 
 If you don't know your token, see [Finding your account token / X-Plex-Token](https://support.plex.tv/hc/en-us/articles/204059436).
 
@@ -209,18 +144,6 @@ name:
   description: Name of the Plex server.
   required: false
   default: Plex
-  type: string
-username:
-  description: The username for the remote Plex server.
-  required: false
-  type: string
-password:
-  description: The password for your given account on the remote Plex server.
-  required: false
-  type: string
-server:
-  description: The name of your remote Plex server.
-  required: false
   type: string
 token:
   description: X-Plex-Token of your remote Plex server.

--- a/source/_components/plex.markdown
+++ b/source/_components/plex.markdown
@@ -185,8 +185,6 @@ Plays a song, playlist, TV episode, or video on a connected client.
 
 The `plex` sensor platform will monitor activity on a given [Plex Media Server](https://plex.tv/). It will create a sensor that shows the number of currently watching users as the state. If you click the sensor for more details it will show you who is watching what.
 
-If you don't know your token, see [Finding your account token / X-Plex-Token](https://support.plex.tv/hc/en-us/articles/204059436).
-
 If you want to enable the plex sensor, add the following lines to your `configuration.yaml`:
 
 ```yaml


### PR DESCRIPTION
**Description:**
Removes some options in the `sensor` platform and fixes some outdated text. First step in several changes to the Plex component.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26444

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html