### PR TITLE
Document new set_state_service config for light platforms that have it

### DIFF
--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -10,7 +10,7 @@ ha_qa_scale: internal
 
 The `flux` switch platform will change the temperature of your lights similar to the way flux works on your computer, using circadian rhythm. They will be bright during the day, and gradually fade to a red/orange at night. The `flux` switch restores its last state after startup.
 
-The integration will update your lights based on the time of day. It will only affect lights that are turned on and listed in the flux configuration.
+The integration will update your lights based on the time of day. It will only affect lights that are turned on and listed in the flux configuration unless you use `set_state_service` to provide a lighting-platform-specific service name to use instead of `light.turn_on`.  
 
 During the day (in between `start time` and `sunset time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`.  After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights periodically.
 
@@ -27,6 +27,12 @@ switch:
     lights:
       - light.desk
       - light.lamp
+  - platform: flux
+    name: flux_lifx
+    # will call light.lifx_set_state even when light.bulb is turned off
+    set_state_service: lifx_set_state
+    lights:
+      - light.bulb
 ```
 
 {% configuration %}
@@ -38,6 +44,10 @@ name:
   description: The name to use when displaying this switch.
   required: false
   default: Flux
+  type: string
+set_state_service:
+  description: The service name to call always (even when light is off) instead of light.turn_on
+  required: false
   type: string
 start_time:
   description: The start time.

--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -27,12 +27,6 @@ switch:
     lights:
       - light.desk
       - light.lamp
-  - platform: flux
-    name: flux_lifx
-    # will call light.lifx_set_state even when light.bulb is turned off
-    set_state_service: lifx_set_state
-    lights:
-      - light.bulb
 ```
 
 {% configuration %}


### PR DESCRIPTION
Documentation for https://github.com/home-assistant/home-assistant/pull/29380 (PR 39380)

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
