### PR TITLE
correct templating example

### DIFF
--- a/source/_components/light.template.markdown
+++ b/source/_components/light.template.markdown
@@ -86,7 +86,7 @@ Template Light may get an `unknown` state during startup. This results
 in error messages in your log file until that platform has completed loading.
 If you use `is_state()` function in your template, you can avoid this situation.
 For example, you would replace
-{% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
+{% raw %}`{{ states.switch.source.state == 'on' }}`{% endraw %}
 with this equivalent that returns `true`/`false` and never gives an unknown
 result:
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}


### PR DESCRIPTION
Current example shows the same preferred template twice, without the template that would be the one to substitute....

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
