### PR TITLE
Docs: Explain Markdown card renderer and supported specs

### DIFF
--- a/source/_lovelace/markdown.markdown
+++ b/source/_lovelace/markdown.markdown
@@ -4,7 +4,10 @@ sidebar_label: Markdown
 description: "Markdown card is used to render markdown"
 ---
 
-Markdown card is used to render [markdown](http://commonmark.org/help/).
+Markdown card is used to render [Markdown](https://commonmark.org/help/).
+
+The renderer uses [Marked.js](https://marked.js.org), which supports [several specifications of Markdown](https://marked.js.org/#/README.md#specifications), including CommonMark, GitHub Flavored Markdown (GFM) and `markdown.pl`.
+ 	 
 
 <p class='img'>
 <img src='/images/lovelace/lovelace_markdown.png' alt='Screenshot of the markdown card'>
@@ -18,7 +21,7 @@ type:
   type: string
 content:
   required: true
-  description: "Content to render as [markdown](http://commonmark.org/help/). May contain [templates](/docs/configuration/templating/)."
+  description: "Content to render as [Markdown](https://commonmark.org/help/). May contain [templates](/docs/configuration/templating/)."
   type: string
 title:
   required: false


### PR DESCRIPTION
**Description:**

Knowing the specifics of what Markdown syntaxes are supported on the Markdown card is very important when writing content.  This change explains which renderer is used and the specs it supports.

~**Pull request in home-assistant (if applicable):**~

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
