### PR TITLE
Hint that problems with °-symbol is caused by configuration not saved as UTF-8

### DIFF
--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -75,7 +75,7 @@ sensor:
   - platform: command_line
     name: HD Temperature
     command: "hddtemp -n /dev/sda"
-    # If errors occur, make sure configuration.yaml is encoded as UTF-8
+    # If errors occur, make sure configuration file is encoded as UTF-8
     unit_of_measurement: "°C"
 ```
 
@@ -90,7 +90,7 @@ sensor:
   - platform: command_line
     name: CPU Temperature
     command: "cat /sys/class/thermal/thermal_zone0/temp"
-    # If errors occur, make sure configuration.yaml is encoded as UTF-8
+    # If errors occur, make sure configuration file is encoded as UTF-8
     unit_of_measurement: "°C"
     value_template: '{{ value | multiply(0.001) | round(1) }}'
 ```

--- a/source/_integrations/sensor.command_line.markdown
+++ b/source/_integrations/sensor.command_line.markdown
@@ -75,7 +75,7 @@ sensor:
   - platform: command_line
     name: HD Temperature
     command: "hddtemp -n /dev/sda"
-    # If errors occur, remove degree symbol below
+    # If errors occur, make sure configuration.yaml is encoded as UTF-8
     unit_of_measurement: "°C"
 ```
 
@@ -90,7 +90,7 @@ sensor:
   - platform: command_line
     name: CPU Temperature
     command: "cat /sys/class/thermal/thermal_zone0/temp"
-    # If errors occur, remove degree symbol below
+    # If errors occur, make sure configuration.yaml is encoded as UTF-8
     unit_of_measurement: "°C"
     value_template: '{{ value | multiply(0.001) | round(1) }}'
 ```


### PR DESCRIPTION
**Description:**
Hint that problems with °-symbol is caused by configuration not saved as UTF-8

## Checklist:

- [x] Branch: Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
