### PR TITLE
Include note about Z-Wave secure inclusion bandwidth usage

### DIFF
--- a/source/_docs/z-wave/adding.markdown
+++ b/source/_docs/z-wave/adding.markdown
@@ -69,6 +69,10 @@ After defining your network key, follow these steps to add (include) a secure Z-
 3. Activate your device to be included by following the instructions provided with the device
 4. With the device in its final location, run a *Heal Network*
 
+<div class='note warning'>
+Secure devices require additional bandwidth, and too many secure devices can slow down your Z-Wave network. We recommend only using secure inclusion for devices that require it, such as locks.
+</div>
+
 ## Removing Devices
 
 To remove (exclude) a Z-Wave device from your system:


### PR DESCRIPTION
**Description:**
Z-Wave secure inclusion uses more bandwidth for communications and can slow down your network. This adds a note to the docs to mention that as we've seen performance issues in discord with too many chatty nodes that were secure included.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
