### PR TITLE
🔗 Fix broken links in Tellstick, Android IP Webcam, Squeezebox and Hassbian / installation documentation

### DIFF
--- a/source/_addons/tellstick.markdown
+++ b/source/_addons/tellstick.markdown
@@ -92,7 +92,7 @@ For more information about the configuration including protocols, see the [telld
 
 If you wish to teach a self-learning device in your TellStick configuration:
 
-Go to Home Assistant [service call](http://hassio.local:8123/dev-service) in Developer tools and select.
+Go to Home Assistant service call in Developer tools and select.
 
 - Service: `hassio.addon_stdin`
 - Enter service Data:

--- a/source/_docs/installation/hassbian/installation.markdown
+++ b/source/_docs/installation/hassbian/installation.markdown
@@ -13,7 +13,7 @@ One of the easiest ways to install Home Assistant on your Raspberry Pi Zero, 2, 
 
 <div class='note warning'>
 
-Please remember to ensure you're using an [appropriate power supply](https://www.raspberrypi.org/help/faqs/#powerReqs) with your Pi. Mobile chargers may not be suitable since some were only designed to provide just enough power to the device it was designed for by the manufacturer. **Do not** try to power the Pi from the USB port on a TV, computer, or similar.
+Please remember to ensure you're using an [appropriate power supply](https://www.raspberrypi.org/documentation/faqs/#pi-power) with your Pi. Mobile chargers may not be suitable since some were only designed to provide just enough power to the device it was designed for by the manufacturer. **Do not** try to power the Pi from the USB port on a TV, computer, or similar.
 
 </div>
 
@@ -22,7 +22,7 @@ Additional information is available in this [video](https://www.youtube.com/watc
 
 After initial boot an installer will run in the background, this will download and install the newest version of [hassbian-config](https://github.com/home-assistant/hassbian-scripts) and Home-Assistant, this takes around 10 minutes to complete, after it has finished, you will be prompted to login: `hassbian login:`. Installation is complete at this point. The default username is `pi` and the password is `raspberry`.
 
-Open a browser on a device that's connected to the same network as your Raspberry Pi and point it to Home Assistant at [http://hassbian.local:8123]. If you want to login via SSH, the default username is `pi` and password is `raspberry` (please change this by running `passwd`). The Home Assistant configuration is located at `/home/homeassistant/.homeassistant/`.
+Open a browser on a device that's connected to the same network as your Raspberry Pi and point it to Home Assistant at `http://hassbian.local:8123`. If you want to login via SSH, the default username is `pi` and password is `raspberry` (please change this by running `passwd`). The Home Assistant configuration is located at `/home/homeassistant/.homeassistant/`.
 
 If you find that the web page is not reachable after 30 minutes or so, check that you have files in `/home/homeassistant/.homeassistant/`, if there are no files in this location then run the installer manually using this command: `sudo systemctl start install_homeassistant.service`.
 

--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -14,7 +14,7 @@ Although these installation steps specifically mention a Raspberry Pi, you can g
 
 <div class='note warning'>
 
-Please remember to ensure you're using an [appropriate power supply](https://www.raspberrypi.org/help/faqs/#powerReqs) with your Pi. Mobile chargers may not be suitable, since some are designed to only provide the full power with that manufacturer's handsets. USB ports on your computer also will not supply enough power and must not be used.
+Please remember to ensure you're using an [appropriate power supply](https://www.raspberrypi.org/documentation/faqs/#pi-power) with your Pi. Mobile chargers may not be suitable, since some are designed to only provide the full power with that manufacturer's handsets. USB ports on your computer also will not supply enough power and must not be used.
 
 </div>
 
@@ -84,7 +84,7 @@ Start Home Assistant for the first time. This will complete the installation for
 ```bash
 (homeassistant) $ hass
 ```
-You can now reach your installation on your Raspberry Pi over the web interface on [http://ipaddress:8123](http://ipaddress:8123).
+You can now reach your installation on your Raspberry Pi over the web interface on `http://ipaddress:8123`.
 
 <div class='note'>
 

--- a/source/_integrations/android_ip_webcam.markdown
+++ b/source/_integrations/android_ip_webcam.markdown
@@ -202,4 +202,4 @@ camera:
 
 The `android_ip_webcam` sensor platform lets you observe states of [Android IP webcam](https://play.google.com/store/apps/details?id=com.pas.webcam) sensors through Home Assistant. Devices will be configured automatically.
 
-You can setup your own sensors by examining the JSON file from the webcam server: http://IP:8080/sensors.json
+You can setup your own sensors by examining the JSON file from the webcam server: `http://IP:8080/sensors.json`

--- a/source/_integrations/squeezebox.markdown
+++ b/source/_integrations/squeezebox.markdown
@@ -63,7 +63,7 @@ transporter_toslink:
 
 Call a custom Squeezebox JSONRPC API.
 
-See documentation for this interface on http://HOST:PORT/html/docs/cli-api.html?player= where HOST and PORT are the host name and port for your Logitech Media Server.
+See documentation for this interface on `http://HOST:PORT/html/docs/cli-api.html?player=` where HOST and PORT are the host name and port for your Logitech Media Server.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION
**Description:**
Fix broken links in Tellstick, Android IP Webcam, Squeezebox and Hassbian / installation documentation. Related to #10491

**Pull request in home-assistant (if applicable):** N/a

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
