### PR TITLE
Update slightly outdated Dev Tools instructions

### DIFF
--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -11,7 +11,7 @@ The configuration options to call a config are the same between all integrations
 Examples on this page will be given as part of an automation integration configuration but different approaches can be used for other integrations too.
 
 <div class='note'>
-Use the <img src='/images/screenshots/developer-tool-services-icon.png' class='no-shadow' height='38' /> service developer tool in the frontend to discover available services.
+Use the "Services" tab under Developer Tools to discover available services.
 </div>
 
 ### The basics


### PR DESCRIPTION
**Description:**
Minor tweak.. This used the previous Services icon which is no longer in use... Services is now a tab (text only) within Developer Tools since Home Assistant 0.96.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
