### PR TITLE
Adds key codes to emulated Roku documentation

### DIFF
--- a/source/_components/emulated_roku.markdown
+++ b/source/_components/emulated_roku.markdown
@@ -84,8 +84,23 @@ Field | Description
 `key` | the code of the pressed key when the command `type` is `keypress`, `keyup` or `keydown`.
 `app_id` | the id of the app that was launched when command `type` is `launch`.
 
-The available keys are listed here:
-[Roku key codes](https://sdkdocs.roku.com/display/sdkdoc/External+Control+API#ExternalControlAPI-KeypressKeyValues)
+Available key codes |
+------------------- |
+`Home`
+`Rev`
+`Fwd`
+`Play`
+`Select`
+`Left`
+`Right`
+`Down`
+`Up`
+`Back`
+`InstantReplay`
+`Info`
+`Backspace`
+`Search`
+`Enter`
 
 ## Automations
 


### PR DESCRIPTION
**Description:**
The link given to the valid key codes is dead and isn't in the Roku dev docs. I found the codes elsewhere and thought they'd be useful here.

## Checklist:

- [✓] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ✓] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
