### PR TITLE
Add documentation for tado fallback setting

### DIFF
--- a/source/_integrations/tado.markdown
+++ b/source/_integrations/tado.markdown
@@ -11,7 +11,7 @@ ha_release: 0.41
 ha_iot_class: Cloud Polling
 ---
 
-The `tado` integration platform is used as an interface to the [my.tado.com](https://my.tado.com/webapp/#/account/sign-in) website.
+The `tado` integration platform is used as an interface to the [my.tado.com](https://my.tado.com/) website.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -32,16 +32,21 @@ tado:
 
 {% configuration %}
 username:
-  description: Your username for my.tado.com.
+  description: Your username for [my.tado.com](https://my.tado.com/).
   required: true
   type: string
 password:
-  description: Your password for my.tado.com.
+  description: Your password for [my.tado.com](https://my.tado.com/).
   required: true
   type: string
+fallback:
+  description: Indicates if you want to fallback to Smart Schedule on the next Schedule change, or stay in Manual mode until you set the mode back to Auto.
+  required: false
+  type: boolean
+  default: true
 {% endconfiguration %}
 
-The tado thermostats are internet connected thermostats. There exists an unofficial API at [my.tado.com](https://my.tado.com/webapp/#/account/sign-in), which is used by their website and now by this component.
+The tado thermostats are internet connected thermostats. There exists an unofficial API at [my.tado.com](https://my.tado.com/), which is used by their website and now by this component.
 
 It currently supports presenting the current temperature, the setting temperature and the current operation mode. Switching the mode is also supported. If no user is at home anymore, the devices are showing the away-state. Switching to away-mode is not supported.
 


### PR DESCRIPTION
**Description:**
Add documentation for tado `fallback` setting.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29246

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
