### PR TITLE
Added undocumented verify_ssl parameter

### DIFF
--- a/source/_components/scrape.markdown
+++ b/source/_components/scrape.markdown
@@ -51,6 +51,10 @@ authentication:
   description: Type of the HTTP authentication. Either `basic` or `digest`.
   required: false
   type: string
+verify_ssl:
+  description: Enables/disables verification of SSL-certificate, for example if self-signed.
+  required: false
+  type: boolean
 username:
   description: The username for accessing the website.
   required: false

--- a/source/_components/scrape.markdown
+++ b/source/_components/scrape.markdown
@@ -52,9 +52,10 @@ authentication:
   required: false
   type: string
 verify_ssl:
-  description: Enables/disables verification of SSL-certificate, for example if self-signed.
+  description: Enables/disables verification of SSL-certificate, for example if it is self-signed.
   required: false
   type: boolean
+  default: true
 username:
   description: The username for accessing the website.
   required: false


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
