### PR TITLE
Improve scene.create service

### DIFF
--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -95,7 +95,7 @@ Create a new scene without having to configure it by calling the `scene.create` 
 
 You need to pass a `scene_id` in lowercase and with underscores instead of spaces. You also need to specify the entities in the same format as when configuring the scene.
 
-If the scene was previously created by `scene.create`, it will be overwritten. If the scene was created by YAML, an error will occur.
+If the scene was previously created by `scene.create`, it will be overwritten. If the scene was created by YAML, nothing happens but a warning in your log files.
 
 ```yaml
 # Example automation

--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -95,6 +95,8 @@ Create a new scene without having to configure it by calling the `scene.create` 
 
 You need to pass a `scene_id` in lowercase and with underscores instead of spaces. You also need to specify the entities in the same format as when configuring the scene.
 
+If the scene was previously created by `scene.create`, it will be overwritten. If the scene was created by YAML, an error will occur.
+
 ```yaml
 # Example automation
 automation:


### PR DESCRIPTION
**Description:**
If the scene was previously created by `scene.create`, it will be overwritten. If the scene was created by YAML, nothing happens but a warning in your log files.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28533

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
