### PR TITLE
Remove MEDIA PLAYER SOURCES paragraph for google assistant

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -208,15 +208,6 @@ By default these cannot be opened by Google Assistant unless a `secure_devices_p
 
 For the Alarm Control Panel if a code is set it must be the same as the `secure_devices_pin`. If `code_arm_required` is set to `false` the system will arm without prompting for the pin.
 
-### Media Player Sources
-
-Media Player sources are sent via the Modes trait in Google Assistant.
-There is currently a limitation with this feature that requires a hard-coded set of settings. Because of this, the only sources that will be usable by this feature [are listed here](https://developers.google.com/actions/reference/smarthome/traits/modes).
-
-#### Example Command:
-
-"Hey Google, change input source to TV on Living Room Receiver"
-
 ### Room/Area support
 
 Entities that have not got rooms explicitly set and that have been placed in Home Assistant areas will return room hints to Google with the devices in those areas.


### PR DESCRIPTION
## Description:
With the introduction of dynamic modes and toggles, this is no longer a limitation as Google has removed the whitelisted modes. See this [blog post](https://developers.googleblog.com/2019/10/announcing-dynamic-modes-and-toggles.html).

> Starting today, you no longer have to get the names and synonyms provided in your SYNC response approved. The Google Assistant dynamically determines the necessary grammar for users to invoke these traits.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
