### PR TITLE
Add Air Humidifier CB (zhimi.humidifier.cb1)

### DIFF
--- a/source/_integrations/fan.xiaomi_miio.markdown
+++ b/source/_integrations/fan.xiaomi_miio.markdown
@@ -29,6 +29,7 @@ Air Purifier Super    | zhimi.airpurifier.sa1  | |
 Air Purifier Super 2  | zhimi.airpurifier.sa2  | |
 Air Humidifier        | zhimi.humidifier.v1    | |
 Air Humidifier CA1    | zhimi.humidifier.ca1   | |
+Air Humidifier CB1    | zhimi.humidifier.cb1   | |
 Air Fresh VA2         | zhimi.airfresh.va2     | |
 
 
@@ -246,6 +247,33 @@ Air Fresh VA2         | zhimi.airfresh.va2     | |
   - depth
   - dry
 
+### Air Humidifier CB (zhimi.humidifier.cb1)
+
+- On, Off
+- Operation modes (silent, medium, high, auto)
+- Buzzer (on, off)
+- Child lock (on, off)
+- LED (on, off), LED brightness (bright, dim, off)
+- Target humidity (30, 40, 50, 60, 70, 80)
+- Dry mode (on, off)
+- Attributes
+  - speed
+  - speed_list
+  - model
+  - temperature
+  - humidity
+  - mode
+  - buzzer
+  - child_lock
+  - target_humidity
+  - led_brightness
+  - use_time
+  - hardware_version
+  - motor_speed
+  - depth
+  - dry
+  - supported_features
+ 
 ### Air Fresh VA2
 
 * Power (on, off)
@@ -447,7 +475,7 @@ Set the target humidity.
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.                  |
 | `humidity`                |       no | Target humidity. Allowed values are 30, 40, 50, 60, 70 and 80   |
 
-### Service `fan.xiaomi_miio_set_dry_on` (Air Humidifier CA only)
+### Service `fan.xiaomi_miio_set_dry_on` (Air Humidifier CA and CB)
 
 Turn the dry mode on.
 
@@ -455,7 +483,7 @@ Turn the dry mode on.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_dry_off` (Air Humidifier CA only)
+### Service `fan.xiaomi_miio_set_dry_off` (Air Humidifier CA and CB)
 
 Turn the dry mode off.
 


### PR DESCRIPTION
Since version 0.4.6, python-miio library support Air Humidifier CB (zhimi.humidifier.cb1), see release notes here: https://github.com/rytilahti/python-miio/releases/tag/0.4.6 and PR here: https://github.com/rytilahti/python-miio/pull/493/files. I've tested it on my setup with Home Assistant 0.102.1 and it works fine (I see the following attributes: https://www.screencast.com/t/jEg815pD), however, that model of Air Humidifier was not mentioned in the docs, so I added it.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
