### PR TITLE
Added revert to UI edit mode instructions

### DIFF
--- a/source/lovelace/yaml-mode.markdown
+++ b/source/lovelace/yaml-mode.markdown
@@ -96,3 +96,5 @@ Your previously customized Lovelace UI won't be modifiable anymore and won't fol
   - There you see the config for your actual Lovelace UI, you can copy that into the `<config>/ui-lovelace.yaml` file.
 
 Navigate to `<YOUR HASS URL>/lovelace`. When you make changes to `ui-lovelace.yaml`, you don't have to restart Home Assistant or refresh the page. Just hit the refresh button in the menu at the top of the UI.
+
+To revert to using the UI to edit Lovelace, remove the `configuration.yaml` Lovelace entry and copy your `lovelace.yaml` content back into the raw config section of Home Assiatant and restart.

--- a/source/lovelace/yaml-mode.markdown
+++ b/source/lovelace/yaml-mode.markdown
@@ -97,4 +97,4 @@ Your previously customized Lovelace UI won't be modifiable anymore and won't fol
 
 Navigate to `<YOUR HASS URL>/lovelace`. When you make changes to `ui-lovelace.yaml`, you don't have to restart Home Assistant or refresh the page. Just hit the refresh button in the menu at the top of the UI.
 
-To revert to using the UI to edit Lovelace, remove the `configuration.yaml` Lovelace entry and copy your `lovelace.yaml` content back into the raw config section of Home Assiatant and restart.
+To revert back to using the UI to edit your Lovelace interface, remove the `lovelace` sections from your `configuration.yaml` and copy the contents of your `ui-lovelace.yaml` into the raw config section of Home Assistant and restart.


### PR DESCRIPTION
Added revert to UI edit mode instructions after a user identified that this was not obvious in the Lovelace discord topic.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
