### PR TITLE
remove 'from' clause for updater notification example

### DIFF
--- a/source/_integrations/updater.markdown
+++ b/source/_integrations/updater.markdown
@@ -70,7 +70,6 @@ automation:
   trigger:
     - platform: state
       entity_id: binary_sensor.updater
-      from: 'off'
       to: 'on'
   action:
     - service: notify.notify


### PR DESCRIPTION
**Description:**
Depending on the state of your system the state for the updater may be `off` or
it may be `unavailable` (if the system has restarted recently,
it'll be `unavailable`). Therefore, we can't assume the automation
should on fire when going from `off` to `on`.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
