### PR TITLE
Update service name and domain for harmony in docs

### DIFF
--- a/source/_integrations/harmony.markdown
+++ b/source/_integrations/harmony.markdown
@@ -182,7 +182,7 @@ data:
   delay_secs: 0.6
 ```
 
-### Service `remote.harmony_change_channel`
+### Service `harmony.change_channel`
 
 Sends the change channel command to the Harmony HUB
 
@@ -194,13 +194,13 @@ Sends the change channel command to the Harmony HUB
 A typical service call for changing the channel would be::
 
 ```yaml
-service: remote.change_channel
+service: harmony.change_channel
 data:
   entity_id: remote.tv_room
   channel: 200
 ```
 
-### Service `remote.harmony_sync`
+### Service `harmony.sync`
 
 Force synchronization between the Harmony device and the Harmony cloud.
 


### PR DESCRIPTION
**Description:** 
Update the service name and domain for harmony services. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29146

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
