### PR TITLE
Add documentation for homekit disable_characteristics

### DIFF
--- a/source/_components/homekit.markdown
+++ b/source/_components/homekit.markdown
@@ -50,6 +50,12 @@ homekit:
         - feature: toggle_mute
     switch.bedroom_outlet:
       type: outlet
+    fan.kitchen_fan:
+      turn_on_data:
+        speed: "low"
+    light.misbehaving_light:
+      disable_characteristics:
+        - "Brightness"
 ```
 
 {% configuration %}
@@ -145,6 +151,14 @@ homekit:
                 required: false
                 type: string
                 default: '`switch`'
+              disable_characteristics:
+                description: Only for `light` and `fan` entities. Disables the HomeKit accessory characteristics. Valid characteristics for lights are `Brightness`, `ColorTemperature`, ` Hue` or `Saturation`.  Valid characteristics for fans are `RotationSpeed`, `RotationDirection` or `SwingMode`. 
+                required: false
+                type: list
+              turn_on_data:
+                description: Only for `light` and `fan` entities. The data to be sent to the `light.turn_on` and `fan.turn_on` service. Please see the [light turn on service schema]({{site_root}}/components/light#service-lightturn_on) for valid configurations.
+                required: false
+                type: map
 {% endconfiguration %}
 
 


### PR DESCRIPTION
**Description:**

Adds documentation for disable characteristics in homekit component

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27113

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
