### PR TITLE
2019-10-30-release-101.markdown fixed typo for Hass.io link

### DIFF
--- a/source/_posts/2019-10-30-release-101.markdown
+++ b/source/_posts/2019-10-30-release-101.markdown
@@ -50,7 +50,7 @@ Your webhook should be available from the internet, if you have a cloud subscrip
 
 As you may have already read, we'll be sunsetting Hassbian.
 
-Hassbian was a superset of Raspbian optimized for Home Assistant. With limited time from the developers and easier alternatives as [Hass.io](hhttps://www.home-assistant.io/hassio/) it is time to sunset Hassbian.
+Hassbian was a superset of Raspbian optimized for Home Assistant. With limited time from the developers and easier alternatives as [Hass.io](https://www.home-assistant.io/hassio/) it is time to sunset Hassbian.
 
 A big thank you to all those who worked on Hassbian - specifically [@landrash](https://github.com/landrash), who was the primary driver of this for so long, and [@ludeeus](https://github.com/ludeeus).
 


### PR DESCRIPTION
**Description:**
The link for Hass.io had a h to much, so the url was not valid


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
