### PR TITLE
Discovery now included in default configuration

### DIFF
--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -47,7 +47,7 @@ Zeroconf discoverable integrations [Axis](/integrations/axis/)/[ESPHome](/integr
 
 </div>
 
-Discovery is now included in the defalult configuration. To load this component manually, add the following lines to your `configuration.yaml`:
+`discovery` is included in the defalult configuration. To load this component manually, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -47,7 +47,7 @@ Zeroconf discoverable integrations [Axis](/integrations/axis/)/[ESPHome](/integr
 
 </div>
 
-To load this component, add the following lines to your `configuration.yaml`:
+Discovery is now included in the defalult configuration. To load this component manually, add the following lines to your `configuration.yaml`:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
Discovery is now included in the default configuration, and adding it manually actually generates an error message (at least in Hass.IO 102.2).

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
