### PR TITLE
Remove link to a under construction site

### DIFF
--- a/source/_integrations/hook.markdown
+++ b/source/_integrations/hook.markdown
@@ -8,7 +8,7 @@ ha_iot_class: Assumed State
 ha_release: 0.34
 ---
 
-The `hook` integration allows you to control the [Hook Smart Home Hub](http://www.hooksmarthome.com/) from within Home Assistant.
+The `hook` integration allows you to control the Hook Smart Home Hub from within Home Assistant.
 
 Hook allows you to control cheap mains electrical outlets, like these ones at [Amazon](https://amzn.to/2WVZdGG).
 


### PR DESCRIPTION
Seems that the site is under construction and i couldn't find any other reference to a webpage for the product. Except for 3rd party ones.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
