### PR TITLE
Add host port config to Homematic

### DIFF
--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -133,6 +133,10 @@ host:
   description: IP address of CCU/Homegear device.
   required: true
   type: string
+port:
+  description: "Port of CCU/Homegear XML-RPC Server. Wireless: 2001, wired: 2000, IP: 2010"
+  required: false
+  type: integer
 username:
   description: When fetching names via JSON-RPC, you need to specify a user with guest-access to the CCU.
   required: false
@@ -172,6 +176,7 @@ homematic:
   hosts:
     ccu2:
       host: 127.0.0.1
+      port: 2001
       username: Admin
       password: secret
 


### PR DESCRIPTION
**Description:**

This adds documentation for new homematic host port parameter in PR below.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30077

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
