### PR TITLE
Clarification of namespace usage in logger

### DIFF
--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -53,7 +53,15 @@ logger:
 
     # log level for the `aiohttp` Python package
     aiohttp: error
+
+    # log level for both 'glances_api' and 'glances' integration
+    homeassistant.components.glances: fatal
+    glances_api: fatal
 ```
+
+The log entries are in the form  
+*timestamp* *log-level* *thread* [**namespace**] *message*  
+where **namespace** is the *<component_namespace>* currently logging. 
 
 {% configuration %}
   default:
@@ -70,6 +78,9 @@ logger:
         description: Logger namespace of the component. See [log_level](#log-levels).
         type: string
 {% endconfiguration %}
+
+In the example, do note the difference between 'glances_api' and 'homeassistant.components.glances' namespaces, 
+both of which are at root. They are logged by different APIs.
 
 ### Log Levels
 


### PR DESCRIPTION
**Description:**
Namespace clarification after log flooding

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28156

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
