### PR TITLE
Add second option to factory-reset Hue bulbs

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -102,9 +102,22 @@ enable_quirks:
 
 To add new devices to the network, call the `permit` service on the `zha` domain. Do this by clicking the Service icon in Developer tools and typing `zha.permit` in the **Service** dropdown box. Next, follow the device instructions for adding, scanning or factory reset.
 
-In case you want to add Philips Hue bulbs that have previously been added to another bridge, have a look at: [https://github.com/vanviegen/hue-thief/](https://github.com/vanviegen/hue-thief/)
-
 ## Troubleshooting
+
+### Add Philips Hue bulbs that have previously been added to another bridge
+
+Philips Hue bulbs that have previously been added to another bridge won't show up during search. You have to restore your bulbs back to factory settings first. To achieve this, you basically have the following options.
+
+#### Philips Hue Dimmer Switch
+Using a Philips Hue Dimmer Switch is probably the easiest way to factory-reset your bulbs. For this to work, the remote doesn't have to be paired with your previous bridge.
+
+1. Turn on your Hue bulb you want to reset
+2. Hold the Dimmer Switch near your bulb (< 10 cm)
+3. Press and hold the (I)/(ON) and (O)/(OFF) buttons of the Dimmer Switch for about 10 seconds until your bulb starts to blink
+4. Your bulb should stop blinking and eventually turning on again. At the same time, a green light on the top left of your remote indicates that your bulb has been successfully reset to factory settings.
+
+#### hue-thief
+Follow the instructions on [https://github.com/vanviegen/hue-thief/](https://github.com/vanviegen/hue-thief/) (EZSP-based Zigbee USB stick required)
 
 ### ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -109,6 +109,7 @@ To add new devices to the network, call the `permit` service on the `zha` domain
 Philips Hue bulbs that have previously been added to another bridge won't show up during search. You have to restore your bulbs back to factory settings first. To achieve this, you basically have the following options.
 
 #### Philips Hue Dimmer Switch
+
 Using a Philips Hue Dimmer Switch is probably the easiest way to factory-reset your bulbs. For this to work, the remote doesn't have to be paired with your previous bridge.
 
 1. Turn on your Hue bulb you want to reset
@@ -117,6 +118,7 @@ Using a Philips Hue Dimmer Switch is probably the easiest way to factory-reset y
 4. Your bulb should stop blinking and eventually turning on again. At the same time, a green light on the top left of your remote indicates that your bulb has been successfully reset to factory settings.
 
 #### hue-thief
+
 Follow the instructions on [https://github.com/vanviegen/hue-thief/](https://github.com/vanviegen/hue-thief/) (EZSP-based Zigbee USB stick required)
 
 ### ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts


### PR DESCRIPTION
**Description:**
Add instructions on how-to reset Philips Hue bulbs with Philips Hue Dimmer Switch in order to use them with ZHA integration.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
