### PR TITLE
Update fritzbox_netmonitor additional package information

### DIFF
--- a/source/_integrations/fritzbox_netmonitor.markdown
+++ b/source/_integrations/fritzbox_netmonitor.markdown
@@ -11,7 +11,7 @@ ha_iot_class: Local Polling
 The `fritzbox_netmonitor` sensor monitors the network statistics exposed by [AVM Fritz!Box](https://avm.de/produkte/fritzbox/) routers.
 
 <div class='note warning'>
-It might be necessary to install additional packages: <code>sudo apt-get install libxslt-dev libxml2-dev python3-lxml</code>
+If not running Hass.io it might be necessary to install additional packages: <code>sudo apt-get install libxslt-dev libxml2-dev python3-lxml</code>
 If you are working with the All-in-One installation, you may also need to execute also within your virtual environment the command <code>pip3 install lxml</code>; be patient this will take a while.
 </div>
 


### PR DESCRIPTION
**Description:**
With Hass.io installing additional packages is not necessary.

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
