### PR TITLE
Reword and provide additional information

### DIFF
--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -3,11 +3,11 @@ title: "Advanced Configuration"
 description: "Instructions to get Home Assistant configured."
 ---
 
-Until now we have been able to configure Home Assistant purely via the user interface. However, not all options are accessible via the user interface. The other options are accessible via the Home Assistant configuration file called `configuration.yaml`. A default one is created when Home Assistant started for the first time.
+The onboarding process takes care of the initial setup for Home Assistant, such as naming your home and selecting your location. After initial onboarding, these options can be changed in the user interface by clicking on Configuration in the sidebar and clicking on General, or by manually editing them in the Home Assistant configuration file called `configuration.yaml`. This section will explain how to do the latter.
 
 <div class='note'>
 
-This final step of the getting started only applies if you've installed Home Assistant via Hass.io. If you've used another installation method, [see here](/docs/configuration/).
+The steps below only apply if you've installed Home Assistant via Hass.io. If you've used another installation method, [see here](/docs/configuration/).
 
 </div>
 
@@ -24,19 +24,39 @@ Under the "Core" section you will find HASS Configurator.
  - Now start the add-on by clicking on START.
  - Open the user interface by clicking on OPEN WEB UI.
 
-Now let's make a small change using the configurator: we are going to change the name and location of your Home Assistant installation.
+Now let's make a change using the configurator: we are going to change the name, location, unit system, and time zone of your Home Assistant installation.
 
  - Click the folder icon in the top left of the configurator window to open the file browser sidebar.
  - Click the `configuration.yaml` file (in the `/config/` folder) to load it into the main Configurator edit window.
- - Find the `homeassistant:` configuration block, which should be the first thing in `configuration.yaml`. In this block, update `name`, `latitude`, `longitude`, `unit_system` and `time_zone` to match yours.
+ - Add the following to this file (preferably at the very top, but it ultimately doesn't matter):
+ ```yaml
+     homeassistant:
+       name: Home
+       latitude: xx.xxxx
+       longitude: xx.xxxx
+       unit_system: imperial
+       time_zone: America/Chicago
+  ```
+<div class='note'>
+ 
+  Valid options for `unit_system` are `imperial` or `metric`. See [here](https://timezonedb.com/time-zones) for a list of valid time zones. Enter the appropriate option found under the Time Zone column at that page.
+
+</div>
+
  - Click the save icon in the top right to commit changes.
- - Most changes in `configuration.yaml` require Home Assistant to be restarted to see the changes. You can verify that your changes are acceptable by running a config check. Do this by clicking on Configuration in the sidebar, click on "Server Control" and click on the "CHECK CONFIG" button. When it's valid, it will show the text "Configuration valid!".
- - Now Restart Home Assistant using the "restart" in the Server management section on the same page. In order for "Check Config" to be visible, you must enable "Advanced Mode" on your user profile.
+ - Most changes in `configuration.yaml` require Home Assistant to be restarted to see the changes. You can verify that your changes are acceptable by running a config check. Do this by clicking on Configuration in the sidebar, click on "Server Control" and click on the CHECK CONFIG button. When it's valid, it will show the text "Configuration valid!"
+ - Now Restart Home Assistant using the RESTART button in the Server management section on the same page. In order for "Check Config" to be visible, you must enable "Advanced Mode" on your user profile.
 
 <p class='img'>
 <img src='/images/screenshots/configuration-validation.png' />
 Screenshot of the "General" page in the configuration panel.
 </p>
+
+<div class='note'>
+ 
+  If you have watched any videos about setting up Home Assistant using `configuration.yaml` (particularly ones that are old), you might notice your default configuration file is much smaller than what the videos show. Don't be concerned, you haven't done anything wrong. Many items in the default configuration files shown in those old videos are now included in the `default_config:` line that you see in your configuration file. [See here](/integrations/default_config/) for more information on what's included in that line.
+
+</div>
 
 ### Editing config via Samba/Windows Networking
 


### PR DESCRIPTION
This information was outdated, especially with the addition of `default_config`. Hopefully these changes make it clearer for new users who are confused about the missing `homeassistant:` line in their default configuration (this is something that has been popping up in the forum lately).

I linked to an external source for the time zone names. Perhaps we should add this list to Home Assistant website instead (or if it already exists, my apologies: I can point it to that instead).

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
