### PR TITLE
Missing end bracket of `is_state` function

### DIFF
--- a/source/_lovelace/markdown.markdown
+++ b/source/_lovelace/markdown.markdown
@@ -67,6 +67,6 @@ card:
       - {{ l.entity }}
     {%- endfor %}
 
-    And the door is {% if is_state('binary_sensor.door', 'on' %} open {% else %} closed {% endif %}.
+    And the door is {% if is_state('binary_sensor.door', 'on') %} open {% else %} closed {% endif %}.
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
