### PR TITLE
Revert changes in PR #10678

### DIFF
--- a/source/_integrations/alexa.smart_home.markdown
+++ b/source/_integrations/alexa.smart_home.markdown
@@ -168,7 +168,7 @@ Alexa can link your Amazon account to your Home Assistant account. Therefore Hom
   * `Access Token URI`: https://[YOUR HOME ASSISTANT URL:PORT]/auth/token
   * `Client ID`:
     - https://pitangui.amazon.com/ if you are in US
-    - https://layla.amazon.com/ if you are in EU
+    - https://layla.amazon.co.uk/ if you are in EU
     - https://alexa.amazon.co.jp/ if you are in JP and AU (not verified yet)
     
     The trailing slash is important here.

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -218,7 +218,7 @@ In this section you'll find some real-life examples of how to use this sensor, b
 
 #### Using Python request module
 
-As already shown on the [API](/developers/rest_api/) page, it's very simple to use Python and the [Requests](http://docs.python-requests.org/en/latest/) module for the interaction with Home Assistant.
+As already shown on the [API](/developers/rest_api/) page, it's very simple to use Python and the [Requests](https://requests.kennethreitz.org//en/latest/) module for the interaction with Home Assistant.
 
 ```python
 response = requests.post(

--- a/source/_posts/2015-11-22-survey-november-2015.markdown
+++ b/source/_posts/2015-11-22-survey-november-2015.markdown
@@ -19,7 +19,7 @@ Of course most users are running with the [automation](/getting-started/automati
 
 The [Alarm control panels](/integrations/alarm_control_panel/) and the [camera component](/integrations/camera/) are both used by around one third of the participants of the survey. It's safe to say that they cover a niche, but they will gain momentum when people discover how they can build alarm systems with Home Assistant.
 
-[Philips Hue](/integrations/hue) is the "winner" in the light category closely followed by [MQTT lights](components/light.mqtt/). [Google Cast](/integrations/cast) and [ Plex](/integrations/plex#media-player) are the top media player platforms. [Pushbullet](/integrations/pushbullet) is by far the most-used [notification platform](/integrations/notify/). If you followed the recent efforts to improve this platform it's comprehensible.
+[Philips Hue](/integrations/hue) is the "winner" in the light category closely followed by [MQTT lights](/integrations/light.mqtt/). [Google Cast](/integrations/cast) and [ Plex](/integrations/plex#media-player) are the top media player platforms. [Pushbullet](/integrations/pushbullet) is by far the most-used [notification platform](/integrations/notify/). If you followed the recent efforts to improve this platform it's comprehensible.
 
 It's interesting to see that most of the sensor, switch, and thermostat platforms are used. A lot of people seem to be interested in the weather data provided by the [Forecast sensor](/integrations/darksky). The MQTT sensors and switches are deployed in almost 50% of all Home Assistant setups.
 

--- a/source/_posts/2016-07-28-esp8266-and-micropython-part1.markdown
+++ b/source/_posts/2016-07-28-esp8266-and-micropython-part1.markdown
@@ -56,7 +56,7 @@ Type "help()" for more information.
 
 <div class='note'>
 
-The public build of the firmware may be different than the firmware distributed to the backers of the Kickstarter campaign. Especially in regard of the [available modules](http://docs.micropython.org/en/latest/esp8266/py-modindex.html), turned on debug messages, and alike. Also, the WebREPL may not be started by default.
+The public build of the firmware may be different than the firmware distributed to the backers of the Kickstarter campaign. Especially in regard of the [available modules](http://docs.micropython.org/en/latest/esp8266/quickref.html), turned on debug messages, and alike. Also, the WebREPL may not be started by default.
 
 </div>
 

--- a/source/_posts/2017-11-12-tor.markdown
+++ b/source/_posts/2017-11-12-tor.markdown
@@ -97,4 +97,4 @@ The setup described in this blog post is easy and relatively secure, but anyone 
 
 This "Stealth"-mode adds an extra layer of security to your Hidden Service by only responding to a client that passes a unique secret cookie as it connects. Obviously, this requires additional configuration on the Tor client applications.
 
-Additional information can be found in the [Tor documentation](/docs/ecosystem/tor/) and the [Tor add-on repository](https://github.com/hassio-addons/addon-tor), including how to setup the "Stealth"-mode. The Tor Project itself provides details about a variaty of topics in their  [documentation](https://www.torproject.org/docs/documentation.html.en).
+Additional information can be found in the [Tor documentation](/docs/ecosystem/tor/) and the [Tor add-on repository](https://github.com/hassio-addons/addon-tor), including how to setup the "Stealth"-mode. The Tor Project itself provides details about a variety of topics in their  [documentation](https://www.torproject.org/docs/documentation.html.en).

--- a/source/_posts/2017-11-12-tor.markdown
+++ b/source/_posts/2017-11-12-tor.markdown
@@ -88,7 +88,7 @@ Simply download and install the [Tor Browser](https://www.torproject.org/project
 Some other clients:
 
 - [Orbot](https://guardianproject.info/apps/orbot/) for Android
-- [Orfox](https://play.google.com/store/apps/details?id=info.guardianproject.orfox&hl=nl) for Android
+- ~~[Orfox](https://play.google.com/store/apps/details?id=info.guardianproject.orfox&hl=nl) for Android~~ Orfox for Android has been deprecated. Please use [Tor Browser for Android](https://www.torproject.org/download/#android). More information about the deprecation [here](https://trac.torproject.org/projects/tor/ticket/29955).
 - [Onion Browser](https://mike.tig.as/onionbrowser/) for iOS
 
 ## Cranking up security

--- a/source/_posts/2017-11-18-release-58.markdown
+++ b/source/_posts/2017-11-18-release-58.markdown
@@ -23,7 +23,7 @@ Talking about our translators, we now have 445 people with an account to help wi
 
 And because more translations is more better, [@robbiet480] has added the iOS app to Lokalise, our translation management platform. The iOS app is currently supported in 7 different languages.
 
-[Learn more about how to help with translations](/blog/2017/11/05/frontend-translations/)
+[Learn more about how to help with translations](/2017/11/06/frontend-translations/)
 
 ## Frontend improvements continue
 

--- a/source/_posts/2018-07-21-release-74.markdown
+++ b/source/_posts/2018-07-21-release-74.markdown
@@ -30,7 +30,7 @@ To try it out today, [read these instructions](https://developers.home-assistant
 
 We keep seeing [great examples](https://twitter.com/home_assistant/status/1019579208622845953) of UIs built with Lovelace. Follow us on social media ([FB](https://www.facebook.com/homeassistantio/?ref=bookmarks), [Twitter](https://twitter.com/home_assistant)) where we will keep sharing great examples.
 
-For the Lovelace changes in this release, check out the [changelog](/lovelace/changelog/). To help our development and design teams, we've also introduced a [Lovelace card gallery](https://home-assistant-lovelace-gallery.netlify.com/).
+For the Lovelace changes in this release, check out the [changelog](/lovelace/changelog/). To help our development and design teams, we've also introduced a [Lovelace card gallery](https://www.awesome-ha.com/).
 
 Thanks to [@c727], [@jeradM] and [@ciotlosm] for leading this effort ❤️
 

--- a/source/_posts/2018-07-21-release-74.markdown
+++ b/source/_posts/2018-07-21-release-74.markdown
@@ -30,7 +30,7 @@ To try it out today, [read these instructions](https://developers.home-assistant
 
 We keep seeing [great examples](https://twitter.com/home_assistant/status/1019579208622845953) of UIs built with Lovelace. Follow us on social media ([FB](https://www.facebook.com/homeassistantio/?ref=bookmarks), [Twitter](https://twitter.com/home_assistant)) where we will keep sharing great examples.
 
-For the Lovelace changes in this release, check out the [changelog](/lovelace/changelog/). To help our development and design teams, we've also introduced a [Lovelace card gallery](https://www.awesome-ha.com/).
+For the Lovelace changes in this release, check out the [changelog](/lovelace/changelog/). To help our development and design teams, we've also introduced a [Lovelace card gallery](https://home-assistant-lovelace-gallery.netlify.com/).
 
 Thanks to [@c727], [@jeradM] and [@ciotlosm] for leading this effort ❤️
 

--- a/source/_posts/2019-01-24-nest-cannot-access-data.markdown
+++ b/source/_posts/2019-01-24-nest-cannot-access-data.markdown
@@ -8,7 +8,7 @@ author_twitter: balloob
 categories: Public-Service-Announcement
 ---
 
-**Update 1 (Jan 24):** We got some reports from people that they are still able to create accounts and generate the right keys. We just verified and this is the case. So for now you can still access your data, which is good. We're still puzzled on the response to our tweet. And thanks to Reddit user /u/lefos123 for [pointing out](https://www.reddit.com/r/homeassistant/comments/ajgiz2/nest_locks_users_out_of_their_own_data/eevh8on/) that they [announced this](https://nestdevelopers.io/t/client-reviews-currently-suspended/1548) on Nov 2018.
+**Update 1 (Jan 24):** We got some reports from people that they are still able to create accounts and generate the right keys. We just verified and this is the case. So for now you can still access your data, which is good. We're still puzzled on the response to our tweet. And thanks to Reddit user /u/lefos123 for [pointing out](https://www.reddit.com/r/homeassistant/comments/ajgiz2/nest_locks_users_out_of_their_own_data/eevh8on/) that they ~~[announced this](https://nestdevelopers.io/t/client-reviews-currently-suspended/1548)~~ [updated link](https://developers.nest.com/) on Nov 2018.
 
 Although it's still working, we're still scared about the future of the Nest API.
 

--- a/source/lovelace/changelog.markdown
+++ b/source/lovelace/changelog.markdown
@@ -168,7 +168,7 @@ description: "Changelog of the Lovelace UI."
 - 🔧 [history graph card]: Fix cache of image between views
 
 ## Changes in 0.74.0
-- 📣 [Lovelace card gallery](https://home-assistant-lovelace-gallery.netlify.com/)
+- 📣 [Lovelace card gallery](https://www.awesome-ha.com/)
 - 🔧 Async communication improvements
 
 ### Views


### PR DESCRIPTION
**Description:**

Back out of changes to the Lovelace card gallery.
PR #10678 
Issue #10491 


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant.io/pull/10678

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
