### PR TITLE
Fix Link for filtrete

### DIFF
--- a/source/_integrations/radiotherm.markdown
+++ b/source/_integrations/radiotherm.markdown
@@ -8,7 +8,7 @@ ha_iot_class: Local Polling
 ha_release: 0.7.6
 ---
 
-The `radiotherm` climate platform let you control a thermostat from [Radio Thermostat](http://www.radiothermostat.com/) or [3M Filtrete](http://www.radiothermostat.com/filtrete/products/). Your thermostat must have the Wi-Fi module installed and connected to your network.
+The `radiotherm` climate platform let you control a thermostat from [Radio Thermostat](http://www.radiothermostat.com/) or [3M Filtrete](https://www.filtrete.com/). Your thermostat must have the Wi-Fi module installed and connected to your network.
 
 The underlying library supports:
 


### PR DESCRIPTION
Not 100% sure that it's the correct one but seems that they have split and created a dedicated webpage for filtrete

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
