### PR TITLE
[PATCH0] Add cache_ttl parameter description for ebusd

### DIFF
--- a/source/_integrations/ebusd.markdown
+++ b/source/_integrations/ebusd.markdown
@@ -34,6 +34,11 @@ port:
   type: integer
   required: false
   default: 8888
+cache_ttl:
+  description: Ask ebusd to return cached value if age is less than this value, seconds.
+  type: integer
+  required: false
+  default: 900
 name:
   description: The name to use when displaying this ebusd instance.
   type: string


### PR DESCRIPTION
**Description:**

Document cache_ttl parameter for ebusd

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27710

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
