### PR TITLE
clarified Wink integration initial setup

### DIFF
--- a/source/_integrations/wink.markdown
+++ b/source/_integrations/wink.markdown
@@ -52,7 +52,9 @@ Wink requests three pieces of information from the user when they sign up for a 
 2. `Website:` The external address of your Home Assistant instance. If not externally accessible you can use your email address.
 3. `Redirect URI:` This should be `http://192.168.1.5:8123/auth/wink/callback` replacing the IP with the internal IP of your Home Assistant box.
 
-No settings are required in the `configuration.yaml` other than `wink:` this is because you will be guided through setup via the configurator on the frontend.
+No settings are required in the `configuration.yaml` other than `wink:`. 
+
+After adding `wink:` to your `configuration.yaml` and restarting Home Assistant you will see a persistent notification on the frontend with a `CONFIGURE` button that will guide you through the setup via the frontend configurator.
 
 <div class='note'>
 When using the configurator make sure the initial setup is performed on the same local network as the Home Assistant server, if not from the same box Home Assistant is running on. This will allow for authentication redirects to happen correctly.


### PR DESCRIPTION
**Description:**
Clarified the initial setup steps for the Wink integration. The word "Configurator" can be ambiguous and confusing for hass.io users, so walking through the process of the persistent notification should clear things up.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
