### PR TITLE
clarifies mi home app version requirement

### DIFF
--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -54,15 +54,15 @@ name:
 
 ## Platform Services
 
-In addition to all of the services provided by the `vacuum` integration (`start`, `pause`, `stop`, `return_to_base`, `locate`, `set_fan_speed` and `send_command`), the `xiaomi_miio` platform introduces specific services to access the remote control mode of the robot. These are:
+In addition to all of the services provided by the `vacuum` integration (`start`, `pause`, `stop`, `return_to_base`, `locate`, `set_fan_speed` and `send_command`), the `xiaomi` platform introduces specific services to access the remote control mode of the robot. These are:
 
-- `xiaomi_miio.vacuum_remote_control_start`
-- `xiaomi_miio.vacuum_remote_control_stop`
-- `xiaomi_miio.vacuum_remote_control_move`
-- `xiaomi_miio.vacuum_remote_control_move_step`
-- `xiaomi_miio.vacuum_clean_zone`
+- `xiaomi_remote_control_start`
+- `xiaomi_remote_control_stop`
+- `xiaomi_remote_control_move`
+- `xiaomi_remote_control_move_step`
+- `xiaomi_clean_zone`
 
-### Service `xiaomi_miio.vacuum_remote_control_start`
+### Service `vacuum.xiaomi_remote_control_start`
 
 Start the remote control mode of the robot. You can then move it with `remote_control_move`; when done, call `remote_control_stop`.
 
@@ -70,7 +70,7 @@ Start the remote control mode of the robot. You can then move it with `remote_co
 |---------------------------|----------|---------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific robot                      |
 
-### Service `xiaomi_miio.vacuum_remote_control_stop`
+### Service `vacuum.xiaomi_remote_control_stop`
 
 Exit the remote control mode of the robot.
 
@@ -78,7 +78,7 @@ Exit the remote control mode of the robot.
 |---------------------------|----------|---------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific robot                      |
 
-### Service `xiaomi_miio.vacuum_remote_control_move`
+### Service `vacuum.xiaomi_remote_control_move`
 
 Remote control the robot. Please ensure you first set it in remote control mode with `remote_control_start`.
 
@@ -89,7 +89,7 @@ Remote control the robot. Please ensure you first set it in remote control mode 
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
 
-### Service `xiaomi_miio.vacuum_remote_control_move_step`
+### Service `vacuum.xiaomi_remote_control_move_step`
 
 Enter remote control mode, make one move, stop, and exit remote control mode.
 
@@ -100,7 +100,7 @@ Enter remote control mode, make one move, stop, and exit remote control mode.
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
 
-### Service `xiaomi_miio.vacuum_clean_zone`
+### Service `vacuum.xiaomi_clean_zone`
 
 Start the cleaning operation in the areas selected for the number of repeats indicated.
 
@@ -110,7 +110,7 @@ Start the cleaning operation in the areas selected for the number of repeats ind
 | `zone`                    |       no | List of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
 | `repeats`                 |       no | Number of cleaning repeats for each zone between 1 and 3. |
 
-Example of `xiaomi_miio.vacuum_clean_zone` use:
+Example of `vacuum.xiaomi_clean_zone` use:
 
 Inline array:
 {% raw %}
@@ -122,7 +122,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: xiaomi_miio.vacuum_clean_zone
+    - service: vacuum.xiaomi_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
         repeats: '{{states('input_number.vacuum_passes')|int}}'
@@ -140,7 +140,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: xiaomi_miio.vacuum_clean_zone
+    - service: vacuum.xiaomi_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
         repeats: '{{states('input_number.vacuum_passes')|int}}'
@@ -159,7 +159,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: xiaomi_miio.vacuum_clean_zone
+    - service: vacuum.xiaomi_clean_zone
       data:
         entity_id: vacuum.xiaomi_vacuum
         repeats: 1

--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -54,15 +54,15 @@ name:
 
 ## Platform Services
 
-In addition to all of the services provided by the `vacuum` integration (`start`, `pause`, `stop`, `return_to_base`, `locate`, `set_fan_speed` and `send_command`), the `xiaomi` platform introduces specific services to access the remote control mode of the robot. These are:
+In addition to all of the services provided by the `vacuum` integration (`start`, `pause`, `stop`, `return_to_base`, `locate`, `set_fan_speed` and `send_command`), the `xiaomi_miio` platform introduces specific services to access the remote control mode of the robot. These are:
 
-- `xiaomi_remote_control_start`
-- `xiaomi_remote_control_stop`
-- `xiaomi_remote_control_move`
-- `xiaomi_remote_control_move_step`
-- `xiaomi_clean_zone`
+- `xiaomi_miio.vacuum_remote_control_start`
+- `xiaomi_miio.vacuum_remote_control_stop`
+- `xiaomi_miio.vacuum_remote_control_move`
+- `xiaomi_miio.vacuum_remote_control_move_step`
+- `xiaomi_miio.vacuum_clean_zone`
 
-### Service `vacuum.xiaomi_remote_control_start`
+### Service `xiaomi_miio.vacuum_remote_control_start`
 
 Start the remote control mode of the robot. You can then move it with `remote_control_move`; when done, call `remote_control_stop`.
 
@@ -70,7 +70,7 @@ Start the remote control mode of the robot. You can then move it with `remote_co
 |---------------------------|----------|---------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific robot                      |
 
-### Service `vacuum.xiaomi_remote_control_stop`
+### Service `xiaomi_miio.vacuum_remote_control_stop`
 
 Exit the remote control mode of the robot.
 
@@ -78,7 +78,7 @@ Exit the remote control mode of the robot.
 |---------------------------|----------|---------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific robot                      |
 
-### Service `vacuum.xiaomi_remote_control_move`
+### Service `xiaomi_miio.vacuum_remote_control_move`
 
 Remote control the robot. Please ensure you first set it in remote control mode with `remote_control_start`.
 
@@ -89,7 +89,7 @@ Remote control the robot. Please ensure you first set it in remote control mode 
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
 
-### Service `vacuum.xiaomi_remote_control_move_step`
+### Service `xiaomi_miio.vacuum_remote_control_move_step`
 
 Enter remote control mode, make one move, stop, and exit remote control mode.
 
@@ -100,7 +100,7 @@ Enter remote control mode, make one move, stop, and exit remote control mode.
 | `rotation`                |       no | Rotation: between -179 degrees and 179 degrees            |
 | `duration`                |       no | The number of milliseconds that the robot should move for |
 
-### Service `vacuum.xiaomi_clean_zone`
+### Service `xiaomi_miio.vacuum_clean_zone`
 
 Start the cleaning operation in the areas selected for the number of repeats indicated.
 
@@ -110,7 +110,7 @@ Start the cleaning operation in the areas selected for the number of repeats ind
 | `zone`                    |       no | List of zones. Each zone is an array of 4 integer value. Example: [[23510,25311,25110,26361]] |
 | `repeats`                 |       no | Number of cleaning repeats for each zone between 1 and 3. |
 
-Example of `vacuum.xiaomi_clean_zone` use:
+Example of `xiaomi_miio.vacuum_clean_zone` use:
 
 Inline array:
 {% raw %}
@@ -122,7 +122,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: vacuum.xiaomi_clean_zone
+    - service: xiaomi_miio.vacuum_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
         repeats: '{{states('input_number.vacuum_passes')|int}}'
@@ -140,7 +140,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: vacuum.xiaomi_clean_zone
+    - service: xiaomi_miio.vacuum_clean_zone
       data_template:
         entity_id: vacuum.xiaomi_vacuum
         repeats: '{{states('input_number.vacuum_passes')|int}}'
@@ -159,7 +159,7 @@ automation:
       platform: homeassistant
     condition: []
     action:
-    - service: vacuum.xiaomi_clean_zone
+    - service: xiaomi_miio.vacuum_clean_zone
       data:
         entity_id: vacuum.xiaomi_vacuum
         repeats: 1
@@ -206,9 +206,9 @@ The following table shows the units of measurement for each attribute:
 
 <div class='note'>
 
-As per Version 5.4.49 the Android Mi Home app stores the token readable in the log files. It can easily be retrieved in the folder Smarthome on in the Android device. Just open the text file inside the Smarthome/logs folder and search for the token.
+If using an Android device to retrieve the Access Token only `v5.4.49` of Mi Home is confirmed working (December 2019). Use `v5.4.49` of Mi Home locate a text file under the `Smarthome/logs` folder where the 32 character token is stored. There will likely be several text files in this directory, search all of them for the word 'token' and you should find it there. Be advised that the latest version of Mi Home does not store the token in clear text.
 <br/> <br/>
-The iPhone app still stores the token in the SQLite db as of v4.23.4 (Nov 17, 2019).
+The iPhone app still stores the token in the SQLite db as of `v4.23.4` (Nov 17, 2019).
 <br/> <br/>
 After resetting the WiFi settings of the Xiaomi robot vacuum, a new Access Token will be generated and therefore these instructions need to be followed again.
 <br/> <br/>
@@ -217,116 +217,25 @@ These instructions are written for the Mi Home app - not for the new RoboRock ap
 This token (32 hexadecimal characters) is required for the Xiaomi Mi Robot Vacuum, Mi Robot 2 (Roborock) Vacuum, Xiaomi Philips Lights and Xiaomi IR Remote. The Xiaomi Gateway uses another security method and requires a `key` (16 alphanumeric chars), which can be obtained easily via a hidden menu item at the Mi-Home app or using the `miio` command line tool.
 </div>
 
-### Miio command line tool
+### Android (not rooted)
 
-You can install the command line tool using the following command:
+> If using an Android device to retrieve the Access Token only `v5.4.49` of Mi Home is confirmed working (December 2019).  
 
-```bash
-npm install -g miio
-```
+1. To begin, set up your Robovac with the latest version of Mi Home on your primary Android device as you normally would.
+2. Using `v5.4.49` of Mi Home locate a text file under the `Smarthome/logs` folder where the 32 character token is stored.
+3. There will likely be several text files in this directory, search all of them for the word 'token' and you should find it there. Be advised that the latest version of Mi Home does not store the token in clear text.
 
-Discovering devices on the current network:
 
-```bash
-miio discover
-```
+### Linux and Rooted Android
 
-This will list devices that are connected to the same network as your computer. Let it run for a while so it has a chance to reach all devices, as it might take a minute or two for all devices to answer.
-
-The commands outputs each device on this format:
-
-```text
-Device ID: 48765421
-Model info: zhimi.airpurifier.m1
-Address: 192.168.100.9
-Token: token-as-hex-here via auto-token
-Support: At least basic
-```
-
-The information output is:
-
-- `Device ID` - The unique identifier of the device, does not change if the device is reset.
-- `Model ID`- The model id if it could be determined, this indicates what type of device it is.
-- `Address` - The IP that the device has on the network.
-- `Token` - The token of the device or `???` if it could not be automatically determined.
-
-### Windows and Android
-
-To fetch the token follow these instructions depending on your mobile phone platform.
-
-1. Configure the robot with [Mi Home version 5.0.30](https://www.apkmirror.com/apk/xiaomi-inc/mihome/mihome-5-0-30-release/). Make sure to select the correct region, as Xiaomi uses different product names for different geographical areas.
-2. Download and extract the [MiToolKit.zip](https://github.com/ultrara1n/MiToolkit/releases).
-3. Enable developer mode and USB debugging on the Android phone and plug it into the computer.
-4. Change the MiToolKit language to English if you need to.
-5. Click "Extract Token".
-6. On the phone, you must confirm the backup. DO NOT enter any password and press the button to make the backup.
-7. Once you have confirmed the backup the token extraction will begin, it should appear in the MiToolKit shortly.
-8. If you don't get a token, close MiToolKit completely, delete the folder MiToolkit\apps\com.xiaomi.smarthome and relaunch MiToolKit to force recreate a new backup (sometimes the files would not be overwritten before deleting the old ones).
-
-### Linux and Android (not rooted)
-
-Follow the pairing process using your phone and Mi-Home app. You will be able to retrieve the token from an SQLite file inside your phone.
-
-Before you begin you need to install `libffi-dev` and `libssl-dev` by running the command below. This is needed for `python-miio` to be installed correctly.
-
-```bash
-sudo apt-get install libffi-dev libssl-dev
-```
-
-If your Home Assistant installation is running in a [virtualenv](/docs/installation/virtualenv/#upgrading-home-assistant), make sure you activate it by running the commands below.
-
-```bash
-sudo -u homeassistant -H -s
-source /srv/homeassistant/bin/activate
-```
-
-To fetch the token follow these instructions depending on your mobile phone platform.
-
-1. Configure the robot with [Mi Home version 5.0.30](https://www.apkmirror.com/apk/xiaomi-inc/mihome/mihome-5-0-30-release/). Make sure to select the correct region, as Xiaomi uses different product names for different geographical areas.
-2. Enable developer mode, USB debugging and plug the Android phone into the computer.
-3. Get ADB by running `apt-get install android-tools-adb` or `apt-get install adb`.
-4. `adb devices` should list your device. Consult the ADB manual if necessary.
-5. Issue a backup command via adb: `adb backup -noapk com.xiaomi.smarthome -f backup.ab` (set a password if prompted on your phone). Some devices may require single quotes in the command `adb backup '-noapk com.xiaomi.smarthome -f backup.ab'`.
-6. Download the ['ADB Backup Extractor'](https://sourceforge.net/projects/adbextractor/files/latest/download).
-7. Extract the data from the backup: (enter the password, if prompted)
-   ```bash
-   java -jar Android\ Backup\ Utilities/Android\ Backup\ Extractor/android-backup-extractor-20171005-bin/abe.jar unpack backup.ab unpacked.tar
-   ```
-8. Untar the unpacked data: `tar -xvf unpacked.tar`.
-9. The following command returns the token for your Xiaomi vacuum bot:
-    ```bash
-    sqlite3 apps/com.xiaomi.smarthome/db/miio2.db 'select token from devicerecord where name like "%Vacuum%";'
-    ```
-
-### Linux and Android (rooted!)
-
-Follow the pairing process using your phone and Mi-Home app. You will be able to retrieve the token from an SQLite file inside your phone.
-
-Before you begin you need to install `libffi-dev` and `libssl-dev` by running the command below. This is needed for `python-miio` to be installed correctly.
-
-```bash
-sudo apt-get install libffi-dev libssl-dev
-```
-
-If your Home Assistant installation is running in a [virtualenv](/docs/installation/virtualenv/#upgrading-home-assistant), make sure you activate it by running the commands below.
-
-```bash
-sudo -u homeassistant -H -s
-source /srv/homeassistant/bin/activate
-```
-
-To fetch the token follow these instructions depending on your mobile phone platform.
-
-1. Configure the robot with [Mi Home version 5.0.30](https://www.apkmirror.com/apk/xiaomi-inc/mihome/mihome-5-0-30-release/). Make sure to select the correct region, as Xiaomi uses different product names for different geographical areas.
-2. Enable developer mode, USB debugging and root permission only for ADB on the Android phone and plug it into the computer.
-3. Get ADB (e.g, using `apt-get install android-tools-adb`).
-4. The command `adb devices` should list your device.
-5. The command `adb root` (does work for development builds only: ones with `ro.debuggable=1`).
-6. The command `adb shell` (for those using Magisk based root the this command won't work. After entering a shell, type `su` to enter the root shell and try again).
-7. The following command returns a list of all registered devices including IP address and token:
-    ```bash
-    echo "select name,localIP,token from devicerecord;" | sqlite3 /data/data/com.xiaomi.smarthome/databases/miio2.db
-    ```
+1. To begin, set up your Robovac with the latest version of Mi Home on your primary Android device as you normally would.
+2. Ensure successful operation using the latest Mi Home app and give the Vacuum a static IP in your router or however you do that on your LAN.
+3. Install version `v5.4.54` of Mi Home on your rooted Android device and login (you can't have two version of Mi Home installed at the same time).
+4. Ensure you are using the same server every time
+5. Ensure successful operation using 5.4.54 (locate is a nice simple test)
+6. Using adb we will now extract the token from the rooted phone
+7. Use adb shell to connect to your device and become root (if using Magisck root do `adb shell -> su -> whoami` to ensure root access.
+8. Then run grep -R '"token"' /data/data/com.xiaomi.smarthome and grab the token
 
 ### iOS
 
@@ -363,34 +272,42 @@ To fetch the token follow these instructions depending on your mobile phone plat
 8. Select `Browse Data` tab from the DB Browser and switch to table called `devicerecord`
 9. This will display all the connected devices information with the token.
 
-### Selecting token manually (Windows and Android)
+### Miio command line tool
 
-The following instruction explained an alternative method, in case the MiToolKit didn't work.
+Use of Miio should be done before the Vacuum is connected to Mi Home. If you already connected to the app you will need to delete it and then join the ad-hoc Wifi network the Vacuum creates. If the vacuum is already paired it's likely this method will only return `???` as your token.
 
-Software Required:
+You can install the command line tool using the following command:
 
-- Android ADB is contained in [Android SDK](https://developer.android.com/studio/releases/platform-tools)
-- [Mi Home version 5.0.30](https://www.apkmirror.com/apk/xiaomi-inc/mihome/mihome-5-0-30-release/)
-- [Android Backup Extractor](https://sourceforge.net/projects/adbextractor/)
-- [SQLite Browser](https://sqlitebrowser.org/)
-1. Install an old Version of MiHome (e.g. Mi Home version 5.0.30) on your Android-Device
-2. Open MiHome, log-in and add your devices. Make sure to select the correct region, as Xiaomi uses different product names for different geographical areas.
-3. Enable USB-Debugging on your Android
-4. Create a backup from your MiHome App, by using adb
-  ```bash
-  adb backup com.xiaomi.smarthome
-  ```
-  Now the backup App opens on you Android-Device. You don't need to set a password, just click save.
-5. Extract the backup-file with android-backup-extractor
-  ```bash
-  java -jar abe.jar unpack backup.ab backup.tar
-  ```
-  After that, you will be able to open the file with WinRaR or what ever you like.
-6. Go to \apps\com.xiaomi.smarthome\db
-7. Open miio2.db with SQLite Browser
-8. You can find your device tokens in "devicerecord" table
+```bash
+npm install -g miio
+```
 
-## Retrieving the Zone Coordinates
+Discovering devices on the current network:
+
+```bash
+miio discover
+```
+
+This will list devices that are connected to the same network as your computer. Let it run for a while so it has a chance to reach all devices, as it might take a minute or two for all devices to answer.
+
+The commands outputs each device on this format:
+
+```text
+Device ID: 48765421
+Model info: zhimi.airpurifier.m1
+Address: 192.168.100.9
+Token: token-as-hex-here via auto-token
+Support: At least basic
+```
+
+The information output is:
+
+- `Device ID` - The unique identifier of the device, does not change if the device is reset.
+- `Model ID`- The model id if it could be determined, this indicates what type of device it is.
+- `Address` - The IP that the device has on the network.
+- `Token` - The token of the device or `???` if it could not be automatically determined.
+
+## Retrieving Zoned Cleaning Coordinates
 
 ### Using FloleVac (Android)
 
@@ -399,3 +316,20 @@ Software Required:
 3. Open Map (make sure you're on the same network as your vacuum cleaner)
 4. Select "Zone cleanup" and draw a box around the zone you'd like to clean
 5. Long press "Cleanup" and the zone coordinates will be copied to your clipboard
+
+### Using RoboRock Control Center (requires Valetudo firmware)
+
+[RRCC](https://github.com/LazyT/rrcc) supports both rooted and non-rooted Vacuums and acts as a mostly fully featured replacement for Mi Home that works locally without the cloud. If you have installed the rooted firmware [Valetudo](https://github.com/Hypfer/Valetudo) you are able to SSH into your Vacuum and enable MQTT plus use map functions with no cloud requirement.
+
+Using the map editor you are able to acquire the co-ordinates required for zoned clean up. Here is an example script for zoned clean up:
+
+```
+vacuum_kitchen:
+  alias: "vacuum kitchen"
+  sequence:
+    - service: vacuum.send_command
+      data:
+        entity_id: 'vacuum.xiaomi_vacuum_cleaner'
+        command: app_zoned_clean
+        params: [[23084,26282,27628,29727,1]]
+```


### PR DESCRIPTION
**Description:**

Clarifies the token retrieval process, explicitly states an update to the working Mi Home app version and adds a notes about Roborock Control Center and Valetudo firmware for user discovery purposes.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
