### PR TITLE
Document possible options for `operator` in entity-filter card

### DIFF
--- a/source/_lovelace/entity-filter.markdown
+++ b/source/_lovelace/entity-filter.markdown
@@ -84,7 +84,7 @@ value:
   type: string
 operator:
   required: false
-  description: Operator to use in the comparison.
+  description: Operator to use in the comparison. Can be `==`, `<=`, `<`, `>=`, `>`, `!=` or `regex`.
   type: string
 attribute:
   required: false


### PR DESCRIPTION
**Description:** This adds the options that can be set for the new entity-filter attribute `operator`. Currently, one had to check the source to find out what was available.

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant-polymer/issues/3692

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
