### PR TITLE
Provide link to How to enable i2c on HassOS instructions.

### DIFF
--- a/source/_integrations/mcp23017.markdown
+++ b/source/_integrations/mcp23017.markdown
@@ -14,7 +14,7 @@ The `mcp23017` integration is the base for all related mcp23017 platforms in Hom
 
 For more details about the MCP23017 I2C I/O port expander you can find its datasheet here: [MCP23017](https://www.microchip.com/wwwproducts/en/MCP23017).
 
-If you are using Hass.io you can’t use existing methods to enable the I2C bus on a Raspberry Pi, you will have to [enable the I2C interface in the Hass.io configuration](https://github.com/home-assistant/hassos/blob/dev/Documentation/boards/raspberrypi.md#i2c) using a USB stick. To accomplish that follow this step by step instructions: [Enable HassOS i2c](https://www.home-assistant.io/hassio/enable_i2c).
+If you are using Hass.io on HassOS you can’t use existing methods to enable the I2C bus on a Raspberry Pi, you will have to [enable the I2C interface in the Hass.io configuration](https://github.com/home-assistant/hassos/blob/dev/Documentation/boards/raspberrypi.md#i2c) using a USB stick. To accomplish that, follow this step by step instructions: [Enable HassOS i2c](https://www.home-assistant.io/hassio/enable_i2c).
 
 ## Binary Sensor
 

--- a/source/_integrations/mcp23017.markdown
+++ b/source/_integrations/mcp23017.markdown
@@ -14,6 +14,8 @@ The `mcp23017` integration is the base for all related mcp23017 platforms in Hom
 
 For more details about the MCP23017 I2C I/O port expander you can find its datasheet here: [MCP23017](https://www.microchip.com/wwwproducts/en/MCP23017).
 
+If you are using Hass.io you can’t use existing methods to enable the I2C bus on a Raspberry Pi, you will have to [enable the I2C interface in the Hass.io configuration](https://github.com/home-assistant/hassos/blob/dev/Documentation/boards/raspberrypi.md#i2c) using a USB stick. To accomplish that follow this step by step instructions: [Enable HassOS i2c](https://www.home-assistant.io/hassio/enable_i2c).
+
 ## Binary Sensor
 
 The `mcp23017` binary sensor platform allows you to read sensor values from the I/O pins of your [MCP23017 I2C I/O expander](https://www.adafruit.com/product/732).


### PR DESCRIPTION
**Description:**
Added a paragraph that links to the instructions on how to enable i2c on HassOS using a USB stick.

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
