### PR TITLE
Fixed generic.camera links #10491

### DIFF
--- a/source/_posts/2018-05-18-release-70.markdown
+++ b/source/_posts/2018-05-18-release-70.markdown
@@ -358,7 +358,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [bmw_connected_drive docs]: /integrations/bmw_connected_drive/
 [camera docs]: /integrations/camera/
 [camera.familyhub docs]: /integrations/familyhub
-[camera.generic docs]: /integrations/generic
+[camera.generic docs]: /integrations/generic_ip_camera
 [climate.mysensors docs]: /integrations/climate.mysensors/
 [climate.sensibo docs]: /integrations/sensibo
 [climate.venstar docs]: /integrations/venstar

--- a/source/_posts/2018-07-16-release-73-2.markdown
+++ b/source/_posts/2018-07-16-release-73-2.markdown
@@ -79,7 +79,7 @@ Local, so cannot be impacted:
 - [camera.amcrest](/integrations/amcrest)
 - [camera.doorbird](/integrations/doorbird#camera)
 - [camera.familyhub](/integrations/familyhub)
-- [camera.generic](/integrations/generic)
+- [camera.generic](/integrations/generic_ip_camera)
 - [camera.mjpeg](/integrations/mjpeg)
 - [camera.proxy](/integrations/proxy)
 - [camera.synology](/integrations/synology)

--- a/source/_posts/2018-08-29-release-77.markdown
+++ b/source/_posts/2018-08-29-release-77.markdown
@@ -425,7 +425,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [bmw_connected_drive docs]: /integrations/bmw_connected_drive/
 [calendar.google docs]: /integrations/calendar.google/
 [camera docs]: /integrations/camera/
-[camera.generic docs]: /integrations/generic
+[camera.generic docs]: /integrations/generic_ip_camera
 [camera.proxy docs]: /integrations/proxy
 [camera.push docs]: /integrations/push
 [climate docs]: /integrations/climate/

--- a/source/_posts/2019-03-20-release-90.markdown
+++ b/source/_posts/2019-03-20-release-90.markdown
@@ -721,7 +721,7 @@ Users will need to change `- platform: firetv` to `- platform: androidtv` in the
 [binary_sensor.workday docs]: /integrations/workday
 [camera docs]: /integrations/camera/
 [camera.ffmpeg docs]: /integrations/camera.ffmpeg/
-[camera.generic docs]: /integrations/generic
+[camera.generic docs]: /integrations/generic_ip_camera
 [camera.onvif docs]: /integrations/onvif
 [camera.proxy docs]: /integrations/proxy
 [camera.xeoma docs]: /integrations/xeoma


### PR DESCRIPTION
**Description:**

Link updates for camera.generic to point to [generic_ip_camera](https://www.home-assistant.io/integrations/generic_ip_camera)

Ref #10491 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
