### PR TITLE
📚Update pushbullet link in /configuration/yaml, fix linting errors

### DIFF
--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -7,7 +7,7 @@ redirect_from: /getting-started/yaml/
 Home Assistant uses the [YAML](http://yaml.org/) syntax for configuration. YAML might take a while to get used to but is really powerful in allowing you to express complex configurations.
 
 For each integration that you want to use in Home Assistant, you add code in your `configuration.yaml` file to specify its settings.
-The following example entry specifies that you want to use the [notify component](/integrations/notify) with the [pushbullet platform](/integrations/notify.pushbullet).
+The following example entry specifies that you want to use the [notify component](/integrations/notify) with the [pushbullet platform](/integrations/pushbullet).
 
 
 ```yaml
@@ -62,7 +62,7 @@ sensor:
     state_topic: sensor2/topic
 ```
 
-### Using Environment Variables
+## Using Environment Variables
 
 You can include values from your system's environment variables with `!env_var`.
 
@@ -71,7 +71,7 @@ http:
   api_password: !env_var PASSWORD
 ```
 
-#### Default Value
+### Default Value
 
 If an environment variable is not set, you can fallback to a default value.
 


### PR DESCRIPTION
**Description:**

Update link to pushbullet integration, update file for linting.

#10491

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
