### PR TITLE
Added info on how to install dependencies for bluetooth_tracker

### DIFF
--- a/source/_integrations/bluetooth_tracker.markdown
+++ b/source/_integrations/bluetooth_tracker.markdown
@@ -10,6 +10,12 @@ ha_release: 0.18
 
 This tracker discovers new devices on boot and tracks Bluetooth devices periodically based on `interval_seconds` value. It is not required to pair the devices with each other! Devices discovered are stored with 'bt_' as the prefix for device MAC addresses in `known_devices.yaml`.
 
+This platform requires pybluez to be installed. On Debian based installs, run
+
+```bash
+sudo apt install bluetooth libbluetooth-dev
+```
+
 To use the Bluetooth tracker in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
**Description:** Added info on how to install dependencies for bluetooth_tracker

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
