### PR TITLE
Adding charset to imap component

### DIFF
--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -55,6 +55,11 @@ search:
   required: false
   default: UnSeen UnDeleted
   type: string
+charset:
+  description: The characterset used for this connection
+  required: false
+  default: UTF-8
+  type: string
 {% endconfiguration %}
 
 ### Configuring IMAP Searches
@@ -68,7 +73,7 @@ By default, this integration will count unread emails. By configuring the search
 #### Full configuration sample with search
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry for gmail
 sensor:
   - platform: imap
     server: imap.gmail.com
@@ -76,4 +81,15 @@ sensor:
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
     search: FROM <sender@email.com>, SUBJECT <subject here>
+    charset: utf-8
+
+# Example configuration.yaml entry for Office 365
+sensor:
+  - platform: imap
+    server: outlook.office365.com
+    port: 993
+    username: email@address.com
+    password: password
+    search: FROM <sender@email.com>, SUBJECT <subject here>
+    charset: US-ASCII
 ```


### PR DESCRIPTION
**Description:**

The imap component did not work with office 365 because of the wrong charset.
The default charset is UTF-8 in the imap component, Office 365 does not support this.

(This is my first PR, so a little help is appreciated :) )


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28154

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
