### PR TITLE
Update group.markdown

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -15,20 +15,17 @@ Check the **States** <img src='/images/screenshots/developer-tool-states-icon.pn
 ```yaml
 # Example configuration.yaml entry
 group:
-  kitchen:
-    name: Kitchen
-    entities:
-      - switch.kitchen_pin_3
-  climate:
-    name: Climate
-    entities:
-      - sensor.bedroom_temp
-      - sensor.porch_temp
-  awesome_people:
-    name: Awesome People
-    entities:
-      - device_tracker.dad_smith
-      - device_tracker.mom_smith
+  name: Kitchen
+  entities:
+    - switch.kitchen_pin_3
+  name: Climate
+  entities:
+    - sensor.bedroom_temp
+    - sensor.porch_temp
+  name: Awesome People
+  entities:
+    - device_tracker.dad_smith
+    - device_tracker.mom_smith
 ```
 
 {% configuration %}


### PR DESCRIPTION
updated the example yaml to remove initial group identifier that is deprecated. Only name: is needed now.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
