### PR TITLE
nginx_proxy: Add documentation for `cloudflare` flag

### DIFF
--- a/source/_addons/nginx_proxy.markdown
+++ b/source/_addons/nginx_proxy.markdown
@@ -17,7 +17,8 @@ In the `http` section of the `configuration.yaml` file remove `ssl_certificate`,
     "active": false,
     "default": "nginx_proxy_default*.conf",
     "servers": "nginx_proxy/*.conf"
-  }
+  },
+  "cloudflare": false
 }
 ```
 
@@ -40,6 +41,11 @@ hsts:
   type: string
 customize:
   description: If true, additional NGINX configuration files for the default server and additional servers are read from files in the `/share` directory specified by the `default` and `servers` variables.
+  required: false
+  type: boolean
+  default: false
+cloudflare:
+  description: If enabled, configure Nginx with a list of IP addresses directly from Cloudflare that will be used for `set_real_ip_from` directive Nginx config.
   required: false
   type: boolean
   default: false


### PR DESCRIPTION
**Description:**
Partial fix for: https://github.com/home-assistant/hassio-addons/issues/776
See also: https://github.com/home-assistant/hassio-addons/pull/795


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#751

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
