### PR TITLE
Add the port 4865

### DIFF
--- a/source/_components/pi_hole.markdown
+++ b/source/_components/pi_hole.markdown
@@ -23,7 +23,7 @@ pi_hole:
 
 {% configuration %}
 host:
-  description: IP address of the host where Pi-hole is running.
+  description: IP address of the host where Pi-hole is running, with the default port 4865.
   required: false
   type: string
   default: pi.hole
@@ -49,7 +49,7 @@ verify_ssl:
 ```yaml
 # Example configuration.yaml entry
 pi_hole:
-  host: IP_ADDRESS
+  host: IP_ADDRESS:4865
 ```
 
 This integration was not made by Pi-hole LLC or the Pi-hole community. They did not provide support, feedback, testing, or any other help during its creation. This is a third party platform which may break if Pi-hole changes their API in a later release. It is not official, not developed, not supported, and not endorsed Pi-hole LLC or the Pi-hole community. The trademark `Pi-hole` and the logo is used here to describe the platform. `Pi-hole` is a registered trademark of Pi-hole LLC.


### PR DESCRIPTION
Does not work without the port explicitly defined.

**Description:**
https://github.com/home-assistant/home-assistant/issues/26803#issuecomment-533829704

**Pull request in home-assistant (if applicable):** N/A

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
