### PR TITLE
Add optional name for clarity when using multiple SAJ solar inverters

### DIFF
--- a/source/_integrations/saj.markdown
+++ b/source/_integrations/saj.markdown
@@ -32,7 +32,7 @@ host:
   required: true
   type: string
 name:
-  description: "The name of your SAJ Solar Inverter. (Optional but required when adding multiple inverters for unique sensors.)"
+  description: "An optional name for your SAJ Solar Inverter."
   required: false
   type: string
 type:
@@ -61,40 +61,17 @@ Sensors available in the library:
 | today_time         | h    | Inverter's running time for today.                                           |
 | today_max_current  | W    | Maximum current power for today. (only for connection via ethernet module)   |
 | total_yield        | kWh  | Total kWh generated to date.                                                 |
-| total_time         | h    | Total running time of the inverter .                                         |
+| total_time         | h    | Total running time of the inverter.                                          |
 | total_co2_reduced  | kg   | Total CO2 in kg reduced.                                                     |
 | temperature        | °C   | Temperature of the inverter.                                                 |
 | state              | N/A  | Live state of the inverter.                                                  |
-
-## Multiple inverters
-
-When adding multiple inverters you need to specify a name that will be part of the sensor entity id.
-If you do not specify names when adding multiple inverters you are probably see an error like this:
-```text
-Error doing job: Task exception was never retrieved
-Traceback (most recent call last):
-  File "/home/frederic/home-assistant/homeassistant/helpers/entity_platform.py", line 399, in _async_add_entity
-    raise HomeAssistantError(msg)
-homeassistant.exceptions.HomeAssistantError: Entity id already exists: sensor.saj_current_power. Platform saj does not generate unique IDs
-```
-
-Below an example configuration for multiple inverters:
-
-```yaml
-sensor:
-  - platform: saj
-    name: MY_FIRST_INVERTER
-    host: IP_ADDRESS_OF_DEVICE
-  - platform: saj
-    name: MY_SECOND_INVERTER
-    host: IP_ADDRESS_OF_DEVICE
-```
 
 ## Full configuration example for WiFi inverters
 
 ```yaml
 sensor:
   - platform: saj
+    name: MY_INVERTER_NAME
     host: IP_ADDRESS_OF_DEVICE
     type: wifi
     username: USERNAME

--- a/source/_integrations/saj.markdown
+++ b/source/_integrations/saj.markdown
@@ -70,7 +70,7 @@ Sensors available in the library:
 
 When adding multiple inverters you need to specify a name that will be part of the sensor entity id.
 If you do not specify names when adding multiple inverters you are probably see an error like this:
-```
+```text
 Error doing job: Task exception was never retrieved
 Traceback (most recent call last):
   File "/home/frederic/home-assistant/homeassistant/helpers/entity_platform.py", line 399, in _async_add_entity

--- a/source/_integrations/saj.markdown
+++ b/source/_integrations/saj.markdown
@@ -31,6 +31,10 @@ host:
   description: "The IP address of the SAJ Solar Inverter."
   required: true
   type: string
+name:
+  description: "The name of your SAJ Solar Inverter. (Optional but required when adding multiple inverters for unique sensors.)"
+  required: false
+  type: string
 type:
   description: "Type of connection module: 'ethernet' or 'wifi'"
   required: false
@@ -61,6 +65,30 @@ Sensors available in the library:
 | total_co2_reduced  | kg   | Total CO2 in kg reduced.                                                     |
 | temperature        | °C   | Temperature of the inverter.                                                 |
 | state              | N/A  | Live state of the inverter.                                                  |
+
+## Multiple inverters
+
+When adding multiple inverters you need to specify a name that will be part of the sensor entity id.
+If you do not specify names when adding multiple inverters you are probably see an error like this:
+```
+Error doing job: Task exception was never retrieved
+Traceback (most recent call last):
+  File "/home/frederic/home-assistant/homeassistant/helpers/entity_platform.py", line 399, in _async_add_entity
+    raise HomeAssistantError(msg)
+homeassistant.exceptions.HomeAssistantError: Entity id already exists: sensor.saj_current_power. Platform saj does not generate unique IDs
+```
+
+Below an example configuration for multiple inverters:
+
+```yaml
+sensor:
+  - platform: saj
+    name: MY_FIRST_INVERTER
+    host: IP_ADDRESS_OF_DEVICE
+  - platform: saj
+    name: MY_SECOND_INVERTER
+    host: IP_ADDRESS_OF_DEVICE
+```
 
 ## Full configuration example for WiFi inverters
 


### PR DESCRIPTION
**Description:**
I've added an optional configuration parameter to specify a name for the inverter.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28612

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
