### PR TITLE
Add note about tvOS 13

### DIFF
--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -18,7 +18,7 @@ There is currently support for the following device types within Home Assistant:
 - [Remote](#remote)
 
 <div class='note'>
-Currently, you must have Home Sharing enabled for this to work. Support for pairing Home Assistant with your device will be supported in a later release.
+Currently, this component does not work with tvOS 13. You must have Home Sharing enabled for this to work with previous versions. Support for pairing Home Assistant with your device will be supported in a later release.
 </div>
 
 ## Configuration


### PR DESCRIPTION
Add to existing note clarifying that apple_tv is currently not compatible with the latest tvOS.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
