### PR TITLE
Fix notebook link

### DIFF
--- a/source/_docs/ecosystem/notebooks/installation.markdown
+++ b/source/_docs/ecosystem/notebooks/installation.markdown
@@ -39,7 +39,7 @@ You will get an empty notebook with one cell. Cells can contain code or text. To
   <img src='{{site_root}}/images/screenshots/jupyter-notebook.png' />
 </p>
 
-The downloadable version of this notebook is available in the [Home Assistant notebooks repository](https://github.com/home-assistant/home-assistant-notebooks/blob/master/first-notebook.ipynb).
+The downloadable version of this notebook is available in the [Home Assistant notebooks repository](https://github.com/home-assistant/home-assistant-notebooks/blob/master/other/first-notebook.ipynb).
 
 
 As you can see is the Jupyter notebook workflow is very similar to working directly with a Python shell. One advantage of notebooks is that you can go back and forth between cells as you please and save your work.


### PR DESCRIPTION
**Description:**

Fix First Jupyter Notebook link.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
