### PR TITLE
Add white line to comply with markdown rules.

### DIFF
--- a/source/_components/homematicip_cloud.markdown
+++ b/source/_components/homematicip_cloud.markdown
@@ -80,11 +80,11 @@ authtoken:
 {% endconfiguration %}
 
 ## Adding and removing devices and group via native HomematicIP APP
+
 Devices and groups are instantly removed from Homeassistant when removed in the native HomematicIP APP.
 Groups are instantly created in Homeassistant when created in the native HomematicIP APP.
 Devices are created with a delay of 30 seconds in Homeassistant when created in the native HomematicIP APP.
 Within this delay the device registration should be completed in the App, otherwise the device name will be a default one based on the device type. This can easily be fixed in the Homeassistant entity registry afterwards.
-
 
 ## Implemented and tested devices
 


### PR DESCRIPTION
**Description:**
As remarked my @klaasnicolaas after merge:
According to the markdown rules, there should be a white line between the heading and text 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
