### PR TITLE
Added 'availability_template' to Template Cover platform

### DIFF
--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -19,6 +19,7 @@ To enable Template Covers in your installation,
 add the following to your `configuration.yaml` file:
 
 {% raw %}
+
 ```yaml
 # Example configuration.yaml entry
 cover:
@@ -33,7 +34,12 @@ cover:
           service: script.close_garage_door
         stop_cover:
           service: script.stop_garage_door
+        availability_template: >-
+          {%- if not is_state('dependant_device.state', 'unavailable') %}
+            true
+          {% endif %}
 ```
+
 {% endraw %}
 
 {% configuration %}
@@ -62,6 +68,11 @@ cover:
         description: Defines a template to specify which icon to use.
         required: false
         type: template
+      availability_template:
+        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+        required: false
+        type: template
+        default: the device is always `available`
       device_class:
         description: Sets the [class of the device](/components/cover/), changing the device state and icon that is displayed on the frontend.
         required: false
@@ -136,6 +147,7 @@ This example converts a garage door with a controllable switch and position
 sensor into a cover.
 
 {% raw %}
+
 ```yaml
 cover:
   - platform: template
@@ -162,6 +174,7 @@ cover:
             mdi:garage
           {% endif %}
 ```
+
 {% endraw %}
 
 ### Multiple Covers
@@ -169,6 +182,7 @@ cover:
 This example allows you to control two or more covers at once.
 
 {% raw %}
+
 ```yaml
 homeassistant:
   customize:
@@ -249,6 +263,7 @@ automation:
           entity_id: cover.cover_group
           position: 25
 ```
+
 {% endraw %}
 
 ### Change The Icon
@@ -256,6 +271,7 @@ automation:
 This example shows how to change the icon based on the cover state.
 
 {% raw %}
+
 ```yaml
 cover:
   - platform: template
@@ -282,6 +298,7 @@ cover:
             mdi:window-closed
           {% endif %}
 ```
+
 {% endraw %}
 
 ### Change The Entity Picture
@@ -289,6 +306,7 @@ cover:
 This example shows how to change the entity picture based on the cover state.
 
 {% raw %}
+
 ```yaml
 cover:
   - platform: template
@@ -315,4 +333,5 @@ cover:
             /local/cover-closed.png
           {% endif %}
 ```
+
 {% endraw %}

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -69,7 +69,7 @@ cover:
         required: false
         type: template
       availability_template:
-        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
+        description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
         required: false
         type: template
         default: true

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -34,10 +34,6 @@ cover:
           service: script.close_garage_door
         stop_cover:
           service: script.stop_garage_door
-        availability_template: >-
-          {%- if not is_state('dependant_device.state', 'unavailable') %}
-            true
-          {% endif %}
 ```
 
 {% endraw %}

--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -69,10 +69,10 @@ cover:
         required: false
         type: template
       availability_template:
-        description: "Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`"
+        description: Defines a template to get the `available` state of the component. If the template returns `true` the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`
         required: false
         type: template
-        default: the device is always `available`
+        default: true
       device_class:
         description: Sets the [class of the device](/components/cover/), changing the device state and icon that is displayed on the frontend.
         required: false


### PR DESCRIPTION
Added documentation `availability_template` configuration option for Template Cover platform components.

https://github.com/home-assistant/home-assistant/pull/26509

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html


<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10123"><img src="https://gitpod.io/api/apps/github/pbs/github.com/grillp/home-assistant.io.git/3245873adf520e285b99380743ca83959fc1c5f8.svg" /></a>

