### PR TITLE
Update instructions for using Check Config Tool

### DIFF
--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -28,7 +28,7 @@ Please note that if you click on **Trigger** of an automation in the frontend, *
 All this makes that Trigger feature pretty limited and nearly useless for debugging purposes so you need to find another way.
 Make sure you check and adapt to your circumstances appropriate examples from Automation Trigger, Conditions and Actions.
 
-It is also useful to go to **Configuration** -> **Server Control** and click on **Check Config** button in Configuration validation section to make sure there are no syntax errors before restarting Home Assistant.
+It is also useful to go to **Configuration** -> **Server Control** and click on **Check Config** button in Configuration validation section to make sure there are no syntax errors before restarting Home Assistant. In order for **Check Config** to be visible, you must enable **Advanced Mode** on your user profile.
 
 If your automation uses templates in any part, you can do the following to make sure it works as expected:
 

--- a/source/_integrations/withings.markdown
+++ b/source/_integrations/withings.markdown
@@ -2,7 +2,7 @@
 title: "Withings"
 description: "Instructions on how to integrate Withings health products within Home Assistant."
 logo: withings.png
-ha_category: 
+ha_category:
   - Health
   - Sensor
 ha_release: 0.99
@@ -15,7 +15,7 @@ The `withings` sensor platform consumes data from various health products produc
 
 ### Step 1 - Create a Withings Account
 
-You must have a developer account to distribute the data. [Create a free development account](https://account.withings.com/partner/add_oauth2). 
+You must have a developer account to distribute the data. [Create a free development account](https://account.withings.com/partner/add_oauth2).
 
 Values for your account:
 
@@ -42,7 +42,7 @@ Withings supports multiple profiles per account. Each profile has a person's nam
 
 ### Step 3 - Authorize Home Assistant
 
-- Confirm your YAML configuration is valid by using the `Check Config` tool.
+- Confirm your YAML configuration is valid by using the `Check Config` tool (see note).
 - Restart Home Assistant.
 - Go to the integrations page.
 - Add a Withings integration.
@@ -50,11 +50,13 @@ Withings supports multiple profiles per account. Each profile has a person's nam
 - On the Withings site, choose the profile you selected in the previous step (if prompted).
   - Note: It's important you select the same profile from the previous step. Choosing a different one will result in Home Assistant displaying data for profile 2, but it will be labeled as profile 1.
 - Authorize the application. Your browser will redirect you to your Home Assistant URL.
-  - Note: If you get a browser error saying the site is inaccessible, you can modify the 
+  - Note: If you get a browser error saying the site is inaccessible, you can modify the
   `http://domain` portion of the URL to something you know is accessible, locally or publically. For example, `http://localhost:8123`.
   This occurs when the base URL provided by Home Assistant to Withings is not accessible to the outside world.
   Changing the domain will not affect how data is synchronized.
 - Data will synchronize immediately and update every 5 minutes.
+
+Note: In order for "Check Config" to be visible, you must enable "Advanced Mode" on your user profile. The "Check Config" tool can be found by clicking "Configuration" from the sidebar (cog icon) and then clicking "Server Control".
 
 ## Configuration
 

--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -31,7 +31,7 @@ Now let's make a small change using the configurator: we are going to change the
  - Find the `homeassistant:` configuration block, which should be the first thing in `configuration.yaml`. In this block, update `name`, `latitude`, `longitude`, `unit_system` and `time_zone` to match yours.
  - Click the save icon in the top right to commit changes.
  - Most changes in `configuration.yaml` require Home Assistant to be restarted to see the changes. You can verify that your changes are acceptable by running a config check. Do this by clicking on Configuration in the sidebar, click on General and click on the "Check Config" button. When it's valid, it will show the text "Configuration valid!".
- - Now Restart Home Assistant using the "restart" in the Server management section on the same page.
+ - Now Restart Home Assistant using the "restart" in the Server management section on the same page. In order for "Check Config" to be visible, you must enable "Advanced Mode" on your user profile.
 
 <p class='img'>
 <img src='/images/screenshots/configuration-validation.png' />


### PR DESCRIPTION
**Description:**

Add explanation that to view the check config tool advanced mode must be enabled. In response to #10591 although changed all references found. Surprisingly, only three pages (except change logs) reference the tool. Moved target to current as suggested. 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
