### PR TITLE
Tell people they need opensslv.h and cffi.h in order to use

### DIFF
--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -12,6 +12,18 @@ It's recommended when installing Python packages that you use a [virtual environ
 
 This is a generic guide for running Home Assistant under Python. We recommend to use [our recommended installation guides](/docs/installation/#recommended). The steps below may be shorter but some users find difficulty when applying updates and may run into issues.
 
+{% comment %}
+I propose language somewhat like the following since I have
+answered too many questions on why pip3 install homeassistant fails.
+90+% of the time it seems that the user is missing the specific
+dependencies on opensslv.h and cffi.h.  Clearly, the actual name of such
+packages is dependent upon distro, so I cannot be more specific.  Suit
+yourself on any changes you make to my language or if you just through
+it out.
+{% endcomment %}
+
+Before you begin the guide below, ensure that you have a *so called standard* build environment that includes things like make, gcc, python3 including python3 setuptools and pip modules.  Less obvious is the need to install `openssl-dev` (for opensslv.h) and `libffi-dev` (for cffi.h) in order for things to build later on.
+
 </div>
 
 {% comment %}

--- a/source/_docs/installation/virtualenv.markdown
+++ b/source/_docs/installation/virtualenv.markdown
@@ -12,17 +12,7 @@ It's recommended when installing Python packages that you use a [virtual environ
 
 This is a generic guide for running Home Assistant under Python. We recommend to use [our recommended installation guides](/docs/installation/#recommended). The steps below may be shorter but some users find difficulty when applying updates and may run into issues.
 
-{% comment %}
-I propose language somewhat like the following since I have
-answered too many questions on why pip3 install homeassistant fails.
-90+% of the time it seems that the user is missing the specific
-dependencies on opensslv.h and cffi.h.  Clearly, the actual name of such
-packages is dependent upon distro, so I cannot be more specific.  Suit
-yourself on any changes you make to my language or if you just through
-it out.
-{% endcomment %}
-
-Before you begin the guide below, ensure that you have a *so called standard* build environment that includes things like make, gcc, python3 including python3 setuptools and pip modules.  Less obvious is the need to install `openssl-dev` (for opensslv.h) and `libffi-dev` (for cffi.h) in order for things to build later on.
+Before you begin the guide below, ensure that you have a *so-called standard* build environment that includes things like `make`, `gcc`, `python3`, including Python 3 `setuptools` and `pip` modules. Less obvious is the need to install `openssl-dev` (for opensslv.h) and `libffi-dev` (for cffi.h) for things to build later on.
 
 </div>
 


### PR DESCRIPTION
pip install homeassistant (at least on armv7/armhf).

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
