### PR TITLE
Add icon_code sensor to Environment Canada

### DIFF
--- a/source/_components/environment_canada.markdown
+++ b/source/_components/environment_canada.markdown
@@ -99,6 +99,7 @@ sensor:
     - `humidity` - The current humidity, in %.
     - `visibility` - The current visibility, in km.
     - `condition` - A brief text statement of the current weather conditions, e.g. "Sunny".
+    - `icon_code` - A two-digit number corresponding to a condition icon, as specified in these [image to description](https://dd.weather.gc.ca/citypage_weather/docs/Current_Conditions_Icons-Icones_conditions_actuelles.pdf) and [code to description](https://dd.weather.gc.ca/citypage_weather/docs/current_conditions_icon_code_descriptions_e.csv) mappings.
     - `wind_speed` - The current sustained wind speed, in km/h.
     - `wind_gust` - The current wind gust, in km/h.
     - `wind_dir` - The current cardinal wind direction, e.g. "SSW".


### PR DESCRIPTION
**Description:**

Adds description of `icon_code` sensor.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26646

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
