### PR TITLE
rflink deprecation and other doc fixes

### DIFF
--- a/source/_integrations/light.rflink.markdown
+++ b/source/_integrations/light.rflink.markdown
@@ -99,18 +99,6 @@ devices:
           required: false
           default: true
           type: boolean
-        aliasses:
-          description: (**deprecated**) Alternative RFLink ID's this device is known by.
-          required: false
-          type: [list, string]
-        group_aliasses:
-          description: "(**deprecated**) `aliases` which only respond to group commands."
-          required: false
-          type: [list, string]
-        no_group_aliasses:
-          description: "(**deprecated**) `aliases` which do not respond to group commands."
-          required: false
-          type: [list, string]
 {% endconfiguration %}
 
 ### Light state

--- a/source/_integrations/sensor.rflink.markdown
+++ b/source/_integrations/sensor.rflink.markdown
@@ -63,10 +63,6 @@ devices:
           description: "Alternative RFLink ID's this device is known by."
           required: false
           type: [list, string]
-        aliasses:
-          description: "(**deprecated**) Alternative RFLink ID's this device is known by."
-          required: false
-          type: [list, string]
 {% endconfiguration %}
 
 ## Sensors types

--- a/source/_integrations/sensor.rflink.markdown
+++ b/source/_integrations/sensor.rflink.markdown
@@ -65,7 +65,7 @@ devices:
           type: [list, string]
 {% endconfiguration %}
 
-## Sensors types
+## Sensor types
 
 Sensor type values:
 

--- a/source/_integrations/switch.rflink.markdown
+++ b/source/_integrations/switch.rflink.markdown
@@ -82,7 +82,7 @@ devices:
           default: 1
           type: integer
         group:
-          description: Allow light to respond to group commands (ALLON/ALLOFF).
+          description: Allow switch to respond to group commands (ALLON/ALLOFF).
           required: false
           default: true
           type: boolean

--- a/source/_integrations/switch.rflink.markdown
+++ b/source/_integrations/switch.rflink.markdown
@@ -87,15 +87,15 @@ devices:
           default: true
           type: boolean
         aliases:
-          description: "(**deprecated**) Alternative RFLink ID's this device is known by."
+          description: Alternative RFLink ID's this device is known by.
           required: false
           type: [list, string]
         group_aliases:
-          description: "(**deprecated**) `aliases` which only respond to group commands."
+          description: "`aliases` which only respond to group commands."
           required: false
           type: [list, string]
         no_group_aliases:
-          description: "(**deprecated**) `aliases` which do not respond to group commands."
+          description: "`aliases` which do not respond to group commands."
           required: false
           type: [list, string]
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**

See individual commit messages for details.

home-assistant/home-assistant#29972 is related, but this can go in already now without waiting that to be applied.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#8348 (old)

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
