### PR TITLE
Newer Alexa devices require port 80

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -65,7 +65,7 @@ host_ip:
   required: false
   type: string
 listen_port:
-  description: The port the Hue bridge API web server will run on. This can be any free port on your system. However, all new Alexa devices require listen_port: 80. 
+  description: "The port the Hue bridge API web server will run on. This can be any free port on your system. However, all new Alexa devices require listen_port: 80." 
   required: false
   type: integer
   default: 8300

--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -31,6 +31,8 @@ It is recommended to assign a static IP address to the computer running Home Ass
 
 Both Google Home and Alexa use the device they were initially set up with for communication with `emulated_hue`. In other words: if you remove/replace this device you will also break `emulated_hue`. To recover your `emulated_hue` functionality, backup your `config/emulated_hue_ids.json` file, delete the original one and reboot your Home Assistant instance.
 
+If you added or upgraded to a newer Alexa device and devices are not found, you must change to listen_port: 80. If Alexa responds with "value is out of range for device..." it means switches were automatically added as lights in discovery. Remove each device in the Alexa app. Turn on all the switches in Home Assistant. In the Alexa app go to "Add New Device" select "Switch" and then "other" to add them correctly.
+
 </div>
 
 ### Configuration
@@ -63,7 +65,7 @@ host_ip:
   required: false
   type: string
 listen_port:
-  description: The port the Hue bridge API web server will run on. This can be any free port on your system.
+  description: The port the Hue bridge API web server will run on. This can be any free port on your system. However, all new Alexa devices require listen_port: 80. 
   required: false
   type: integer
   default: 8300


### PR DESCRIPTION
Added a note because the new Alexa devices add each entity as a light by default resulting in "value is out of range for device..." and the fix for it found in the forums.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
