### PR TITLE
Update venstar.markdown to current preset_modes

### DIFF
--- a/source/_integrations/venstar.markdown
+++ b/source/_integrations/venstar.markdown
@@ -25,9 +25,10 @@ Currently supported functionality:
 - Turning on away preset
 - Turning on hold mode preset
 
-The following values are supported for the hold_mode state attribute:
-- `off`: *Enables* the scheduling functionality.
+The following values are supported for the preset_mode state attribute:
+- `none`: *Enables* the scheduling functionality.
 - `temperature`: *Disables* the schedule and holds the set temperature indefinitely.
+- `away`: Places the thermostat in away mode
 
 Note - Please ensure that you update your thermostat to the latest firmware. Initially tested on firmware 5.10 and currently VH6.79.  
 


### PR DESCRIPTION
edited the "hold mode" statement to be preset_mode. Changed the 'off' preset_mode to 'none', and added the 'away' preset_mode. Confusing to a relatively new user since hold mode isn't in the states  dev tools or general climate documentation, and 'off' isn't a valid preset_mode

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
