### PR TITLE
Remove state_template

### DIFF
--- a/source/_docs/mqtt/processing_json.markdown
+++ b/source/_docs/mqtt/processing_json.markdown
@@ -17,13 +17,6 @@ To use this, add the following key to your `configuration.yaml`:
 ```yaml
 switch:
   platform: mqtt
-  state_format: 'json:somekey[0].value'
-```
-It is also possible to extract JSON values by using a value template:
-
-```yaml
-switch:
-  platform: mqtt
   value_template: '{% raw %}{{ value_json.somekey[0].value }}{% endraw %}'
 ```
 


### PR DESCRIPTION
https://github.com/home-assistant/home-assistant.io/issues/10024

**Description:**

Remove state_template from documentation

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
