### PR TITLE
Correct the example on templates

### DIFF
--- a/source/_components/template.markdown
+++ b/source/_components/template.markdown
@@ -79,7 +79,7 @@ sensor:
 
 ### Startup
 
-If you are using the state of a platform that takes extra time to load, the Template Sensor may get an `unknown` state during startup. To avoid this (and the resulting error messages in your log file), you can use `is_state()` function in your template. For example, you would replace {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %} with this equivalent that returns `true`/`false` and never gives an `unknown` result:
+If you are using the state of a platform that takes extra time to load, the Template Sensor may get an `unknown` state during startup. To avoid this (and the resulting error messages in your log file), you can use `is_state()` function in your template. For example, you would replace {% raw %}`{{ states.cover.source.state == 'open' }}`{% endraw %} with this equivalent that returns `true`/`false` and never gives an `unknown` result:
 
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
 


### PR DESCRIPTION
**Description:**

Same as #10332 but for sensor templates too.

see: https://discordapp.com/channels/330944238910963714/330944238910963714/622227432786755615

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant# n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
