### PR TITLE
Automation example for Lutron integration

### DIFF
--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -73,3 +73,18 @@ After setup, scenes will appear in Home Assistant using the area, keypad and but
 ## Occupancy Sensors
 
 Any configured Powr Savr occuancy sensors will be added as occupancy binary sensors. Lutron reports occupancy for an area, rather than reporting individual sensors. Sensitivity and timeouts are controlled on the sensors themselves, not in software.
+
+## Example Automations
+``` yaml
+- alias: "keypad button pressed notification"
+  trigger:
+    - platform: event
+      event_type: lutron_event
+      event_data:
+        id: office_pico_on
+        action: single
+  action:
+    - service: notify.telegram
+      data_template:
+        message: "pico just turned on!"
+```

--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -75,6 +75,7 @@ After setup, scenes will appear in Home Assistant using the area, keypad and but
 Any configured Powr Savr occuancy sensors will be added as occupancy binary sensors. Lutron reports occupancy for an area, rather than reporting individual sensors. Sensitivity and timeouts are controlled on the sensors themselves, not in software.
 
 ## Example Automations
+
 ``` yaml
 - alias: "keypad button pressed notification"
   trigger:
@@ -85,6 +86,6 @@ Any configured Powr Savr occuancy sensors will be added as occupancy binary sens
         action: single
   action:
     - service: notify.telegram
-      data_template:
+      data:
         message: "pico just turned on!"
 ```


### PR DESCRIPTION
**Description:**
added an example of how to trigger an automation from a keypad button press. This was loosely explained previously, but takes prior knowledge to understand. An example is much easier to understand and implement.
@klaasnicolaas - sorry about the messed up PR, here's a new one against `current`. Thanks!

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
