### PR TITLE
Corrected template

### DIFF
--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -107,7 +107,7 @@ automation (note that you will need a
 automation:
   trigger:
     platform: template
-    value_template: "{{ states('sensor.time') == (state_attr('input_datetime.bedroom_alarm_clock_time', 'timestamp') | int | timestamp_custom('%H:%M', False)) }}"
+    value_template: "{{ states('sensor.time') == (state_attr('input_datetime.bedroom_alarm_clock_time', 'timestamp') | int | timestamp_custom('%H:%M', True)) }}"
   action:
     service: light.turn_on
     entity_id: light.bedroom


### PR DESCRIPTION
Changed the `timestamp_custom` `local_boolean` to `true` as the template was formatted to return a UTC time and compare it to a local time from `sensor.time`.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
