### PR TITLE
Remove Plex manual config flow

### DIFF
--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -29,9 +29,7 @@ Local and secure connections are preferred when setting up an Integration. After
 
 </div>
 
-Alternatively, you can manually configure a Plex server connection by selecting the "Manual setup" option when configuring a Plex integration. This will allow you to specify the server connection options which will be validated before setup is completed. The available options are similar to the **Configuration Variables** section below.
-
-If [discovery](/components/discovery/) is enabled and a local Plex server is found, a legacy `media_player` configuration (i.e., a `plex.conf` file) will be imported. GDM can be enabled via the Plex Web App under **Settings** -> **(Server Name)** -> **Settings** -> **Network** and choosing **Enable local network discovery (GDM)**.
+If [discovery](/integrations/discovery/) is enabled and a local Plex server is found, a legacy `media_player` configuration (i.e., a `plex.conf` file) will be imported. GDM can be enabled via the Plex Web App under **Settings** -> **(Server Name)** -> **Settings** -> **Network** and choosing **Enable local network discovery (GDM)**.
 
 The `plex` integration can also be configured via `configuration.yaml`:
 


### PR DESCRIPTION
**Description:**
Remove references to the manual config flow step.

Also catches a dangling `components` -> `integrations` change.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27291

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html