### PR TITLE
Removed obsolete paragraph from mqtt climate component documentation

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -10,10 +10,6 @@ ha_iot_class: Local Polling
 
 The `mqtt` climate platform lets you control your MQTT enabled HVAC devices.
 
-The platform currently works in optimistic mode, which means it does not obtain states from MQTT topics, but it sends and remembers control commands.
-
-It uses a sensor under the hood to obtain the current temperature.
-
 ## Configuration
 
 To enable this climate platform in your installation, first add the following to your `configuration.yaml` file:


### PR DESCRIPTION
**Description:**

It seems that this paragraph has become invalid since further down in the documentation it is mentioned that the integration will not work in optimistic mode if these options are set.

Also, there is no sensor anymore. Temperature is provided via MQTT.

Since this paragraph is from 2017 and everything else is younger, I guess that people just forgot to edit it while updating the documentation.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
