### PR TITLE
Update changes to whitelisting local ips

### DIFF
--- a/source/_components/wirelesstag.markdown
+++ b/source/_components/wirelesstag.markdown
@@ -47,17 +47,17 @@ password:
 
 <div class='note'>
 
-  To enable local push notifications from the Tags Manager, you need to add the IP address of the Tags Manager into `trusted_networks` under Authentication Providers. See the [Authentication Providers](https://www.home-assistant.io/docs/authentication/providers/#trusted-networks) for details.
+To enable local push notifications from the Tags Manager, you need to add the IP address of the Tags Manager into `trusted_networks` under Authentication Providers. See the [Authentication Providers](https://www.home-assistant.io/docs/authentication/providers/#trusted-networks) for details.
+ 
+If you are using a version prior to v0.89 you can do the whitelisting under the [HTTP](/components/http) integration.
   
-  Note: if you are using a version prior to v0.89 you can do the whitelisting under the [HTTP](/components/http) component.
-  
-  Additionally, you need add at least one [WirelessTag binary sensor](#binary-sensor) in config to start receiving local push notifications.
+Additionally, you need to add at least one [WirelessTag binary sensor](#binary-sensor) in the configuration to start receiving local push notifications.
 
 </div>
 
 <div class='note warning'>
 
-  Tags Manager supports local push notifications for `http` schema only. So if your hass uses `https`, local push notifications are disabled and data is received via cloud polling.
+Tags Manager supports local push notifications for `http` schema only. So if your Home Assistant uses `https`, local push notifications are disabled and data is received via cloud polling.
 
 </div>
 

--- a/source/_components/wirelesstag.markdown
+++ b/source/_components/wirelesstag.markdown
@@ -47,7 +47,10 @@ password:
 
 <div class='note'>
 
-  To enable local push notifications from the Tags Manager, you need to add the IP address of the Tags Manager into whitelist in `http` component; i.e., add it to `trusted_networks`. See the [HTTP](/components/http/) for details.
+  To enable local push notifications from the Tags Manager, you need to add the IP address of the Tags Manager into `trusted_networks` under Authentication Providers. See the [Authentication Providers](https://www.home-assistant.io/docs/authentication/providers/#trusted-networks) for details.
+  
+  Note: if you are using a version prior to v0.89 you can do the whitelisting under the [HTTP](/components/http) component.
+  
   Additionally, you need add at least one [WirelessTag binary sensor](#binary-sensor) in config to start receiving local push notifications.
 
 </div>


### PR DESCRIPTION
This isn't done under the HTTP component any more (since v0.89) - added new version and noted previous version options

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
