### PR TITLE
Add broadcast address for WOL and samsungtv

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -48,6 +48,11 @@ mac:
   description: "The MAC address of the Samsung Smart TV, e.g., `00:11:22:33:44:55:66`. Required for power on support via wake on lan."
   required: false
   type: string
+broadcast_address:
+  description: The broadcast address on which to send the Wake-On-Lan packet.
+  required: false
+  default: 255.255.255.255
+  type: string
 {% endconfiguration %}
 
 Currently known supported models:


### PR DESCRIPTION
**Description:**
Include broadcast_address to allow wake-on-lan for multiple networks.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28819

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
