### PR TITLE
Update http documentation for trusted_proxies CIDR

### DIFF
--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -114,7 +114,10 @@ http:
     - https://www.home-assistant.io
   use_x_forwarded_for: true
   trusted_proxies:
+    # specify a single IP
     - 10.0.0.200
+    # you can also use CIDR to specify a whole range
+    - 172.17.0.0/16
   ip_ban_enabled: true
   login_attempts_threshold: 5
 ```
@@ -153,6 +156,9 @@ After a ban is added a Persistent Notification is populated to the Home Assistan
 Please note, that sources from `trusted_networks` won't be banned automatically.
 
 </div>
+
+If you are using a load balancer (e.g. Nginx, Traefik etc) with Docker then all requests will appear to come from the IP of your load balancer and therefore IP block all clients. To get the real IP you must set `use_x_forwarded_for` to true and add Dockers IP range to trusted_proxies (the default Docker IP range is 172.17.0.0/16 but it will use other ranges if this is already taken on your network).
+
 
 ## Hosting files
 


### PR DESCRIPTION
**Description:**

It took me a little while to setup ip_bans properly with Docker, I also didn't realise you could use CIDR in http config. This should make life a little easier for people.

## Checklist:

- [*] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [*] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
