### PR TITLE
Require the entity_id for all Xiaomi miIO services

### DIFF
--- a/source/_integrations/fan.xiaomi_miio.markdown
+++ b/source/_integrations/fan.xiaomi_miio.markdown
@@ -311,7 +311,7 @@ Set the fan speed/operation mode.
 
 | Service data attribute    | Optional | Description                                                         |
 |---------------------------|----------|---------------------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific air purifier. Else targets all.              |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.                      |
 | `speed`                   |       no | Fan speed. Valid values are 'Auto', 'Silent', 'Favorite' and 'Idle' |
 
 ### Service `fan.xiaomi_miio_set_buzzer_on` (Air Purifier Pro excluded)
@@ -320,7 +320,7 @@ Turn the buzzer on.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_buzzer_off` (Air Purifier Pro excluded)
 
@@ -328,7 +328,7 @@ Turn the buzzer off.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_led_on` (Air Purifiers only)
 
@@ -336,7 +336,7 @@ Turn the led on.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_led_off` (Air Purifiers only)
 
@@ -344,7 +344,7 @@ Turn the led off.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_child_lock_on`
 
@@ -352,7 +352,7 @@ Turn the child lock on.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_child_lock_off`
 
@@ -360,7 +360,7 @@ Turn the child lock off.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_led_brightness` (Air Purifier 2S and Air Purifier Pro excluded)
 
@@ -368,7 +368,7 @@ Set the led brightness. Supported values are 0 (Bright), 1 (Dim), 2 (Off).
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `brightness`              |       no | Brightness, between 0 and 2.                            |
 
 ### Service `fan.xiaomi_miio_set_favorite_level` (Air Purifiers only)
@@ -377,7 +377,7 @@ Set the favorite level of the operation mode "favorite".
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `level`                   |       no | Level, between 0 and 16.                                |
 
 ### Service `fan.xiaomi_miio_set_auto_detect_on` (Air Purifier 2S and Air Purifier Pro only)
@@ -386,7 +386,7 @@ Turn the auto detect on.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_auto_detect_off` (Air Purifier 2S and Air Purifier Pro only)
 
@@ -394,7 +394,7 @@ Turn the auto detect off.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_learn_mode_on` (Air Purifier 2 only)
 
@@ -402,7 +402,7 @@ Turn the learn mode on.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_learn_mode_off` (Air Purifier 2 only)
 
@@ -410,7 +410,7 @@ Turn the learn mode off.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_volume` (Air Purifier Pro only)
 
@@ -418,7 +418,7 @@ Set the sound volume.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `volume`                  |       no | Volume, between 0 and 100.                              |
 
 ### Service `fan.xiaomi_miio_reset_filter` (Air Purifier 2 only)
@@ -427,7 +427,7 @@ Reset the filter lifetime and usage.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_extra_features` (Air Purifier only)
 
@@ -435,7 +435,7 @@ Set the extra features.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `features`                |       no | Integer, known values are 0 and 1.                      |
 
 ### Service `fan.xiaomi_miio_set_target_humidity` (Air Humidifier only)
@@ -444,7 +444,7 @@ Set the target humidity.
 
 | Service data attribute    | Optional | Description                                                     |
 |---------------------------|----------|-----------------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.                  |
 | `humidity`                |       no | Target humidity. Allowed values are 30, 40, 50, 60, 70 and 80   |
 
 ### Service `fan.xiaomi_miio_set_dry_on` (Air Humidifier CA only)
@@ -453,7 +453,7 @@ Turn the dry mode on.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
 ### Service `fan.xiaomi_miio_set_dry_off` (Air Humidifier CA only)
 
@@ -461,4 +461,4 @@ Turn the dry mode off.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miIO fan entity. Else targets all. |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |

--- a/source/_integrations/light.xiaomi_miio.markdown
+++ b/source/_integrations/light.xiaomi_miio.markdown
@@ -138,7 +138,7 @@ Set one of the 4 available fixed scenes.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 | `scene`                   |       no | Scene, between 1 and 4.                               |
 
 ### Service `light.xiaomi_miio_set_delayed_turn_off`
@@ -147,7 +147,7 @@ Delayed turn off.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 | `time_period`             |       no | Time period for the delayed turn off.                 |
 
 ### Service `light.xiaomi_miio_reminder_on` (Eyecare Smart Lamp 2 only)
@@ -156,7 +156,7 @@ Enable the eye fatigue reminder/notification.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
 ### Service `light.xiaomi_miio_reminder_off` (Eyecare Smart Lamp 2 only)
 
@@ -164,7 +164,7 @@ Disable the eye fatigue reminder/notification.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
 ### Service `light.xiaomi_miio_night_light_mode_on`  (Eyecare Smart Lamp 2 only)
 
@@ -172,7 +172,7 @@ Turn the smart night light mode on.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
 ### Service `light.xiaomi_miio_night_light_mode_off`  (Eyecare Smart Lamp 2 only)
 
@@ -180,7 +180,7 @@ Turn the smart night light mode off.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
 ### Service `light.xiaomi_miio_eyecare_mode_on`  (Eyecare Smart Lamp 2 only)
 
@@ -188,7 +188,7 @@ Turn the eyecare mode on.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
 ### Service `light.xiaomi_miio_eyecare_mode_off`  (Eyecare Smart Lamp 2 only)
 
@@ -196,4 +196,4 @@ Turn the eyecare mode off.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific light. Else targets all.       |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |

--- a/source/_integrations/switch.xiaomi_miio.markdown
+++ b/source/_integrations/switch.xiaomi_miio.markdown
@@ -94,7 +94,7 @@ Turn the wifi led on.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miio switch entity. Else targets all.  |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO switch entity.       |
 
 ### Service `switch.xiaomi_miio_set_wifi_led_off` (Power Strip only)
 
@@ -102,7 +102,7 @@ Turn the wifi led off.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miio switch entity. Else targets all.  |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO switch entity.       |
 
 ### Service `switch.xiaomi_miio_set_power_price` (Power Strip)
 
@@ -110,7 +110,7 @@ Set the power price.
 
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miio switch entity. Else targets all.  |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO switch entity.       |
 | `price`                   |       no | Power price, between 0 and 999.                         |
 
 ### Service `switch.xiaomi_miio_set_power_mode` (Power Strip V1 only)
@@ -119,5 +119,5 @@ Set the power mode.
 
 | Service data attribute    | Optional | Description                                                   |
 |---------------------------|----------|---------------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific Xiaomi miio switch entity. Else targets all.  |
+| `entity_id`               |       no | Only act on a specific Xiaomi miIO switch entity.             |
 | `mode`                    |       no | Power mode, valid values are 'normal' and 'green'             |

--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -68,7 +68,7 @@ Start the remote control mode of the robot. You can then move it with `remote_co
 
 | Service data attribute    | Optional | Description                                       |
 |---------------------------|----------|---------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific robot; default targets all |
+| `entity_id`               |       no | Only act on a specific robot                      |
 
 ### Service `vacuum.xiaomi_remote_control_stop`
 
@@ -76,7 +76,7 @@ Exit the remote control mode of the robot.
 
 | Service data attribute    | Optional | Description                                       |
 |---------------------------|----------|---------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific robot; default targets all |
+| `entity_id`               |       no | Only act on a specific robot                      |
 
 ### Service `vacuum.xiaomi_remote_control_move`
 
@@ -84,7 +84,7 @@ Remote control the robot. Please ensure you first set it in remote control mode 
 
 | Service data attribute    | Optional | Description                                               |
 |---------------------------|----------|-----------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific robot; default targets all         |
+| `entity_id`               |       no | Only act on a specific robot                              |
 | `velocity`                |       no | Speed: between -0.29 and 0.29                             |
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
@@ -95,7 +95,7 @@ Enter remote control mode, make one move, stop, and exit remote control mode.
 
 | Service data attribute    | Optional | Description                                               |
 |---------------------------|----------|-----------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific robot; default targets all         |
+| `entity_id`               |       no | Only act on a specific robot                              |
 | `velocity`                |       no | Speed: between -0.29 and 0.29                             |
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
@@ -106,9 +106,9 @@ Start the cleaning operation in the areas selected for the number of repeats ind
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific robot; default targets all       |
+| `entity_id`               |       no | Only act on a specific robot                          |
 | `zone`                    |       no | List of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
-| `repeats`                    |       no | Number of cleaning repeats for each zone between 1 and 3. |
+| `repeats`                 |       no | Number of cleaning repeats for each zone between 1 and 3. |
 
 Example of `vacuum.xiaomi_clean_zone` use:
 


### PR DESCRIPTION
**Description:**

Update docs because of recent HA core changes: home-assistant/home-assistant#19006

Fixes: https://github.com/home-assistant/home-assistant/issues/24554

**Pull request in home-assistant (if applicable):** None.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
