### PR TITLE
Update switch documentation for all entities

### DIFF
--- a/source/_integrations/switch.markdown
+++ b/source/_integrations/switch.markdown
@@ -23,4 +23,4 @@ In the frontend open the sidebar. At the bottom, under **Developer Tools**, clic
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on a specific switch. Otherwise, it targets all switches.
+| `entity_id`            |      no  | The entity ID of the switch to control. To target all switches, set the entity ID to `all`|


### PR DESCRIPTION
**Description:**
home-assistant/home-assistant#19006 changed the way services interact with all entities. This PR just updates the documentation to reflect that the user must use `all` to target all switches

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#19006

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
