### PR TITLE
Updated link to mvg-live

### DIFF
--- a/source/_integrations/mvglive.markdown
+++ b/source/_integrations/mvglive.markdown
@@ -24,7 +24,7 @@ sensor:
 
 {% configuration %}
 station:
-  description: Name of the stop or station. Visit [the MVG live web site](https://www.mvg-live.de/) to find valid names.
+  description: Name of the stop or station. Visit [the MVG live web site](https://www.mvg-live.de/ims/dfiStaticAuswahl.svc) to find valid names. Be aware, that not all data of interest might be available (i.e. bus departure-times in Haar).
   required: true
   type: string
 destinations:


### PR DESCRIPTION
Changed link to https://www.mvg-live.de/ims/dfiStaticAuswahl.svc, since the old link gets forwarded to another webpage which does not show the correct station name to use. Added a short remark about the possibility of missing data on mvg-live.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
