### PR TITLE
Clarify the behavior of the updater component

### DIFF
--- a/source/_integrations/updater.markdown
+++ b/source/_integrations/updater.markdown
@@ -8,7 +8,7 @@ ha_qa_scale: internal
 ha_release: 0.8
 ---
 
-The `updater` binary sensor will check daily for new releases. The state will be "on" when an update is available. Otherwise, the state will be "off". The newer version, as well as the link to the release notes, are attributes of the updater. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this binary sensor on Hass.io.
+The `updater` binary sensor will check daily for new releases. The state will be "on" when an update is available. Otherwise, the state will be "off". The newer version, as well as the link to the release notes, are attributes of the updater. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this binary sensor on Hass.io. The `updater` binary sensor will wait one hour after startup until it performs the first update. For this period it will be in the state `unavailable`. After that it will check once a day for new releases.
 
 The updater integration will also collect basic information about the running Home Assistant instance and its environment. The information includes the current Home Assistant version, the time zone, Python version and operating system information. No identifiable information (i.e., IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/integrations/updater).
 

--- a/source/_integrations/updater.markdown
+++ b/source/_integrations/updater.markdown
@@ -8,9 +8,11 @@ ha_qa_scale: internal
 ha_release: 0.8
 ---
 
-The `updater` binary sensor will check daily for new releases. The state will be "on" when an update is available. Otherwise, the state will be "off". The newer version, as well as the link to the release notes, are attributes of the updater. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this binary sensor on Hass.io. The `updater` binary sensor will wait one hour after startup until it performs the first update. For this period it will be in the state `unavailable`. After that it will check once a day for new releases.
+The `updater` binary sensor will check daily for new releases. The state will be "on" when an update is available. Otherwise, the state will be "off". The newer version, as well as the link to the release notes, are attributes of the updater. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this binary sensor on Hass.io.
 
 The updater integration will also collect basic information about the running Home Assistant instance and its environment. The information includes the current Home Assistant version, the time zone, Python version and operating system information. No identifiable information (i.e., IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/integrations/updater).
+
+The `updater` binary sensor will wait one hour after startup until it performs the first update. For this period it will be in the state `unavailable`. After that it will check once a day for new releases.
 
 ## Configuration
 

--- a/source/_integrations/updater.markdown
+++ b/source/_integrations/updater.markdown
@@ -12,7 +12,11 @@ The `updater` binary sensor will check daily for new releases. The state will be
 
 The updater integration will also collect basic information about the running Home Assistant instance and its environment. The information includes the current Home Assistant version, the time zone, Python version and operating system information. No identifiable information (i.e., IP address, GPS coordinates, etc.) will ever be collected. If you are concerned about your privacy, you are welcome to scrutinize the Python [source code](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/integrations/updater).
 
+<div class='note'>
+
 The `updater` binary sensor will wait one hour after startup until it performs the first update. For this period it will be in the state `unavailable`. After that it will check once a day for new releases.
+
+</div>
 
 ## Configuration
 


### PR DESCRIPTION
**Description:**
Explains that the updater will be unavailable for one hour after startup. This avoids questions like the ones that have occurred here: https://github.com/home-assistant/home-assistant/issues/26293

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
