### PR TITLE
Add arrival and departure to here_travel_time

### DIFF
--- a/source/_integrations/here_travel_time.markdown
+++ b/source/_integrations/here_travel_time.markdown
@@ -134,9 +134,8 @@ sensor:
     route_mode: fastest
     traffic_mode: false
     unit_system: imperial
+    departure: "17:00:00"
     scan_interval: 2678400 # 1 month
-    
-
 ```
 
 ## Entity Tracking

--- a/source/_integrations/here_travel_time.markdown
+++ b/source/_integrations/here_travel_time.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Transport
   - Sensor
 ha_iot_class: Cloud Polling
-ha_release: '0.100'
+ha_release: '0.108'
 ha_codeowners:
   - '@eifinger'
 ---

--- a/source/_integrations/here_travel_time.markdown
+++ b/source/_integrations/here_travel_time.markdown
@@ -89,6 +89,15 @@ traffic_mode:
   required: false
   type: boolean
   default: false
+arrival:
+  description: "Time when travel is expected to end. A 24 hour time string like `08:00:00`. On a sensor update it will be combined with the current date to get travel time for that moment. Cannot be used in combination with `departure`. Can only be used in combination with `mode: publicTransportTimeTable`"
+  required: false
+  type: time
+departure:
+  description: "Time when travel is expected to end. A 24 hour time string like `08:00:00`. On a sensor update it will be combined with the current date to get travel time for that moment. Cannot be used in combination with `arrival`. The default is now (the current date and time)" 
+  required: false
+  type: time
+  default: "now"
 unit_system:
   description: "You can choose between `metric` or `imperial`."
   required: false

--- a/source/_integrations/here_travel_time.markdown
+++ b/source/_integrations/here_travel_time.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Transport
   - Sensor
 ha_iot_class: Cloud Polling
-ha_release: '0.108'
+ha_release: '0.100'
 ha_codeowners:
   - '@eifinger'
 ---


### PR DESCRIPTION
**Description:**

Documentation for the new options `arrival` and `departure`.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29909

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
