### PR TITLE
Update docs to clarify domain for alarmdecoder services to reflect code changes

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -135,7 +135,7 @@ The Alarm Decoder integration gives you access to several services for you to co
 - `alarm_arm_night`: Arms the alarm in instant mode; all faults will trigger the alarm. Additionally, the entry delay is turned off on the doors.
 - `alarm_disarm`: Disarms the alarm from any state. Also clears a `check_zone` flag after an alarm was triggered.
 - `alarmdecoder.alarm_keypress`: Sends a string of characters to the alarm, as if you had touched those keys on a keypad.
-- `alarmdecoder_alarm_toggle_chime`: Toggles the alarm's chime state.
+- `alarmdecoder.alarm_toggle_chime`: Toggles the alarm's chime state.
 
 <div class='note'>
 
@@ -157,11 +157,11 @@ Using a combination of the available services and attributes, you can create swi
       friendly_name: Chime
       value_template: "{{ is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) }}"
       turn_on:
-        service: alarm_control_panel.alarmdecoder_alarm_toggle_chime
+        service: alarmdecoder.alarm_toggle_chime
         data:
           code: !secret alarm_code
       turn_off:
-        service: alarm_control_panel.alarmdecoder_alarm_toggle_chime
+        service: alarmdecoder.alarm_toggle_chime
         data:
           code: !secret alarm_code
       icon_template: >-


### PR DESCRIPTION
**Description:** 
Update the domain and service name for alarm_control_panel.alarmdecoder_alarm_toggle_chime. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29127

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
