### PR TITLE
update service names for xiaomi_miio in docs

### DIFF
--- a/source/_integrations/fan.xiaomi_miio.markdown
+++ b/source/_integrations/fan.xiaomi_miio.markdown
@@ -314,7 +314,7 @@ Set the fan speed/operation mode.
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.                      |
 | `speed`                   |       no | Fan speed. Valid values are 'Auto', 'Silent', 'Favorite' and 'Idle' |
 
-### Service `fan.xiaomi_miio_set_buzzer_on` (Air Purifier Pro excluded)
+### Service `xiaomi_miio.fan_set_buzzer_on` (Air Purifier Pro excluded)
 
 Turn the buzzer on.
 
@@ -322,7 +322,7 @@ Turn the buzzer on.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_buzzer_off` (Air Purifier Pro excluded)
+### Service `xiaomi_miio.fan_set_buzzer_off` (Air Purifier Pro excluded)
 
 Turn the buzzer off.
 
@@ -330,7 +330,7 @@ Turn the buzzer off.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_led_on` (Air Purifiers only)
+### Service `xiaomi_miio.fan_set_led_on` (Air Purifiers only)
 
 Turn the led on.
 
@@ -338,7 +338,7 @@ Turn the led on.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_led_off` (Air Purifiers only)
+### Service `xiaomi_miio.fan_set_led_off` (Air Purifiers only)
 
 Turn the led off.
 
@@ -346,7 +346,7 @@ Turn the led off.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_child_lock_on`
+### Service `xiaomi_miio.fan_set_child_lock_on`
 
 Turn the child lock on.
 
@@ -354,7 +354,7 @@ Turn the child lock on.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_child_lock_off`
+### Service `xiaomi_miio.fan_set_child_lock_off`
 
 Turn the child lock off.
 
@@ -362,7 +362,7 @@ Turn the child lock off.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_led_brightness` (Air Purifier 2S and Air Purifier Pro excluded)
+### Service `xiaomi_miio.fan_set_led_brightness` (Air Purifier 2S and Air Purifier Pro excluded)
 
 Set the led brightness. Supported values are 0 (Bright), 1 (Dim), 2 (Off).
 
@@ -371,7 +371,7 @@ Set the led brightness. Supported values are 0 (Bright), 1 (Dim), 2 (Off).
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `brightness`              |       no | Brightness, between 0 and 2.                            |
 
-### Service `fan.xiaomi_miio_set_favorite_level` (Air Purifiers only)
+### Service `xiaomi_miio.fan_set_favorite_level` (Air Purifiers only)
 
 Set the favorite level of the operation mode "favorite".
 
@@ -380,7 +380,7 @@ Set the favorite level of the operation mode "favorite".
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `level`                   |       no | Level, between 0 and 16.                                |
 
-### Service `fan.xiaomi_miio_set_auto_detect_on` (Air Purifier 2S and Air Purifier Pro only)
+### Service `xiaomi_miio.fan_set_auto_detect_on` (Air Purifier 2S and Air Purifier Pro only)
 
 Turn the auto detect on.
 
@@ -388,7 +388,7 @@ Turn the auto detect on.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_auto_detect_off` (Air Purifier 2S and Air Purifier Pro only)
+### Service `xiaomi_miio.fan_set_auto_detect_off` (Air Purifier 2S and Air Purifier Pro only)
 
 Turn the auto detect off.
 
@@ -396,7 +396,7 @@ Turn the auto detect off.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_learn_mode_on` (Air Purifier 2 only)
+### Service `xiaomi_miio.fan_set_learn_mode_on` (Air Purifier 2 only)
 
 Turn the learn mode on.
 
@@ -404,7 +404,7 @@ Turn the learn mode on.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_learn_mode_off` (Air Purifier 2 only)
+### Service `xiaomi_miio.fan_set_learn_mode_off` (Air Purifier 2 only)
 
 Turn the learn mode off.
 
@@ -412,7 +412,7 @@ Turn the learn mode off.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_volume` (Air Purifier Pro only)
+### Service `xiaomi_miio.fan_set_volume` (Air Purifier Pro only)
 
 Set the sound volume.
 
@@ -421,7 +421,7 @@ Set the sound volume.
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `volume`                  |       no | Volume, between 0 and 100.                              |
 
-### Service `fan.xiaomi_miio_reset_filter` (Air Purifier 2 only)
+### Service `xiaomi_miio.fan_reset_filter` (Air Purifier 2 only)
 
 Reset the filter lifetime and usage.
 
@@ -429,7 +429,7 @@ Reset the filter lifetime and usage.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_extra_features` (Air Purifier only)
+### Service `xiaomi_miio.fan_set_extra_features` (Air Purifier only)
 
 Set the extra features.
 
@@ -438,7 +438,7 @@ Set the extra features.
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 | `features`                |       no | Integer, known values are 0 and 1.                      |
 
-### Service `fan.xiaomi_miio_set_target_humidity` (Air Humidifier only)
+### Service `xiaomi_miio.fan_set_target_humidity` (Air Humidifier only)
 
 Set the target humidity.
 
@@ -447,7 +447,7 @@ Set the target humidity.
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.                  |
 | `humidity`                |       no | Target humidity. Allowed values are 30, 40, 50, 60, 70 and 80   |
 
-### Service `fan.xiaomi_miio_set_dry_on` (Air Humidifier CA only)
+### Service `xiaomi_miio.fan_set_dry_on` (Air Humidifier CA only)
 
 Turn the dry mode on.
 
@@ -455,7 +455,7 @@ Turn the dry mode on.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Service `fan.xiaomi_miio_set_dry_off` (Air Humidifier CA only)
+### Service `xiaomi_miio.fan_set_dry_off` (Air Humidifier CA only)
 
 Turn the dry mode off.
 

--- a/source/_integrations/light.xiaomi_miio.markdown
+++ b/source/_integrations/light.xiaomi_miio.markdown
@@ -132,7 +132,7 @@ model:
 
 ## Platform Services
 
-### Service `light.xiaomi_miio_set_scene`
+### Service `xiaomi_miio.light_set_scene`
 
 Set one of the 4 available fixed scenes.
 
@@ -141,7 +141,7 @@ Set one of the 4 available fixed scenes.
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 | `scene`                   |       no | Scene, between 1 and 4.                               |
 
-### Service `light.xiaomi_miio_set_delayed_turn_off`
+### Service `xiaomi_miio.light_set_delayed_turn_off`
 
 Delayed turn off.
 

--- a/source/_integrations/light.xiaomi_miio.markdown
+++ b/source/_integrations/light.xiaomi_miio.markdown
@@ -150,7 +150,7 @@ Delayed turn off.
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 | `time_period`             |       no | Time period for the delayed turn off.                 |
 
-### Service `light.xiaomi_miio_reminder_on` (Eyecare Smart Lamp 2 only)
+### Service `xiaomi_miio.light_reminder_on` (Eyecare Smart Lamp 2 only)
 
 Enable the eye fatigue reminder/notification.
 
@@ -158,7 +158,7 @@ Enable the eye fatigue reminder/notification.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
-### Service `light.xiaomi_miio_reminder_off` (Eyecare Smart Lamp 2 only)
+### Service `xiaomi_miio.light_reminder_off` (Eyecare Smart Lamp 2 only)
 
 Disable the eye fatigue reminder/notification.
 
@@ -166,7 +166,7 @@ Disable the eye fatigue reminder/notification.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
-### Service `light.xiaomi_miio_night_light_mode_on`  (Eyecare Smart Lamp 2 only)
+### Service `xiaomi_miio.light_night_light_mode_on`  (Eyecare Smart Lamp 2 only)
 
 Turn the smart night light mode on.
 
@@ -174,7 +174,7 @@ Turn the smart night light mode on.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
-### Service `light.xiaomi_miio_night_light_mode_off`  (Eyecare Smart Lamp 2 only)
+### Service `xiaomi_miio.light_night_light_mode_off`  (Eyecare Smart Lamp 2 only)
 
 Turn the smart night light mode off.
 
@@ -182,7 +182,7 @@ Turn the smart night light mode off.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
-### Service `light.xiaomi_miio_eyecare_mode_on`  (Eyecare Smart Lamp 2 only)
+### Service `xiaomi_miio.light_eyecare_mode_on`  (Eyecare Smart Lamp 2 only)
 
 Turn the eyecare mode on.
 
@@ -190,7 +190,7 @@ Turn the eyecare mode on.
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO light entity.      |
 
-### Service `light.xiaomi_miio_eyecare_mode_off`  (Eyecare Smart Lamp 2 only)
+### Service `xiaomi_miio.light_eyecare_mode_off`  (Eyecare Smart Lamp 2 only)
 
 Turn the eyecare mode off.
 

--- a/source/_integrations/remote.xiaomi_miio.markdown
+++ b/source/_integrations/remote.xiaomi_miio.markdown
@@ -111,7 +111,7 @@ The Xiaomi IR Remote Platform currently supports two different formats for IR co
 
 ### Raw
 
-A raw command is a command learned from [`remote.xiaomi_miio_learn_command`](/integrations/remote.xiaomi_miio/#remotexiaomi_miio_learn_command).
+A raw command is a command learned from [`xiaomi_miio.remote_learn_command`](/integrations/remote.xiaomi_miio/#xiaomi_miioremote_learn_command).
 
 A raw command is defined as in the following example:
 
@@ -158,7 +158,7 @@ The Xiaomi IR Remote Platform registers two services.
 
 Allows sending either named commands using an identifier or sending commands as one of the two types defined in [Command Types](/integrations/remote.xiaomi_miio/#command-types).
 
-### `remote.xiaomi_miio_learn_command`
+### `xiaomi_miio.remote_learn_command`
 
 Used to learn new commands.
 

--- a/source/_integrations/switch.xiaomi_miio.markdown
+++ b/source/_integrations/switch.xiaomi_miio.markdown
@@ -88,7 +88,7 @@ model:
 
 ## Platform Services
 
-### Service `switch.xiaomi_miio_set_wifi_led_on` (Power Strip only)
+### Service `xiaomi_miio.switch_set_wifi_led_on` (Power Strip only)
 
 Turn the wifi led on.
 
@@ -96,7 +96,7 @@ Turn the wifi led on.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO switch entity.       |
 
-### Service `switch.xiaomi_miio_set_wifi_led_off` (Power Strip only)
+### Service `xiaomi_miio.switch_set_wifi_led_off` (Power Strip only)
 
 Turn the wifi led off.
 
@@ -104,7 +104,7 @@ Turn the wifi led off.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO switch entity.       |
 
-### Service `switch.xiaomi_miio_set_power_price` (Power Strip)
+### Service `xiaomi_miio.switch_set_power_price` (Power Strip)
 
 Set the power price.
 
@@ -113,7 +113,7 @@ Set the power price.
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO switch entity.       |
 | `price`                   |       no | Power price, between 0 and 999.                         |
 
-### Service `switch.xiaomi_miio_set_power_mode` (Power Strip V1 only)
+### Service `xiaomi_miio.switch_set_power_mode` (Power Strip V1 only)
 
 Set the power mode.
 

--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -54,15 +54,15 @@ name:
 
 ## Platform Services
 
-In addition to all of the services provided by the `vacuum` integration (`start`, `pause`, `stop`, `return_to_base`, `locate`, `set_fan_speed` and `send_command`), the `xiaomi` platform introduces specific services to access the remote control mode of the robot. These are:
+In addition to all of the services provided by the `vacuum` integration (`start`, `pause`, `stop`, `return_to_base`, `locate`, `set_fan_speed` and `send_command`), the `xiaomi_miio` platform introduces specific services to access the remote control mode of the robot. These are:
 
-- `xiaomi_remote_control_start`
-- `xiaomi_remote_control_stop`
-- `xiaomi_remote_control_move`
-- `xiaomi_remote_control_move_step`
-- `xiaomi_clean_zone`
+- `xiaomi_miio.vacuum_remote_control_start`
+- `xiaomi_miio.vacuum_remote_control_stop`
+- `xiaomi_miio.vacuum_remote_control_move`
+- `xiaomi_miio.vacuum_remote_control_move_step`
+- `xiaomi_miio.vacuum_clean_zone`
 
-### Service `vacuum.xiaomi_remote_control_start`
+### Service `xiaomi_miio.vacuum_remote_control_start`
 
 Start the remote control mode of the robot. You can then move it with `remote_control_move`; when done, call `remote_control_stop`.
 
@@ -70,7 +70,7 @@ Start the remote control mode of the robot. You can then move it with `remote_co
 |---------------------------|----------|---------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific robot                      |
 
-### Service `vacuum.xiaomi_remote_control_stop`
+### Service `xiaomi_miio.vacuum_remote_control_stop`
 
 Exit the remote control mode of the robot.
 
@@ -78,7 +78,7 @@ Exit the remote control mode of the robot.
 |---------------------------|----------|---------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific robot                      |
 
-### Service `vacuum.xiaomi_remote_control_move`
+### Service `xiaomi_miio.vacuum_remote_control_move`
 
 Remote control the robot. Please ensure you first set it in remote control mode with `remote_control_start`.
 
@@ -89,7 +89,7 @@ Remote control the robot. Please ensure you first set it in remote control mode 
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
 
-### Service `vacuum.xiaomi_remote_control_move_step`
+### Service `xiaomi_miio.vacuum_remote_control_move_step`
 
 Enter remote control mode, make one move, stop, and exit remote control mode.
 
@@ -100,7 +100,7 @@ Enter remote control mode, make one move, stop, and exit remote control mode.
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
 
-### Service `vacuum.xiaomi_clean_zone`
+### Service `xiaomi_miio.vacuum_clean_zone`
 
 Start the cleaning operation in the areas selected for the number of repeats indicated.
 
@@ -110,7 +110,7 @@ Start the cleaning operation in the areas selected for the number of repeats ind
 | `zone`                    |       no | List of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
 | `repeats`                 |       no | Number of cleaning repeats for each zone between 1 and 3. |
 
-Example of `vacuum.xiaomi_clean_zone` use:
+Example of `xiaomi_miio.vacuum_clean_zone` use:
 
 Inline array:
 {% raw %}
@@ -122,7 +122,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: vacuum.xiaomi_clean_zone
+    - service: xiaomi_miio.vacuum_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
         repeats: '{{states('input_number.vacuum_passes')|int}}'
@@ -140,7 +140,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: vacuum.xiaomi_clean_zone
+    - service: xiaomi_miio.vacuum_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
         repeats: '{{states('input_number.vacuum_passes')|int}}'
@@ -159,7 +159,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: vacuum.xiaomi_clean_zone
+    - service: xiaomi_miio.vacuum_clean_zone
       data:
         entity_id: vacuum.xiaomi_vacuum
         repeats: 1


### PR DESCRIPTION
**Description:** Update service names in docs to match home-assistant/home-assistant#29134 to move services in proper domain


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29134

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
