### PR TITLE
Pulseaudio: Changed default port from 4712 to 4713

### DIFF
--- a/source/_integrations/pulseaudio_loopback.markdown
+++ b/source/_integrations/pulseaudio_loopback.markdown
@@ -46,7 +46,7 @@ host:
 port:
   description: The port that Pulseaudio is listening on.
   required: false
-  default: 4712
+  default: 4713
   type: integer
 buffer_size:
   description: How much data to load from Pulseaudio at once.


### PR DESCRIPTION
**Description:**
Changed default port from 4712 to 4713, see https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/Network/#index1h2

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28857<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
