### PR TITLE
Update reference to HA app to reflect current version

### DIFF
--- a/source/_cookbook/track_battery_level.markdown
+++ b/source/_cookbook/track_battery_level.markdown
@@ -4,6 +4,9 @@ description: "Basic example how to track the battery level of your mobile device
 ha_category: Automation Examples
 ---
 
+### Android and iOS Devices
+The [Home Assistant Companion Apps](https://companion.home-assistant.io/) for iOS and Android pass the current battery level to Home Assistant with every location update. The default name of the sensor used is `sensor.battery_level`.
+
 ### iOS Devices
 
 If you have a device running iOS (iPhone, iPad, etc), The [iCloud](/integrations/icloud) integration is gathering various details about your device including the battery level. To display it in the Frontend use a [template sensor](/integrations/template). You can also use the `battery` [sensor device class](/integrations/sensor/#device-class) to dynamically change the icon with the battery level.
@@ -26,10 +29,6 @@ sensor:
 ```
 {% endraw %}
 
-### Android and iOS Devices
-While running the [Owntracks](/integrations/owntracks) device tracker you can retrieve the battery level. 
-How you achieve this depends on how you have configured your Owntracks instance. 
-
 #### MQTT
 If you have configured Owntracks to send reports via MQTT you can use the received data via a MQTT sensor.
 Replace username with your MQTT username (for the embedded MQTT it's simply homeassistant), and deviceid with the set Device ID in Owntracks.
@@ -48,7 +47,7 @@ sensor:
 
 #### HTTP
 
-If you have configured Owntracks to send reports to your Home Assistant instance via HTTP you can use a template sensor. 
+If you have configured Owntracks to send reports to your Home Assistant instance via HTTP you can use a template sensor.
 Replace `deviceid` with the set Device ID in Owntracks.
 
 {% raw %}

--- a/source/_docs/frontend/mobile.markdown
+++ b/source/_docs/frontend/mobile.markdown
@@ -4,7 +4,7 @@ description: "Android/iOS instructions to add Home Assistant to your homescreen.
 redirect_from: /getting-started/mobile/
 ---
 
-Home Assistant has [a companion app for iOS](/docs/ecosystem/ios/).
+Home Assistant has [a companion apps for Android and iOS](/docs/ecosystem/ios/).
 
 On both Android and iOS, you can add the Home Assistant "web app" to your homescreen as if it was native (Home Assistant leverages the W3C [manifest.json](https://w3c.github.io/manifest/) support).
 

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -206,7 +206,7 @@ The template condition will test if the [given template][template] renders a val
 ```yaml
 condition:
   condition: template
-  value_template: "{% raw %}{{ (state_attr('device_tracker.iphone', 'battery')|int) > 50 }}{% endraw %}"
+  value_template: "{% raw %}{{ (state_attr('device_tracker.iphone', 'battery_level')|int) > 50 }}{% endraw %}"
 ```
 
 Within an automation, template conditions also have access to the `trigger` variable as [described here][automation-templating].

--- a/source/_integrations/device_tracker.markdown
+++ b/source/_integrations/device_tracker.markdown
@@ -83,7 +83,7 @@ devicename:
 
 <div class='note warning'>
 
-In the example above, `devicename` refers to the detected name of the device.  For instance, `my_iphone`.
+In the example above, `devicename` refers to the detected name of the device.  For example, with `nmap`, this will be the MAC address (with byte separators omitted).
 
 </div>
 

--- a/source/_integrations/opensky.markdown
+++ b/source/_integrations/opensky.markdown
@@ -39,7 +39,7 @@ Both events have three attributes:
 - **callsign**: Callsign of the flight.
 - **altitude**: Altitude of the flight in meters.
 
-To receive notifications of the entering flights, add the following lines to your `configuration.yaml` file:
+To receive notifications of the entering flights using the [Home Assistant Companion App](https://companion.home-assistant.io/), add the following lines to your `configuration.yaml` file:
 
 {% raw %}
 ```yaml
@@ -49,7 +49,7 @@ automation:
       platform: event
       event_type: opensky_entry
     action:
-      service: notify.ios_YOURIPHONENAME
+      service: notify.mobile_app_<device_name>
       data_template:
         message : 'Flight entry of {{ trigger.event.data.callsign }} '
 ```


### PR DESCRIPTION
**Description:**

The iOS app has recently been updated to version 2.0/2019. With this there have been several breaking changes [see here](https://companion.home-assistant.io/en/getting_started/migration.html#breaking-changes).

Updated docs that contain examples or references to the iOS app to either use the _new_ cross-platform `mobile_app` domain or where no longer relevant (e.g. `known_devices.yaml`) to a different example.

Also added references to Android app where appropriate. 

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
