### PR TITLE
emulated_hue note for sleep cycle and sleep as android

### DIFF
--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -37,7 +37,7 @@ If you added or upgraded to a newer Alexa device and devices are not found, you 
 
 <div class='note'>
 
-<a href="https://www.sleepcycle.com" target="_blank">Sleep Cycle</a> and <a href="https://sleep.urbandroid.org" target="_blank"> Sleep as Android</a>: smart alarm clock app can use emulated_hue to turn on and off enitites. Sleep Cycle only has it implemented in the iOS app, see <a href="https://support.sleepcycle.com/hc/en-us/articles/207670385-Does-Sleep-Cycle-integrates-with-Phillips-Hue-" target="_blank">Sleep Cycle support</a>. The app requires the same configuration as Google Home and does not work if type is defined as alexa in configuration.
+[Sleep Cycle](https://www.sleepcycle.com) and [Sleep as Android](https://sleep.urbandroid.org): smart alarm clock app can use emulated_hue to turn on and off enitites. Sleep Cycle only has it implemented in the iOS app, see [Sleep Cycle support](https://support.sleepcycle.com/hc/en-us/articles/207670385-Does-Sleep-Cycle-integrates-with-Phillips-Hue-). The app requires the same configuration as Google Home and does not work if type is defined as alexa in configuration.
 
 </div>
 

--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -35,6 +35,12 @@ If you added or upgraded to a newer Alexa device and devices are not found, you 
 
 </div>
 
+<div class='note'>
+
+<a href="https://www.sleepcycle.com" target="_blank">Sleep Cycle</a> and <a href="https://sleep.urbandroid.org" target="_blank"> Sleep as Android</a>: smart alarm clock app can use emulated_hue to turn on and off enitites. Sleep Cycle only has it implemented in the iOS app, see <a href="https://support.sleepcycle.com/hc/en-us/articles/207670385-Does-Sleep-Cycle-integrates-with-Phillips-Hue-" target="_blank">Sleep Cycle support</a>. The app requires the same configuration as Google Home and does not work if type is defined as alexa in configuration.
+
+</div>
+
 ### Configuration
 
 To enable the emulated Hue bridge, add one of the following configs to your `configuration.yaml` file:

--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -37,7 +37,7 @@ If you added or upgraded to a newer Alexa device and devices are not found, you 
 
 <div class='note'>
 
-[Sleep Cycle](https://www.sleepcycle.com) and [Sleep as Android](https://sleep.urbandroid.org): smart alarm clock app can use emulated_hue to turn on and off enitites. Sleep Cycle only has it implemented in the iOS app, see [Sleep Cycle support](https://support.sleepcycle.com/hc/en-us/articles/207670385-Does-Sleep-Cycle-integrates-with-Phillips-Hue-). The app requires the same configuration as Google Home and does not work if type is defined as alexa in configuration.
+[Sleep Cycle](https://www.sleepcycle.com) and [Sleep as Android](https://sleep.urbandroid.org): smart alarm clock app can use emulated_hue to turn on and off entities. Sleep Cycle only has it implemented in the iOS app, see [Sleep Cycle support](https://support.sleepcycle.com/hc/en-us/articles/207670385-Does-Sleep-Cycle-integrates-with-Phillips-Hue-). The app requires the same configuration as Google Home and does not work if the type is defined as Alexa in the configuration.
 
 </div>
 


### PR DESCRIPTION
**Description:**
Note describing how to use sleep cycle and sleep as android in emulated hue using full state view

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#26650

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html