### PR TITLE
The lack of reload is gone

### DIFF
--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -6,10 +6,6 @@ redirect_from: /topics/packages/
 
 Packages in Home Assistant provide a way to bundle different component's configuration together. We already learned about the two configuration styles (specifying platforms entries together or individually) on the [adding devices](/docs/configuration/devices/) page. Both of these configuration methods require you to create the integration key in the main `configuration.yaml` file. With packages we have a way to include different components, or different configuration parts using any of the `!include` directives introduced in [splitting the configuration](/docs/configuration/splitting_configuration).
 
-<div class='note tip'>
-Note that if you use packages for your configuration, the configuration reloading buttons in the configuration panel will not reload your packages.
-</div>
-
 Packages are configured under the core `homeassistant/packages` in the configuration and take the format of a package name (no spaces, all lower case) followed by a dictionary with the package config. For example, package `pack_1` would be created as:
 
 ```yaml


### PR DESCRIPTION
The ability to reload automations etc in packages has long been addressed, apparently

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
