### PR TITLE
update docs for mill service domain change

### DIFF
--- a/source/_integrations/mill.markdown
+++ b/source/_integrations/mill.markdown
@@ -36,7 +36,7 @@ password:
 
 This platform supports a service to set the temperature for the room connected to heater in the Mill app:
 
-`climate.mill_set_room_temperature`
+`mill.set_room_temperature`
 
 
 | Service data attribute | Optional | Description |


### PR DESCRIPTION
**Description:** 
Update the domain and service name for climate.mill_set_room_temperature. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29132

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
