### PR TITLE
Update docs to clarify domain for monoprice services to reflect code changes

### DIFF
--- a/source/_integrations/monoprice.markdown
+++ b/source/_integrations/monoprice.markdown
@@ -52,7 +52,7 @@ sources:
   type: integer
 {% endconfiguration %}
 
-### Service `snapshot`
+### Service `monoprice.snapshot`
 
 Take a snapshot of one or more zones' states. This service, and the following one are useful if you want to play a doorbell or notification sound and resume playback afterward. If no `entity_id` is provided, all zones are snapshotted.
 
@@ -66,7 +66,7 @@ The following attributes are stored in a snapshot:
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`s of zones.
 
-### Service `restore`
+### Service `monoprice.restore`
 
 Restore a previously taken snapshot of one or more speakers. If no `entity_id` is provided, all zones are restored.
 


### PR DESCRIPTION
**Description:** 
Update the domain and service name for media_player.snapshot and media_player.restore. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29099

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
