### PR TITLE
Fixes GitHub source links on integration pages

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -10,7 +10,7 @@
 
   {%- assign file_parts = page.url | split: '/' | last | split: '.' -%}
   {%- assign imp_name = file_parts | first -%}
-  {%- assign imp_url = imp_name | prepend: '/integrations/' | append: '/' -%}
+  {%- assign imp_url = imp_name | prepend: '/components/' | append: '/' -%}
 
   <div class="section">
     <kb-alert-link integration="{{ imp_name }}"></kb-alert-link>


### PR DESCRIPTION
**Description:**

Fixes integration GitHub source links on integration pages.

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
