### PR TITLE
Added brightness_scale_min to MQTT lights

### DIFF
--- a/source/_components/light.mqtt.markdown
+++ b/source/_components/light.mqtt.markdown
@@ -70,6 +70,11 @@ brightness_scale:
   required: false
   type: integer
   default: 255
+brightness_scale_min:
+  description: "Defines the minimum brightness value (i.e. 0%) of the MQTT device."
+  required: false
+  type: integer
+  default: 0
 brightness_state_topic:
   description: The MQTT topic subscribed to receive brightness state updates.
   required: false


### PR DESCRIPTION
**Description:**
Added docs for brightness_scale_min proposed change to mqtt lights

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
