### PR TITLE
Unifi Docs are contradictory

### DIFF
--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -22,7 +22,7 @@ There is currently support for the following device types within Home Assistant:
 
 Home Assistant offers UniFi integration through **Configuration** -> **Integrations** -> **UniFi Controller**.
 
-Enter `host address`, `user name` and `password` and then continue to select which `site` you want to connect to Home Assistant. The user needs administrator privileges in order to control POE switches.
+Enter `host` address, `username` and `password` and then continue to select which `site` you want to connect to Home Assistant. The user needs administrator privileges in order to control POE switches.
 
 ### Extra configuration for device tracker
 
@@ -33,7 +33,7 @@ You can augment the behavior of UniFi device tracker by adding
 unifi:
   controllers:
     - host: unifi
-      site: My site
+      site: 'My site'
       ssid_filter:
         - 'HomeSSID'
         - 'IoTSSID'


### PR DESCRIPTION
**Description:**
A couple of minor changes toward improving config clarity.
It says to set username and password before setting site but setting the `username` parameter here in configuration.yaml, shows up as an 'invalid parameter' in logs.  Looking at the code, username and password do seem to be legit parameters(AFAICT) but they're not listed as valid params (in yaml example above), so not sure what going on for manual yaml config.

Creating a new integration through UI does ask for username and password.
 
Further docs modification necessary.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>
