### PR TITLE
Corrected math in description of twilight.

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -234,8 +234,8 @@ Although the actual amount of light depends on weather, topography and land cove
 
   This is what is meant by twilight for the average person: Under clear weather conditions, civil twilight approximates the limit at which solar illumination suffices for the human eye to clearly distinguish terrestrial objects. Enough illumination renders artificial sources unnecessary for most outdoor activities.
 
-- Nautical twilight: 6° > Solar angle > -12°
-- Astronomical twilight: 12° > Solar angle > -18°
+- Nautical twilight: -6° > Solar angle > -12°
+- Astronomical twilight: -12° > Solar angle > -18°
 
 A very thorough explanation of this is available in the Wikipedia article about the [Twilight](https://en.wikipedia.org/wiki/Twilight).
 


### PR DESCRIPTION
**Description:**
The description of twilights in the sun trigger section was missing some key negative signs. This adds them. 

**Pull request in home-assistant (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
