### PR TITLE
Document binary_sensor platform for iaqualink integration

### DIFF
--- a/source/_components/iaqualink.markdown
+++ b/source/_components/iaqualink.markdown
@@ -3,6 +3,7 @@ title: "Jandy iAqualink"
 description: "Instructions on how to configure Jandy iAqualink integration."
 logo: iaqualink.png
 ha_category:
+  - Binary Sensor
   - Climate
   - Light
   - Sensor
@@ -15,6 +16,7 @@ ha_iot_class: Cloud Polling
 
 There is currently support for the following device types within Home Assistant:
 
+- Binary Sensor
 - Climate
 - Light
 - Sensor


### PR DESCRIPTION
**Description:**

Document new binary_sensor platform for iaqualink integration.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26616

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
