### PR TITLE
Aadd extract instruction to getting started guide

### DIFF
--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -42,7 +42,7 @@ We will need a few things to get started with installing Home Assistant. The Ras
 
 ### Software requirements
 
-- Download the HassOS image for [your device](/hassio/installation/)
+- Download and extract the HassOS image for [your device](/hassio/installation/)
 - Download [balenaEtcher] to write the image to an SD card
 
 [balenaEtcher]: https://www.balena.io/etcher


### PR DESCRIPTION
It is not obvious that the downloaded file needs to be extracted before flashing it. I assumed balenaEtcher did it automatically and spent an entire afternoon trying to figure out why the raspberry pi was not booting up. Hopefully, this change will prevent someone from making the same mistake in the future.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
