### PR TITLE
change to partly-cloudy

### DIFF
--- a/source/_integrations/weather.markdown
+++ b/source/_integrations/weather.markdown
@@ -22,7 +22,7 @@ The `weather` platform only knows the below listed conditions. The reason for th
 - 'hail'
 - 'lightning'
 - 'lightning-rainy'
-- 'partlycloudy'
+- 'partly-cloudy'
 - 'pouring'
 - 'rainy'
 - 'snowy'


### PR DESCRIPTION
following discussion on home-assistant/home-assistant#29569 this aims use partly-cloudy all through HA's weather integrations and backend. Will Pr all integrations and documentation accordingly

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
