### PR TITLE
new component: pcal9535a

### DIFF
--- a/source/_components/pcal9535a.markdown
+++ b/source/_components/pcal9535a.markdown
@@ -10,17 +10,17 @@ ha_release: 0.101
 ha_iot_class: Local Polling
 ---
 
-The `pcal9535a` integration is the base for all related pcal9535a platforms in Home Assistant. There is no setup needed for the integration itself, for the platforms please check their corresponding sections.
+The `pcal9535a` integration is the base for all related pcal9535a platforms in Home Assistant. There is no setup needed for the integration itself, for the platforms, please check their corresponding sections.
 
 One of the use cases is [Seeed studio Raspberry Pi Relay Board](http://wiki.seeedstudio.com/Raspberry_Pi_Relay_Board_v1.0/).
 
-For more details about the PCAL9535A I2C I/O port expander you can find its datasheet here: [PCAL9535A](https://www.nxp.com/docs/en/data-sheet/PCAL9535A.pdf).
+For more details about the PCAL9535A I2C I/O port expander, you can find its datasheet here: [PCAL9535A](https://www.nxp.com/docs/en/data-sheet/PCAL9535A.pdf).
 
 ## Binary Sensor
 
 The `pcal9535a` binary sensor platform allows you to read sensor values from the I/O pins of your [PCAL9535A I2C I/O expander](https://www.nxp.com/products/interfaces/ic-spi-serial-interface-devices/ic-general-purpose-i-o/low-voltage-16-bit-ic-bus-i-o-port-with-interrupt-and-agile-i-o:PCAL9535A).
 
-The pin numbers are from 0 to 15 where: 0-7 correspond to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
+The pin numbers are from 0 to 15, where: 0-7 corresponds to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
 
 ### Configuration
 
@@ -30,7 +30,6 @@ To use the I/O pins of an pcal9535a connected to an I2C bus of your Raspberry Pi
 # Example configuration.yaml entry
 binary_sensor:
   - platform: pcal9535a
-    i2c_address: 0x20
     pins:
       0: PIR Office
       1: PIR Bedroom
@@ -79,7 +78,7 @@ pull_mode:
 
 The `pcal9535a` switch platform allows you to write to the I/O pins of your [PCAL9535A I2C I/O expander](https://www.nxp.com/products/interfaces/ic-spi-serial-interface-devices/ic-general-purpose-i-o/low-voltage-16-bit-ic-bus-i-o-port-with-interrupt-and-agile-i-o:PCAL9535A).
 
-The pin numbers are from 0 to 15 where: 0-7 correspond to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
+The pin numbers are from 0 to 15, where: 0-7 corresponds to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
 
 ### Configuration
 
@@ -89,7 +88,6 @@ To use the I/O pins of an pcal9535a connected to an I2C bus of your Raspberry Pi
 # Example configuration.yaml entry
 switch:
   - platform: pcal9535a
-    i2c_address: 0x20
     pins:
       11: Fan Office
       12: Light Desk

--- a/source/_components/pcal9535a.markdown
+++ b/source/_components/pcal9535a.markdown
@@ -20,7 +20,7 @@ For more details about the PCAL9535A I2C I/O port expander, you can find its dat
 
 The `pcal9535a` binary sensor platform allows you to read sensor values from the I/O pins of your [PCAL9535A I2C I/O expander](https://www.nxp.com/products/interfaces/ic-spi-serial-interface-devices/ic-general-purpose-i-o/low-voltage-16-bit-ic-bus-i-o-port-with-interrupt-and-agile-i-o:PCAL9535A).
 
-The pin numbers are from 0 to 15, where: 0-7 corresponds to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
+The pin numbers are from 0 to 15, where: 0-7 correspond to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
 
 ### Configuration
 
@@ -78,7 +78,7 @@ pull_mode:
 
 The `pcal9535a` switch platform allows you to write to the I/O pins of your [PCAL9535A I2C I/O expander](https://www.nxp.com/products/interfaces/ic-spi-serial-interface-devices/ic-general-purpose-i-o/low-voltage-16-bit-ic-bus-i-o-port-with-interrupt-and-agile-i-o:PCAL9535A).
 
-The pin numbers are from 0 to 15, where: 0-7 corresponds to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
+The pin numbers are from 0 to 15, where: 0-7 correspond to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
 
 ### Configuration
 

--- a/source/_components/pcal9535a.markdown
+++ b/source/_components/pcal9535a.markdown
@@ -6,7 +6,7 @@ ha_category:
   - DIY
   - Binary Sensor
   - Switch
-ha_release: 0.99
+ha_release: 0.101
 ha_iot_class: Local Polling
 ---
 

--- a/source/_components/pcal9535a.markdown
+++ b/source/_components/pcal9535a.markdown
@@ -24,7 +24,7 @@ The pin numbers are from 0 to 15, where: 0-7 correspond to port P0 (P0_0 - P0_7)
 
 ### Configuration
 
-To use the I/O pins of an pcal9535a connected to an I2C bus of your Raspberry Pi as binary sensors, add the following to your `configuration.yaml` file:
+To use the I/O pins of an PCAL9535A connected to an I2C bus of your Raspberry Pi as binary sensors, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -55,11 +55,6 @@ pins:
       description: The pin numbers (from 0 to 15) and corresponding names.
       required: true
       type: [integer, string]
-scan_interval:
-  description: Interval to scan for sensor state changes in seconds.
-  required: false
-  type: integer
-  default: 15
 invert_logic:
   description: If `true`, inverts the output logic to ACTIVE LOW.
   required: false
@@ -82,7 +77,7 @@ The pin numbers are from 0 to 15, where: 0-7 correspond to port P0 (P0_0 - P0_7)
 
 ### Configuration
 
-To use the I/O pins of an pcal9535a connected to an I2C bus of your Raspberry Pi as switches, add the following to your `configuration.yaml` file:
+To use the I/O pins of a PCAL9535A connected to an I2C bus of your Raspberry Pi as switches, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -120,7 +115,7 @@ invert_logic:
   type: boolean
 strength:
   description: >
-    Control the output drive level of the GPIO. Each GPIO can be configured independently to one of the four possible output current levels. By programming these bits the user is changing the number of transistor pairs or ‘fingers’ that drive the I/O pad.
+    Control the output drive level of the GPIO. Each GPIO can be configured independently to one of the four possible output current levels. By programming these bits, the user is changing the number of transistor pairs or ‘fingers’ that drive the I/O pad.
     Options are `0.25`, `0.5`, `0.75`, `1.0`.
   required: false
   default: "`1.0`"

--- a/source/_components/pcal9535a.markdown
+++ b/source/_components/pcal9535a.markdown
@@ -6,7 +6,7 @@ ha_category:
   - DIY
   - Binary Sensor
   - Switch
-ha_release: 0.101
+ha_release: 0.102
 ha_iot_class: Local Polling
 ---
 

--- a/source/_components/pcal9535a.markdown
+++ b/source/_components/pcal9535a.markdown
@@ -1,0 +1,130 @@
+---
+title: "PCAL9535A I2C GPIO expander"
+description: "Instructions on how to integrate the PCAL9535A GPIO pin expander with I2C interface into Home Assistant."
+logo: raspberry-pi.png
+ha_category:
+  - DIY
+  - Binary Sensor
+  - Switch
+ha_release: 0.99
+ha_iot_class: Local Polling
+---
+
+The `pcal9535a` integration is the base for all related pcal9535a platforms in Home Assistant. There is no setup needed for the integration itself, for the platforms please check their corresponding sections.
+
+One of the use cases is [Seeed studio Raspberry Pi Relay Board](http://wiki.seeedstudio.com/Raspberry_Pi_Relay_Board_v1.0/).
+
+For more details about the PCAL9535A I2C I/O port expander you can find its datasheet here: [PCAL9535A](https://www.nxp.com/docs/en/data-sheet/PCAL9535A.pdf).
+
+## Binary Sensor
+
+The `pcal9535a` binary sensor platform allows you to read sensor values from the I/O pins of your [PCAL9535A I2C I/O expander](https://www.nxp.com/products/interfaces/ic-spi-serial-interface-devices/ic-general-purpose-i-o/low-voltage-16-bit-ic-bus-i-o-port-with-interrupt-and-agile-i-o:PCAL9535A).
+
+The pin numbers are from 0 to 15 where: 0-7 correspond to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
+
+### Configuration
+
+To use the I/O pins of an pcal9535a connected to an I2C bus of your Raspberry Pi as binary sensors, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+  - platform: pcal9535a
+    i2c_address: 0x20
+    pins:
+      0: PIR Office
+      1: PIR Bedroom
+```
+
+{% configuration %}
+i2c_bus:
+  description: i2c bus number of PCAL9535A chip.
+  required: false
+  type: integer
+  default: 1
+i2c_address:
+  description: i2c address of PCAL9535A chip.
+  required: false
+  type: integer
+  default: "`0x20`"
+pins:
+  description: List of used pins.
+  required: true
+  type: map
+  keys:
+    "pin: name":
+      description: The pin numbers (from 0 to 15) and corresponding names.
+      required: true
+      type: [integer, string]
+scan_interval:
+  description: Interval to scan for sensor state changes in seconds.
+  required: false
+  type: integer
+  default: 15
+invert_logic:
+  description: If `true`, inverts the output logic to ACTIVE LOW.
+  required: false
+  type: boolean
+  default: "`false` (ACTIVE HIGH)"
+pull_mode:
+  description: >
+    Type of internal pull resistor to use.
+    Options are `UP` - pull-up resistor, `DOWN` - pull-down resistor, `DISABLED` - resistors disconnected.
+  required: false
+  type: string
+  default: "`DISABLED`"
+{% endconfiguration %}
+
+## Switch
+
+The `pcal9535a` switch platform allows you to write to the I/O pins of your [PCAL9535A I2C I/O expander](https://www.nxp.com/products/interfaces/ic-spi-serial-interface-devices/ic-general-purpose-i-o/low-voltage-16-bit-ic-bus-i-o-port-with-interrupt-and-agile-i-o:PCAL9535A).
+
+The pin numbers are from 0 to 15 where: 0-7 correspond to port P0 (P0_0 - P0_7) and 8-15 to port P1 (P1_0 - P1_7).
+
+### Configuration
+
+To use the I/O pins of an pcal9535a connected to an I2C bus of your Raspberry Pi as switches, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: pcal9535a
+    i2c_address: 0x20
+    pins:
+      11: Fan Office
+      12: Light Desk
+```
+
+{% configuration %}
+i2c_bus:
+  description: i2c bus number of PCAL9535A chip.
+  required: false
+  type: integer
+  default: 1
+i2c_address:
+  description: i2c address of PCAL9535A chip.
+  required: false
+  type: integer
+  default: "`0x20`"
+pins:
+  description: Array of used pins.
+  required: true
+  type: list
+  keys:
+    pin:
+      description: The pin numbers (from 0 to 15) and corresponding names.
+      required: true
+      type: [integer, string]
+invert_logic:
+  description: If true, inverts the output logic to ACTIVE LOW.
+  required: false
+  default: false
+  type: boolean
+strength:
+  description: >
+    Control the output drive level of the GPIO. Each GPIO can be configured independently to one of the four possible output current levels. By programming these bits the user is changing the number of transistor pairs or ‘fingers’ that drive the I/O pad.
+    Options are `0.25`, `0.5`, `0.75`, `1.0`.
+  required: false
+  default: "`1.0`"
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
Signed-off-by: Denis Shulyaka <Shulyaka@gmail.com>

**Description:** Support for PCAL9535A I2C GPIO PIN expander

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26563

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
