### PR TITLE
No longer feature Arduino and Wemo

### DIFF
--- a/source/_integrations/arduino.markdown
+++ b/source/_integrations/arduino.markdown
@@ -6,7 +6,6 @@ ha_category:
   - DIY
   - Sensor
   - Switch
-featured: true
 ha_release: pre 0.7
 ha_iot_class: Local Polling
 ---

--- a/source/_integrations/wemo.markdown
+++ b/source/_integrations/wemo.markdown
@@ -8,7 +8,6 @@ ha_category:
   - Fan
   - Light
   - Switch
-featured: true
 ha_release: pre 0.7
 ---
 


### PR DESCRIPTION
**Description:**
No longer feature Arduino and Wemo to have a rectangle again.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
