### PR TITLE
Fix crimereports documentation

### DIFF
--- a/source/_integrations/crimereports.markdown
+++ b/source/_integrations/crimereports.markdown
@@ -100,4 +100,4 @@ These incident types are available:
 
 ### Events
 
-The `crimealerts` sensor fires a `crimealerts_incident` event when a new incident is detected, including the type, description, time, location, and coordinates of the incident.
+The `crimereports` sensor fires a `crimereports_incident` event when a new incident is detected, including the type, description, time, location, and coordinates of the incident.


### PR DESCRIPTION
**Description:**
Fixes the documentation for the crimereports integration. The event fired is actually called `crimereports_incident`.

Fixes https://github.com/home-assistant/home-assistant/issues/26280

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
