### PR TITLE
Add ha_iot_class to comfoconnect

### DIFF
--- a/source/_integrations/comfoconnect.markdown
+++ b/source/_integrations/comfoconnect.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Fan
   - Sensor
 ha_release: 0.48
+ha_iot_class: "Local Push"
 ---
 
 The `comfoconnect` integration lets you control Zehnder ComfoAir [Q350](https://www.international.zehnder-systems.com/products-and-systems/comfosystems/zehnder-comfoair-q350-tr)/[Q450](https://www.international.zehnder-systems.com/products-and-systems/comfosystems/zehnder-comfoair-q450-tr)/[Q600](https://www.international.zehnder-systems.com/products-and-systems/comfosystems/zehnder-comfoair-q600-st)


### PR DESCRIPTION
**Description:**
Add `ha_iot_class` to comfoconnect docs.

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
