### PR TITLE
fix hmip script name

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -51,7 +51,7 @@ The authentification token will be generated and stored internally.
 
 Generate the authentication token:
 
-`generate_auth_token.py`
+`hmip_generate_auth_token.py`
 
 Add the information to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**
This fixes the name of Homematic IP cloud script to generate auth tokens.
This should be fixed in current branch.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
