### PR TITLE
Fix openalpr_local links

### DIFF
--- a/source/_posts/2016-09-29-async-sleepiq-emoncms-stocks.markdown
+++ b/source/_posts/2016-09-29-async-sleepiq-emoncms-stocks.markdown
@@ -172,7 +172,7 @@ Since 0.28 [automation rules](/blog/2016/09/10/notify-group-reload-api-pihole/#r
 [Modbus]: /integrations/modbus/
 [Nest]: /integrations/nest/
 [Nuimo]: /integrations/nuimo_controller/
-[OpenALPR]: /integrations/openalpr_local_local
+[OpenALPR]: /integrations/openalpr_local/
 [passwordless]: /integrations/http/
 [Simplepush]: /integrations/simplepush
 [Slack]: /integrations/slack

--- a/source/_posts/2017-01-14-iss-usps-images-packages.markdown
+++ b/source/_posts/2017-01-14-iss-usps-images-packages.markdown
@@ -176,7 +176,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [packages]: /topics/packages/
 [pico]: /integrations/picotts
 [ping]: /integrations/ping
-[plates]: /integrations/openalpr_local_local
+[plates]: /integrations/openalpr_local/
 [quebec]: /integrations/hydroquebec
 [rest]: /integrations/rest_command/
 [sma]: /integrations/sma#sensors

--- a/source/_posts/2017-11-04-release-57.markdown
+++ b/source/_posts/2017-11-04-release-57.markdown
@@ -562,7 +562,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [hassio docs]: /integrations/hassio/
 [history docs]: /integrations/history/
 [http docs]: /integrations/http/
-[image_processing.openalpr_local docs]: /integrations/openalpr_local_local
+[image_processing.openalpr_local docs]: /integrations/openalpr_local/
 [input_number docs]: /integrations/input_number/
 [input_text docs]: /integrations/input_text/
 [introduction docs]: /integrations/introduction/


### PR DESCRIPTION
**Description:**
Fix openalpr_local links. Referencing #10491 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
