### PR TITLE
Clarity edit

### DIFF
--- a/source/_integrations/input_number.markdown
+++ b/source/_integrations/input_number.markdown
@@ -52,7 +52,7 @@ input_number:
         description: Initial value when Home Assistant starts.
         required: false
         type: float
-        default: 0
+        default: The value at shutdown
       step:
         description: Step value for the slider. Smallest value `0.001`.
         required: false


### PR DESCRIPTION
The docs say that the default value is zero, then that it's restored if you don't set the default value...

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
