### PR TITLE
Update MQTT Device Tracker mapping payloads to zones/states

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -123,7 +123,6 @@ modes:
   type: list
 action_topic:
   description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cooling`, `heating`, `drying`, or `off`.
-_components/climate.mqtt.markdown
   required: false
   type: string
 action_template:

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -123,6 +123,7 @@ modes:
   type: list
 action_topic:
   description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cooling`, `heating`, `drying`, or `off`.
+_components/climate.mqtt.markdown
   required: false
   type: string
 action_template:

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -121,14 +121,6 @@ modes:
   required: false
   default: ['auto', 'off', 'cool', 'heat', 'dry', 'fan_only']
   type: list
-action_topic:
-  description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cooling`, `heating`, `drying`, or `off`.
-  required: false
-  type: string
-action_template:
-  description: A template to render the value received on the `action_topic` with.
-  requred: false
-  type: template
 temperature_command_topic:
   description: The MQTT topic to publish commands to change the target temperature.
   required: false

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -121,6 +121,14 @@ modes:
   required: false
   default: ['auto', 'off', 'cool', 'heat', 'dry', 'fan_only']
   type: list
+action_topic:	
+  description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cooling`, `heating`, `drying`, or `off`.	
+  required: false	
+  type: string	
+action_template:	
+  description: A template to render the value received on the `action_topic` with.	
+  requred: false	
+  type: template
 temperature_command_topic:
   description: The MQTT topic to publish commands to change the target temperature.
   required: false

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -125,7 +125,7 @@ action_topic:
   description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cooling`, `heating`, `drying`, or `off`.
   required: false
   type: string
-action_template:	
+action_template:
   description: A template to render the value received on the `action_topic` with.
   requred: false
   type: template

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -121,13 +121,13 @@ modes:
   required: false
   default: ['auto', 'off', 'cool', 'heat', 'dry', 'fan_only']
   type: list
-action_topic:	
-  description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cooling`, `heating`, `drying`, or `off`.	
-  required: false	
-  type: string	
+action_topic:
+  description: The MQTT topic on which to listen for the current action state of the HVAC. Expects `idle`, `cooling`, `heating`, `drying`, or `off`.
+  required: false
+  type: string
 action_template:	
-  description: A template to render the value received on the `action_topic` with.	
-  requred: false	
+  description: A template to render the value received on the `action_topic` with.
+  requred: false
   type: template
 temperature_command_topic:
   description: The MQTT topic to publish commands to change the target temperature.

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -57,12 +57,12 @@ device_tracker:
   devices:
     paulus_oneplus: 'location/paulus'
     annetherese_n4: 'location/annetherese'
-  qos: `1`
-  payload_home: `present`
-  payload_not_home: `not present`
+  qos: '1'
+  payload_home: 'present'
+  payload_not_home: 'not present'
   payload_custom:
-    work1: `work_paulus`
-    work2: `work_annetherese`
+    work1: 'work_paulus'
+    work2: 'work_annetherese'
 ```
 
 ## Usage

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -60,7 +60,7 @@ device_tracker:
   qos: '1'
   payload_home: 'present'
   payload_not_home: 'not present'
-  payload_custom:
+  payload_other_zones:
     work1: 'work_paulus'
     work2: 'work_annetherese'
 ```

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -46,8 +46,10 @@ payload_not_home:
 payload_custom:
   description: A dictionary to map payload values to custom zones (e.g. not `home` and `not_home`). The keys are the payloads and the values are the corresponding locations that the payload represents.
   required: false
-  type: map
+  type: string
 {% endconfiguration %}
+
+## Full example configuration
 
 ```yaml
 # Complete configuration.yaml entry

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -28,7 +28,7 @@ device_tracker:
 devices:
   description: A dictionary where the keys are devices and the values are their corresponding topic.
   required: true
-  type: map
+  type: list
 qos:
   description: The QoS level of the topic.
   required: false
@@ -46,7 +46,7 @@ payload_not_home:
 payload_custom:
   description: A dictionary to map payload values to custom zones (e.g. not `home` and `not_home`). The keys are the payloads and the values are the corresponding locations that the payload represents.
   required: false
-  type: map
+  type: list
 {% endconfiguration %}
 
 ## Complete example configuration

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -34,12 +34,12 @@ qos:
   required: false
   type: integer
 payload_home:
-  description: The payload that represents the home state for the device.
+  description: The payload value that represents the 'home' state for the device.
   required: false
   type: string
   default: 'home'
 payload_not_home:
-  description: The payload that represents the not home state for the device.
+  description: The payload value that represents the 'not_home' state for the device.
   required: false
   type: string
   default: 'not_home'

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -44,7 +44,7 @@ payload_not_home:
   type: string
   default: 'not_home'
 payload_custom:
-  description: A dictionary to map payload values to custom zones (e.g. not 'home' and 'not_home'). The keys are the payloads and the values are the corresponding locations that the payload represents.
+  description: A dictionary to map payload values to custom zones. The keys are the payloads and the values are the corresponding locations that the payload represents.
   required: false
   type: list
 {% endconfiguration %}

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -22,7 +22,7 @@ device_tracker:
     devices:
       paulus_oneplus: 'location/paulus'
       annetherese_n4: 'location/annetherese'
-    custom_payload:
+    payload_custom:
       present: home
       not present: not_home
 ```
@@ -36,7 +36,7 @@ qos:
   description: The QoS level of the topic.
   required: false
   type: integer
-custom_payload:
+payload_custom:
   description: A dictionary where the keys are payloads and the values are the corresponding locations that should be set for the device when the given payload is published to a device topic. This parameter should be used when the device or application that is publishing MQTT device tracker updates is not sending values that HomeAssistant will natively recognize (e.g. `home`, `not_home`, and any custom zones you have defined).
   required: false
   type: map

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -43,10 +43,6 @@ payload_not_home:
   required: false
   type: string
   default: 'not_home'
-payload_other_zones:
-  description: List of payloads with the zones they correspond to. This parameter allows the device tracker to maintain states for other zones aside from 'home' and 'not_home' when the payload value does not match the zone name.
-  required: false
-  type: list
 {% endconfiguration %}
 
 ## Complete example configuration
@@ -60,9 +56,6 @@ device_tracker:
   qos: 1
   payload_home: 'present'
   payload_not_home: 'not present'
-  payload_other_zones:
-    work1: 'work_paulus'
-    work2: 'work_annetherese'
 ```
 
 ## Usage

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -46,10 +46,10 @@ payload_not_home:
 payload_custom:
   description: A dictionary to map payload values to custom zones (e.g. not `home` and `not_home`). The keys are the payloads and the values are the corresponding locations that the payload represents.
   required: false
-  type: string
+  type: map
 {% endconfiguration %}
 
-## Full example configuration
+## Complete example configuration
 
 ```yaml
 # Complete configuration.yaml entry

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -53,8 +53,8 @@ payload_custom:
 # Complete configuration.yaml entry
 device_tracker:
   devices:
-      paulus_oneplus: 'location/paulus'
-      annetherese_n4: 'location/annetherese'
+    paulus_oneplus: 'location/paulus'
+    annetherese_n4: 'location/annetherese'
   qos: 1
   payload_home: present
   payload_not_home: not present

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -26,7 +26,7 @@ device_tracker:
 
 {% configuration %}
 devices:
-  description: A dictionary where the keys are devices and the values are their corresponding topic.
+  description: List of devices with their topic.
   required: true
   type: list
 qos:
@@ -44,7 +44,7 @@ payload_not_home:
   type: string
   default: 'not_home'
 payload_other_zones:
-  description: A dictionary where the keys are the payloads and the values are the corresponding zones that the payload represents. This parameter allows the device tracker to maintain states for other zones aside from 'home' and 'not_home' when the payload value does not match the zone name.
+  description: List of payloads with the zones they correspond to. This parameter allows the device tracker to maintain states for other zones aside from 'home' and 'not_home' when the payload value does not match the zone name.
   required: false
   type: list
 {% endconfiguration %}

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -49,7 +49,7 @@ payload_not_home:
   type: string
   default: `not_home`
 payload_custom:
-  description: A dictionary to map payload values to custom zones (e.g. not `home` and `not_home`). The key is the payload and the value is the location that the payload represents.
+  description: A dictionary to map payload values to custom zones (e.g. not `home` and `not_home`). The keys are the payloads and the values are the corresponding locations that the payload represents.
   required: false
   type: map
 {% endconfiguration %}

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -43,8 +43,8 @@ payload_not_home:
   required: false
   type: string
   default: 'not_home'
-payload_custom:
-  description: A dictionary to map payload values to custom zones. The keys are the payloads and the values are the corresponding locations that the payload represents.
+payload_other_zones:
+  description: A dictionary where the keys are the payloads and the values are the corresponding zones that the payload represents. This parameter allows the device tracker to maintain states for other zones aside from 'home' and 'not_home' when the payload value does not match the zone name.
   required: false
   type: list
 {% endconfiguration %}

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -37,14 +37,14 @@ payload_home:
   description: The payload that represents the home state for the device.
   required: false
   type: string
-  default: `home`
+  default: 'home'
 payload_not_home:
   description: The payload that represents the not home state for the device.
   required: false
   type: string
-  default: `not_home`
+  default: 'not_home'
 payload_custom:
-  description: A dictionary to map payload values to custom zones (e.g. not `home` and `not_home`). The keys are the payloads and the values are the corresponding locations that the payload represents.
+  description: A dictionary to map payload values to custom zones (e.g. not 'home' and 'not_home'). The keys are the payloads and the values are the corresponding locations that the payload represents.
   required: false
   type: list
 {% endconfiguration %}

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -22,9 +22,11 @@ device_tracker:
     devices:
       paulus_oneplus: 'location/paulus'
       annetherese_n4: 'location/annetherese'
+    payload_home: present
+    payload_not_home: not present
     payload_custom:
-      present: home
-      not present: not_home
+      work1: pauluswork
+      work2: annetheresework
 ```
 
 {% configuration %}
@@ -36,8 +38,18 @@ qos:
   description: The QoS level of the topic.
   required: false
   type: integer
+payload_home:
+  description: The payload that represents the home state for the device.
+  required: false
+  type: string
+  default: `home`
+payload_not_home:
+  description: The payload that represents the not home state for the device.
+  required: false
+  type: string
+  default: `not_home`
 payload_custom:
-  description: A dictionary where the keys are payloads and the values are the corresponding locations that should be set for the device when the given payload is published to a device topic. This parameter should be used when the device or application that is publishing MQTT device tracker updates is not sending values that HomeAssistant will natively recognize (e.g. `home`, `not_home`, and any custom zones you have defined).
+  description: A dictionary to map payload values to custom zones (e.g. not `home` and `not_home`). The key is the payload and the value is the location that the payload represents.
   required: false
   type: map
 {% endconfiguration %}

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -22,11 +22,6 @@ device_tracker:
     devices:
       paulus_oneplus: 'location/paulus'
       annetherese_n4: 'location/annetherese'
-    payload_home: present
-    payload_not_home: not present
-    payload_custom:
-      work1: pauluswork
-      work2: annetheresework
 ```
 
 {% configuration %}
@@ -53,6 +48,20 @@ payload_custom:
   required: false
   type: map
 {% endconfiguration %}
+
+```yaml
+# Complete configuration.yaml entry
+device_tracker:
+  devices:
+      paulus_oneplus: 'location/paulus'
+      annetherese_n4: 'location/annetherese'
+  qos: 1
+  payload_home: present
+  payload_not_home: not present
+  payload_custom:
+    work1: work_paulus
+    work2: work_annetherese
+```
 
 ## Usage
 

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -57,7 +57,7 @@ device_tracker:
   devices:
     paulus_oneplus: 'location/paulus'
     annetherese_n4: 'location/annetherese'
-  qos: '1'
+  qos: 1
   payload_home: 'present'
   payload_not_home: 'not present'
   payload_other_zones:

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -22,17 +22,24 @@ device_tracker:
     devices:
       paulus_oneplus: 'location/paulus'
       annetherese_n4: 'location/annetherese'
+    custom_payload:
+      present: home
+      not present: not_home
 ```
 
 {% configuration %}
 devices:
-  description: List of devices with their topic.
+  description: A dictionary where the keys are devices and the values are their corresponding topic.
   required: true
-  type: list
+  type: map
 qos:
   description: The QoS level of the topic.
   required: false
   type: integer
+custom_payload:
+  description: A dictionary where the keys are payloads and the values are the corresponding locations that should be set for the device when the given payload is published to a device topic. This parameter should be used when the device or application that is publishing MQTT device tracker updates is not sending values that HomeAssistant will natively recognize (e.g. `home`, `not_home`, and any custom zones you have defined).
+  required: false
+  type: map
 {% endconfiguration %}
 
 ## Usage

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -57,12 +57,12 @@ device_tracker:
   devices:
     paulus_oneplus: 'location/paulus'
     annetherese_n4: 'location/annetherese'
-  qos: 1
-  payload_home: present
-  payload_not_home: not present
+  qos: `1`
+  payload_home: `present`
+  payload_not_home: `not present`
   payload_custom:
-    work1: work_paulus
-    work2: work_annetherese
+    work1: `work_paulus`
+    work2: `work_annetherese`
 ```
 
 ## Usage


### PR DESCRIPTION
**Description:**
I currently use the SmartThings MQTT bridge featured on the blog here to publish state changes from my SmartThings connected devices to HomeAssistant. I am currently unable to create an MQTT Device Tracker in HA that can connect to a SmartThings presence sensor because the bridge publishes the states of "present" and "not present", but HA expects "home" and "not_home".

As such, I have added a new optional map parameter to the component that will allow users to map topic payloads to states that HA would expect.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27143

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
