### PR TITLE
Add template extension coordinates

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -305,6 +305,39 @@ Closest to some entity:
 
 {% endraw %}
 
+### Coordinates
+
+- `coordinates()` will return the coordinates stored as a state or attributes of an entity. If the state is an `entity_id` it will try to get the coordinates from that.
+
+### Coodinates examples
+
+Get coordinates from entities.
+
+{% raw %}
+```text
+Get coordinates from a device_tracker: {{ coordinates('device_tracker.me') }}
+Get coordinates from a zone: {{ coordinates('zone.work') }}
+```
+{% endraw %}
+
+Get coordinates from nested entities.
+
+{% raw %}
+```yaml
+Given the config
+input_select:
+  dynamic_device_tracker:
+    options:
+      - device_tracker.me
+      - device_tracker.not_me
+    initial: device_tracker.me
+```
+
+```text
+Use the device_tracker currently selected: {{ coordinates('input_select.dynamic_device_tracker') }}
+```
+{% endraw %}
+
 ### Formatting
 
 - `float` will format the output as float.


### PR DESCRIPTION
**Description:**

This template extension will allow for a clean and reusable way to enable dynamic `travel_time` sensors. The issue was discussed several times in the forum [here](https://community.home-assistant.io/t/custom-component-here-travel-time/125908/152?) and [here](https://community.home-assistant.io/t/waze-travel-time-update/50955/275) as well as in the PRs #27237 #28716.

Using this template the following config is possible:

```yaml
input_select:
  here_destination_preset:
    options:
      - zone.home
      - zone.office
      - zone.somewheredefault

sensor:
  - platform: here_travel_time
    api_key: my_api_key
    name: Reistijd
    origin_template: {{ coordinates('device_tracker.myphone') }}
    destination_template: {{ coordinates('input_select.here_destination_preset') }}

automation:    
  - alias: 'set'
    trigger:
      - platform: homeassistant
        event: start
      - platform: time
        at: 00:00
    action:
       service: input_select.select_option
       data_template:
        entity_id: input_select.here_destination_preset
        option: "{% if is_state('device_tracker.myphone','home') %}zone.office{% elif is_state('device_tracker.myphone','office') %}zone.home{% else %}zone.somewheredefault{% endif %}"
````

The simple case `{{ coordinates('device_tracker.myphone') }}` can already be accomplished with existing methods but now the user does not have to know that a `device_tracker` stores `latitude` and `longitude` as attributes.

The nested case `{{ coordinates('input_select.here_destination_preset') }}` is currently only possible by creating a complex structure of dependent `template_sensors` using complex templates.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30019

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
