### PR TITLE
Add version requirements to for option in trigger

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -132,6 +132,12 @@ automation:
 
 The `for` template(s) will be evaluated when an entity changes as specified.
 
+<div class='note warning'>
+  
+  Template support to template trigger's `for` option was added in 0.96 and won't work in previous versions.
+
+</div>
+
 ### State trigger
 
 Triggers when the state of any of given entities changes. If only `entity_id` is given trigger will activate for all state changes, even if only state attributes change.


### PR DESCRIPTION
Add version requirements about template support to template trigger `for` option. This was added in 0.96. In the previous version, this will throw:

> Invalid config for [automation]: expected int for dictionary value @ data[‘trigger’][0][‘for’][‘seconds’]. Got None. (See /config/automations.yaml, line 73). Please check the docs at https://home-assistant.io/components/automation/

More info here: https://community.home-assistant.io/t/template-value-in-for-time-since-trigger/12482/27?u=misiu