### PR TITLE
Update python logger link

### DIFF
--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -17,7 +17,7 @@ This integration allows you to write Python scripts that are exposed as services
 | `logger` | A logger to allow you to log messages: `logger.info()`, `logger.warning()`, `logger.error()`. [API reference][logger-api]
 
 [hass-api]: /developers/development_hass_object/
-[logger-api]: https://docs.python.org/3.4/library/logging.html#logger-objects
+[logger-api]: https://docs.python.org/3.7/library/logging.html#logger-objects
 
 ## Writing your first script
 


### PR DESCRIPTION
Refer to python 3.7 (instead of 3.4) logger documentation

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
