### PR TITLE
Yeelight - Rename and correct Lan Control link in docs

### DIFF
--- a/source/_integrations/yeelight.markdown
+++ b/source/_integrations/yeelight.markdown
@@ -113,9 +113,9 @@ Per default the bulb limits the amount of requests per minute to 60, a limitatio
 <div class='note'>
 
 Before trying to control your light through Home Assistant, you have to setup your bulb using Yeelight app. ( [Android](https://play.google.com/store/apps/details?id=com.yeelight.cherry&hl=fr), [IOS](https://itunes.apple.com/us/app/yeelight/id977125608?mt=8) ).
-In the bulb property, you have to enable "LAN Mode" (previously called "Developer mode"). LAN mode may only be available with the latest firmware installed on your bulb.  Firmware can be updated in the application after connecting the bulb.
+In the bulb property, you have to enable "LAN Control" (previously called "Developer mode"). LAN Control may only be available with the latest firmware installed on your bulb.  Firmware can be updated in the application after connecting the bulb.
 Determine your bulb IP (using router, software, ping...).
-Information on how to enable "LAN Mode" can be found [here](https://getyeti.co/posts/how-to-control-yeelight-and-your-smarthome-with-yeti).
+Information on how to enable "LAN Control" can be found [here](https://www.yeelight.com/faqs/lan_control).
 
 </div>
 


### PR DESCRIPTION
**Description:**

"LAN Mode" appears to be known now as "LAN Control" in the Yeelight app. Also, the instructions to enable LAN Control was a dead link. This has been corrected to point to the official Yeelight instructions.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
