### PR TITLE
Simplify Android TV setup instructions

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -144,13 +144,11 @@ media_player:
 
 ## ADB Setup
 
-This integration works by sending ADB commands to your Android TV / Fire TV device.
+This integration works by sending ADB commands to your Android TV / Fire TV device. There are two ways to accomplish this.
 
 <div class='note'>
-When connecting to your device for the first time, a dialog will appear on your Android TV / Fire TV asking your to approve the connection. Check the box that says "always allow connections from this device" and hit OK.
+When connecting to your device for the first time, a dialog will appear on your Android TV / Fire TV asking you to approve the connection. Check the box that says "always allow connections from this device" and hit OK.
 </div>
-
-There are two ways to accomplish this:
 
 ### 1. ADB Server
 
@@ -236,7 +234,7 @@ Available key commands include:
 
 The full list of key commands can be found [here](https://github.com/JeffLIrion/python-androidtv/blob/bf1058a2f746535921b3f5247801469c4567e51a/androidtv/constants.py#L143-L186).
 
-You can also use the command `GET_PROPERTIES` to retrieve the properties used by Home Assistant to update the device's state.  These will be stored in the media player's `'adb_response'` attribute and logged at the INFO level, this information can be used to help improve state detection in the backend [androidtv](https://github.com/JeffLIrion/python-androidtv) package.
+You can also use the command `GET_PROPERTIES` to retrieve the properties used by Home Assistant to update the device's state.  These will be stored in the media player's `'adb_response'` attribute and logged at the INFO level. This information can be used to help improve state detection in the backend [androidtv](https://github.com/JeffLIrion/python-androidtv) package, and also to define your own [custom state detection](#custom-state-detection) rules.
 
 A list of various intents can be found [here](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304).
 

--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -29,21 +29,15 @@ For Fire TV devices, the instructions are as follows:
 ```yaml
 # Example configuration.yaml entry
 media_player:
-  # Use the Python ADB implementation without authentication
+  # Use the Python ADB implementation
   - platform: androidtv
     name: Android TV 1
     host: 192.168.0.111
 
-  # Use the Python ADB implementation with authentication
+  # Use an ADB server for sending ADB commands
   - platform: androidtv
     name: Android TV 2
     host: 192.168.0.222
-    adbkey: "/config/android/adbkey"
-
-  # Use an ADB server for sending ADB commands
-  - platform: androidtv
-    name: Android TV 3
-    host: 192.168.0.123
     adb_server_ip: 127.0.0.1
 ```
 
@@ -63,11 +57,11 @@ port:
   default: 5555
   type: integer
 adbkey:
-  description: The path to your `adbkey` file.
+  description: The path to your `adbkey` file; if not provided, Home Assistant will generate a key for you (if necessary).
   required: false
   type: string
 adb_server_ip:
-  description: The IP address of the ADB server.
+  description: The IP address of the ADB server. If this is provided, the integration will utilize an [ADB server](#1-adb-server) to communicate with the device.
   required: false
   type: string
 adb_server_port:
@@ -110,14 +104,14 @@ turn_off_command:
 ```yaml
 # Example configuration.yaml entry
 media_player:
-  # Use an ADB server to setup an Android TV device, provide
-  # an app name, override the default turn on/off commands,
-  # and provide custom state detection rules
+  # Use the Python ADB implementation with a user-provided key to setup an
+  # Android TV device. Provide an app name, override the default turn on/off
+  # commands, and provide custom state detection rules.
   - platform: androidtv
     name: Android TV
     device_class: androidtv
     host: 192.168.0.222
-    adb_server_ip: 127.0.0.1
+    adbkey: "/config/android/adbkey"
     apps:
       com.amazon.tv.launcher: "Fire TV"
     turn_on_command: "input keyevent 3"
@@ -138,19 +132,25 @@ media_player:
             'wake_lock_size': 1       # this indentation is important!
         - 'standby'
 
-  # Use the Python ADB implementation with authentication
-  # to setup a Fire TV device and don't get the running apps
+  # Use an ADB server to setup a Fire TV device and don't get the running apps.
   - platform: androidtv
     name: Fire TV
     device_class: firetv
     host: 192.168.0.222
-    adbkey: "/config/android/adbkey"
+    adb_server_ip: 127.0.0.1
+    adb_server_port: 5037
     get_sources: false
 ```
 
 ## ADB Setup
 
-This integration works by sending ADB commands to your Android TV / Fire TV device. There are two ways to accomplish this:
+This integration works by sending ADB commands to your Android TV / Fire TV device.
+
+<div class='note'>
+When connecting to your device for the first time, a dialog will appear on your Android TV / Fire TV asking your to approve the connection. Check the box that says "always allow connections from this device" and hit OK.
+</div>
+
+There are two ways to accomplish this:
 
 ### 1. ADB Server
 
@@ -160,46 +160,29 @@ For Hass.io users, you can install the [Android Debug Bridge](https://github.com
 
 ### 2. Python ADB Implementation
 
-The second option is to connect to your device using the `adb-shell` Python package.
+The second option is to connect to your device using the `adb-shell` Python package. As of Home Assistant 0.101, if a key is needed for authentication and it is not provided by the `adbkey` configuration option, then Home Assistant will generate a key for you.
 
-If your device requires ADB authentication, you will need to follow the instructions in the [ADB Authentication](#adb-authentication) section below. Once you have an authenticated key, this approach does not require any additional setup or addons. However, users with newer devices may find that the ADB connection is unstable. For a Fire TV device, you can try setting the `get_sources` configuration option to `false`.  If the problem cannot be resolved, you should use the ADB server option.
-
-#### ADB Authentication
-
-If you get a "Device authentication required, no keys available" error when trying to set up your Android TV or Fire TV, then you'll need to create an adbkey and add its path to your configuration. Follow the instructions on this page to connect to your device from your computer: [Connecting to Fire TV Through adb](https://developer.amazon.com/zh/docs/fire-tv/connecting-adb-to-device.html).
-
-<div class='note warning'>
-In the dialog appearing on your Android TV / Fire TV, you must check the box that says "always allow connections from this device." ADB authentication in Home Assistant will only work using a trusted key.
-</div>
-
-Once you've successfully connected to your Android TV / Fire TV via the command `adb connect <ipaddress>:5555`, the file `adbkey` will be created on your computer. The default locations for this file are (from [https://developer.android.com/studio/command-line/adb](https://developer.android.com/studio/command-line/adb)):
-
-- Linux and Mac: `$HOME/.android.`
-- Windows: `%userprofile%\.android.`
-
-Copy the `adbkey` file to your Home Assistant folder and add the path to the `adbkey` file to your configuration.
+Prior to Home Assistant 0.101, this approach did not work well for newer devices. Efforts have been made to resolve these issues, but if you experience problems then you should use the ADB server option.
 
 ## ADB Troubleshooting
 
-If you receive the error message `Error while setting up platform androidtv` in your log when trying to set up an Android TV or Fire TV device, then there is probably an issue with your ADB connection. Here are some possible causes.
+If the setup for your Android TV or Fire TV device fails, then there is probably an issue with your ADB connection. Here are some possible causes.
 
-1. ADB is not enabled on your device.
+1. You have the wrong IP address for the device.
 
-2. You are already connected to the Android TV / Fire TV via ADB from another device. Only one device can be connected, so disconnect the other device, restart the Android TV / Fire TV (for good measure), and then restart Home Assistant.
+2. ADB is not enabled on your device.
 
-3. If you are using the [Python ADB implementation](#2-python-adb-implementation):
+3. You are already connected to the Android TV / Fire TV via ADB from another device. Only one device can be connected, so disconnect the other device, restart the Android TV / Fire TV (for good measure), and then restart Home Assistant.
 
-   * This method often does not work for newer devices. Use the [ADB server](#1-adb-server) approach instead.
+4. You need to approve the ADB connection; see the note in the [ADB Setup](#adb-setup) section above.
 
-   * Your key is not pre-authenticated. Before using the `adbkey` in Home Assistant, you _**must**_ connect to your device using the ADB binary and tell it to always allow connections from this computer. For more information, see the section [ADB Authentication](#adb-authentication) above.
+5. Some Android TV devices (e.g., Philips TVs running Android TV) only accept the initial ADB connection request over their Wi-Fi interface. If you have the TV wired, you need to connect it to WiFi and try the initial connection again. Once the authentication has been granted via Wi-Fi, you can connect to the TV over the wired interface as well.
 
-   * Home Assistant does not have the appropriate permissions for the `adbkey` file and so it is not able to use it. Once you fix the permissions, the integration should work.
-
-4. Some Android TV devices (e.g., Philips TVs running Android TV) only accept the initial ADB connection request over their Wi-Fi interface. If you have the TV wired, you need to connect it to WiFi and try the initial connection again. Once the authentication has been granted via Wi-Fi, you can connect to the TV over the wired interface as well.
+6. If you are using the [Python ADB implementation](#2-python-adb-implementation) approach, as mentioned above, there may be some issues with newer devices. In this case, you should use the [ADB server](#1-adb-server) approach instead.
 
 ## Services
 
-### `media_player.select_source`
+### (Fire TV devices only) `media_player.select_source`
 
 For Fire TV devices, you can launch an app using the `media_player.select_source` command. Simply provide the app ID as the `source`.  You can also stop an app by prefixing the app ID with a `!`. For example, you could define [scripts](/docs/scripts) to start and stop Netflix as follows:
 
@@ -254,6 +237,8 @@ Available key commands include:
 The full list of key commands can be found [here](https://github.com/JeffLIrion/python-androidtv/blob/bf1058a2f746535921b3f5247801469c4567e51a/androidtv/constants.py#L143-L186).
 
 You can also use the command `GET_PROPERTIES` to retrieve the properties used by Home Assistant to update the device's state.  These will be stored in the media player's `'adb_response'` attribute and logged at the INFO level, this information can be used to help improve state detection in the backend [androidtv](https://github.com/JeffLIrion/python-androidtv) package.
+
+A list of various intents can be found [here](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304).
 
 ## Custom State Detection
 


### PR DESCRIPTION
**Description:**

Now that HA can generate a key, it is no longer necessary for the user to first connect to the device from another computer, copy the key to their HA configuration directory, and add it to their configuration.

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/27344

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
