### PR TITLE
Update for Python 3.8

### DIFF
--- a/source/_docs/installation/fedora.markdown
+++ b/source/_docs/installation/fedora.markdown
@@ -11,12 +11,6 @@ Install the development package of Python.
 sudo dnf -y install python3-devel redhat-rpm-config
 ```
 
-and Home Assistant itself.
-
-```bash
-pip3 install homeassistant
-```
-
 To isolate the Home Assistant installation a [`venv`](https://docs.python.org/3/library/venv.html) is handy. First create a new directory to store the installation and adjust the permissions.
 
 ```bash
@@ -24,19 +18,20 @@ sudo mkdir -p /opt/homeassistant
 sudo useradd -rm homeassistant -G dialout
 sudo chown -R homeassistant:homeassistant /opt/homeassistant
 ```
+
 Now switch to the new directory, setup the `venv`, and activate it.
 
 ```bash
 sudo -u homeassistant -H -s
 cd /opt/homeassistant
-python3.6 -m venv .
+python3.8 -m venv .
 source bin/activate
 ```
 
 Install Home Assistant itself.
 
 ```bash
-$ pip3 install homeassistant colorlog
+pip3 install homeassistant colorlog
 ```
 
 Check the [autostart](/docs/autostart/systemd/) section in the documentation for further details and the [Firewall section](/docs/installation/troubleshooting/#no-access-to-the-frontend) if you want to access your Home Assistant installation.


### PR DESCRIPTION
**Description:**
Only support installation in `venv`.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
