### PR TITLE
Fix blog link

### DIFF
--- a/source/_posts/2017-11-18-release-58.markdown
+++ b/source/_posts/2017-11-18-release-58.markdown
@@ -23,7 +23,7 @@ Talking about our translators, we now have 445 people with an account to help wi
 
 And because more translations is more better, [@robbiet480] has added the iOS app to Lokalise, our translation management platform. The iOS app is currently supported in 7 different languages.
 
-[Learn more about how to help with translations](/2017/11/06/frontend-translations/)
+[Learn more about how to help with translations](/blog/2017/11/06/frontend-translations/)
 
 ## Frontend improvements continue
 


### PR DESCRIPTION
**Description:**
Fix broken blog link. Referencing #10491 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
