### PR TITLE
Update documentation for HomeKit Bridge (home-assistant#26791)

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -82,6 +82,14 @@ homekit:
         required: false
         type: boolean
         default: false
+      advertise_ip:
+        description: If you need to override the IP address used for mDNS advertisement. (For example, using network isolation in Docker and together with an mDNS forwarder like `avahi-daemon` in reflector mode)
+        required: false
+        type: string
+      advertise_mac:
+        description: If you need to override the MAC address used for mDNS advertisement. (For example, using network isolation in Docker and together with an mDNS forwarder like `avahi-daemon` in reflector mode)
+        required: false
+        type: string
       filter:
         description: Filters for entities to be included/excluded from HomeKit. ([Configure Filter](#configure-filter))
         required: false
@@ -324,6 +332,20 @@ To avoid any errors, after you have successfully paired your Home Assistant Brid
 
 </div>
 
+## Docker Network Isolation
+
+The `advertise_ip` and `advertise_mac` options can be used to run this integration even inside a ephemeral Docker container with network isolation enabled, e.g. not using the host network.
+
+To use `advertise_ip` and `advertise_mac`, add the options to your `homekit` config:
+
+```yaml
+homekit:
+  advertise_ip: "STATIC_IP_OF_YOUR_DOCKER_HOST"
+  advertise_mac: "STATIC_MAC_OF_YOUR_DOCKER_HOST_OR_RANDOM_MAC"
+```
+
+Restart your Home Assistant instance. This feature requires running an mDNS forwarder on your Docker host, e.g. `avahi-daemon` in reflector mode. This kind of setup most likely requires `safe_mode` during bridge setup.
+
 ## Supported Components
 
 The following integrations are currently supported:
@@ -402,6 +424,8 @@ Remember that the iOS device needs to be in the same local network as the Home A
 #### `Home Assistant Bridge` doesn't appear in the Home App (for pairing) - Docker
 
 Set `network_mode: host`. If you have further problems this [issue](https://github.com/home-assistant/home-assistant/issues/15692) might help.
+
+You can also try to use `avahi-daemon` in reflector mode together with the options `advertise_ip` and `advertise_mac`, see above.
 
 #### `Home Assistant Bridge` doesn't appear in the Home App (for pairing) - VirtualBox
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -164,8 +164,8 @@ homekit:
 After Home Assistant has started, the entities specified by the filter are exposed to HomeKit if they are [supported](#supported-components). To add them:
 
 1. Open the Home Assistant frontend. A new card will display the `pin code`. Note: If pin code is not displayed, check "Notifications" (the bell icon) in the upper-right of the Home Assistant UI.
-1. Open the `Home` app.
-2. Click `Add Accessory`, then select `Don't Have a Code or Can't Scan?` and choose the `Home Assistant Bridge`.
+2. Open the `Home` app.
+3. Click `Add Accessory`, then select `Don't Have a Code or Can't Scan?` and choose the `Home Assistant Bridge`.
 4. Confirm that you are adding an `Uncertified Accessory` by clicking on `Add Anyway`.
 5. Enter the `PIN` code.
 6. Follow the setup by clicking on `Next` and lastly `Done` in the top right-hand corner.

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -334,7 +334,7 @@ To avoid any errors, after you have successfully paired your Home Assistant Brid
 
 ## Docker Network Isolation
 
-The `advertise_ip` and `advertise_mac` options can be used to run this integration even inside a ephemeral Docker container with network isolation enabled, e.g. not using the host network.
+The `advertise_ip` and `advertise_mac` options can be used to run this integration even inside an ephemeral Docker container with network isolation enabled, e.g., not using the host network.
 
 To use `advertise_ip` and `advertise_mac`, add the options to your `homekit` config:
 
@@ -344,7 +344,7 @@ homekit:
   advertise_mac: "STATIC_MAC_OF_YOUR_DOCKER_HOST_OR_RANDOM_MAC"
 ```
 
-Restart your Home Assistant instance. This feature requires running an mDNS forwarder on your Docker host, e.g. `avahi-daemon` in reflector mode. This kind of setup most likely requires `safe_mode` during bridge setup.
+Restart your Home Assistant instance. This feature requires running an mDNS forwarder on your Docker host, e.g., `avahi-daemon` in reflector mode. This kind of setup most likely requires `safe_mode` during the bridge setup.
 
 ## Supported Components
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -86,10 +86,6 @@ homekit:
         description: If you need to override the IP address used for mDNS advertisement. (For example, using network isolation in Docker and together with an mDNS forwarder like `avahi-daemon` in reflector mode)
         required: false
         type: string
-      advertise_mac:
-        description: If you need to override the MAC address used for mDNS advertisement. (For example, using network isolation in Docker and together with an mDNS forwarder like `avahi-daemon` in reflector mode)
-        required: false
-        type: string
       filter:
         description: Filters for entities to be included/excluded from HomeKit. ([Configure Filter](#configure-filter))
         required: false
@@ -334,14 +330,13 @@ To avoid any errors, after you have successfully paired your Home Assistant Brid
 
 ## Docker Network Isolation
 
-The `advertise_ip` and `advertise_mac` options can be used to run this integration even inside an ephemeral Docker container with network isolation enabled, e.g., not using the host network.
+The `advertise_ip` option can be used to run this integration even inside an ephemeral Docker container with network isolation enabled, e.g., not using the host network.
 
-To use `advertise_ip` and `advertise_mac`, add the options to your `homekit` config:
+To use `advertise_ip`, add the option to your `homekit` config:
 
 ```yaml
 homekit:
   advertise_ip: "STATIC_IP_OF_YOUR_DOCKER_HOST"
-  advertise_mac: "STATIC_MAC_OF_YOUR_DOCKER_HOST_OR_RANDOM_MAC"
 ```
 
 Restart your Home Assistant instance. This feature requires running an mDNS forwarder on your Docker host, e.g., `avahi-daemon` in reflector mode. This kind of setup most likely requires `safe_mode` during the bridge setup.
@@ -425,7 +420,7 @@ Remember that the iOS device needs to be in the same local network as the Home A
 
 Set `network_mode: host`. If you have further problems this [issue](https://github.com/home-assistant/home-assistant/issues/15692) might help.
 
-You can also try to use `avahi-daemon` in reflector mode together with the options `advertise_ip` and `advertise_mac`, see above.
+You can also try to use `avahi-daemon` in reflector mode together with the option `advertise_ip`, see above.
 
 #### `Home Assistant Bridge` doesn't appear in the Home App (for pairing) - VirtualBox
 


### PR DESCRIPTION
**Description:**
- Add documentation for advertise_ip option
- Add documentation section for Docker Network Isolation
- Update homekit.markdown

**Pull request in home-assistant:** home-assistant/home-assistant#26791

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
