### PR TITLE
fix grouping and sorting for versions >= 0.100.x

### DIFF
--- a/plugins/filters.rb
+++ b/plugins/filters.rb
@@ -100,13 +100,10 @@ module Jekyll
         if minor.length == 1
           "#{major}.X"
         else
-          "#{major}.#{minor[0]}X"
+          "#{major}.#{minor.chop}X"
         end
       }.map { |v|
         sort_key = v[1][-1]["sort_key"]
-        if v[0] == "0.X"
-          sort_key = "0.01" # Ensure 0.X is always sorted at bottom.
-        end
 
         total_new_components = 0
 
@@ -115,7 +112,7 @@ module Jekyll
         end
 
         { "label" => v[0], "versions" => v[1], "new_components_count" => total_new_components, "sort_key" => sort_key }
-      }.sort_by { |v| v["sort_key"] }.reverse
+      }.sort_by { |v| Gem::Version.new(v["sort_key"]) }.reverse
     end
 
     # Get version N behind current


### PR DESCRIPTION
**Description:**

Fixes the grouping and sort order of the versions list on the integrations page for versions after 0.100.x.

When grouped by the first character of the minor version, it groups 0.100 with 0.1. We can instead chop off the last character and have an accurate group. I also fixed the sort order and was able to remove a custom sort key that wasn't needed anymore.

![image](https://user-images.githubusercontent.com/118850/66726302-816b0600-ee06-11e9-9b5f-7117a0ecc9d3.png)

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
