### PR TITLE
Add climate service to Homematic IP Cloud

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -215,7 +215,7 @@ Deactivates the vacation mode immediately.
 ```yaml
 ...
 action:
-  service: homematicip_cloud.deactivate_vacation_mode
+  service: homematicip_cloud.deactivate_vacation
   data:
     accesspoint_id: 3014xxxxxxxxxxxxxxxxxxxx
 ```

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -159,6 +159,7 @@ Within this delay the device registration should be completed in the App, otherw
 - `homematicip_cloud.activate_vacation`: Activates the vacation mode until the given time.
 - `homematicip_cloud.deactivate_eco_mode`: Deactivates the eco mode immediately.
 - `homematicip_cloud.deactivate_vacation`: Deactivates the vacation mode immediately.
+- `homematicip_cloud.set_active_climate_profile`: Set the active climate profile index.
 
 ### Service Examples
 
@@ -218,6 +219,21 @@ action:
   data:
     accesspoint_id: 3014xxxxxxxxxxxxxxxxxxxx
 ```
+
+Set the active climate profile index.
+
+The index of the climate profile is 1-based. 
+You can get the required index from the native Homematic IP App.
+
+```yaml
+...
+action:
+  service: homematicip_cloud.deactivate_vacation_mode
+  data:
+    entity_id: climate.livingroom
+    climate_profile_index: 1
+```
+
 
 ## Additional info
 

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -228,7 +228,7 @@ You can get the required index from the native Homematic IP App.
 ```yaml
 ...
 action:
-  service: homematicip_cloud.deactivate_vacation_mode
+  service: homematicip_cloud.set_active_climate_profile
   data:
     entity_id: climate.livingroom
     climate_profile_index: 1


### PR DESCRIPTION
**Description:**
Add climate service to Homematic IP Cloud to select the active profile


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27772

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
