### PR TITLE
Add scene apply docs

### DIFF
--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -32,13 +32,13 @@ scene:
 
 {% configuration %}
 name:
-  description: Friendly name of scene.
-  required: true
-  type: string
+description: Friendly name of scene.
+required: true
+type: string
 entities:
-  description: Entities to control.
-  required: true
-  type: list
+description: Entities to control.
+required: true
+type: list
 {% endconfiguration %}
 
 As you can see, there are two ways to define the states of each `entity_id`:
@@ -50,14 +50,43 @@ Scenes can be activated using the service `scene.turn_on` (there is no 'scene.tu
 
 ```yaml
 # Example automation
-...
+---
 automation:
   trigger:
     platform: state
     entity_id: device_tracker.sweetheart
-    from: 'not_home'
-    to: 'home'
+    from: "not_home"
+    to: "home"
   action:
     service: scene.turn_on
     entity_id: scene.romantic
 ```
+
+## Applying a scene without defining it
+
+With the `scene.apply` service you are able to apply a scene without first defining it via configuration. Instead, you pass the states as part of the service data. The format of the data is the same as the `entities` field in a configuration.
+
+```yaml
+# Example automation
+---
+automation:
+  trigger:
+    platform: state
+    entity_id: device_tracker.sweetheart
+    from: "not_home"
+    to: "home"
+  action:
+    service: scene.apply
+    data:
+      entities:
+        light.tv_back_light:
+          state: on
+          brightness: 100
+        light.ceiling: off
+        media_player.sony_bravia_tv:
+          source: HDMI 1
+```
+
+## Reloading scenes
+
+Whenever you make a change to your scene configuration, you can call the `scene.reload` service to reload the scenes.

--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -50,7 +50,6 @@ Scenes can be activated using the service `scene.turn_on` (there is no 'scene.tu
 
 ```yaml
 # Example automation
----
 automation:
   trigger:
     platform: state
@@ -68,7 +67,6 @@ With the `scene.apply` service you are able to apply a scene without first defin
 
 ```yaml
 # Example automation
----
 automation:
   trigger:
     platform: state

--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -32,13 +32,13 @@ scene:
 
 {% configuration %}
 name:
-description: Friendly name of scene.
-required: true
-type: string
+  description: Friendly name of scene.
+  required: true
+  type: string
 entities:
-description: Entities to control.
-required: true
-type: list
+  description: Entities to control.
+  required: true
+  type: list
 {% endconfiguration %}
 
 As you can see, there are two ways to define the states of each `entity_id`:


### PR DESCRIPTION
**Description:**
Add documentation for the scene.apply service.

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/27298

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
