### PR TITLE
Reflect the correct default retain status

### DIFF
--- a/source/_docs/mqtt/birth_will.markdown
+++ b/source/_docs/mqtt/birth_will.markdown
@@ -41,7 +41,7 @@ birth_message:
     retain:
       description: If the published message should have the retain flag on or not.
       required: false
-      default: true
+      default: false
       type: boolean
 will_message:
   description: Will Message
@@ -64,6 +64,6 @@ will_message:
     retain:
       description: If the published message should have the retain flag on or not.
       required: false
-      default: true
+      default: false
       type: boolean
 {% endconfiguration %}


### PR DESCRIPTION
See https://github.com/home-assistant/home-assistant/pull/27574
See https://github.com/home-assistant/home-assistant/issues/27573

**Description:**

Reflect the correct default retain status

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/27574

## Checklist:

- [*] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [*] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
