### PR TITLE
Remove services from Hive "TOC"

### DIFF
--- a/source/_integrations/hive.markdown
+++ b/source/_integrations/hive.markdown
@@ -18,18 +18,14 @@ The `hive` integration is the main integration to set up and integrate all suppo
 
 This integration uses the unofficial API used in the official Hive website [https://my.hivehome.com](https://my.hivehome.com), and you will need to use the same Username and Password you use on the Hive website to configure this Hive integration in Home Assistant.
 
-There is currently support for the following services and platforms within Home Assistant:
+There is currently support for the following platforms within Home Assistant:
 
-- [Services](#services)
-  - [Service `hive.boost_heating`](#service-hiveboost_heating)
-  - [Service `hive.boost_hot_water`](#service-hiveboost_hot_water)
-- [Platforms](#platforms)
-  - [Binary Sensor](#binary-sensor)
-  - [Climate](#climate)
-  - [Light](#light)
-  - [Sensor](#sensor)
-  - [Switch](#switch)
-  - [Water Heater](#water-heater)
+- [Binary Sensor](#binary-sensor)
+- [Climate](#climate)
+- [Light](#light)
+- [Sensor](#sensor)
+- [Switch](#switch)
+- [Water Heater](#water-heater)
 
 To add your Hive devices into your Home Assistant installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
**Description:**

Follows https://github.com/home-assistant/home-assistant.io/pull/11434#discussion_r357031121

Hive is the only component which have a TOC with "Services", we only reference supported platforms.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
