### PR TITLE
Added 'availability_template' to all Template Fan platform

### DIFF
--- a/source/_components/fan.template.markdown
+++ b/source/_components/fan.template.markdown
@@ -29,10 +29,6 @@ fan:
         speed_template: "{{ states('input_select.speed') }}"
         oscillating_template: "{{ states('input_select.osc') }}"
         direction_template: "{{ states('input_select.direction') }}"
-        availability_template: >-
-          {%- if not is_state('dependant_device.state', 'unavailable') %}
-            true
-          {% endif %}
         turn_on:
           service: script.fan_on
         turn_off:

--- a/source/_components/fan.template.markdown
+++ b/source/_components/fan.template.markdown
@@ -84,10 +84,10 @@ fan:
         required: false
         type: template
       availability_template:
-        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
         required: false
         type: template
-        default: the device is always `available`
+        default: true
       turn_on:
         description: Defines an action to run when the fan is turned on.
         required: true

--- a/source/_components/fan.template.markdown
+++ b/source/_components/fan.template.markdown
@@ -80,7 +80,7 @@ fan:
         required: false
         type: template
       availability_template:
-        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
+        description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
         required: false
         type: template
         default: true

--- a/source/_components/fan.template.markdown
+++ b/source/_components/fan.template.markdown
@@ -17,6 +17,7 @@ To enable Template Fans in your installation, add the following to your
 `configuration.yaml` file:
 
 {% raw %}
+
 ```yaml
 # Example configuration.yaml entry
 fan:
@@ -28,6 +29,10 @@ fan:
         speed_template: "{{ states('input_select.speed') }}"
         oscillating_template: "{{ states('input_select.osc') }}"
         direction_template: "{{ states('input_select.direction') }}"
+        availability_template: >-
+          {%- if not is_state('dependant_device.state', 'unavailable') %}
+            true
+          {% endif %}
         turn_on:
           service: script.fan_on
         turn_off:
@@ -49,6 +54,7 @@ fan:
           - '2'
           - '3'
 ```
+
 {% endraw %}
 
 {% configuration %}
@@ -77,6 +83,11 @@ fan:
         description: "Defines a template to get the direction of the fan. Valid value: 'forward'/'reverse'"
         required: false
         type: template
+      availability_template:
+        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+        required: false
+        type: template
+        default: the device is always `available`
       turn_on:
         description: Defines an action to run when the fan is turned on.
         required: true


### PR DESCRIPTION
Added documentation `availability_template` configuration option for Template Fan platform components.

https://github.com/home-assistant/home-assistant/pull/26511

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10123"><img src="https://gitpod.io/api/apps/github/pbs/github.com/grillp/home-assistant.io.git/3245873adf520e285b99380743ca83959fc1c5f8.svg" /></a>

