### PR TITLE
Update pushetta.markdown

### DIFF
--- a/source/_integrations/pushetta.markdown
+++ b/source/_integrations/pushetta.markdown
@@ -53,6 +53,6 @@ curl -X POST \
   http://api.pushetta.com/api/pushes/home-assistant/
 ```
 
-For further details, please check the [API](http://pushetta.com/pushetta-api/).
+For further details, please check the [API](http://www.pushetta.com/pushetta-api/).
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).


### PR DESCRIPTION
pushetta requires www in API URL

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
