### PR TITLE
Updating documentation for Alarm Device Class for Binary Sensors

### DIFF
--- a/source/_components/binary_sensor.markdown
+++ b/source/_components/binary_sensor.markdown
@@ -15,6 +15,7 @@ Binary sensors gather information about the state of devices which have a "digit
 The way these sensors are displayed in the frontend can be modified in the [customize section](/getting-started/customizing-devices/). The following device classes are supported for binary sensors:
 
 - **None**: Generic on/off. This is the default and doesn't need to be set.
+- **alarm**: `On` means armed, `Off` means disarmed
 - **battery**: `On` means low, `Off` means normal
 - **cold**: `On` means cold, `Off` means normal
 - **connectivity**: `On` means connected, `Off` means disconnected


### PR DESCRIPTION
**Description:**
Adding documentation for (hopefully) newly added Device Class for Binary Sensors

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
