### PR TITLE
Revert lovelace gallery

### DIFF
--- a/source/_posts/2018-07-21-release-74.markdown
+++ b/source/_posts/2018-07-21-release-74.markdown
@@ -30,7 +30,7 @@ To try it out today, [read these instructions](https://developers.home-assistant
 
 We keep seeing [great examples](https://twitter.com/home_assistant/status/1019579208622845953) of UIs built with Lovelace. Follow us on social media ([FB](https://www.facebook.com/homeassistantio/?ref=bookmarks), [Twitter](https://twitter.com/home_assistant)) where we will keep sharing great examples.
 
-For the Lovelace changes in this release, check out the [changelog](/lovelace/changelog/). To help our development and design teams, we've also introduced a [Lovelace card gallery](https://home-assistant-lovelace-gallery.netlify.com/).
+For the Lovelace changes in this release, check out the [changelog](/lovelace/changelog/). To help our development and design teams, we've also introduced a [Lovelace card gallery](https://home-assistant-lovelace-gallery.netlify.com).
 
 Thanks to [@c727], [@jeradM] and [@ciotlosm] for leading this effort ❤️
 

--- a/source/_posts/2018-07-21-release-74.markdown
+++ b/source/_posts/2018-07-21-release-74.markdown
@@ -30,8 +30,6 @@ To try it out today, [read these instructions](https://developers.home-assistant
 
 We keep seeing [great examples](https://twitter.com/home_assistant/status/1019579208622845953) of UIs built with Lovelace. Follow us on social media ([FB](https://www.facebook.com/homeassistantio/?ref=bookmarks), [Twitter](https://twitter.com/home_assistant)) where we will keep sharing great examples.
 
-For the Lovelace changes in this release, check out the [changelog](/lovelace/changelog/). To help our development and design teams, we've also introduced a [Lovelace card gallery](https://home-assistant-lovelace-gallery.netlify.com/).
-
 Thanks to [@c727], [@jeradM] and [@ciotlosm] for leading this effort ❤️
 
 I'm happy to announce that this release introduces support for Tuya thanks to [@huangyupeng]. Tuya produces cheap cloud-enabled devices that are sold under a wide variety of brand names across the globe, and now they work with Home Assistant too!

--- a/source/_posts/2018-07-21-release-74.markdown
+++ b/source/_posts/2018-07-21-release-74.markdown
@@ -30,7 +30,7 @@ To try it out today, [read these instructions](https://developers.home-assistant
 
 We keep seeing [great examples](https://twitter.com/home_assistant/status/1019579208622845953) of UIs built with Lovelace. Follow us on social media ([FB](https://www.facebook.com/homeassistantio/?ref=bookmarks), [Twitter](https://twitter.com/home_assistant)) where we will keep sharing great examples.
 
-For the Lovelace changes in this release, check out the [changelog](/lovelace/changelog/). To help our development and design teams, we've also introduced a [Lovelace card gallery](https://home-assistant-lovelace-gallery.netlify.com).
+For the Lovelace changes in this release, check out the [changelog](/lovelace/changelog/). To help our development and design teams, we've also introduced a [Lovelace card gallery](https://home-assistant-lovelace-gallery.netlify.com/).
 
 Thanks to [@c727], [@jeradM] and [@ciotlosm] for leading this effort ❤️
 


### PR DESCRIPTION
**Description:**

Back out of changes to the Lovelace card gallery.
PR #10678 
Issue #10491 


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant.io/pull/10678

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

