### PR TITLE
Luci component doc update

### DIFF
--- a/source/_integrations/luci.markdown
+++ b/source/_integrations/luci.markdown
@@ -11,12 +11,6 @@ _This is one of multiple ways we support OpenWRT. For an overview, see [openwrt]
 
 This is a presence detection scanner for OpenWRT using [luci](https://openwrt.org/docs/techref/luci).
 
-<div class='note'>
-
-This integration requires a [workaround](https://github.com/home-assistant/home-assistant/issues/1258#issuecomment-252469880) when using luci with HTTPS and a self-signed certificate.
-
-</div>
-
 Before this scanner can be used you have to install the luci RPC package on OpenWRT:
 
 ```bash


### PR DESCRIPTION
**Description:**

Minor update. 
Removed note for workaround if using HTTPS and self-signed certificate. It's not needed anymore. There is new option `verify_ssl` for Luci compoment, introduced in HASS 0.101. If using self-signed cert, just set `verify_ssl` to `false` in `configuration.yaml`. 

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
