### PR TITLE
Update samba.markdown to help users find shares

### DIFF
--- a/source/_addons/samba.markdown
+++ b/source/_addons/samba.markdown
@@ -14,7 +14,7 @@ Be careful when setting up port forwarding for remote access. If you don't restr
 
 <div class='note'>
 
-Sometimes shares will not show up under network in Windows. Then you could open the file browser, click the address field where it says "> Network" and type //HASSIO to access Hassio shares.
+Sometimes shares will not show up under network in Windows. Then you could open the file browser, click the address field where it says "> Network" and type //HASSIO to access Hass.io shares.
 
 </div>
 

--- a/source/_addons/samba.markdown
+++ b/source/_addons/samba.markdown
@@ -12,6 +12,12 @@ Be careful when setting up port forwarding for remote access. If you don't restr
 
 </div>
 
+<div class='note'>
+
+Sometimes shares will not show up under network in Windows. Then you could open the file browser, click the address field where it says "> Network" and type //HASSIO to access Hassio shares.
+
+</div>
+
 ```json
 {
   "workgroup": "WORKGROUP",


### PR DESCRIPTION
Sometimes shares do not show up in windows and you have to manually find them. This is not obvious for all users.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
