### PR TITLE
Fix typo #10491

### DIFF
--- a/source/_integrations/dispatcher.markdown
+++ b/source/_integrations/dispatcher.markdown
@@ -12,7 +12,7 @@ ha_iot_class: Configurable
 This platform is meant for developers only.
 </div>
 
-The `dispatcher` camera platform allows developers to create virtual camera's.
+The `dispatcher` camera platform allows developers to create virtual cameras.
 
 ## Configuration
 


### PR DESCRIPTION
**Description:**
Fix typo #10491 


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
