### PR TITLE
Add sensor platform to WLED integration

### DIFF
--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -4,6 +4,7 @@ description: "Instructions on how to integrate WLED with Home Assistant."
 logo: wled.png
 ha_category:
   - Light
+  - Sensor
   - Switch
 ha_release: 0.102
 ha_iot_class: Local Polling
@@ -40,6 +41,14 @@ entity.
 
 Only native supported features of a light in Home Assistant are supported
 (which includes effects).
+
+## Sensors	
+
+This integration provides sensors for the following information from WLED:	
+
+- Estimated current.	
+- Uptime.	
+- Free memory.
 
 ## Switches
 


### PR DESCRIPTION
**Description:**

Adds the sensor platform to the WLED integration, providing:

- Uptime
- Free memory on the device
- The estimated amount of current the device is using

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28632

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
