### PR TITLE
correct wrong quote

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -61,7 +61,7 @@ image:
   type: string
 secondary_info:
   required: false
-  description: "Show additional info. Values: `entity-id`, `last-changed`, `last-triggered' (only for automations and scripts)."
+  description: "Show additional info. Values: `entity-id`, `last-changed`, `last-triggered` (only for automations and scripts)."
   type: string
 format:
   required: false


### PR DESCRIPTION

![Schermafbeelding 2019-12-14 om 10 57 26](https://user-images.githubusercontent.com/33354141/70847127-d526b980-1e60-11ea-9905-3679b94abd6b.jpg)
corrected `last-triggered' to `last-triggered`

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
