### PR TITLE
Update on onyo.markdown

### DIFF
--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -82,6 +82,12 @@ List of source names:
 - xm
 - sirius
 
+If your source is not listed above, and you want to figure out how to format that source name so you can map it's entry, you can use the onkyo-eiscp python module to discover the exact naming needed. First change your receiver's source to the one that you need to define, and then run:
+
+```bash
+onkyo --host 192.168.0.100 source=query
+```
+
 To find your receivers max volume use the onkyo-eiscp python module set the receiver to its maximum volume
 (don't do this whilst playing something!) and run:
 

--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -82,7 +82,7 @@ List of source names:
 - xm
 - sirius
 
-If your source is not listed above, and you want to figure out how to format that source name so you can map it's entry, you can use the onkyo-eiscp python module to discover the exact naming needed. First change your receiver's source to the one that you need to define, and then run:
+If your source is not listed above, and you want to figure out how to format that source name so you can map its entry, you can use the `onkyo-eiscp` Python module to discover the exact naming needed. First, change your receiver's source to the one that you need to define, and then run:
 
 ```bash
 onkyo --host 192.168.0.100 source=query


### PR DESCRIPTION
**Description:**
The default source list for the Onkyo integration does not include all sources, and there is an easy way to determine exact source names. In my case, even though my receiver displays "Blu-ray/DVD" on screen, the "bd-dvd" source value was incorrect, and the correct input was "bd", which isn't in the default list, and is also pretty counter-intuitive.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
