### PR TITLE
Link correction  to ESPHome API

### DIFF
--- a/source/_integrations/esphome.markdown
+++ b/source/_integrations/esphome.markdown
@@ -9,7 +9,7 @@ ha_release: 0.85
 ha_iot_class: Local Push
 ---
 
-This integration allows you to connect your [ESPHome](https://esphome.io) devices directly into Home Assistant with the [native ESPHome API](https://esphome.io/integrations/api.html).
+This integration allows you to connect your [ESPHome](https://esphome.io) devices directly into Home Assistant with the [native ESPHome API](https://esphome.io/components/api.html).
 
 ## Setup the integration via the integrations screen
 


### PR DESCRIPTION
**Description:**

Link correction  to ESPHome API

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
