### PR TITLE
Add precision for no-break space in state_with_unit

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -65,7 +65,7 @@ Extensions allow templates to access all of the Home Assistant specific states a
 
 </div>
 
-Besides the normal [state object methods and properties](/topics/state_object/), `states.sensor.temperature.state_with_unit` will print the state of the entity and, if available, the unit.
+Besides the normal [state object methods and properties](/topics/state_object/), `states.sensor.temperature.state_with_unit` will print the state of the entity and, if available, the unit. With `state_with_unit`method the state and the unit will be separated by a `NO-BREAK SPACE` Unicode characters.
 
 #### States examples
 


### PR DESCRIPTION
**Description:**
Link to a the PR below, I add precision in the usage of `state_with_unit`method in a template.
The space used to separate the state and the unit is a `NO-BREAK SPACE` Unicode character.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26814

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html