### PR TITLE
Add link for zigbee.markdown (starter Zigbee doc) to index.markdown

### DIFF
--- a/source/docs/index.markdown
+++ b/source/docs/index.markdown
@@ -24,6 +24,12 @@ The documentation covers beginner to advanced topics around the installation, se
     </div>
     <div class='title'>Z-Wave</div>
   </a>
+  <a class='option-card' href='/docs/zigbee/'>
+    <div class='img-container'>
+      <img src='/images/supported_brands/zigbee.png' />
+    </div>
+    <div class='title'>Zigbee</div>
+  </a>
   <a class='option-card' href='/docs/mqtt/'>
     <div class='img-container'>
       <img src='/images/supported_brands/mqtt.png' />


### PR DESCRIPTION
Adding a link for zigbee.markdown (starter Zigbee doc) to index.markdown. Depends on #10582 being accepted first.

Hope that this will help Zigbee become more of a first-class citizen in Home Assistant, just like Z-Wave already is.

The purpose is to expose the Zigbee Home Assistant integration and show in same light as the Z-Wave integration.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
