### PR TITLE
alarmdecoder relay config is also used for zone expanders

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -103,11 +103,11 @@ zones:
       required: false
       type: integer
     relayaddr:
-      description: "Address of the relay expander board to associate with the zone. (ex: 12, 13, 14, or 15). Typically used in cases where a panel will not send bypassed zones such as motion during an armed home state, the Vista 20P is an example of this. Alarmdecoder can emulate a zone expander board and the panel can be programmed to push zone events to this virtual expander. This allows the bypassed zone binary sensors to be utilized. One example is using bypassed motion sensors at night for motion-based automated lights while the system is armed with the motion sensor bypassed."
+      description: "Address of the relay or zone expander board to associate with the zone. (ex: 12, 13, 14, or 15). Typically used in cases where a panel will not send bypassed zones such as motion during an armed home state, the Vista 20P is an example of this. Alarmdecoder can emulate a zone expander board and the panel can be programmed to push zone events to this virtual expander. This allows the bypassed zone binary sensors to be utilized. One example is using bypassed motion sensors at night for motion-based automated lights while the system is armed with the motion sensor bypassed."
       required: inclusive
       type: integer
     relaychan:
-      description: "Channel of the relay expander board to associate with the zone. (ex: 1, 2, 3, or 4)"
+      description: "Channel of the relay or zone expander board to associate with the zone. (ex: 1, 2, 3, or 4 for relay expander boards, 1 - 8 for zone expander boards)"
       required: inclusive
       type: integer
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**

This is a minor update to the documentation for the alarmdecoder integration to indicate that the relay settings are also used for zone expander boards.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27167

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
