### PR TITLE
Fix links to `device_class` for MQTT sensor

### DIFF
--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -89,9 +89,9 @@ unique_id:
   required: false
   type: string
 device_class:
-  description: The type/class of the sensor to set the icon in the frontend.
+  description: The [type/class](/integrations/sensor/#device-class) of the sensor to set the icon in the frontend.
   required: false
-  type: device_class
+  type: string
   default: None
 device:
   description: "Information about the device this sensor is a part of to tie it into the [device registry](https://developers.home-assistant.io/docs/en/device_registry_index.html). Only works through [MQTT discovery](/docs/mqtt/discovery/) and when [`unique_id`](#unique_id) is set."

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -91,7 +91,7 @@ unique_id:
 device_class:
   description: The [type/class](/integrations/sensor/#device-class) of the sensor to set the icon in the frontend.
   required: false
-  type: string
+  type: device_class
   default: None
 device:
   description: "Information about the device this sensor is a part of to tie it into the [device registry](https://developers.home-assistant.io/docs/en/device_registry_index.html). Only works through [MQTT discovery](/docs/mqtt/discovery/) and when [`unique_id`](#unique_id) is set."


### PR DESCRIPTION
**Description:**
Fix links to `device_class`

## Checklist:

- [x] Branch: Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
