### PR TITLE
Add remote.toggle

### DIFF
--- a/source/_integrations/harmony.markdown
+++ b/source/_integrations/harmony.markdown
@@ -95,6 +95,10 @@ Start an activity. Will start the default `activity` from configuration.yaml if 
 | `entity_id`            |       no | Entity ID to target.
 | `activity`             |      yes | Activity ID or Activity Name to start.
 
+### Service `remote.toggle`
+
+..........
+
 ##### Example
 
 In the file 'harmony_REMOTENAME.conf' you can find the available activities, for example:

--- a/source/_integrations/harmony.markdown
+++ b/source/_integrations/harmony.markdown
@@ -99,6 +99,10 @@ Start an activity. Will start the default `activity` from configuration.yaml if 
 
 ..........
 
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |       no | Entity ID to target.
+
 ##### Example
 
 In the file 'harmony_REMOTENAME.conf' you can find the available activities, for example:


### PR DESCRIPTION
Missed `remote.toggle` service description.
Here mentioned: 
https://www.home-assistant.io/integrations/remote/
and working (but not 100%ok)
https://community.home-assistant.io/t/harmony-activities-volume-slider-and-lovelace/72419/109?u=qbaf

**Description:**
Service remote.toggle do not always toggle activity indicated in service_data. It does toggle active activity. If no one is activated, it toggle correctly.

