### PR TITLE
Add missed domain name change for APNS service docs

### DIFF
--- a/source/_integrations/apns.markdown
+++ b/source/_integrations/apns.markdown
@@ -48,7 +48,7 @@ sandbox:
 
 The APNS platform will register two services, `notify.NOTIFIER_NAME` and `apns.apns_NOTIFIER_NAME`.
 
-### notify.apns_NOTIFIER_NAME
+### apns.apns_NOTIFIER_NAME
 
 This service will register device IDs with Home Assistant. In order to receive a notification a device must be registered. The app on the device can use this service to send an ID to Home Assistant during startup, the ID will be stored in `[NOTIFIER_NAME]_apns.yaml`.
 


### PR DESCRIPTION
**Description:** The docs were updated to reflect the domain change for one of the APNS services, but one reference was missed. This PR will address the missed reference

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29165

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
