### PR TITLE
Added documentation for "autobypass" option added to the AlarmDecoder integration

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -82,7 +82,7 @@ panel_display:
   default: false
   type: boolean
 autobypass:
-  description: If this is set to True, then when arming (home or away), it will automatically bypass all open zones (sending "6#")
+  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#')".
   required: false
   default: false
   type: boolean

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -81,7 +81,7 @@ panel_display:
   default: false
   type: boolean
 autobypass:
-  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#')".
+  description: "If this is set to `true`, then, when arming (home or away), it will automatically bypass all open zones (sending '6#')".
   required: false
   default: false
   type: boolean

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -35,11 +35,11 @@ alarmdecoder:
     port: 10000
   panel_display: false
   zones:
-    01:
+    1:
       name: 'Smoke Detector'
       type: 'smoke'
       rfid: '0123456'
-    02:
+    2:
       name: 'Front Door'
       type: 'opening'
 ```
@@ -81,7 +81,7 @@ panel_display:
   default: false
   type: boolean
 autobypass:
-  description: "If this is set to `true`, then, when arming (home or away), it will automatically bypass all open zones (sending '6#')".
+  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#')".
   required: false
   default: false
   type: boolean

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -81,7 +81,7 @@ panel_display:
   default: false
   type: boolean
 autobypass:
-  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#')".
+  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#')."
   required: false
   default: false
   type: boolean

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -34,7 +34,6 @@ alarmdecoder:
     host: 192.168.1.20
     port: 10000
   panel_display: false
-  autobypass: False
   zones:
     01:
       name: 'Smoke Detector'

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -35,11 +35,11 @@ alarmdecoder:
     port: 10000
   panel_display: false
   zones:
-    1:
+    01:
       name: 'Smoke Detector'
       type: 'smoke'
       rfid: '0123456'
-    2:
+    02:
       name: 'Front Door'
       type: 'opening'
 ```

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -34,6 +34,7 @@ alarmdecoder:
     host: 192.168.1.20
     port: 10000
   panel_display: false
+  autobypass: False
   zones:
     01:
       name: 'Smoke Detector'
@@ -77,6 +78,11 @@ device:
       type: string
 panel_display:
   description: Create a sensor called sensor.alarm_display to match the Alarm Keypad display.
+  required: false
+  default: false
+  type: boolean
+autobypass:
+  description: If this is set to True, then when arming (home or away), it will automatically bypass all open zones (sending "6#")
   required: false
   default: false
   type: boolean


### PR DESCRIPTION
**Description:**
Added a new configuration option in the AlarmDecoder integration, that allows one to force a bypass of all open zones at the time of arming their alarm.

## Checklist:

- [Y ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ Y] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
