### PR TITLE
Include port number in 'adb connect' command

### DIFF
--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -174,7 +174,7 @@ If you get a "Device authentication required, no keys available" error when tryi
 In the dialog appearing on your Android TV / Fire TV, you must check the box that says "always allow connections from this device." ADB authentication in Home Assistant will only work using a trusted key.
 </div>
 
-Once you've successfully connected to your Android TV / Fire TV via the command `adb connect <ipaddress>`, the file `adbkey` will be created on your computer. The default locations for this file is (from [https://developer.android.com/studio/command-line/adb](https://developer.android.com/studio/command-line/adb)):
+Once you've successfully connected to your Android TV / Fire TV via the command `adb connect <ipaddress>:5555`, the file `adbkey` will be created on your computer. The default locations for this file is (from [https://developer.android.com/studio/command-line/adb](https://developer.android.com/studio/command-line/adb)):
 
 - Linux and Mac: `$HOME/.android.`
 - Windows: `%userprofile%\.android.`


### PR DESCRIPTION
the command `adb connect <ipaddress>` doesn't work unless port is specified. The command `adb connect<ipaddress>:5555` works.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
