### PR TITLE
update nuheat docs to reflect service domain for 'resume_program'

### DIFF
--- a/source/_integrations/nuheat.markdown
+++ b/source/_integrations/nuheat.markdown
@@ -159,7 +159,7 @@ Sets the thermostat's preset mode. Without a preset mode set it run the thermost
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
 | `hold_mode` | no | New value of hold mode.
 
-### Service `resume_program`
+### Service `nuheat.resume_program`
 
 Resumes the currently active schedule.
 


### PR DESCRIPTION
**Description:**
Update docs to clarify that `resume_program` is in the `nuheat` domain whereas all other services are standard services provided by the `climate` domain

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29133

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
