### PR TITLE
Add new option to bluetooth tracker for discovering devices

### DIFF
--- a/source/_components/bluetooth_tracker.markdown
+++ b/source/_components/bluetooth_tracker.markdown
@@ -21,6 +21,11 @@ device_tracker:
 ```
 
 {% configuration %}
+discover_new_devices:
+  description: Whether to discover new Bluetooth devices.
+  required: false
+  type: boolean
+  default: true
 request_rssi:
   description: Performs a request for the "Received signal strength indication" (RSSI) of each tracked device.
   required: false


### PR DESCRIPTION
**Description:**
This PR adds a new option for controlling whether to discover new devices - `discover_new_devices` (previously undocumented using `track_new_devices`)

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26641

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
