### PR TITLE
Add support for enocean window handle FA 10 00 (Hoppe)

### DIFF
--- a/source/_integrations/enocean.markdown
+++ b/source/_integrations/enocean.markdown
@@ -34,7 +34,6 @@ The following devices have been confirmed to work out of the box:
 - EnOcean STM-330 temperature sensor
 - Hoppe SecuSignal window handle from Somfy
 
-
 If you own a device not listed here, please check whether your device can talk in one of the listed [EnOcean Equipment Profiles](https://www.enocean-alliance.org/what-is-enocean/specifications/) (EEP). 
 If it does, it will most likely work. 
 The available profiles are usually listed somewhere in the device manual. 
@@ -190,7 +189,6 @@ device_class:
   default: powersensor
 {% endconfiguration %}
 
-
 ### Power sensor
 
 This has been tested with a Permundo PSC234 switch, but any device sending EEP **A5-12-01** messages will work.
@@ -205,7 +203,6 @@ sensor:
     id: [0x01,0x90,0x84,0x3C]
     device_class: powersensor
 ```
-
 
 ### Humidity sensor
 
@@ -299,11 +296,13 @@ sensor:
     range_min: 0
     range_max: 250
 ```
+
 ### Window handle
 
 As of now the Hoppe SecuSignal window handle from Somfy has been succesfully tested. However any mechanical window handle that follows the enocean RPS telegram spec F6 10 00 (Hoppe AG) is supported.
 
 To configure a window handle, add the following code to your `configuration.yaml`:
+
 ```yaml
 # Example configuration.yaml entry for window handle EEP F6-10-00
 sensor:
@@ -312,13 +311,14 @@ sensor:
     id: [0xDE,0xAD,0xBE,0xEF]
     device_class: windowhandle
 ```
+
 The configuration does not have any optional parameters.
 
 The window handle sensor can have the following states:
+
 - **closed**: The window handle is in closed position (typically down, or 6 o'clock)
 - **open**: The window handle is in open position (typically left or right, or 3 o'clock or 9 o'clock)
 - **tilt**: The window handle is in tilt position (typically up or 12 o'clock)
-
 
 ## Switch
 

--- a/source/_integrations/enocean.markdown
+++ b/source/_integrations/enocean.markdown
@@ -19,7 +19,7 @@ The `enocean` integration adds support for some of these devices. You will need 
 There is currently support for the following device types within Home Assistant:
 
 - [Binary Sensor](#binary-sensor) - Wall switches
-- [Sensor](#sensor) - Power meters, temperature sensors and humidity sensors
+- [Sensor](#sensor) - Power meters, temperature sensors, humidity sensors and window handles
 - [Light](#light) - Dimmers
 - [Switch](#switch)
 
@@ -32,6 +32,7 @@ The following devices have been confirmed to work out of the box:
 - Omnio WS-CH-102-L-rw battery-less wall switch
 - Permundo PSC234 (switch and power monitor)
 - EnOcean STM-330 temperature sensor
+- Hoppe SecuSignal window handle from Somfy
 
 
 If you own a device not listed here, please check whether your device can talk in one of the listed [EnOcean Equipment Profiles](https://www.enocean-alliance.org/what-is-enocean/specifications/) (EEP). 
@@ -160,6 +161,7 @@ The EnOcean sensor platform currently supports the following device types:
  * [power sensor](#power-sensor)
  * [humidity sensor](#humidity-sensor)
  * [temperature sensor](#temperature-sensor)
+ * [window handle](#window-handle)
  
 To use your EnOcean device, you first have to set up your [EnOcean hub](#hub) and then add the following to your `configuration.yaml` file:
 
@@ -297,6 +299,26 @@ sensor:
     range_min: 0
     range_max: 250
 ```
+### Window handle
+
+As of now the Hoppe SecuSignal window handle from Somfy has been succesfully tested. However any mechanical window handle that follows the enocean RPS telegram spec F6 10 00 (Hoppe AG) is supported.
+
+To configure a window handle, add the following code to your `configuration.yaml`:
+```yaml
+# Example configuration.yaml entry for window handle EEP F6-10-00
+sensor:
+  - name: Living Room Window Handle
+    platform: enocean
+    id: [0xDE,0xAD,0xBE,0xEF]
+    device_class: windowhandle
+```
+The configuration does not have any optional parameters.
+
+The window handle sensor can have the following states:
+- **closed**: The window handle is in closed position (typically down, or 6 o'clock)
+- **open**: The window handle is in open position (typically left or right, or 3 o'clock or 9 o'clock)
+- **tilt**: The window handle is in tilt position (typically up or 12 o'clock)
+
 
 ## Switch
 

--- a/source/_integrations/enocean.markdown
+++ b/source/_integrations/enocean.markdown
@@ -299,7 +299,7 @@ sensor:
 
 ### Window handle
 
-As of now the Hoppe SecuSignal window handle from Somfy has been succesfully tested. However any mechanical window handle that follows the enocean RPS telegram spec F6 10 00 (Hoppe AG) is supported.
+As of now, the Hoppe SecuSignal window handle from Somfy has been successfully tested. However, any mechanical window handle that follows the EnOcean RPS telegram spec F6 10 00 (Hoppe AG) is supported.
 
 To configure a window handle, add the following code to your `configuration.yaml`:
 


### PR DESCRIPTION
Add documentation description for home assistant PR 29968 https://github.com/home-assistant/home-assistant/pull/29968 to describe window handle setup in configuration.yaml file

**Description:** Add documentation for Hoppe SecuSignal window handle and other enocean F6 10 00 devices

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29968

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
