### PR TITLE
Broken link fix for htu21d.markdown

### DIFF
--- a/source/_integrations/htu21d.markdown
+++ b/source/_integrations/htu21d.markdown
@@ -8,7 +8,7 @@ ha_release: 0.48
 ha_iot_class: Local Push
 ---
 
-The `htu21d` sensor platform allows you to read the temperature and humidity from a [HTU21D sensor](http://www.datasheetspdf.com/PDF/HTU21D/779951/1) connected via [I2c](https://en.wikipedia.org/wiki/I²C) bus (SDA, SCL pins).
+The `htu21d` sensor platform allows you to read the temperature and humidity from a [HTU21D sensor](https://cdn-shop.adafruit.com/datasheets/1899_HTU21D.pdf) connected via [I2c](https://en.wikipedia.org/wiki/I²C) bus (SDA, SCL pins).
 
 Tested devices:
 


### PR DESCRIPTION
Link to datasheet broken
Broken link: http://www.datasheetspdf.com/PDF/HTU21D/779951/1
New link: https://cdn-shop.adafruit.com/datasheets/1899_HTU21D.pdf

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
