### PR TITLE
Clarify Sonos manual configuration

### DIFF
--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -123,9 +123,21 @@ Force start playing the queue, allows switching from another stream (such as rad
 
 ## Advanced use
 
-For advanced uses, there are some manual configuration options available.
+For advanced uses, there are some manual configuration options available. These are usually only needed if you have a complex network setup where Home Assistant and Sonos are not on the same subnet.
 
-If you have multiple network devices, you can provide the IP address of the device that should be used for Sonos auto-discovery.
+You can disable auto-discovery by specifying the Sonos IP addresses:
+
+```yaml
+# Example configuration.yaml entry with manually specified Sonos IP addresses
+sonos:
+  media_player:
+    hosts:
+      - 192.0.2.25
+      - 192.0.2.26
+      - 192.0.2.27
+```
+
+If your Home Assistant server has multiple IP addresses, you can provide the IP address that should be used for Sonos auto-discovery. This is rarely needed since all addresses should be tried by default.
 
 ```yaml
 # Example configuration.yaml entry using Sonos discovery on a specific interface
@@ -134,23 +146,10 @@ sonos:
     interface_addr: 192.0.2.1
 ```
 
-You can also specify one or more hosts to connect to if they cannot be found with Sonos auto-discovery.
-
+The Sonos speakers will attempt to connect back to Home Assistant to deliver change events (using TCP port 1400). You can change the IP address that Home Assistant advertises to Sonos speakers. This can help in NAT scenarios such as when _not_ using the Docker option `--net=host`:
 ```yaml
-# Example configuration.yaml entry with manually specified addresses
+# Example configuration.yaml entry modifying the advertised host address
 sonos:
   media_player:
-    hosts: 192.0.2.25
-```
-
-or, for multiple hosts:
-
-```yaml
-# Example configuration.yaml entry with manually specified addresses
-sonos:
-  media_player:
-    hosts:
-      - 192.0.2.25
-      - 192.0.2.26
-      - 192.0.2.27
+    advertise_addr: 192.0.2.1
 ```


### PR DESCRIPTION
**Description:**

* Move static IP configuration to the top since it is the most usual manual setup.
* Mention `advertise_addr` (added in home-assistant/home-assistant#4177 _and_ home-assistant/home-assistant#16007 but never documented).
* Stress that manual configuration is rarely needed.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
