### PR TITLE
Remove broken link from 0.103 release notes

### DIFF
--- a/source/_posts/2019-12-11-release-103.markdown
+++ b/source/_posts/2019-12-11-release-103.markdown
@@ -160,7 +160,7 @@ The following integrations are added in this release:
 - Add Proxmox VE integration ([@K4ds3] - [#27315]) ([proxmoxve docs]) (new-integration)
 - Add flume support ([@ChrisMandich] - [#27235]) ([flume docs]) (new-integration)
 - StarLine integration ([@Anonym-tsk] - [#27197]) ([starline docs]) (new-integration)
-- Add intent integration to expose intent handle API ([@balloob] - [#29124]) ([conversation docs]) ([intent docs]) (new-integration)
+- Add intent integration to expose intent handle API ([@balloob] - [#29124]) ([conversation docs]) (new-integration)
 - Dsmr reader ([@depl0y] - [#28701]) ([dsmr_reader docs]) ([fleetgo docs]) ([openhardwaremonitor docs]) (new-integration)
 - Add ATEN PE component for ATEN eco PDUs ([@mtdcr] - [#27960]) ([aten_pe docs]) (new-integration)
 


### PR DESCRIPTION
**Description:**

Removes a broken link to something we don't have docs for.
Was auto-generated by the release script.

fixes #11439

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
