### PR TITLE
Broken links fix for tellstick.markdown

### DIFF
--- a/source/_addons/tellstick.markdown
+++ b/source/_addons/tellstick.markdown
@@ -6,7 +6,7 @@ description: "Telldus TellStick service enabler and tools."
 Setting up the [Tellstick](http://telldus.com) service and tools contained in the [telldus-core](http://developer.telldus.com/) package and adding configuration to enable Tellstick and Tellstick Duo to work on your Hass.io.
 
 To use this add-on, you first install it from the list of Built-in add-ons in Hass.io.
-After installation you are presented with a default and example configuration, to alter this you must follow both the JSON format and also be aligned with the [valid parameters for Tellstick configuration file (tellstick.conf)](https://developer.telldus.com/wiki/TellStick_conf).
+After installation you are presented with a default and example configuration, to alter this you must follow both the JSON format and also be aligned with the [valid parameters for Tellstick configuration file (tellstick.conf)](http://developer.telldus.com/wiki/TellStick_conf).
 
 After any changes have been made to the configuration, you need to restart the add-on for the changes to take effect.
 
@@ -86,7 +86,7 @@ code:
   type: string
 {% endconfiguration %}
 
-For more information about the configuration including protocols, see the [telldus documentation](https://developer.telldus.com/wiki/TellStick_conf).
+For more information about the configuration including protocols, see the [telldus documentation](http://developer.telldus.com/wiki/TellStick_conf).
 
 ## Service calls
 


### PR DESCRIPTION
Broken link: https://developer.telldus.com/wiki/TellStick_conf
The server at developer.telldus.com does not support https. Fixed 2 links.
HTTPS returns error 502 Bad gateway.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
