### PR TITLE
Removed missing link, updated future to past tense

### DIFF
--- a/source/_integrations/hipchat.markdown
+++ b/source/_integrations/hipchat.markdown
@@ -8,15 +8,16 @@ ha_release: 0.52
 ---
 
 <div class='note'>
-This integration will be removed from Home Assistant in the future. Slack has taken over Hipchat and Stride and will therefore stop these platforms. For more information: <a href="https://www.atlassian.com/blog/announcements/new-atlassian-slack-partnership">announcement</a>.
-<br>
-<br>
-Hipchat was disconnected on February 15th, 2019. This document is now legacy.
+This integration was removed from Home Assistant. Slack [has taken](https://www.atlassian.com/blog/announcements/new-atlassian-slack-partnership) over Hipchat and Stride and will therefore stop these platforms. Hipchat was disconnected on February 15th, 2019. This document is now legacy.
 </div>
 
 The `hipchat` platform allows you to send notifications from Home Assistant to [HipChat](https://hipchat.com/).
 
+## Setup
+
 You need to obtain a [HipChat API token](https://developer.atlassian.com/hipchat/guide/hipchat-rest-api/api-access-tokens#APIaccesstokens-Usergeneratedtokens) to be able to send notifications.
+
+## Configuration
 
 To enable the HipChat notification in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_integrations/hipchat.markdown
+++ b/source/_integrations/hipchat.markdown
@@ -11,7 +11,7 @@ ha_release: 0.52
 This integration will be removed from Home Assistant in the future. Slack has taken over Hipchat and Stride and will therefore stop these platforms. For more information: <a href="https://www.atlassian.com/blog/announcements/new-atlassian-slack-partnership">announcement</a>.
 <br>
 <br>
-Hipchat will be discontinued after February 15th, 2019. This to give customers the opportunity to make a switch.
+Hipchat was disconnected on February 15th, 2019. This document is now legacy.
 </div>
 
 The `hipchat` platform allows you to send notifications from Home Assistant to [HipChat](https://hipchat.com/).
@@ -61,7 +61,6 @@ format:
 host:
   description: Setting the host will override the default HipChat server host.
   required: false
-  default: "https://api.hipchat.com/"
   type: string
 {% endconfiguration %}
 


### PR DESCRIPTION
Changes to HipChat page, adjusted the future tense to past tense for a past date. Removed link that is no longer exists. Left the rest of the page in case needed for historical purposes.

#10491 

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
