### PR TITLE
Broken link fix for 2017-01-18-numbers.markdown

### DIFF
--- a/source/_posts/2017-01-18-numbers.markdown
+++ b/source/_posts/2017-01-18-numbers.markdown
@@ -12,7 +12,7 @@ It's week 3 of 2017 and great things did already happen. This is just a little r
 
 - In the [OSS Metrics leaderboard](https://ossmetrics.com/leaderboard) we are on place 30. Within three months we moved from our starting place which was 66 in September 2016 up to the current one.
 - We were listed on [Github Trending](https://github.com/trending/python). Also, was [@balloob](https://github.com/balloob) mentioned as trending developer.
-- [@balloob](https://github.com/balloob)'s talk at the OpenIoT Summit 2016 was rated as one of the [Top 5 videos](http://technewsdir.com/top-5-videos-from-embedded-linux-conference-and-openiot-summit-2016) of the conference.
+- [@balloob](https://github.com/balloob)'s talk at the OpenIoT Summit 2016 was rated as one of the [Top 5 videos](https://www.linuxfoundation.org/blog/2017/01/top-5-videos-from-embedded-linux-conference-and-openiot-summit-2016/) of the conference.
 - We now ship over [500](/integrations/#all) components and platforms.
 - We processed over 3500 Pull requests on the [main repository](https://github.com/home-assistant/home-assistant) so far. 
 


### PR DESCRIPTION
Broken link: http://technewsdir.com/top-5-videos-from-embedded-linux-conference-and-openiot-summit-2016
New link: https://www.linuxfoundation.org/blog/2017/01/top-5-videos-from-embedded-linux-conference-and-openiot-summit-2016/

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
