### PR TITLE
Remove analytics-receiver source ref

### DIFF
--- a/source/_posts/2016-10-24-explaining-the-updater.markdown
+++ b/source/_posts/2016-10-24-explaining-the-updater.markdown
@@ -45,12 +45,7 @@ We decided to have it enabled by default because we consider the information tha
 
 It is in our short-term planning to add an option to control this to our frontend.
 
-## Source Code
-The source code of our updater AWS Lambda function is now available [here][source].
-
-
 [0.31]: /blog/2016/10/22/flash-briefing-updater-hacktoberfest/#comment-2965607849
 [geolite]: https://dev.maxmind.com/geoip/geoip2/geolite2/
 [opt-out]: /integrations/updater/
 [rpi-image]: /blog/2016/10/01/we-have-raspberry-image-now/
-[source]: https://github.com/home-assistant/Analytics-Receiver


### PR DESCRIPTION
Ref #10491

Removes reference to Analytics-receiver
Ref #10491 

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
