### PR TITLE
Fix Hive table of content links

### DIFF
--- a/source/_integrations/hive.markdown
+++ b/source/_integrations/hive.markdown
@@ -21,8 +21,8 @@ This integration uses the unofficial API used in the official Hive website [http
 There is currently support for the following services and platforms within Home Assistant:
 
 - [Services](#services)
-  - [Service `hive.boost_heating`](#service-hiveboostheating)
-  - [Service `hive.boost_hot_water`](#service-hiveboosthotwater)
+  - [Service `hive.boost_heating`](#service-hiveboost_heating)
+  - [Service `hive.boost_hot_water`](#service-hiveboost_hot_water)
 - [Platforms](#platforms)
   - [Binary Sensor](#binary-sensor)
   - [Climate](#climate)


### PR DESCRIPTION
**Description:**

Just fixing two TOC service links

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
