### PR TITLE
Lovelace: add show_state option to picture-glance and glance cards

### DIFF
--- a/source/_lovelace/glance.markdown
+++ b/source/_lovelace/glance.markdown
@@ -75,6 +75,11 @@ show_last_changed:
   description: Overwrites the state display with the relative time since last changed.
   type: boolean
   default: false
+show_state:
+  required: false
+  description: Show entity state-text.
+  type: boolean
+  default: true
 tap_action:
   required: false
   description: Action to take on tap

--- a/source/_lovelace/picture-glance.markdown
+++ b/source/_lovelace/picture-glance.markdown
@@ -58,6 +58,11 @@ entity:
   required: false
   description: Entity to use for `state_image`.
   type: string
+show_state:
+  required: false
+  description: Show entity state-text.
+  type: boolean
+  default: true
 tap_action:
   required: false
   description: Action to take on tap
@@ -178,6 +183,11 @@ icon:
   required: false
   description: Overwrites default icon.
   type: string
+show_state:
+  required: false
+  description: Show entity state-text.
+  type: boolean
+  default: true
 tap_action:
   required: false
   description: Action to take on tap


### PR DESCRIPTION
**Description:**

https://github.com/home-assistant/home-assistant-polymer/pull/3937
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
