### PR TITLE
config validation is in Server Control

### DIFF
--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -30,7 +30,7 @@ Now let's make a small change using the configurator: we are going to change the
  - Click the `configuration.yaml` file (in the `/config/` folder) to load it into the main Configurator edit window.
  - Find the `homeassistant:` configuration block, which should be the first thing in `configuration.yaml`. In this block, update `name`, `latitude`, `longitude`, `unit_system` and `time_zone` to match yours.
  - Click the save icon in the top right to commit changes.
- - Most changes in `configuration.yaml` require Home Assistant to be restarted to see the changes. You can verify that your changes are acceptable by running a config check. Do this by clicking on Configuration in the sidebar, click on General and click on the "Check Config" button. When it's valid, it will show the text "Configuration valid!".
+ - Most changes in `configuration.yaml` require Home Assistant to be restarted to see the changes. You can verify that your changes are acceptable by running a config check. Do this by clicking on Configuration in the sidebar, click on "Server Control" and click on the "CHECK CONFIG" button. When it's valid, it will show the text "Configuration valid!".
  - Now Restart Home Assistant using the "restart" in the Server management section on the same page. In order for "Check Config" to be visible, you must enable "Advanced Mode" on your user profile.
 
 <p class='img'>


### PR DESCRIPTION
config validation is in Configuration -> Server Control and not in Configuration -> General

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
