### PR TITLE
Update to clarify path declaration in lovelace config

### DIFF
--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -13,7 +13,7 @@ You can enable the Cast integration by going to the Integrations page inside the
 
 ## Home Assistant Cast
 
-Home Assistant has its own Cast application to show the Home Assistant UI on any Chromecast device.  You can use it by adding the [Cast entity row](/lovelace/entities/#cast) to your Lovelace UI, or by calling the `cast.show_lovelace_view` service.  The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on.
+Home Assistant has its own Cast application to show the Home Assistant UI on any Chromecast device.  You can use it by adding the [Cast entity row](/lovelace/entities/#cast) to your Lovelace UI, or by calling the `cast.show_lovelace_view` service.  The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on.  The `path` has to be defined in your lovelace yaml for each view as outlined in the [views documentation](/lovelace/views/#path).
 
 ```json
 {

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -13,7 +13,7 @@ You can enable the Cast integration by going to the Integrations page inside the
 
 ## Home Assistant Cast
 
-Home Assistant has its own Cast application to show the Home Assistant UI on any Chromecast device.  You can use it by adding the [Cast entity row](/lovelace/entities/#cast) to your Lovelace UI, or by calling the `cast.show_lovelace_view` service.  The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on.  The `path` has to be defined in your lovelace yaml for each view as outlined in the [views documentation](/lovelace/views/#path).
+Home Assistant has its own Cast application to show the Home Assistant UI on any Chromecast device.  You can use it by adding the [Cast entity row](/lovelace/entities/#cast) to your Lovelace UI, or by calling the `cast.show_lovelace_view` service. The service takes the path of a Lovelace view and an entity ID of a Cast device to show the view on. A `path` has to be defined in your Lovelace YAML for each view, as outlined in the [views documentation](/lovelace/views/#path).
 
 ```json
 {


### PR DESCRIPTION
This was not very clear as many people were having this issue:

https://community.home-assistant.io/t/google-cast-error-unable-to-find-a-view-with-path-xxxx/138180/48

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
