### PR TITLE
Add example MQTT lighting discovery payload, categorise examples

### DIFF
--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -236,6 +236,8 @@ The following software has built-in support for MQTT discovery:
 
 ### Examples
 
+#### Motion detection (binary sensor)
+
 A motion detection device which can be represented by a [binary sensor](/integrations/binary_sensor.mqtt/) for your garden would send its configuration as JSON payload to the Configuration topic. After the first message to `config`, then the MQTT messages sent to the state topic will update the state in Home Assistant.
 
 - Configuration topic: `homeassistant/binary_sensor/garden/config`
@@ -259,6 +261,18 @@ Delete the sensor by sending an empty message.
 $ mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/binary_sensor/garden/config" -m ''
 ```
 
+#### Sensors with multiple values
+
+Setting up a sensor with multiple measurement values requires multiple consecutive configuration topic submissions.
+
+- Configuration topic no1: `homeassistant/sensor/sensorBedroomT/config`
+- Configuration payload no1: `{"device_class": "temperature", "name": "Temperature", "state_topic": "homeassistant/sensor/sensorBedroom/state", "unit_of_measurement": "°C", "value_template": "{% raw %}{{ value_json.temperature}}{% endraw %}" }`
+- Configuration topic no2: `homeassistant/sensor/sensorBedroomH/config`
+- Configuration payload no2: `{"device_class": "humidity", "name": "Humidity", "state_topic": "homeassistant/sensor/sensorBedroom/state", "unit_of_measurement": "%", "value_template": "{% raw %}{{ value_json.humidity}}{% endraw %}" }`
+- Common state payload: `{ "temperature": 23.20, "humidity": 43.70 }`
+
+#### Switches
+
 Setting up a switch is similar but requires a `command_topic` as mentioned in the [MQTT switch documentation](/integrations/switch.mqtt/).
 
 - Configuration topic: `homeassistant/switch/irrigation/config`
@@ -276,27 +290,45 @@ Set the state.
 $ mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/switch/irrigation/set" -m ON
 ```
 
-Setting up a sensor with multiple measurement values requires multiple consecutive configuration topic submissions.
-
-- Configuration topic no1: `homeassistant/sensor/sensorBedroomT/config`
-- Configuration payload no1: `{"device_class": "temperature", "name": "Temperature", "state_topic": "homeassistant/sensor/sensorBedroom/state", "unit_of_measurement": "°C", "value_template": "{% raw %}{{ value_json.temperature}}{% endraw %}" }`
-- Configuration topic no2: `homeassistant/sensor/sensorBedroomH/config`
-- Configuration payload no2: `{"device_class": "humidity", "name": "Humidity", "state_topic": "homeassistant/sensor/sensorBedroom/state", "unit_of_measurement": "%", "value_template": "{% raw %}{{ value_json.humidity}}{% endraw %}" }`
-- Common state payload: `{ "temperature": 23.20, "humidity": 43.70 }`
+#### Abbreviating topic names
 
 Setting up a switch using topic prefix and abbreviated configuration variable names to reduce payload length.
 
 - Configuration topic: `homeassistant/switch/irrigation/config`
 - Command topic: `homeassistant/switch/irrigation/set`
 - State topic: `homeassistant/switch/irrigation/state`
-- Payload:  `{"~": "homeassistant/switch/irrigation", "name": "garden", "cmd_t": "~/set", "stat_t": "~/state"}`
+- Configuration payload: `{"~": "homeassistant/switch/irrigation", "name": "garden", "cmd_t": "~/set", "stat_t": "~/state"}`
 
-Setting up a climate integration (heat only) with abbreviated configuration variable names to reduce payload length.
+#### Lighting
+
+Setting up a [light that takes JSON payloads](/integrations/light.mqtt/#json-schema), with abbreviated configuration variable names:
+
+- Configuration topic: `homeassistant/light/kitchen/config`
+- Command topic: `homeassistant/light/kitchen/set`
+- State topic: `homeassistant/light/kitchen/state`
+- Example state payload: `{"state": "ON", "brightness": 255}`
+- Configuration payload:
+
+  ```json
+  {
+    "~": "homeassistant/light/kitchen",
+    "name": "Kitchen",
+    "unique_id": "kitchen_light",
+    "cmd_t": "~/set",
+    "stat_t": "~/state",
+    "schema": "json",
+    "brightness": true
+  }
+  ```
+
+#### Climate control
+
+Setting up a climate integration (heat only):
 
 - Configuration topic: `homeassistant/climate/livingroom/config`
 - Configuration payload:
 
-```yaml
+```json
 {
   "name":"Livingroom",
   "mode_cmd_t":"homeassistant/climate/livingroom/thermostatModeCmd",
@@ -320,7 +352,7 @@ Setting up a climate integration (heat only) with abbreviated configuration vari
 - State topic: `homeassistant/climate/livingroom/state`
 - State payload:
 
-```yaml
+```json
 {
   "mode":"off",
   "target_temp":"21.50",


### PR DESCRIPTION
**Description:**

MQTT discovery was broken for a lighting integration I'm working on because I included the `device_class` attribute. 😞 

```
Exception in async_discover when dispatching 'mqtt_discovery_new_light_mqtt': ({'name': 'CBus Light 1', 'command_topic': 'homeassistant/light/cbus_1/set', 'state_topic': 'homeassistant/light/cbus_1', 'device_class': 'light', 'schema': 'json', 'brightness': True, 'platform': 'mqtt'},)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/mqtt/light/__init__.py", line 56, in async_discover
    config = PLATFORM_SCHEMA(discovery_payload)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/validators.py", line 208, in __call__
    return self._exec((Schema(val) for val in self.validators), v)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/validators.py", line 287, in _exec
    raise e if self.msg is None else AllInvalid(self.msg, path=path)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/validators.py", line 283, in _exec
    v = func(v)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 817, in validate_callable
    return schema(data)
  File "/usr/src/homeassistant/homeassistant/components/mqtt/light/__init__.py", line 34, in validate_mqtt_light
    return schemas[value[CONF_SCHEMA]](value)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 432, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: extra keys not allowed @ data['device_class']
```

To make things easier, I added a worked example of a light configuration payload which uses the MQTT-JSON schema (that supports all the features).

While here, I also added headers and untangled the examples into a (subjectively) nicer order.

**Pull request in home-assistant (if applicable):** (not applicable)
