### PR TITLE
Correct docs for adding a picture to a person

### DIFF
--- a/source/_integrations/person.markdown
+++ b/source/_integrations/person.markdown
@@ -93,7 +93,7 @@ By following the instructions on the [customizing entities](/docs/configuration/
 
 ```yaml
 customize:
-  person.ada6789:
+  person.ada:
     entity_picture: "/local/ada.jpg"
 ```
 


### PR DESCRIPTION
Change documentation to correctly use the `name` of the person, rather than the `id`, in the `customize:` section.

**Description:**
The `customize:` section of the configuration uses the `name` of the person, rather than the `id` (as indicated in the current documentation). This PR corrects the documentation.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
