### PR TITLE
Add initial list of compatible apps to Mobile App page

### DIFF
--- a/source/_integrations/mobile_app.markdown
+++ b/source/_integrations/mobile_app.markdown
@@ -22,3 +22,7 @@ This integration is by default enabled, unless you've disabled or removed the [`
 # Example configuration.yaml entry
 mobile_app:
 ```
+
+## Apps that use Mobile App
+* [Home Assistant for iOS](https://apps.apple.com/us/app/home-assistant/id1099568401?ls=1) (official)
+* [Home Assistant for Android](https://play.google.com/store/apps/details?id=io.homeassistant.companion.android) (official)

--- a/source/_integrations/mobile_app.markdown
+++ b/source/_integrations/mobile_app.markdown
@@ -24,5 +24,6 @@ mobile_app:
 ```
 
 ## Apps that use Mobile App
-* [Home Assistant for iOS](https://apps.apple.com/us/app/home-assistant/id1099568401?ls=1) (official)
-* [Home Assistant for Android](https://play.google.com/store/apps/details?id=io.homeassistant.companion.android) (official)
+
+- [Home Assistant for iOS](https://apps.apple.com/us/app/home-assistant/id1099568401?ls=1) (official)
+- [Home Assistant for Android](https://play.google.com/store/apps/details?id=io.homeassistant.companion.android) (official)


### PR DESCRIPTION
**Description:**
When you try to set up the Mobile App integration from within HA, the config flow says "Open the mobile app to set up the integration with Home Assistant. **See the docs for a list of compatible apps.**"

It links here and there is no list of compatible apps, so I am rectifying that now. Just adding the two official apps for now since I'm not 100% sure which third party apps use `mobile_app:` (I think Ariela, HA Client, HassApp?). Can be expanded upon later.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
