### PR TITLE
Update Sonos introduction

### DIFF
--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -6,16 +6,16 @@ ha_category:
   - Media Player
 featured: true
 ha_release: 0.7.3
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ---
 
-The `sonos` integration allows you to control your [Sonos](https://www.sonos.com) HiFi wireless speakers and audio integrations from Home Assistant. By default it supports auto-discovery provided by Home Assistant, and you don't need to add anything to your `configuration.yaml`.
+The `sonos` integration allows you to control your [Sonos](https://www.sonos.com) wireless speakers from Home Assistant. It also works with IKEA Symfonisk speakers.
 
-If you don't have the discovery integration enabled, you can configure the Sonos integration by going to the integrations page inside the config panel.
+You can configure the Sonos integration by going to the integrations page inside the config panel.
 
 ## Services
 
-Sonos makes various services available to allow configuring groups. They are currently registered under the media player component.
+The Sonos integration makes various custom services available.
 
 ### Service `sonos.snapshot`
 


### PR DESCRIPTION
**Description:**

* Sonos is now local push (since home-assistant/home-assistant#12126)
* The integration has been tested with IKEA Symfonisk (albeit not by me)
* Auto-discovery of Sonos no longer depends on the discovery integration
* Services now allow for more than group management
* Services have been moved to the `sonos` domain (in home-assistant/home-assistant#23670)

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
