### PR TITLE
Update docs to clarify domain for bluesound services to reflect code changes

### DIFF
--- a/source/_integrations/bluesound.markdown
+++ b/source/_integrations/bluesound.markdown
@@ -55,7 +55,7 @@ media_player:
       - host: 192.168.1.131
 ```
 
-### Service `bluesound_join`
+### Service `bluesound.join`
 
 Group players together under a single master speaker. That will make a new group or join an existing group.
 
@@ -64,7 +64,7 @@ Group players together under a single master speaker. That will make a new group
 | `master` | no | A single `entity_id` that will become/hold the master speaker.
 | `entity_id` | no | String or list of a single `entity_id` that will group to master speaker.
 
-### Service `bluesound_unjoin`
+### Service `bluesound.unjoin`
 
 Remove one or more speakers from a group of speakers. If no `entity_id` is provided, all speakers are unjoined.
 
@@ -72,7 +72,7 @@ Remove one or more speakers from a group of speakers. If no `entity_id` is provi
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of `entity_id`s that will be separated from their master speaker.
 
-### Service `bluesound_set_sleep_timer`
+### Service `bluesound.set_sleep_timer`
 
 Sets a timer that will turn off the speaker. For each time you call this it will increase the time by one step. The steps are (in minutes): 15, 30, 45, 60, 90, 0.
 If you increase an ongoing timer of for example 13 minutes, it will increase it to 15. If the timer is set to 90, it will remove the time (hence the 0).
@@ -81,7 +81,7 @@ If you increase an ongoing timer of for example 13 minutes, it will increase it 
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of `entity_id`s that will have their timers set.
 
-### Service `bluesound_clear_sleep_timer`
+### Service `bluesound.clear_sleep_timer`
 
 Clear the sleep timer on a speaker, if one is set.
 


### PR DESCRIPTION
**Description:** 
Update the domain and service name for media_player.bluesound_*. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29111

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
