### PR TITLE
Add iOS/macOS certificate requirements

### DIFF
--- a/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
@@ -14,12 +14,6 @@ Change to your Home Assistant [configuration directory](/getting-started/configu
 
 The certificate **must** be `.pem` extension.
 
-If you are going to use this certificate with the iOS app, you need to ensure you complete **all** fields during the certificate creation process, then:
-
-* Send **only** the `certificate.pem` file to the iOS device, using airdrop or other transfer method.
-* Open the `.pem` file on the iOS device, follow the prompts to trust and install it.
-* If you are using iOS 10.3 or newer then [additional steps](https://support.apple.com/en-us/HT204477) are needed.
-
 ```bash
 openssl req -sha256 -newkey rsa:4096 -nodes -keyout privkey.pem -x509 -days 730 -out certificate.pem
 ```
@@ -46,3 +40,23 @@ sudo chmod 755 certificate.pem privkey.pem
 ```
 
 A tutorial "[Working with SSL Certificates, Private Keys and CSRs](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs)" could give you some insight about special cases.
+
+### iOS and macOS Specific Requirements
+
+#### iOS
+If you are going to use this certificate with the iOS app, you need to ensure you complete **all** fields during the certificate creation process, then:
+
+* Send **only** the `certificate.pem` file to the iOS device, using airdrop or other transfer method.
+* Open the `.pem` file on the iOS device, follow the prompts to trust and install it.
+* If you are using iOS 10.3 or newer then [additional steps](https://support.apple.com/en-us/HT204477) are needed.
+
+#### iOS 13 and macOS 10.15
+
+There are [new security requirements](https://support.apple.com/en-us/HT210176) for TLS server certificates in iOS 13 and macOS 10.15. To summarize:
+
+* The key size must be greater than or equal to 2048 bits.
+* A hash algorithm from the SHA-2 family is required. SHA-1 signed certificates are no longer trusted for TLS.
+* The DNS name of the server must be included in the Subject Alternative Name extension of the certificate.
+* For certificates issued after July 1, 2019:
+  * Certificates must contain an ExtendedKeyUsage (EKU) extension containing the id-kp-serverAuth OID.
+  * Certificates must have a validity period of 825 days or fewer.


### PR DESCRIPTION
**Description:**
Add clarifying documentation about certificate requirements for iOS and macOS when using self-signed certificates with Home Assistant.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
