### PR TITLE
Corrected example and scan interval info

### DIFF
--- a/source/_components/switch.modbus.markdown
+++ b/source/_components/switch.modbus.markdown
@@ -18,7 +18,6 @@ To use your Modbus switches in your installation, add the following to your `con
 # Example configuration.yaml entry
 switch:
   platform: modbus
-  scan_interval: 10
   coils:
     - name: Switch1
       hub: hub1
@@ -117,3 +116,22 @@ register:
 {% endconfiguration %}
 
 It's possible to change the default 30 seconds scan interval for the switch state updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.
+
+### Full example
+
+Example a temperature sensor with a 10 seconds scan interval:
+
+```yaml
+switch:
+  platform: modbus
+  scan_interval: 10
+  coils:
+    - name: Switch1
+      hub: hub1
+      slave: 1
+      coil: 13
+    - name: Switch2
+      hub: hub1
+      slave: 2
+      coil: 14
+```

--- a/source/_components/switch.modbus.markdown
+++ b/source/_components/switch.modbus.markdown
@@ -18,7 +18,7 @@ To use your Modbus switches in your installation, add the following to your `con
 # Example configuration.yaml entry
 switch:
   platform: modbus
-  slave: 1
+  scan_interval: 10
   coils:
     - name: Switch1
       hub: hub1
@@ -115,3 +115,5 @@ register:
       default: same as command_off
       type: integer
 {% endconfiguration %}
+
+It's possible to change the default 30 seconds scan interval for the switch state updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.


### PR DESCRIPTION
slave: 1 option in platform configuration causes an error on 0.98.2 
added scan_interval: info
also it seems to me ha_iot_class: should be Local Pull because Modbus all about Pull data from slaves by master

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
