### PR TITLE
Fix example spacing

### DIFF
--- a/source/_components/iss.markdown
+++ b/source/_components/iss.markdown
@@ -61,6 +61,6 @@ camera:
   - platform: generic
     name: ISS
     still_image_url: http://staticmap.openstreetmap.de/staticmap.php?center={{ state_attr('binary_sensor.iss', 'lat') }},{{ state_attr('binary_sensor.iss', 'long') }}&zoom=4&size=865x512&maptype=mapnik&markers={{ state_attr('binary_sensor.iss', 'lat') }},{{ state_attr('binary_sensor.iss', 'long') }},lightblue
-     limit_refetch_to_url_change: true
+    limit_refetch_to_url_change: true
 ```
 {% endraw %}


### PR DESCRIPTION
"limit_refetch_to_url_change" had incorrect spacing and caused errors when copied directly and pasted into configuration.yaml

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
