### PR TITLE
Fixes a broken link in the cookbook

### DIFF
--- a/source/_cookbook/perform_actions_based_on_input_select.markdown
+++ b/source/_cookbook/perform_actions_based_on_input_select.markdown
@@ -69,7 +69,7 @@ automation:
       data:
         entity_id: media_player.nursery
 ```
-A little bit more complex example that uses [`input_select`](/components/input_select/) and template to decide what to play, and which [Chromecast](components/media_player.cast/) to play on.
+A little bit more complex example that uses [`input_select`](/components/input_select/) and template to decide what to play, and which [Chromecast](/components/cast/) to play on.
 
 ```yaml
 input_select:


### PR DESCRIPTION
**Description:**

Dead link fix

Related to #10491

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
