### PR TITLE
Update transmission.markdown

### DIFF
--- a/source/_components/transmission.markdown
+++ b/source/_components/transmission.markdown
@@ -71,6 +71,7 @@ scan_interval:
 ## Default Sensors
 
 Default sensors are now added with the following schema "sensor.transmission(or name if used)_variable_here"
+
 - sensor.transmission_active_torrents
 - sensor.transmission_completed_torrents
 - sensor.transmission_down_speed

--- a/source/_components/transmission.markdown
+++ b/source/_components/transmission.markdown
@@ -66,29 +66,21 @@ scan_interval:
   description: How frequently to query for new data. Defaults to 120 seconds.
   required: false
   type: integer
-monitored_conditions:
-  type: integer
-  description: "List of monitored conditions. Possible values are:"
-  required: false
-  type: list
-  keys:
-    current_status:
-      description: The status of your Transmission daemon.
-    download_speed:
-      description: The current download speed [MB/s].
-    upload_speed:
-      description: The current upload speed [MB/s].
-    active_torrents:
-      description: The current number of active torrents.
-    paused_torrents:
-      description: The current number of paused torrents.
-    total_torrents:
-      description: The total number of torrents present in the client.
-    started_torrents:
-      description: The current number of started torrents (downloading).
-    completed_torrents:
-      description: The current number of completed torrents (seeding)
 {% endconfiguration %}
+
+## Default Sensors
+
+Default sensors are now added with the following schema "sensor.transmission(or name if used)_variable_here"
+- sensor.transmission_active_torrents
+- sensor.transmission_completed_torrents
+- sensor.transmission_down_speed
+- sensor.transmission_paused_torrents
+- sensor.transmission_started_torrents
+- sensor.transmission_status
+- sensor.transmission_total_torrents
+- sensor.transmission_up_speed
+
+*Previous methods used "monitored_conditions", this is no longer valid.*
 
 ## Event Automation
 


### PR DESCRIPTION
Added default new sensors and removed the no longer valid "monitored_conditions".
[__init__py reference](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/transmission/__init__.py)
See TransmissionData class,

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
