### PR TITLE
clarification of round modes

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -325,7 +325,10 @@ Some of these functions can also be used in a [filter](https://jinja.palletsproj
 - `e` mathematical constant, approximately 2.71828.
 - `pi` mathematical constant, approximately 3.14159.
 - `tau` mathematical constant, approximately 6.28318.
-- Filter `round(x)` will convert the input to a number and round it to `x` decimals.
+- Filter `round(x)` will convert the input to a number and round it to `x` decimals. Round has four modes and the default mode (with no mode specified) will [round-to-even](https://en.wikipedia.org/wiki/Rounding#Roundhalfto_even).
+  - `round(x, "floor")` will always round down to `x` decimals
+  - `round(x, "ceil")` will always round up to `x` decimals
+  - `round(1, "half")` will always round to the nearest .5 value. `x` should be 1 for this mode
 - Filter `max` will obtain the largest item in a sequence.
 - Filter `min` will obtain the smallest item in a sequence.
 - Filter `value_one|bitwise_and(value_two)` perform a bitwise and(&) operation with two values.


### PR DESCRIPTION
**Description:**
different round modes were available (floor, ceil) but not documented.
a new round mode introduced with home-assistant/home-assistant#28948 is now also documented.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
