### PR TITLE
Fix Transmission example message formatting

### DIFF
--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -97,6 +97,8 @@ Inside of the event, there is the name of the torrent that is started or complet
 
 Example of configuration of an automation with completed torrents:
 
+{% raw %}
+
 ```yaml
 - alias: Completed Torrent
   trigger:
@@ -108,6 +110,8 @@ Example of configuration of an automation with completed torrents:
       title: "Torrent completed!"
       message: "{{trigger.event.data.name}}"
 ```
+
+{% endraw %}
 
 ## Services
 


### PR DESCRIPTION
**Description:**
The Transmission example code didn't escape the event message so it didn't show in the example. 
## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
