### PR TITLE
Add a way to retrieve battery level via HTTP

### DIFF
--- a/source/_cookbook/track_battery_level.markdown
+++ b/source/_cookbook/track_battery_level.markdown
@@ -48,8 +48,8 @@ sensor:
 
 #### HTTP
 
-If you have configured Owntracks to send reports to your Homeassistant instance via HTTP you can use a template sensor. 
-Replace deviceid with the set Device ID in Owntracks.
+If you have configured Owntracks to send reports to your Home Assistant instance via HTTP you can use a template sensor. 
+Replace `deviceid` with the set Device ID in Owntracks.
 
 {% raw %}
 ```yaml

--- a/source/_cookbook/track_battery_level.markdown
+++ b/source/_cookbook/track_battery_level.markdown
@@ -27,8 +27,12 @@ sensor:
 {% endraw %}
 
 ### Android and iOS Devices
+While running the [Owntracks](/components/device_tracker.owntracks/) device tracker you can retrieve the battery level. 
+How you achieve this depends on how you have configured your Owntracks instance. 
 
-While running the [Owntracks](/components/device_tracker.owntracks/) device tracker you can retrieve the battery level with a MQTT sensor. Replace username with your MQTT username (for the embedded MQTT it's simply homeassistant), and deviceid with the set Device ID in Owntracks.
+#### MQTT
+If you have configured Owntracks to send reports via MQTT you can use the received data via a MQTT sensor.
+Replace username with your MQTT username (for the embedded MQTT it's simply homeassistant), and deviceid with the set Device ID in Owntracks.
 
 {% raw %}
 ```yaml
@@ -39,5 +43,21 @@ sensor:
     unit_of_measurement: "%"
     value_template: '{{ value_json.batt }}'
     device_class: battery
+```
+{% endraw %}
+
+#### HTTP
+
+If you have configured Owntracks to send reports to your Homeassistant instance via HTTP you can use a template sensor. 
+Replace deviceid with the set Device ID in Owntracks.
+
+{% raw %}
+```yaml
+sensor:
+- platform: template
+    sensors:
+      your_battery_sensor_name:
+        value_template: '{{ states.device_tracker.deviceid.attributes.battery_level }}'
+        unit_of_measurement: '%'
 ```
 {% endraw %}

--- a/source/_cookbook/track_battery_level.markdown
+++ b/source/_cookbook/track_battery_level.markdown
@@ -57,7 +57,7 @@ sensor:
 - platform: template
     sensors:
       your_battery_sensor_name:
-        value_template: '{{ states.device_tracker.deviceid.attributes.battery_level }}'
+        value_template: "{{ state_attr('device_tracker.deviceid', 'battery_level') }}"
         unit_of_measurement: '%'
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**
The MQTT way of receiving data only seems to work if you have configured a MQTT backend. 
Added a template sensor to get the battery level with a HTTP Owntracks backend.
This way is tested on my Hometracks system.

**Pull request in home-assistant (if applicable):** 

## Checklist:

- [x ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
