### PR TITLE
Add verisure ethernet status

### DIFF
--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -93,6 +93,11 @@ giid:
   description: The GIID of your installation (If you have more then one alarm system). To find the GIID for your systems run 'python verisure.py EMAIL PASSWORD installations'.
   required: false
   type: string
+ethernet_status:
+  description: Set to `true` to show ethernet connection status, `false` to disable.
+  required: false
+  type: boolean
+  default: true
 {% endconfiguration %}
 
 ## Alarm Control Panel


### PR DESCRIPTION
**Description:**
Update documentation accordingly to PR https://github.com/home-assistant/home-assistant/pull/28656

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28656

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
