### PR TITLE
Add notice about imports

### DIFF
--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -19,6 +19,12 @@ This integration allows you to write Python scripts that are exposed as services
 [hass-api]: /developers/development_hass_object/
 [logger-api]: https://docs.python.org/3.4/library/logging.html#logger-objects
 
+<div class='note'>
+
+It is not possible to use Python imports with this integration. If you want to do more advanced scripts, you can take a look at [AppDaemon](/docs/ecosystem/appdaemon/)
+
+</div>
+
 ## Writing your first script
 
  - Add to `configuration.yaml`: `python_script:`


### PR DESCRIPTION
Sometimes people are confused, because their Python scripts with imports don't work. I added a notice about that topic.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
