### PR TITLE
Update freebox documentation

### DIFF
--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -47,7 +47,9 @@ returned json should contain an api_domain (`host`) and a https_port (`port`).
 Please consult the [api documentation](https://dev.freebox.fr/sdk/os/) for more information.
 
 <div class='note warning'>
-If you change your Freebox router for a new one you will need to delete the `freebox.conf` file located in your Home Assistant config directory to make the association again.
+  
+If you change your Freebox router for a new one, you need to delete the `freebox.conf` file located in your Home Assistant configuration directory to make the association again.
+
 </div>
 
 ### Initial setup

--- a/source/_integrations/freebox.markdown
+++ b/source/_integrations/freebox.markdown
@@ -46,6 +46,10 @@ You can find out your Freebox host and port by opening the address <http://mafre
 returned json should contain an api_domain (`host`) and a https_port (`port`).
 Please consult the [api documentation](https://dev.freebox.fr/sdk/os/) for more information.
 
+<div class='note warning'>
+If you change your Freebox router for a new one you will need to delete the `freebox.conf` file located in your Home Assistant config directory to make the association again.
+</div>
+
 ### Initial setup
 
 <div class='note warning'>


### PR DESCRIPTION
**Description:**
Some users are in trouble when they change the freebox router for a new one (failure, upgrade...)
Adding indications to solve this.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
