### PR TITLE
Clarify supported devices

### DIFF
--- a/source/_integrations/lg_soundbar.markdown
+++ b/source/_integrations/lg_soundbar.markdown
@@ -12,7 +12,7 @@ The `lg_soundbar` platform allows you to control [LG Soundbars](https://www.lg.c
 
 Supported devices:
 
-- The SK range
+- Devices in the SK range with Ethernet and/or Wi-Fi
 
 Compatible devices will be automatically added if the [`discovery`](/integrations/discovery/) integration is enabled.
 


### PR DESCRIPTION
**Description:** I updated the documentation of the LG soundbar, to indicate that only devices with Ethernet or Wi-Fi are supported. (Some devices only have Bluetooth.)


**Pull request in home-assistant (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
