### PR TITLE
Add two missing fields to events in Abode

### DIFF
--- a/source/_integrations/abode.markdown
+++ b/source/_integrations/abode.markdown
@@ -90,6 +90,8 @@ Field | Description
 `event_type` | The type of the event.
 `event_utc` | The UTC timestamp of the event.
 `user_name` | The Abode user that triggered the event, if applicable.
+`app_type` | The Abode app that triggered the event (e.g. web app, iOS app, etc.).
+`event_by` | The keypad user that triggered the event.
 `date` | The date of the event in the format `MM/DD/YYYY`.
 `time` | The time of the event in the format `HH:MM AM`.
 


### PR DESCRIPTION
**Description:**

Two new fields were added to events based on this PR: https://github.com/home-assistant/home-assistant/pull/28124

@libots If you could double check that these descriptions make sense, that would be much appreciated. I just based it off your description in the PR you made. :)

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28124
Already merged in the current release.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
