### PR TITLE
Update weblink.markdown

### DIFF
--- a/source/_integrations/weblink.markdown
+++ b/source/_integrations/weblink.markdown
@@ -11,7 +11,7 @@ ha_qa_scale: internal
 The `weblink` integration allows you to display links in the Home Assistant frontend.
 
 <div class='note'>
-The below documentation applies to the classic "States" user interface. Starting with Home Assistant 0.86, Lovelace is the new default interface. For information on configuring weblinks in Lovelace please follow [these instructions](/lovelace/entities/#weblink) instead.
+The below documentation applies to the classic "States" user interface. Starting with Home Assistant 0.86, Lovelace is the new default interface. For information on configuring weblinks in Lovelace please follow <a href="/lovelace/entities/#weblink">these instructions</a> instead.
 </div>
 
 ## Configuration

--- a/source/_integrations/weblink.markdown
+++ b/source/_integrations/weblink.markdown
@@ -11,7 +11,9 @@ ha_qa_scale: internal
 The `weblink` integration allows you to display links in the Home Assistant frontend.
 
 <div class='note'>
-The below documentation applies to the classic "States" user interface. Starting with Home Assistant 0.86, Lovelace is the new default interface. For information on configuring weblinks in Lovelace please follow <a href="/lovelace/entities/#weblink">these instructions</a> instead.
+
+The below documentation applies to the classic "States" user interface. Starting with Home Assistant 0.86, Lovelace is the new default interface. For information on configuring weblinks in Lovelace please follow [these instructions](/lovelace/entities/#weblink) instead.
+
 </div>
 
 ## Configuration


### PR DESCRIPTION
Changed link to html, because the note-block is a div.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
