### PR TITLE
Rename configuration variable

### DIFF
--- a/source/_integrations/wake_on_lan.markdown
+++ b/source/_integrations/wake_on_lan.markdown
@@ -61,12 +61,12 @@ To enable this switch in your installation, add the following to your `configura
 # Example configuration.yaml entry
 switch:
   - platform: wake_on_lan
-    mac_address: "00-01-02-03-04-05"
+    mac: "00-01-02-03-04-05"
 ```
 
 {% configuration %}
-mac_address:
-  description: MAC address to send the wake up command to.
+mac:
+  description: The MAC address to send the wake up command to.
   required: true
   type: string
 name:


### PR DESCRIPTION
**Description:**
It's now `mac:` and no longer `mac_address:`

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28830

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
