### PR TITLE
Update zwave devices page

### DIFF
--- a/source/_docs/z-wave/devices.markdown
+++ b/source/_docs/z-wave/devices.markdown
@@ -33,9 +33,9 @@ The key improvements are:
 
 ### Z-Wave Security 2
 
-From 2 April 2017 all newly approved Z-Wave devices will have to support the Security 2 (S2) framework. At the time of writing this (March 2018) OpenZWave does not support the S2 framework.
+From 2 April 2017 all newly approved Z-Wave devices will have to support the Security 2 (S2) framework. At the time of writing this (October 2019) OpenZWave does not support the S2 framework.
 
-## Device power
+## Device Power
 
 Your Z-Wave mesh network is built with the devices that are mains powered (whether directly, or via a USB adapter), these relay traffic for other nodes, building the network. These devices are always awake and you can query them, or send configuration changes, at any time.
 
@@ -65,8 +65,8 @@ Polling needs to be enabled per device, you can control this through the *pollin
 
 The Central Scene command class isn't yet supported in OpenZWave (there is [work in progress](https://github.com/OpenZWave/open-zwave/pull/1125) to provide it it), though Home Assistant has introduced some support with [change 9178](https://github.com/home-assistant/home-assistant/pull/9178) which was part of 0.53 and [documented here](/docs/z-wave/device-specific/#homeseer-switches).
 
-## Is my device supported
+## Is my device supported?
 
-You can check to see if OpenZWave supports your particular device by looking at the [OpenZWave github](https://github.com/OpenZWave/open-zwave/tree/master/config). Be aware that being listed here doesn't mean that it will be supported in Home Assistant, since the version of OpenZWave used by Home Assistant will often lag the github by a few months.
+You can check to see if OpenZWave supports your particular device by looking at the [OpenZWave 1.4 github](https://github.com/OpenZWave/open-zwave/tree/1.4/config). Be aware that being listed here doesn't mean that it will be supported in Home Assistant, since the version of OpenZWave used by Home Assistant will often lag the github by a few months.
 
 Even if your device isn't listed there, it's likely that it will still work as expected as long as the device complies with the Z-Wave standards. The OpenZWave wiki describes how [you can add support](https://github.com/OpenZWave/open-zwave/wiki/Adding-Devices) for your device if it isn't listed.


### PR DESCRIPTION
**Description:**
Update Z-Wave Devices docs page with the following:
S2 still not supported in OZW as of 10/2019
Update config github link to the OZW1.4 branch since HA is still on 1.4 and the master branch is for OZW1.6

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
