### PR TITLE
broadlink.send service in broadlink integration doc should include switch note

### DIFF
--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -464,6 +464,8 @@ script:
             - "JgBGAJSTFDUUNhM2ExITEhMSExITEhM2EzYTNhQRFBEUERQRFBEUNRQ2ExITNhMSExITNhMSExITEhM2ExITNhQ1FBEUNhMADQUAAA=="
 ```
 
+You still need to set up a `switch` entity for your broadlink device even if you plan to use only `broadlink.send` service.
+
 ### Using E-Control remotes
 
 If you already have your remotes learned on E-Control app you can use this method to "copy" them to Home Assistant.


### PR DESCRIPTION
Description for broadlink.send service should include a note that broadlink switch entity still should be created even if user plan to use only broadlink.send. Otherwise it's not obvious from the documentation.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
