### PR TITLE
Update counter instructions for Dev Tools redesign in 0.96

### DIFF
--- a/source/_integrations/counter.markdown
+++ b/source/_integrations/counter.markdown
@@ -112,7 +112,7 @@ With this service the properties of the counter can be changed while running.
 
 ### Use the service
 
-Select <img src='/images/screenshots/developer-tool-services-icon.png' alt='service developer tool icon' class="no-shadow" height="38" /> **Services** from the **Developer Tools**. Choose **counter** from the list of **Domains**, select the **Service**, enter something like the sample below into the **Service Data** field, and hit **CALL SERVICE**.
+Select the **Services** tab from within **Developer Tools**. Choose **counter** from the list of **Domains**, select the **Service**, enter something like the sample below into the **Service Data** field, and hit **CALL SERVICE**.
 
 ```json
 {


### PR DESCRIPTION
**Description:**
Since HA 0.96 it no longer uses the service icon, and is now a tab under Developer Tools.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
