### PR TITLE
Remove pre 0.80 upgrade help

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -26,41 +26,6 @@ To use Google Assistant, your Home Assistant configuration has to be [externally
 
 </div>
 
-## Migrate to release 0.80 and above
-
-<div class='note'>
-
-If this is the first time setting up your Google Assistant integration, you can skip this section and continue with the [manual setup instructions](#first-time-setup) below.
-
-</div>
-
-Since release 0.80, the `Authorization Code` type of `OAuth` account linking is supported. To migrate your existing configuration from release 0.79 or below, you need:
-
-1. Change your `Account linking` setting in [Actions on Google console](https://console.actions.google.com/).  Select the `Develop` tab at the top of the page.  Then select `Account linking` from the left side menu.
-    - Change `Linking type` to `OAuth` and `Authorization Code`.
-    - In the `OAuth Client information` section:
-        - Change `Client ID` to `https://oauth-redirect.googleusercontent.com/`, the trailing slash is important.
-        - Input any string you like into `Client Secret`, Home Assistant doesn't need this field.
-        - Change `Authorization URL` to `https://[YOUR HOME ASSISTANT URL:PORT]/auth/authorize` (replace with your actual URL).
-        - Change `Token URL` to `https://[YOUR HOME ASSISTANT URL:PORT]/auth/token` (replace with your actual URL).
-    - In the `Configure your client` section:
-        - Do **NOT** check `Google to transmit clientID and secret via HTTP basic auth header`.
-    - Click `Save` at the top right corner, then click `Test` (also at the top right corner) to generate a new draft version of the Test App.
-2. Change your `configuration.yaml` file:
-    - Remove `client_id`, `access_token`, `agent_user_id` config from `google_assistant:` since they are no longer needed.
-3. Restart Home Assistant, open the `Google Home` app on your mobile phone then go to `Account > Settings > Assistant > Home Control`, press the `3 dot icon in the top right > Manage accounts > [test] your app name > Unlink account` Then relink your account by selecting `[test] your app name` again.
-4. A browser will open and ask you to login to your Home Assistant instance and will redirect back to the `Google Assistant` app right afterward.
-
-<div class='note'>
-
-If you've added Home Assistant to the home screen, you have to first remove it from home screen, otherwise, this HTML5 app will show up instead of a browser. Using it would prevent Home Assistant to redirect back to the `Google Assistant` app.
-
-If you're still having trouble, make sure that you're not connected to the same network Home Assistant is running on, e.g., use 4G/LTE instead.
-
-</div>
-
-## First time setup
-
 You need to create an API Key with the [Google Cloud API Console](https://console.cloud.google.com/apis/api/homegraph.googleapis.com/overview) which allows you to update devices without unlinking and relinking an account (see [below](#troubleshooting-the-request_sync-service)). If you don't provide one, the `google_assistant.request_sync` service is not exposed. It is recommended to set up this configuration key as it also allows the usage of the following command, "Ok Google, sync my devices". Once you have set up this component, you will need to call this service (or command) each time you add a new device that you wish to control via the Google Assistant integration.
 
 1. Create a new project in the [Actions on Google console](https://console.actions.google.com/).
@@ -114,7 +79,7 @@ If you've added Home Assistant to the home screen, you have to first remove it f
     3. Go to Credentials, which you can find on the left navigation bar under the key icon, and select API Key from Create Credentials.
     4. Note down the generated API Key and use this in the configuration.
 
-## Configuration
+### Configuration
 
 Now add the following lines to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**
Drop some old notes about how to upgrade an old 0.80 configuration. That is way to old to have such a prominant place in documentation.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
