### PR TITLE
add last-triggered to secondary_info

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -61,7 +61,7 @@ image:
   type: string
 secondary_info:
   required: false
-  description: "Show additional info. Values: `entity-id`, `last-changed`."
+  description: "Show additional info. Values: `entity-id`, `last-changed`, `last-triggered' (only for automations and scripts)."
   type: string
 format:
   required: false


### PR DESCRIPTION
adding info to the docs following PR https://github.com/home-assistant/home-assistant-polymer/pull/4222 which add last-triggered to the secondary_info options

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
