### PR TITLE
✏️ Fix Binary Sensor category problem

### DIFF
--- a/source/_components/updater.markdown
+++ b/source/_components/updater.markdown
@@ -3,7 +3,7 @@ title: "Updater"
 description: "Detecting when Home Assistant updates are available."
 logo: home-assistant.png
 ha_category:
-  - binary_sensor
+  - Binary Sensor
 ha_qa_scale: internal
 ha_release: 0.8
 ---


### PR DESCRIPTION
**Description:**
This will hopefully solve the problem that a 2nd binary sensor category is present in the integrations overview.

Fix for: #10355 

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
