### PR TITLE
Add info about images to Discord documentation

### DIFF
--- a/source/_integrations/discord.markdown
+++ b/source/_integrations/discord.markdown
@@ -84,3 +84,5 @@ You can tag any user inside a channel by using their user ID in the message like
 For more information about creating and authorizing bots, visit the [OAuth2 information page](https://discordapp.com/developers/docs/topics/oauth2)
 
 To use notifications effectively, please see the [getting started with automation page](/getting-started/automation/).
+
+Images are uploaded to Discord when a message is sent. As such, a local path to the image is required (i.e. `/config/www/garage.jpg` as opposed to `/local/garage.jpg`), and updating an image after sending it in a message will not update the message in Discord.


### PR DESCRIPTION
**Description:**
Add a note to the Discord documentation about how images are used.

Resolves home-assistant/home-assistant#26560

**Pull request in home-assistant (if applicable):** N/A

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
