### PR TITLE
Add Presence Netatmo Camera services (set_light_auto, set_light_on, s…

### DIFF
--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -251,6 +251,18 @@ camera:
     - camera_name2
 ```
 
+### Services (only for camera)
+
+The services below permit to control whether the camera should monitor and alert on motion detection. Also, it allows to control the status of the flood light (only for Presence model).
+
+| Service | Description |
+| ------- | ----------- |
+| enable_motion_detection | Enable motion detection and alert. 
+| disable_motion_detection | Disable motion detection and alert. 
+| set_light_auto | Presence model only : Set flood light on automatic mode.
+| set_light_on | Presence model only : Set flood light on.
+| set_light_off | Presence model only : Set flood light off.
+
 ## Climate
 
 The `netatmo` thermostat platform is consuming the information provided by a [Netatmo Smart Thermostat](https://www.netatmo.com/product/energy/thermostat) thermostat. This integration allows you to view the current temperature and setpoint.


### PR DESCRIPTION
**Description:**
The services below permit to control whether the camera should monitor and alert on motion detection. Also, it allows to control the status of the flood light (only for Presence model).

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27970

## Checklist:

- [ x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
