### PR TITLE
Add tests for Mi Router 3

### DIFF
--- a/source/_integrations/device_tracker.xiaomi.markdown
+++ b/source/_integrations/device_tracker.xiaomi.markdown
@@ -44,5 +44,5 @@ See the [device tracker integration page](/integrations/device_tracker/) for ins
 To ensure that your router is compatible, navigate to `http://YOUR_ROUTER_IP/api/misystem/devicelist`.
 You should see a listing of the device currently connected to your router.
 
-However, some users report that even when the previous URL does not work, they have been able to integrate their Mi Router 3 in Home Assistant. E.g. some users with the Mi Router 3 and firmware version 2.10.46 Stable have integrated their routers successfully and an alternative URL to test integration with is `http://YOUR_ROUTER_IP/cgi-bin/luci/api/misystem/devicelist`. Navigating to this page should show the `{"code":401,"msg":"Invalid token"}` message.
+However, some users report that even when the previous URL does not work, they have been able to integrate their Mi Router 3 in Home Assistant. E.g., some users with the Mi Router 3 and firmware version 2.10.46 Stable have integrated their routers successfully and an alternative URL to test integration with is `http://YOUR_ROUTER_IP/cgi-bin/luci/api/misystem/devicelist`. Navigating to this page should show the `{"code":401,"msg":"Invalid token"}` message.
 

--- a/source/_integrations/device_tracker.xiaomi.markdown
+++ b/source/_integrations/device_tracker.xiaomi.markdown
@@ -43,3 +43,6 @@ See the [device tracker integration page](/integrations/device_tracker/) for ins
 
 To ensure that your router is compatible, navigate to `http://YOUR_ROUTER_IP/api/misystem/devicelist`.
 You should see a listing of the device currently connected to your router.
+
+However, some users report that even when the previous URL does not work, they have been able to integrate their Mi Router 3 in Home Assistant. E.g. some users with the Mi Router 3 and firmware version 2.10.46 Stable have integrated their routers successfully and an alternative URL to test integration with is `http://YOUR_ROUTER_IP/cgi-bin/luci/api/misystem/devicelist`. Navigating to this page should show the `{"code":401,"msg":"Invalid token"}` message.
+


### PR DESCRIPTION
Even when proposed URL does not work, I have managed to sucessfully integrate my Mi Router 3 with HA.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
