### PR TITLE
Adds redirect for buienradar camera component

### DIFF
--- a/source/_redirects
+++ b/source/_redirects
@@ -213,6 +213,7 @@
 /components/camera.august /integrations/august#camera
 /components/camera.axis /integrations/axis
 /components/camera.blink /integrations/blink
+/components/camera.buienradar /integrations/buienradar#camera
 /components/camera.canary /integrations/canary#camera
 /components/camera.dispatcher /integrations/dispatcher
 /components/camera.doorbird /integrations/doorbird#camera


### PR DESCRIPTION
**Description:**
When camera component is mis-configured, an error includes a URL
to documentation.

However, this page did not exist due to a missing redirect.

```
2019-10-01 11:42:01 ERROR (MainThread) [homeassistant.config] Invalid config for [camera.buienradar]: [interval] is an invalid option for [camera.buienradar]. Check: camera.buienradar->interval. (See ~/.homeassistant/configuration.yaml, line 30). Please check the docs at https://home-assistant.io/components/camera.buienradar/
```

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html