### PR TITLE
Broken link fix for alexa.flash_briefings.markdown

### DIFF
--- a/source/_integrations/alexa.flash_briefings.markdown
+++ b/source/_integrations/alexa.flash_briefings.markdown
@@ -72,7 +72,7 @@ Please refer to the [Amazon documentation][flash-briefing-api-docs] for more inf
 - To invoke your flash briefing, open the Alexa app on your phone or go to the [Alexa Settings Site][alexa-settings-site], open the "Skills" configuration section, select "Your Skills", scroll to the bottom, tap on the Flash Briefing Skill you just created, enable it, then manage Flash Briefing and adjust ordering as necessary.  Finally ask your Echo for your "news","flash briefing", or "briefing".
 
 [amazon-dev-console]: https://developer.amazon.com
-[flash-briefing-api]: https://developer.amazon.com/alexa-skills-kit/flash-briefing
+[flash-briefing-api]: https://developer.amazon.com/docs/flashbriefing/understand-the-flash-briefing-skill-api.html
 [flash-briefing-api-docs]: https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/flash-briefing-skill-api-feed-reference
 [large-icon]: /images/integrations/alexa/alexa-512x512.png
 [small-icon]: /images/integrations/alexa/alexa-108x108.png


### PR DESCRIPTION
Broken link: https://developer.amazon.com/alexa-skills-kit/flash-briefing
New link: https://developer.amazon.com/docs/flashbriefing/understand-the-flash-briefing-skill-api.html

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
