### PR TITLE
flip the logic on how component source links are generated

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -9,7 +9,7 @@
   </div>
 
   {%- assign file_parts = page.url | split: '/' | last | split: '.' -%}
-  {%- assign imp_name = file_parts | first -%}
+  {%- assign imp_name = file_parts | last -%}
   {%- assign imp_url = imp_name | prepend: '/components/' | append: '/' -%}
 
   <div class="section">


### PR DESCRIPTION
**Description:**

Integration docs pages such as sensor.mqtt link the source page to components/sensor instead of components/mqtt. This can be misleading for people that are looking for the source of the specific component they are looking at.

*Based on the current branch this time (very sorry about screwing up my last PR and wasting people's time)

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
