### PR TITLE
Add name option to season sensor

### DIFF
--- a/source/_integrations/season.markdown
+++ b/source/_integrations/season.markdown
@@ -41,5 +41,5 @@ name:
   description: "An identifier for the sensor in the frontend."
   required: false
   type: string
-  default: `season`
+  default: Season
 {% endconfiguration %}

--- a/source/_integrations/season.markdown
+++ b/source/_integrations/season.markdown
@@ -37,4 +37,9 @@ type:
   required: false
   type: string
   default: astronomical
+name:
+  description: "An identifier for the sensor in the frontend."
+  required: false
+  type: string
+  default: `season`
 {% endconfiguration %}


### PR DESCRIPTION

![grafik](https://user-images.githubusercontent.com/46536646/69919635-5d7b8680-147f-11ea-9da6-b8f3209cc822.png)


**Description:**
- add name option to the season sensor

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29302<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
