### PR TITLE
Add note about Snips Console not being available any longer

### DIFF
--- a/source/_integrations/snips.markdown
+++ b/source/_integrations/snips.markdown
@@ -7,9 +7,11 @@ ha_category:
 ha_release: 0.48
 ---
 
-```
-Snips Console no longer available due to acquisition by Sonos. For more details read ![here](https://forum.snips.ai/t/important-message-regarding-the-snips-console/4145). 
-```
+<div class='note warning'>
+  
+The Snips Console no longer available due to acquisition by Sonos. For more details, read the [announcement on the Snips forum](https://forum.snips.ai/t/important-message-regarding-the-snips-console/4145).
+
+</div>
 
 The [Snips Voice Platform](https://www.snips.ai) allows users to add powerful voice assistants to their Raspberry Pi devices without compromising on privacy. It runs 100% on-device, and does not require an internet connection. It features Hotword Detection, Automatic Speech Recognition (ASR), Natural Language Understanding (NLU) and Dialog Management.
 

--- a/source/_integrations/snips.markdown
+++ b/source/_integrations/snips.markdown
@@ -7,6 +7,10 @@ ha_category:
 ha_release: 0.48
 ---
 
+```
+Snips Console no longer available due to acquisition by Sonos. For more details read ![here](https://forum.snips.ai/t/important-message-regarding-the-snips-console/4145). 
+```
+
 The [Snips Voice Platform](https://www.snips.ai) allows users to add powerful voice assistants to their Raspberry Pi devices without compromising on privacy. It runs 100% on-device, and does not require an internet connection. It features Hotword Detection, Automatic Speech Recognition (ASR), Natural Language Understanding (NLU) and Dialog Management.
 
 The latest documentation can be found here: [Snips Platform Documentation](https://docs.snips.ai/).


### PR DESCRIPTION
**Description:**
Due to acquisition by Sonos Snips Console will no longer be available

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
