### PR TITLE
Document switch platform for iaqualink integration

### DIFF
--- a/source/_components/iaqualink.markdown
+++ b/source/_components/iaqualink.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Climate
   - Light
   - Sensor
+  - Switch
 ha_release: 0.99
 ha_iot_class: Cloud Polling
 ---
@@ -17,6 +18,7 @@ There is currently support for the following device types within Home Assistant:
 - Climate
 - Light
 - Sensor
+- Switch
 
 ## Configuration
 


### PR DESCRIPTION
**Description:**

Add mentions of switch platform being now supported.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26545

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
