### PR TITLE
Update automation_sun.markdown

### DIFF
--- a/source/_cookbook/automation_sun.markdown
+++ b/source/_cookbook/automation_sun.markdown
@@ -17,7 +17,7 @@ automation:
     entity_id: group.all_devices
     state: home
   action:
-    service: homeassistant.turn_on
+    service: light.turn_on
     entity_id: group.living_room_lights
 ```
 


### PR DESCRIPTION
Change to the proper service use. Better to use as an example.

**Description:**
Change to the proper service use. Better to use as an example.
Change from homeassistant. to light. service.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
