### PR TITLE
Clarify differences between user and admin accounts for Obihai

### DIFF
--- a/source/_components/obihai.markdown
+++ b/source/_components/obihai.markdown
@@ -36,11 +36,14 @@ password:
   default: admin
 {% endconfiguration %}
 
-The following is a list of expected sensors and their expected states:
+The following is a list of expected sensors and their expected states when using the `user` account:
+
+- Sensor if the device requires a reboot (`True` or `False`)
+- Sensor for each configured service (`0` for no calls, `1` for a call and `2` for call waiting/3way calling)
+- Sensor for the last reboot date
+
+In addition to the above list the `admin` account can expect to see the following sensors:
 
 - Obihai service status (`Normal`, `Down` or other states from Obihais network)
 - Sensors for each phone port in use (`On Hook`, `Off Hook` and `Ringing`)
 - Sensors for last caller name and number (this is also the current incoming call, will also show `--` if no data provided)
-- Sensor if the device requires a reboot (`True` or `False`)
-- Sensor for each configured service (`0` for no calls, `1` for a call and `2` for call waiting/3way calling)
-- Sensor for the last reboot date


### PR DESCRIPTION
**Description:**

Clarify differences between `user` and `admin` accounts for Obihai

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant# N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
