### PR TITLE
Removed reference to input_slider

### DIFF
--- a/source/_integrations/input_number.markdown
+++ b/source/_integrations/input_number.markdown
@@ -8,12 +8,6 @@ ha_release: 0.55
 ha_qa_scale: internal
 ---
 
-<div class='note'>
-
-Before version 0.55 this integration was known as `input_slider` and did not have the `mode` configuration option. Also, service `select_value` is now `set_value`.
-
-</div>
-
 The `input_number` integration allows the user to define values that can be controlled via the frontend and can be used within conditions of automation. The frontend can display a slider, or a numeric input box. Changes to the slider or numeric input box generate state events. These state events can be utilized as `automation` triggers as well.
 
 To enable this input number in your installation, add the following lines to your `configuration.yaml`:


### PR DESCRIPTION
Long enough has passed since 0.55, referencing how things were back then is just causing confusion.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
