### PR TITLE
fix http config entry for DuckDNS addon

### DIFF
--- a/source/_addons/duckdns.markdown
+++ b/source/_addons/duckdns.markdown
@@ -50,7 +50,8 @@ Use the following configuration in Home Assistant to use the generated certifica
 
 ```yaml
 http:
-  base_url: https://my-domain.duckdns.org:8123
+  base_url: my-domain.duckdns.org
+  server_port: 8123  # 8123 is also the default value
   ssl_certificate: /ssl/fullchain.pem
   ssl_key: /ssl/privkey.pem
 ```


### PR DESCRIPTION
**Description:**
I spend hours yesterday struggling with this and reading through many many discussions.

The example now will actually work.

Apparently one shouldn't have the port number inside `base_url` and `https://` isn't needed.

For clarity I've added the `server_port` entry with a comment that `8123` is the default.


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
