### PR TITLE
Document new 'register_type' parameter for modbus binary sensor

### DIFF
--- a/source/_integrations/binary_sensor.modbus.markdown
+++ b/source/_integrations/binary_sensor.modbus.markdown
@@ -52,6 +52,10 @@ coils:
       description: Coil number.
       required: true
       type: integer
+    register_type:
+      description: Modbus register type (coil, discrete_input), default coil.
+      required: false
+      type: string
 {% endconfiguration %}
 
 It's possible to change the default 30 seconds scan interval for the sensor updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27397

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
