### PR TITLE
Update 'other machine types' section in docs

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -182,10 +182,19 @@ curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/mast
  - `raspberrypi2`
  - `raspberrypi3`
  - `raspberrypi3-64`
+ - `raspberrypi4`
+ - `raspberrypi4-64`
  - `odroid-c2`
  - `odroid-cu2`
  - `odroid-xu`
  - `orangepi-prime`
+ - `tinker`
+ - `qemuarm`
+ - `qemuarm-64`
+ - `qemux86`
+ - `qemux86-64`
+
+See the [hassio-installer](https://github.com/home-assistant/hassio-installer) Github page for an up-to-date listing of supported machine types.
 
 <div class='note'>
 When you use this installation method, the core SSH add-on may not function correctly. If that happens, use the community SSH add-on. Some of the documentation might not work for your installation either.


### PR DESCRIPTION
**Description:**

I noticed the list of machine types supported by `hassio_install.sh` wasn't up-to-date with the list on [Github](https://github.com/home-assistant/hassio-installer). I updated the list and added a reference to the Github page. Maybe the duplicate list should be removed from here and instead add a reference to the Github?

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
