### PR TITLE
Fix markdown table syntax for system log events

### DIFF
--- a/source/_integrations/system_log.markdown
+++ b/source/_integrations/system_log.markdown
@@ -53,7 +53,7 @@ Write a log entry
 Errors and warnings are posted as the event `system_log_event`, so it is possible to write automations that trigger whenever a warning or error occurs. The following information is included in each event:
 
 | Field       | Description                                                                 |
-|-------------------------------------------------------------------------------------------|
+|-------------|-----------------------------------------------------------------------------|
 | `level`     | Either `WARNING` or `ERROR` depending on severity.                          |
 | `source`    | File that triggered the error, e.g., `core.py` or `media_player/yamaha.py`. |
 | `exception` | Full stack trace if available, an empty string otherwise.                   |


### PR DESCRIPTION
**Description:** fix a simple markdown error in a table in the documentation for system log events

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
