### PR TITLE
Replace api_password with a generic example

### DIFF
--- a/source/_docs/tools/keyring.markdown
+++ b/source/_docs/tools/keyring.markdown
@@ -12,14 +12,14 @@ $ hass --script keyring --help
 To store a password in keyring, replace your password or API key with `!secret` and an identifier in `configuration.yaml` file.
 
 ```yaml
-http:
-  api_password: !secret http_password
+integration1:
+  api_key: !secret integration1_key
 ```
 
 Create an entry in your keyring.
 
 ```bash
-$ hass --script keyring set http_password
+$ hass --script keyring set integration1_key
 ```
 
 If you launch Home Assistant now, you will be prompted for the keyring password to unlock your keyring.


### PR DESCRIPTION
**Description:**
Remove `api_password` from docs.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
