### PR TITLE
Missing the required "detector" value

### DIFF
--- a/source/_integrations/doods.markdown
+++ b/source/_integrations/doods.markdown
@@ -23,6 +23,7 @@ The configuration loosely follows the tensorflow configuration. To enable this p
 image_processing:
   - platform: doods
     url: "http://<my doods server>:8080"
+    detector: default
     source:
       - entity_id: camera.front_yard
 ```
@@ -47,7 +48,7 @@ url:
     type: string
 detector:
     description: The DOODS detector to use
-    required: false
+    required: true
     type: string
 confidence:
     description: The default confidence for any detected objects where not explicitly set


### PR DESCRIPTION
Agreed with arsaboo that detector needs to be defined, only value that I could find was "default"

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
