### PR TITLE
Add external link for tutorial about CA

### DIFF
--- a/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
@@ -9,7 +9,7 @@ If your Home Assistant instance is only accessible from your local network you c
 
 The solution is to use a self-signed certificate. As you most likely don't have a certification authority (CA) your browser will complain about the security. If you have a CA then this will not be an issue.
 
-If you use Chrome browser version 58 of above or **don't want to have issues regarding a non-trusted CA or CN (Common Name)**, follow this full tutorial: [Create Root Certificate Authority and self-signed certificate for your Home Assistant. Compatible with Chrome browser > version 58](https://gist.github.com/tiagofreire-pt/4920be8d03a3dfa8201c6afedd00305e). Otherwise, follow this:
+If you use Chrome browser version 58 or above and/or **don't want to have issues regarding a non-trusted CA or CN (Common Name)**, follow this full tutorial: [Create Root Certificate Authority and self-signed certificate for your Home Assistant. Compatible with Chrome browser > version 58](https://gist.github.com/tiagofreire-pt/4920be8d03a3dfa8201c6afedd00305e). Otherwise, follow this:
 
 To create a certificate locally, you need the [OpenSSL](https://www.openssl.org/) command-line tool.
 

--- a/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
@@ -1,12 +1,15 @@
 ---
-title: "Self-signed certificate for SSL/TLS"
-description: "Configure a self-signed certificate to use with Home Assistant"
+title: "Certificate Authority and self-signed certificate for SSL/TLS"
+description: "Configure a Certificate Authority and self-signed certificate to use with Home Assistant"
 redirect_from: /cookbook/tls_self_signed_certificate/
 ---
 
 If your Home Assistant instance is only accessible from your local network you can still protect the communication between your browsers and the frontend with SSL/TLS. 
-[Let's encrypt]({{site_root}}/blog/2017/09/27/effortless-encryption-with-lets-encrypt-and-duckdns/) will only work if you have a DNS entry and remote access is allowed. 
+[Let's encrypt]({{site_root}}/blog/2017/09/27/effortless-encryption-with-lets-encrypt-and-duckdns/) will only work if you have a DNS entry and remote access is allowed.
+
 The solution is to use a self-signed certificate. As you most likely don't have a certification authority (CA) your browser will complain about the security. If you have a CA then this will not be an issue.
+
+If you use Chrome browser version 58 of above or **don't want to have issues regarding a non-trusted CA or CN (Common Name)**, follow this full tutorial: [Create Root Certificate Authority and self-signed certificate for your Home Assistant. Compatible with Chrome browser > version 58](https://gist.github.com/tiagofreire-pt/4920be8d03a3dfa8201c6afedd00305e). Otherwise, follow this:
 
 To create a certificate locally, you need the [OpenSSL](https://www.openssl.org/) command-line tool.
 


### PR DESCRIPTION
**Description:**

The creation of self-signed certificates is already described and there is no need for the extra-effort if the HA user does not have a proper CA or the skills to create one. 

As the CA creation is out of HA scope, a link with a complete tutorial was added for those who want to do the extra-mile about SSL certificates full compliance.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
