### PR TITLE
Update Hassio beta instructions

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -85,12 +85,12 @@ hassio ha update --version=0.XX.X
 
 ## Run the beta version on Hass.io
 
-If you would like to test next release before anyone else, you can install the beta version released every two weeks:
+If you would like to test next release before anyone else, you can install the beta version released every three weeks:
 
 1. Backup your installation, using the snapshot functionality Hass.io offers.
-2. Check the RC release notes for breaking changes on [Home Assistant release notes](https://rc--home-assistant-docs.netlify.com/latest-release-notes/). Be sure to check all release notes between the version you are running and the one you are upgrading to. Use the search function in your browser (`CTRL + f`) and search for **Breaking Changes**.
-3. Select _System_ from the _Hass.io_ menu, then select _Join Beta Channel_ under _Hass.io supervisor_, then select _Reload_.
-4. Select _Dashboard_ from the _Hass.io_ menu, and then select _Update_.
+2. Check the [Home Assistant RC release notes](https://rc.home-assistant.io/latest-release-notes/) for breaking changes. Be sure to check all release notes between the version you are running and the one you are upgrading to. Use the search function in your browser (`CTRL + f`) and search for **Breaking Changes**.
+3. Select _System_ tab from the _Hass.io_ menu, then select _Join Beta Channel_ under _Hass.io supervisor_, then select _Reload_.
+4. Select _Dashboard_ tab from the _Hass.io_ menu, and then select _Update_.
 
 ## Alternative: install on a generic Linux host
 


### PR DESCRIPTION
**Description:**
The release schedule changed from 2 weeks to 3 weeks, fixed a link that was broken, and added a tiny bit more clarification to the instructions.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
