### PR TITLE
Add breaking change descriptions

### DIFF
--- a/source/_posts/2019-11-20-release-102.markdown
+++ b/source/_posts/2019-11-20-release-102.markdown
@@ -57,16 +57,54 @@ Experiencing issues introduced by this release? Please report them in our [issue
 
 ## Breaking Changes
 
-- Modernize Huawei LTE ([@scop] - [#26675]) ([huawei_lte docs]) (breaking change)
-- Removes unwanted tradfri battery sensor ([@ludeeus] - [#28181]) ([tradfri docs]) (breaking change)
-- Show all UPNP/IGD sensors in one device ([@escoand] - [#27517]) ([upnp docs]) (breaking change)
-- Change ps4 state off to state standby ([@ktnrg45] - [#28261]) ([ps4 docs]) (breaking change)
-- SSDP matching improvements ([@scop] - [#28285]) ([ssdp docs]) (breaking change)
-- Align attribute naming between light and switch for HomematicIP Cloud ([@SukramJ] - [#28271]) ([homematicip_cloud docs]) (breaking change)
-- Update Plugwise ([@bouwew] - [#28237]) ([plugwise docs]) (breaking change)
-- Use friendly app names for Fire TV sources ([@JeffLIrion] - [#28417]) ([androidtv docs]) (breaking change)
-- Update Homekit climate.py to remap current mode ([@GaryOkie] - [#28625]) ([homekit_controller docs]) (breaking change)
-- Correct openalpr_local config option name ([@HexF] - [#28746]) ([openalpr_local docs]) (breaking change)
+- __Huawei LTE__ - Configuration has been consolidated below `huawei_lte`. Device tracker no longer uses known_devices.yaml but entity registry. - ([@scop] - [#26675]) ([huawei_lte docs])
+  
+  Example configuration yaml:
+  ```yaml
+  huawei_lte:
+    - url: http://192.168.100.1/
+      username: admin
+      password: something
+  ```
+  
+- __Ikea Tradfri__ - This removes the battery sensor that was created for the signal repeater. The sensor would never have a state, and after some inspection, it does not look like that device present any valuable metrics. - ([@ludeeus] - [#28181]) ([tradfri docs])
+
+- __UPNP/IGD__ -  All UPNP/IGD sensors are now in one device. You have to remove and re-add the integration to get rid of the previous devices. ([@escoand] - [#27517]) ([upnp docs])
+
+- __PS4__ - State `off` is now State `standby`. Affects user defined scripts, automations, etc. ([@ktnrg45] - [#28261]) ([ps4 docs])
+
+- __SSDP__ -  `ssdp` in manifest.json has changed; it is now a list of dicts, and as we now match using the UPnP device description fields directly, `device_type` has to be renamed to `deviceType`. No included integrations use it at the moment, nor are they broken by this change. If any custom integrations are using it, they need to adjust accordingly. ([@scop] - [#28285]) ([ssdp docs])
+
+- __HomematicIP Cloud__ - The attribute naming between Homematic IP `HmIP-BSM` (light) and `HmIP-FSM/HmIP-PSM` (switch) was different and in case of light not correct. The attributes for `HmIP-BSM` have been renamed:
+  
+  * energy_counter_kwh --> today_energy_kwh
+  * power_consumption --> current_power_w
+
+  Please check your automations, scripts, scenes, etc., if you are using the old attributes in templates, and replace them with the new ones. - ([@SukramJ] - [#28271]) ([homematicip_cloud docs])
+
+- __Plugwise__ - Detection of a legacy Anna (firmware 1.8.x) is no longer automatic: owners of a legacy Anna have to provide info in configuration.yaml, the last line. This change was needed to be able to fix issue #26520. - ([@bouwew] - [#28237]) ([plugwise docs])
+
+  Example configuration yaml:
+  ```yaml
+  climate:
+    - platform: plugwise
+      name: your_device_name
+      password: your_password
+      host: your_anna_ip
+      legacy_anna: true
+   ```
+   
+- __Android TV__ - The `source` and `sources_list` attributes for Fire TV devices will use friendly app names instead of app IDs (e.g., "Netflix" instead of "com.netflix.ninja"). If you are using these attributes in automations, sensors, etc., you will need to update them.
+  * If you are currently checking that the `source` attribute of a Fire TV device is a particular app ID, you have two options:
+    * Check the `app_id` attribute instead
+    * Replace that app ID with the friendly name for the app.
+  * If you are currently checking the `sources_list` attribute, then you will need to check for friendly app names instead of app IDs.
+  
+  You can still use app IDs for the media_player.select_source service. - ([@JeffLIrion] - [#28417]) ([androidtv docs])
+  
+- __Homekit__ - Thermostats supported by the Homekit Controller component were reporting "off" for the running status when the HVAC was powered on but not actively heating or cooling. This `hvac_action` attribute will now properly return "idle" instead of off. Any logic that tests for the `hvac_action` condition of `off` will need to change to `idle`. There is no change to any other states. - ([@GaryOkie] - [#28625]) ([homekit_controller docs])
+
+- __OpenALPR local__ - The "alp_bin" option has been corrected to "alpr_bin" as is outlined in the documentation. Users should check their config and update if necessary. ([@HexF] - [#28746]) ([openalpr_local docs])
 
 ## Beta Fixes
 


### PR DESCRIPTION
breaking change summaries added

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
