### PR TITLE
`value_template` added to configuration

### DIFF
--- a/source/_integrations/scrape.markdown
+++ b/source/_integrations/scrape.markdown
@@ -43,6 +43,10 @@ name:
   required: false
   default: Web scrape
   type: string
+value_template:
+  description: Defines a template to get the state of the sensor.
+  required: false
+  type: template
 unit_of_measurement:
   description: Defines the units of measurement of the sensor, if any.
   required: false


### PR DESCRIPTION
I believe it's missing

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
