### PR TITLE
Documentation update for PR #28409: Allow setting an MQTT fan to a custom-named speed

### DIFF
--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -120,7 +120,7 @@ speed_value_template:
   required: false
   type: string
 speeds:
-  description: "List of speeds this fan is capable of running at. Valid entries are `off`, `low`, `medium` and `high`."
+  description: "List of speeds this fan is capable of running at. May include, but is not limited to, `off`, `low`, `medium` and `high`."
   required: false
   type: [string, list]
 availability_topic:


### PR DESCRIPTION
**Description:**
Documentation update to state that the speeds list for MQTT fans is not hard-constrained to the entries `off`, `low`, `medium` and `high` 

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28409

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
