### PR TITLE
Clarity update on the script docs

### DIFF
--- a/source/_integrations/script.markdown
+++ b/source/_integrations/script.markdown
@@ -8,7 +8,7 @@ ha_qa_scale: internal
 ha_release: 0.7
 ---
 
-The `script` integration allows users to specify a sequence of actions to be executed by Home Assistant when turned on. The script integration will create an entity for each script and allow them to be controlled via services.
+The `script` integration allows users to specify a sequence of actions to be executed by Home Assistant. These are run when you turn the script on. The script integration will create an entity for each script and allow them to be controlled via services.
 
 ## Configuration
 


### PR DESCRIPTION
**Description:**

It came up today in [DrZzs Discord](https://discordapp.com/channels/469330414121517056/476055894447357952/632626645139980288) that the wording makes it seem like scripts are run when Home Assistant starts. A minor tweak to make it hopefully clearer that it's turning on _the script_ that makes it run.
**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
