### PR TITLE
Remove hardware that is not recommended

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -8,11 +8,7 @@ The following will take you through the steps required to install Hass.io.
 1. Download the appropriate install option:
 
    - As an image for your device:
-  
-     - [Raspberry Pi Zero][pi1] (not recommended for more than testing)
-     - [Raspberry Pi Zero W][pi0-w] (not recommended for more than testing)
-     - [Raspberry Pi 1 Model B][pi1] (not recommended for more than testing)
-     - [Raspberry Pi 2 Model B][pi2]
+   
      - [Raspberry Pi 3 Model B and B+ 32bit][pi3-32] (recommended)
      - [Raspberry Pi 3 Model B and B+ 64bit][pi3-64]
      - [(RC) Raspberry Pi 4 Model B 32bit][pi4-32] (recommended)


### PR DESCRIPTION
I think these should be removed for a better user experience. If it isn't recommended then they shouldn't be listed. Maybe keep them in the assets for people who like to dig around?

**Description:**
Remove hardware from the list which encourages a bad experience.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
