### PR TITLE
Add Home Assistant Cast service docs

### DIFF
--- a/source/_components/cast.markdown
+++ b/source/_components/cast.markdown
@@ -15,6 +15,17 @@ discovered if you enable [the discovery integration](/components/discovery/). If
 you don't have the discovery integration enabled, you can enable the Cast
 integration by going to the Integrations page inside the config panel.
 
+## Home Assistant Cast
+
+The Cast integration allows you to start Home Assistant Cast on any Chromecast device. This is done via the `cast.show_lovelace_view` service. The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on.
+
+```json
+{
+  "entity_id": "media_player.office_display_4",
+  "view_path": "lights"
+}
+```
+
 ## Advanced use
 
 The Cast integration has some extra configuration options available for advanced
@@ -38,20 +49,20 @@ You may need to enable Multicast DNS (MDNS) on your router if you are on a diffe
 
 {% configuration %}
 media_player:
-  description: A list that contains all Cast devices.
-  required: true
-  type: list
-  keys:
-    host:
-      description: Use only if you don't want to scan for devices.
-      required: false
-      type: string
-    ignore_cec:
-      description: >
-        A list of Chromecasts that should ignore CEC data for determining the
-        active input. [See the upstream documentation for more information.](https://github.com/balloob/pychromecast#ignoring-cec-data)
-      required: false
-      type: list
+description: A list that contains all Cast devices.
+required: true
+type: list
+keys:
+host:
+description: Use only if you don't want to scan for devices.
+required: false
+type: string
+ignore_cec:
+description: >
+A list of Chromecasts that should ignore CEC data for determining the
+active input. [See the upstream documentation for more information.](https://github.com/balloob/pychromecast#ignoring-cec-data)
+required: false
+type: list
 {% endconfiguration %}
 
 If you want to manually configure multiple Cast media players, you can define

--- a/source/_components/cast.markdown
+++ b/source/_components/cast.markdown
@@ -17,7 +17,7 @@ integration by going to the Integrations page inside the config panel.
 
 ## Home Assistant Cast
 
-The Cast integration allows you to start Home Assistant Cast on any Chromecast device. This is done via the `cast.show_lovelace_view` service. The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on.
+The Cast integration allows you to start Home Assistant Cast on any Chromecast device, using the `cast.show_lovelace_view` service. The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on.
 
 ```json
 {

--- a/source/_components/cast.markdown
+++ b/source/_components/cast.markdown
@@ -49,20 +49,20 @@ You may need to enable Multicast DNS (MDNS) on your router if you are on a diffe
 
 {% configuration %}
 media_player:
-description: A list that contains all Cast devices.
-required: true
-type: list
-keys:
-host:
-description: Use only if you don't want to scan for devices.
-required: false
-type: string
-ignore_cec:
-description: >
-A list of Chromecasts that should ignore CEC data for determining the
-active input. [See the upstream documentation for more information.](https://github.com/balloob/pychromecast#ignoring-cec-data)
-required: false
-type: list
+  description: A list that contains all Cast devices.
+  required: true
+  type: list
+  keys:
+    host:
+      description: Use only if you don't want to scan for devices.
+      required: false
+      type: string
+    ignore_cec:
+      description: >
+        A list of Chromecasts that should ignore CEC data for determining the
+        active input. [See the upstream documentation for more information.](https://github.com/balloob/pychromecast#ignoring-cec-data)
+      required: false
+      type: list
 {% endconfiguration %}
 
 If you want to manually configure multiple Cast media players, you can define

--- a/source/_posts/2019-08-06-home-assistant-cast.markdown
+++ b/source/_posts/2019-08-06-home-assistant-cast.markdown
@@ -59,5 +59,5 @@ entities:
 
 This is the first release of Home Assistant Cast, and so we focused on the minimum that was worthy of a release. We still have some more things planned:
 
-- Allow starting Home Assistant Cast from Home Assistant itself (not a browser), as part of an automation or script.
+- Allow starting Home Assistant Cast from Home Assistant itself (not a browser), as part of an automation or script. [This is live now since Home Assistant 0.99.](/components/cast/#home-assistant-cast)
 - Use Home Assistant Cast as a text-to-speech target (inspired by [lovelace-browser-commander by @thomasloven](https://github.com/thomasloven/lovelace-browser-commander)).


### PR DESCRIPTION
**Description:**
Add docs for  the  new `cast.show_lovelace_view` service.

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/26566

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
