### PR TITLE
Fixes code fencing in DeConz documentation

### DIFF
--- a/source/_components/deconz.markdown
+++ b/source/_components/deconz.markdown
@@ -79,13 +79,21 @@ Set attribute of device in deCONZ using [Rest API](http://dresden-elektronik.git
 
 Either `entity` or `field` must be provided. If both are present, `field` will be interpreted as a subpath under the device path corresponding to the specified `entity`:
 
+```json
 { "field": "/lights/1", "data": {"name": "light2"} }
+```
 
+```json
 { "entity": "light.light1", "data": {"name": "light2"} }
+```
 
+```json
 { "entity": "light.light1", "field: "/state", "data": {"on": true} }
+```
 
+```json
 { "field": "/config", "data": {"permitjoin": 60} }
+```
 
 #### Service `deconz.device_refresh`
 


### PR DESCRIPTION
**Description:**

Fixes code fencing in DeConz documentation

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
