### PR TITLE
Add quarterly cycle to utility_meter

### DIFF
--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -37,7 +37,7 @@ source:
   required: true
   type: string
 cycle:
-  description: How often to reset the counter. Valid values are `hourly`, `daily`, `weekly`, `monthly` and `yearly`.
+  description: How often to reset the counter. Valid values are `hourly`, `daily`, `weekly`, `monthly`, `quarterly` and `yearly`.
   required: true
   type: string
 offset:


### PR DESCRIPTION
Add quarterly cycle to utility_meter for tariffs of
3 month cycles.

**Description:**

Add quarterly cycle to utility_meter for tariffs of 3 month cycles.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29534

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
