### PR TITLE
Document port number

### DIFF
--- a/source/_components/solax.markdown
+++ b/source/_components/solax.markdown
@@ -27,6 +27,11 @@ ip_address:
   description: The IP address of your Solax system.
   required: true
   type: string
+port:
+  required: false
+  type: integer
+  default: 80
+  description: The port number
 {% endconfiguration %}
 
 ### Optional template sensor


### PR DESCRIPTION
**Description:**

Adding port option to solax integration

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26705

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
