### PR TITLE
fix typo in docs

### DIFF
--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -149,7 +149,7 @@ data:
 
 ### Next/Previous buttons
 
-The behaviour of the next and previsous buttons is different depending on the active source:
+The behaviour of the next and previous buttons is different depending on the active source:
 
  - if the source is 'LiveTV' (television): next/previous buttons act as channel up/down
  - otherwise: next/previous buttons act as next/previous track


### PR DESCRIPTION
**Description:**
Fixes a small typo

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
