### PR TITLE
Added 'availability_template' to all Template Light platform

### DIFF
--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -17,6 +17,7 @@ To enable Template Lights in your installation, add the following to your
 `configuration.yaml` file:
 
 {% raw %}
+
 ```yaml
 # Example configuration.yaml entry
 light:
@@ -34,7 +35,12 @@ light:
           service: script.theater_lights_level
           data_template:
             brightness: "{{ brightness }}"
+        availability_template: >-
+          {%- if not is_state('dependant_device.state', 'unavailable') %}
+            true
+          {% endif %}
 ```
+
 {% endraw %}
 
 {% configuration %}
@@ -64,7 +70,12 @@ light:
       icon_template:
         description: Defines a template for an icon or picture, e.g. showing a different icon for different states.
         required: false
-        type: template        
+        type: template
+      availability_template:
+        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+        required: false
+        type: template
+        default: the device is always `available`
       turn_on:
         description: Defines an action to run when the light is turned on.
         required: true
@@ -104,6 +115,7 @@ make; the [Media Player component](/components/media_player/) needs a floating
 point percentage value from `0.0` to `1.0`.
 
 {% raw %}
+
 ```yaml
 light:
   - platform: template
@@ -142,6 +154,7 @@ light:
             0
           {% endif %}
 ```
+
 {% endraw %}
 
 ### Change The Icon
@@ -149,6 +162,7 @@ light:
 This example shows how to change the icon based on the light state.
 
 {% raw %}
+
 ```yaml
 light:
   - platform: template
@@ -186,6 +200,7 @@ light:
             entity_id: media_player.receiver
             is_volume_muted: true
 ```
+
 {% endraw %}
 
 ### Change The Entity Picture
@@ -193,6 +208,7 @@ light:
 This example shows how to change the entity picture based on the light state.
 
 {% raw %}
+
 ```yaml
 light:
   - platform: template
@@ -230,4 +246,5 @@ light:
             entity_id: media_player.receiver
             is_volume_muted: true
 ```
+
 {% endraw %}

--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -35,10 +35,6 @@ light:
           service: script.theater_lights_level
           data_template:
             brightness: "{{ brightness }}"
-        availability_template: >-
-          {%- if not is_state('dependant_device.state', 'unavailable') %}
-            true
-          {% endif %}
 ```
 
 {% endraw %}

--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -72,10 +72,10 @@ light:
         required: false
         type: template
       availability_template:
-        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
         required: false
         type: template
-        default: the device is always `available`
+        default: true
       turn_on:
         description: Defines an action to run when the light is turned on.
         required: true

--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -68,7 +68,7 @@ light:
         required: false
         type: template
       availability_template:
-        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
+        description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
         required: false
         type: template
         default: true


### PR DESCRIPTION
Added documentation `availability_template` configuration option for Template Light platform components.

https://github.com/home-assistant/home-assistant/pull/26512

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10123"><img src="https://gitpod.io/api/apps/github/pbs/github.com/grillp/home-assistant.io.git/3245873adf520e285b99380743ca83959fc1c5f8.svg" /></a>

