### PR TITLE
Fixing the indenting

### DIFF
--- a/source/_components/plex.markdown
+++ b/source/_components/plex.markdown
@@ -38,7 +38,7 @@ You can also enable the `plex` platform directly by adding the following lines t
 ```yaml
 # Example configuration.yaml entry
 plex:
-    token: MYSECRETTOKEN
+  token: MYSECRETTOKEN
 ```
 
 <div class='note warning'>
@@ -95,14 +95,14 @@ media_player:
 ```yaml
 # Complete configuration.yaml entry
 plex:
-   host: 192.168.1.100
-   port: 32400
-   token: MY_SECRET_TOKEN
-   ssl: true
-   verify_ssl: true
-   media_player:
-     use_episode_art: true
-     show_all_controls: false
+  host: 192.168.1.100
+  port: 32400
+  token: MY_SECRET_TOKEN
+  ssl: true
+  verify_ssl: true
+  media_player:
+    use_episode_art: true
+    show_all_controls: false
 ```
 
 ## Media Player


### PR DESCRIPTION
The example configs had broken indents

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
