### PR TITLE
Minor corrections to Android TV documentation

### DIFF
--- a/source/_components/androidtv.markdown
+++ b/source/_components/androidtv.markdown
@@ -162,7 +162,7 @@ For Hass.io users, you can install the [Android Debug Bridge](https://github.com
 
 ### 2. Python ADB Implementation
 
-The second option is to connect to your device using the `adb` Python package.
+The second option is to connect to your device using the `adb-shell` Python package.
 
 If your device requires ADB authentication, you will need to follow the instructions in the [ADB Authentication](#adb-authentication) section below. Once you have an authenticated key, this approach does not require any additional setup or addons. However, users with newer devices may find that the ADB connection is unstable. For a Fire TV device, you can try setting the `get_sources` configuration option to `false`.  If the problem cannot be resolved, you should use the ADB server option.
 
@@ -174,7 +174,7 @@ If you get a "Device authentication required, no keys available" error when tryi
 In the dialog appearing on your Android TV / Fire TV, you must check the box that says "always allow connections from this device." ADB authentication in Home Assistant will only work using a trusted key.
 </div>
 
-Once you've successfully connected to your Android TV / Fire TV via the command `adb connect <ipaddress>:5555`, the file `adbkey` will be created on your computer. The default locations for this file is (from [https://developer.android.com/studio/command-line/adb](https://developer.android.com/studio/command-line/adb)):
+Once you've successfully connected to your Android TV / Fire TV via the command `adb connect <ipaddress>:5555`, the file `adbkey` will be created on your computer. The default locations for this file are (from [https://developer.android.com/studio/command-line/adb](https://developer.android.com/studio/command-line/adb)):
 
 - Linux and Mac: `$HOME/.android.`
 - Windows: `%userprofile%\.android.`


### PR DESCRIPTION
**Description:**

* The backend ADB package is now `adb-shell`, not `adb`
* Change "The default locations for this file is" to "The default locations for this file are"

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html