### PR TITLE
Update picture-glance.markdown

### DIFF
--- a/source/_lovelace/picture-glance.markdown
+++ b/source/_lovelace/picture-glance.markdown
@@ -56,7 +56,7 @@ aspect_ratio:
   type: string
 entity:
   required: false
-  description: Entity to use for `state_image`.
+  description: Entity to use for `state_image` and `state_filter`.
   type: string
 show_state:
   required: false
@@ -320,6 +320,7 @@ Specify different [CSS filters](https://developer.mozilla.org/en-US/docs/Web/CSS
 state_filter:
   "on": brightness(110%) saturate(1.2)
   "off": brightness(50%) hue-rotate(45deg)
+entity: switch.decorative_lights
 ```
 
 ## Examples


### PR DESCRIPTION
**Description:**
Extended the description for the entity entry and the state_filter example (now including an entity entry.

Reason is that the state_filter requires an entity entry. This was not documented yet.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
