### PR TITLE
Add documentation for input_*.reload service.

### DIFF
--- a/source/_integrations/input_boolean.markdown
+++ b/source/_integrations/input_boolean.markdown
@@ -42,6 +42,18 @@ input_boolean:
         type: icon
 {% endconfiguration %}
 
+### Services
+
+This integration provides the following services to modify the state of the `input_boolean` and a service to reload the
+configuration without restarting Home Assistant itself.
+
+| Service | Data | Description |
+| ------- | ---- | ----------- |
+| `turn_on` | `entity_id(s)`<br>`area_id(s)` | Set the value of specific `input_boolean` entities to `on`
+| `turn_off` | `entity_id(s)`<br>`area_id(s)` | Set the value of specific `input_boolean` entities to `off`
+| `toggle` | `entity_id(s)`<br>`area_id(s)` | Toggle the value of specific `input_boolean` entities
+| `reload` | | Reload `input_boolean` configuration |
+
 ### Restore State
 
 If you set a valid value for `initial` this integration will start with state set to that value. Otherwise, it will restore the state it had prior to Home Assistant stopping.

--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -82,7 +82,7 @@ If you set a valid value for `initial` this integration will start with state se
 
 ### Services
 
-Available service: `input_datetime.set_datetime`.
+Available service: `input_datetime.set_datetime` and `input_datetime.reload`.
 
 Service data attribute | Format String | Description
 -|-|-
@@ -91,6 +91,8 @@ Service data attribute | Format String | Description
 `datetime` | `%Y-%m-%d %H:%M:%S` | This can be used to dynamically set both the date & time.
 
 To set both the date and time in the same call, use `date` and `time` together, or use `datetime` by itself. Using `datetime` has the advantage that both can be set using one template.
+
+`input_dateteime.reload` service allows one to reload `input_datetime`'s configuration without restarting Home Assistant itself.
 
 ## Automation Examples
 

--- a/source/_integrations/input_number.markdown
+++ b/source/_integrations/input_number.markdown
@@ -73,6 +73,18 @@ input_number:
         type: icon
 {% endconfiguration %}
 
+### Services
+
+This integration provides the following services to modify the state of the `input_number` and a service to reload the
+configuration without restarting Home Assistant itself.
+
+| Service | Data | Description |
+| ------- | ---- | ----------- |
+| `decrement` | `entity_id(s)`<br>`area_id(s)` | Decrement the value of specific `input_number` entities by `step` 
+| `increment` | `entity_id(s)`<br>`area_id(s)` | Increment the value of specific `input_number` entities by `step`
+| `reload` | | Reload `input_number` configuration |
+| `set_value` | `value`<br>`entity_id(s)`<br>`area_id(s)` | Set the value of specific `input_number` entities
+
 ### Restore State
 
 If you set a valid value for `initial` this integration will start with state set to that value. Otherwise, it will restore the state it had prior to Home Assistant stopping.

--- a/source/_integrations/input_select.markdown
+++ b/source/_integrations/input_select.markdown
@@ -74,6 +74,7 @@ This integration provides three services to modify the state of the `input_selec
 | `set_options` | `options`<br>`entity_id(s)` | Set the options for specific `input_select` entities.
 | `select_previous` | | Select the previous option.
 | `select_next` | | Select the next option.
+| `reload` | | Reload `input_select` configuration |
 
 ### Scenes
 

--- a/source/_integrations/input_text.markdown
+++ b/source/_integrations/input_text.markdown
@@ -71,11 +71,12 @@ input_text:
 
 ### Services
 
-This integration provides a single service to modify the state of the `input_text`.
+This integration provides a service to modify the state of the `input_text` and a service to reload the `input_text` configuration without restarting Home Assistant itself.
 
 | Service | Data | Description |
 | ------- | ---- | ----------- |
 | `set_value` | `value`<br>`entity_id(s)` | Set the value for specific `input_text` entities.
+| `reload` | | Reload `input_text` configuration |
 
 ### Restore State
 


### PR DESCRIPTION
**Description:**
Update documentation for `input_boolean`, `input_datetime`, `input_number`, `input_select` and `input_text` integrations with `reload` service.

**Pull request in home-assistant:**
- home-assistant/home-assistant#29379
- home-assistant/home-assistant#29581
- home-assistant/home-assistant#29584
- home-assistant/home-assistant#29644
- home-assistant/home-assistant#29647

There're 5 commits in this PR, one for each integration. If you wish so, I can split those into different PRs. Lemme know.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
