### PR TITLE
Fix mqtt discovery links

### DIFF
--- a/source/_posts/2017-07-02-release-48.markdown
+++ b/source/_posts/2017-07-02-release-48.markdown
@@ -469,7 +469,7 @@ light:
 [media_player.plex docs]: /integrations/plex#media-player
 [media_player.soundtouch docs]: /integrations/soundtouch
 [mqtt docs]: /integrations/mqtt/
-[mqtt.discovery docs]: /integrations/mqtt.discovery/
+[mqtt.discovery docs]: /docs/mqtt/discovery/
 [notify.clicksend docs]: /integrations/clicksend
 [notify.html5 docs]: /integrations/html5
 [notify.smtp docs]: /integrations/smtp

--- a/source/_posts/2017-11-18-release-58.markdown
+++ b/source/_posts/2017-11-18-release-58.markdown
@@ -428,7 +428,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [media_player.webostv docs]: /integrations/webostv#media-player
 [media_player.yamaha_musiccast docs]: /integrations/yamaha_musiccast/
 [mqtt docs]: /integrations/mqtt/
-[mqtt.discovery docs]: /integrations/mqtt.discovery/
+[mqtt.discovery docs]: /docs/mqtt/discovery/
 [mqtt.server docs]: /integrations/mqtt.server/
 [mqtt_statestream docs]: /integrations/mqtt_statestream/
 [neato docs]: /integrations/neato/


### PR DESCRIPTION
**Description:**
Fix outdated links for mqtt discovery page. Referencing #10491.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
