### PR TITLE
Update SolarEdge_local documentation

### DIFF
--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -11,7 +11,7 @@ ha_iot_class: Local Polling
 
 The `solaredge_local` platform uses the local API available on some SolarEdge Inverters to allow you to get details from your SolarEdge solar power setup and integrate these into your Home Assistant installation.
 
-Only specific models support the local API. The local API is available on single phase inverters that do not have a display, tree-phase inverters that end the model number with a 4. Please check the datasheets carefully if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection".
+Only specific models support the local API. The local API is available on inverters that do not have a lcd character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection".
 
 You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu.
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -16,9 +16,6 @@ Only specific models support the local API. The local API is available on invert
 You can check if the local API works by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. 
 
 <div class='note'>
-
-SolarEdge has disabled the local polling functionality on newer software versions. The last known software version is: 4.5.41 You can check your software version in the [SolarEdge monitoring portal](https://monitoring.solaredge.com).
-
   
 If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -15,9 +15,8 @@ Only specific models support the local API. The local API is available on invert
 
 You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. If your inveter does not support the local API, you can use the [cloud based version](https://www.home-assistant.io/integrations/solaredge/)
 
-
 <div class='note'>
-SolarEdge has disabled the local polling functionality on newer software versions. The last known software version is: 4.5.41 You can check your software version in the [SolarEdge monitoring website](https://monitoring.solaredge.com)
+SolarEdge has disabled the local polling functionality on newer software versions. The last known software version is: 4.5.41 You can check your software version in the 
 </div>
 
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -11,13 +11,16 @@ ha_iot_class: Local Polling
 
 The `solaredge_local` platform uses the local API available on some SolarEdge Inverters to allow you to get details from your SolarEdge solar power setup and integrate these into your Home Assistant installation.
 
-Only specific models support the local API. The local API is available on inverters that do not have an LCD character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection". these inverters also have a partnumber that ends with a 4 for example: SEXXK-XXXXXBXX4 SEXXXXH-XXXXXBXX4
+Only specific models support the local API. The local API is available on inverters that do not have an LCD character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection". These inverters also have a part number that ends with a 4. For example: SEXXK-XXXXXBXX4 or SEXXXXH-XXXXXBXX4
 
-You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
+You can check if the local API works by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. 
 
 <div class='note'>
-  
+
 SolarEdge has disabled the local polling functionality on newer software versions. The last known software version is: 4.5.41 You can check your software version in the [SolarEdge monitoring portal](https://monitoring.solaredge.com).
+
+  
+If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
 
 </div>
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -11,7 +11,7 @@ ha_iot_class: Local Polling
 
 The `solaredge_local` platform uses the local API available on some SolarEdge Inverters to allow you to get details from your SolarEdge solar power setup and integrate these into your Home Assistant installation.
 
-Only specific models support the local API. The local API is available on inverters that do not have an LCD character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection".
+Only specific models support the local API. The local API is available on inverters that do not have an LCD character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection". these inverters also have a partnumber that ends with a 4 for example: SEXXK-XXXXXBXX4 SEXXXXH-XXXXXBXX4
 
 You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -17,7 +17,7 @@ You can check by finding the IP address of your inverter and visiting it in a br
 
 <div class='note'>
 SolarEdge has disabled the local polling functionality in there latesed updates. The last known software version is 4.5.41
-If your inveter does not support the local API, you can use the [cloud based version](/integrations/solaredge/) instead.
+If your inveter does not support the local API, you can use the [cloud based version](https://www.home-assistant.io/integrations/solaredge/)
 </div>
 
 ## Configuration

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -13,12 +13,13 @@ The `solaredge_local` platform uses the local API available on some SolarEdge In
 
 Only specific models support the local API. The local API is available on inverters that do not have a lcd character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection".
 
-You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu.
+You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. If your inveter does not support the local API, you can use the [cloud based version](https://www.home-assistant.io/integrations/solaredge/)
+
 
 <div class='note'>
-SolarEdge has disabled the local polling functionality in there latesed updates. The last known software version is 4.5.41
-If your inveter does not support the local API, you can use the [cloud based version](https://www.home-assistant.io/integrations/solaredge/)
+SolarEdge has disabled the local polling functionality on newer software versions. The last known software version is: 4.5.41 You can check your software version in the [SolarEdge monitoring website](https://monitoring.solaredge.com)
 </div>
+
 
 ## Configuration
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -13,10 +13,12 @@ The `solaredge_local` platform uses the local API available on some SolarEdge In
 
 Only specific models support the local API. The local API is available on inverters that do not have a lcd character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection".
 
-You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. If your inveter does not support the local API, you can use the [cloud based version](https://www.home-assistant.io/integrations/solaredge/)
+You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. If your inveter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
 
 <div class='note'>
-SolarEdge has disabled the local polling functionality on newer software versions. The last known software version is: 4.5.41 You can check your software version in the 
+  
+SolarEdge has disabled the local polling functionality on newer software versions. The last known software version is: 4.5.41 You can check your software version in the [SolarEdge monitoring portal](https://www.home-assistant.io/integrations/solaredge/)
+
 </div>
 
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -11,11 +11,12 @@ ha_iot_class: Local Polling
 
 The `solaredge_local` platform uses the local API available on some SolarEdge Inverters to allow you to get details from your SolarEdge solar power setup and integrate these into your Home Assistant installation.
 
-Only specific models support the local API. The local API is available on the SExxxxH-US models with SetApp as well as European three-phase inverters SEXXK-XXXTXBXX4 models with SetApp like SE3K-E10K, SE12.5K-SE27.6K and SE33.3K. Please check the datasheets carefully if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection".
+Only specific models support the local API. The local API is available on single phase inverters that do not have a display, tree-phase inverters that end the model number with a 4. Please check the datasheets carefully if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection".
 
-You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see the SolarEdge logo and a "Commissioning" menu.
+You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu.
 
 <div class='note'>
+SolarEdge has disabled the local polling functionality in there latesed updates. The last known software version is 4.5.41
 If your inveter does not support the local API, you can use the [cloud based version](/integrations/solaredge/) instead.
 </div>
 
@@ -26,8 +27,8 @@ To use the SolarEdge sensors in your installation, add the following to your con
 ```yaml
 # Example configuration.yaml entry
 sensor:
-  platform: solaredge_local
-  ip_address: IP_ADDRESS
+  - platform: solaredge_local
+    ip_address: IP_ADDRES
 ```
 
 {% configuration %}

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -11,13 +11,13 @@ ha_iot_class: Local Polling
 
 The `solaredge_local` platform uses the local API available on some SolarEdge Inverters to allow you to get details from your SolarEdge solar power setup and integrate these into your Home Assistant installation.
 
-Only specific models support the local API. The local API is available on inverters that do not have a lcd character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection".
+Only specific models support the local API. The local API is available on inverters that do not have an LCD character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection".
 
-You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. If your inveter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
+You can check by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
 
 <div class='note'>
   
-SolarEdge has disabled the local polling functionality on newer software versions. The last known software version is: 4.5.41 You can check your software version in the [SolarEdge monitoring portal](https://www.home-assistant.io/integrations/solaredge/)
+SolarEdge has disabled the local polling functionality on newer software versions. The last known software version is: 4.5.41 You can check your software version in the [SolarEdge monitoring portal](https://monitoring.solaredge.com).
 
 </div>
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -70,5 +70,7 @@ sensor:
     sensors:
       solaredge_energy_this_year_template:
         value_template: "{{ (states('sensor.solaredge_energy_this_year') | float / 1000) | round(2) }}"
+        unit_of_measurement: 'KWh'
+        icon_template: "mdi:solar-power"
 ```
 {% endraw %}


### PR DESCRIPTION
**Description:**
One of the configuration.yaml examples was wrong.
Added more specific info for what kind of inverters it works.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
