### PR TITLE
Fix broken links in credits.markdown

### DIFF
--- a/source/developers/credits.markdown
+++ b/source/developers/credits.markdown
@@ -2119,9 +2119,6 @@ This page contains a list of people who have contributed in one way or another t
 - [Comic Chang (@comicchang)](https://github.com/comicchang "1 total commits to the Home Assistant orga:
 1 commit to home-assistant.io
 ")
-- [ComputerCandy (@ComputerCandy)](https://github.com/ComputerCandy "1 total commits to the Home Assistant orga:
-1 commit to home-assistant.io
-")
 - [Conrad Juhl Andersen (@cnrd)](https://github.com/cnrd "17 total commits to the Home Assistant orga:
 9 commits to home-assistant
 5 commits to home-assistant.io
@@ -9891,7 +9888,7 @@ This page contains a list of people who have contributed in one way or another t
 1 commit to home-assistant
 1 commit to home-assistant.io
 ")
-- [Stephan Grobler (@stephanfx)](https://github.com/stephanfx "1 total commits to the Home Assistant orga:
+- [Stephan Grobler (@stephangrobler)](https://github.com/stephangrobler "1 total commits to the Home Assistant orga:
 1 commit to home-assistant.io
 ")
 - [stephanerosi (@stephanerosi)](https://github.com/stephanerosi "11 total commits to the Home Assistant orga:


### PR DESCRIPTION
User @ComputerCandy does no longer exist on github. Broken link: https://github.com/ComputerCandy,
User @stephanfx changed handle to @stephangrobler. Broken link: https://github.com/stephanfx New link: https://github.com/stephangrobler

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
