### PR TITLE
Update bluetooth_le_tracker.markdown

### DIFF
--- a/source/_components/bluetooth_le_tracker.markdown
+++ b/source/_components/bluetooth_le_tracker.markdown
@@ -37,7 +37,7 @@ device_tracker:
 track_new_devices:
   description: If new discovered devices are tracked by default.
   required: false
-  default: true
+  default: false
   type: boolean
 interval_seconds:
   description: Seconds between each scan for new devices.


### PR DESCRIPTION
set track_new_devices default to false, as in the version 0.97.2 it is false.
I had checked the code to understand why nothing was detected and the conclusion is the default value is false

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
