### PR TITLE
fix(configuration): mac_address is now mac

### DIFF
--- a/source/_integrations/wake_on_lan.markdown
+++ b/source/_integrations/wake_on_lan.markdown
@@ -61,11 +61,11 @@ To enable this switch in your installation, add the following to your `configura
 # Example configuration.yaml entry
 switch:
   - platform: wake_on_lan
-    mac_address: "00-01-02-03-04-05"
+    mac: "00-01-02-03-04-05"
 ```
 
 {% configuration %}
-mac_address:
+mac:
   description: MAC address to send the wake up command to.
   required: true
   type: string


### PR DESCRIPTION
**Description:**

It seem that now `mac_address` it's just `mac`

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
