### PR TITLE
Add service description for route53

### DIFF
--- a/source/_integrations/route53.markdown
+++ b/source/_integrations/route53.markdown
@@ -101,3 +101,7 @@ ttl:
   type: integer
   default: 300
 {% endconfiguration %}
+
+### Service `route53.update_records`
+
+Use this service to manually trigger an update of the dns records.

--- a/source/_integrations/route53.markdown
+++ b/source/_integrations/route53.markdown
@@ -102,6 +102,8 @@ ttl:
   default: 300
 {% endconfiguration %}
 
+## Services
+
 ### Service `route53.update_records`
 
-Use this service to manually trigger an update of the dns records.
+Use this service to manually trigger an update of the DNS records.


### PR DESCRIPTION
**Description:**
Add service description for route53.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27774

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
