### PR TITLE
replace broken blockquotes with italic

### DIFF
--- a/source/_integrations/dialogflow.markdown
+++ b/source/_integrations/dialogflow.markdown
@@ -15,17 +15,17 @@ Dialogflow could be [integrated](https://dialogflow.com/docs/integrations/) with
 
 Using Dialogflow will be easy to create conversations like:
 
- > User: What is the temperature at home?
- >
- > Bot: The temperature is 34 degrees
+_User: What is the temperature at home?_
 
- > User: Turn on the light
- >
- > Bot: In which room?
- >
- > User: In the kitchen
- >
- > Bot: Turning on kitchen light
+_Bot: The temperature is 34 degrees_
+
+_User: Turn on the light_
+
+_Bot: In which room?_
+
+_User: In the kitchen_
+
+_Bot: Turning on kitchen light_
 
 To use this integration, you should define a conversation (intent) in Dialogflow, configure Home Assistant with the speech to return and, optionally, the action to execute.
 

--- a/source/_integrations/snips.markdown
+++ b/source/_integrations/snips.markdown
@@ -81,11 +81,11 @@ sudo systemctl start "snips-*"
 
 Snips is now ready to take voice commands from the microphone. To trigger the listening, simply say
 
-> Hey Snips
+_Hey Snips_
 
 followed by a command, e.g.
 
-> Set the lights to green in the living room
+_Set the lights to green in the living room_
 
 As the Snips Platform parses this query into an intent, it will be published on MQTT, on the `hermes/intent/<intentName>` topic. The Snips Home Assistant integration subscribes to this topic, and handles the intent according to the rules defined in `configuration.yaml` file, as explained below.
 


### PR DESCRIPTION
**Description:**
Blockquotes are broken due to strange signs. Some remaining blockquotes I could easily find have been replaced with italics.

See:
https://www.home-assistant.io/integrations/dialogflow/
https://www.home-assistant.io/integrations/snips/

Related to:
https://github.com/home-assistant/home-assistant.io/pull/10750

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
