### PR TITLE
OpenGarage: Add SSL documentation

### DIFF
--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -23,7 +23,9 @@ cover:
       device_key: opendoor
       name: Left Garage Door
     garage2:
-      host: 192.168.1.13
+      protocol: https
+      host: garage.example.com
+      port: 443
       device_key: opendoor
       name: Right Garage Door
 ```
@@ -39,6 +41,11 @@ covers:
       required: true
       type: map
       keys:
+        protocol:
+          description: "The protocol (`http` or `https`) to use."
+          required: false
+          type: string
+          default: http
         host:
           description: IP address of device.
           required: true
@@ -123,4 +130,5 @@ customize:
   sensor.garage_car_present:
     icon: mdi:car
 ```
+
 {% endraw %}

--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -24,6 +24,7 @@ cover:
       name: Left Garage Door
     garage2:
       protocol: https
+      verify_ssl: false
       host: garage.example.com
       port: 443
       device_key: opendoor
@@ -46,9 +47,11 @@ covers:
           required: false
           type: boolean
           default: false
+        verify_ssl:
+          description: Enable or disable SSL certificate verification. Set to false if you have a self-signed SSL certificate and haven't installed the CA certificate to enable verification.
           required: false
-          type: string
-          default: http
+          default: true
+          type: boolean
         host:
           description: IP address of device.
           required: true

--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -41,8 +41,11 @@ covers:
       required: true
       type: map
       keys:
-        protocol:
-          description: "The protocol (`http` or `https`) to use."
+        ssl:
+          description: Use HTTPS instead of HTTP to connect.
+          required: false
+          type: boolean
+          default: false
           required: false
           type: string
           default: http


### PR DESCRIPTION
**Description:** Document an option in Home Assistant's OpenGarage integration that allows users to use SSL

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29038

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
