### PR TITLE
Added note for users of earlier versions than 0.97

### DIFF
--- a/source/_integrations/google_maps.markdown
+++ b/source/_integrations/google_maps.markdown
@@ -49,4 +49,5 @@ scan_interval:
 {% endconfiguration %}
 
 <div class='note'>
-As of release 0.97 Google Passwords are no longer required in your config. Users coming from earlier releases should only remove the password entry from their config file (username is still required) and restart Home Assistant. The cookie file previously generated should still be valid and will allow the tracker to continue functioning normally until the cookie is invalidated.</div>
+As of release 0.97 Google passwords are no longer required in your configuration. Users coming from earlier releases should only remove the password entry from their configuration file (username is still required) and restart Home Assistant. The cookie file previously generated should still be valid and will allow the tracker to continue functioning normally until the cookie is invalidated.
+</div>

--- a/source/_integrations/google_maps.markdown
+++ b/source/_integrations/google_maps.markdown
@@ -47,3 +47,6 @@ scan_interval:
   default: 60
   type: integer
 {% endconfiguration %}
+
+<div class='note'>
+As of release 0.97 Google Passwords are no longer required in your config. Users coming from earlier releases should only remove the password entry from their config file (username is still required) and restart Home Assistant. The cookie file previously generated should still be valid and will allow the tracker to continue functioning normally until the cookie is invalidated.</div>


### PR DESCRIPTION
Updated page with a note for users coming from earlier versions than 0.97 to only remove password from the config file. Used parts of the text from the breaking change text for release 0.97.

Fixes issue #10179

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
