### PR TITLE
Correct grammar and improve clarity

### DIFF
--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -7,7 +7,7 @@ description: "Getting started: How to install Home Assistant."
 
 Note for contributors:
 
-The getting started guide aims at getting new users get Home Assistant  up and
+The getting started guide aims at getting new users get Home Assistant up and
 running as fast as possible. Nothing else. All other things should not be
 written down, as it creates a spaghetti of links and the user will lose focus.
 
@@ -25,20 +25,20 @@ So here are guidelines:
 
 {% endcomment %}
 
-The goal of this getting started guide is to get Home Assistant running on a Raspberry Pi. The easiest way to do this is by using [Hass.io](/hassio/), which is our own all in one solution that turns Raspberry Pi's and other devices into the ultimate home automation hubs.
+This guide will help you get Home Assistant running on a Raspberry Pi. The easiest way to do this is by using the [Hass.io](/hassio/) installer, which is our all-in-one solution that turns Raspberry Pis and other devices into the ultimate home automation hub.
 
-Follow this guide if you want to get started with Home Assistant easily, or if you have little or no Linux experience. For advanced users or if you don't have a [device that is supported by this guide][supported], check our [alternative installation methods](/docs/installation/). Once you finish your alternative installation, you can continue at the [next step][next-step].
+Follow this guide if you want to get started with Home Assistant easily or if you have little to no Linux experience. For advanced users (or if you don't have a [device that is supported by this guide][supported]), check out our [alternative installation methods](/docs/installation/). Once you finish your alternative installation, you can continue at the [next step][next-step].
 
 [supported]: /hassio/installation/
 
 ### Suggested hardware
 
-We will need a few things to get started with installing Home Assistant. The latest Raspberry Pi model makes a good and affordable starting point for your home automation journey. Links below lead to Amazon US. If you're not in the US, you should be able to find these items in web stores in your country.
+We will need a few things to get started with installing Home Assistant. The Raspberry Pi 3 Model B+ is a good, affordable starting point for your home automation journey. Links below lead to Amazon US. If you're not in the US, you should be able to find these items in web stores in your country.
 
 - [Raspberry Pi 3 Model B+](https://amzn.to/2IAyNl0) + [Power Supply](https://www.raspberrypi.org/help/faqs/#powerReqs) (at least 2.5A)
-- [Micro SD Card](https://amzn.to/2X0Z2di). Ideally get one that is [Application Class 2](https://www.sdcard.org/developers/overview/application/index.html) as they handle small I/O much more consistently than cards not optimized to host applications. Size 32 GB or bigger recommended.
-- SD Card reader. Part of most laptops, and also available as [standalone USB sticks](https://amzn.to/2WWxntY) (the brand doesn't matter, just pick the cheapest)
-- Ethernet cable (optional, Hass.io can work with WiFi as well)
+- [Micro SD Card](https://amzn.to/2X0Z2di). Ideally get one that is [Application Class 2](https://www.sdcard.org/developers/overview/application/index.html) as they handle small I/O much more consistently than cards not optimized to host applications. A 32 GB or bigger card is recommended.
+- SD Card reader. This is already part of most laptops, but you can purchase a [standalone USB adapter](https://amzn.to/2WWxntY) if you don't have one. The brand doesn't matter, just pick the cheapest.
+- Ethernet cable. Hass.io can work with Wi-Fi, but an Ethernet connection would be more reliable.
 
 ### Software requirements
 
@@ -49,21 +49,21 @@ We will need a few things to get started with installing Home Assistant. The lat
 
 ### Installing Hass.io
 
-1. Put the SD card in your SD card reader.
+1. Put the SD card in your card reader.
 2. Open balenaEtcher, select the Hass.io image and flash it to the SD card.
-3. Unmount the SD card and remove it from your SD card reader.
-4. Only if you want to configure WiFi or a Static IP (requires USB stick):
-   - Format a USB-Stick to FAT32 with volume-name `CONFIG`.
-   - Create a folder named `network` in the root of the newly formatted USB-stick.
-   - Within that folder create a file named `my-network` without extension.
+3. Unmount the SD card and remove it from your card reader.
+4. Follow this step if you want to configure Wi-Fi or a static IP address (this step requires a flash drive). Otherwise, move to step 5.
+   - Format a flash drive to FAT32 with the volume name `CONFIG`.
+   - Create a folder named `network` in the root of the newly-formatted flash drive.
+   - Within that folder, create a file named `my-network` without a file extension.
    - Copy one of [the examples] to the `my-network` file and adjust accordingly.
-   - Plug the USB-stick into the Raspberry Pi 3.
+   - Plug the flash drive into the Raspberry Pi.
 
-5. Insert the SD card into your Raspberry Pi 3. If you are going to use an Ethernet cable, connect that too.
-6. Connect your Raspberry Pi to the power supply, so it turns on.
-7. The Raspberry Pi will now boot up, connect to the Internet and download the latest version of Home Assistant, which will take about 20 minutes.
-8. Home Assistant will be available at `http://hassio.local:8123`. If you are running an older Windows or have stricter network configuration, you might need to access Home Assistant at `http://hassio:8123`.
-9. If you have used a USB-stick for configuring the network, it can now be removed.
+5. Insert the SD card into your Raspberry Pi. If you are going to use an Ethernet cable, connect that too.
+6. Connect your power supply to the Raspberry Pi.
+7. The Raspberry Pi will now boot up, connect to the Internet and download the latest version of Home Assistant. This will take about 20 minutes.
+8. Home Assistant will be available at `http://hassio.local:8123`. If you are running an older Windows version or have a stricter network configuration, you might need to access Home Assistant at `http://hassio:8123`.
+9. If you have used a flash drive for configuring the network, you can now remove it.
 
 [the examples]: https://github.com/home-assistant/hassos/blob/dev/Documentation/network.md
 

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -63,7 +63,7 @@ We will need a few things to get started with installing Home Assistant. The Ras
 6. Connect your power supply to the Raspberry Pi.
 7. The Raspberry Pi will now boot up, connect to the Internet and download the latest version of Home Assistant. This will take about 20 minutes.
 8. Home Assistant will be available at `http://hassio.local:8123`. If you are running an older Windows version or have a stricter network configuration, you might need to access Home Assistant at `http://hassio:8123`.
-9. If you have used a USB stick for configuring the network, you can now remove it.
+9. If you used a USB stick for configuring the network, you can now remove it.
 
 [the examples]: https://github.com/home-assistant/hassos/blob/dev/Documentation/network.md
 

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -52,18 +52,18 @@ We will need a few things to get started with installing Home Assistant. The Ras
 1. Put the SD card in your card reader.
 2. Open balenaEtcher, select the Hass.io image and flash it to the SD card.
 3. Unmount the SD card and remove it from your card reader.
-4. Follow this step if you want to configure Wi-Fi or a static IP address (this step requires a flash drive). Otherwise, move to step 5.
-   - Format a flash drive to FAT32 with the volume name `CONFIG`.
-   - Create a folder named `network` in the root of the newly-formatted flash drive.
+4. Follow this step if you want to configure Wi-Fi or a static IP address (this step requires a USB stick). Otherwise, move to step 5.
+   - Format a USB stick to FAT32 with the volume name `CONFIG`.
+   - Create a folder named `network` in the root of the newly-formatted USB stick.
    - Within that folder, create a file named `my-network` without a file extension.
    - Copy one of [the examples] to the `my-network` file and adjust accordingly.
-   - Plug the flash drive into the Raspberry Pi.
+   - Plug the USB stick into the Raspberry Pi.
 
 5. Insert the SD card into your Raspberry Pi. If you are going to use an Ethernet cable, connect that too.
 6. Connect your power supply to the Raspberry Pi.
 7. The Raspberry Pi will now boot up, connect to the Internet and download the latest version of Home Assistant. This will take about 20 minutes.
 8. Home Assistant will be available at `http://hassio.local:8123`. If you are running an older Windows version or have a stricter network configuration, you might need to access Home Assistant at `http://hassio:8123`.
-9. If you have used a flash drive for configuring the network, you can now remove it.
+9. If you have used a USB stick for configuring the network, you can now remove it.
 
 [the examples]: https://github.com/home-assistant/hassos/blob/dev/Documentation/network.md
 


### PR DESCRIPTION
The current version of this documentation refers to the Raspberry Pi 3 B+ as "the latest version" which is no longer correct with the release of the Pi 4. I changed this to explicitly refer to the 3 B+ instead of saying "the latest version." Do we want to continue saying "the latest version" and change the other references to the Pi 4 (and change the Amazon affiliate link)? The Hass.io installer for the Pi 4 is still an RC which is why I ask.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
