### PR TITLE
Removed documentation for nonexistent nuki service

### DIFF
--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -48,11 +48,3 @@ See the [Nuki Website](https://nuki.io/en/support/smart-lock/sl-features/locking
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`s Nuki Locks.
 | `unlatch` | yes | Boolean - Whether to unlatch the door when first opening it.
-
-### Service `check_connection` 
-
-This will force the communication between the bridge and the lock, updating the available attribute.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`s Nuki Locks.


### PR DESCRIPTION
**Description:** While moving nuki service definitions to the correct services.yaml, I noticed a service definition in the docs that doesn't exist.


**Pull request in home-assistant (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
