### PR TITLE
Add info about torrents that is accessible with templating

### DIFF
--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -125,7 +125,8 @@ Adds a new torrent to download. It can either be a URL (http, https or ftp), mag
 
 The state attribute contains information about the torrents that are currently downloading.  You can see this information in Developer Tools->States->sensor.transmission_torrent_info->Attributes or by adding a Markdown Card to Lovelace.
 
-```raw
+{% raw %}
+```jinja2 
 content: >
   {% set payload = state_attr('sensor.transmission_torrent_info',
   'torrent_info') %}
@@ -135,3 +136,4 @@ content: >
   remaining {% endfor %}
 type: markdown
 ```
+{% endraw %}

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -125,7 +125,7 @@ Adds a new torrent to download. It can either be a URL (http, https or ftp), mag
 
 The state attribute contains information about the torrents that are currently downloading.  You can see this information in Developer Tools->States->sensor.transmission_torrent_info->Attributes or by adding a Markdown Card to Lovelace.
 
-```jinja2
+```raw
 content: >
   {% set payload = state_attr('sensor.transmission_torrent_info',
   'torrent_info') %}

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -118,3 +118,20 @@ Adds a new torrent to download. It can either be a URL (http, https or ftp), mag
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `torrent` | no | Torrent to download
+
+## Templating
+
+### Sensor `torrent_info`
+
+The state attribute contains information about the torrents that are currently downloading.  You can see this information in Developer Tools->States->sensor.transmission_torrent_info->Attributes or by adding a Markdown Card to Lovelace.
+
+```
+content: >
+  {% set payload = state_attr('sensor.transmission_torrent_info',
+  'torrent_info') %}
+
+  {% for torrent in payload.items() %} {% set name = torrent[0] %} {% set data =
+  torrent[1] %} {{ name }} is {{ data.percent_done }}% complete, {{ data.eta }}
+  remaining {% endfor %}
+type: markdown
+```

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -123,10 +123,10 @@ Adds a new torrent to download. It can either be a URL (http, https or ftp), mag
 
 ### Sensor `started_torrents`
 
-The state attribute torrent_info contains information about the torrents that are currently downloading.  You can see this information in Developer Tools->States->sensor.transmission_started_torrents->Attributes or by adding a Markdown Card to Lovelace.
+The state attribute `torrent_info` contains information about the torrents that are currently downloading. You can see this information in **Developer Tools** -> **States** -> `sensor.transmission_started_torrents` -> **Attributes**, or by adding a Markdown Card to Lovelace.
 
 {% raw %}
-```jinja2 
+```yaml
 content: >
   {% set payload = state_attr('sensor.transmission_started_torrents', 'torrent_info') %}
 

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -125,7 +125,7 @@ Adds a new torrent to download. It can either be a URL (http, https or ftp), mag
 
 The state attribute contains information about the torrents that are currently downloading.  You can see this information in Developer Tools->States->sensor.transmission_torrent_info->Attributes or by adding a Markdown Card to Lovelace.
 
-```
+```jinja2
 content: >
   {% set payload = state_attr('sensor.transmission_torrent_info',
   'torrent_info') %}

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -121,19 +121,18 @@ Adds a new torrent to download. It can either be a URL (http, https or ftp), mag
 
 ## Templating
 
-### Sensor `torrent_info`
+### Sensor `started_torrents`
 
-The state attribute contains information about the torrents that are currently downloading.  You can see this information in Developer Tools->States->sensor.transmission_torrent_info->Attributes or by adding a Markdown Card to Lovelace.
+The state attribute torrent_info contains information about the torrents that are currently downloading.  You can see this information in Developer Tools->States->sensor.transmission_started_torrents->Attributes or by adding a Markdown Card to Lovelace.
 
 {% raw %}
 ```jinja2 
 content: >
-  {% set payload = state_attr('sensor.transmission_torrent_info',
-  'torrent_info') %}
+  {% set payload = state_attr('sensor.transmission_started_torrents', 'torrent_info') %}
 
-  {% for torrent in payload.items() %} {% set name = torrent[0] %} {% set data =
-  torrent[1] %} {{ name }} is {{ data.percent_done }}% complete, {{ data.eta }}
-  remaining {% endfor %}
+  {% for torrent in payload.items() %} {% set name = torrent[0] %} {% set data = torrent[1] %}
+  
+  {{ name|truncate(20) }} is {{ data.percent_done }}% complete, {{ data.eta }} remaining {% endfor %}
 type: markdown
 ```
 {% endraw %}


### PR DESCRIPTION
Add documentation for implementing a template that can access the state attribute of sensor torrent_info.

https://github.com/home-assistant/home-assistant/pull/27111




<a href="https://gitpod.io/#https://github.com/home-assistant/home-assistant.io/pull/10574"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JPHutchins/home-assistant.io.git/83a71950b61124b07db289751f8713614a7000af.svg" /></a>

