### PR TITLE
Add device_class section into Modbus sensor and binary sensor docs

### DIFF
--- a/source/_integrations/binary_sensor.modbus.markdown
+++ b/source/_integrations/binary_sensor.modbus.markdown
@@ -52,6 +52,11 @@ coils:
       description: Coil number.
       required: true
       type: integer
+    device_class:
+      description: The [type/class](/integrations/binary_sensor/#device-class) of the binary sensor to set the icon in the frontend.
+      required: false
+      type: device_class
+      default: None
 {% endconfiguration %}
 
 It's possible to change the default 30 seconds scan interval for the sensor updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.

--- a/source/_integrations/sensor.modbus.markdown
+++ b/source/_integrations/sensor.modbus.markdown
@@ -73,6 +73,11 @@ registers:
       description: Unit to attach to value.
       required: false
       type: integer
+    device_class:
+      description: The [type/class](/integrations/sensor/#device-class) of the sensor to set the icon in the frontend.
+      required: false
+      type: device_class
+      default: None
     count:
       description: Number of registers to read.
       required: false


### PR DESCRIPTION
**Description:**
Update documentation for modbus sensor and binary sensor:
- Add configuration section about ```device_class```.

**Pull request in home-assistant:** home-assistant/home-assistant#30030

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
