### PR TITLE
Fix Client ID in setup instructions

### DIFF
--- a/source/_integrations/alexa.smart_home.markdown
+++ b/source/_integrations/alexa.smart_home.markdown
@@ -168,7 +168,7 @@ Alexa can link your Amazon account to your Home Assistant account. Therefore Hom
   * `Access Token URI`: https://[YOUR HOME ASSISTANT URL:PORT]/auth/token
   * `Client ID`:
     - https://pitangui.amazon.com/ if you are in US
-    - https://layla.amazon.co.uk/ if you are in EU
+    - https://layla.amazon.com/ if you are in EU
     - https://alexa.amazon.co.jp/ if you are in JP and AU (not verified yet)
     
     The trailing slash is important here.


### PR DESCRIPTION
Hi 
I've just setup an alexa skill using these instructions.
All seemed to work well.

2 Issues
1. The Client ID for EU doesn't seem to be correct.
I've fixed it here.

2. Error linking lambda and skill

When attaching the lamdba reference to the Skill I came across the issue and solution below (found from the error msg)
https://forums.developer.amazon.com/questions/183361/failed-to-save-skill-information.html
I could add a note for that , but I'm assuming it's something local to what I did.

Hope it helps
Peter

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
