### PR TITLE
Fix incorrect warning

### DIFF
--- a/source/_addons/mosquitto.markdown
+++ b/source/_addons/mosquitto.markdown
@@ -23,7 +23,7 @@ Set up [Mosquitto](https://mosquitto.org/) as MQTT broker.
 
 <div class='warning note'>
 
-Since version 4.1 of the addon, an explicit ACL definition is now required, [see these instructions](https://www.home-assistant.io/addons/mosquitto/#access-control-lists-acls).
+Since version 4.1 of the addon, an explicit ACL definition is now required if you plan to use legacy logins and `"anonymous": true` [see these instructions](https://www.home-assistant.io/addons/mosquitto/#access-control-lists-acls).
 
 </div>
 


### PR DESCRIPTION
ACL is not required if using HA users and no anonymous access.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
