### PR TITLE
Update directions to user profile page

### DIFF
--- a/source/_integrations/frontend.markdown
+++ b/source/_integrations/frontend.markdown
@@ -111,7 +111,7 @@ automation:
 
 ### Manual Theme Selection
 
-When themes are enabled in the `configuration.yaml` file, a new option will show up in the user profile menu (accessed by clicking your user account initials at the top of the sidebar). You can then choose any installed theme from the dropdown list and it will be applied immediately.
+When themes are enabled in the `configuration.yaml` file, a new option will show up in the user profile page (accessed by clicking your user account initials at the bottom of the sidebar). You can then choose any installed theme from the dropdown list and it will be applied immediately.
 
 <p class='img'>
   <img src='/images/frontend/user-theme.png' />
@@ -138,7 +138,7 @@ HTML will be loaded via `<link rel='import' href='{{ extra_url }}' async>` on an
 
 ### Manual Language Selection
 
-The browser language is automatically detected. To use a different language, go to the user profile menu (accessed by clicking your user account initials at the top of the sidebar) and select one. It will be applied immediately.
+The browser language is automatically detected. To use a different language, go to the user profile page (accessed by clicking your user account initials at the bottom of the sidebar) and select one. It will be applied immediately.
 
 <p class='img'>
   <img src='/images/frontend/user-language.png' />


### PR DESCRIPTION
**Description:**
User profile page was moved from the top of sidebar to bottom of sidebar starting in 0.96, this text was outdated.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
