### PR TITLE
Bump Python version in Travis CI example

### DIFF
--- a/source/_docs/ecosystem/backup/backup_github.markdown
+++ b/source/_docs/ecosystem/backup/backup_github.markdown
@@ -159,7 +159,7 @@ Example .travis.yml
 ```yaml
 language: python
 python:
-  - "3.5"
+  - "3.7"
 before_install:
   - mv travis_secrets.yaml secrets.yaml
   - sudo apt-get install -y libudev-dev


### PR DESCRIPTION
**Description:**
Bump Python version to 3.7 in `.travis.yml` example now that Python 3.5 is deprecated in HA.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
