### PR TITLE
Fix broken link Elgato Avea

### DIFF
--- a/source/_integrations/avea.markdown
+++ b/source/_integrations/avea.markdown
@@ -8,7 +8,7 @@ ha_release: 0.97
 ha_iot_class: Local Polling
 ---
 
-[Elgato Avea](http://web.archive.org/web/20170930210431/https://www.elgato.com/avea) is a Bluetooth light bulb that is no longer supported by the manufacturer. The `avea` integration allows you to control all your Avea bulbs with Home Assistant.
+[Elgato Avea](https://www.elgato.com/en/news/elgato-avea-transform-your-home) is a Bluetooth light bulb that is no longer supported by the manufacturer. The `avea` integration allows you to control all your Avea bulbs with Home Assistant.
 
 ### Configuration
 


### PR DESCRIPTION
Fixed broken link Elgato Avea by changing it to press release page with all product info.

Related to #10491

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
