### PR TITLE
PCAL9535A typo correction: binary_sensors are inputs

### DIFF
--- a/source/_integrations/pcal9535a.markdown
+++ b/source/_integrations/pcal9535a.markdown
@@ -56,7 +56,7 @@ pins:
       required: true
       type: [integer, string]
 invert_logic:
-  description: If `true`, inverts the output logic to ACTIVE LOW.
+  description: If `true`, inverts the input logic to ACTIVE LOW.
   required: false
   type: boolean
   default: "`false` (ACTIVE HIGH)"


### PR DESCRIPTION
**Description:**

Looks like a simple copy and paste error from the description of the switch.

## Checklist:

- [X ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
