### PR TITLE
Added 'availability_template' to Template Binary Sensor platform

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -28,10 +28,6 @@ binary_sensor:
         friendly_name: "Sun is up"
         value_template: >-
           {{ state_attr('sun.sun', 'elevation')|float > 0 }}
-        availability_template: >-
-          {%- if not is_state('dependant_device.state', 'unavailable') %}
-            true
-          {% endif %}
 ```
 
 {% endraw %}
@@ -60,7 +56,7 @@ sensors:
           required: false
           type: device_class
           default: None
-        value_template: 
+        value_template:
           description: The sensor is `on` if the template evaluates as `True` and `off` otherwise. The actual appearance in the frontend (`Open`/`Closed`, `Detected`/`Clear` etc) depends on the sensor’s device_class value
           required: true
           type: template

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -60,7 +60,7 @@ sensors:
           required: false
           type: device_class
           default: None
-        value_template:
+        value_template: 
           description: The sensor is `on` if the template evaluates as `True` and `off` otherwise. The actual appearance in the frontend (`Open`/`Closed`, `Detected`/`Clear` etc) depends on the sensor’s device_class value
           required: true
           type: template
@@ -77,6 +77,15 @@ sensors:
           description: Defines a template for the entity picture of the sensor.
           required: false
           type: template
+        attribute_templates:
+          description: Defines templates for attributes of the sensor.
+          required: false
+          type: map
+          keys:
+            "attribute: template":
+              description: The attribute and corresponding template.
+              required: true
+              type: template
         delay_on:
           description: The amount of time the template state must be ***met*** before this sensor will switch to `on`.
           required: false
@@ -229,6 +238,35 @@ binary_sensor:
              or is_state('binary_sensor.family_room_144', 'on') }}
 ```
 
+{% endraw %}
+
+### Device Tracker sensor with Latitude and Longitude Attributes
+
+This example shows how to combine an non-GPS (e.g. NMAP) and GPS device tracker while still including latitude and longitude attributes
+
+{% raw %}
+```yaml
+binary_sensor:
+  - platform: template
+    sensors:
+      my_device:
+        value_template: >-
+          {{ is_state('device_tracker.my_device_nmap','home') or is_state('device_tracker.my_device_gps','home') }}
+        device_class: 'presence'
+        attribute_templates:
+          latitude: >-
+            {% if is_state('device_tracker.my_device_nmap','home') %}
+              {{ state_attr('zone.home','latitude') }}
+            {% else %}
+              {{ state_attr('device_tracker.my_device_gps','latitude') }}
+            {% endif %}
+          longitude: >-
+            {% if is_state('device_tracker.my_device_nmap','home') %}
+              {{ state_attr('zone.home','longitude') }}
+            {% else %}
+              {{ state_attr('device_tracker.my_device_gps','longitude') }}
+            {% endif %}
+```
 {% endraw %}
 
 ### Change the icon when state changes

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -18,6 +18,7 @@ other entities. The state of a Template Binary Sensor can only be `on` or
 Here is an example of adding a Template Binary Sensor to the `configuration.yaml` file:
 
 {% raw %}
+
 ```yaml
 # Example configuration.yaml entry
 binary_sensor:
@@ -27,7 +28,12 @@ binary_sensor:
         friendly_name: "Sun is up"
         value_template: >-
           {{ state_attr('sun.sun', 'elevation')|float > 0 }}
+        availability_template: >-
+          {%- if not is_state('dependant_device.state', 'unavailable') %}
+            true
+          {% endif %}
 ```
+
 {% endraw %}
 
 {% configuration %}
@@ -58,6 +64,11 @@ sensors:
           description: The sensor is `on` if the template evaluates as `True` and `off` otherwise. The actual appearance in the frontend (`Open`/`Closed`, `Detected`/`Clear` etc) depends on the sensor’s device_class value
           required: true
           type: template
+        availability_template:
+          description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+          required: false
+          type: template
+          default: the device is always `available`
         icon_template:
           description: Defines a template for the icon of the sensor.
           required: false
@@ -66,15 +77,6 @@ sensors:
           description: Defines a template for the entity picture of the sensor.
           required: false
           type: template
-        attribute_templates:
-          description: Defines templates for attributes of the sensor.
-          required: false
-          type: map
-          keys:
-            "attribute: template":
-              description: The attribute and corresponding template.
-              required: true
-              type: template
         delay_on:
           description: The amount of time the template state must be ***met*** before this sensor will switch to `on`.
           required: false
@@ -118,6 +120,7 @@ sensor of `furnace` that provides a current reading for the fan motor, we can
 determine if the furnace is running by checking that it is over some threshold:
 
 {% raw %}
+
 ```yaml
 binary_sensor:
   - platform: template
@@ -127,6 +130,7 @@ binary_sensor:
         device_class: heat
         value_template: "{{ states('sensor.furnace')|float > 2.5 }}"
 ```
+
 {% endraw %}
 
 ### Switch as Sensor
@@ -137,6 +141,7 @@ original switch can then be hidden by
 [customizing](/getting-started/customizing-devices/).
 
 {% raw %}
+
 ```yaml
 binary_sensor:
   - platform: template
@@ -148,6 +153,7 @@ binary_sensor:
         device_class: opening
         value_template: "{{ is_state('switch.door', 'on') }}"
 ```
+
 {% endraw %}
 
 ### Combining Multiple Sensors
@@ -157,6 +163,7 @@ status. When using templates with binary sensors, you need to return
 `true` or `false` explicitly.
 
 {% raw %}
+
 ```yaml
 binary_sensor:
   - platform: template
@@ -169,6 +176,7 @@ binary_sensor:
              and is_state('sensor.kitchen_co_status', 'Ok')
              and is_state('sensor.wardrobe_co_status', 'Ok') }}
 ```
+
 {% endraw %}
 
 ### Washing Machine Running
@@ -180,6 +188,7 @@ finished. By utilizing `delay_off`, we can have this sensor only turn off if
 there has been no washer activity for 5 minutes.
 
 {% raw %}
+
 ```yaml
 # Determine when the washing machine has a load running.
 binary_sensor:
@@ -192,9 +201,10 @@ binary_sensor:
         value_template: >-
           {{ states('sensor.washing_machine_power')|float > 0 }}
 ```
+
 {% endraw %}
 
-### Is Anyone Home?
+### Is Anyone Home
 
 This example is determining if anyone is home based on the combination of device
 tracking and motion sensors. It's extremely useful if you have kids/baby sitter/
@@ -203,6 +213,7 @@ trackable device in Home Assistant. This is providing a composite of WiFi based
 device tracking and Z-Wave multisensor presence sensors.
 
 {% raw %}
+
 ```yaml
 binary_sensor:
   - platform: template
@@ -217,45 +228,17 @@ binary_sensor:
              or is_state('binary_sensor.porch_ms6_1_129', 'on')
              or is_state('binary_sensor.family_room_144', 'on') }}
 ```
-{% endraw %}
 
-### Device Tracker sensor with Latitude and Longitude Attributes
-
-This example shows how to combine an non-GPS (e.g. NMAP) and GPS device tracker while still including latitude and longitude attributes
-
-{% raw %}
-```yaml
-binary_sensor:
-  - platform: template
-    sensors:
-      my_device:
-        value_template: >-
-          {{ is_state('device_tracker.my_device_nmap','home') or is_state('device_tracker.my_device_gps','home') }}
-        device_class: 'presence'
-        attribute_templates:
-          latitude: >-
-            {% if is_state('device_tracker.my_device_nmap','home') %}
-              {{ state_attr('zone.home','latitude') }}
-            {% else %}
-              {{ state_attr('device_tracker.my_device_gps','latitude') }}
-            {% endif %}
-          longitude: >-
-            {% if is_state('device_tracker.my_device_nmap','home') %}
-              {{ state_attr('zone.home','longitude') }}
-            {% else %}
-              {{ state_attr('device_tracker.my_device_gps','longitude') }}
-            {% endif %}
-```
 {% endraw %}
 
 ### Change the icon when state changes
 
 This example demonstrates how to use `icon_template` to change the entity's
-icon as its state changes, it evaluates the state of its own sensor and uses a 
-conditional statement to output the appropriate icon. 
-
+icon as its state changes, it evaluates the state of its own sensor and uses a
+conditional statement to output the appropriate icon.
 
 {% raw %}
+
 ```yaml
 sun:
 binary_sensor:
@@ -273,4 +256,5 @@ binary_sensor:
             mdi:weather-sunset-down
           {% endif %}
 ```
+
 {% endraw %}

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -65,10 +65,10 @@ sensors:
           required: true
           type: template
         availability_template:
-          description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+          description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
           required: false
           type: template
-          default: the device is always `available`
+          default: true
         icon_template:
           description: Defines a template for the icon of the sensor.
           required: false

--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -65,7 +65,7 @@ sensors:
           required: true
           type: template
         availability_template:
-          description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
+          description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
           required: false
           type: template
           default: true


### PR DESCRIPTION
Added documentation `availability_template` configuration option for Template Binary Sensor platform components.

https://github.com/home-assistant/home-assistant/pull/26510

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10123"><img src="https://gitpod.io/api/apps/github/pbs/github.com/grillp/home-assistant.io.git/3245873adf520e285b99380743ca83959fc1c5f8.svg" /></a>

