### PR TITLE
Added missing services to Nuki

### DIFF
--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -47,6 +47,22 @@ This will unlatch the door, ie. open it (provided this works with your type of d
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`s Nuki Locks.
 
+### Service `unlock`
+
+This will unlock the door without unlatching it.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that point at `entity_id`s Nuki Locks.
+
+### Service `lock`
+
+This will lock the door.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | yes | String or list of strings that point at `entity_id`s Nuki Locks.
+
 ### Service `lock_n_go`
 
 This will first unlock, wait a few seconds (20 by default) then re-lock. The wait period can be customized through the app.


### PR DESCRIPTION
I added the missing services `unlock` and `lock` to the services list.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
