### PR TITLE
Fix link to Private Voice Assistant blog post

### DIFF
--- a/source/_posts/2019-11-20-release-102.markdown
+++ b/source/_posts/2019-11-20-release-102.markdown
@@ -27,7 +27,7 @@ It's been developed by [@CedrickFlocon](https://github.com/CedrickFlocon) and th
 
 ## Private Voice Assistant
 
-We teamed up with Stanford to tightly integrate their open, privacy-preserving virtual assistant Almond into Home Assistant. For more information, see the [separate blog post](/blog/2019/11/14/privacy-focused-voice-assistant/).
+We teamed up with Stanford to tightly integrate their open, privacy-preserving virtual assistant Almond into Home Assistant. For more information, see the [separate blog post](/blog/2019/11/20/privacy-focused-voice-assistant/).
 
 ## Account Linking
 


### PR DESCRIPTION
**Description:**

Fixes the link to the "Almond & Ada: privacy-focused voice assistant" blog post.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
