### PR TITLE
Set state_filter to required

### DIFF
--- a/source/_lovelace/entity-filter.markdown
+++ b/source/_lovelace/entity-filter.markdown
@@ -23,7 +23,7 @@ entities:
   description: A list of entity IDs or `entity` objects, see below.
   type: list
 state_filter:
-  required: false
+  required: true
   description: List of strings representing states or `filter` objects, see below.
   type: list
 card:


### PR DESCRIPTION
Changed the main state_filter to required as it is required for the filter card. State_filter under entity is not required.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
