### PR TITLE
Update the stop attribute type to string

### DIFF
--- a/source/_integrations/nextbus.markdown
+++ b/source/_integrations/nextbus.markdown
@@ -43,7 +43,7 @@ route:
 stop:
   description: The stop tag from NextBus.
   required: true
-  type: integer
+  type: string
 name:
   description: Name to use in the frontend.
   required: false


### PR DESCRIPTION
**Description:**
The `stop` attribute will be updated to accept a string instead of an integer.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27765
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
