### PR TITLE
Update pi_hole.markdown

### DIFF
--- a/source/_components/pi_hole.markdown
+++ b/source/_components/pi_hole.markdown
@@ -23,7 +23,7 @@ pi_hole:
 
 {% configuration %}
 host:
-  description: IP address of the host where Pi-hole is running.
+  description: IP address and Port of the host where Pi-hole is running. Pi-hole uses port 4865 by default.
   required: false
   type: string
   default: pi.hole
@@ -49,7 +49,7 @@ verify_ssl:
 ```yaml
 # Example configuration.yaml entry
 pi_hole:
-  host: IP_ADDRESS
+  host: IP_ADDRESS:PORT
 
 sensor:
   - platform: pi_hole


### PR DESCRIPTION
**Description:**
Since the changes to 0.99.0, port needs to be specified on Hass.io for the sensors to be seen. The documents do not reflect this change. The listed config did not work under Hass.io.

Current working config looks like; 

pi_hole:
  host: 192.168.1.101:4865

IP being the machine running Hass.io and hosting Pi-hole through Community Hass.io Add-ons

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
