### PR TITLE
Add an entry for the "code" attribute

### DIFF
--- a/source/_integrations/satel_integra.markdown
+++ b/source/_integrations/satel_integra.markdown
@@ -52,6 +52,10 @@ port:
   required: false
   default: 7094
   type: integer
+code:
+  description: The INTEGRA ID (found in DLOADX under "Communication configuration" or in polish "Komunikacja Konfiguracji" section), it's needed for making use of the switchable_outputs
+  required: false
+  type: integer
 partitions:
   description: List of the partitions to operate on.
   required: false

--- a/source/_integrations/satel_integra.markdown
+++ b/source/_integrations/satel_integra.markdown
@@ -55,7 +55,7 @@ port:
 code:
   description: The INTEGRA ID (found in DLOADX under "Communication configuration" or in polish "Komunikacja Konfiguracji" section), it's needed for making use of the switchable_outputs
   required: false
-  type: integer
+  type: string
 partitions:
   description: List of the partitions to operate on.
   required: false

--- a/source/_integrations/satel_integra.markdown
+++ b/source/_integrations/satel_integra.markdown
@@ -53,7 +53,7 @@ port:
   default: 7094
   type: integer
 code:
-  description: The INTEGRA ID (found in DLOADX under "Communication configuration" or in polish "Komunikacja Konfiguracji" section), it's needed for making use of the switchable_outputs
+  description: The INTEGRA ID (found in DLOADX under "Communication configuration" or in polish "Komunikacja Konfiguracji" section), it's needed for making use of the switchable_outputs.
   required: false
   type: string
 partitions:


### PR DESCRIPTION
**Description:**
Adding an entry for the code attribute. Not having it caused me an error while using the switchable_outputs.

https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/satel_integra/__init__.py#L77

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
