### PR TITLE
Add info about call direction sensor

### DIFF
--- a/source/_integrations/obihai.markdown
+++ b/source/_integrations/obihai.markdown
@@ -41,6 +41,7 @@ The following is a list of expected sensors and their expected states when using
 - Sensor if the device requires a reboot (`True` or `False`)
 - Sensor for each configured service (`0` for no calls, `1` for a call and `2` for call waiting/3way calling)
 - Sensor for the last reboot date
+- Sensor for call direction (`No Active Calls`, `Inbound Call` or `Outbound Call`) 
 
 In addition to the above list the `admin` account can expect to see the following sensors:
 


### PR DESCRIPTION
**Description:**

Add some info about the call direction sensor.  I was unable to update `next` as there was a merge conflict (https://discordapp.com/channels/330944238910963714/330990175188418561/626674569637527562).  Now that the conflict is resolved have submitted this small change.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#26867

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
