### PR TITLE
Improved doorbird setup documentation

### DIFF
--- a/source/_integrations/doorbird.markdown
+++ b/source/_integrations/doorbird.markdown
@@ -53,7 +53,7 @@ devices:
       required: true
       type: string
     username:
-      description: The username of a non-administrator user account on the device ([User setup](https://www.home-assistant.io/integrations/doorbird/#setup))
+      description: The username of a non-administrator user account on the device ([User setup](/integrations/doorbird/#setup))
       required: true
       type: string
     password:

--- a/source/_integrations/doorbird.markdown
+++ b/source/_integrations/doorbird.markdown
@@ -19,7 +19,13 @@ There is currently support for the following device types within Home Assistant:
 
 ## Setup
 
-The user, which you are going to use with Home Assistant, needs the "API-Operator" permission enabled.
+It is recommended to set up a new account on your Doorbird for use with Home Assistant. This can be added via the Doorbird App by choosing Administration -> (User) Add. This user, needs specific permissions enabled, depending on what functionality you want:
+
+- Live view -> Watch Always
+- Last motion -> Motion + History
+- Last ring -> History
+
+In addition, the "API-Operator" permission needs to be enabled as well.
 
 ## Configuration
 
@@ -47,7 +53,7 @@ devices:
       required: true
       type: string
     username:
-      description: The username of a non-administrator user account on the device. This user needs the "API-Operator" permission enabled on Doorbird. It is recommended to set up a new account on your Doorbird for use with Home Assistant. This can be added via the Doorbird App by choosing Administration -> (User) Add. When the new account is created, you will need to enable the permission "API-Operator" in the "permissions" option.
+      description: The username of a non-administrator user account on the device ([User setup](https://www.home-assistant.io/integrations/doorbird/#setup))
       required: true
       type: string
     password:


### PR DESCRIPTION
**Description:**
As I'm always following practices of giving least permissions needed for my devices, I had created a user with only the API-operator, as it was the only permission listed in the documentation.
This caused no video streams to show up in HA.

I've updated the documentation to reflect which permissions are needed for which functionality, as well as moved the user creation documentation to the setup (made more sense imo)

**Pull request in home-assistant (if applicable):** None

## Checklist:
- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
