### PR TITLE
Add HMIP-SAM to Homematic IP Cloud

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -84,6 +84,7 @@ Within this delay the device registration should be completed in the App, otherw
   * Combined Alarm Control Panal with INTERNAL and EXTERNAL Security zones (*HmIP-SecurityZone*)
 
 * homematicip_cloud.binary_sensor
+  * Acceleration Sensor (*HMIP-SAM*)
   * Window and door contact (*HmIP-SWDO, -I*)
   * Contact Interface flush-mount – 1 channel (*HmIP-FCI1*)
   * Contact Interface (*HmIP-SCI*)


### PR DESCRIPTION
**Description:**
Add HMIP-SAM to Homematic IP Cloud

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27199

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
