### PR TITLE
Creates redirect for /components -> /integrations

### DIFF
--- a/source/_redirects
+++ b/source/_redirects
@@ -1097,6 +1097,7 @@
 /components/xiaomi /integrations/xiaomi_aqara
 
 # Renaming components to integrations
+/components /integrations
 /components/abode /integrations/abode
 /components/acer_projector /integrations/acer_projector
 /components/actiontec /integrations/actiontec


### PR DESCRIPTION
**Description:**

One redirect missing 😢 
This adds a redirect for the `/components` -> `/integrations`.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
