### PR TITLE
clarify options' use

### DIFF
--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -10,9 +10,6 @@ ha_qa_scale: internal
 ---
 
 The time and date (`time_date`) sensor platform adds one or more sensors to your Home Assistant state machine.
-It also displays the time in various formats, the date, or both in non-Lovelace mode.  
-Note that you have to add all options you need access to even if you don't want them to be displayed.
-
 To have these sensors available in your installation, add the following to your `configuration.yaml` file (each option creates a separate sensor that contains appropriate data):
 
 ```yaml

--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -9,9 +9,11 @@ ha_release: pre 0.7
 ha_qa_scale: internal
 ---
 
-The time and date (`time_date`) sensor platform simple displays the time in various formats, the date, or both.
+The time and date (`time_date`) sensor platform adds one or more sensors to your Home Assistant state machine.
+It also displays the time in various formats, the date, or both in non-Lovelace mode.  
+Note that you have to add all options you need access to even if you don't want them to be displayed.
 
-To enable this sensor in your installation, add the following to your `configuration.yaml` file:
+To have these sensors available in your installation, add the following to your `configuration.yaml` file (each option creates a separate sensor that contais appropriate data):
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -13,7 +13,7 @@ The time and date (`time_date`) sensor platform adds one or more sensors to your
 It also displays the time in various formats, the date, or both in non-Lovelace mode.  
 Note that you have to add all options you need access to even if you don't want them to be displayed.
 
-To have these sensors available in your installation, add the following to your `configuration.yaml` file (each option creates a separate sensor that contais appropriate data):
+To have these sensors available in your installation, add the following to your `configuration.yaml` file (each option creates a separate sensor that contains appropriate data):
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
The current description looks outdated to me because:
1. In Lovelace the time/date is not displayed when we open default_view
2. If only - 'time' specified, no `sensor.date` or anything else exists (and it's not clear as the configuration variable name is `display_options` (maybe now it's better to make it deprecated and change to `options` or something)?

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
