### PR TITLE
Fix typo in installation.markdown

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -180,7 +180,7 @@ curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/mast
  - `raspberrypi3-64`
  - `odroid-c2`
  - `odroid-cu2`
- - `odriod-xu`
+ - `odroid-xu`
  - `orangepi-prime`
 
 <div class='note'>


### PR DESCRIPTION
**Description:**
Fix typo in installation.markdown

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
