### PR TITLE
Fix Owntracks link

### DIFF
--- a/source/_integrations/device_tracker.markdown
+++ b/source/_integrations/device_tracker.markdown
@@ -58,7 +58,7 @@ device_tracker:
       track_new_devices: true
 ```
 
-Multiple device trackers can be used in parallel, such as [Owntracks](/integrations/owntracks/#using-owntracks-with-other-device-trackers) and [Nmap](/integrations/nmap_tracker/). The state of the device will be determined by the source that reported last.
+Multiple device trackers can be used in parallel, such as [Owntracks](/integrations/owntracks/) and [Nmap](/integrations/nmap_tracker/). The state of the device will be determined by the source that reported last.
 
 ## `known_devices.yaml`
 


### PR DESCRIPTION
**Description:**

Points to a heading that doesn't exist.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
