### PR TITLE
Correct discord notification service call example

### DIFF
--- a/source/_components/discord.markdown
+++ b/source/_components/discord.markdown
@@ -74,7 +74,9 @@ This channel ID has to be used as the target when calling the notification servi
     message: "A message from Home Assistant"
     target: ["1234567890", "0987654321"]
     data:
-      images: "/tmp/garage_cam"
+      images: 
+      - "/tmp/garage_cam"
+      - "/tmp/garage.jpg"
 ```
 
 ### Notes


### PR DESCRIPTION
The current example for the notify service doesn't correctly send images in this component.

Changed the example to reflect a list of images.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
