### PR TITLE
Reddit integration doesn't support two-factor auth

### DIFF
--- a/source/_integrations/reddit.markdown
+++ b/source/_integrations/reddit.markdown
@@ -14,6 +14,10 @@ The Reddit sensor integrates data from [Reddit](https://reddit.com/) to monitor 
 
 To set up this sensor, you will need to generate a `client_id` and `client_secret` for the user account you will use to connect. Follow the first steps in [this Wiki page](https://github.com/reddit-archive/reddit/wiki/OAuth2-Quick-Start-Example).
 
+<div class='note'>
+This integration does not support Reddit's two-factor authentication. If you use two-factor authentication for your Reddit account, create a separate Reddit account without two-factor authentication for use with Home Assistant.
+</div>
+
 ## Configuration
 
 To enable this platform, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
Add a note that this integration doesn't support two-factor authentication.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
