### PR TITLE
speedtest port 8080

### DIFF
--- a/source/_integrations/speedtestdotnet.markdown
+++ b/source/_integrations/speedtestdotnet.markdown
@@ -15,6 +15,8 @@ Enabling this integration will automatically create the Speedtest.net Sensors fo
 
 By default, a speed test will be run every hour. The user can change the update frequency in the configuration by defining the `scan_interval` for a speed test to run.
 
+Most Speedtest.net servers require TCP port 8080 outbound to function. Without this port open you may experience significant delays or no results at all. See note on their [help page](https://www.speedtest.net/help).
+
 ## Configuration
 
 For the `server_id` check the list of [available servers](https://www.speedtest.net/speedtest-servers.php).


### PR DESCRIPTION
Speedtest.net uses a non-standard web port which can catch people off guard, especially if they have a secured IOT network.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
