### PR TITLE
List of expected sensors and their states for Obihai

### DIFF
--- a/source/_components/obihai.markdown
+++ b/source/_components/obihai.markdown
@@ -35,3 +35,12 @@ password:
   type: string
   default: admin
 {% endconfiguration %}
+
+The following is a list of expected sensors and their expected states:
+
+- Obihai service status (`Normal`, `Down` or other states from Obihais network)
+- Sensors for each phone port in use (`On Hook`, `Off Hook` and `Ringing`)
+- Sensors for last caller name and number (this is also the current incoming call, will also show `--` if no data provided)
+- Sensor if the device requires a reboot (`True` or `False`)
+- Sensor for each configured service (`0` for no calls, `1` for a call and `2` for call waiting/3way calling)
+- Sensor for the last reboot date


### PR DESCRIPTION
**Description:**

Provide the user with the list of sensors and their states for the Obihai integration.  This integration is already merged and ready for 0.99 release (https://github.com/home-assistant/home-assistant/pull/26537 and #10324 ).  This change will help clarify sensors and states for users so they know what to expect.  Please include this in the 0.99 release.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
