### PR TITLE
Add livestream meetup in Berlin to state of the union page

### DIFF
--- a/source/state-of-the-union/index.markdown
+++ b/source/state-of-the-union/index.markdown
@@ -29,6 +29,9 @@ The presentation is going to start at:
 
 URL of live stream coming soon!
 
-## Local Meet-Ups
+## Local Meetups
 
+If you would like to meet other Home Assistant users and watch the livestream together, check out the following local meetups:
+
+ - [Berlin](https://www.meetup.com/Berlin-Home-Assistant/events/265634883/)
  - [Rhein-Main Area](https://www.meetup.com/de-DE/Home-Assistant-Meetup-Rhein-Main-Neckar/events/265920456/)


### PR DESCRIPTION
**Description:**

Add livestream meetup in Berlin to state of the union page.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
