### PR TITLE
changed blockquote to italic in Buienradar

### DIFF
--- a/source/_integrations/buienradar.markdown
+++ b/source/_integrations/buienradar.markdown
@@ -113,5 +113,7 @@ version of the name will be used as the name of the entity.
 With the default of "Buienradar loop" the entity name becomes
 `camera.buienradar_loop`.
 
+<div class='note'>
 [Usage statement:](https://www.buienradar.nl/overbuienradar/gratis-weerdata)
-> Buienradar makes free weather data available for use by individuals and businesses (website/intranet). The use of the weather data is allowed for **non-commercial purposes**. Please refer to the full usage statement linked above to confirm your use or to request permission.
+Buienradar makes free weather data available for use by individuals and businesses (website/intranet). The use of the weather data is allowed for **non-commercial purposes**. Please refer to the full usage statement linked above to confirm your use or to request permission.
+</div>

--- a/source/_integrations/buienradar.markdown
+++ b/source/_integrations/buienradar.markdown
@@ -113,5 +113,5 @@ version of the name will be used as the name of the entity.
 With the default of "Buienradar loop" the entity name becomes
 `camera.buienradar_loop`.
 
-*[Usage statement:](https://www.buienradar.nl/overbuienradar/gratis-weerdata)
-Buienradar makes free weather data available for use by individuals and businesses (website/intranet). The use of the weather data is allowed for **non-commercial purposes**. Please refer to the full usage statement linked above to confirm your use or to request permission.*
+_[Usage statement:](https://www.buienradar.nl/overbuienradar/gratis-weerdata)
+Buienradar makes free weather data available for use by individuals and businesses (website/intranet). The use of the weather data is allowed for **non-commercial purposes**. Please refer to the full usage statement linked above to confirm your use or to request permission._

--- a/source/_integrations/buienradar.markdown
+++ b/source/_integrations/buienradar.markdown
@@ -113,7 +113,5 @@ version of the name will be used as the name of the entity.
 With the default of "Buienradar loop" the entity name becomes
 `camera.buienradar_loop`.
 
-<div class='note'>
-[Usage statement:](https://www.buienradar.nl/overbuienradar/gratis-weerdata)
-Buienradar makes free weather data available for use by individuals and businesses (website/intranet). The use of the weather data is allowed for **non-commercial purposes**. Please refer to the full usage statement linked above to confirm your use or to request permission.
-</div>
+*[Usage statement:](https://www.buienradar.nl/overbuienradar/gratis-weerdata)
+Buienradar makes free weather data available for use by individuals and businesses (website/intranet). The use of the weather data is allowed for **non-commercial purposes**. Please refer to the full usage statement linked above to confirm your use or to request permission.*


### PR DESCRIPTION
**Description:**
Changing the blockquote to italic, because the blockquote acts weird by adding \201C and \201D. See https://www.home-assistant.io/integrations/buienradar/

A similar change was done here, which contained the same issue: https://github.com/home-assistant/home-assistant.io/pull/9974

If we actually fix the blockquotes, then feel free to close this PR. I have no clue though how to fix it otherwise ;)

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
