### PR TITLE
Clarity on enabling MQTT TLS

### DIFF
--- a/source/_docs/mqtt/certificate.markdown
+++ b/source/_docs/mqtt/certificate.markdown
@@ -16,7 +16,7 @@ mqtt:
 
 {% configuration %}
 certificate:
-  description: "'auto' or the certificate authority certificate file that is to be treated as trusted by this client. 'auto' uses the bundled certificates. If a file is specified the file should contain the root certificate of the certificate authority that signed your broker's certificate, but may contain multiple certificates. Example: `/home/user/identrust-root.pem`"
+  description: "'auto' or the certificate authority certificate file that is to be treated as trusted by this client. To enable a secure (TLS) connection to your server you must define the 'certitificate' configuration parameter. 'auto' uses the certifite CAs bundled certificates. If a file is specified the file should contain the root certificate of the certificate authority that signed your broker's certificate, but may contain multiple certificates. Example: `/home/user/identrust-root.pem`."
   required: false
   type: string
 client_key:


### PR DESCRIPTION
**Description:**
Clarified that you MUST define the `certificate` parameter to enable TLS connections to the MQTT server. This was not clear to me and was fighting with getting the right PEM/CRT file setup as connections were failing. When I then selected 'auto' it worked as designed. It would be better if there was an 'enable_tls' config parameter that would enable it and default to 'auto', but that's a code change.

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
