### PR TITLE
Added new supported devices

### DIFF
--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -388,6 +388,8 @@ The `entity_id` names will be `light.device_name`, where `device_name` is define
 ### Verified supported lights
 
 - IKEA Trådfri bulb E14 WS Opal 400lm
+- IKEA Trådfri bulb E14 WS Opal 600lm
+- IKEA Trådfri Bulb E27 WS clear 950lm
 - IKEA Trådfri Bulb E27 WS Opal 980lm
 - IKEA Trådfri Bulb E27 WS Opal 1000lm
 - IKEA Trådfri Bulb E27 WS & RGB Opal 600lm


### PR DESCRIPTION
I'm using the following models with this Deconz addon:
- IKEA Trådfri bulb E14 WS Opal 600lm
- IKEA Trådfri Bulb E27 WS clear 950lm
Since few weeks ago with no issues.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ Y] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [Y ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
