### PR TITLE
Support custom source type for MQTT device tracker

### DIFF
--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -44,7 +44,7 @@ payload_not_home:
   type: string
   default: 'not_home'
 source_type:
-  description: Attribute of a device tracker that affects state when being used to track a [person](https://www.home-assistant.io/integrations/person/). Valid options are `gps`, `router`, `bluetooth`, or `bluetooth_le`.
+  description: Attribute of a device tracker that affects state when being used to track a [person](/integrations/person/). Valid options are `gps`, `router`, `bluetooth`, or `bluetooth_le`.
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_integrations/device_tracker.mqtt.markdown
+++ b/source/_integrations/device_tracker.mqtt.markdown
@@ -43,6 +43,10 @@ payload_not_home:
   required: false
   type: string
   default: 'not_home'
+source_type:
+  description: Attribute of a device tracker that affects state when being used to track a [person](https://www.home-assistant.io/integrations/person/). Valid options are `gps`, `router`, `bluetooth`, or `bluetooth_le`.
+  required: false
+  type: string
 {% endconfiguration %}
 
 ## Complete example configuration
@@ -56,6 +60,7 @@ device_tracker:
   qos: 1
   payload_home: 'present'
   payload_not_home: 'not present'
+  source_type: bluetooth
 ```
 
 ## Usage


### PR DESCRIPTION
**Description:**
Add configuration option for MQTT device tracker to set a source type. This allows the device tracker to be used to control a person component's state differently depending on whether it's a stationary device or GPS based device.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27838

Note: depends on #10581 to be merged first (https://github.com/home-assistant/home-assistant.io/pull/10856/commits/7001d4c4c4e73ab7c8bf0a447586ba095fbe5f73) is the only commit relevant to this particular PR

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
