### PR TITLE
Fix example in Template Cover considerations

### DIFF
--- a/source/_components/cover.template.markdown
+++ b/source/_components/cover.template.markdown
@@ -109,10 +109,10 @@ Template Cover may get an `unknown` state during startup. This results in error
 messages in your log file until that platform has completed loading.
 If you use `is_state()` function in your template, you can avoid this situation.
 For example, you would replace
-{% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
+{% raw %}`{{ states.cover.source.state == 'open' }}`{% endraw %}
 with this equivalent that returns `true`/`false` and never gives an unknown
 result:
-{% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
+{% raw %}`{{ is_state('cover.source', 'open') }}`{% endraw %}
 
 ## Optimistic Mode
 


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
