### PR TITLE
Added missing information about reload core service

### DIFF
--- a/source/_docs/configuration/basic.markdown
+++ b/source/_docs/configuration/basic.markdown
@@ -63,3 +63,7 @@ whitelist_external_dirs:
   required: false
   type: list
 {% endconfiguration %}
+
+### Reload Core Service
+
+Home Assistant offers a service to reload the core configuration while Home Assistant is running called `homeassistant.reload_core_config`. This allows you to change any of the above sections and see it being applied without having to restart Home Assistant. To call this service, go to the "Service" tab under Developer Tools, select the `homeassistant.reload_core_config` service and click the "CALL SERVICE" button. Alternatively, you can press the "Reload Core" button under Configuration > Server Control.


### PR DESCRIPTION
**Description:**


Information about the core reload service is currently only under the customize docs. Core reload is useful for changing anything under the `homeassistant:` config. This is not yet reflected anywhere in the docs. I copy/pasted the information from the customize page with a minor tweak to show it can be used for changes in any section of `homeassistant:`.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
