### PR TITLE
Add description for undocumented service in duckdns

### DIFF
--- a/source/_integrations/duckdns.markdown
+++ b/source/_integrations/duckdns.markdown
@@ -31,6 +31,15 @@ duckdns:
     type: string
 {% endconfiguration %}
 
+## Service `set_txt`
+
+Set the TXT record of your duckdns subdomain.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `txt` | no | Peyload for the TXT record.
+
+
 <div class='note'>
 
 If you are running the Hass.io [DuckDNS add-on](/addons/duckdns/) this integration is not required. The add-on will keep your IP updated with DuckDNS.

--- a/source/_integrations/duckdns.markdown
+++ b/source/_integrations/duckdns.markdown
@@ -37,7 +37,7 @@ Set the TXT record of your DuckDNS subdomain.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `txt` | no | Payload for the TXT record.
+| `txt` | no | Payload for the TXT record. |
 
 
 <div class='note'>

--- a/source/_integrations/duckdns.markdown
+++ b/source/_integrations/duckdns.markdown
@@ -33,11 +33,11 @@ duckdns:
 
 ## Service `set_txt`
 
-Set the TXT record of your duckdns subdomain.
+Set the TXT record of your DuckDNS subdomain.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `txt` | no | Peyload for the TXT record.
+| `txt` | no | Payload for the TXT record.
 
 
 <div class='note'>


### PR DESCRIPTION
**Description:**

Add description for set txt service in duckdns integrations.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28248

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
