### PR TITLE
adding documentation for the yandex_transport component

### DIFF
--- a/source/_components/yandex_transport.markdown
+++ b/source/_components/yandex_transport.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Yandex transport"
-description: "Instructions on how to setup Yandex transport with Home Assistant."
+description: "Instructions on how to set up Yandex transport with Home Assistant."
 logo: yandex.png
 ha_category:
   - Sensor
@@ -10,10 +10,11 @@ ha_release: "0.100"
 
 The `yandex_tranport` sensor platform uses [Yandex Maps](https://maps.yandex.ru/) it will give you the time until the next departure time from a bus/tramway/etc stop.
 
-The [Yandex Maps](https://maps.yandex.ru/) website can help to determine the id of your bus stop. You can select bus stop by clicking on the map, and look to the url:
+The [Yandex Maps](https://maps.yandex.ru/) website can help to determine the id of your bus stop. You can select a bus stop by clicking on the map, and look to the URL:
 
-https://yandex.ru/maps/213/moscow/?ll=37.722565%2C55.806662&masstransit%5BstopId%5D=stop__9642962&mode=masstransit&z=16.52
-where stop id is: **9642962**
+`https://yandex.ru/maps/213/moscow/?ll=37.722565%2C55.806662&masstransit%5BstopId%5D=stop__9642962&mode=masstransit&z=16.52`
+
+Where stop id is: **9642962**
 
 If you want to track only specific routes, you can add them in the routes section.
 
@@ -34,7 +35,7 @@ stop_id:
   required: true
   type: string
 routes:
-  description: A list of a specific bus/tramway/etc routes at the stop. This is the same as the bus number, e.g., `83`. If the routes with letters contain cyrillic symbols, so write them to configuration.yaml BY cyrillic.
+  description: "A list of a specific bus, tramway, etc routes at the stop. This is the same as the bus number, e.g., `83`. If the routes with letters contain Cyrillic symbols, so write them to `configuration.yaml` in Cyrillic."
   required: false
   type: list
 name:
@@ -65,7 +66,7 @@ sensor:
 
 ## Options For Entities
 
-You can configure view information about next bus using lovelace card.
+You can configure view information about the next bus using Lovelace card.
 To enable displaying the relative time in your `default_vew` add the following lines:
 
 ```yaml

--- a/source/_components/yandex_transport.markdown
+++ b/source/_components/yandex_transport.markdown
@@ -16,7 +16,7 @@ The [Yandex Maps](https://maps.yandex.ru/) website can help to determine the id 
 https://yandex.ru/maps/213/moscow/?ll=37.722565%2C55.806662&masstransit%5BstopId%5D=stop__9642962&mode=masstransit&z=16.52
 where stop id is: **9642962**
 
-if you want to look only specific routes, you can add them in routes section.
+If you want to track only specific routes, you can add them in the routes section.
 
 ## Configuration
 

--- a/source/_components/yandex_transport.markdown
+++ b/source/_components/yandex_transport.markdown
@@ -5,8 +5,6 @@ logo: yandex.png
 ha_category:
   - Transport
 ha_release: 0.99
-redirect_from:
- - /components/sensor.yandex_tranport/
 ---
 
 The `yandex_tranport` sensor platform uses [Yandex Maps](https://maps.yandex.ru/) it will give you the time until the next departure time from a bus/tramway/etc stop.

--- a/source/_components/yandex_transport.markdown
+++ b/source/_components/yandex_transport.markdown
@@ -27,9 +27,6 @@ To activate Yandex Transport, add the following lines to your `configuration.yam
 sensor:
   - platform: yandex_tranport
     stop_id: YOUR_STOP_ID
-    routes: #optionaly
-       - 916
-       - 118
 ```
 
 {% configuration %}
@@ -47,5 +44,39 @@ name:
   default: Yandex Transport
   type: string
 {% endconfiguration %}
+
+## Full configuration example
+
+The configuration sample below shows how an entry can look like:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: yandex_transport
+    name: Bus_to_subway
+    stop_id: 9639579
+    routes:
+      - 63
+      - 179
+      - 179к
+      - 154
+      - 591
+      - 677к
+```
+
+## Options For Entities
+You can configure view information about next bus using lovelace card.
+To enable displaying the relative time in your `default_vew` add the following lines:
+```yaml
+# Example default_view entry
+title: Home Assistant
+views:
+    cards:
+      - entities:
+          - entity: sensor.yandex_transport
+            format: relative
+        type: entities
+    path: default_view
+```
 
 Data provided by https://maps.yandex.ru

--- a/source/_components/yandex_transport.markdown
+++ b/source/_components/yandex_transport.markdown
@@ -3,8 +3,9 @@ title: "Yandex transport"
 description: "Instructions on how to setup Yandex transport with Home Assistant."
 logo: yandex.png
 ha_category:
+  - Sensor
   - Transport
-ha_release: 0.99
+ha_release: "0.100"
 ---
 
 The `yandex_tranport` sensor platform uses [Yandex Maps](https://maps.yandex.ru/) it will give you the time until the next departure time from a bus/tramway/etc stop.
@@ -63,8 +64,10 @@ sensor:
 ```
 
 ## Options For Entities
+
 You can configure view information about next bus using lovelace card.
 To enable displaying the relative time in your `default_vew` add the following lines:
+
 ```yaml
 # Example default_view entry
 title: Home Assistant

--- a/source/_components/yandex_transport.markdown
+++ b/source/_components/yandex_transport.markdown
@@ -1,0 +1,51 @@
+---
+title: "Yandex transport"
+description: "Instructions on how to setup Yandex transport with Home Assistant."
+logo: yandex.png
+ha_category:
+  - Transport
+ha_release: 0.99
+redirect_from:
+ - /components/sensor.yandex_tranport/
+---
+
+The `yandex_tranport` sensor platform uses [Yandex Maps](https://maps.yandex.ru/) it will give you the time until the next departure time from a bus/tramway/etc stop.
+
+The [Yandex Maps](https://maps.yandex.ru/) website can help to determine the id of your bus stop. You can select bus stop by clicking on the map, and look to the url:
+
+https://yandex.ru/maps/213/moscow/?ll=37.722565%2C55.806662&masstransit%5BstopId%5D=stop__9642962&mode=masstransit&z=16.52
+where stop id is: **9642962**
+
+if you want to look only specific routes, you can add them in routes section.
+
+## Configuration
+
+To activate Yandex Transport, add the following lines to your `configuration.yaml`:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: yandex_tranport
+    stop_id: YOUR_STOP_ID
+    routes: #optionaly
+       - 916
+       - 118
+```
+
+{% configuration %}
+stop_id:
+  description: The ID of the transport stop to get the information for.
+  required: true
+  type: string
+routes:
+  description: A list of a specific bus/tramway/etc routes at the stop. This is the same as the bus number, e.g., `83`. If the routes with letters contain cyrillic symbols, so write them to configuration.yaml BY cyrillic.
+  required: false
+  type: list
+name:
+  description: A friendly name for this sensor.
+  required: false
+  default: Yandex Transport
+  type: string
+{% endconfiguration %}
+
+Data provided by https://maps.yandex.ru


### PR DESCRIPTION
https://github.com/home-assistant/home-assistant/pull/26252#discussion_r321543743

**Description:**
Documentation for Yandex Transport component:
https://github.com/home-assistant/home-assistant/pull/26252#discussion_r321543743 

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
