### PR TITLE
🚚 Move integrations to the right folder

### DIFF
--- a/source/_integrations/apprise.markdown
+++ b/source/_integrations/apprise.markdown
@@ -4,10 +4,10 @@ description: "Instructions on how to add Apprise notifications to Home Assistant
 logo: apprise.png
 ha_category:
   - Notifications
-ha_release: "0.101"
+ha_release: 0.101
 ---
 
-The [Apprise service](https://github.com/caronc/apprise/) is an all-in-one solution to open up Home Assistant to _just about_ every Notification platform (such as Amazon SNS, Discord, Telegram, Slack, MSTeams, Twilio, etc.
+The [Apprise service](https://github.com/caronc/apprise/) is an all-in-one solution to open up Home Assistant to _just about_ every Notification platform (such as Amazon SNS, Discord, Telegram, Slack, MSTeams, Twilio, etc.)
 
 To use Apprise supported notifications, add the following to your `configuration.yaml` file:
 

--- a/source/_integrations/sinch.markdown
+++ b/source/_integrations/sinch.markdown
@@ -4,7 +4,7 @@ description: "Instructions on how to add Sinch notifications to Home Assistant."
 logo: sinch.png
 ha_category:
   - Notifications
-ha_release: 0.100
+ha_release: 0.101
 ---
 
 The `sinch` platform uses [Sinch](https://www.sinch.com/products/messaging/sms/) to deliver notifications from Home Assistant.


### PR DESCRIPTION
**Description:**
I noticed that 2 integrations pages were in the wrong place and the release number was incorrect.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
