### PR TITLE
Counter configure with value

### DIFF
--- a/source/_integrations/counter.markdown
+++ b/source/_integrations/counter.markdown
@@ -71,7 +71,7 @@ If `restore` is set to `false`, the `initial` value will only be used when no pr
 
 ## Services
 
-Available services: `increment`, `decrement`, and `reset`.
+Available services: `increment`, `decrement`, `reset` and `configure`.
 
 #### Service `counter.increment`
 
@@ -106,7 +106,9 @@ With this service the properties of the counter can be changed while running.
 | `entity_id`            |      no  | Name of the entity to take action, e.g., `counter.my_custom_counter`. |
 | `minimum`              |     yes  | Set new value for minimum. None disables minimum. |
 | `maximum`              |     yes  | Set new value for maximum. None disables maximum. |
-| `step`                 |     yes  | Set new value for step |
+| `step`                 |     yes  | Set new value for step. |
+| `initial`              |     yes  | Set new value for initial. |
+| `value`                |     yes  | Set the counters state to the given value. |
 
 
 


### PR DESCRIPTION
**Description:**
This extends the service `counter.configure` by the fields `initial` and `value`.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28066

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
