### PR TITLE
Added 'availability_template' to all Template Switch platform

### DIFF
--- a/source/_integrations/switch.template.markdown
+++ b/source/_integrations/switch.template.markdown
@@ -59,7 +59,7 @@ switch:
         required: true
         type: template
       availability_template:
-        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
+        description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
         required: false
         type: template
         default: true

--- a/source/_integrations/switch.template.markdown
+++ b/source/_integrations/switch.template.markdown
@@ -63,10 +63,10 @@ switch:
         required: true
         type: template
       availability_template:
-        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
         required: false
         type: template
-        default: the device is always `available`
+        default: true
       turn_on:
         description: Defines an action to run when the switch is turned on.
         required: true

--- a/source/_integrations/switch.template.markdown
+++ b/source/_integrations/switch.template.markdown
@@ -36,10 +36,6 @@ switch:
           service: switch.turn_off
           data:
             entity_id: switch.skylight_close
-        availability_template: >-
-          {%- if not is_state('dependant_device.state', 'unavailable') %}
-            true
-          {% endif %}
 ```
 
 {% endraw %}

--- a/source/_integrations/switch.template.markdown
+++ b/source/_integrations/switch.template.markdown
@@ -20,6 +20,7 @@ This can simplify the GUI and make it easier to write automations. You can mark 
 To enable Template Switches in your installation, add the following to your `configuration.yaml` file:
 
 {% raw %}
+
 ```yaml
 # Example configuration.yaml entry
 switch:
@@ -35,7 +36,12 @@ switch:
           service: switch.turn_off
           data:
             entity_id: switch.skylight_close
+        availability_template: >-
+          {%- if not is_state('dependant_device.state', 'unavailable') %}
+            true
+          {% endif %}
 ```
+
 {% endraw %}
 
 {% configuration %}
@@ -56,6 +62,11 @@ switch:
         description: Defines a template to set the state of the switch.
         required: true
         type: template
+      availability_template:
+        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+        required: false
+        type: template
+        default: the device is always `available`
       turn_on:
         description: Defines an action to run when the switch is turned on.
         required: true
@@ -87,6 +98,7 @@ In this section you find some real-life examples of how to use this switch.
 This example shows a switch that copies another switch.
 
 {% raw %}
+
 ```yaml
 switch:
   - platform: template
@@ -102,6 +114,7 @@ switch:
           data:
             entity_id: switch.source
 ```
+
 {% endraw %}
 
 ### Toggle Switch
@@ -109,6 +122,7 @@ switch:
 This example shows a switch that takes its state from a sensor and toggles a switch.
 
 {% raw %}
+
 ```yaml
 switch:
   - platform: template
@@ -125,6 +139,7 @@ switch:
           data:
             entity_id: switch.blind_toggle
 ```
+
 {% endraw %}
 
 ### Sensor and Two Switches
@@ -133,6 +148,7 @@ This example shows a switch that takes its state from a sensor, and uses two
 momentary switches to control a device.
 
 {% raw %}
+
 ```yaml
 switch:
   - platform: template
@@ -149,6 +165,7 @@ switch:
           data:
             entity_id: switch.skylight_close
 ```
+
 {% endraw %}
 
 ### Change The Icon
@@ -156,6 +173,7 @@ switch:
 This example shows how to change the icon based on the day/night cycle.
 
 {% raw %}
+
 ```yaml
 switch:
   - platform: template
@@ -177,6 +195,7 @@ switch:
             mdi:garage
           {% endif %}
 ```
+
 {% endraw %}
 
 ### Change The Entity Picture
@@ -184,6 +203,7 @@ switch:
 This example shows how to change the entity picture based on the day/night cycle.
 
 {% raw %}
+
 ```yaml
 switch:
   - platform: template
@@ -205,4 +225,5 @@ switch:
             /local/garage-closed.png
           {% endif %}
 ```
+
 {% endraw %}


### PR DESCRIPTION
Added documentation `availability_template` configuration option for all Template Switch platform components.

https://github.com/home-assistant/home-assistant/pull/26513

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10123"><img src="https://gitpod.io/api/apps/github/pbs/github.com/grillp/home-assistant.io.git/3245873adf520e285b99380743ca83959fc1c5f8.svg" /></a>

