### PR TITLE
Adding proto to xiaomi_aqara configuration.

### DIFF
--- a/source/_components/xiaomi_aqara.markdown
+++ b/source/_components/xiaomi_aqara.markdown
@@ -112,6 +112,11 @@ gateways:
       required: false
       type: boolean
       default: false
+    proto:
+      description: Protocol to use for the HA <-> gateway communications. This is only required if the gateway doesn't use 1.0 protocol. 
+      required: false
+      type: string
+      default: 1.0
 discovery_retry:
   description: Number of times that Home Assistant should try to reconnect to the gateway.
   required: false


### PR DESCRIPTION
**Description:**
Addition an optional configuration key `proto` to let the module know how to communicate with the gateway for 2.0/3.0 protocol devices (like air conditioning companion)

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27042

## Checklist:

- [ y] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ y] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
