### PR TITLE
Isolated distro specific install command

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -148,10 +148,13 @@ You also need to have Docker-CE installed. There are well-documented procedures 
 To prepare your machine for the Hass.io installation, run the following commands:
 
 For Ubuntu:
+
 ```bash
 add-apt-repository universe
 ```
+
 Debian/Ubuntu:
+
 ```bash
 sudo -i
 apt-get install software-properties-common

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -147,10 +147,14 @@ You also need to have Docker-CE installed. There are well-documented procedures 
 
 To prepare your machine for the Hass.io installation, run the following commands:
 
+For Ubuntu:
+```bash
+add-apt-repository universe
+```
+Debian/Ubuntu:
 ```bash
 sudo -i
 apt-get install software-properties-common
-add-apt-repository universe
 apt-get update
 apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
 curl -fsSL get.docker.com | sh


### PR DESCRIPTION
A minor change to abstract out one command that does not apply to the Debian distro.

https://github.com/home-assistant/home-assistant.io/compare/current...borland502:patch-1

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
