### PR TITLE
Add D6100 to the supported Samsung TV models

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -54,6 +54,7 @@ Currently known supported models:
 
 - C7700
 - D5500
+- D6100
 - D6300SF
 - D6500
 - D6505


### PR DESCRIPTION
**Description:**
Add D6100 to the supported Samsung TV models

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
