### PR TITLE
Fix Raspberry model to be consistent in docs

### DIFF
--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -33,7 +33,7 @@ Follow this guide if you want to get started with Home Assistant easily or if yo
 
 ### Suggested hardware
 
-We will need a few things to get started with installing Home Assistant. The Raspberry Pi 3 Model B+ is a good, affordable starting point for your home automation journey. Links below lead to Amazon US. If you're not in the US, you should be able to find these items in web stores in your country.
+We will need a few things to get started with installing Home Assistant. The Raspberry Pi 4 Model B is a good, affordable starting point for your home automation journey. Links below lead to Amazon US. If you're not in the US, you should be able to find these items in web stores in your country.
 
 - [Raspberry Pi 4 Model B (2GB)](https://amzn.to/2XULT2z) + [Power Supply](https://www.raspberrypi.org/help/faqs/#powerReqs) (at least 2.5A)
 - [Micro SD Card](https://amzn.to/2X0Z2di). Ideally get one that is [Application Class 2](https://www.sdcard.org/developers/overview/application/index.html) as they handle small I/O much more consistently than cards not optimized to host applications. A 32 GB or bigger card is recommended.


### PR DESCRIPTION
**Description:**
In the Getting Started guide you recommend RPi 4 as a suggested hardware; however, in description you mention the older RPi 3 B+ model. I fixed the description to match with the rest of page.

I created the PR against the ```next``` branch, because it is not critical. If you suggest to create it against ```current```, I can do that as well.

**Related Pull request:** #11516

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
