### PR TITLE
Add link for zigbee.markdown (starter Zigbee doc) to index.markdown

### DIFF
--- a/source/docs/index.markdown
+++ b/source/docs/index.markdown
@@ -24,6 +24,12 @@ The documentation covers beginner to advanced topics around the installation, se
     </div>
     <div class='title'>Z-Wave</div>
   </a>
+  <a class='option-card' href='/docs/zigbee/'>
+    <div class='img-container'>
+      <img src='/images/supported_brands/zigbee.png' />
+    </div>
+    <div class='title'>Zigbee</div>
+  </a>
   <a class='option-card' href='/docs/mqtt/'>
     <div class='img-container'>
       <img src='/images/supported_brands/mqtt.png' />


### PR DESCRIPTION
**Description:**

Adding a link for zigbee.markdown (starter Zigbee doc) to index.markdown (current branch). Depends on #10585 being accepted first.

The purpose is to expose the Zigbee Home Assistant integration and show in the same light as the Z-Wave integration. I hope that this will help the existing Zigbee integration become more of a first-class citizen in Home Assistant, just like the existing Z-Wave integration already is. 

One of the reasons for me creating a separate PR for this from #10585 is to give you the option of accepting that and rejecting this index PR if you so wish. As a non-developer, I also currently am not good enough with Git to edit two separate files (using GitHub web interface to edit and create files) :P

PS: This PR is for the 'current' branch and replaces #10583 which was based on the 'next' branch.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
