### PR TITLE
added port to documentation

### DIFF
--- a/source/_components/pi_hole.markdown
+++ b/source/_components/pi_hole.markdown
@@ -30,7 +30,7 @@ host:
 port:
   description: TCP/IP port of Pi-hole.
   required: false
-  type: int
+  type: integer
   default: 80
 location:
   description: The installation location of the Pi-hole API.

--- a/source/_components/pi_hole.markdown
+++ b/source/_components/pi_hole.markdown
@@ -27,6 +27,11 @@ host:
   required: false
   type: string
   default: pi.hole
+port:
+  description: TCP/IP port of Pi-hole.
+  required: false
+  type: int
+  default: 80
 location:
   description: The installation location of the Pi-hole API.
   required: false


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
