### PR TITLE
Fix link to home-assistant-android github repo

### DIFF
--- a/source/_posts/2019-11-20-release-102.markdown
+++ b/source/_posts/2019-11-20-release-102.markdown
@@ -21,7 +21,7 @@ Alright, so what's new? A lot.
 
 At the State of the Union we announced that we have released the initial version of the official [Home Assistant Android app](https://play.google.com/store/apps/details?id=io.homeassistant.companion.android). It's still a work in progress, but the basic version already works.
 
-It's been developed by [@CedrickFlocon](https://github.com/CedrickFlocon) and the source is [available on GitHub](https://play.google.com/store/apps/details?id=io.homeassistant.companion.android). We've already seen some other developers step in, so that's great! Keep it coming.
+It's been developed by [@CedrickFlocon](https://github.com/CedrickFlocon) and the source is [available on GitHub](https://github.com/home-assistant/home-assistant-android). We've already seen some other developers step in, so that's great! Keep it coming.
 
 <!--more-->
 


### PR DESCRIPTION
**Description:**
Fixes the link for the Android App's GitHub page. Currently the url links to Google Play, not GitHub.

**Pull request in home-assistant (if applicable):** NA

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
