### PR TITLE
Fix a small typo in cloudflare integration doc

### DIFF
--- a/source/_integrations/cloudflare.markdown
+++ b/source/_integrations/cloudflare.markdown
@@ -7,7 +7,7 @@ ha_category:
 ha_release: 0.74
 ---
 
-With the `cloudflare` integration can you keep your Cloudflare records up to date.
+With the `cloudflare` integration you can keep your Cloudflare records up to date.
 
 The integration will run every hour, but can also be started manually by using the service `cloudflare.update_records` under services.
 


### PR DESCRIPTION
Just spotted what I believe is a small typo, nothing really important. Thought I would fix it though.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
