### PR TITLE
Add how XBox Live sensors are named.

### DIFF
--- a/source/_integrations/xbox_live.markdown
+++ b/source/_integrations/xbox_live.markdown
@@ -17,7 +17,7 @@ Please also make sure to connect your Xbox account on that site.
 The configuration requires you to specify XUIDs which are the unique identifiers
 for profiles. These can be determined on [XboxAPI.com](https://xboxapi.com/) by
 either looking at your own profile page or using their interactive documentation
-to search for gamertags.
+to search for gamertags. Sensor names default to the gamertag associated with an XUID.
 
 To use the Xbox Live sensor in your installation,
 add the following to your `configuration.yaml` file:
@@ -42,3 +42,4 @@ xuid:
   required: true
   type: list
 {% endconfiguration %}
+


### PR DESCRIPTION
**Description:**
It took me a long time to find my sensor, because I was expecting it to have xbox in the name. Adding a bit about how sensors are named to save someone else the frustration.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
