### PR TITLE
🚧 Add note about NS API changes

### DIFF
--- a/source/_integrations/nederlandse_spoorwegen.markdown
+++ b/source/_integrations/nederlandse_spoorwegen.markdown
@@ -8,6 +8,12 @@ ha_iot_class: Cloud Polling
 ha_release: 0.57
 ---
 
+<div class='note warning'>
+
+  Since October 1, 2019, this integration no longer works due to changes in the NS API. [Work is being done](https://github.com/aquatix/ns-api/pull/17) on a solution, but this can still take several releases before it works again.
+
+</div>
+
 This sensor will provide you with time table information of the [Nederlandse Spoorwegen](https://www.ns.nl/) train service in the Netherlands.
 
 You must create an application [here](https://www.ns.nl/ews-aanvraagformulier/) to obtain a `password`.


### PR DESCRIPTION
**Description:**
NS announced at the beginning of this year that they would adjust the available API. The current integration only worked with the old API.

The API has been fully deprecated since October 1, so it no longer works in Home Assistant until the python lib has been updated to work with new NS API.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
