### PR TITLE
Document opentherm_gw options flow

### DIFF
--- a/source/_integrations/opentherm_gw.markdown
+++ b/source/_integrations/opentherm_gw.markdown
@@ -46,9 +46,23 @@ id:
 {% endconfiguration %}
 
 <div class='note'>
-The precision and floor_temperature settings that were supported in configuration.yaml entries have been temporarily removed. The values will be lost upon import of the configuration.yaml entry into the Integrations panel. These features will be re-added soon.
+The precision and floor_temperature settings that were supported in configuration.yaml entries have been lost upon import of the configuration.yaml entry into the Integrations panel. You can now configure them as per the following Options paragraph.
 </div>
 
+# Options
+
+The OpenTherm Gateway can be further configured through the integration settings in the web interface
+The following options are available:
+{% configuration %}
+Precision:
+  description: "The desired precision for this device. Can be used to match your actual thermostat's precision. Set to `0` to use the default value for your unit preference."
+  type: float
+  default: "`0.5` for Celsius and `1.0` for Fahrenheit."
+Floor Temperature:
+  description: "Some thermostats round all temperatures down to the lower value according to their precision. Default behavior for Home Assistant is to round temperatures to the nearest value. Enable this setting to override this behavior and round to the lower value according to the configured precision."
+  type: boolean
+  default: Disabled
+{% endconfiguration %}
 
 ## Services
 


### PR DESCRIPTION
**Description:**
The `opentherm_gw` integration can now be configured with an options flow.
This PR adds documentation for the options.

Note that this PR includes the changes in #10584. Any conflicts that may arise will be dealt with.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27316

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
