### PR TITLE
Update docs to change domain for local_file service to reflect code changes

### DIFF
--- a/source/_integrations/local_file.markdown
+++ b/source/_integrations/local_file.markdown
@@ -34,7 +34,7 @@ name:
   type: string
 {% endconfiguration %}
 
-### Service `camera.local_file_update_file_path`
+### Service `local_file.update_file_path`
 
 Use this service to change the file displayed by the camera.
 


### PR DESCRIPTION
**Description:**
Update the domain and service name for `camera.local_file_update_file_path` to `local_file.update_file_path`. I started down this path because of home-assistant/home-assistant#27289 and based on the introduction [here](https://developers.home-assistant.io/docs/en/dev_101_services.html) and comment [here](https://github.com/home-assistant/home-assistant/issues/27289#issuecomment-539414699), I felt this change made sense. If I am misunderstanding the intent please let me know so that I don't keep moving through these changes, as I have noticed this pattern emerging across a bunch of integrations as I commented [here](https://github.com/home-assistant/home-assistant/issues/27289#issuecomment-555835089). Unfortunately I don't have a device to test most of these integrations.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#28890

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
