### PR TITLE
Fix websocket sensor link

### DIFF
--- a/source/_posts/2018-10-29-release-81.markdown
+++ b/source/_posts/2018-10-29-release-81.markdown
@@ -790,7 +790,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [rflink docs]: /integrations/rflink/
 [route53 docs]: /integrations/route53/
 [sabnzbd docs]: /integrations/sabnzbd/
-[sensor.api_streams docs]: /integrations/sensor.websocket_apis/
+[sensor.api_streams docs]: /integrations/sensor.websocket_api/
 [sensor.bloomsky docs]: /integrations/bloomsky/#sensor
 [sensor.bmw_connected_drive docs]: /integrations/bmw_connected_drive
 [sensor.dnsip docs]: /integrations/dnsip


### PR DESCRIPTION
**Description:**
Update link to websocket sensor doc. Referencing #10491 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
