### PR TITLE
Fixes sidebar on integration pages

### DIFF
--- a/source/_includes/site/sidebar.html
+++ b/source/_includes/site/sidebar.html
@@ -1,6 +1,6 @@
 <div class="grid">
   {% assign url_parts = page.url | split: '/' %}
-  {% if url_parts[1] == 'components' %}
+  {% if url_parts[1] == 'integrations' %}
     {% include asides/component_navigation.html %}
   {% elsif url_parts[1] == 'cookbook' %}
     {% include asides/cookbook_navigation.html %}


### PR DESCRIPTION
**Description:**

During the move made in #10488, the sidebar on the integration pages wasn't adjusted, causing the default sidebar (as show on the blog pages) to be displayed. This PR addresses this issue.

**Pull request in home-assistant (if applicable):** n/a
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
