### PR TITLE
Updating callback URL

### DIFF
--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -28,10 +28,10 @@ To create the required Spotify application:
 - Add a **Redirect URI** in one of the following forms:
 
  If you are not using SSL:
-  `http://<your_home_assistant_url_or_local_ip>:<port>/api/spotify`
+  `http://<your_home_assistant_url_or_local_ip>/api/spotify`
 
  If you are using SSL:
-  `https://<your_home_assistant_url_or_local_ip>:<port>/api/spotify`
+  `https://<your_home_assistant_url_or_local_ip>/api/spotify`
 
 - Click **Save** after adding the URI.
 


### PR DESCRIPTION
**Description:**
Had problems with integrating Spotiy in HA, but I found out the callback url with version 0.102.3 is send without the port: `https%3A%2F%2Fhomeassistant.mydomain.de%2Fapi%2Fspotify&scope=user-modify-playback-state+user-read-playback-state+user-read-private` . So I edited the callback URL in the Spotiy app and was able to add Spotify to HA




**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
