### PR TITLE
Update bmw_connected_drive url of GitHub library repo

### DIFF
--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -16,7 +16,7 @@ The `bmw_connected_drive` integration lets you retrieve data of your BMW vehicle
 
 The `bmw_connected_drive` integration also works with (recent) Mini vehicles. You need to have a working Mini Connected account, and a Mini Connected enabled vehicle for this to work.
 
-For compatibility with your BMW vehicle check the [bimmer_connected page](https://github.com/m1n3rva/bimmer_connected) on github.
+For compatibility with your BMW vehicle check the [bimmer_connected page](https://github.com/bimmerconnected/bimmer_connected) on GitHub.
 
 This integration provides the following platforms:
 


### PR DESCRIPTION
**Description:**
Change url of BimmerConnected Github repo which has changed recently.

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
