### PR TITLE
Add switch platform to WLED integration

### DIFF
--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -4,6 +4,7 @@ description: "Instructions on how to integrate WLED with Home Assistant."
 logo: wled.png
 ha_category:
   - Light
+  - Switch
 ha_release: 0.102
 ha_iot_class: Local Polling
 ha_qa_scale: platinum
@@ -39,6 +40,14 @@ entity.
 
 Only native supported features of a light in Home Assistant are supported
 (which includes effects).
+
+## Switches
+
+The integration will create a number of switches:
+
+- Nightlight.
+- Sync Receive.
+- Sync Send.
 
 ## Services
 


### PR DESCRIPTION
**Description:**

Adds the switch platform to the WLED integration, allowing the user to:

- Toggle sync send
- Toggle sync receive
- Toggle Nightlight

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28606

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
