### PR TITLE
Updates time_date with mention to date_time_utc

### DIFF
--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -20,13 +20,14 @@ sensor:
       - 'time'
       - 'date'
       - 'date_time'
+      - 'date_time_utc'
       - 'date_time_iso'
       - 'time_date'
       - 'time_utc'
       - 'beat'
 ```
 
-- **display_options** array (*Required*): The option to display. The types *date_time*, *time_date*, and *date_time_iso* shows the date and the time. The other types just the time or the date. *beat* shows the [Swatch Internet Time](https://www.swatch.com/en_us/internet-time).
+- **display_options** array (*Required*): The option to display. The types *date_time*, *date_time_utc*, *time_date*, and *date_time_iso* shows the date and the time. The other types just the time or the date. *beat* shows the [Swatch Internet Time](https://www.swatch.com/en_us/internet-time).
 
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/time_date.png' />


### PR DESCRIPTION
Adds display option date_time_utc to the documentation for time_date sensor.  Related to [home-assistant PR 30158](https://github.com/home-assistant/home-assistant/pull/30158) adding the date_time_utc display option.

**Description:**

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30158

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
