### PR TITLE
Add action_topic and action_template parameters to MQTT Climate component documentation

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -121,6 +121,14 @@ modes:
   required: false
   default: ['auto', 'off', 'cool', 'heat', 'dry', 'fan_only']
   type: list
+action_topic:
+  description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cool`, or `heat`.
+  required: false
+  type: string
+action_template:
+  description: A template to render the value received on the `action_topic` with.
+  requred: false
+  type: template
 temperature_command_topic:
   description: The MQTT topic to publish commands to change the target temperature.
   required: false

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -122,7 +122,7 @@ modes:
   default: ['auto', 'off', 'cool', 'heat', 'dry', 'fan_only']
   type: list
 action_topic:
-  description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cool`, or `heat`.
+  description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cooling`, `heating`, `drying`, or `off`.
   required: false
   type: string
 action_template:


### PR DESCRIPTION
**Description:**
I saw that support for these new parameters was added in a recent release but the docs haven't been updated accordingly.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#https://github.com/home-assistant/home-assistant/pull/25260

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
