### PR TITLE
Access Token URI must use port 443 (w/ valid cert)

### DIFF
--- a/source/_integrations/alexa.smart_home.markdown
+++ b/source/_integrations/alexa.smart_home.markdown
@@ -173,6 +173,7 @@ Alexa can link your Amazon account to your Home Assistant account. Therefore Hom
 - Input all information required. Assuming your Home Assistant can be accessed by https://[YOUR HOME ASSISTANT URL:PORT]
   * `Authorization URI`: https://[YOUR HOME ASSISTANT URL:PORT]/auth/authorize
   * `Access Token URI`: https://[YOUR HOME ASSISTANT URL:PORT]/auth/token
+    - Note: you must use a valid/trusted SSL Certificate and port 443 for account linking to work
   * `Client ID`:
     - https://pitangui.amazon.com/ if you are in US
     - https://layla.amazon.com/ if you are in EU


### PR DESCRIPTION
Amazon reps have stated this is a requirement, and stating it up front will will help many people trying to use the default port of 8123, even  with a trusted certificate

https://forums.developer.amazon.com/questions/74075/alexa-oauth-20-https-problem.html

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
