### PR TITLE
Insolvency warning updated

### DIFF
--- a/source/_integrations/nello.markdown
+++ b/source/_integrations/nello.markdown
@@ -10,7 +10,7 @@ ha_iot_class: Cloud Polling
 ---
 
 <div class="note warning">
-Locumi Labs, the manufacturer of Nello, entered insolvency on the 2<sup>nd</sup> of October 2019 closed their cloud service. Since Nello One locks require this cloud service, the locks will cease to operate as of the 18<sup>th</sup> October 2019.
+Locumi Labs, the manufacturer of Nello, went bankrupt on 2 October 2019. Since Nello One locks require this cloud service, the locks will no longer work if the Nello shuts down the servers, which according to the official announcement should not happen for the time being. Nello has promised existing users via email that they will work on an alternative to use the lock without a server.
 </div>
 
 The `nello` platform allows you to control [Nello](https://www.nello.io) intercoms.


### PR DESCRIPTION
**Description:**

This is the email I got from nello:

> Hi User,
> 
> we are still looking for a solution for the continued operation of nello and will keep the server running longer than until October 18th. This means that your nello one will still work after 18.10. for the time being.
> 
> As soon as we have 100% clarity about the further development, we will get back to you.
> 
> Many greetings,
> 
> the whole nello team

All my hope are in https://github.com/nello-one/nello-pi


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
