### PR TITLE
icon configuration variable: unification

### DIFF
--- a/source/_integrations/input_boolean.markdown
+++ b/source/_integrations/input_boolean.markdown
@@ -37,7 +37,7 @@ input_boolean:
         type: boolean
         default: false
       icon:
-        description: Icon to display for the component.
+        description: Icon to display in front of the input element in the frontend.
         required: false
         type: icon
 {% endconfiguration %}

--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -54,7 +54,7 @@ input_datetime:
         type: boolean
         default: false
       icon:
-        description: Icon to display in the frontend.
+        description: Icon to display in front of the box/slider in the frontend.
         required: false
         type: icon
       initial:

--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -54,7 +54,7 @@ input_datetime:
         type: boolean
         default: false
       icon:
-        description: Icon to display in front of the box/slider in the frontend.
+        description: Icon to display in front of the input element in the frontend.
         required: false
         type: icon
       initial:

--- a/source/_integrations/input_number.markdown
+++ b/source/_integrations/input_number.markdown
@@ -74,7 +74,7 @@ input_number:
         required: false
         type: string
       icon:
-        description: Icon to display in front of the box/slider in the frontend.
+        description: Icon to display in front of the input element in the frontend.
         required: false
         type: icon
 {% endconfiguration %}

--- a/source/_integrations/input_select.markdown
+++ b/source/_integrations/input_select.markdown
@@ -49,7 +49,7 @@ input_select:
         type: map
         default: First element of options
       icon:
-        description: Icon to display for the component.
+        description: Icon to display in front of the input element in the frontend.
         required: false
         type: icon
 {% endconfiguration %}

--- a/source/_integrations/input_text.markdown
+++ b/source/_integrations/input_text.markdown
@@ -53,6 +53,10 @@ input_text:
         required: false
         type: string
         default: empty
+      icon:
+        description: Icon to display in front of the input element in the frontend.
+        required: false
+        type: icon
       pattern:
         description: Regex pattern for client side validation.
         required: false


### PR DESCRIPTION
**Description:**
I think it would be beneficial to have the right (no **components**!) and consistent wording about common `icon` configuration variable in all input_xxx articles.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
