### PR TITLE
Allow hostname resolver for fritzbox

### DIFF
--- a/source/_integrations/fritzbox_callmonitor.markdown
+++ b/source/_integrations/fritzbox_callmonitor.markdown
@@ -48,7 +48,7 @@ name:
   default: Phone
   type: string
 host:
-  description: The IP address of your router, e.g., 192.168.1.1. It is optional since every fritzbox is also reachable by using the IP address 169.254.1.1.
+  description: The IP address of your router, e.g., 192.168.1.1. It is optional since every fritzbox is also reachable by using the IP address 169.254.1.1. If you have a local DNS server and have assigned a hostname to your fritzbox, you can also use that here instead of the IP address.
   required: false
   default: 169.254.1.1
   type: string

--- a/source/_integrations/fritzbox_callmonitor.markdown
+++ b/source/_integrations/fritzbox_callmonitor.markdown
@@ -23,6 +23,7 @@ $ sudo apt-get install libxml2-dev libxslt-dev \
 
 If you installed Home Assistant in a virtualenv, also run the following command inside it.
 Be patient this will take a while.
+
 ```bash
 pip3 install lxml
 ```
@@ -48,7 +49,7 @@ name:
   default: Phone
   type: string
 host:
-  description: The IP address of your router, e.g., 192.168.1.1. It is optional since every fritzbox is also reachable by using the IP address 169.254.1.1. If you have a local DNS server and have assigned a hostname to your fritzbox, you can also use that here instead of the IP address.
+  description: The IP address of your router, e.g., 192.168.1.1. It is optional since every FRITZ!Box is also reachable by using the IP address 169.254.1.1. If you have a local DNS server and have assigned a hostname to your FRITZ!Box, you can also use that here instead of the IP address.
   required: false
   default: 169.254.1.1
   type: string


### PR DESCRIPTION
**Description:**

Update the documentation, to mention that using hostnames is also allowed,
in addition to using IP addresses for the Fritzbox.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28761
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
