### PR TITLE
Update emulated_hue.markdown

### DIFF
--- a/source/_components/emulated_hue.markdown
+++ b/source/_components/emulated_hue.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Emulated Hue Bridge"
-description: "Instructions on how to emulated Hue Bridge within Home Assistant."
+description: "Instructions on how to emulate a Hue Bridge within Home Assistant."
 logo: home-assistant.png
 ha_category:
   - Hub
@@ -47,9 +47,9 @@ emulated_hue:
 ```yaml
 # Amazon Echo example configuration.yaml entry
 emulated_hue:
-# Required if there is no older Echo device (Like an Echo Dot 1 or 2) in the same network
   host_ip: YOUR.HASSIO.IP.ADDRESS
   listen_port: 80
+  # Alexa stopped working on different ports. Search for "Philipps Hue Bridge V1 (round)" in the Alexa App to discover devices.
 ```
 
 {% configuration %}


### PR DESCRIPTION
Alexa stopped working on other ports than 80 in recent firmware updates.
According to @schiegg using port 80 and let Alexa search for a "Philipps Hue Bridge V1 (round)" in the Alexa App to discover devices is a widespread solution: https://github.com/home-assistant/home-assistant/issues/26860#issuecomment-534450248

I could confirm that the port change also led to Alexa finding my devices again.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
