### PR TITLE
Added 'availability_template' to Template Sensor platform

### DIFF
--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -28,10 +28,6 @@ sensor:
         friendly_name: "Sun angle"
         unit_of_measurement: 'degrees'
         value_template: "{{ state_attr('sun.sun', 'elevation') }}"
-        availability_template: >-
-          {%- if not is_state('dependant_device.state', 'unavailable') %}
-            true
-          {% endif %}
 
       sunrise:
         value_template: "{{ state_attr('sun.sun', 'next_rising') }}"

--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -18,6 +18,7 @@ The `template` platform supports sensors which get their values from other entit
 The configuration of Template Sensors depends on what you want them to be. Adding the following to your `configuration.yaml` file will create two sensors, one for the current sun angle and one for the time of the next sunrise:
 
 {% raw %}
+
 ```yaml
 # Example configuration.yaml entry
 sensor:
@@ -27,10 +28,15 @@ sensor:
         friendly_name: "Sun angle"
         unit_of_measurement: 'degrees'
         value_template: "{{ state_attr('sun.sun', 'elevation') }}"
+        availability_template: >-
+          {%- if not is_state('dependant_device.state', 'unavailable') %}
+            true
+          {% endif %}
 
       sunrise:
         value_template: "{{ state_attr('sun.sun', 'next_rising') }}"
 ```
+
 {% endraw %}
 
 {% configuration %}
@@ -68,15 +74,11 @@ sensor:
         description: Defines a template for the entity picture of the sensor.
         required: false
         type: template
-      attribute_templates:
-        description: Defines templates for attributes of the sensor.
+      availability_template:
+        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
         required: false
-        type: map
-        keys:
-          "attribute: template":
-            description: The attribute and corresponding template.
-            required: true
-            type: template
+        type: template
+        default: the device is always `available`
       device_class:
         description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
         required: false
@@ -105,6 +107,7 @@ In this section, you find some real-life examples of how to use this sensor.
 This example shows the sun angle in the frontend.
 
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -114,6 +117,7 @@ sensor:
         unit_of_measurement: '°'
         value_template: "{{ '%+.1f'|format(state_attr('sun.sun', 'elevation')) }}"
 ```
+
 {% endraw %}
 
 ### Renaming Sensor Output
@@ -122,6 +126,7 @@ If you don't like the wording of a sensor output, then the Template Sensor can h
 a simple example:
 
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -135,6 +140,7 @@ sensor:
             down
           {% endif %}
 ```
+
 {% endraw %}
 
 ### Multiline Example With an `if` Test
@@ -142,6 +148,7 @@ sensor:
 This example shows a multiple line template with an `if` test. It looks at a sensing switch and shows `on`/`off` in the frontend.
 
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -159,6 +166,7 @@ sensor:
             failed
           {% endif %}
 ```
+
 {% endraw %}
 
 ### Change The Unit of Measurement
@@ -166,6 +174,7 @@ sensor:
 With a Template Sensor, it's easy to convert given values into others if the unit of measurement doesn't fit your needs.
 
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -180,6 +189,7 @@ sensor:
         unit_of_measurement: 'kB/s'
         value_template: "{{ states('sensor.transmission_up_speed')|float * 1024 }}"
 ```
+
 {% endraw %}
 
 ### Change The Icon
@@ -187,6 +197,7 @@ sensor:
 This example shows how to change the icon based on the day/night cycle.
 
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -206,6 +217,7 @@ sensor:
             mdi:weather-night
           {% endif %}
 ```
+
 {% endraw %}
 
 ### Change The Entity Picture
@@ -213,6 +225,7 @@ sensor:
 This example shows how to change the entity picture based on the day/night cycle.
 
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -232,6 +245,7 @@ sensor:
             /local/nighttime.png
           {% endif %}
 ```
+
 {% endraw %}
 
 ### Change the Friendly Name Used in the Frontend
@@ -239,6 +253,7 @@ sensor:
 This example shows how to change the `friendly_name` based on a state.
 
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -253,38 +268,7 @@ sensor:
         value_template: "{{ states('sensor.power_consumption') }}"
         unit_of_measurement: 'kW'
 ```
-{% endraw %}
 
-### Add Custom Attributes
-
-This example shows how to add custom attributes.
-
-{% raw %}
-```yaml
-sensor:
-  - platform: template
-    sensors:
-      my_device:
-        value_template: >-
-          {% if is_state('device_tracker.my_device_nmap','home') %}
-            Home
-          {% else %}
-            {{ states('device_tracker.my_device_gps') }}
-          {% endif %}
-        attribute_templates:
-          latitude: >-
-            {% if is_state('device_tracker.my_device_nmap','home') %}
-              {{ state_attr('zone.home','latitude') }}
-            {% else %}
-              state_attr('device_tracker.my_device_gps','latitude')
-            {% endif %}
-          longitude: >-
-            {% if is_state('device_tracker.my_device_nmap','home') %}
-              {{ state_attr('zone.home','longitude') }}
-            {% else %}
-              {{ state_attr('device_tracker.my_device_gps','longitude') }}
-            {% endif %}
-```
 {% endraw %}
 
 ### Working without entities
@@ -294,6 +278,7 @@ The `template` sensors are not limited to use attributes from other entities but
 This template contains no entities that will trigger an update, so we add an `entity_id:` line with an entity that will force an update - here we're using a [date sensor](/components/sensor.time_date/) to get a daily update:
 
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -304,6 +289,7 @@ sensor:
         friendly_name: 'Not smoking'
         unit_of_measurement: "Days"
 ```
+
 {% endraw %}
 
 Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute.
@@ -311,6 +297,7 @@ Useful entities to choose might be `sensor.date` which update once per day or `s
 An alternative to this is to create an interval-based automation that calls the service `homeassistant.update_entity` for the entities requiring updates. This modified example updates every 5 minutes:
 
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -330,4 +317,5 @@ automation:
       - service: homeassistant.update_entity
         entity_id: sensor.nonsmoker
 ```
+
 {% endraw %}

--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -72,6 +72,7 @@ sensor:
         type: template
       attribute_templates:
         description: Defines templates for attributes of the sensor.
+        required: false
         type: map
         keys:
           "attribute: template":

--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -71,7 +71,7 @@ sensor:
         required: false
         type: template
       availability_template:
-        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
+        description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
         required: false
         type: template
         default: true

--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -75,10 +75,10 @@ sensor:
         required: false
         type: template
       availability_template:
-        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
         required: false
         type: template
-        default: the device is always `available`
+        default: true
       device_class:
         description: Sets the class of the device, changing the device state and icon that is displayed on the UI (see below). It does not set the `unit_of_measurement`.
         required: false

--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -70,6 +70,14 @@ sensor:
         description: Defines a template for the entity picture of the sensor.
         required: false
         type: template
+      attribute_templates:
+        description: Defines templates for attributes of the sensor.
+        type: map
+        keys:
+          "attribute: template":
+            description: The attribute and corresponding template.
+            required: true
+            type: template        
       availability_template:
         description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
         required: false
@@ -266,6 +274,37 @@ sensor:
 ```
 
 {% endraw %}
+
+### Add Custom Attributes
+
+This example shows how to add custom attributes.
+
+{% raw %}
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      my_device:
+        value_template: >-
+          {% if is_state('device_tracker.my_device_nmap','home') %}
+            Home
+          {% else %}
+            {{ states('device_tracker.my_device_gps') }}
+          {% endif %}
+        attribute_templates:
+          latitude: >-
+            {% if is_state('device_tracker.my_device_nmap','home') %}
+              {{ state_attr('zone.home','latitude') }}
+            {% else %}
+              state_attr('device_tracker.my_device_gps','latitude')
+            {% endif %}
+          longitude: >-
+            {% if is_state('device_tracker.my_device_nmap','home') %}
+              {{ state_attr('zone.home','longitude') }}
+            {% else %}
+              {{ state_attr('device_tracker.my_device_gps','longitude') }}
+            {% endif %}
+```{% endraw %}
 
 ### Working without entities
 

--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -305,7 +305,9 @@ sensor:
             {% else %}
               {{ state_attr('device_tracker.my_device_gps','longitude') }}
             {% endif %}
-```{% endraw %}
+```
+
+{% endraw %}
 
 ### Working without entities
 


### PR DESCRIPTION
Added documentation `availability_template` configuration option for Template Sensor platform components.

https://github.com/home-assistant/home-assistant/pull/26516

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10123"><img src="https://gitpod.io/api/apps/github/pbs/github.com/grillp/home-assistant.io.git/3245873adf520e285b99380743ca83959fc1c5f8.svg" /></a>

