### PR TITLE
Update docs for upcoming MyQ changes

### DIFF
--- a/source/_integrations/myq.markdown
+++ b/source/_integrations/myq.markdown
@@ -20,7 +20,6 @@ cover:
   - platform: myq
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
-    type: chamberlain
 ```
 
 {% configuration %}
@@ -30,10 +29,6 @@ username:
   type: string
 password:
   description: Your MyQ account password.
-  required: true
-  type: string
-type:
-  description: "Your device type/brand. Supported types are `chamberlain`, `liftmaster`, `craftsman` and `merlin`."
   required: true
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**

This PR updates the MyQ docs to remove the `type` configuration parameter.

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/28069

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
