### PR TITLE
Update proxmoxve.markdown

### DIFF
--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -22,7 +22,7 @@ To use the `proxmoxve` component, add the following config to your `configuratio
 
 ```yaml
 # Example configuration.yaml entry
-proxmox:
+proxmoxve:
   - host: IP_ADDRESS
     username: USERNAME
     password: PASSWORD
@@ -84,7 +84,7 @@ nodes:
 Example with multiple VMs and no containers:
 
 ```yaml
-proxmox:
+proxmoxve:
   - host: IP_ADDRESS
     username: USERNAME
     password: PASSWORD


### PR DESCRIPTION
integration not found as "proxmox" in configuration.  Updated YAML nodes to reflect the name "proxmoxve"

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
