### PR TITLE
No dollar signs in shell code

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -10,7 +10,8 @@ var remarkrc = {
     },
     plugins: [
         ["frontmatter"],
-        ["lint-fenced-code-flag"]
+        ["lint-fenced-code-flag"],
+        ["lint-no-shell-dollars"]
     ]
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -718,6 +718,17 @@
         "unist-util-visit": "^1.1.1"
       }
     },
+    "remark-lint-no-shell-dollars": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-shell-dollars/-/remark-lint-no-shell-dollars-1.0.3.tgz",
+      "integrity": "sha512-fT3lQMTjEkPryL+63qDP1NfrohP3tG5i3SkNWSSR4VLU6OSsSSXlHGQGjo0ag//+EPKHB5/9frB/YQ0gDEPRGQ==",
+      "dev": true,
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
     "remark-message-control": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/remark-message-control/-/remark-message-control-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "remark-frontmatter": "^1.3.2",
         "remark-lint": "^6.0.5",
         "remark-lint-fenced-code-flag": "^1.0.3",
+        "remark-lint-no-shell-dollars": "^1.0.3",
         "remark-stringify": "^7.0.3"
     },
     "scripts": {

--- a/source/_components/bluetooth_le_tracker.markdown
+++ b/source/_components/bluetooth_le_tracker.markdown
@@ -17,7 +17,7 @@ Devices discovered are stored with 'BLE_' as the prefix for device mac addresses
 This platform requires pybluez to be installed. On Debian based installs, run
 
 ```bash
-$ sudo apt install bluetooth
+sudo apt install bluetooth
 ```
 
 Before you get started with this platform, please note that:
@@ -54,9 +54,9 @@ Some BTLE devices (e.g., fitness trackers) are only visible to the devices that 
 Normally accessing the Bluetooth stack is reserved for root, but running programs that are networked as root is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 and hcitool the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](http://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
 
 ```bash
-$ sudo apt-get install libcap2-bin
-$ sudo setcap 'cap_net_raw,cap_net_admin+eip' `readlink -f \`which python3\``
-$ sudo setcap 'cap_net_raw+ep' `readlink -f \`which hcitool\``
+sudo apt-get install libcap2-bin
+sudo setcap 'cap_net_raw,cap_net_admin+eip' `readlink -f \`which python3\``
+sudo setcap 'cap_net_raw+ep' `readlink -f \`which hcitool\``
 ```
 
 A restart of Home Assistant is required.

--- a/source/_components/eddystone_temperature.markdown
+++ b/source/_components/eddystone_temperature.markdown
@@ -18,14 +18,14 @@ All beacons that support the Eddystone protocol, have a temperature sensor and c
 As this platform uses `bluez` to scan for Bluetooth LE devices **a Linux OS with bluez installed** is required. In addition to that, the `libbluetooth` headers need to be installed:
 
 ```bash
-$ sudo apt-get install libbluetooth-dev
+sudo apt-get install libbluetooth-dev
 ```
 
 Scanning for Bluetooth LE devices also requires special permissions. To grant these to the python executable execute the following:
 
 ```bash
-$ sudo apt-get install libcap2-bin
-$ sudo setcap 'cap_net_raw,cap_net_admin+eip' $(readlink -f $(which python3))
+sudo apt-get install libcap2-bin
+sudo setcap 'cap_net_raw,cap_net_admin+eip' $(readlink -f $(which python3))
 ```
 
 To use your Eddystone beacon in your installation, add the following to your `configuration.yaml` file:

--- a/source/_components/ffmpeg.markdown
+++ b/source/_components/ffmpeg.markdown
@@ -41,9 +41,9 @@ ffmpeg_bin:
 To get the binary on Raspbian Debian Jessie Lite on a RPi you need to perform the following:
 
 ```bash
-$ sudo echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
-$ sudo apt-get update
-$ sudo apt-get -t jessie-backports install ffmpeg
+sudo echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
+sudo apt-get update
+sudo apt-get -t jessie-backports install ffmpeg
 ```
 
 We can use now following in the configuration:
@@ -60,7 +60,7 @@ In most cases, `ffmpeg` automatically detects all needed options to read a video
 First, check that your stream is playable by `ffmpeg` outside of Home Assistant with (use option `-an` or `-vn` to disable video or audio stream):
 
 ```bash
-$ ffmpeg -i INPUT -an -f null -
+ffmpeg -i INPUT -an -f null -
 ```
 
 Now you should be able to see what is going wrong. The following list contains some common problems and solutions:

--- a/source/_components/hdmi_cec.markdown
+++ b/source/_components/hdmi_cec.markdown
@@ -34,8 +34,8 @@ If you are using [Hass.io](/hassio/) then just move forward to the configuration
 Create a symlink to the `cec` installation including the _cec.so file. Keep in mind different installation methods will result in different locations of cec.
 
 ```bash
-$ ln -s /path/to/your/installation/of/cec.py /path/to/your/venv/lib/python*/site-packages
-$ ln -s /path/to/your/installation/of/_cec.so /path/to/your/venv/lib/python*/site-packages
+ln -s /path/to/your/installation/of/cec.py /path/to/your/venv/lib/python*/site-packages
+ln -s /path/to/your/installation/of/_cec.so /path/to/your/venv/lib/python*/site-packages
 
 ```
 
@@ -44,9 +44,8 @@ $ ln -s /path/to/your/installation/of/_cec.so /path/to/your/venv/lib/python*/sit
 For the default virtual environment of a [HASSbian Image for Raspberry Pi](/docs/installation/raspberry-pi/) the command would be as follows.
 
 ```bash
-$ ln -s /usr/local/lib/python*/dist-packages/cec.py /srv/homeassistant/lib/python*/site-packages
-$ ln -s /usr/local/lib/python*/dist-packages/_cec.so /srv/homeassistant/lib/python*/site-packages
-
+ln -s /usr/local/lib/python*/dist-packages/cec.py /srv/homeassistant/lib/python*/site-packages
+ln -s /usr/local/lib/python*/dist-packages/_cec.so /srv/homeassistant/lib/python*/site-packages
 ```
 
 <div class='note'>

--- a/source/_components/pandora.markdown
+++ b/source/_components/pandora.markdown
@@ -20,22 +20,22 @@ This media player uses the [Pianobar command-line Pandora client](https://github
 The version of pianobar that comes with Jessie has a bug, so you have to build a more recent version. The latest version depends on a recent version of libraries associated with ffmpeg, so you should make sure you go through the backport process documented in [The FFmpeg component](/components/ffmpeg/) before doing this. Install the following basic dependencies:
 
 ```bash
-$ sudo apt-get install git libao-dev libgcrypt11-dev libfaad-dev libmad0-dev libjson-c-dev make pkg-config  libcurl4-openssl-dev
+sudo apt-get install git libao-dev libgcrypt11-dev libfaad-dev libmad0-dev libjson-c-dev make pkg-config  libcurl4-openssl-dev
 ```
 
 And now install the backported ffmpeg-related libraries (note that if you're using an older version of ffmpeg for other things on this machine, you may encounter issues after doings this):
 
 ```bash
-$ sudo apt-get -t jessie-backports install libav-tools libavcodec-extra libavcodec-dev libavfilter-dev libavformat-dev
+sudo apt-get -t jessie-backports install libav-tools libavcodec-extra libavcodec-dev libavfilter-dev libavformat-dev
 ```
 
 Now clone the Pianobar repo and build pianobar:
 
 ```bash
-$ git clone https://github.com/PromyLOPh/pianobar.git
-$ cd pianobar
-$ make clean && make
-$ sudo make install
+git clone https://github.com/PromyLOPh/pianobar.git
+cd pianobar
+make clean && make
+sudo make install
 ```
 
 Configure Pianobar to auto-login and start playing a station (optional, see `man pianobar`) by creating and editing the `~/.config/pianobar/config` file:

--- a/source/_components/recorder.markdown
+++ b/source/_components/recorder.markdown
@@ -169,7 +169,7 @@ If you are using the default `FULL` recovery model for MS SQL Server you will ne
 If you are running a database server instance on the same server as Home Assistant then you must ensure that this service starts before Home Assistant. For a Linux instance running Systemd (Raspberry Pi, Debian, Ubuntu and others) then you should edit the service file.
 
 ```bash
-$ sudo nano /etc/systemd/system/home-assistant@homeassistant.service
+sudo nano /etc/systemd/system/home-assistant@homeassistant.service
 ```
 
 and add the service for the database, for example, PostgreSQL:
@@ -183,7 +183,7 @@ After=network.target postgresql.service
 Save the file then reload `systemctl`:
 
 ```bash
-$ sudo systemctl daemon-reload
+sudo systemctl daemon-reload
 ```
 
 ## Installation notes
@@ -205,15 +205,15 @@ For MariaDB you may have to install a few dependencies. If you're using MariaDB 
 On the Python side we use the `mysqlclient`:
 
 ```bash
-$ sudo apt-get install libmariadbclient-dev libssl-dev
-$ pip3 install mysqlclient
+sudo apt-get install libmariadbclient-dev libssl-dev
+pip3 install mysqlclient
 ```
 
 For MySQL you may have to install a few dependencies. You can choose between `pymysql` and `mysqlclient`:
 
 ```bash
-$ sudo apt-get install default-libmysqlclient-dev libssl-dev
-$ pip3 install mysqlclient
+sudo apt-get install default-libmysqlclient-dev libssl-dev
+pip3 install mysqlclient
 ```
 
 After installing the dependencies, it is required to create the database manually. During the startup, Home Assistant will look for the database specified in the `db_url`. If the database doesn't exist, it will not automatically create it for you.
@@ -225,8 +225,8 @@ Once Home Assistant finds the database, with the right level of permissions, all
 For PostgreSQL you may have to install a few dependencies:
 
 ```bash
-$ sudo apt-get install postgresql-server-dev-X.Y
-$ pip3 install psycopg2
+sudo apt-get install postgresql-server-dev-X.Y
+pip3 install psycopg2
 ```
 
 For using Unix Sockets, add the following line to your [`pg_hba.conf`](https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html):
@@ -250,14 +250,14 @@ A service restart will work as well.
 For MS SQL Server you may have to install a few dependencies:
 
 ```bash
-$ sudo apt-get install freetds-dev
-$ pip3 install pymssql
+sudo apt-get install freetds-dev
+pip3 install pymssql
 ```
 
 If you are in a virtual environment, don't forget to activate it before installing the pymssql package.
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ pip3 install pymssql
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install pymssql
 ```

--- a/source/_components/samsungtv.markdown
+++ b/source/_components/samsungtv.markdown
@@ -148,16 +148,16 @@ No additional actions are required
 You will need to activate the venv and install the websocket library:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ pip3 install websocket-client
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install websocket-client
 ```
 ### Other install methods
 
 You will need to install the `websocket-client` Python package in your Home Assistant install. This will probably be done with:
 
 ```bash
-$ pip3 install websocket-client
+pip3 install websocket-client
 ```
 
 Remembering to activate your venv if you're using a venv install.

--- a/source/_components/seven_segments.markdown
+++ b/source/_components/seven_segments.markdown
@@ -22,14 +22,14 @@ If you are using [Hass.io](/hassio/) then just move forward to the configuration
 `ssocr` needs to be available on your system. Check the installation instruction below:
 
 ```bash
-$ sudo dnf -y install imlib2-devel # Fedora
-$ sudo apt install libimlib2-dev # Ubuntu
-$ brew install imlib2 # macOS
-$ git clone https://github.com/auerswal/ssocr.git
-$ cd ssocr
-$ make
-$ sudo make PREFIX=/usr install # On most systems
-$ make deb # (Optional) This allows you to make a deb so that you apt is aware of ssocr
+sudo dnf -y install imlib2-devel # Fedora
+sudo apt install libimlib2-dev # Ubuntu
+brew install imlib2 # macOS
+git clone https://github.com/auerswal/ssocr.git
+cd ssocr
+make
+sudo make PREFIX=/usr install # On most systems
+make deb # (Optional) This allows you to make a deb so that you apt is aware of ssocr
 ```
 
 To enable the OCR of a seven segment display in your installation, add the following to your `configuration.yaml` file:

--- a/source/_components/snips.markdown
+++ b/source/_components/snips.markdown
@@ -24,18 +24,18 @@ Snips takes voice or text as input and produces *intents* as output, which are e
 The Snips platform can be installed via the Snips APT/Debian repository.
 
 ```bash
-$ sudo apt-get update
-$ sudo apt-get install -y dirmngr
-$ sudo bash -c  'echo "deb https://raspbian.snips.ai/$(lsb_release -cs) stable main" > /etc/apt/sources.list.d/snips.list'
-$ sudo apt-key adv --keyserver pgp.mit.edu --recv-keys D4F50CDCA10A2849
-$ sudo apt-get update
-$ sudo apt-get install -y snips-platform-voice
+sudo apt-get update
+sudo apt-get install -y dirmngr
+sudo bash -c  'echo "deb https://raspbian.snips.ai/$(lsb_release -cs) stable main" > /etc/apt/sources.list.d/snips.list'
+sudo apt-key adv --keyserver pgp.mit.edu --recv-keys D4F50CDCA10A2849
+sudo apt-get update
+sudo apt-get install -y snips-platform-voice
 ```
 
 Note that if the keyserver pgp.mit.edu is down then try to use another one in the 4th line, like pgp.surfnet.nl:
 
 ```bash
-$ sudo apt-key adv --keyserver pgp.surfnet.nl --recv-keys D4F50CDCA10A2849
+sudo apt-key adv --keyserver pgp.surfnet.nl --recv-keys D4F50CDCA10A2849
 ```
 
 ### Creating an assistant
@@ -45,13 +45,13 @@ Head over to the [Snips Console](https://console.snips.ai) to create your assist
 The next step is to get the assistant to work on your device. Unzip and copy the `assistant` folder that you downloaded from the web console to the path. Assuming your downloaded `assistant` folder is on your desktop, just run:
 
 ```bash
-$ scp -r ~/Desktop/assistant pi@<raspi_hostname.local_or_IP>:/home/pi/.
+scp -r ~/Desktop/assistant pi@<raspi_hostname.local_or_IP>:/home/pi/.
 ```
 
 Now ssh into your Raspberry Pi:
 
 ```bash
-$ ssh pi@<raspi_hostname.local_or_IP>
+ssh pi@<raspi_hostname.local_or_IP>
 ```
 
 By default, this command is `ssh pi@raspberrypi.local`, if you are using the default Raspberry Pi hostname.
@@ -76,7 +76,7 @@ Make sure that a microphone is plugged to the Raspberry Pi. If you are having tr
 Start the Snips Voice Platform by starting the `snips-*` services:
 
 ```bash
-$ sudo systemctl start "snips-*"
+sudo systemctl start "snips-*"
 ```
 
 Snips is now ready to take voice commands from the microphone. To trigger the listening, simply say

--- a/source/_cookbook/fail2ban.markdown
+++ b/source/_cookbook/fail2ban.markdown
@@ -11,19 +11,19 @@ This is a quick guide on how to set up `fail2ban` for Home Assistant. Contains e
 Debian/Ubuntu:
 
 ```bash
-$ sudo apt-get install fail2ban
+sudo apt-get install fail2ban
 ```
 
 CentOS/RHEL:
 
 ```bash
-$ sudo yum install epel-release
-$ sudo yum install -y fail2ban
+sudo yum install epel-release
+sudo yum install -y fail2ban
 ```
 Fedora:
 
 ```bash
-$ sudo dnf install -y fail2ban
+sudo dnf install -y fail2ban
 ```
 
 For other package managers use the appropriate commands.
@@ -42,7 +42,7 @@ logger:
 Restart Home Assistant to activate the changes:
 
 ```bash
-$ sudo systemctl restart home-assistant
+sudo systemctl restart home-assistant
 ```
 
 Tail the Home Assistant log then log out of the Home Assistant web interface and attempt logging in with an incorrect password, look for a line like `Login attempt or request with invalid authentication from xxx.xxx.xxx.xxx`:
@@ -141,20 +141,20 @@ sudo tail -f -n 20 /var/log/fail2ban.log
 Now that fail2ban is working it can be enabled for startup at boot time, also raise the bantime from 30 seconds to what ever you would like. 8 hours is 28800 seconds.
 
 ```bash
-$ sudo sed -i 's/bantime = 30/bantime = 28800/g' /etc/fail2ban/jail.d/ha.conf
-$ sudo systemctl enable fail2ban
-$ sudo systemctl restart fail2ban
+sudo sed -i 's/bantime = 30/bantime = 28800/g' /etc/fail2ban/jail.d/ha.conf
+sudo systemctl enable fail2ban
+sudo systemctl restart fail2ban
 ```
 
 A final note, if you need to unban an IP it can be done with `fail2ban-client`:
 
 ```bash
-$ sudo fail2ban-client set JAILNAME unbanip IPADDRESS
+sudo fail2ban-client set JAILNAME unbanip IPADDRESS
 ```
 eg:
 
 ```bash
-$ sudo fail2ban-client set ha unbanip xxx.xxx.xxx.xxx
+sudo fail2ban-client set ha unbanip xxx.xxx.xxx.xxx
 ```
 
 Fail2ban should now be configured and running, if an IP address is banned you will receive an email with WHOIS details about the IP address that attempted to connect, if not you will need configure Postfix or another MTA (Mail Transport Agent).

--- a/source/_cookbook/owntracks_two_mqtt_broker.markdown
+++ b/source/_cookbook/owntracks_two_mqtt_broker.markdown
@@ -81,9 +81,9 @@ password_file /etc/mosquitto/pwfile
 Create a password for `mosquitto-ext`
  
 ```bash
-$ docker exec -it mosquitto-ext /bin/bash
-$ cd /etc/mosquitto/
-$ mosquitto_passwd -c /etc/mosquitto/pwfile <userID>
+docker exec -it mosquitto-ext /bin/bash
+cd /etc/mosquitto/
+mosquitto_passwd -c /etc/mosquitto/pwfile <userID>
 ```
  
 ### OwnTracks settings for Android

--- a/source/_docs/asterisk_mbox.markdown
+++ b/source/_docs/asterisk_mbox.markdown
@@ -35,7 +35,7 @@ Before beginning make sure that you have the following:
 2. Install the `asterisk_mbox_server` python module:
 
    ```bash
-   $ pip3 install asterisk_mbox_server
+   pip3 install asterisk_mbox_server
    ```
 
 3. Create a configuration file for the server
@@ -65,13 +65,13 @@ Before beginning make sure that you have the following:
    Once complete, ensure this file is only accessible by the Asterisk user:
 
    ```bash
-   $ sudo chown asterisk:asterisk /etc/asterisk/asterisk_mbox.ini
-   $ sudo chmod 600 /etc/asterisk/asterisk_mbox.ini
+   sudo chown asterisk:asterisk /etc/asterisk/asterisk_mbox.ini
+   sudo chmod 600 /etc/asterisk/asterisk_mbox.ini
    ```
 4. Interactively start the server to verify it is functioning
 
    ```bash
-   $ sudo -u asterisk asterisk_mbox_server -v --cfg /etc/asterisk/asterisk_mbox.ini
+   sudo -u asterisk asterisk_mbox_server -v --cfg /etc/asterisk/asterisk_mbox.ini
    ```
 
    Now complete the [Home Assistant configuration](/components/asterisk_mbox) and verify that Home Assistant can communicate with the server

--- a/source/_docs/autostart/upstart.markdown
+++ b/source/_docs/autostart/upstart.markdown
@@ -122,8 +122,8 @@ esac
 To install this script, download it, tweak it to you liking, and install it by following the directions in the header. This script will setup Home Assistant to run when the system boots. To start/stop Home Assistant manually, issue the following commands:
 
 ```bash
-$ sudo service hass-daemon start
-$ sudo service hass-daemon stop
+sudo service hass-daemon start
+sudo service hass-daemon stop
 ```
 
 When running Home Assistant with this script, the configuration directory will be located at `/var/opt/homeassistant`. This directory will contain a verbose log rather than simply an error log.

--- a/source/_docs/ecosystem/backup/backup_dropbox.markdown
+++ b/source/_docs/ecosystem/backup/backup_dropbox.markdown
@@ -22,8 +22,8 @@ In the Python script you can specify which files and directories should be exclu
 ### Step 1: Linking your Dropbox account
 
 ```bash
-$ chmod +x dropbox_uploader.sh
-$ ./dropbox_uploader.sh
+chmod +x dropbox_uploader.sh
+./dropbox_uploader.sh
 ```
 Follow the instructions you see on your screen.
 

--- a/source/_docs/ecosystem/backup/backup_github.markdown
+++ b/source/_docs/ecosystem/backup/backup_github.markdown
@@ -34,8 +34,8 @@ Some best practices to consider before putting your configuration on GitHub:
 In order to put your configuration on GitHub, you must install the Git package on your Home Assistant server (instructions below will work on Raspberry Pi, Ubuntu or any Debian-based system) *Note: this isn't required in Hass.io, it's included as default so proceed to step 2*:
 
 ```bash
-$ sudo apt-get update
-$ sudo apt-get install git
+sudo apt-get update
+sudo apt-get install git
 ```
 
 ### Step 2: Creating `.gitignore`
@@ -88,11 +88,11 @@ More information on the layout of the file can be found in the [.gitignore manua
 In your Home Assistant directory, type the following commands as the Home Assistant user, replacing the email address and name with your information:
 
 ```bash
-$ git init
-$ git config user.email "you@example.com"
-$ git config user.name "Your Name"
-$ git add .
-$ git commit
+git init
+git config user.email "you@example.com"
+git config user.name "Your Name"
+git add .
+git commit
 ```
 
 After the `git commit` command, you will be asked to enter a message for the commit.  This will add a comment beside each file on GitHub describing the purpose for the commit. In this case, you can enter something like "Initial commit of my Home Assistant configuration". To exit the editor, press `CTRL + C` and then `:wq` which will exit and save the changes. 
@@ -110,8 +110,8 @@ Once you are sure you are using `secrets.yaml` and `.gitignore` correctly, it is
 In your Home Assistant directory, type the following commands as the Home Assistant user, replacing "username" in the URL with your GitHub username:
 
 ```bash
-$ git remote add origin https://github.com/username/Home-AssistantConfig
-$ git push -u origin master
+git remote add origin https://github.com/username/Home-AssistantConfig
+git push -u origin master
 ```
 
 You will be asked to enter your GitHub username and password (or ssh key passphrase if you use [GitHub with ssh](https://help.github.com/categories/ssh/)).
@@ -184,8 +184,8 @@ home_elevation: 0
 You can enter these commands to get a list of the files in your local Git repository and a status of files that have changed but not committed yet:
 
 ```bash
-$ git ls-files
-$ git status
+git ls-files
+git status
 ```
 Examples:
 

--- a/source/_docs/ecosystem/certificates/lets_encrypt.markdown
+++ b/source/_docs/ecosystem/certificates/lets_encrypt.markdown
@@ -76,7 +76,7 @@ SSH in to your system running Home Assistant and login.
 Type the following command to list your network interfaces:
 
 ```bash
-$ ifconfig
+ifconfig
 ```
 
 You will receive an output similar to the image below:
@@ -91,7 +91,7 @@ Make a note of the interface name and the IP address you are currently on. In th
 Then type the following command to open the text file that controls your network connection:
 
 ```bash
-$ sudo nano /etc/dhcpcd.conf
+sudo nano /etc/dhcpcd.conf
 ```
 
 At the bottom of the file add the following lines:
@@ -121,7 +121,7 @@ Press Ctrl + x to close the editor, pressing Y to save the changes when prompted
 Reboot your device running HA:
 
 ```bash
-$ sudo reboot
+sudo reboot
 ```
 
 When it comes back up check that you can SSH in to it again on the IP address you wrote down.
@@ -248,35 +248,35 @@ sudo adduser homeassistant sudo
 If you did not already log in as the user that currently runs Home Assistant, change to that user (usually `homeassistant` or `hass` - you may have used a command similar to this in the past):
 
 ```bash
-$ sudo -u homeassistant -H -s
+sudo -u homeassistant -H -s
 ```
 
 Make sure you are in the home directory for the Home Assistant user:
 
 ```bash
-$ cd
+cd
 ```
 
 We will now make a directory for the certbot software, download it and give it the correct permissions:
 
 ```text
-$ mkdir certbot
-$ cd certbot/
-$ wget https://dl.eff.org/certbot-auto
-$ chmod a+x certbot-auto
+mkdir certbot
+cd certbot/
+wget https://dl.eff.org/certbot-auto
+chmod a+x certbot-auto
 ```
 
 You might need to stop Home Assistant before continuing with the next step. You can do this via the Web-UI or use the following command if you are running on Hassbian:
 
 ```text
-$ sudo systemctl stop home-assistant@homeassistant.service
+sudo systemctl stop home-assistant@homeassistant.service
 ```
 
 You can restart Home Assistant after the next step using the same command and replacing `stop` with `start`.
 Now we will run the certbot program to get our SSL certificate. You will need to include your email address and your DuckDNS URL in the appropriate places:
 
 ```text
-$ ./certbot-auto certonly --standalone --preferred-challenges http-01 --email your@email.address -d examplehome.duckdns.org
+./certbot-auto certonly --standalone --preferred-challenges http-01 --email your@email.address -d examplehome.duckdns.org
 ```
 
 Once the program has run it will generate a certificate and other files and place them in a folder `/etc/letsencrypt/` .
@@ -284,7 +284,7 @@ Once the program has run it will generate a certificate and other files and plac
 Confirm this file has been populated:
 
 ```bash
-$ ls /etc/letsencrypt/live/
+ls /etc/letsencrypt/live/
 ```
 
 This should show a folder named exactly after your DuckDNS URL.
@@ -292,8 +292,8 @@ This should show a folder named exactly after your DuckDNS URL.
 Our Home Assistant user needs access to files within the letsencrypt folder, so issue the following commands to change the permissions.
 
 ```bash
-$ sudo chmod 755 /etc/letsencrypt/live/
-$ sudo chmod 755 /etc/letsencrypt/archive/
+sudo chmod 755 /etc/letsencrypt/live/
+sudo chmod 755 /etc/letsencrypt/archive/
 ```
 
 Did all of that go without a hitch? Wahoo! Your Let's Encrypt certificate is now ready to be used with Home Assistant. Move to step 5 to put it all together
@@ -403,8 +403,8 @@ If you do not wish to set up a sensor you can skip straight to step 8 to learn h
 The sensor will rely on a command line program that needs to be installed on your device running Home Assistant. SSH in to the device and run the following commands:
 
 ```bash
-$ sudo apt-get update
-$ sudo apt-get install ssl-cert-check
+sudo apt-get update
+sudo apt-get install ssl-cert-check
 ```
 
 <div class='note'>
@@ -449,13 +449,13 @@ To set a cron job to run the script at regular intervals:
  * Change to your Home Assistant user (where `homeassistant` is the name of the user):
 
 ```bash
-$ sudo -u homeassistant -H -s
+sudo -u homeassistant -H -s
 ```
 
  * Open the crontab:
 
 ```bash
-$ crontab -e
+crontab -e
 ```
 
  * If you are a TWO-RULE Person: Scroll to the bottom of the file and paste in the following line
@@ -506,19 +506,19 @@ To manually update:
  * Change to your Home Assistant user (where `homeassistant` is the name of the user):
 
 ```bash
-$ sudo -u homeassistant -H -s
+sudo -u homeassistant -H -s
 ```
 
  * Change to your certbot folder
 
 ```bash
-$ cd ~/certbot/
+cd ~/certbot/
 ```
 
  * Run the renewal command
 
 ```bash
-$ ./certbot-auto renew --quiet --no-self-upgrade --standalone --preferred-challenges http-01
+./certbot-auto renew --quiet --no-self-upgrade --standalone --preferred-challenges http-01
 ```
 
 * If you are a ONE-RULE person, replace the `certbot-auto` command above with `~/certbot/certbot-auto renew --quiet --no-self-upgrade --standalone --preferred-challenges tls-sni-01 --tls-sni-01-port 8123 --pre-hook "sudo systemctl stop home-assistant@homeassistant.service" --post-hook "sudo systemctl start home-assistant@homeassistant.service"`

--- a/source/_docs/ecosystem/certificates/tls_domain_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_domain_certificate.markdown
@@ -15,11 +15,11 @@ If your Home Assistant instance is only accessible from your local network you c
 ### Run certbot
 
 ```bash
-$ mkdir certbot
-$ cd certbot
-$ wget https://dl.eff.org/certbot-auto
-$ chmod a+x certbot-auto
-$ sudo ./certbot-auto --manual certonly --preferred-challenges dns -d "mydomain.com" --email your@email.address
+mkdir certbot
+cd certbot
+wget https://dl.eff.org/certbot-auto
+chmod a+x certbot-auto
+sudo ./certbot-auto --manual certonly --preferred-challenges dns -d "mydomain.com" --email your@email.address
 ```
 
 * Agree to Terms of Service

--- a/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
@@ -21,7 +21,7 @@ If you are going to use this certificate with the iOS app, you need to ensure yo
 * If you are using iOS 10.3 or newer then [additional steps](https://support.apple.com/en-us/HT204477) are needed.
 
 ```bash
-$ openssl req -sha256 -newkey rsa:4096 -nodes -keyout privkey.pem -x509 -days 730 -out certificate.pem
+openssl req -sha256 -newkey rsa:4096 -nodes -keyout privkey.pem -x509 -days 730 -out certificate.pem
 ```
 
 For details about the parameters, please check the OpenSSL documentation. Provide the requested information during the generation process. 
@@ -41,8 +41,8 @@ A restart of Home Assistant is required for the changes to take effect.
 If you get any log error about *ssl_key* or *ssl_certificate* that is **not a file for dictionary value** when run Home Assistant, you need to change owner or access permission of the `.pem` files as following:
   
 ```bash
-$ sudo chown homeassistant:homeassistant certificate.pem privkey.pem
-$ sudo chmod 755 certificate.pem privkey.pem
+sudo chown homeassistant:homeassistant certificate.pem privkey.pem
+sudo chmod 755 certificate.pem privkey.pem
 ```
 
 A tutorial "[Working with SSL Certificates, Private Keys and CSRs](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs)" could give you some insight about special cases.

--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -37,11 +37,11 @@ Instead of example.com, use your domain. You will need to renew this certificate
 If you do not own your own domain, you may generate a self-signed certificate. This will not work with IFTTT, but it will encrypt all of your Home Assistant traffic.
 
 ```bash
-$ openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 9999
-$ openssl rsa -in key.pem -out key.pem
-$ sudo cp key.pem cert.pem /etc/nginx/ssl
-$ sudo chmod 600 /etc/nginx/ssl/key.pem /etc/nginx/ssl/cert.pem
-$ sudo chown root:root /etc/nginx/ssl/key.pem /etc/nginx/ssl/cert.pem
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 9999
+openssl rsa -in key.pem -out key.pem
+sudo cp key.pem cert.pem /etc/nginx/ssl
+sudo chmod 600 /etc/nginx/ssl/key.pem /etc/nginx/ssl/cert.pem
+sudo chown root:root /etc/nginx/ssl/key.pem /etc/nginx/ssl/cert.pem
 ```
 
 ### 4. Create dhparams file
@@ -49,8 +49,8 @@ $ sudo chown root:root /etc/nginx/ssl/key.pem /etc/nginx/ssl/cert.pem
 As a fair warning, this file will take a while to generate.
 
 ```bash
-$ cd /etc/nginx/ssl
-$ sudo openssl dhparam -out dhparams.pem 2048
+cd /etc/nginx/ssl
+sudo openssl dhparam -out dhparams.pem 2048
 ```
 
 ### 5. Install configuration file in nginx.
@@ -66,9 +66,9 @@ Some Linux distributions (including CentOS and Fedora) will not have the `/etc/n
 ### 6. Enable the Home Assistant configuration.
 
 ```bash
-$ cd /etc/nginx/sites-enabled
-$ sudo unlink default
-$ sudo ln ../sites-available/hass default
+cd /etc/nginx/sites-enabled
+sudo unlink default
+sudo ln ../sites-available/hass default
 ```
 
 ### 7. Start NGINX.

--- a/source/_docs/installation/armbian.markdown
+++ b/source/_docs/installation/armbian.markdown
@@ -8,8 +8,8 @@ description: "Instructions to install Home Assistant on an Armbian-powered syste
 Setup Python and `pip`:
 
 ```bash
-$ sudo apt-get update
-$ sudo apt-get install python3-dev python3-pip
+sudo apt-get update
+sudo apt-get install python3-dev python3-pip
 ```
 
 Now that you installed python, there are two ways to install Home Assistant:
@@ -17,8 +17,8 @@ Now that you installed python, there are two ways to install Home Assistant:
 2. Alternatively, you can install Home Assistant for the user you created when first booting Armbian:
 
 ```bash
-$ sudo pip3 install homeassistant
-$ hass --open-ui
+sudo pip3 install homeassistant
+hass --open-ui
 ```
 
 Running these commands will:

--- a/source/_docs/installation/centos.markdown
+++ b/source/_docs/installation/centos.markdown
@@ -10,33 +10,33 @@ To run Python 3.x on [CentOS](https://www.centos.org/) or RHEL (Red Hat Enterpri
 First of all install the software collection repository as root and [scl utils](https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html-single/Software_Collections_Guide/). For example, on CentOS:
 
 ```bash
-$ sudo yum install centos-release-scl
-$ sudo yum-config-manager --enable centos-sclo-rh-testing
-$ sudo yum install -y scl-utils
+sudo yum install centos-release-scl
+sudo yum-config-manager --enable centos-sclo-rh-testing
+sudo yum install -y scl-utils
 ```
 
 Install some dependencies you'll need later.
 
 ```bash
-$ sudo yum install gcc gcc-c++ systemd-devel
+sudo yum install gcc gcc-c++ systemd-devel
 ```
 
 Then install the Python 3.6 package. If you are using CentOS 7 then you may have to install the packages for Python 3.6 using RHEL Methods listed here: https://www.softwarecollections.org/en/scls/rhscl/rh-python36/) for this to work as mentioned above.
 
 ```bash
-$ sudo yum install rh-python36
+sudo yum install rh-python36
 ```
 
 This is part of the slight change when trying to install Python 3.6 and running the command `python36 --version` which will after install give you the correct version, but won't allow you to set the software collection using the `scl` command. This command downloads the RH collection of Python to allow you to run `scl` command to enable the environment in `bash` and then run the automate command using the template.
 
 ```bash
-$ yum install rh-python36
+yum install rh-python36
 ```
 
 ### Start using software collections
 
 ```bash
-$ scl enable rh-python36 bash
+scl enable rh-python36 bash
 ```
 
 Once installed, switch to your `homeassistant` user (if you've set one up), enable the software collection and check that it has set up the new version of Python:

--- a/source/_docs/installation/fedora.markdown
+++ b/source/_docs/installation/fedora.markdown
@@ -8,29 +8,29 @@ description: "Installation of Home Assistant on your Fedora computer."
 Install the development package of Python.
 
 ```bash
-$ sudo dnf -y install python3-devel redhat-rpm-config
+sudo dnf -y install python3-devel redhat-rpm-config
 ```
 
 and Home Assistant itself.
 
 ```bash
-$ pip3 install homeassistant
+pip3 install homeassistant
 ```
 
 To isolate the Home Assistant installation a [`venv`](https://docs.python.org/3/library/venv.html) is handy. First create a new directory to store the installation and adjust the permissions.
 
 ```bash
-$ sudo mkdir -p /opt/homeassistant
-$ sudo useradd -rm homeassistant -G dialout
-$ sudo chown -R homeassistant:homeassistant /opt/homeassistant
+sudo mkdir -p /opt/homeassistant
+sudo useradd -rm homeassistant -G dialout
+sudo chown -R homeassistant:homeassistant /opt/homeassistant
 ```
 Now switch to the new directory, setup the `venv`, and activate it.
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ cd /opt/homeassistant
-$ python3.6 -m venv .
-$ source bin/activate
+sudo -u homeassistant -H -s
+cd /opt/homeassistant
+python3.6 -m venv .
+source bin/activate
 ```
 
 Install Home Assistant itself.

--- a/source/_docs/installation/hassbian.markdown
+++ b/source/_docs/installation/hassbian.markdown
@@ -16,6 +16,6 @@ Hassbian is our customized operating system for the Raspberry Pi Zero, 2,3 and 3
 When instructions tell you to activate the virtual environment to install a Python library, or perform some tasks, the following commands will do this:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
 ```

--- a/source/_docs/installation/hassbian/common-tasks.markdown
+++ b/source/_docs/installation/hassbian/common-tasks.markdown
@@ -12,7 +12,7 @@ Connect to the Raspberry Pi over ssh. Default user name is `pi` and password is 
 Linux and Mac OS users execute the following command in a terminal.
 
 ```bash
-$ ssh pi@ip-address-of-pi
+ssh pi@ip-address-of-pi
 ```
 
 Windows users start [Putty][ssh-putty], enter the IP address of the Raspberry Pi in the *Host name* field and port 22 in the *Port* field. Then click *Open* and a terminal window will open. Enter the credentials. Default user name is `pi` and password is `raspberry`.
@@ -24,7 +24,7 @@ Optionally, starting with Windows 10 anniversary update, you can use the built-i
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo systemctl stop home-assistant@homeassistant.service
+sudo systemctl stop home-assistant@homeassistant.service
 ```
 
 Replace `stop` with `start` or `restart` to get the desired functionality.
@@ -41,12 +41,12 @@ You can use `hassbian-config` to automate the process by running `sudo hassbian-
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo systemctl stop home-assistant@homeassistant.service
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ pip3 install --upgrade homeassistant
-$ exit
-$ sudo systemctl start home-assistant@homeassistant.service
+sudo systemctl stop home-assistant@homeassistant.service
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install --upgrade homeassistant
+exit
+sudo systemctl start home-assistant@homeassistant.service
 ```
 
 This will in order do the following:
@@ -63,9 +63,9 @@ This will in order do the following:
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ hass
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+hass
 ```
 
 This will start Home Assistant in your shell and output anything that ends up in the log and more into the console. This will fail if the Home Assistant service is already running so don't forget to [stop][stop-homeassistant] it first. If you want the log output to be colored, execute `hass --script check_config` first. This will install the `colorlog` module.
@@ -75,9 +75,9 @@ This will start Home Assistant in your shell and output anything that ends up in
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ hass --script check_config
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+hass --script check_config
 ```
 
 This will output any errors in your configuration files to console.
@@ -87,9 +87,9 @@ This will output any errors in your configuration files to console.
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ cd /home/homeassistant/.homeassistant
-$ nano home-assistant.log
+sudo -u homeassistant -H -s
+cd /home/homeassistant/.homeassistant
+nano home-assistant.log
 ```
 
 This will in order do the following:
@@ -102,7 +102,7 @@ Optionally, you can also view the log with `journalctl`.
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo journalctl -fu home-assistant@homeassistant.service
+sudo journalctl -fu home-assistant@homeassistant.service
 ```
 
 ### Edit the Home Assistant configuration
@@ -110,9 +110,9 @@ $ sudo journalctl -fu home-assistant@homeassistant.service
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ cd /home/homeassistant/.homeassistant
-$ nano configuration.yaml
+sudo -u homeassistant -H -s
+cd /home/homeassistant/.homeassistant
+nano configuration.yaml
 ```
 
 This will in order do the following:
@@ -126,7 +126,7 @@ It's generally recommended that you read the [Getting started][configuring-homea
 ### Change locale, timezone and keyboard layout
 
 ```bash
-$ sudo raspi-config
+sudo raspi-config
 ```
 
 [configuring-homeassistant]: /getting-started/configuration/

--- a/source/_docs/installation/hassbian/upgrading.markdown
+++ b/source/_docs/installation/hassbian/upgrading.markdown
@@ -8,8 +8,8 @@ Hassbian is based on Raspbian and uses the same repositories. Any changes to Ras
 Log in as the `pi` account and execute the following commands:
 
 ```bash
-$ sudo apt-get update
-$ sudo apt-get -y upgrade
+sudo apt-get update
+sudo apt-get -y upgrade
 ```
 
 #### Updating Home Assistant
@@ -23,10 +23,10 @@ You can use `hassbian-config` to automate the process by running `sudo hassbian-
 To update the Home Assistant installation execute the following command as the `pi` user.
 
 ```bash
-$ sudo systemctl stop home-assistant@homeassistant.service
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ pip3 install --upgrade homeassistant
-$ exit
-$ sudo systemctl start home-assistant@homeassistant.service
+sudo systemctl stop home-assistant@homeassistant.service
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install --upgrade homeassistant
+exit
+sudo systemctl start home-assistant@homeassistant.service
 ```

--- a/source/_docs/installation/macos.markdown
+++ b/source/_docs/installation/macos.markdown
@@ -10,9 +10,9 @@ To run Home Assistant on macOS, you need to install Python first. Download Pytho
 Open a terminal and install Home Assistant in a virtual environment:
 
 ```bash
-$ python3 -m venv homeassistant
-$ source homeassistant/bin/activate
-$ pip3 install homeassistant
+python3 -m venv homeassistant
+source homeassistant/bin/activate
+pip3 install homeassistant
 ```
 
 You can then configure Home Assistant to autostart by following [this guide](/docs/autostart/macos/).

--- a/source/_docs/installation/python.markdown
+++ b/source/_docs/installation/python.markdown
@@ -13,8 +13,8 @@ If you're running a Linux-based platform, we strongly recommend you follow the i
 Once Python is installed, execute the following code in a console:
 
 ```bash
-$ pip3 install homeassistant
-$ hass --open-ui
+pip3 install homeassistant
+hass --open-ui
 ```
 
 Running these commands will:

--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -28,44 +28,44 @@ $ ssh pi@ipaddress
 Changing the default password is encouraged.
 
 ```bash
-$ passwd
+passwd
 ```
 
 Update the system.
 
 ```bash
-$ sudo apt-get update
-$ sudo apt-get upgrade -y
+sudo apt-get update
+sudo apt-get upgrade -y
 ```
 
 Install the dependencies.
 
 ```bash
-$ sudo apt-get install python3 python3-dev python3-venv python3-pip libffi-dev libssl-dev
+sudo apt-get install python3 python3-dev python3-venv python3-pip libffi-dev libssl-dev
 ```
 
 Add an account for Home Assistant called `homeassistant`.
 Since this account is only for running Home Assistant the extra arguments of `-rm` is added to create a system account and create a home directory. The arguments `-G dialout,gpio,i2c` adds the user to the `dialout`, `gpio` and the `i2c` group. The first is required for using Z-Wave and Zigbee controllers, while the second is required to communicate with Raspberry's GPIO.
 
 ```bash
-$ sudo useradd -rm homeassistant -G dialout,gpio,i2c
+sudo useradd -rm homeassistant -G dialout,gpio,i2c
 ```
 
 Next we will create a directory for the installation of Home Assistant and change the owner to the `homeassistant` account.
 
 ```bash
-$ cd /srv
-$ sudo mkdir homeassistant
-$ sudo chown homeassistant:homeassistant homeassistant
+cd /srv
+sudo mkdir homeassistant
+sudo chown homeassistant:homeassistant homeassistant
 ```
 
 Next up is to create and change to a virtual environment for Home Assistant. This will be done as the `homeassistant` account.
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ cd /srv/homeassistant
-$ python3 -m venv .
-$ source bin/activate
+sudo -u homeassistant -H -s
+cd /srv/homeassistant
+python3 -m venv .
+source bin/activate
 ```
 Once you have activated the virtual environment (notice the prompt change) you will need to run the following command to install a required python package.
 
@@ -99,9 +99,9 @@ If you want to setup `hass` as a daemon and autostart it on boot please refer to
 To update to the latest version of Home Assistant follow these simple steps:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ pip3 install --upgrade homeassistant
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install --upgrade homeassistant
 ```
 
 Once the last command executes, restart the Home Assistant service to apply the latest updates. Please keep in mind that some updates may take longer to start up than others. If Home Assistant fails to start, make sure you check the **Breaking Changes** from the [Release Notes](https://github.com/home-assistant/home-assistant/releases).
@@ -111,9 +111,9 @@ Once the last command executes, restart the Home Assistant service to apply the 
 In the event that a Home Assistant version doesn't play well with your hardware setup, you can downgrade to a previous release. For example:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ pip3 install homeassistant==0.XX.X
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install homeassistant==0.XX.X
 ```
 
 ### Run the beta version
@@ -121,9 +121,9 @@ $ pip3 install homeassistant==0.XX.X
 If you would like to test next release before anyone else, you can install the beta version released every two weeks, for example:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ pip3 install --pre --upgrade homeassistant
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install --pre --upgrade homeassistant
 ```
 
 ### Run the development version
@@ -137,9 +137,9 @@ If you want to stay on the bleeding-edge Home Assistant development branch, you 
 For example:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
-$ pip3 install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+pip3 install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
 ```
 
 ### Activating the virtual environment
@@ -147,6 +147,6 @@ $ pip3 install --upgrade git+git://github.com/home-assistant/home-assistant.git@
 When instructions tell you to activate the virtual environment, the following commands will do this:
 
 ```bash
-$ sudo -u homeassistant -H -s
-$ source /srv/homeassistant/bin/activate
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
 ```

--- a/source/_docs/installation/troubleshooting.markdown
+++ b/source/_docs/installation/troubleshooting.markdown
@@ -13,7 +13,7 @@ This utility should have been installed as part of the Python installation. Chec
 If you are able to successfully run `python3 --version` but not `pip3`, install Home Assistant by running the following command instead:
 
 ```bash
-$ python3 -m pip install homeassistant
+python3 -m pip install homeassistant
 ```
 
 On a Debian system, you can also install python3 by `sudo apt-get install python3`, and pip3 by `sudo apt-get install python3-pip`.
@@ -22,7 +22,7 @@ On a Debian system, you can also install python3 by `sudo apt-get install python
 [Pip](https://pip.pypa.io/en/stable/) should come bundled with the latest Python 3 but is omitted by some distributions. If you are unable to run `python3 -m pip --version` you can install `pip` by [downloading the installer](https://bootstrap.pypa.io/get-pip.py) and running it with Python 3:
 
 ```bash
-$ python3 get-pip.py
+python3 get-pip.py
 ```
 
 #### libyaml is not found or a compiler error
@@ -43,21 +43,21 @@ To fix this you will need to open your machine's firewall for TCP traffic to por
 For systems with **firewalld** (Fedora, CentOS/RHEL, etc.):
 
 ```bash
-$ sudo firewall-cmd --permanent --add-port=8123/tcp
-$ sudo firewall-cmd --reload
+sudo firewall-cmd --permanent --add-port=8123/tcp
+sudo firewall-cmd --reload
 ```
 
 For UFW systems (Ubuntu, Debian, Raspbian, etc.):
 
 ```bash
-$ sudo ufw allow 8123/tcp
+sudo ufw allow 8123/tcp
 ```
 
 For `iptables` systems (was the default for older distributions):
 
 ```bash
-$ iptables -I INPUT -p tcp --dport 8123 -j ACCEPT
-$ iptables-save > /etc/network/iptables.rules  # your rules may be saved elsewhere
+iptables -I INPUT -p tcp --dport 8123 -j ACCEPT
+iptables-save > /etc/network/iptables.rules  # your rules may be saved elsewhere
 ```
 
 #### After upgrading, your browser login gets stuck at the "loading data" step

--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -23,23 +23,23 @@ It should not contain any OS specific instructions.
 
  1. Create a virtual environment in your current directory:
     ```bash
-    $ python3 -m venv homeassistant
+    python3 -m venv homeassistant
     ```
  2. Open the virtual environment:
     ```bash
-    $ cd homeassistant
+    cd homeassistant
     ```
  3. Activate the virtual environment:
     ```bash
-    $ source bin/activate
+    source bin/activate
     ```
  4. Install Home Assistant:
     ```bash
-    $ python3 -m pip install homeassistant
+    python3 -m pip install homeassistant
     ```    
  5. Run Home Assistant:
     ```bash
-    $ hass --open-ui
+    hass --open-ui
     ```
  6. You can now reach the web interface on `http://ipaddress:8123/` - the first start may take a couple of minutes before the web interface is available. This can take longer if you're using lower-end hardware like a Raspberry Pi Zero.
  
@@ -49,9 +49,9 @@ It should not contain any OS specific instructions.
 
  2. Open the directory where the virtual environment is located, activate the virtual environment, then upgrade Home Assistant:
     ```bash
-    $ cd homeassistant
-    $ source bin/activate
-    $ python3 -m pip install --upgrade homeassistant
+    cd homeassistant
+    source bin/activate
+    python3 -m pip install --upgrade homeassistant
     ```
  3. Start Home Assistant
  4. You can now reach the web interface on `http://ipaddress:8123/` - the first start may take some time before the web interface is available, depending on how many integrations need to be upgraded.
@@ -61,9 +61,9 @@ It should not contain any OS specific instructions.
 In the event that a Home Assistant version doesn't play well with your hardware setup, you can downgrade to a previous release. For example:
 
 ```bash
-$ cd homeassistant
-$ source bin/activate
-$ pip3 install homeassistant==0.XX.X
+cd homeassistant
+source bin/activate
+pip3 install homeassistant==0.XX.X
 ```
 
 #### Run the beta version
@@ -71,9 +71,9 @@ $ pip3 install homeassistant==0.XX.X
 If you would like to test next release before anyone else, you can install the beta version, for example:
 
 ```bash
-$ cd homeassistant
-$ source bin/activate
-$ pip3 install --pre --upgrade homeassistant
+cd homeassistant
+source bin/activate
+pip3 install --pre --upgrade homeassistant
 ```
 
 #### Run the development version
@@ -87,9 +87,9 @@ If you want to stay on the bleeding-edge Home Assistant development branch, you 
 For example:
 
 ```bash
-$ cd homeassistant
-$ source bin/activate
-$ pip3 install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+cd homeassistant
+source bin/activate
+pip3 install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
 ```
 
 ### Notes
@@ -109,7 +109,7 @@ Looking for more advanced guides? Check our [Raspbian guide](/docs/installation/
 If you've upgraded Python (for example, you were running 3.7.1 and now you've installed 3.7.3) then you'll need to build a new virtual environment. Simply rename your existing virtual environment directory:
 
 ```bash
-$ mv homeassistant homeassistant.old
+mv homeassistant homeassistant.old
 ```
 
 Then follow the [Install](#install) steps again, being sure to use the newly installed version of Python.

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -137,7 +137,7 @@ $ docker run -d --name="home-assistant" -v /home/pi/homeassistant:/config -v /et
 If the path of `/dev/ttyACM0` doesn't work then you can find the path of the stick by disconnecting and then reconnecting it, and running the following in the Docker host:
 
 ```bash
-$ ls -1tr /dev/tty*|tail -n 1
+ls -1tr /dev/tty*|tail -n 1
 ```
 
 The `modemmanager` package will interfere with any Z-Wave (or Zigbee) stick and should be removed or disabled. Failure to do so will result in random failures of those components. For example you can disable with `sudo systemctl disable ModemManager` and remove with `sudo apt-get purge modemmanager`
@@ -149,7 +149,7 @@ You do not need to install any software to use Z-Wave.
 To find the path of your Z-Wave USB stick, disconnect it and then reconnect it to your system and run:
 
 ```bash
-$ ls -1tr /dev/tty*|tail -n 1
+ls -1tr /dev/tty*|tail -n 1
 ```
 
 ### Community install methods
@@ -173,7 +173,7 @@ You may also have to install the Python development libraries for your version o
 To find the path of your Z-Wave USB stick, disconnect it and then reconnect it to your system and run:
 
 ```bash
-$ ls -ltr /dev/tty*|tail -n 1
+ls -ltr /dev/tty*|tail -n 1
 ```
 
 That will give you a line that looks something like this:
@@ -187,7 +187,7 @@ Where the date and time displayed is approximately the time you connected the US
 Or, if there is no result, try to find detailed USB connection info with:
 
 ```bash
-$ dmesg | grep USB
+dmesg | grep USB
 ```
 
 If Home Assistant (`hass`) runs with another user (e.g., *homeassistant*) you need to give access to the stick with:
@@ -210,13 +210,13 @@ The output from `ls -ltr` above contains the following information:
 When installing on macOS you may have to also run the command below ahead of time, replace "x.x" with the version of Python (`$ python3 --version`) you have installed.
 
 ```bash
-$ sudo /Applications/Python\ x.x/Install\ Certificates.command
+sudo /Applications/Python\ x.x/Install\ Certificates.command
 ```
 
 On macOS you can find the USB stick with:
 
 ```bash
-$ ls /dev/cu.usbmodem*
+ls /dev/cu.usbmodem*
 ```
 
 ## Troubleshooting
@@ -242,7 +242,7 @@ systemctl disable ModemManager.service
 Sometimes the device may not be accessible and you'll get an error message upon startup about not being able to set up Z-Wave. Run the following command for your device path (here we're using `/dev/ttyAMA0` for our Razberry board):
 
 ```bash
-$ ls -l /dev/ttyAMA0
+ls -l /dev/ttyAMA0
 ```
 
 You should then see something like this:
@@ -254,20 +254,20 @@ crw-rw---- 1 root dialout 204, 64 Apr  1 12:34 /dev/ttyAMA0
 The important pieces are the first piece `crw-rw----` and the group `dialout`. If those are different then, for your device path, run:
 
 ```bash
-$ sudo chgrp dialout /dev/ttyAMA0
-$ sudo chmod g+rw /dev/ttyAMA0
+sudo chgrp dialout /dev/ttyAMA0
+sudo chmod g+rw /dev/ttyAMA0
 ```
 
 Check too that the account you're running Home Assistant as is in the `dialout` group. For instance, if you're using `homeassistant`:
 
 ```bash
-$ groups homeassistant
+groups homeassistant
 ```
 
 That should include `dialout`, if it doesn't then:
 
 ```bash
-$ sudo usermod -aG dialout homeassistant
+sudo usermod -aG dialout homeassistant
 ```
 
 ### Unable to install Python Openzwave

--- a/source/_posts/2015-09-18-monitoring-with-glances-and-home-assistant.markdown
+++ b/source/_posts/2015-09-18-monitoring-with-glances-and-home-assistant.markdown
@@ -22,14 +22,14 @@ In this post a default Fedora 22 Workstation installation is used on the host th
 First some extra packages are needed beside Glances, especially the [bottle](http://bottlepy.org/docs/dev/index.html) webserver. I guess that Glances is available for your distribution as well. Otherwise follow those [instructions](https://github.com/nicolargo/glances#installation).
 
 ```bash
-$ sudo dnf -y install glances python-bottle
+sudo dnf -y install glances python-bottle
 ```
 
 On Fedora the Firewall settings are strict. Let's open port 61208 to allow other hosts to connect to that port. This is not needed if you just want to observe your local machine. 
 
 ```bash
-$ sudo firewall-cmd --permanent --add-port=61208/tcp
-$ sudo firewall-cmd --reload
+sudo firewall-cmd --permanent --add-port=61208/tcp
+sudo firewall-cmd --reload
 ```
 
 Launch `glances` and keep an eye on the output.

--- a/source/_posts/2015-12-07-influxdb-and-grafana.markdown
+++ b/source/_posts/2015-12-07-influxdb-and-grafana.markdown
@@ -18,13 +18,13 @@ The `influxdb` component makes it possible to transfer all state changes from Ho
 The first step is to install the InfluxDB packages. If you are not running Fedora, check the [installation](https://influxdb.com/docs/v0.9/introduction/installation.html) section for further details.
 
 ```bash
-$ sudo dnf -y install http://influxdb.s3.amazonaws.com/influxdb-0.9.5.1-1.x86_64.rpm
+sudo dnf -y install http://influxdb.s3.amazonaws.com/influxdb-0.9.5.1-1.x86_64.rpm
 ```
 
 Launch the InfluxDB service.
 
 ```bash
-$ sudo systemctl start influxdb
+sudo systemctl start influxdb
 ```
 
 If everything went well, then the web interface of the database should be accessible at [http://localhost:8083/](http://localhost:8083/). Create a database `home_assistant` to use with Home Assistant either with the web interface or the commandline tool `influx`.
@@ -77,15 +77,15 @@ time			domain		entity_id	value
 [Grafana](http://grafana.org/) is a dashboard that can create graphs from different sources including InfluxDB. The installation is simple, and there are detailed steps for many different configurations on the [Grafana installation](http://docs.grafana.org/installation/) page. For a recent system that is running Fedora:
 
 ```bash
-$ sudo dnf -y install https://grafanarel.s3.amazonaws.com/builds/grafana-2.5.0-1.x86_64.rpm
+sudo dnf -y install https://grafanarel.s3.amazonaws.com/builds/grafana-2.5.0-1.x86_64.rpm
 ```
 
 Start the grafana server.
 
 ```bash
-$ sudo systemctl daemon-reload
-$ sudo systemctl start grafana-server
-$ sudo systemctl status grafana-server
+sudo systemctl daemon-reload
+sudo systemctl start grafana-server
+sudo systemctl status grafana-server
 ```
 
 Login with the username `admin` and the password `admin` at [http://localhost:3000/login](http://localhost:3000/login). Now follow the [InfluxDB setup instructions](http://docs.grafana.org/datasources/influxdb/).
@@ -103,4 +103,3 @@ If the graph is not showing up in the dashboard you need to adjust the time rang
   <img src='/images/blog/2015-12-influxdb/grafana-graph.png' />
   Grafana Temperature graph
 </p>
-

--- a/source/_posts/2016-07-06-pocketchip-running-home-assistant.markdown
+++ b/source/_posts/2016-07-06-pocketchip-running-home-assistant.markdown
@@ -28,27 +28,27 @@ First a couple of tweaks like setting up `sudo`, upgrading the existing installa
 A Debian installation is available by default. This means that some dependencies for Home Assistant are missing. I haven't checked if a new build for the PocketCHIP would include them. So, after a `$ sudo apt-get update` installing those dependencies take a minute or two.
 
 ```bash
-$ sudo apt-get install python3-dev python3-pip python3-venv
+sudo apt-get install python3-dev python3-pip python3-venv
 ```
 
 As usual I run Python applications in a [venv](https://docs.python.org/3/library/venv.html).
 
 ```bash
-$ pvenv ha
+pvenv ha
 ```
 
 Let's activate the created environment.
 
 ```bash
-$ cd ha
-$ source bin/activate
+cd ha
+source bin/activate
 ```
 
 If you haven't seen the next two commands already then you should visit our [frontsite](/).
 
 ```bash
-$ pip3 install homeassistant
-$ hass --open-ui
+pip3 install homeassistant
+hass --open-ui
 ```
 
 With `surf` the browsing experience on the low-resolution display is not that great. Most smartphones, even very cheap ones, have touchscreens with higher resolutions. Nevermind, [`midori`](https://twitter.com/fabaff/status/748852317047418880) is not better.
@@ -59,4 +59,3 @@ With `surf` the browsing experience on the low-resolution display is not that gr
 </p>
 
 Well, with PocketCHIP and Home Assistant you could run your home automation on a 49 USD device with a touchscreen, an integrated USP, and a keyboard. With the GPIO available on top of the display you could even connect your PocketCHIP directly to sensors and actuators.
-

--- a/source/_posts/2016-07-16-sqlalchemy-knx-join-simplisafe.markdown
+++ b/source/_posts/2016-07-16-sqlalchemy-knx-join-simplisafe.markdown
@@ -15,8 +15,8 @@ It's time for Home Assistant 0.24 and it's full of new integration for your Home
 [Roy Hooper][@rhooper] did an amazing job migrating the history support from being tied to SQLite to use the ORM SQLAlchemy instead. This means that you can now use **any** SQL backend for the history. So besides SQLite you can now databases like MySQL or PostgreSQL. However, this does require that you install [SQLAlchemy] and run a command to migrate your existing history over. We tried to make the process as seamless as possible by introducing a new command line script: 
 
 ```bash
-$ pip3 install SQLAlchemy
-$ hass --script db_migrator --config /path/to/config
+pip3 install SQLAlchemy
+hass --script db_migrator --config /path/to/config
 ```
 
 You can omit the `--config` option if you use the default configuration directory. Run the script with `--help` to get more options.

--- a/source/_posts/2017-02-03-hassbian-toybox.markdown
+++ b/source/_posts/2017-02-03-hassbian-toybox.markdown
@@ -24,12 +24,12 @@ Currently includes:
 All of these scripts are available in the directory `/home/pi/hassbian-scripts/`. This directory is actually a cloned git repository that's cloned on first boot and can be updated to the latest release with ease after.
 To update the hassbian-scripts directory execute the following command as the `pi` user.
 ```bash
-$ cd hassbian-scripts
-$ git pull
+cd hassbian-scripts
+git pull
 ```
 To use any of the hassbian-scripts, execute the following command as the `pi` user. Here we use the libcec script as an example.
 ```bash
-$ sudo ./hassbian-scripts/install_libcec.sh
+sudo ./hassbian-scripts/install_libcec.sh
 ```
 
 For more information about these scripts have a look a the [hassbian-scripts repository][hassbian-repo]. 

--- a/source/_posts/2017-02-04-babyphone.markdown
+++ b/source/_posts/2017-02-04-babyphone.markdown
@@ -29,10 +29,10 @@ We change the platform name for binary sensor in 0.38 from `ffmpeg` to `ffmpeg_n
 On Raspbian Jessie, you can setup [FFmpeg](/components/ffmpeg) and install an [icecast2](http://icecast.org/) server using:
 
 ```bash
-$ sudo echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
-$ sudo apt-get update
-$ sudo apt-get -t jessie-backports install ffmpeg
-$ sudo apt-get install icecast2
+sudo echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
+sudo apt-get update
+sudo apt-get -t jessie-backports install ffmpeg
+sudo apt-get install icecast2
 ```
 
 We setup an icecast mount point for our babyphone and update `/etc/icecast2/icecast.xml`:

--- a/source/_posts/2017-05-01-home-assistant-on-raspberry-pi-zero-in-30-minutes.markdown
+++ b/source/_posts/2017-05-01-home-assistant-on-raspberry-pi-zero-in-30-minutes.markdown
@@ -63,8 +63,8 @@ It's a good idea to change the password. To do so, use the `passwd` command.
 Next, type the following two commands into the SSH console:
 
 ```bash
-$ sudo systemctl enable install_homeassistant.service
-$ sudo systemctl start install_homeassistant.service
+sudo systemctl enable install_homeassistant.service
+sudo systemctl start install_homeassistant.service
 ```
 
 Wait about 15-20 minutes and voilà you have your Home Assistant on your Raspberry Pi Zero W in 30 minutes.

--- a/source/_posts/2018-03-29-fedora-atomic.markdown
+++ b/source/_posts/2018-03-29-fedora-atomic.markdown
@@ -35,8 +35,8 @@ Deployments:
 The release is 27.100. The latest is 27.105. So, let's update the host and reboot it.
 
 ```bash
-$ sudo atomic host upgrade
-$ sudo systemctl reboot
+sudo atomic host upgrade
+sudo systemctl reboot
 ```
 
 You can also see that Docker is already running. No installation needed.
@@ -54,21 +54,21 @@ Further we will cover how it works for Home Assistant and [Mosquitto](https://mo
 Instead of `docker` we can use the command-line tool [`atomic`](http://www.projectatomic.io/docs/usr-bin-atomic/) to perform a lot of tasks. Download the images for the containers. We are pulling the images from [Docker Hub](https://hub.docker.com/), thus we need to add the registry to use.
 
 ```bash
-$ sudo atomic install docker.io/​homeassistant/home-assistant
-$ sudo atomic install docker.io/eclipse-mosquitto
+sudo atomic install docker.io/​homeassistant/home-assistant
+sudo atomic install docker.io/eclipse-mosquitto
 ```
 
 Both containers need additional directories for persistent storage.
 
 ```bash
-$ sudo mkdir -p /opt/home-assistant
-$ sudo mkdir -p /opt/mosquitto/{config,data,log}
+sudo mkdir -p /opt/home-assistant
+sudo mkdir -p /opt/mosquitto/{config,data,log}
 ```
 
 We need a copy of `mosquitto.conf` to run Mosquitto later:
 
 ```bash
-$ sudo curl -o /opt/mosquitto/config/mosquitto.conf \
+sudo curl -o /opt/mosquitto/config/mosquitto.conf \
   https://raw.githubusercontent.com/eclipse/mosquitto/master/mosquitto.conf
 ```
 
@@ -125,14 +125,14 @@ Exit to be not longer `root`.
 Reload `systemd` to make it aware of the new configurations.
 
 ```bash
-$ sudo systemctl daemon-reload
+sudo systemctl daemon-reload
 ```
 
 Now, both container can be controlled by `systemctl`.
 
 ```bash
-$ sudo systemctl enable home-assistant.service --now
-$ sudo systemctl enable mosquitto.service --now
+sudo systemctl enable home-assistant.service --now
+sudo systemctl enable mosquitto.service --now
 ```
 
 Check with `$ sudo systemctl status [name].service` if there are error or the services are running.

--- a/source/hassio/commandline.markdown
+++ b/source/hassio/commandline.markdown
@@ -13,40 +13,40 @@ On the SSH command line, you can use the `hassio` command to retrieve logs, chec
 ## Home Assistant
 
 ```bash
-$ hassio homeassistant check
-$ hassio homeassistant info
-$ hassio homeassistant logs
-$ hassio homeassistant options
-$ hassio homeassistant rebuild
-$ hassio homeassistant restart
-$ hassio homeassistant start
-$ hassio homeassistant stats
-$ hassio homeassistant stop
-$ hassio homeassistant update
+hassio homeassistant check
+hassio homeassistant info
+hassio homeassistant logs
+hassio homeassistant options
+hassio homeassistant rebuild
+hassio homeassistant restart
+hassio homeassistant start
+hassio homeassistant stats
+hassio homeassistant stop
+hassio homeassistant update
 ```
 
 ## Supervisor
 
 ```bash
-$ hassio supervisor info
-$ hassio supervisor logs
-$ hassio supervisor reload
-$ hassio supervisor update
+hassio supervisor info
+hassio supervisor logs
+hassio supervisor reload
+hassio supervisor update
 ```
 
 ## Host
 
 ```bash
-$ hassio host reboot
-$ hassio host shutdown
-$ hassio host update
+hassio host reboot
+hassio host shutdown
+hassio host update
 ```
 
 ## Hardware
 
 ```bash
-$ hassio hardware info
-$ hassio hardware audio
+hassio hardware info
+hassio hardware audio
 ```
 
 ## Usage examples


### PR DESCRIPTION
**Description:**

Removes the use of dollar `$` prefixes in shellcode across the code base, making everything consistent. Extended remark to keep it consistent for the foreseeing future.

It improves readability, less noisy and easier to copy and paste if the dollar signs are omitted when they are not needed. An exception is made when there is a need to distinguish between typed commands and command output.

This PR:
- Adds [remark-lint-no-shell-dollars](https://github.com/remarkjs/remark-lint/tree/master/packages/remark-lint-no-shell-dollars)
- Ensured all pages are now consistent

References:
- [Markdownlint MD014 - Dollar signs used before commands without showing output](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md014---dollar-signs-used-before-commands-without-showing-output)
- [Markdown style guide - Dollar signs in shell code](https://cirosantilli.com/markdown-style-guide#dollar-signs-in-shell-code)

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
