### PR TITLE
Update Lutron Caseta documentation

### DIFF
--- a/source/_integrations/lutron_caseta.markdown
+++ b/source/_integrations/lutron_caseta.markdown
@@ -18,10 +18,10 @@ This integration only supports the [Caseta](http://www.casetawireless.com) line 
 
 The currently supported Caseta devices are:
 
-- Wall and plug-in dimmers as Home Assistant
-- Wall switches as Home Assistant
-- Scenes as Home Assistant
-- Lutron shades as Home Assistant
+- Wall and plug-in dimmers as [lights](#light)
+- Wall switches as [switches](#switch)
+- Scenes as [scenes](#scene)
+- Lutron shades as [covers](#cover)
 
 When configured, the `lutron_caseta` integration will automatically discover the currently supported devices as setup in the Lutron Smart Bridge. The name assigned in the Lutron mobile app will be used to form the `entity_id` used in Home Assistant. e.g., a dimmer called 'Lamp' in a room called 'Bedroom' becomes `light.bedroom_lamp` in Home Assistant.
 


### PR DESCRIPTION
**Description:** Fixes links that got broken when the pages got combined in #8324 and fixes grammar since partial description of link was left on the page.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
