### PR TITLE
Eliminating wrong/ambiguous calendar_id parameter

### DIFF
--- a/source/_integrations/calendar.google.markdown
+++ b/source/_integrations/calendar.google.markdown
@@ -178,7 +178,7 @@ You can use the service `google.add_event` to create a new calendar event in a c
 
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
-| `calendar_id` | no | The id of the calendar you want. |	*****@group.calendar.google.com
+| `calendar_id` | no | The id of the calendar you want. | *****@group.calendar.google.com
 | `summary` | no | Acts as the title of the event. | Bowling
 | `description` | yes | The description of the event. | Birthday bowling
 | `start_date_time` | yes | The date and time the event should start. | 2019-03-10 20:00:00

--- a/source/_integrations/calendar.google.markdown
+++ b/source/_integrations/calendar.google.markdown
@@ -178,7 +178,7 @@ You can use the service `google.add_event` to create a new calendar event in a c
 
 | Service data attribute | Optional | Description | Example |
 | ---------------------- | -------- | ----------- | --------|
-| `calendar_id` | no | The id of the calendar you want. |	Your email
+| `calendar_id` | no | The id of the calendar you want. |	*****@group.calendar.google.com
 | `summary` | no | Acts as the title of the event. | Bowling
 | `description` | yes | The description of the event. | Birthday bowling
 | `start_date_time` | yes | The date and time the event should start. | 2019-03-10 20:00:00


### PR DESCRIPTION
**Description:**
The explanation to the calendar_id threw me off - it *must* be the cal_id from the calendar, 
not the name of the calendar. 
Changing the parameter in the table to make it more clear for other people.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
