### PR TITLE
Add disable Modem Manager in Hass.io generic install

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -156,6 +156,7 @@ sudo -i
 apt-get install software-properties-common
 apt-get update
 apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
+systemctl disable ModemManager
 curl -fsSL get.docker.com | sh
 ```
 


### PR DESCRIPTION
**Description:**

Add a command to disable the Modem Manager by default when installing Hass.io on a generic Linux system.

Having this in here prevents issues/questions with serial port issues later on.

**Pull request in home-assistant (if applicable):** n/a
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
