### PR TITLE
Remove host/netsh commands from docker directives

### DIFF
--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -39,17 +39,19 @@ $ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v /P
 Alternatively, `docker-compose` works with any recent release of `docker-ce` on macOS. Note that (further down this page) we provide an example `docker-compose.yml` however it differs from the `docker run` example above. To make the .yml directives match, you would need to make _two_ changes: first add the equivalent `ports:` directive, then _remove_ the `network_mode: host` section. This is because `Port mapping is incompatible with network_mode: host:`. More details can be found at [Docker networking docs](https://docs.docker.com/network/). Note also the `/dev/tty*` device name used by your Arduino etc. devices will differ from the Linux example, so the compose `mount:` may require updates.
 
 ### Windows
+
 Docker containers are completely isolated from its Windows host system. So when you delete a container, all the changes you made to that container are also removed. If you want to have configuration files or other assets remain persistent, try mounting Windows folders on containers.
 
-Before proceeding make sure you have shared out a drive for docker to mount to.  This will allow saving of config files to persist on the local machine rather than in the docker container. (which may be destroyed when upgraded)
-https://docs.docker.com/docker-for-windows/#shared-drives
-https://docs.docker.com/docker-for-windows/troubleshoot/#verify-domain-user-has-permissions-for-shared-drives-volumes
+Before proceeding, make sure you have shared out a drive for docker to mount to. This will allow the saving of config files to persist on the local machine rather than in the docker container (which may be destroyed when upgraded).
+
+<https://docs.docker.com/docker-for-windows/#shared-drives>
+<https://docs.docker.com/docker-for-windows/troubleshoot/#verify-domain-user-has-permissions-for-shared-drives-volumes>
 
 ```powershell
 $ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v /PATH_TO_YOUR_CONFIG:/config --net=host homeassistant/home-assistant:stable
 ```
 
-It’s easier to understand the trick when put into practice. Here we would like to mount a current working directory (something like C:\Users\<your login name>\homeassistant make sure this exists first) into the homeassistant/home-assistant:stable image at the /config location in the container. We would do that as so:
+It’s easier to understand the trick when put into practice. Here we would like to mount a current working directory (something like `C:\Users\<your login name>\homeassistant` make sure this exists first) into the `homeassistant/home-assistant:stable` image at the `/config` location in the container. We would do that as so:
 
 ```powershell
 $ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v //c/Users/<your login name>/homeassistant:/config --net=host homeassistant/home-assistant:stable
@@ -211,7 +213,7 @@ As the docker command becomes more complex, switching to `docker-compose` can be
       environment:
         - TZ=America/New_York
       restart: always
-	  network_mode: host
+      network_mode: host
 ```
 
 Then start the container with:

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -39,16 +39,20 @@ $ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v /P
 Alternatively, `docker-compose` works with any recent release of `docker-ce` on macOS. Note that (further down this page) we provide an example `docker-compose.yml` however it differs from the `docker run` example above. To make the .yml directives match, you would need to make _two_ changes: first add the equivalent `ports:` directive, then _remove_ the `network_mode: host` section. This is because `Port mapping is incompatible with network_mode: host:`. More details can be found at [Docker networking docs](https://docs.docker.com/network/). Note also the `/dev/tty*` device name used by your Arduino etc. devices will differ from the Linux example, so the compose `mount:` may require updates.
 
 ### Windows
+Docker containers are completely isolated from its Windows host system. So when you delete a container, all the changes you made to that container are also removed. If you want to have configuration files or other assets remain persistent, try mounting Windows folders on containers.
+
+Before proceeding make sure you have shared out a drive for docker to mount to.  This will allow saving of config files to persist on the local machine rather than in the docker container. (which may be destroyed when upgraded)
+https://docs.docker.com/docker-for-windows/#shared-drives
+https://docs.docker.com/docker-for-windows/troubleshoot/#verify-domain-user-has-permissions-for-shared-drives-volumes
 
 ```powershell
-$ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v /PATH_TO_YOUR_CONFIG:/config --net=host homeassistant/home-assistant:stable
+$ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v /PATH_TO_YOUR_CONFIG:/config -p 8123:8123 homeassistant/home-assistant:stable
 ```
 
-When running Home Assistant in Docker on Windows, you may have some difficulty getting ports to map for routing (since the `--net=host` switch actually applies to the hypervisor's network interface). To get around this, you will need to add port proxy ipv4 rules to your local Windows machine, like so (Replacing '192.168.1.10' with whatever your Windows IP is, and '10.0.50.2' with whatever your Docker container's IP is):
+It’s easier to understand the trick when put into practice. Here we would like to mount a current working directory (something like C:\Users\<your login name>\homeassistant make sure this exists first) into the homeassistant/home-assistant:stable image at the /config location in the container. We would do that as so:
 
-```bash
-netsh interface portproxy add v4tov4 listenaddress=192.168.1.10 listenport=8123 connectaddress=10.0.50.2 connectport=8123
-netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=8123 connectaddress=10.0.50.2 connectport=8123
+```powershell
+$ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v //c/Users/<your login name>/homeassistant:/config -p 8123:8123 homeassistant/home-assistant:stable
 ```
 
 This will let you access your Home Assistant portal from `http://localhost:8123`, and if you forward port 8123 on your router to your machine IP, the traffic will be forwarded on through to the docker container.
@@ -199,8 +203,9 @@ As the docker command becomes more complex, switching to `docker-compose` can be
         - /PATH_TO_YOUR_CONFIG:/config
       environment:
         - TZ=America/New_York
+      ports:
+        - "8123:8123"
       restart: always
-      network_mode: host
 ```
 
 Then start the container with:
@@ -241,6 +246,8 @@ or in a `docker-compose.yml` file:
         - /dev/ttyACM0:/dev/ttyACM0
       environment:
         - TZ=America/New_York
+      ports:
+      - "8123:8123"
       restart: always
       network_mode: host
 ```

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -46,13 +46,20 @@ https://docs.docker.com/docker-for-windows/#shared-drives
 https://docs.docker.com/docker-for-windows/troubleshoot/#verify-domain-user-has-permissions-for-shared-drives-volumes
 
 ```powershell
-$ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v /PATH_TO_YOUR_CONFIG:/config -p 8123:8123 homeassistant/home-assistant:stable
+$ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v /PATH_TO_YOUR_CONFIG:/config --net=host homeassistant/home-assistant:stable
 ```
 
 It’s easier to understand the trick when put into practice. Here we would like to mount a current working directory (something like C:\Users\<your login name>\homeassistant make sure this exists first) into the homeassistant/home-assistant:stable image at the /config location in the container. We would do that as so:
 
 ```powershell
-$ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v //c/Users/<your login name>/homeassistant:/config -p 8123:8123 homeassistant/home-assistant:stable
+$ docker run --init -d --name="home-assistant" -e "TZ=America/Los_Angeles" -v //c/Users/<your login name>/homeassistant:/config --net=host homeassistant/home-assistant:stable
+```
+
+When running Home Assistant in Docker on Windows, you may have some difficulty getting ports to map for routing (since the `--net=host` switch actually applies to the hypervisor's network interface). To get around this, you will need to add port proxy ipv4 rules to your local Windows machine, like so (Replacing '192.168.1.10' with whatever your Windows IP is, and '10.0.50.2' with whatever your Docker container's IP is):
+
+```bash
+netsh interface portproxy add v4tov4 listenaddress=192.168.1.10 listenport=8123 connectaddress=10.0.50.2 connectport=8123
+netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=8123 connectaddress=10.0.50.2 connectport=8123
 ```
 
 This will let you access your Home Assistant portal from `http://localhost:8123`, and if you forward port 8123 on your router to your machine IP, the traffic will be forwarded on through to the docker container.
@@ -203,9 +210,8 @@ As the docker command becomes more complex, switching to `docker-compose` can be
         - /PATH_TO_YOUR_CONFIG:/config
       environment:
         - TZ=America/New_York
-      ports:
-        - "8123:8123"
       restart: always
+	  network_mode: host
 ```
 
 Then start the container with:
@@ -246,8 +252,6 @@ or in a `docker-compose.yml` file:
         - /dev/ttyACM0:/dev/ttyACM0
       environment:
         - TZ=America/New_York
-      ports:
-      - "8123:8123"
       restart: always
       network_mode: host
 ```


### PR DESCRIPTION
Added -p 8123:8123 to the Windows docker command line.  Seems more reliable and easier for users.
Add ports to docker-compose.yaml files for easier launches..

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
