### PR TITLE
Update link to speedtestservers

### DIFF
--- a/source/_integrations/speedtestdotnet.markdown
+++ b/source/_integrations/speedtestdotnet.markdown
@@ -43,7 +43,7 @@ monitored_conditions:
       description: "The upload speed (Mbit/s)."
 server_id:
   description: Specify the speed test server to perform the test against.
-  required: true
+  required: false
   type: integer
 scan_interval:
   description: "Minimum time interval between updates. Supported formats: `scan_interval: 'HH:MM:SS'`, `scan_interval: 'HH:MM'` and Time period dictionary (see example below)."

--- a/source/_integrations/speedtestdotnet.markdown
+++ b/source/_integrations/speedtestdotnet.markdown
@@ -94,7 +94,6 @@ Every half hour of every day:
 ```yaml
 # Example configuration.yaml entry
 speedtestdotnet:
-  server_id: 9999
   scan_interval:
     minutes: 30
   monitored_conditions:

--- a/source/_integrations/speedtestdotnet.markdown
+++ b/source/_integrations/speedtestdotnet.markdown
@@ -17,7 +17,7 @@ By default, a speed test will be run every hour. The user can change the update 
 
 ## Configuration
 
-For the `server_id` check the list of [available servers](https://www.speedtest.net/speedtest-servers.php).
+For the `server_id` check the list of [available servers](http://www.speedtestserver.com).
 
 To add Speedtest.net sensors to your installation, add the following to your `configuration.yaml` file:
 
@@ -43,7 +43,7 @@ monitored_conditions:
       description: "The upload speed (Mbit/s)."
 server_id:
   description: Specify the speed test server to perform the test against.
-  required: false
+  required: true
   type: integer
 scan_interval:
   description: "Minimum time interval between updates. Supported formats: `scan_interval: 'HH:MM:SS'`, `scan_interval: 'HH:MM'` and Time period dictionary (see example below)."
@@ -94,6 +94,7 @@ Every half hour of every day:
 ```yaml
 # Example configuration.yaml entry
 speedtestdotnet:
+  server_id: 9999
   scan_interval:
     minutes: 30
   monitored_conditions:


### PR DESCRIPTION
The link to the speedtestservers seems to be broken. The new link does work. Also the server_id seems to be mandatory at this point. So this sets the server_id to be required and in the example configuration.yaml inserts an example server_id.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
