### PR TITLE
We were missing a `/`

### DIFF
--- a/source/_posts/2019-10-25-rip-hassbian.markdown
+++ b/source/_posts/2019-10-25-rip-hassbian.markdown
@@ -40,5 +40,5 @@ Last but not least, thank you to all of those who contributed, in any way, to th
 [@ludeeus]: https://github.com/ludeeus
 [pi-gen]: https://github.com/Hassbian/pi-gen
 [hassbian-scripts]: https://github.com/Hassbian/hassbian-scripts
-[Manual installation on a Raspberry Pi]: docs/installation/raspberry-pi/
+[Manual installation on a Raspberry Pi]: /docs/installation/raspberry-pi/
 [raspbian]: https://www.raspberrypi.org/downloads/raspbian/


### PR DESCRIPTION
The URL for the manual install was missing the leading `/`

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
