### PR TITLE
Update Venstar ColorTouch markdown

### DIFF
--- a/source/_integrations/venstar.markdown
+++ b/source/_integrations/venstar.markdown
@@ -10,17 +10,18 @@ ha_iot_class: Local Polling
 
 
 The `venstar` climate platform allows you to control [Venstar](https://www.venstar.com/) thermostats from Home Assistant.
-Venstar thermostats feature a local API that allows for automation without the need for a cloud service.
+Venstar thermostats feature a local API that allows for automation without the need for their Skyport cloud service.
 
 Currently supported and tested thermostats:
 
-- Color Touch T7900
+- ColorTouch T7900  
+- ColorTouch T7850  (No Humidity control)
 
 Currently supported functionality:
 - Setting heat/cool temperature when the thermostat is in the appropriate mode.
 - Changing the operation mode of the thermostat (heat/cool/off/auto)
 - Turning the fan on/off
-- Reading and setting the humidity level and limits
+- Reading and setting the humidity level and limits (T7900 only)
 - Turning on away preset
 - Turning on hold mode preset
 
@@ -28,7 +29,9 @@ The following values are supported for the hold_mode state attribute:
 - `off`: *Enables* the scheduling functionality.
 - `temperature`: *Disables* the schedule and holds the set temperature indefinitely.
 
-Note - Please ensure you update your thermostat to the latest firmware. Currently tested on firmware 5.10.
+Note - Please ensure that you update your thermostat to the latest firmware. Initially tested on firmware 5.10 and currently VH6.79.  
+
+Local API mode needs to be enabled via the thermostat's *Menu > WiFi > Local API Options > Local API - ON*
 
 To set it up, add the following information to your `configuration.yaml` file:
 


### PR DESCRIPTION
Add ColorTouch T7850 as a supported/tested thermostat as well as list the currently tested firmware version VH6.79.   Add a note how to enable local API.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
