### PR TITLE
Add note for disco lights when HA is running

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -27,7 +27,7 @@ It's totally normal for your Z-Wave stick to cycle through its LEDs (Yellow, Blu
 
 Use the following example commands from a terminal session on your Pi where your Z-Wave stick is connected.
 
-**Note:** You should only do this when HA has been stopped.
+**Note:** You should only do this when Home Assistant has been stopped.
 
 Turn off "Disco lights":
 

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -27,6 +27,8 @@ It's totally normal for your Z-Wave stick to cycle through its LEDs (Yellow, Blu
 
 Use the following example commands from a terminal session on your Pi where your Z-Wave stick is connected.
 
+**Note:** You should only do this when HA has been stopped.
+
 Turn off "Disco lights":
 
 ```bash


### PR DESCRIPTION
See https://github.com/home-assistant/home-assistant/issues/28642#issuecomment-552678145

Adds a note that you should stop HA when applying a Disco-lights "fix" to the AEOTEC Z-Stick.