### PR TITLE
point to custom attributes card

### DIFF
--- a/source/_integrations/nmbs.markdown
+++ b/source/_integrations/nmbs.markdown
@@ -58,5 +58,5 @@ show_on_map:
 
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/nmbs-card-example.png' />
-  <p>Example using the Lovelace Attributes card</p>
+  <p>Example using the <a href="https://github.com/custom-cards/entity-attributes-card">Lovelace Attributes custom card</a> </p>
 </p>


### PR DESCRIPTION
since this is the official HA documentation, it should be clearly indicated the referenced Attributes card is a custom card. Also, please provide the link directly

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
