### PR TITLE
Inserted a note about using the correct TLD

### DIFF
--- a/source/_integrations/google_maps.markdown
+++ b/source/_integrations/google_maps.markdown
@@ -15,7 +15,8 @@ The `google_maps` platform allows you to detect presence using the unofficial AP
 You first need to create an additional Google account and share your location with that account. This platform will use that account to fetch the location of your device(s). 
 
 1. You have to setup sharing through the Google Maps app on your mobile phone. You can find more information [here](https://support.google.com/accounts?p=location_sharing).
-2. You need to use the cookies from that account after you have properly authenticated which you can retrieve with either [Export cookies](https://addons.mozilla.org/en-US/firefox/addon/export-cookies-txt/?src=search) for firefox (make sure that "Prefix HttpOnly cookies" is unchecked) or [cookies.txt](https://chrome.google.com/webstore/detail/cookiestxt/njabckikapfpffapmjgojcnbfjonfjfg?hl=en-US) for chrome.
+2. You need to use the cookies from that account after you have properly authenticated which you can retrieve with either [Export cookies](https://addons.mozilla.org/en-US/firefox/addon/export-cookies-txt/?src=search) for firefox (make sure that "Prefix HttpOnly cookies" is unchecked) or [cookies.txt](https://chrome.google.com/webstore/detail/cookiestxt/njabckikapfpffapmjgojcnbfjonfjfg?hl=en-US) for chrome.  
+    -  *Note:* Make sure to use the `.com` TLD (e.g.: maps.google.com), otherwise the cookie won't be able to provide a valid session.
 3. Save the cookie file to your Home Assistant configuration directory with the following name: `.google_maps_location_sharing.cookies.` followed by the slugified username of the NEW Google account.
     - For example: if your email was `location.tracker@gmail.com`, the filename would be: `.google_maps_location_sharing.cookies.location_tracker_gmail_com`.
 


### PR DESCRIPTION
Issue #26729

**Description:**
People using the incorrect TLD when generating the cookie, getting an error similar to:
``` ERROR (SyncWorker_9) [homeassistant.components.google_maps.device_tracker] The cookie file provided does not provide a valid session. Please create another one and try again.```

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
