### PR TITLE
Fix typo

### DIFF
--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -8,7 +8,7 @@ ha_release: 0.25
 ha_iot_class: Cloud Push
 ---
 
-The `imap` sensor platform is observing your [IMAP server](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol) and reporting the amount of unread emails.
+The `imap` integration is observing your [IMAP server](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol) and reporting the amount of unread emails.
 
 ## Configuration
 
@@ -56,9 +56,9 @@ search:
   default: UnSeen UnDeleted
   type: string
 charset:
-  description: The characterset used for this connection
+  description: The character set used for this connection.
   required: false
-  default: UTF-8
+  default: utf-8
   type: string
 {% endconfiguration %}
 
@@ -81,7 +81,6 @@ sensor:
     username: YOUR_USERNAME
     password: YOUR_PASSWORD
     search: FROM <sender@email.com>, SUBJECT <subject here>
-    charset: utf-8
 
 # Example configuration.yaml entry for Office 365
 sensor:

--- a/source/_integrations/imap_email_content.markdown
+++ b/source/_integrations/imap_email_content.markdown
@@ -8,7 +8,7 @@ ha_iot_class: Cloud Push
 ha_release: 0.25
 ---
 
-The `imap_email_content` sensor platform will read emails from an IMAP email server and report them as a state change within Home Assistant. This is useful if you have a device that only reports its state via email.
+The `imap_email_content` integration will read emails from an IMAP email server and report them as a state change within Home Assistant. This is useful if you have a device that only reports its state via email.
 
 ## Configuration
 
@@ -20,9 +20,9 @@ sensor:
   - platform: imap_email_content
     server: imap.gmail.com
     port: 993
-    username: USERNAME
-    password: PASSWORD
-    folder: <Folder>
+    username: YOUR_USERNAME
+    password: YOUR_PASSWORD
+    folder: YOUR_FOLDER
     senders:
       - example@gmail.com
 ```
@@ -68,7 +68,7 @@ value_template:
     body:
       description: The body of the email.
     subject:
-      description: The subject of the email.
+      description: The subject of the email.git.
     date:
       description: The date and time the email was sent.
 {% endconfiguration %}
@@ -97,4 +97,4 @@ sensor:
 ```
 {% endraw %}
 
-The same template structure can scan the date, body, or sender for matching text before setting the state of the sensor.
+The same template structure can scan the date, body or sender for matching text before setting the state of the sensor.


### PR DESCRIPTION
**Description:**
Fiy typo

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
