### PR TITLE
Use inverted commas for a number in a string

### DIFF
--- a/source/_components/tuya.markdown
+++ b/source/_components/tuya.markdown
@@ -45,7 +45,7 @@ tuya:
 
 {% configuration %}
 username:
-  description: Your username to log in to Tuya. This may be your phone number.
+  description: Your username to log in to Tuya. This may be your phone number which needs to be in inverted commas as this is a string.
   required: true
   type: string
 password:
@@ -53,7 +53,7 @@ password:
   required: true
   type: string
 country_code:
-  description: "Your account [country code](https://www.countrycode.org/), e.g., 1 for USA or 86 for China."
+  description: "Your account [country code](https://www.countrycode.org/), e.g., 1 for USA or 86 for China." Again in inverted commas.
   required: true
   type: string
 platform:

--- a/source/_components/tuya.markdown
+++ b/source/_components/tuya.markdown
@@ -45,7 +45,7 @@ tuya:
 
 {% configuration %}
 username:
-  description: Your username to log in to Tuya. This may be your phone number which needs to be in inverted commas as this is a string.
+  description: Your username to log in to Tuya. This may be your phone number which needs to be enquoted as this is a string.
   required: true
   type: string
 password:
@@ -53,7 +53,7 @@ password:
   required: true
   type: string
 country_code:
-  description: "Your account [country code](https://www.countrycode.org/), e.g., 1 for USA or 86 for China." Again in inverted commas.
+  description: "Your account [country code](https://www.countrycode.org/), e.g., 1 for USA or 86 for China, again enquoted."
   required: true
   type: string
 platform:


### PR DESCRIPTION
I spent ages trying to figure out why may password would not work until I realized it was a string so my phone number needed to be in inverted commas.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
