### PR TITLE
Adding a small tip about DNS propagation.

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -22,7 +22,7 @@ The Google Assistant integration requires a bit more setup than most due to the 
 
 <div class='note warning'>
 
-To use Google Assistant, your Home Assistant configuration has to be [externally accessible with a hostname and SSL certificate](/docs/configuration/remote/). If you haven't already configured that, you should do so before continuing.
+To use Google Assistant, your Home Assistant configuration has to be [externally accessible with a hostname and SSL certificate](/docs/configuration/remote/). If you haven't already configured that, you should do so before continuing. If you make DNS changes to accomplish this, please ensure you have allowed up to the full 48 hours for DNS changes to propogate, otherwise Google may not be able to reach your server.
 
 </div>
 


### PR DESCRIPTION
**Description:**
I recently had to redo the setup for Google Assistant. Everything was correct (URLs in Google, ports, port forwarding, certs, etc.) but the process was failing when trying to connect with Google Assistant via the app to add the devices. While doing many troubleshooting steps, after some time, it would randomly work once, then not again for some time. More troubleshooting with failures, like analyzing tcpdumps deep, then randomly work for no reason. I had updated my DNS about 12-15 hours prior, which I thought was enough time, but it looks like it needed longer. Simply waiting was sufficient. I am hoping that this tip might save others some time pulling their hair out. :)

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
