### PR TITLE
Remove broken Link

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -38,7 +38,7 @@ is covered under an appropriate open source license and you have the right under
 whether created in whole or in part by you, or you have clearly identified the source of the contribution and any license or other
 restriction (like related patents, trademarks, and license agreements) of which you are personally aware.
 
-## Attribution	
+## Attribution
 
 This Contributor License Agreement is adapted from the GitHub CLA.
 

--- a/CLA.md
+++ b/CLA.md
@@ -38,10 +38,6 @@ is covered under an appropriate open source license and you have the right under
 whether created in whole or in part by you, or you have clearly identified the source of the contribution and any license or other
 restriction (like related patents, trademarks, and license agreements) of which you are personally aware.
 
-## Attribution
-
-This Contributor License Agreement is adapted from the [GitHub CLA][github-cla].
-
 ## Signing
 
 To sign this CLA you must first submit a pull request to a repository under the Home Assistant organization.

--- a/CLA.md
+++ b/CLA.md
@@ -38,6 +38,10 @@ is covered under an appropriate open source license and you have the right under
 whether created in whole or in part by you, or you have clearly identified the source of the contribution and any license or other
 restriction (like related patents, trademarks, and license agreements) of which you are personally aware.
 
+## Attribution	
+
+This Contributor License Agreement is adapted from the GitHub CLA.
+
 ## Signing
 
 To sign this CLA you must first submit a pull request to a repository under the Home Assistant organization.
@@ -46,5 +50,4 @@ To sign this CLA you must first submit a pull request to a repository under the 
 
 This Contributor License Agreement (CLA) was first announced on January 21st, 2017 in [this][cla-blog] blog post and adopted January 28th, 2017.
 
-[github-cla]: https://cla.github.com/agreement
 [cla-blog]: https://home-assistant.io/blog/2017/01/21/home-assistant-governance/


### PR DESCRIPTION
Seems that the CLA link to github is not existing anymore. I have been looking to find a replacement but this is all I found 
https://github.com/github/hub/issues/1781. So I thought I might Remove the Link

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
