### PR TITLE
SmartThings integration option: events

### DIFF
--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -106,6 +106,12 @@ Advanced: If you have multiple locations in SmartThings, each can be integrated 
 
 See the [troubleshooting](#troubleshooting) if you are having issues setting up the integration.
 
+## Integration Options
+
+The SmartThings integration supports the following options (configured through the integration options screen):
+
+1. `Raise events for push updates`: This is an advanced feature which provides access to the raw data received from SmartThings during a push update. When enabled, the integraiton will raise events through the event bus for all push updates--not just button presses. The default is to raise events only for buttons.
+
 ## Events
 
 The SmartThings integration triggers events for select device capabilities.
@@ -131,6 +137,36 @@ The integration will trigger an event when a device with the [button](https://sm
 `location_id`               | The unique id of the location the device is part of. This can be found in the config entry registry or in the [SmartThings Groovy IDE](https://developers.smartthings.com/).
 `value`                     | Describes the action taken on the button. See the [button](https://smartthings.developer.samsung.com/develop/api-ref/capabilities.html#Button) capability reference for a list of possible values (not all are supported by every device).
 `name`                      | The name given to the device in SmartThings.
+
+Event data payloads are logged at the debug level, see [debugging](#debugging) for more information.
+
+### smartthings.update
+
+The integration can be configured to raise events for push updates received. `Raise events for push updates` must be checked in the integration options. This is an advanced feature. Below is an example of the data payload:
+
+```json
+{
+  "location_id": "2a54b9fa-f66c-42d9-8488-d8f036b980c8",
+  "device_id": "42a16cf2-fef7-4ee8-b4a6-d32cb65474b7",
+  "component_id": "main",
+  "name": "Hallway Light",
+  "capability": "switch",
+  "attribute": "switch",
+  "value": "on",
+  "data": {},
+}
+```
+
+| Attribute                 | Description
+|---------------------------|------------------------------------------------------------------|
+`location_id`               | The unique id of the location the device is part of. This can be found in the config entry registry or in the [SmartThings Groovy IDE](https://developers.smartthings.com/).
+`device_id`                 | The unique id of the device in SmartThings. This can be located in the HASS device registry or in the [SmartThings Groovy IDE](https://developers.smartthings.com/).
+`component_id`              | Describes which integration of the device triggered the event. `main` represents the parent device. For devices with child-devices, this attribute identifies the child that raised the event.
+`name`                      | The name given to the device in SmartThings.
+`capability`                | The SmartThings capability that was updated.
+`attribute`                 | The attribute of the capability that was updated.
+`value`                     | The new value of the attribute.
+`data`                      | Data assocaited with the event update.
 
 Event data payloads are logged at the debug level, see [debugging](#debugging) for more information.
 

--- a/source/_components/smartthings.markdown
+++ b/source/_components/smartthings.markdown
@@ -110,7 +110,7 @@ See the [troubleshooting](#troubleshooting) if you are having issues setting up 
 
 The SmartThings integration supports the following options (configured through the integration options screen):
 
-1. `Raise events for push updates`: This is an advanced feature which provides access to the raw data received from SmartThings during a push update. When enabled, the integraiton will raise events through the event bus for all push updates--not just button presses. The default is to raise events only for buttons.
+1. `Raise events for push updates`: This is an advanced feature which provides access to the raw data received from SmartThings during a push update. When enabled, the integration will raise events through the event bus for all push updates--not just button presses. The default is to raise events only for buttons.
 
 ## Events
 
@@ -166,7 +166,7 @@ The integration can be configured to raise events for push updates received. `Ra
 `capability`                | The SmartThings capability that was updated.
 `attribute`                 | The attribute of the capability that was updated.
 `value`                     | The new value of the attribute.
-`data`                      | Data assocaited with the event update.
+`data`                      | Data associated with the event update.
 
 Event data payloads are logged at the debug level, see [debugging](#debugging) for more information.
 


### PR DESCRIPTION
**Description:**

Documents the integration option "Raise events for push updates" and the new event type `smartthings.update` in the SmartThings.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26499

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
