### PR TITLE
Add note to alert about new NS Api

### DIFF
--- a/source/_integrations/nederlandse_spoorwegen.markdown
+++ b/source/_integrations/nederlandse_spoorwegen.markdown
@@ -8,6 +8,8 @@ ha_iot_class: Cloud Polling
 ha_release: 0.57
 ---
 
+**Note: Integration is currently not working for new users because the new NS Api requires a primary and secondary key: https://github.com/home-assistant/home-assistant/issues/26622**
+
 This sensor will provide you with time table information of the [Nederlandse Spoorwegen](https://www.ns.nl/) train service in the Netherlands.
 
 You must create an application [here](https://www.ns.nl/ews-aanvraagformulier/) to obtain a `password`.


### PR DESCRIPTION
You currently can not set up the NS integration due to api incompatibility for new users

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
