### PR TITLE
Nello company status

### DIFF
--- a/source/_integrations/nello.markdown
+++ b/source/_integrations/nello.markdown
@@ -10,7 +10,7 @@ ha_iot_class: Cloud Polling
 ---
 
 <div class="note warning">
-Locumi Labs, the manufacturer of Nello, went bankrupt on 2 October 2019. Since Nello One locks require this cloud service, the locks will no longer work if the Nello shuts down the servers, which according to the official announcement should not happen for the time being. Nello has promised existing users via email that they will work on an alternative to use the lock without a server.
+Nello was recently purchased by an Italian company and is currently trading as normal.
 </div>
 
 The `nello` platform allows you to control [Nello](https://www.nello.io) intercoms.


### PR DESCRIPTION
Updated to state that nello is no longer facing closure. It was bought by an Italian company.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
