### PR TITLE
Added space to title and description

### DIFF
--- a/source/_integrations/pocketcasts.markdown
+++ b/source/_integrations/pocketcasts.markdown
@@ -1,6 +1,6 @@
 ---
-title: PocketCasts
-description: "Instructions on how to set up PocketCasts sensors within Home Assistant."
+title: Pocket Casts
+description: "Instructions on how to set up Pocket Casts sensors within Home Assistant."
 logo: pocketcasts.png
 ha_category:
   - Multimedia


### PR DESCRIPTION
**Description:**
Pocket Cast's branding includes a space in the name. Updated every mention in the page to match.