### PR TITLE
Update androidtv.markdown

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -40,6 +40,12 @@ media_player:
     host: 192.168.0.222
     adbkey: "/config/android/adbkey"
 
+  # Use the Python ADB implementation with authentication on virtual env
+  - platform: androidtv
+    name: Android TV 2
+    host: 192.168.0.222
+    adbkey: "/home/homeassistant/.homeassistant/android/adbkey"
+
   # Use an ADB server for sending ADB commands
   - platform: androidtv
     name: Android TV 3


### PR DESCRIPTION
Added config example on virtual env, seems you have to give an absolute file path to the adbkey file for it to work in virtual env.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
