### PR TITLE
Fixes GitHub repository link

### DIFF
--- a/plugins/environment_variables.rb
+++ b/plugins/environment_variables.rb
@@ -2,7 +2,7 @@ module Jekyll
   class EnvironmentVariablesGenerator < Generator
     def generate(site)
       # https://www.netlify.com/docs/continuous-deployment/#build-environment-variables
-      repo_url = ENV['REPOSITORY_URL'] || 'https://github.com/home-assistant/home-assistant.github.io'
+      repo_url = ENV['REPOSITORY_URL'] || 'https://github.com/home-assistant/home-assistant.io'
 
       # Rewrite urls if repo url is the ssh format.
       if repo_url.start_with? 'git@github.com:'

--- a/source/_integrations/dialogflow.markdown
+++ b/source/_integrations/dialogflow.markdown
@@ -63,7 +63,7 @@ When activated, the [`alexa` integration](/integrations/alexa/) will have Home A
 
 ## Examples
 
-Download [this zip](https://github.com/home-assistant/home-assistant.github.io/blob/next/source/assets/HomeAssistant_APIAI.zip) and load it in your Dialogflow agent (**Settings** -> **Export and Import**) for examples intents to use with this configuration:
+Download [this zip](https://github.com/home-assistant/home-assistant.io/blob/next/source/assets/HomeAssistant_APIAI.zip) and load it in your Dialogflow agent (**Settings** -> **Export and Import**) for examples intents to use with this configuration:
 
 {% raw %}
 ```yaml

--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -116,7 +116,7 @@ Currently tested but not working models:
 None of the 2014 (H) and 2015 (J) model series (e.g., J5200) will work, since Samsung have used a different (encrypted) type of interface for these.
 
 If your model is not on the list then give it a test, if everything works correctly then add it to the list on
-[GitHub](https://github.com/home-assistant/home-assistant.github.io/tree/current/source/_integrations/samsungtv.markdown).
+[GitHub](https://github.com/home-assistant/home-assistant.io/tree/current/source/_integrations/samsungtv.markdown).
 The first letter (U, P, L, H & K) represent the screen type, e.g., LED or Plasma. The second letter represents the region, E is Europe, N is North America and A is Asia & Australia. The two numbers following that represent the screen size.
 If you add your model remember to remove these first 4 characters before adding to the list.
 

--- a/source/_posts/2016-10-02-hacktoberfest.markdown
+++ b/source/_posts/2016-10-02-hacktoberfest.markdown
@@ -34,7 +34,7 @@ Are you not a programmer but still want to contribute to Home Assistant? Check o
 [Hacktoberfest]: https://hacktoberfest.digitalocean.com/
 [Hacktoberfest-reg]: https://hacktoberfest.digitalocean.com/profile
 [issues]: https://github.com/home-assistant/home-assistant/labels/Hacktoberfest
-[issues-doc]: https://github.com/home-assistant/home-assistant.github.io/labels/Hacktoberfest
+[issues-doc]: https://github.com/home-assistant/home-assistant.io/labels/Hacktoberfest
 [dev-env]: /developers/development_environment/
 [dev-chat]: https://discord.gg/8X8DTH4
 [dev-forum]: https://community.home-assistant.io/c/development

--- a/source/_posts/2016-10-22-flash-briefing-updater-hacktoberfest.markdown
+++ b/source/_posts/2016-10-22-flash-briefing-updater-hacktoberfest.markdown
@@ -284,7 +284,7 @@ Thanks for reading all of the above, especially since this week was a pretty lon
 [flash-briefing-docs]: /integrations/alexa/
 [hacktoberfest-blog]: /blog/2016/10/02/hacktoberfest/
 [hacktoberfest-ha-prs]: https://github.com/home-assistant/home-assistant/labels/Hacktoberfest
-[hacktoberfest-site-prs]: https://github.com/home-assistant/home-assistant.github.io/labels/Hacktoberfest
+[hacktoberfest-site-prs]: https://github.com/home-assistant/home-assistant.io/labels/Hacktoberfest
 [hacktoberfest-website]: https://hacktoberfest.digitalocean.com/
 [logo]: /images/blog/2016-10-hacktoberfest/hacktoberfest.png
 [min]: /integrations/min_max
@@ -300,4 +300,4 @@ Thanks for reading all of the above, especially since this week was a pretty lon
 [zero-two-seven-release]: /blog/2016/08/28/notifications-hue-fake-unification/
 [twitter]: https://twitter.com/home_assistant
 [robbie-twitter]: https://twitter.com/robbie
-[blog-orig]: https://github.com/home-assistant/home-assistant.github.io/blob/c937242d154e509d2d84d10c51f654e20556fa21/source/_posts/2016-10-22-flash-briefing-updater-hacktoberfest.markdown
+[blog-orig]: https://github.com/home-assistant/home-assistant.io/blob/c937242d154e509d2d84d10c51f654e20556fa21/source/_posts/2016-10-22-flash-briefing-updater-hacktoberfest.markdown

--- a/source/_posts/2017-02-25-config-panel-and-state-restoration.markdown
+++ b/source/_posts/2017-02-25-config-panel-and-state-restoration.markdown
@@ -307,7 +307,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 
 [docs]: /docs/
 [getting-started]: /getting-started/
-[docs-issue]: https://github.com/home-assistant/home-assistant.github.io/issues/1603
+[docs-issue]: https://github.com/home-assistant/home-assistant.io/issues/1603
 
 [forum]: https://community.home-assistant.io/
 [issue]: https://github.com/home-assistant/home-assistant/issues

--- a/source/_posts/2017-09-29-hacktoberfest.markdown
+++ b/source/_posts/2017-09-29-hacktoberfest.markdown
@@ -36,7 +36,7 @@ Our participation for [Hacktoberfest 2016][hackt-2016] was a huge success. Join 
 [Hacktoberfest]: https://hacktoberfest.digitalocean.com/
 [Hacktoberfest-reg]: https://hacktoberfest.digitalocean.com/profile
 [issues]: https://github.com/home-assistant/home-assistant/labels/Hacktoberfest
-[issues-doc]: https://github.com/home-assistant/home-assistant.github.io/labels/Hacktoberfest
+[issues-doc]: https://github.com/home-assistant/home-assistant.io/labels/Hacktoberfest
 [dev-env]: /developers/development_environment/
 [dev-chat]: https://discord.gg/8X8DTH4
 [dev-forum]: https://community.home-assistant.io/c/development

--- a/source/_posts/2017-11-04-release-57.markdown
+++ b/source/_posts/2017-11-04-release-57.markdown
@@ -35,7 +35,7 @@ Hacktoberfest is obviously about the people contributing to open source. Big tha
 Here are our Hacktoberfest 2017 stats. It's a miracle everyone is still alive:
 
 - Main repo: [273 Pull requests](https://github.com/home-assistant/home-assistant/pulls?utf8=%E2%9C%93&q=merged%3A%3E2017-10-01%20is%3Apr%20label%3AHacktoberfest%20is%3Aclosed%20) were merged out of 307.
-- Docs repo: [295 Pull requests](https://github.com/home-assistant/home-assistant.github.io/pulls?page=1&q=merged%3A%3E2017-10-01+is%3Apr+label%3AHacktoberfest+is%3Aclosed&utf8=%E2%9C%93) merged out of 310.
+- Docs repo: [295 Pull requests](https://github.com/home-assistant/home-assistant.io/pulls?page=1&q=merged%3A%3E2017-10-01+is%3Apr+label%3AHacktoberfest+is%3Aclosed&utf8=%E2%9C%93) merged out of 310.
 - Frontend: [57 pull requests](https://github.com/home-assistant/home-assistant-polymer/pulls?utf8=%E2%9C%93&q=merged%3A%3E2017-10-01%20is%3Apr%20label%3AHacktoberfest%20is%3Aclosed%20) merged.
 
 This means that we processed over 20 Pull requests per day. The result was already visible in 0.56. This release is almost the same. In those releases we were able to add over 40 new integrations.

--- a/source/cookbook/index.markdown
+++ b/source/cookbook/index.markdown
@@ -14,7 +14,7 @@ For [`python_script:` examples](/integrations/python_script/) visit the [Scripts
 [sec-automation]: /integrations/#automation
 [organization]: /integrations/#organization
 
-New recipes can be added via the [home-assistant.io repository](https://github.com/home-assistant/home-assistant.github.io/tree/current/source/_cookbook).
+New recipes can be added via the [home-assistant.io repository](https://github.com/home-assistant/home-assistant.io/tree/current/source/_cookbook).
 
 <div class='note'>
 


### PR DESCRIPTION
**Description:**

Changes the GitHub repository links to the new location.

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
