### PR TITLE
Update secrets.markdown

### DIFF
--- a/source/_docs/configuration/secrets.markdown
+++ b/source/_docs/configuration/secrets.markdown
@@ -13,15 +13,19 @@ The workflow for moving private information to `secrets.yaml` is very similar to
 The entries for password and API keys in the `configuration.yaml` file usually looks like the example below.
 
 ```yaml
-http:
-  api_password: YOUR_PASSWORD
+homeassistant:
+  auth_providers:
+   - type: legacy_api_password
+     api_password: YOUR_PASSWORD
 ```
 
 Those entries need to be replaced with `!secret` and an identifier.
 
 ```yaml
-http:
-  api_password: !secret http_password
+homeassistant:
+  auth_providers:
+   - type: legacy_api_password
+     api_password: !secret http_password
 ```
 
 The `secrets.yaml` file contains the corresponding password assigned to the identifier.


### PR DESCRIPTION
Change because http password moved to auth providers.

**Description:**
Added proper examples to this page

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
