### PR TITLE
Working without entities: conversion example added

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -344,8 +344,8 @@ sensor:
 
 {% endraw %}
 
-Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute.  
-Please note that the resulting template will be evaluated by Home Assistant state engine on every state change of these sensors, which in case of `sensor.time` happens every minute and might have negative impact on performance. 
+Useful entities to choose might be `sensor.date` which update once per day or `sensor.time`, which updates once per minute.  
+Please note that the resulting template will be evaluated by Home Assistant state engine on every state change of these sensors, which in case of `sensor.time` happens every minute and might have a negative impact on performance.
  
 An alternative to this is to create an interval-based automation that calls the service `homeassistant.update_entity` for the entities requiring updates. This modified example updates every 5 minutes:
 

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -329,6 +329,9 @@ sensor:
 {% endraw %}
 
 In this case it is also possible to convert the entity-less template above into one that will be updated automatically:
+
+{% raw %}
+
 ````yaml
 sensor:
   - platform: template
@@ -338,6 +341,9 @@ sensor:
         friendly_name: 'Not smoking'
         unit_of_measurement: "Days"
 ````
+
+{% endraw %}
+
 Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute.  
 Please note that the resulting template will be evaluated by Home Assistant state engine on every state change of these sensors, which in case of `sensor.time` happens every minute and might have negative impact on performance. 
  

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -330,6 +330,36 @@ sensor:
 
 Useful entities to choose might be `sensor.date` which update once per day or `sensor.time` which updates once per minute.
 
+Sometimes it is reasonable to convert an entity-less template that operates with time into one with entities to get your sensor value updated automatically:
+
+{% raw %}
+
+```yaml
+# Original entity-less template sensor that WON'T be updated automatically
+- platform: template
+    sensors:
+      house_asleep:
+        value_template: >-
+          {{ is_state('binary_sensor.anybody_home', 'off') and (now().hour|float > 22 or now().hour|float < 6)) }}
+```
+
+{% endraw %}
+
+{% raw %}
+
+```yaml
+# Converted template sensor that uses sensor.time entity and WILL BE be updated automatically on every sensor.time update (i.e every minute)
+# DON'T FORGET TO ENABLE sensor.time IN YOUR configuration.yaml!
+- platform: template
+    sensors:
+      house_asleep:
+        value_template: >-
+          {% set hour = states('sensor.time').split(':')[0]|int %}
+          {{ is_state('binary_sensor.anybody_home', 'off') and (hour > 22 or hour < 6)) }}
+```
+
+{% endraw %}
+
 An alternative to this is to create an interval-based automation that calls the service `homeassistant.update_entity` for the entities requiring updates. This modified example updates every 5 minutes:
 
 {% raw %}


### PR DESCRIPTION
Thought it's an interesting to mention the trick based on this discussion - https://community.home-assistant.io/t/template-platform-binary-sensor-not-updating/68059/2

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
