### PR TITLE
document scene action for scripts (#27223)

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -34,6 +34,14 @@ The most important one is the action to call a service. This can be done in vari
     brightness: 100
 ```
 
+#### Activate a Scene
+
+Scripts may also use a shortcut syntax for activating scenes instead of calling the `scene.turn_on` service.
+
+```yaml
+- scene: scene.morning_living_room
+```
+
 ### Test a Condition
 
 While executing a script you can add a condition to stop further execution. When a condition does not return `true`, the script will stop executing. There are many different conditions which are documented at the [conditions page].


### PR DESCRIPTION
**Description:**

This adds a small section about the `scene` shortcut being added by the corresponding home-assistant PR.

**Pull request in home-assistant:** home-assistant/home-assistant#27223

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
