### PR TITLE
Update turn_on_light_for_10_minutes_when_motion_detected.markdown

### DIFF
--- a/source/_cookbook/turn_on_light_for_10_minutes_when_motion_detected.markdown
+++ b/source/_cookbook/turn_on_light_for_10_minutes_when_motion_detected.markdown
@@ -16,7 +16,7 @@ automation:
     entity_id: sensor.motion_sensor
     to: 'on'
   action:
-    service: homeassistant.turn_on
+    service: light.turn_on
     entity_id: light.kitchen_light
 
 - alias: Turn off kitchen light 10 minutes after last movement
@@ -27,7 +27,7 @@ automation:
     for:
       minutes: 10
   action:
-    service: homeassistant.turn_off
+    service: light.turn_off
     entity_id: light.kitchen_light
 ```
 
@@ -41,7 +41,7 @@ automation:
     entity_id: sensor.motion_sensor, binary_sensor.front_door, binary_sensor.doorbell
     to: 'on'
   action:
-  - service: homeassistant.turn_on
+  - service: light.turn_on
     data:
       entity_id:
         - light.hallway_0
@@ -57,7 +57,7 @@ automation:
     event_data:
       entity_id: timer.hallway
   action:
-    service: homeassistant.turn_off
+    service: light.turn_off
     data:
       entity_id:
         - light.hallway_0


### PR DESCRIPTION
Changed to the proper light service for controlling lights

**Description:**
Changed to the proper light service for controlling lights

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
