### PR TITLE
Update service.markdown

### DIFF
--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -20,38 +20,30 @@ The MQTT integration will register the service `mqtt.publish` which allows publi
 You need to include either payload or payload_template, but not both.
 </div>
 
-```json
-{
-  "topic": "home-assistant/light/1/command",
-  "payload": "on"
-}
+```yaml
+topic: home-assistant/light/1/command
+payload: on
 ```
 
 {% raw %}
-```json
-{
-  "topic": "home-assistant/light/1/state",
-  "payload_template": "{{ states('device_tracker.paulus') }}"
-}
+```yaml
+topic: "home-assistant/light/1/state
+payload_template: {{ states('device_tracker.paulus') }}
 ```
 {% endraw %}
 
 `payload` must be a string. If you want to send JSON then you need to format/escape it properly. Like:
 
-```json
-{
-  "topic": "home-assistant/light/1/state",
-  "payload":"{\"Status\":\"off\", \"Data\":\"something\"}"
-}
+```yaml
+topic: home-assistant/light/1/state
+payload: {\"Status\":\"off\", \"Data\":\"something\"}
 ``` 
 
 Example of how to use `qos` and `retain`:
 
-```json
-{
-  "topic": "home-assistant/light/1/command",
-  "payload": "on",
-  "qos": 2,
-  "retain": true
-}
+```yaml
+topic: home-assistant/light/1/command
+payload: on
+qos: 2
+retain: true
 ```

--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -36,7 +36,7 @@ payload_template: {{ states('device_tracker.paulus') }}
 
 ```yaml
 topic: home-assistant/light/1/state
-payload: {\"Status\":\"off\", \"Data\":\"something\"}
+payload: "{\"Status\":\"off\", \"Data\":\"something\"}"
 ``` 
 
 Example of how to use `qos` and `retain`:

--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -27,7 +27,7 @@ payload: on
 
 {% raw %}
 ```yaml
-topic: "home-assistant/light/1/state
+topic: home-assistant/light/1/state
 payload_template: {{ states('device_tracker.paulus') }}
 ```
 {% endraw %}


### PR DESCRIPTION

**Description:**

notation changed to yaml


## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
