### PR TITLE
Add Netlify header control to improve CouldFlare caching behavior

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -134,5 +134,6 @@ defaults:
 
 # Support for files Jekyll will normally exclude
 include:
-  - ".well-known"
+  - "_headers"
   - "_redirects"
+  - ".well-known"

--- a/source/_headers
+++ b/source/_headers
@@ -1,5 +1,11 @@
 /*
   Cache-Control: public, max-age: 0, s-max-age=3600, must-revalidate
+  Content-Security-Policy: form-action https:
+  Feature-Policy: vibrate 'none'; geolocation 'none'; midi 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; payment 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
 /*.css
   Cache-Control: public, max-age: 604800, s-max-age=604800
 /*.js

--- a/source/_headers
+++ b/source/_headers
@@ -13,8 +13,8 @@
 /assets/*
   Cache-Control: public, max-age: 0, s-max-age=604800, must-revalidate
 /fonts/*
-  Cache-Control: public, max-age: 0, s-max-age=604800, must-revalidate
+  Cache-Control: public, max-age: 1800, s-max-age=604800, must-revalidate
 /images/*
-  Cache-Control: public, max-age: 0, s-max-age=604800, must-revalidate
+  Cache-Control: public, max-age: 1800, s-max-age=604800, must-revalidate
 /static/*
-  Cache-Control: public, max-age: 0, s-max-age=604800, must-revalidate
+  Cache-Control: public, max-age: 1800, s-max-age=604800, must-revalidate

--- a/source/_headers
+++ b/source/_headers
@@ -1,0 +1,14 @@
+/*
+  Cache-Control: public, max-age: 0, s-max-age=3600, must-revalidate
+/*.css
+  Cache-Control: public, max-age: 604800, s-max-age=604800
+/*.js
+  Cache-Control: public, max-age: 604800, s-max-age=604800
+/assets/*
+  Cache-Control: public, max-age: 0, s-max-age=604800, must-revalidate
+/fonts/*
+  Cache-Control: public, max-age: 0, s-max-age=604800, must-revalidate
+/images/*
+  Cache-Control: public, max-age: 0, s-max-age=604800, must-revalidate
+/static/*
+  Cache-Control: public, max-age: 0, s-max-age=604800, must-revalidate

--- a/source/_includes/javascripts/scripts.html
+++ b/source/_includes/javascripts/scripts.html
@@ -5,7 +5,7 @@ g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js
 s.parentNode.insertBefore(g,s)}(document,'script'));
 </script>
 
-<script type="text/javascript" src="/javascripts/prism.js"></script>
+<script src="/javascripts/prism.js?{{ site.time | date: '%s' }}" type="text/javascript"></script>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>

--- a/source/_includes/site/head.html
+++ b/source/_includes/site/head.html
@@ -28,8 +28,8 @@
     <meta name="twitter:description" content="{{ page.description | default: site.description | strip_html | truncate: 200 }}">
     <meta name="twitter:image" content="{{ page.og_image | default: "/images/default-social.png" | prepend: site.url }}">
 
-    <link href="/stylesheets/prism.css" rel="stylesheet">
-    <link href="/stylesheets/screen.css" media="screen, projection, print" rel="stylesheet">
+        <link href="/stylesheets/prism.css?{{ site.time | date: '%s' }}" rel="stylesheet">
+        <link href="/stylesheets/screen.css?{{ site.time | date: '%s' }}" media="screen, projection, print" rel="stylesheet">
     <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{ site.title }}" type="application/atom+xml">
     <link rel='shortcut icon' href='/images/favicon.ico' />
     <link rel='icon' type='image/png' href='/images/favicon-192x192.png' sizes='192x192' />


### PR DESCRIPTION
### Description:

This PR aims to improve the caching logic we have with Cloudflare & Netlify.

### Current situation

Currently, Netlify's cache-control headers is set to: `max-age=0, must-revalidate, public`.
This destroys the use of caching in CloudFlare, however, in Cloudflare we enforce browser caching on the client-side.

Right now, if we make changes to the site, it may take up to 5 days for the user to see the change (due to the enforce browser cache).

Our current security headers score:
![image](https://user-images.githubusercontent.com/195327/66265455-06f32280-e817-11e9-882a-81e4eecec5ed.png)

### Wanted situation:

This is actually not really the situation it should be.

Furthermore, this does not leverage the true power of Cloudflare. Cloudflare should be the one caching and taking all the hits. Not the browser of the client. Cloudflare can handle it, it was built for it.

From Netlify's end, we want to reduce bandwidth as much as possible, but want to show the newest site as well.

And while we are obviously going to modify headers, let's improve the security headers in the same go.

### Tasks:

- [x] Add Netlify header control file
- [x] Adjust Jekyll to publish the header file in the generated site
- [x] Add [`s-max-age`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Expiration) cache headers to improve edge caching on Cloudflare.
- [x] Adjust Jekyll to have some form of cache-busting on the Javascript & CSS assets.
- [x] Add some security headers
   - [x] `X-Frame-Options`
   - [x] `X-XSS-Protection`
   - [x] `Referrer-Policy`
   - [x] `Feature-Policy`
   - [x] `Content-Security-Policy`
   - [x] `X-Content-Type-Options`
- [ ] Remove Cloudflare's client browser & edge cache enforcement, giving control to the website to finegrain caching policies.

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
