### PR TITLE
Fixes mailto link for Security email

### DIFF
--- a/source/security/index.markdown
+++ b/source/security/index.markdown
@@ -3,8 +3,9 @@ title: "Security"
 description: "Information about disclosing security vulnerabilities in Home Assistant."
 ---
 
-If you think that you have found a security vulnerability in Home Assistant, please disclose it to us via our security e-mail address at [security@home-assistant.io](mailto://security@home-assistant.io).
+If you think that you have found a security vulnerability in Home Assistant, please disclose it to us via our security e-mail address at [security@home-assistant.io](mailto:security@home-assistant.io).
 
 Please do not make vulnerabilities public without notifying us and giving us at least 3 days to respond.
 
 If you are going to write about Home Assistant's security, please get in touch, so we can make sure that all claims are correct.
+  


### PR DESCRIPTION
**Description:**
The mailto link to security@home-assistant.io was broken, this fixes that link.

## Checklist:
- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
