### PR TITLE
Update Aftership documentation - API link

### DIFF
--- a/source/_integrations/aftership.markdown
+++ b/source/_integrations/aftership.markdown
@@ -14,7 +14,7 @@ The sensor value shows the number of packages that are not in `Delivered` state.
 
 ## Setup
 
-To use this sensor, you need an [AfterShip Account](https://accounts.aftership.com/register) and set up an API Key. To set up an API Key go to [AfterShip API](https://secure.aftership.com/#/settings/api) page, and copy existing key or generate a new one.
+To use this sensor, you need an [AfterShip Account](https://accounts.aftership.com/register) and set up an API Key. To set up an API Key go to [AfterShip API](https://admin.aftership.com/settings/api-keys) page, and copy existing key or generate a new one.
 
 <div class='note info'>
 AfterShip recently started requiring having a credit card on file even if you are only using the free plan. That does not change the functionality of the platform, just something to be aware of.


### PR DESCRIPTION
**Description:**
Added URL that links directly to the Aftership API Keys page.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
