### PR TITLE
Rename attributes for statistics sensor in docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,8 +101,8 @@ social:
 # Home Assistant release details
 current_major_version: 0
 current_minor_version: 98
-current_patch_version: 3
-date_released: 2019-09-04
+current_patch_version: 4
+date_released: 2019-09-06
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/_config.yml
+++ b/_config.yml
@@ -101,8 +101,8 @@ social:
 # Home Assistant release details
 current_major_version: 0
 current_minor_version: 98
-current_patch_version: 4
-date_released: 2019-09-06
+current_patch_version: 5
+date_released: 2019-09-07
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/source/_components/statistics.markdown
+++ b/source/_components/statistics.markdown
@@ -11,7 +11,7 @@ redirect_from:
  - /components/sensor.statistics/
 ---
 
-The `statistics` sensor platform consumes the state from other sensors. It exports the `mean` value as state and the following values as attributes: `count`, `mean`, `median`, `stdev`, `variance`, `total`, `min`, `max`, `min_age`, `max_age`, `change`, `average_change` and `change_rate`. If it's a binary sensor then only state changes are counted.
+The `statistics` sensor platform consumes the state from other sensors. It exports the `mean` value as state and the following values as attributes: `count`, `mean`, `median`, `stdev`, `variance`, `total`, `min_value`, `max_value`, `min_age`, `max_age`, `change`, `average_change` and `change_rate`. If it's a binary sensor then only state changes are counted.
 
 If you are running the [recorder](/components/recorder/) component, on startup the data is read from the database. So after a restart of the platform, you will immediately have data available. If you're using the [history](/components/history/) component, this will automatically also start the `recorder` integration on startup.
 If you are *not* running the `recorder` component, it can take time till the sensor starts to work because a couple of attributes need more than one value to do the calculation.

--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -258,7 +258,7 @@ sensor:
   - platform: template
     sensors:
       nonsmoker:
-        value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
+        value_template: "{{ (( as_timestamp(now()) - as_timestamp(strptime('06.07.2018', '%d.%m.%Y')) ) / 86400 ) | round(2) }}"
         entity_id: sensor.date
         friendly_name: 'Not smoking'
         unit_of_measurement: "Days"
@@ -275,7 +275,7 @@ sensor:
   - platform: template
     sensors:
       nonsmoker:
-        value_template: '{{ (( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(2) }}'
+        value_template: "{{ (( as_timestamp(now()) - as_timestamp(strptime('06.07.2018', '%d.%m.%Y')) ) / 86400 ) | round(2) }}"
         entity_id: []
         friendly_name: 'Not smoking'
         unit_of_measurement: "Days"

--- a/source/_docs/ecosystem/hass-configurator.markdown
+++ b/source/_docs/ecosystem/hass-configurator.markdown
@@ -6,8 +6,8 @@ redirect_from: /ecosystem/hass-configurator/
 
 ### Configuration UI for Home Assistant
 
-Since there currently is no nice way to edit the yaml-files Home Assistant is using through the frontend, here is a small webapp that hopefully makes the configuration easier. It is a customized and embedded [Ace editor](https://ace.c9.io/), which has syntax highlighting for yaml, the format used for Home Assistants configuration files. There is an integrated file browser to select whatever file you want to edit. When you're done with editing the file, click the save-button and it will replace the original.
-Essentially this is a browser-based alternative to modifying your configuration through SSH, Windows + SMB, Github etc..
+Since there is currently no nice way to edit the YAML files Home Assistant is using through the frontend, here is a small webapp that hopefully makes configuration easier. It is a customized and embedded [Ace editor](https://ace.c9.io/), which has syntax highlighting for YAML, the format used for Home Assistant's configuration files. There is also an integrated file browser to select whatever file you want to edit. When you're done editing the file, simply click the save button and your changes will be applied.
+This is essentially a browser-based alternative to modifying your configuration through SSH, Windows + SMB, Github, etc.
 
 <p class='img'>
 <img src='/images/hassio/screenshots/addon-hass-configurator.png'>
@@ -16,10 +16,10 @@ Screenshot of the HASS Configurator.
 
 ### Feature list
 
-- Web-Based editor to modify your files
+- Web-based editor to modify your files
 - Upload and download files
 - Git integration
-- Lists of available triggers, events, entities, conditions and services. Selected element gets inserted into the editor at the last cursor position.
+- List of available triggers, events, entities, conditions and services. Selected element gets inserted into the editor at the last cursor position.
 - Check valid configuration and restart Home Assistant directly with the click of a button
 - SSL support
 - Optional authentication and IP filtering for additional security
@@ -33,7 +33,7 @@ Consider running the configurator as a user with limited privileges to limit pos
 </div>
 
 ### Installation (Linux, macOS)
-There are no dependencies on Python modules that are not part of the standard library. And all the fancy JavaScript libraries are loaded from CDN (which means this doesn't work when you're offline).
+There are no dependencies on Python modules that are not part of the standard library. All the fancy JavaScript libraries are loaded from CDN (which means this doesn't work when you're offline).
 - Copy [configurator.py](https://github.com/danielperna84/hass-configurator/blob/master/configurator.py) to your Home Assistant configuration directory (e.g `/home/homeassistant/.homeassistant`): `wget https://raw.githubusercontent.com/danielperna84/hass-configurator/master/configurator.py`
 - Make it executable: `sudo chmod 755 configurator.py`
 - (Optional) Set the `GIT` variable in configurator.py to `True` if [GitPython](https://gitpython.readthedocs.io/) is installed on your system. This is required if you want to make use of the Git integration.
@@ -41,8 +41,8 @@ There are no dependencies on Python modules that are not part of the standard li
 - To terminate the process do the usual `CTRL+C`, maybe once or twice
 
 ### Configuration
-Near the top of the `configurator.py`-file you will find some global variables you can change to customize the configurator. If you are unfamiliar with Python: when setting variables of the type _string_, you have to write that within quotation marks. The default settings are fine for just checking out the configurator quickly. With more customized setups you should change some settings though.
-To keep your settings across updates it is also possible to save settings in an external file. In that case copy [settings.conf](https://github.com/danielperna84/hass-configurator/blob/master/settings.conf) wherever you like and append the full path to the file to the command when starting the configurator. e.g., `sudo .configurator.py /home/homeassistant/.homeassistant/mysettings.conf`. This file is in JSON format. So make sure it has a valid syntax (you can set the editor to JSON to get syntax highlighting for the settings). The major difference to the settings in the py-file is, that `None` becomes `null`.
+Near the top of the `configurator.py` file you will find some global variables you can change to customize the configurator. When setting variables of the type _string_, the string must be within quotation marks. The default settings are fine for just checking out the configurator quickly. For more customized setups it might be advisable to change some settings.
+To keep your settings across updates it is also possible to save settings in an external file. In that case copy [settings.conf](https://github.com/danielperna84/hass-configurator/blob/master/settings.conf) wherever you like and append the full path to the file to the command when starting the configurator. e.g., `sudo .configurator.py /home/homeassistant/.homeassistant/mysettings.conf`. This file is in JSON format, so make sure it has a valid syntax (you can set the editor to JSON to get syntax highlighting for the settings). The major difference to the settings in the .py file is that `None` becomes `null`.
 
 #### LISTENIP (string)
 The IP the service is listening on. By default it is binding to `0.0.0.0`, which is every interface on the system.
@@ -70,20 +70,20 @@ Files and folders to ignore in the UI, e.g., `IGNORE_PATTERN = [".*", "*.log", "
 If set to `True`, directories will be displayed at the top of the filebrowser.
 #### GIT (bool)
 Set this variable to `True` to enable Git integration. This feature requires [GitPython](https://gitpython.readthedocs.io)
- to be installed on the system that is running the configurator. For technical reasons this feature can not be enabled with the static settings file.
+ to be installed on the system that is running the configurator. For technical reasons this feature cannot be enabled with the static settings file.
 
 __Note regarding `ALLOWED_NETWORKS`, `BANNED_IPS` and `BANLIMIT`__:
 The way this is implemented works in the following order:
 
 1. (Only if `CREDENTIALS` is set) Check credentials
-  - Failure: Retry `BANLIMIT` times, after that return error 420 (unless you try again without any authentication headers set, e.g., private tab of your browser)
+  - Failure: Retry `BANLIMIT` times, after that return error 420 (unless you try again without any authentication headers set, such as in a private tab of your browser)
   - Success: Continue
 2. Check if client IP address is in `BANNED_IPS`
   - Yes: Return error 420
   - No: Continue
 3. Check if client IP address is in `ALLOWED_NETWORKS`
-  - No: Return error 420
   - Yes: Continue and display UI of configurator
+  - No: Return error 420
 
 ### Embedding into Home Assistant
 Home Assistant has the [panel_iframe](/components/panel_iframe/) component. With this it is possible to embed the configurator directly into Home Assistant, allowing you to modify your configuration through the Home Assistant frontend.
@@ -98,11 +98,11 @@ panel_iframe:
 ```
 
 <div class='note warning'>
-Be careful when setting up port forwarding to the configurator while embedding it into Home Assistant. If you don't restrict access by requiring authentication and / or blocking based on client IP addresses, your configuration will be exposed to the internet!
+Be careful when setting up port forwarding to the configurator while embedding it into Home Assistant. If you don't restrict access by requiring authentication and/or blocking based on client IP addresses, your configuration will be exposed to the Internet!
 </div>
 
 ### Daemonizing / Keeping the configurator running
-Since the configurator script on its own is no service, you will have to take some extra steps to keep it running. Here are five options (for Linux), but there are more, depending on your usecase.
+Since the configurator script on its own is not a service, you will have to take some extra steps to keep it running. Here are five options (for Linux), but there are more depending on your usecase.
 
 1. Fork the process into the background with the command:
 `nohup sudo ./configurator.py &`

--- a/source/_includes/site/footer.html
+++ b/source/_includes/site/footer.html
@@ -19,6 +19,7 @@
             <li><a href='https://developers.home-assistant.io'>Developers</a></li>
             <li><a href='https://data.home-assistant.io'>Data Science</a></li>
             <li><a href='mailto:hello@home-assistant.io'>Contact</a> (no support!)</li>
+            <li><a href='/security/'>Security Vulnerabilities</a></li>
             <li><a href='/privacy/'>Privacy</a></li>
             <li><a href='https://status.home-assistant.io'>System Status</a></li>
           </ul>

--- a/source/_posts/2019-08-28-release-98.markdown
+++ b/source/_posts/2019-08-28-release-98.markdown
@@ -193,6 +193,10 @@ Screencap of the batcave video.
 [version docs]: https://www.home-assistant.io/components/version/
 [websocket_api docs]: https://www.home-assistant.io/components/websocket_api/
 
+## Release 0.98.3 - September 4
+
+ - Fix Tuya switches ([@balloob])
+
 ## If you need help...
 
 ...don't hesitate to use our very active [forums](https://community.home-assistant.io/) or join us for a little [chat](https://discord.gg/c5DvZ4e).

--- a/source/_posts/2019-08-28-release-98.markdown
+++ b/source/_posts/2019-08-28-release-98.markdown
@@ -193,9 +193,15 @@ Screencap of the batcave video.
 [version docs]: https://www.home-assistant.io/components/version/
 [websocket_api docs]: https://www.home-assistant.io/components/websocket_api/
 
-## Release 0.98.3 - September 4
+## Release 0.98.4 - September 4
 
  - Fix Tuya switches ([@balloob])
+
+## Release 0.98.5 - September 6
+
+We have been notified by Gregor Godbersen that our markdown renderer was vulnerable for an XSS attack if exposed to specially crafted markdown. This was introduced in the Home Assistant 0.98 release. We have verified that Home Assistant 0.98.0 does not render unsafe markdown, yet still wanted to make sure to issue an update as soon as possible.
+
+More information in this [frontend pull request](https://github.com/home-assistant/home-assistant-polymer/pull/3640).
 
 ## If you need help...
 

--- a/source/security/index.markdown
+++ b/source/security/index.markdown
@@ -1,0 +1,10 @@
+---
+title: "Security"
+description: "Information about disclosing security vulnerabilities in Home Assistant."
+---
+
+If you think that you have found a security vulnerability in Home Assistant, please disclose it to us via our security e-mail address at [security@home-assistant.io](mailto://security@home-assistant.io).
+
+Please do not make vulnerabilities public without notifying us and giving us at least 3 days to respond.
+
+If you are going to write about Home Assistant's security, please get in touch, so we can make sure that all claims are correct.


### PR DESCRIPTION
**Description:**
As tested in 0.98.5 the `min` and `max` attributes are actually `min_value` and `max_value`.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
