### PR TITLE
Cleanup honeywell docs

### DIFF
--- a/source/_integrations/honeywell.markdown
+++ b/source/_integrations/honeywell.markdown
@@ -10,29 +10,9 @@ ha_iot_class: Cloud Polling
 
 The `honeywell` climate platform integrates Home Assistant with _US-based_ [Honeywell Total Connect Comfort (TCC)](https://mytotalconnectcomfort.com/portal/) climate systems.
 
-It does not support the home security functionality of TCC.
+It uses the [somecomfort](https://github.com/kk7ds/somecomfort) client library. It does not support the home security functionality of TCC.
 
-It uses the [somecomfort](https://github.com/kk7ds/somecomfort) client library.
-
-<div class='note'>
-
-There is some potential confusion over this integration because it was previously implemented as a combination of two _distinct_ climate systems, one being US-based, the other EU-based.
-
-These two regions are _not_ interchangeable, and the `eu` region is now deprecated.  Ongoing support for such systems is available via the [evohome](/integrations/evohome/) integration.
-
-</div>
-
-### US-based Systems
-
-These systems are based in North America, and temperatures are usually in Fahrenheit. They would likely be HVAC systems. They always use the [somecomfort](https://github.com/kk7ds/somecomfort) client library. In this integration, this is called the `us` region.
-
-If your system is US-based, then you can access your system via [https://mytotalconnectcomfort.com/portal/](https://mytotalconnectcomfort.com/portal/) (note the `/portal/`).
-
-### EU-based Systems
-
-These systems are based in Europe (including the UK & Ireland), and temperatures are usually in Celsius. They would likely be heating-only systems. They always use the [evohome-client](https://github.com/watchforstock/evohome-client) client library. In this integration, this is called the `eu` region.
-
-If your system is EU-based, then you can access it via [https://international.mytotalconnectcomfort.com/](https://international.mytotalconnectcomfort.com/) (note the `international`).
+If your system is compatible with this integration, then you will be able access your it via [https://mytotalconnectcomfort.com/portal/](https://mytotalconnectcomfort.com/portal/) (note the `/portal/`).
 
 ## Configuration
 


### PR DESCRIPTION
**Description:**
Cleans up the honeywell documentation - removes chaff left over from when evohome was pulled out of honeywell.

**Pull request in home-assistant (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
