### PR TITLE
Fix insteon links across blog posts 

### DIFF
--- a/source/_posts/2017-05-20-automation-editor-zwave-panel-ocr.markdown
+++ b/source/_posts/2017-05-20-automation-editor-zwave-panel-ocr.markdown
@@ -132,7 +132,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Don't interact with hass directly ([@fabaff] - [#7099]) ([binary_sensor.mystrom docs]) (new-platform)
 - Support for the PiFace Digital I/O module ([@basschipper] - [#7494]) ([rpi_pfio docs]) ([binary_sensor.rpi_pfio docs]) ([switch.rpi_pfio docs]) (new-platform)
 - Upgrade limitlessled to 1.0.7 ([@corneyl] - [#7525]) ([light.limitlessled docs])
-- Update docstrings and log messages ([@fabaff] - [#7526]) ([light.blinksticklight docs]) ([light.enocean docs]) ([light.flux_led docs]) ([light.insteon_local docs]) ([light.insteon_plm docs]) ([light.isy994 docs]) ([light.limitlessled docs]) ([light.mystrom docs])
+- Update docstrings and log messages ([@fabaff] - [#7526]) ([light.blinksticklight docs]) ([light.enocean docs]) ([light.flux_led docs]) ([light.insteon docs]) ([light.insteon docs]) ([light.isy994 docs]) ([light.limitlessled docs]) ([light.mystrom docs])
 - Try to request current_location Automatic scope ([@armills] - [#7447]) ([device_tracker.automatic docs])
 - Add myStrom binary sensor ([@fabaff] - [#7530])
 - Add not-context-manager ([@fabaff] - [#7523])
@@ -373,8 +373,8 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [light.blinksticklight docs]: /components/blinksticklight
 [light.enocean docs]: /components/enocean#light
 [light.flux_led docs]: /components/flux_led
-[light.insteon_local docs]: /components/insteon/
-[light.insteon_plm docs]: /components/insteon/
+[light.insteon docs]: /components/insteon/
+[light.insteon docs]: /components/insteon/
 [light.isy994 docs]: /components/isy994
 [light.lifx docs]: /components/lifx
 [light.limitlessled docs]: /components/limitlessled

--- a/source/_posts/2017-08-12-release-51.markdown
+++ b/source/_posts/2017-08-12-release-51.markdown
@@ -102,7 +102,7 @@ vacuum:
 - directv: add configuration glue for Genie slaves ([@sielicki] - [#8713]) ([media_player.directv docs])
 - bump python-telegram-bot to 7.0.1 for fully support Bot API 3.2 ([@azogue] - [#8715]) ([telegram_bot docs])
 - Add proxy support for telegram_bot ([@azogue] - [#8717]) ([telegram_bot docs])
-- python-insteonplm module version bump ([@nugget] - [#8736]) ([insteon_plm docs])
+- python-insteonplm module version bump ([@nugget] - [#8736]) ([insteon docs])
 - New media_player platform for Russound devices using the RIO protocol ([@wickerwaka] - [#8448]) ([media_player.russound_rio docs]) (new-platform)
 - Add toggle to remotes ([@alanfischer] - [#8483]) ([remote docs]) ([remote.apple_tv docs]) ([remote.harmony docs]) ([remote.itach docs])
 - added invert_state optional parameter ([@gwhiteCL] - [#8695]) ([cover.rpi_gpio docs])
@@ -376,7 +376,7 @@ vacuum:
 [history docs]: /components/history/
 [image_processing.opencv docs]: /components/opencv
 [influxdb docs]: /components/influxdb/
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [light.decora_wifi docs]: /components/decora_wifi/
 [light.flux_led docs]: /components/flux_led
 [light.lifx docs]: /components/lifx

--- a/source/_posts/2017-08-26-release-0-52.markdown
+++ b/source/_posts/2017-08-26-release-0-52.markdown
@@ -148,7 +148,7 @@ usps:
 - bump python-ecobee-api version to 0.0.8 ([@nkgilley] - [#9074]) ([ecobee docs])
 - Bump abodepy to 0.7.1 ([@arsaboo] - [#9077]) ([abode docs])
 - async_query returns False if connection to server failed, handle this properly ([@molobrakos] - [#9070]) ([media_player.squeezebox docs])
-- Added insteonplm device_override multiple capabilities ([@teharris1] - [#9078]) ([insteon_plm docs])
+- Added insteonplm device_override multiple capabilities ([@teharris1] - [#9078]) ([insteon docs])
 - Upgrade uber_rides to 0.5.1 ([@fabaff] - [#9080]) (sensor.uber docs)
 - Upgrade discord.py to 0.16.10 ([@fabaff] - [#9082]) ([notify.discord docs])
 - Fix `device` attribute in fritz_callmonitor.py (fixes #9055) ([@max-te] - [#9081]) ([sensor.fritzbox_callmonitor docs])
@@ -324,7 +324,7 @@ usps:
 [fan.isy994 docs]: /components/isy994
 [image_processing.dlib_face_detect docs]: /components/dlib_face_detect
 [image_processing.dlib_face_identify docs]: /components/dlib_face_identify
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [light.decora_wifi docs]: /components/decora_wifi/
 [light.flux_led docs]: /components/flux_led
 [light.hue docs]: /components/hue

--- a/source/_posts/2017-09-09-release-53.markdown
+++ b/source/_posts/2017-09-09-release-53.markdown
@@ -166,7 +166,7 @@ frontend:
 - Add Geofency device tracker ([@gunnarhelgason] - [#9106]) ([device_tracker.geofency docs]) (new-platform)
 - flux: fix for when stop_time is after midnight ([@abmantis] - [#8932])
 - Change attribute names ([@emlt] - [#9277]) ([switch.dlink docs]) (breaking change)
-- insteon_plm: fix typo in attributes ([@drkp] - [#9284]) ([insteon_plm docs])
+- insteon: fix typo in attributes ([@drkp] - [#9284]) ([insteon docs])
 - discovery: If unknown NetDisco service discovered, log about it. ([@pfalcon] - [#9280])
 - Upgrade youtube_dl to 2017.9.2 ([@fabaff] - [#9279]) ([media_extractor docs])
 - Upgrade python-telegram-bot to 8.0.0 ([@fabaff] - [#9282]) ([telegram_bot docs]) ([switch.rest docs])
@@ -385,7 +385,7 @@ frontend:
 [image_processing.dlib_face_detect docs]: /components/dlib_face_detect
 [image_processing.dlib_face_identify docs]: /components/dlib_face_identify
 [input_text docs]: /components/input_text/
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [light.homematic docs]: /components/homematic
 [light.hue docs]: /components/hue
 [light.lutron_caseta docs]: /components/lutron_caseta/

--- a/source/_posts/2018-03-09-release-65.markdown
+++ b/source/_posts/2018-03-09-release-65.markdown
@@ -178,7 +178,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 <!--more-->
 ## Breaking Changes
 
-- Insteon PLM: If you have created platform overrides in your configuration.yaml file to change a your INSTEON device to map to a different Home Assistant platform, that mapping will no longer be in effect. Please see the new device override capabilities in the [insteon_plm documentation](/components/insteon_plm/). ([@teharris1] - [#12534]) ([insteon_plm docs]) ([binary_sensor.insteon_plm docs]) ([fan.insteon_plm docs]) ([light.insteon_plm docs]) ([sensor.insteon_plm docs]) ([switch.insteon_plm docs]) (breaking change)
+- Insteon: If you have created platform overrides in your configuration.yaml file to change a your INSTEON device to map to a different Home Assistant platform, that mapping will no longer be in effect. Please see the new device override capabilities in the [insteon documentation](/components/insteon/). ([@teharris1] - [#12534]) ([insteon docs]) ([binary_sensor.insteon docs]) ([fan.insteon docs]) ([light.insteon docs]) ([sensor.insteon docs]) ([switch.insteon docs]) (breaking change)
 - AirVisual's air index unit is AQI (Air Quality Index), not PSI (Pressure per Square Inch). ([@chilicheech] - [#12730]) ([sensor.airvisual docs]) (breaking change)
 - TekSavvy Sensor: The sensor entity id for peak upload usage used to be `sensor.teksavvy_on_peak_upload_` this has been changed to `sensor.teksavvy_on_peak_upload`. The `usage` title was shared between and therefore indeterminate between GB and % usage. Therefore % usage entity ID has been changed to `sensor.teksavvy_usage_ratio` ([@mikeodr] - [#12325]) ([sensor.teksavvy docs]) (breaking change)
 - Egardia redesign - generic component and sensor support ([@jeroenterheerdt] - [#11994]) ([egardia docs]) ([alarm_control_panel.egardia docs]) ([binary_sensor.egardia docs]) (breaking change) (new-platform)
@@ -199,7 +199,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Removing asyncio.coroutine syntax from HASS core ([@Julius2342] - [#12509])
 - Synology Chat as a notification platform ([@cmsimike] - [#12596]) ([notify.synology_chat docs]) (new-platform)
 - Enable pytradfri during build, and include in Docker ([@lwis] - [#12662])
-- Upgrade insteonplm to 0.8.2 (required refactoring) ([@teharris1] - [#12534]) ([insteon_plm docs]) ([binary_sensor.insteon_plm docs]) ([fan.insteon_plm docs]) ([light.insteon_plm docs]) ([sensor.insteon_plm docs]) ([switch.insteon_plm docs]) (breaking change)
+- Upgrade insteonplm to 0.8.2 (required refactoring) ([@teharris1] - [#12534]) ([insteon docs]) ([binary_sensor.insteon docs]) ([fan.insteon docs]) ([light.insteon docs]) ([sensor.insteon docs]) ([switch.insteon docs]) (breaking change)
 - Homekit Update, Support for TempSensor (°F) ([@cdce8p] - [#12676]) ([homekit docs])
 - Fix formatting of minutes for sleep start in the fitbit sensor ([@awkwardDuck] - [#12664]) ([sensor.fitbit docs])
 - KNX Component: Scene support and expose sensor values ([@Julius2342] - [#11978]) ([knx docs]) ([scene docs]) ([binary_sensor.knx docs]) (new-platform)
@@ -549,7 +549,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [binary_sensor.concord232 docs]: /components/concord232#binary-sensor
 [binary_sensor.egardia docs]: /components/egardia#binary-sensor
 [binary_sensor.hikvision docs]: /components/hikvision
-[binary_sensor.insteon_plm docs]: /components/insteon_plm/
+[binary_sensor.insteon docs]: /components/insteon/
 [binary_sensor.isy994 docs]: /components/isy994
 [binary_sensor.knx docs]: /components/binary_sensor.knx/
 [binary_sensor.upcloud docs]: /components/upcloud#binary-sensor
@@ -573,7 +573,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [device_tracker.tesla docs]: /components/tesla
 [device_tracker.ubus docs]: /components/ubus
 [egardia docs]: /components/egardia/
-[fan.insteon_plm docs]: /components/insteon/
+[fan.insteon docs]: /components/insteon/
 [frontend docs]: /components/frontend/
 [google_assistant docs]: /components/google_assistant/
 [group docs]: /components/group/
@@ -582,7 +582,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [hue docs]: /components/hue/
 [ihc docs]: /components/ihc/
 [influxdb docs]: /components/influxdb/
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [knx docs]: /components/knx/
 [light docs]: /components/light/
 [light.demo docs]: /components/light.demo/
@@ -590,7 +590,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [light.group docs]: /components/light.group/
 [light.hue docs]: /components/hue
 [light.hyperion docs]: /components/hyperion
-[light.insteon_plm docs]: /components/insteon/
+[light.insteon docs]: /components/insteon/
 [light.knx docs]: /components/light.knx/
 [light.lifx docs]: /components/lifx
 [light.limitlessled docs]: /components/limitlessled
@@ -617,7 +617,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [sensor.folder docs]: /components/folder
 [sensor.history_stats docs]: /components/history_stats
 [sensor.imap docs]: /components/imap
-[sensor.insteon_plm docs]: /components/insteon/
+[sensor.insteon docs]: /components/insteon/
 [sensor.luftdaten docs]: /components/luftdaten#sensor
 [sensor.netatmo docs]: /components/netatmo#sensor
 [sensor.plex docs]: /components/plex#sensor
@@ -636,7 +636,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [sensor.zestimate docs]: /components/zestimate
 [shopping_list docs]: /components/shopping_list/
 [switch.edimax docs]: /components/edimax
-[switch.insteon_plm docs]: /components/insteon_plm/
+[switch.insteon docs]: /components/insteon/
 [switch.rest docs]: /components/switch.rest/
 [switch.tesla docs]: /components/tesla
 [switch.upcloud docs]: /components/upcloud#switch

--- a/source/_posts/2018-04-14-release-67.markdown
+++ b/source/_posts/2018-04-14-release-67.markdown
@@ -143,7 +143,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Update HAP-python to 1.1.8 ([@cdce8p] - [#13563]) ([homekit docs])
 - Update ha-philips_js to 0.0.3 ([@danielperna84] - [#13702]) ([media_player.philips_js docs])
 - Coverage & Codeowners ([@kellerza] - [#13700])
-- Bump insteonplm to 0.8.6 to fix sensor message handling ([@teharris1] - [#13691]) ([insteon_plm docs])
+- Bump insteonplm to 0.8.6 to fix sensor message handling ([@teharris1] - [#13691]) ([insteon docs])
 - Fix asuswrt ap mode failure ([@shuaiger] - [#13693]) ([device_tracker docs])
 - Support color temperature in Homekit ([@morberg] - [#13658]) ([homekit docs])
 - Remove unused CONF_WATCHERS ([@robmarkcole] - [#13678]) ([folder_watcher docs])
@@ -355,7 +355,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [freedns docs]: /components/freedns/
 [homekit docs]: /components/homekit/
 [hue docs]: /components/hue/
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [light docs]: /components/light/
 [light.nanoleaf_aurora docs]: /components/nanoleaf/
 [light.hue docs]: /components/hue

--- a/source/_posts/2018-05-11-release-69.markdown
+++ b/source/_posts/2018-05-11-release-69.markdown
@@ -177,7 +177,7 @@ rainmachine:
 - Add support for max_volume ([@relvacode] - [#13822]) ([media_player.onkyo docs])
 - Refactor ImageProcessingFaceEntity ([@robmarkcole] - [#14296]) ([image_processing docs]) ([image_processing.dlib_face_detect docs]) ([image_processing.dlib_face_identify docs]) ([image_processing.microsoft_face_detect docs]) ([image_processing.microsoft_face_identify docs])
 - Onkyo: SUPPORT_VOLUME_STEP ([@rsmeral] - [#14299]) ([media_player.onkyo docs])
-- Add All-Linking capabilities ([@teharris1] - [#14065]) ([insteon_plm docs]) ([binary_sensor.insteon_plm docs]) ([fan.insteon_plm docs]) ([light.insteon_plm docs]) ([sensor.insteon_plm docs]) ([switch.insteon_plm docs])
+- Add All-Linking capabilities ([@teharris1] - [#14065]) ([insteon docs]) ([binary_sensor.insteon docs]) ([fan.insteon docs]) ([light.insteon docs]) ([sensor.insteon docs]) ([switch.insteon docs])
 - Add missing 'sensor' to ABODE_PLATFORMS ([@jloutsenhizer] - [#14313]) ([abode docs]) (beta fix)
 - Add debounce to move_cover ([@cdce8p] - [#14314]) ([homekit docs]) (beta fix)
 - Fix module names for custom components ([@balloob] - [#14317]) (beta fix)
@@ -376,7 +376,7 @@ rainmachine:
 [auth docs]: /components/auth/
 [binary_sensor docs]: /components/binary_sensor/
 [binary_sensor.deconz docs]: /components/deconz#binary-sensor
-[binary_sensor.insteon_plm docs]: /components/insteon_plm/
+[binary_sensor.insteon docs]: /components/insteon/
 [binary_sensor.tapsaff docs]: /components/tapsaff
 [binary_sensor.trend docs]: /components/trend
 [binary_sensor.workday docs]: /components/workday
@@ -390,7 +390,7 @@ rainmachine:
 [device_tracker docs]: /components/device_tracker/
 [eight_sleep docs]: /components/eight_sleep/
 [emulated_hue docs]: /components/emulated_hue/
-[fan.insteon_plm docs]: /components/insteon/
+[fan.insteon docs]: /components/insteon/
 [fan.template docs]: /components/fan.template/
 [frontend docs]: /components/frontend/
 [homekit docs]: /components/homekit/
@@ -405,11 +405,11 @@ rainmachine:
 [image_processing.microsoft_face_identify docs]: /components/microsoft_face_identify
 [image_processing.opencv docs]: /components/opencv
 [influxdb docs]: /components/influxdb/
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [light.deconz docs]: /components/deconz#light
 [light.flux_led docs]: /components/flux_led
 [light.hue docs]: /components/hue
-[light.insteon_plm docs]: /components/insteon/
+[light.insteon docs]: /components/insteon/
 [light.mqtt_json docs]: /components/light.mqtt
 [light.wink docs]: /components/wink#light
 [light.xiaomi_aqara docs]: /components/light.xiaomi_aqara/
@@ -448,7 +448,7 @@ rainmachine:
 [sensor.eliqonline docs]: /components/eliqonline
 [sensor.filter docs]: /components/filter
 [sensor.homematicip_cloud docs]: /components/homematicip_cloud/
-[sensor.insteon_plm docs]: /components/insteon/
+[sensor.insteon docs]: /components/insteon/
 [sensor.lastfm docs]: /components/lastfm
 [sensor.mitemp_bt docs]: /components/mitemp_bt
 [sensor.mqtt docs]: /components/sensor.mqtt/
@@ -466,7 +466,7 @@ rainmachine:
 [sensor.yweather docs]: /components/yweather
 [switch.deluge docs]: /components/deluge#switch
 [switch.fritzbox docs]: /components/fritzbox
-[switch.insteon_plm docs]: /components/insteon_plm/
+[switch.insteon docs]: /components/insteon/
 [switch.mqtt docs]: /components/switch.mqtt/
 [switch.rainmachine docs]: /components/rainmachine#switch
 [switch.xiaomi_aqara docs]: /components/switch.xiaomi_aqara/

--- a/source/_posts/2018-05-18-release-70.markdown
+++ b/source/_posts/2018-05-18-release-70.markdown
@@ -69,7 +69,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Homekit style cleanup ([@cdce8p] - [#14556]) ([homekit docs]) (beta fix)
 - fix nanoleaf aurora lights min and max temperature ([@Oro] - [#14571]) ([light.nanoleaf_aurora docs]) (beta fix)
 - Fix ISY moisure sensors showing unknown until a leak is detected ([@OverloadUT] - [#14496]) ([binary_sensor.isy994 docs]) (beta fix)
-- Bump insteonplm version to fix device hanging ([@teharris1] - [#14582]) ([insteon_plm docs]) (beta fix)
+- Bump insteonplm version to fix device hanging ([@teharris1] - [#14582]) ([insteon docs]) (beta fix)
 - Fix hue discovery popping up ([@balloob] - [#14614]) (beta fix)
 - Use libsodium18 ([@balloob] - [#14624]) (beta fix)
 - No longer use backports for ffmpeg ([@balloob] - [#14626]) (beta fix)
@@ -180,7 +180,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Homekit style cleanup ([@cdce8p] - [#14556]) ([homekit docs]) (beta fix)
 - fix nanoleaf aurora lights min and max temperature ([@Oro] - [#14571]) ([light.nanoleaf_aurora docs]) (beta fix)
 - Fix ISY moisure sensors showing unknown until a leak is detected ([@OverloadUT] - [#14496]) ([binary_sensor.isy994 docs]) (beta fix)
-- Bump insteonplm version to fix device hanging ([@teharris1] - [#14582]) ([insteon_plm docs]) (beta fix)
+- Bump insteonplm version to fix device hanging ([@teharris1] - [#14582]) ([insteon docs]) (beta fix)
 - Fix hue discovery popping up ([@balloob] - [#14614]) (beta fix)
 - Use libsodium18 ([@balloob] - [#14624]) (beta fix)
 - No longer use backports for ffmpeg ([@balloob] - [#14626]) (beta fix)
@@ -379,7 +379,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [homematicip_cloud docs]: /components/homematicip_cloud/
 [http docs]: /components/http/
 [image_processing.facebox docs]: /components/facebox
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [iota docs]: /components/iota/
 [isy994 docs]: /components/isy994/
 [konnected docs]: /components/konnected/

--- a/source/_posts/2018-06-22-release-72.markdown
+++ b/source/_posts/2018-06-22-release-72.markdown
@@ -94,7 +94,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Make zone entries work without radius ([@balloob] - [#15032]) ([zone docs]) (beta fix)
 - Bugfix empty entity lists ([@pvizeli] - [#15035]) (beta fix)
 - Rename experimental UI to lovelace ([@balloob] - [#15065]) ([frontend docs]) (beta fix)
-- X10 ([@teharris1] - [#14741]) ([insteon_plm docs]) ([switch.insteon_plm docs]) (beta fix)
+- X10 ([@teharris1] - [#14741]) ([insteon docs]) ([switch.insteon docs]) (beta fix)
 - Fix MQTT Light with RGB and Brightness ([@thinkl33t] - [#15053]) ([light.mqtt docs]) (beta fix)
 - Update Neato Library And Reduce Cloud Calls ([@dshokouhi] - [#15072]) ([neato docs]) ([camera.neato docs]) ([switch.neato docs]) ([vacuum.neato docs]) (beta fix)
 
@@ -207,7 +207,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Make zone entries work without radius ([@balloob] - [#15032]) ([zone docs]) (beta fix)
 - Bugfix empty entity lists ([@pvizeli] - [#15035]) (beta fix)
 - Rename experimental UI to lovelace ([@balloob] - [#15065]) ([frontend docs]) (beta fix)
-- X10 ([@teharris1] - [#14741]) ([insteon_plm docs]) ([switch.insteon_plm docs]) (beta fix)
+- X10 ([@teharris1] - [#14741]) ([insteon docs]) ([switch.insteon docs]) (beta fix)
 - Fix MQTT Light with RGB and Brightness ([@thinkl33t] - [#15053]) ([light.mqtt docs]) (beta fix)
 - Update Neato Library And Reduce Cloud Calls ([@dshokouhi] - [#15072]) ([neato docs]) ([camera.neato docs]) ([switch.neato docs]) ([vacuum.neato docs]) (beta fix)
 
@@ -426,7 +426,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [hassio docs]: /components/hassio/
 [hue docs]: /components/hue/
 [image_processing.facebox docs]: /components/facebox
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [konnected docs]: /components/konnected/
 [light.deconz docs]: /components/deconz#light
 [light.lifx docs]: /components/lifx
@@ -485,7 +485,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [sensor.xiaomi_miio docs]: /components/sensor.xiaomi_miio/
 [sonos docs]: /components/sonos/
 [switch.doorbird docs]: /components/doorbird#switch
-[switch.insteon_plm docs]: /components/insteon_plm/
+[switch.insteon docs]: /components/insteon/
 [switch.linode docs]: /components/linode#switch
 [switch.mystrom docs]: /components/mystrom#switch
 [switch.neato docs]: /components/neato#switch

--- a/source/_posts/2018-07-06-release-73.markdown
+++ b/source/_posts/2018-07-06-release-73.markdown
@@ -92,7 +92,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Added attribute attribution to Digital Ocean component ([@tchellomello] - [#15114]) ([digital_ocean docs]) ([binary_sensor.digital_ocean docs]) ([switch.digital_ocean docs])
 - Make Pollen.com platform async ([@bachya] - [#14963]) ([sensor.pollen docs]) (breaking change)
 - deCONZ small improvements ([@Kane610] - [#15128]) ([deconz docs]) ([light.deconz docs])
-- Bump insteonplm version to 0.11.2 ([@teharris1] - [#15133]) ([insteon_plm docs])
+- Bump insteonplm version to 0.11.2 ([@teharris1] - [#15133]) ([insteon docs])
 - Reorganize mysensors ([@MartinHjelmare] - [#15123])
 - MQTT Alarm Control Panel: add retain option for publishing for cases... ([@b3nj1] - [#15134]) ([alarm_control_panel.mqtt docs])
 - Add discovery support to mqtt climate component. ([@dreizehnelf] - [#15085]) ([mqtt docs]) ([climate.mqtt docs])
@@ -114,7 +114,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Upgrade youtube_dl to 2018.06.25 ([@fabaff] - [#15168]) ([media_extractor docs])
 - Upgrade keyring to 13.0.0 ([@fabaff] - [#15167])
 - Upgrade sendgrid to 5.4.1 ([@fabaff] - [#15166]) ([notify docs])
-- Add Mini remote support to insteon_plm ([@teharris1] - [#15152]) ([insteon_plm docs])
+- Add Mini remote support to insteon_plm ([@teharris1] - [#15152]) ([insteon docs])
 - Warn when using custom components ([@balloob] - [#15172])
 - Philips Hue Scene Activation: Simplified scene lookup logic, improved error handling ([@MizterB] - [#15175]) ([hue docs])
 - Finalize BotVac D7 Support And Further Reduce Cloud Calls ([@dshokouhi] - [#15161]) ([neato docs]) ([camera.neato docs]) ([switch.neato docs]) ([vacuum.neato docs])
@@ -288,7 +288,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [http docs]: /components/http/
 [hue docs]: /components/hue/
 [image_processing.opencv docs]: /components/opencv
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [light.deconz docs]: /components/deconz#light
 [light.flux_led docs]: /components/flux_led
 [light.homekit_controller docs]: /components/homekit_controller

--- a/source/_posts/2018-07-21-release-74.markdown
+++ b/source/_posts/2018-07-21-release-74.markdown
@@ -163,7 +163,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Add HomematicIP Cloud dimmer light device ([@mxworm] - [#15456]) ([light.homematicip_cloud docs])
 - Fix ZWave RGBW lights not producing color without explicit white_value ([@jantman] - [#15412]) ([light.zwave docs])
 - Add IPPassageSensor (HmIP-SPDR) ([@danielperna84] - [#15458]) ([homematic docs])
-- Implement is_on ([@teharris1] - [#15459]) ([switch.insteon_plm docs])
+- Implement is_on ([@teharris1] - [#15459]) ([switch.insteon docs])
 - Remove unnecessary executable permissions ([@scop] - [#15469]) ([fritzbox docs]) ([climate.fritzbox docs]) ([cover.group docs]) ([sensor.wirelesstag docs]) ([switch.amcrest docs]) ([switch.fritzbox docs])
 - Add Tuya light platform ([@huangyupeng] - [#15444]) ([tuya docs]) ([light.tuya docs]) (new-platform)
 - Update homematicip_cloud with enum states ([@mxworm] - [#15460]) ([homematicip_cloud docs]) ([binary_sensor.homematicip_cloud docs]) ([light.homematicip_cloud docs]) ([sensor.homematicip_cloud docs])
@@ -397,7 +397,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [switch.enocean docs]: /components/enocean#switch
 [switch.eufy docs]: /components/eufy
 [switch.fritzbox docs]: /components/fritzbox
-[switch.insteon_plm docs]: /components/insteon_plm/
+[switch.insteon docs]: /components/insteon/
 [switch.tuya docs]: /components/tuya
 [tahoma docs]: /components/tahoma/
 [tts docs]: /components/tts/

--- a/source/_posts/2018-08-03-release-75.markdown
+++ b/source/_posts/2018-08-03-release-75.markdown
@@ -67,7 +67,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 ## Breaking Changes
 
 - Moon sensor states are now lowercase with underscores instead of spaces, allowing it to be translated in the frontend. ([@pvizeli] - [#15498]) ([sensor.moon docs]) (breaking change)
-- Insteon Mini-Remote now emit events instead of show as a binary sensor ([@teharris1] - [#15523]) ([insteon_plm docs]) ([binary_sensor.insteon_plm docs]) ([switch.insteon_plm docs]) (breaking change)
+- Insteon Mini-Remote now emit events instead of show as a binary sensor ([@teharris1] - [#15523]) ([insteon docs]) ([binary_sensor.insteon docs]) ([switch.insteon docs]) (breaking change)
 - Simplisafe to use new API: co, fire, flood, and last_event are no longer part of the SimpliSafe alarm object in the new API and are not available in this upgrade, making this a breaking change for anyone using those. They will be added back in some fashion at a later date (probably exposed as individual sensors) ([@w1ll1am23] - [#15542]) ([alarm_control_panel.simplisafe docs]) (breaking change)
 - Smappee: The updated library shows the temperature as degrees Celsius instead of centi degrees Celsius. ([@visibilityspots] - [#15636]) ([smappee docs]) (breaking change)
 
@@ -95,7 +95,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Implement locate service for neato ([@dshokouhi] - [#15467]) ([neato docs]) ([vacuum.neato docs])
 - Make RS room thermostat discoverable ([@turbokongen] - [#15451]) ([zwave docs])
 - Add support for Tahoma Smoke Sensor ([@fucm] - [#15441]) ([tahoma docs]) ([binary_sensor.tahoma docs]) (new-platform)
-- Mini-Remote events ([@teharris1] - [#15523]) ([insteon_plm docs]) ([binary_sensor.insteon_plm docs]) ([switch.insteon_plm docs]) (breaking change)
+- Mini-Remote events ([@teharris1] - [#15523]) ([insteon docs]) ([binary_sensor.insteon docs]) ([switch.insteon docs]) (breaking change)
 - Update pyatmo ([@gieljnssns] - [#15540]) ([netatmo docs])
 - Update reading when device is added ([@quthla] - [#15548]) ([sensor.bme280 docs])
 - Update config entry id in entity registry ([@balloob] - [#15531])
@@ -313,7 +313,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [auth docs]: /components/auth/
 [binary_sensor.alarmdecoder docs]: /components/alarmdecoder
 [binary_sensor.ihc docs]: /components/ihc#binary-sensor
-[binary_sensor.insteon_plm docs]: /components/insteon_plm/
+[binary_sensor.insteon docs]: /components/insteon/
 [binary_sensor.tahoma docs]: /components/tahoma
 [binary_sensor.trend docs]: /components/trend
 [calendar.todoist docs]: /components/todoist
@@ -347,7 +347,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [http docs]: /components/http/
 [ihc docs]: /components/ihc/
 [image_processing.opencv docs]: /components/opencv
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [light docs]: /components/light/
 [light.deconz docs]: /components/deconz#light
 [light.futurenow docs]: /components/futurenow
@@ -398,7 +398,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [spider docs]: /components/spider/
 [switch docs]: /components/switch/
 [switch.ihc docs]: /components/ihc#switch
-[switch.insteon_plm docs]: /components/insteon_plm/
+[switch.insteon docs]: /components/insteon/
 [switch.mqtt docs]: /components/switch.mqtt/
 [switch.spider docs]: /components/spider
 [switch.tplink docs]: /components/tplink

--- a/source/_posts/2018-08-29-release-77.markdown
+++ b/source/_posts/2018-08-29-release-77.markdown
@@ -224,7 +224,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 - Prevent legacy api password with empty password ([@balloob] - [#16127])
 - Enable auth by default 🙈 ([@balloob] - [#16107]) (breaking change)
 - Remove commented out API password from default config ([@balloob] - [#16147])
-- Spelling fixes ([@scop] - [#16150]) ([insteon_local docs]) ([insteon_plm docs])
+- Spelling fixes ([@scop] - [#16150]) ([insteon docs]) ([insteon docs])
 - Update pydocstyle to 2.1.1 and flake8-docstrings to 1.3.0 ([@scop] - [#14557])
 - Hangouts ([@hobbypunk90] - [#16049]) ([hangouts docs]) ([notify docs]) (new-platform)
 - Hangouts localization typo fix ([@armills] - [#16174]) ([hangouts docs])
@@ -449,7 +449,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [image_processing.opencv docs]: /components/opencv
 [input_datetime docs]: /components/input_datetime/
 [insteon_local docs]: /components/insteon_local/
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [konnected docs]: /components/konnected/
 [light.deconz docs]: /components/deconz#light
 [light.wemo docs]: /components/wemo

--- a/source/_posts/2019-04-24-release-92.markdown
+++ b/source/_posts/2019-04-24-release-92.markdown
@@ -1028,7 +1028,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [ign_sismologia docs]: /components/ign_sismologia/
 [influxdb docs]: /components/influxdb/
 [insteon_local docs]: /components/insteon_local/
-[insteon_plm docs]: /components/insteon_plm/
+[insteon docs]: /components/insteon/
 [introduction docs]: /components/introduction/
 [lcn docs]: /components/lcn/
 [light docs]: /components/light/


### PR DESCRIPTION
**Description:**

Fixes `insteon_plm` references across blog posts. Referenced in #10491

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
# #
