### PR TITLE
Clean up duplicate section in Cast documentation

### DIFF
--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -13,7 +13,7 @@ You can enable the Cast integration by going to the Integrations page inside the
 
 ## Home Assistant Cast
 
-Home Assistant has its own Cast application to show the Home Assistant UI. You can load it on your Chromecast by adding the [Cast entity row](/lovelace/entities/#cast) to your Lovelace UI or by using the `cast.show_lovelace_ui` service. The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on.
+Home Assistant has its own Cast application to show the Home Assistant UI on any Chromecast device.  You can use it by adding the [Cast entity row](/lovelace/entities/#cast) to your Lovelace UI, or by calling the `cast.show_lovelace_view` service.  The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on.
 
 ```json
 {
@@ -21,19 +21,6 @@ Home Assistant has its own Cast application to show the Home Assistant UI. You c
   "view_path": "lights"
 }
 ```
-
-## Home Assistant Cast
-
-The Cast integration allows you to start Home Assistant Cast on any Chromecast device, using the `cast.show_lovelace_view` service. The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on.
-
-```json
-{
-  "entity_id": "media_player.office_display_4",
-  "view_path": "lights"
-}
-```
-
-## Advanced use
 
 Note that Home Assistant Cast requires your Home Assistant installation to be accessible via `https://`. If you're using Home Assistant Cloud, you don't need to do anything. Otherwise you must make sure that you have configured the `base_url` for [the `http` integration](/integrations/http/).
 


### PR DESCRIPTION
**Description:**

It looks like this was introduced accidentally by some kind of glitch, because https://github.com/home-assistant/home-assistant.io/pull/10339 appears to have been merged twice: 48f38a5683d2d0d4310dadf887e88a7825b99bb5 added the section, followed by 0c2c8f86524abcf35968d78aad2d44421204793d on the same branch.

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
