### PR TITLE
Fix copy & paste error in homematic documentation for callback_port

### DIFF
--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -94,7 +94,7 @@ callback_ip:
   required: false
   type: string
 callback_port:
-  description: Set this, if Home Assistant is reachable under a different IP from the CCU (NAT, Docker etc.).
+  description: Set this, if Home Assistant is reachable under a different port from the CCU (NAT, Docker etc.).
   required: false
   type: integer
 resolvenames:


### PR DESCRIPTION
**Description:**
The `callback_port` documentation on the homematic integration page was wrong (Talking about IP instead of port). 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
