### PR TITLE
Add example of condition inside action

### DIFF
--- a/source/_docs/automation/condition.markdown
+++ b/source/_docs/automation/condition.markdown
@@ -29,3 +29,15 @@ automation:
       entity_id: scene.DespiertaDespacho
 ```
 
+Manually triggering an automation from the services page bypasses conditions in the main body of the automation. To evaluate conditions during a manual trigger, include them in the action.
+
+Example of condition in action:
+
+```yaml
+action:
+- condition: state
+  entity_id: binary_sensor.workday_sensor
+  state: 'on'
+- service: scene.turn_on
+  entity_id: scene.WakeupWorkday
+```


### PR DESCRIPTION
Added an example of a condition inside the action and a note that manual trigger bypasses the condition. Based on conversation in: https://community.home-assistant.io/t/automation-with-condition-but-always-triggering/120792/14

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
