### PR TITLE
Add update service and multiple domains to namecheapdns

### DIFF
--- a/source/_integrations/namecheapdns.markdown
+++ b/source/_integrations/namecheapdns.markdown
@@ -20,23 +20,81 @@ To use the integration in your installation, add the following to your `configur
 ```yaml
 # Example configuration.yaml entry
 namecheapdns:
-  domain: example.com
-  password: YOUR_PASSWORD
+  scan_interval: 60
+  domains: 
+    - domain: example.com
+      hosts:
+        - "subdomain"
+        - "@"
+      password: YOUR_PASSWORD
+    - domain: example2.com
+      password: YOUR_SECOND_PASSWORD
 ```
 
 {% configuration %}
-  host:
-    description: The host part or "subdomain" part you want to update.
+  scan_interval:
+    description: Time between updates (in minutes)
     required: false
-    type: string
-  domain:
-    description: Your namecheap TLD (example.com).
-    required: true
-    type: string
-  password:
-    description: The namecheap "Dynamic DNS Password" you can find under the "Advanced DNS" tab.
-    required: true
-    type: string
+    default: 5
+    type: integer
+  domains:
+    description: A list of domains to configure.
+    required: false
+    type: list
+    keys:
+      domain:
+        description: Your namecheap TLD (example.com).
+        required: true
+        type: string
+      hosts:
+        description: A list of hosts on the domain to be updated.
+        required: false
+        default: ["@"]
+        type: list
+      password:
+        description: The namecheap "Dynamic DNS Password" you can find under the "Advanced DNS" tab.
+        required: true
+        type: string
 {% endconfiguration %}
 
-See the [How do I set up a Host for Dynamic DNS?](https://www.namecheap.com/support/knowledgebase/article.aspx/43/11/how-do-i-set-up-a-host-for-dynamic-dns) for further instructions
+See the [How do I set up a Host for Dynamic DNS?](https://www.namecheap.com/support/knowledgebase/article.aspx/43/11/how-do-i-set-up-a-host-for-dynamic-dns) for further instructions.
+
+If you would like to update the root domain, you should use the host "@". In order to update all subdomains, use the host "*".
+
+### Service `update`
+
+ You can use the service `update` to update any domain.
+
+ | Service data attribute | Optional | Description |
+ | ---------------------- | -------- | ----------- |
+ | `domain` | no | String, domain to update, defaults to configured domain.
+ | `host` | no | String, host to update, defaults to configured hose.
+ | `password` | no | String, password as given on namecheap management page, defaults to configured password.
+
+ Examples:
+
+ ```yaml
+ # Example script to update dns
+ script:
+   update_dns:
+     sequence:
+       - service: namecheapdns.update
+         data:
+           domain: myhost.com
+           host: subdomain
+           password: key123ab
+ ```
+ 
+ ### Service `update_all`
+ 
+ You can use the service `update_all` to update all configured domains and hosts.
+ 
+ Examples:
+ 
+  ```yaml
+ # Example script to update dns
+ script:
+   update_all_dns:
+     sequence:
+       - service: namecheapdns.update_all
+ ```


### PR DESCRIPTION
**Description:**

This documentation reflects the changes proposed to `namecheapdns`. It allows the configuration of multiple domains and hosts and adds update services.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28607


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
