### PR TITLE
username-host field - clarify use of '%'

### DIFF
--- a/source/_addons/mariadb.markdown
+++ b/source/_addons/mariadb.markdown
@@ -41,7 +41,7 @@ logins:
       required: true
       type: string
     host:
-      description: Host for account. If you need to connect to this account from multiple hosts, use '%'.
+      description: Host for account. Use '%', to accept connections for this account from any host.
       required: true
       type: string
     password:

--- a/source/_addons/mariadb.markdown
+++ b/source/_addons/mariadb.markdown
@@ -41,7 +41,7 @@ logins:
       required: true
       type: string
     host:
-      description: Host for account. If you need an account on multiple hosts, use '%'.
+      description: Host for account. If you need to connect to this account from multiple hosts, use '%'.
       required: true
       type: string
     password:


### PR DESCRIPTION
**Description:**
Clarify that '%' is used in host field when wanting to connect *from* multiple hosts

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].