### PR TITLE
Fixed two errors

### DIFF
--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -200,7 +200,7 @@ vi /etc/devfs.rules
 Add the following lines 
 ```bash
 [devfsrules_jail_allow_usb=7]  
-add path 'cu\*' unhide  
+add path 'cu\*' mode 0660 group 8123 unhide 
 ```
 
 Reload devfs
@@ -222,7 +222,7 @@ sudo iocage console hass
 ```
 
 ```bash
-ls /dev/cu
+ls /dev/cu*
 ```
 This should ouput the following 
 ```bash


### PR DESCRIPTION
Added the group rights for the dev files, and a missing asterisk in the ls command

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
