### PR TITLE
Add miio lights autodiscovery description

### DIFF
--- a/source/_integrations/light.xiaomi_miio.markdown
+++ b/source/_integrations/light.xiaomi_miio.markdown
@@ -138,8 +138,7 @@ by adding the following to your `configuration.yaml`:
 xiaomi_miio:
 ```
 
-This will trigger automatic discovery at home assistant startup and will add all discovered lights.
-
+This will trigger automatic discovery at Home Assistant startup and will add all discovered lights.
 
 ## Platform Services
 

--- a/source/_integrations/light.xiaomi_miio.markdown
+++ b/source/_integrations/light.xiaomi_miio.markdown
@@ -95,6 +95,7 @@ Supported models: `philips.light.moonlight`
   - brand
 
 
+## Configuration
 
 Please follow the instructions on [Retrieving the Access Token](/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token) to get the API token to use in the `configuration.yaml` file.
 
@@ -129,6 +130,16 @@ model:
   required: false
   type: string
 {% endconfiguration %}
+
+Note that some models (currently `philips.light.bulb` only) can be configured automatically
+by adding the following to your `configuration.yaml`:
+
+```yaml
+xiaomi_miio:
+```
+
+This will trigger automatic discovery at home assistant startup and will add all discovered lights.
+
 
 ## Platform Services
 


### PR DESCRIPTION
**Description:**

Add a few lines about turning on automatic discovery for Xiaomi Miio lights

**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/28647

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
