### PR TITLE
Corrected typo in tplink integration documentation

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -36,7 +36,7 @@ The following devices are known to work with this component.
 
 - HS107 (indoor 2-outlet)
 - HS300 (powerstrip 6-outlet)
-- KP400 (outdoot 2-outlet)
+- KP400 (outdoor 2-outlet)
 
 ### Wall Switches
 


### PR DESCRIPTION
**Description:**
outdoot -> outdoor

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
