### PR TITLE
Add another custom state detection example

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -124,12 +124,21 @@ media_player:
       'com.ellation.vrv':
         - 'audio_state'
       'com.plexapp.android':
-        - 'playing':
-            'media_session_state': 3  # this indentation is important!
-            'wake_lock_size': 3       # this indentation is important!
         - 'paused':
             'media_session_state': 3  # this indentation is important!
             'wake_lock_size': 1       # this indentation is important!
+        - 'playing':
+            'media_session_state': 3  # this indentation is important!
+        - 'standby'
+      'com.amazon.tv.launcher':
+        - 'playing':
+            'wake_lock_size': 4  # this indentation is important!
+        - 'playing':
+            'wake_lock_size': 3  # this indentation is important!
+        - 'paused':
+            'wake_lock_size': 2  # this indentation is important!
+        - 'paused':
+            'wake_lock_size': 1  # this indentation is important!
         - 'standby'
 
   # Use an ADB server to setup a Fire TV device and don't get the running apps.


### PR DESCRIPTION
**Description:**

Add another example of custom state detection. This demonstrates how to allow multiple ways to arrive at a given state (in this case, the playing and paused states). 

Forum post: https://community.home-assistant.io/t/native-support-for-android-tv-android-devices/82792/320

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
