### PR TITLE
fixed templates

### DIFF
--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -258,7 +258,7 @@ sensor:
   - platform: template
     sensors:
       nonsmoker:
-        value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
+        value_template: "{{ (( as_timestamp(now()) - as_timestamp(strptime('06.07.2018', '%d.%m.%Y')) ) / 86400 ) | round(2) }}"
         entity_id: sensor.date
         friendly_name: 'Not smoking'
         unit_of_measurement: "Days"
@@ -275,7 +275,7 @@ sensor:
   - platform: template
     sensors:
       nonsmoker:
-        value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
+        value_template: "{{ (( as_timestamp(now()) - as_timestamp(strptime('06.07.2018', '%d.%m.%Y')) ) / 86400 ) | round(2) }}"
         entity_id: []
         friendly_name: 'Not smoking'
         unit_of_measurement: "Days"


### PR DESCRIPTION
**Description:**
Fixed the last two template examples to valid templates
https://developers.home-assistant.io/docs/en/documentation_standards.html#double-quotes-outside-single-quotes-inside-valid

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
