### PR TITLE
Documentation for RFXtrx tcp change

### DIFF
--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -12,16 +12,33 @@ The `rfxtrx` integration supports RFXtrx devices by [RFXCOM](http://www.rfxcom.c
 To enable RFXtrx in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry for local serial device
 rfxtrx:
-  device: PATH_TO_DEVICE
+  port: /dev/ttyUSB0
+```
+
+OR
+
+```yaml
+# Example configuration.yaml entry for TCP connected device using ser2net
+rfxtrx:
+  host: 192.168.0.2
+  port: 50000
 ```
 
 {% configuration %}
 device:
-  description: "The path to your device, e.g., `/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0` or `/dev/ttyUSB0`."
-  required: true
+  description: "The path to your device, e.g., `/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0` or `/dev/ttyUSB0`. Required if you are using a locally connected USB device."
+  required: false
   type: string
+host:
+  description: "The hostname the remote RFXtrx is available on if connecting via TCP. If this is set, port is required."
+  required: false
+  type: string
+port:
+  description: "The tcp port the remote RFXtrx is available on. If this is set, host is required."
+  required: false
+  type: integer
 debug:
   description: If you want to receive debug output.
   required: false
@@ -37,3 +54,11 @@ dummy:
 Supported protocols
 
 Not all protocols as advertised are enabled on initial setup of your transceiver. Enabling all protocols is not recommended either. Your 433.92 product not showing in the logs? Visit the RFXtrx website to [download RFXmgmr](http://www.rfxcom.com/epages/78165469.sf/nl_NL/?ObjectPath=/Shops/78165469/Categories/Downloads) and enable the required protocol.
+
+#### Ser2Net
+
+You can host your device on another computer by setting up ser2net and example configuration for ser2net looks like this
+
+```text
+50000:raw:0:/dev/ttyUSB0:38400 8DATABITS NONE 1STOPBIT
+```

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -14,7 +14,7 @@ To enable RFXtrx in your installation, add the following to your `configuration.
 ```yaml
 # Example configuration.yaml entry for local serial device
 rfxtrx:
-  port: /dev/ttyUSB0
+  device: /dev/ttyUSB0
 ```
 
 OR
@@ -57,7 +57,7 @@ Not all protocols as advertised are enabled on initial setup of your transceiver
 
 #### Ser2Net
 
-You can host your device on another computer by setting up ser2net and example configuration for ser2net looks like this
+You can host your device on another computer by setting up ser2net and example configuration for ser2net looks like this and then using host/port in your home assistant config.
 
 ```text
 50000:raw:0:/dev/ttyUSB0:38400 8DATABITS NONE 1STOPBIT

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -7,7 +7,7 @@ ha_category:
 ha_release: pre 0.7
 ---
 
-The `rfxtrx` integration supports RFXtrx devices by [RFXCOM](http://www.rfxcom.com) which communicate in the frequency range of 433.92 MHz.
+The `rfxtrx` integration supports RFXtrx devices by [RFXCOM](http://www.rfxcom.com), which communicate in the frequency range of 433.92 MHz.
 
 To enable RFXtrx in your installation, add the following to your `configuration.yaml` file:
 
@@ -32,30 +32,30 @@ device:
   required: false
   type: string
 host:
-  description: "The hostname the remote RFXtrx is available on if connecting via TCP. If this is set, port is required."
+  description: "The hostname the remote RFXtrx is available on if connecting via TCP. If this is set, a port is required."
   required: false
   type: string
 port:
-  description: "The tcp port the remote RFXtrx is available on. If this is set, host is required."
+  description: "The TCP port the remote RFXtrx is available on. If this is set, a host is required."
   required: false
   type: integer
 debug:
-  description: If you want to receive debug output.
+  description: "If you want to receive debug output."
   required: false
   default: false
   type: boolean
 dummy:
-  description: Then you have need a connected drive to test your settings. Can be useful for debugging and testing.
+  description: "Then you need a connected drive to test your settings. Can be useful for debugging and testing."
   required: false
   default: false
   type: boolean
 {% endconfiguration %}
 
-Supported protocols
+## Supported protocols
 
-Not all protocols as advertised are enabled on initial setup of your transceiver. Enabling all protocols is not recommended either. Your 433.92 product not showing in the logs? Visit the RFXtrx website to [download RFXmgmr](http://www.rfxcom.com/epages/78165469.sf/nl_NL/?ObjectPath=/Shops/78165469/Categories/Downloads) and enable the required protocol.
+Not all protocols as advertised are enabled on the initial setup of your transceiver. Enabling all protocols is not recommended either. Your 433.92 product not showing in the logs? Visit the RFXtrx website to [download RFXmgmr](http://www.rfxcom.com/epages/78165469.sf/nl_NL/?ObjectPath=/Shops/78165469/Categories/Downloads) and enable the required protocol.
 
-#### Ser2Net
+### ser2net
 
 You can host your device on another computer by setting up ser2net and example configuration for ser2net looks like this and then using host/port in your home assistant config.
 


### PR DESCRIPTION
**Description:**
Updated documentation in line with allowing rfxtrx to connect over TCP.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28297

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
