### PR TITLE
rest_command now supports PATCH request method

### DIFF
--- a/source/_integrations/rest_command.markdown
+++ b/source/_integrations/rest_command.markdown
@@ -33,7 +33,7 @@ service_name:
       required: true
       type: [string, template]
     method:
-      description: HTTP method to use (get, post, put, or delete).
+      description: HTTP method to use (get, patch, post, put, or delete).
       required: false
       default: get
       type: string
@@ -57,7 +57,7 @@ service_name:
       description: Timeout for requests in seconds.
       required: false
       type: string
-      defaut: 10
+      default: 10
     content_type:
       description: Content type for the request.
       required: false


### PR DESCRIPTION
**Description:**
Documentation update for changes to the `rest_command` integration.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27989

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
