### PR TITLE
Update samsungtv.markdown

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -111,6 +111,7 @@ Currently tested but not working models:
 - JU7500 - Unable to see state and unable to control
 - MU6125 - Unable to see state and unable to control (Tested on UE58MU6125 on port 8001 and 8801)
 - MU6300 - Port set to 8001, turning on works, status not working reliably, turning off is not permanent (it comes back on)
+- NU7475 - State is always "on" and unable to control (but port 8001 *is* open)
 - Q7F - State is always "off" and unable to control via port 8001.
 
 None of the 2014 (H) and 2015 (J) model series (e.g., J5200) will work, since Samsung have used a different (encrypted) type of interface for these.


### PR DESCRIPTION
Tested on my NU7475, trying the power on/off button returns the error {'event': 'ms.channel.unauthorized'}. 
Home Assistant shows the tv as always on.
Port scanning reveals 8001 is open for vcom-tunnel service. There are 15 open ports, I will try to test them all and I'll update again if one works.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
