### PR TITLE
Revert "Allow code elements to wrap if necessary"

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -535,7 +535,7 @@ code {
   font-size: 0.8em;
   color: #1990b8;
   word-spacing: normal;
-  word-break: break-word;
+  word-break: normal;
   word-wrap: normal;
 
   -moz-tab-size: 4;


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#10366

Since it causes issues like this:

![image](https://user-images.githubusercontent.com/195327/66698949-f1806b80-ece2-11e9-8435-a72b286403c6.png)
