### PR TITLE
Allow code elements to wrap if necessary

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -529,7 +529,7 @@ code {
   font-size: 0.8em;
   color: #1990b8;
   word-spacing: normal;
-  word-break: normal;
+  word-break: break-word;
   word-wrap: normal;
 
   -moz-tab-size: 4;


### PR DESCRIPTION
**Description:**

Modifies the CSS for `<code>` elements to allow them to wrap if necessary.

When I navigate from the Home Assistant home page to the Blog section a gutter on the right appears ([screenshot](https://user-images.githubusercontent.com/247634/64910661-9e7dbd80-d710-11e9-8578-2632ee2e9a0f.PNG)). Almost all blog pages seem to be affected by this, some more than others.

This is caused by `<code>` elements forcing out the width of the page in nested lists:

![screenshot](https://i.imgur.com/RHKr71T.png)

If this change is merged the equivalent will look like:

![screenshot](https://i.imgur.com/FW2v0un.png)

- [Before screenshot](https://i.imgur.com/mHsVuy4.png)
- [After screenshot](https://i.imgur.com/uSA1976.png)

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
