### PR TITLE
🚑 Referrer-Policy: no-referrer-when-downgrade, fix s-maxage

### DIFF
--- a/source/_headers
+++ b/source/_headers
@@ -1,20 +1,20 @@
 /*
-  Cache-Control: public, max-age: 0, s-max-age=3600, must-revalidate
+  Cache-Control: public, max-age: 0, s-maxage=3600, must-revalidate
   Content-Security-Policy: form-action https:
   Feature-Policy: vibrate 'none'; geolocation 'none'; midi 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; payment 'none'
-  Referrer-Policy: strict-origin-when-cross-origin
+  Referrer-Policy: no-referrer-when-downgrade
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
 /*.css
-  Cache-Control: public, max-age: 604800, s-max-age=604800
+  Cache-Control: public, max-age: 604800, s-maxage=604800
 /*.js
-  Cache-Control: public, max-age: 604800, s-max-age=604800
+  Cache-Control: public, max-age: 604800, s-maxage=604800
 /assets/*
-  Cache-Control: public, max-age: 0, s-max-age=604800, must-revalidate
+  Cache-Control: public, max-age: 0, s-maxage=604800, must-revalidate
 /fonts/*
-  Cache-Control: public, max-age: 1800, s-max-age=604800, must-revalidate
+  Cache-Control: public, max-age: 1800, s-maxage=604800, must-revalidate
 /images/*
-  Cache-Control: public, max-age: 1800, s-max-age=604800, must-revalidate
+  Cache-Control: public, max-age: 1800, s-maxage=604800, must-revalidate
 /static/*
-  Cache-Control: public, max-age: 1800, s-max-age=604800, must-revalidate
+  Cache-Control: public, max-age: 1800, s-maxage=604800, must-revalidate


### PR DESCRIPTION
**Description:**

Addresses 2 issues:
- Referer control headers cause issues with Discourse forum integration on the homepage
- Typo in the s-maxage headers.

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
