### PR TITLE
MODBUS Component: Fix write_register service attribute (name -> hub)

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -141,7 +141,7 @@ modbus:
 
 | Attribute | Description |
 | --------- | ----------- |
-| name      | Hub name (defaults to 'default' when omitted) |
+| hub       | Hub name (defaults to 'default' when omitted) |
 | unit      | Slave address (set to 255 you talk to Modbus via TCP) |
 | address   | Address of the Register (e.g., 138) |
 | value     | A single value or an array of 16-bit values. Single value will call modbus function code 6. Array will call modbus function code 16. Array might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |


### PR DESCRIPTION
**Description:**

In the wiki it lists "name" as the attribute when the correct attribute is called "hub". This is confusing and can only be realized by reviewing the source code.


## Checklist:

- [ X ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ X ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
