### PR TITLE
Add services to evohome

### DIFF
--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -14,8 +14,8 @@ ha_codeowners:
 
 The `evohome` integration links Home Assistant with all _non-US_ [Honeywell Total Connect Comfort (TCC)](https://international.mytotalconnectcomfort.com/Account/Login) CH/DHW systems, such as:
 
-- The Honeywell evohome CH/DHW system, and
-- The Honeywell Round Thermostat
+- the Honeywell evohome CH/DHW system, and
+- the Honeywell Round Thermostat
 
 It does not support the home security functionality of TCC.
 

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -19,7 +19,7 @@ The `evohome` integration links Home Assistant with all _non-US_ [Honeywell Tota
 
 It does not support the home security functionality of TCC.
 
-It use the [evohome-async](https://github.com/zxdavb/evohome-async) client library.
+It uses the [evohome-async](https://github.com/zxdavb/evohome-async) client library.
 
 If your system is compatible with this integration, then you will be able to access it via [https://international.mytotalconnectcomfort.com/](https://international.mytotalconnectcomfort.com/) (note the `international`).
 
@@ -85,9 +85,9 @@ Some locations have a hidden mode, **AutoWithReset**, that will behave as **Auto
 
 In Home Assistant schema, all this is done via a combination of `HVAC_MODE` and `PRESET_MODE` (but also see the state attributes `systemModeStatus` and `setpointStatus`, below).
 
-## Service Handlers
+## Service Calls
 
-This integration provide service calls to expose the full functionality of evohome beyond the limitations of Home Assistant's standardised schema. Mostly, this is with having specified durations of mode changes, after which time the entities revert to **Auto** or **FollowSchedule**.
+This integration provide service calls to expose the full functionality of evohome beyond the limitations of Home Assistant's standardised schema. Mostly, this relates to specifying the duration of mode changes, after which time the entities revert to **Auto** or **FollowSchedule** (for locations and zones, respectively).
 
 ### evohome.set_system_mode
 

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -5,6 +5,7 @@ logo: honeywell.png
 ha_category:
   - Hub
   - Climate
+  - Water Heater
 ha_release: 0.8
 ha_iot_class: Cloud Polling
 ha_codeowners:
@@ -18,7 +19,7 @@ The `evohome` integration links Home Assistant with all _non-US_ [Honeywell Tota
 
 It does not support the home security functionality of TCC.
 
-It uses the [evohome-async](https://github.com/zxdavb/evohome-async) client library.
+It use the [evohome-async](https://github.com/zxdavb/evohome-async) client library.
 
 If your system is compatible with this integration, then you will be able to access it via [https://international.mytotalconnectcomfort.com/](https://international.mytotalconnectcomfort.com/) (note the `international`).
 
@@ -98,6 +99,10 @@ For some modes, such as **Away**, the duration is in `days`, where 1 day will re
 
 This service call is used to set the system to **AutoWithReset**, and reset all the zones to **FollowSchedule**.
 
+### evohome.evohome.refresh_system
+
+This service call is used to pull the latest state data from the vendor's servers.
+
 ### evohome.set_zone_override
 
 This service call is used to set the `temperature` of a zone as identified by its `entity_id`. This change can either be indefinite, or for a set period of time, after which it will revert to **FollowSchedule**. The duration can be in `minutes` from the current time, or `until` a specified time within the next 24 hours.
@@ -105,10 +110,6 @@ This service call is used to set the `temperature` of a zone as identified by it
 ### evohome.clear_zone_override
 
 This service call is used to set a zone, as identified by its `entity_id`, to **FollowSchedule**.
-
-### evohome.evohome.force_refresh
-
-This service call is used to pull the latest state data from the vendor's servers.
 
 ## Useful Jinja Templates
 

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Hub
   - Climate
   - Water Heater
-ha_release: 0.8
+ha_release: 0.80
 ha_iot_class: Cloud Polling
 ha_codeowners:
   - '@zxdavb'
@@ -25,15 +25,15 @@ If your system is compatible with this integration, then you will be able to acc
 
 ### evohome
 
-evohome is a multi-zone system. Each zone is represented as a **Climate** device: it will expose the zone's operating mode, temperature and setpoint.
+Evohome is a multi-zone system. Each zone is represented as a **Climate** entity: it will expose the zone's operating mode, temperature and setpoint.
 
-The controller/location is also represented as a **Climate** device: it will expose the location's operating mode (see below for details). Note that the controller's current temperature is calculated as an average of all the Zones.
+The location (controller) is also represented as a **Climate** entity: it will expose the location's operating mode (see below for details). Note that the entity's current temperature is calculated as an average of all the Zones.
 
-The DHW controller is represented as a **WaterHeater** device: It will report its current temperature (but not target temperature), and it can be turned on or off.  The target temperature cannot be changed.
+The DHW controller is represented as a **WaterHeater** entity: It will report its current temperature, and it can be turned on or off. The setpoint is not reported, and cannot cannot be changed.
 
 ### Round Thermostat
 
-Although Round Thermostat is, strictly speaking, both a Controller and a single zone; they are merged into a single **Climate** device.
+Such systems usually have only one Round Thermostat, although they can have two. Systems with one such thermostat are merged into a single **Climate** entity. Systems with two thermostats will have a 3rd entity for the TCC locations, much like evohome, above.
 
 ## Configuration
 
@@ -67,7 +67,7 @@ scan_interval:
   default: 300
 {% endconfiguration %}
 
-This is an IoT cloud-polling device, and the recommended `scan_interval` is 180 seconds. Testing has indicated that this is a safe interval that - by itself - shouldn't cause you to be rate-limited by Honeywell.
+This is an IoT cloud-polling integration, and the recommended `scan_interval` is 180 seconds. Testing has indicated that this is a safe interval that - by itself - shouldn't cause you to be rate-limited by Honeywell.
 
 ## System modes, Zone overrides and Inheritance
 
@@ -83,11 +83,11 @@ If the zone's temperature is changed, then it will be a **TemporaryOverride** th
 
 Some controllers have a hidden mode, **AutoWithReset**, that will behave as **Auto**, and will reset all zones to **FollowSchedule**.
 
-In Home Assistant schema, all this is done via acombination of `HVAC_MODE` and `PRESET_MODE` (but also see the state attributes `systemModeStatus` and `setpointStatus`, below).
+In Home Assistant schema, all this is done via a combination of `HVAC_MODE` and `PRESET_MODE` (but also see the state attributes `systemModeStatus` and `setpointStatus`, below).
 
 ## Services
 
-This integration provide service calls to extend the full functionality of evohome beyond the limitations of Home Assistant's standardised schema.  Mostly, this is with having specified durations of mode changes, after which time the entities revert to **Auto** or **FollowSchedule**.
+This integration provide service calls to extend the full functionality of evohome beyond the limitations of Home Assistant's standardised schema. Mostly, this is with having specified durations of mode changes, after which time the entities revert to **Auto** or **FollowSchedule**.
 
 ### evohome.set_system_mode
 

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -18,7 +18,7 @@ The `evohome` integration links Home Assistant with all _non-US_ [Honeywell Tota
 
 It does not support the home security functionality of TCC.
 
-It use the [evohome-async](https://github.com/zxdavb/evohome-async) client library.
+It uses the [evohome-async](https://github.com/zxdavb/evohome-async) client library.
 
 If your system is compatible with this integration, then you will be able to access it via [https://international.mytotalconnectcomfort.com/](https://international.mytotalconnectcomfort.com/) (note the `international`).
 

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -18,9 +18,9 @@ The `evohome` integration links Home Assistant with all _non-US_ [Honeywell Tota
 
 It does not support the home security functionality of TCC.
 
-It uses v2 of the [evohome-client](https://github.com/watchforstock/evohome-client) client library.
+It use the [evohome-client](https://github.com/watchforstock/evohome-client) client library.
 
-Honeywell removed support for higher-precision temperatures from the v2 API, and thus reported temperatures are rounded up to the nearest 0.5C.
+If your system is compatible with this integration, then you will be able to access it via [https://international.mytotalconnectcomfort.com/](https://international.mytotalconnectcomfort.com/) (note the `international`).
 
 ### evohome
 

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -23,7 +23,7 @@ It use the [evohome-async](https://github.com/zxdavb/evohome-async) client libra
 
 If your system is compatible with this integration, then you will be able to access it via [https://international.mytotalconnectcomfort.com/](https://international.mytotalconnectcomfort.com/) (note the `international`).
 
-### evohome
+### Evohome
 
 Evohome is a multi-zone system. Each zone is represented as a **Climate** entity: it will expose the zone's operating mode, temperature and setpoint.
 
@@ -85,9 +85,9 @@ Some locations have a hidden mode, **AutoWithReset**, that will behave as **Auto
 
 In Home Assistant schema, all this is done via a combination of `HVAC_MODE` and `PRESET_MODE` (but also see the state attributes `systemModeStatus` and `setpointStatus`, below).
 
-## Services
+## Service Handlers
 
-This integration provide service calls to extend the full functionality of evohome beyond the limitations of Home Assistant's standardised schema. Mostly, this is with having specified durations of mode changes, after which time the entities revert to **Auto** or **FollowSchedule**.
+This integration provide service calls to expose the full functionality of evohome beyond the limitations of Home Assistant's standardised schema. Mostly, this is with having specified durations of mode changes, after which time the entities revert to **Auto** or **FollowSchedule**.
 
 ### evohome.set_system_mode
 
@@ -99,7 +99,7 @@ For some modes, such as **Away**, the duration is in `days`, where 1 day will re
 
 This service call is used to set the system to **AutoWithReset**, and reset all the zones to **FollowSchedule**.
 
-### evohome.evohome.refresh_system
+### evohome.refresh_system
 
 This service call is used to pull the latest state data from the vendor's servers.
 

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -71,17 +71,17 @@ This is an IoT cloud-polling integration, and the recommended `scan_interval` is
 
 ## System modes, Zone overrides and Inheritance
 
-Controllers support up to six distinct operating modes: **Auto**, **AutoWithEco**, **Away**, **DayOff**, **HeatingOff**, and **Custom**. Not all evohome systems support all modes.
+Evohome locations support up to six distinct operating modes: **Auto**, **AutoWithEco**, **Away**, **DayOff**, **HeatingOff**, and **Custom**. Not all evohome systems support all modes.
 
-Zones support three setpoint modes: **FollowSchedule**, **TemporaryOverride**, and **PermanentOverride** but 'inherit' an operating mode from their controller (the actual algorithm for this is a little more complicated than indicated below).
+Zones support three setpoint modes: **FollowSchedule**, **TemporaryOverride**, and **PermanentOverride** but 'inherit' an operating mode from their location (the actual algorithm for this is a little more complicated than indicated below - please see your vendor's documentation).
 
 For **FollowSchedule**, a zone's `temperature` (target temperature, a.k.a setpoint) is a function of its scheduled temperature and its inherited mode. For example, **AutoWithEco** would be scheduled temperature less 3C.
 
-If the controller is set to **HeatingOff** (temperature set to a minimum) or **Away** (temperature set to 12C), then the zones will inherit that setpoint regardless of their own mode. For **Away**, the DHW controller will also be turned off.
+If the location is set to **HeatingOff** (temperature set to a minimum) or **Away** (temperature set to 12C), then the zones will inherit that setpoint regardless of their own mode. For **Away**, the DHW controller will also be turned off.
 
 If the zone's temperature is changed, then it will be a **TemporaryOverride** that will revert to **FollowSchedule** at the next scheduled setpoint (or in an hour, if there is no such schedule). Zones can be switched between the two override modes without changing the target temperature.
 
-Some controllers have a hidden mode, **AutoWithReset**, that will behave as **Auto**, and will reset all zones to **FollowSchedule**.
+Some locations have a hidden mode, **AutoWithReset**, that will behave as **Auto**, and will reset all zones to **FollowSchedule**.
 
 In Home Assistant schema, all this is done via a combination of `HVAC_MODE` and `PRESET_MODE` (but also see the state attributes `systemModeStatus` and `setpointStatus`, below).
 
@@ -115,7 +115,7 @@ This service call is used to set a zone, as identified by its `entity_id`, to **
 
 The actual operating mode of evohome entities can be tracked via their state attributes, which includes a JSON data structure for the current state called `status`.
 
-For the Controller, see `system_mode_status`:
+For the location (controller), see `system_mode_status`:
 
 {% raw %}
 ```text

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -16,6 +16,7 @@ The `evohome` integration links Home Assistant with all _non-US_ [Honeywell Tota
 
 - the Honeywell evohome CH/DHW system, and
 - the Honeywell Round Thermostat
+- the Honeywell Mobile Access Kit
 
 It does not support the home security functionality of TCC.
 


### PR DESCRIPTION
**Description:**
Add services to evohome: these expose the full functionality of the system, beyond the restrictions of the HA climate schema - mainly the option of setting time limits for operating modes.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29816

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
