### PR TITLE
google_assistant: support for humidity sensors

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -193,7 +193,7 @@ Currently, the following domains are available to be used with Google Assistant,
 - media_player (on/off/set volume (via set volume)/source (via set input source))
 - climate (temperature setting, hvac_mode)
 - vacuum (dock/start/stop/pause)
-- sensor (temperature setting, only for temperature sensor)
+- sensor (temperature setting for temperature sensors and humidity setting for humidity sensors)
 - Alarm Control Panel (Arm/Disarm)
 
 <div class='note warning'>


### PR DESCRIPTION
**Description:**

Expose humidity sensors to Google Assistant

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28695

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
