### PR TITLE
KNX add new sensor type from xknx 0.11.2

### DIFF
--- a/source/_integrations/sensor.knx.markdown
+++ b/source/_integrations/sensor.knx.markdown
@@ -79,6 +79,7 @@ type:
 | 9.001   | temperature        | 2            | °C             |
 | 9.004   | illuminance        | 2            | lx             |
 | 9.005   | speed_ms           | 2            | m/s            |
+| 9.006   | pressure_2byte     | 2            | Pa             |
 | 9.007   | humidity           | 2            | %              |
 | 9.008   | ppm                | 2            | ppm            |
 | 9.020   | voltage            | 2            | mV             |


### PR DESCRIPTION
**Description:**

add DPT 9.006 pressure_2byte sensor type to the list

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27130

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
