### PR TITLE
🔗 Fix broken links in mjpeg and generic ip cam documentation

### DIFF
--- a/source/_integrations/generic_ip_camera.markdown
+++ b/source/_integrations/generic_ip_camera.markdown
@@ -25,11 +25,11 @@ camera:
 
 {% configuration %}
 still_image_url:
-  description: "The URL your camera serves the image on, e.g., http://192.168.1.21:2112/. Can be a [template](/topics/templating/)."
+  description: "The URL your camera serves the image on, e.g., `http://192.168.1.21:2112/`. Can be a [template](/topics/templating/)."
   required: true
   type: string
 stream_source:
-  description: "The URL your camera serves the live stream on, e.g., rtsp://192.168.1.21:554/."
+  description: "The URL your camera serves the live stream on, e.g., `rtsp://192.168.1.21:554/`."
   required: false
   type: string
 name:

--- a/source/_integrations/mjpeg.markdown
+++ b/source/_integrations/mjpeg.markdown
@@ -25,7 +25,7 @@ camera:
 
 {% configuration %}
 mjpeg_url:
-  description: The URL your camera serves the video on, e.g., http://192.168.1.21:2112/
+  description: The URL your camera serves the video on, e.g., `http://192.168.1.21:2112/`
   required: true
   type: string
 still_image_url:


### PR DESCRIPTION
**Description:**
Fix broken links to private addresses in mjpeg and generic ipcam documentation. Related to #10491

**Pull request in home-assistant (if applicable):** n/a

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
