### PR TITLE
Updated heatmiser config to match next release (replaced PR #11272

### DIFF
--- a/source/_integrations/heatmiser.markdown
+++ b/source/_integrations/heatmiser.markdown
@@ -17,25 +17,24 @@ To set it up, add the following information to your `configuration.yaml` file:
 ```yaml
 climate:
   - platform: heatmiser
-    ipaddress: YOUR_IP_ADDRESS
+    host: YOUR_IP_ADDRESS
     port: YOUR_PORT
     tstats:
-      - 1:
-        id: THERMOSTAT_ID
+      - id: THERMOSTAT_ID
         name: THERMOSTAT_NAME
 ```
 
 A single interface can handle up to 32 connected devices.
 
 {% configuration %}
-ipaddress:
+host:
   description: The IP address of your interface.
   required: true
   type: string
 port:
   description: The port that the interface is listening on.
   required: true
-  type: integer
+  type: string
 tstats:
   description: A list of thermostats activated on the gateway.
   required: true


### PR DESCRIPTION
**Description:**

Updated configuration example to match PR in core with configuration changes, submitted now.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29006

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
