### PR TITLE
Show that growatt server can now be added via the front-end

### DIFF
--- a/source/_integrations/growatt_server.markdown
+++ b/source/_integrations/growatt_server.markdown
@@ -13,11 +13,9 @@ This is a sensor to collect information from your Growatt inverters using [Growa
 
 ## Configuration
 
-This integration supports being configured under the integrations button in home assistant.
+This integration supports being configured under the integrations panel in Home Assistant.
 
-To configure it this way go to the configuration tab in your browser and click on integrations,
-Then click on the + and search for "Growatt Server".
-After which you can simply enter the required details.
+To configure it this way go to the configuration tab in your browser and click on integrations. Next, click on the + and search for "Growatt Server" and enter the required details.
 
 If you'd rather use yaml add the following to your `configuration.yaml` file:
 

--- a/source/_integrations/growatt_server.markdown
+++ b/source/_integrations/growatt_server.markdown
@@ -11,11 +11,15 @@ ha_iot_class: Cloud Polling
 
 This is a sensor to collect information from your Growatt inverters using [Growatt server](https://server.growatt.com/).
 
-This will log into your Growatt account and grab the first "Plant", after which it collects the inverters on this plant and creates sensors for these inverters as well as total sensors.
-
 ## Configuration
 
-Add the following to your `configuration.yaml` file:
+This integration supports being configured under the integrations button in home assistant.
+
+To configure it this way go to the configuration tab in your browser and click on integrations,
+Then click on the + and search for "Growatt Server".
+After which you can simply enter the required details.
+
+If you'd rather use yaml add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -45,6 +49,8 @@ name:
   default: Growatt
   type: string
 {% endconfiguration %}
+
+This will log into your Growatt account and grab the first "Plant", after which it collects the inverters on this plant and creates sensors for these inverters as well as total sensors.
 
 ## Example with multiple plants
 


### PR DESCRIPTION
**Description:**

I added support for the integration tab for the growatt_server integration.
So i updated the documentation accordingly

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27546

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
