### PR TITLE
added onvif reboot command

### DIFF
--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -59,7 +59,7 @@ extra_arguments:
 
 Most of the ONVIF cameras support more than one audio/video profile. Each profile provides different image quality. Usually, the first profile has the highest quality and it is the profile used by default. However, you may want to use a lower quality image. One of the reasons may be that your hardware isn't able to render the highest quality image in real-time, especially when running on Raspberry Pi. Therefore you can choose which profile do you want to use by setting in config `profile` variable.
 
-### Service `camera.onvif_ptz`
+### Service `onvif.ptz`
 
 If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your camera.
 
@@ -70,7 +70,7 @@ If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your ca
 | `pan` | Pan direction. Allowed values: `RIGHT`, `LEFT`, `NONE`
 | `zoom` | Zoom. Allowed values: `ZOOM_IN`, `ZOOM_OUT`, `NONE`
 
-### Service `camera.onvif_reboot`
+### Service `onvif.reboot`
 
 If your ONVIF camera supports the reboot command, you will be able to reboot your camera.
 

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -70,4 +70,12 @@ If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your ca
 | `pan` | Pan direction. Allowed values: `RIGHT`, `LEFT`, `NONE`
 | `zoom` | Zoom. Allowed values: `ZOOM_IN`, `ZOOM_OUT`, `NONE`
 
+### Service `camera.onvif_reboot`
+
+If your ONVIF camera supports the reboot command, you will be able to reboot your camera.
+
+| Service data attribute | Description |
+| -----------------------| ----------- |
+| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Else targets all.
+
 If you are running into trouble with this sensor, please refer to the [Troubleshooting section](/integrations/ffmpeg/#troubleshooting).


### PR DESCRIPTION
**Description:**

Addition to send a Reboot command to an onvif compatible camera. mine used to hang up approximately every three weeks. Triggering this service once a week provides stable operation.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29069

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
