### PR TITLE
add raw to the delay template

### DIFF
--- a/source/_integrations/script.markdown
+++ b/source/_integrations/script.markdown
@@ -89,7 +89,7 @@ script: 
           brightness: 100
       - delay:
           # supports seconds, milliseconds, minutes, hours
-          minutes: {{ minutes }}
+          minutes: {% raw %}{{ minutes }}{% endraw %}
       - alias: Living room lights on
         service: light.turn_on
         data:

--- a/source/_integrations/script.markdown
+++ b/source/_integrations/script.markdown
@@ -65,6 +65,8 @@ sequence:
 
 ### Full Configuration
 
+{% raw %}
+
 ```yaml
 script: 
   wakeup:
@@ -89,12 +91,14 @@ script: 
           brightness: 100
       - delay:
           # supports seconds, milliseconds, minutes, hours
-          minutes: {% raw %}{{ minutes }}{% endraw %}
+          minutes: {{ minutes }}
       - alias: Living room lights on
         service: light.turn_on
         data:
           entity_id: group.living_room
 ```
+
+{% endraw %}
 
 ### Passing variables to scripts
 


### PR DESCRIPTION
add raw to the delay template. (credits for this to: @lddubeau )
might need something extra: right now, when visiting this page, no value is displayed for the delay, which wouldn't be correct, since it could suggest it to be valid syntax to do so.

![Schermafbeelding 2019-12-14 om 16 50 30](https://user-images.githubusercontent.com/33354141/70851147-dd4b1d00-1e91-11ea-8162-885b483ffe8c.jpg)


Not sure how to change that in the html of this page, so ask for suggestion on behalf of the team.

please see https://community.home-assistant.io/t/confused-about-script-field-template-in-docs/155023/7?u=mariusthvdb for more info here

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
