### PR TITLE
Add MAC address example to Broadlink documentation

### DIFF
--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -36,7 +36,7 @@ host:
   required: true
   type: string
 mac:
-  description: Device mac address.
+  description: Device MAC address. Use the following format: `AA:BB:CC:DD:EE:FF`.
   required: true
   type: string
 name:
@@ -139,7 +139,7 @@ host:
   required: true
   type: string
 mac:
-  description: Device MAC address.
+  description: Device MAC address. Use the following format: `AA:BB:CC:DD:EE:FF`.
   required: true
   type: string
 timeout:

--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -36,7 +36,7 @@ host:
   required: true
   type: string
 mac:
-  description: Device MAC address. Use the following format: `AA:BB:CC:DD:EE:FF`.
+  description: "Device MAC address. Use the following format: `AA:BB:CC:DD:EE:FF`."
   required: true
   type: string
 name:
@@ -139,7 +139,7 @@ host:
   required: true
   type: string
 mac:
-  description: Device MAC address. Use the following format: `AA:BB:CC:DD:EE:FF`.
+  description: "Device MAC address. Use the following format: `AA:BB:CC:DD:EE:FF`."
   required: true
   type: string
 timeout:


### PR DESCRIPTION
**Description:**
Some forum users were having trouble setting up the Broadlink integration because they added the MAC address in the wrong format.  I added a formatted example.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
