### PR TITLE
Update mhz19.markdown

### DIFF
--- a/source/_integrations/mhz19.markdown
+++ b/source/_integrations/mhz19.markdown
@@ -53,7 +53,7 @@ enable_uart=1
 Then (after a reboot): you can setup the sensor using:
 
 ```yaml
-  serial_device: /dev/tty.S0
+  serial_device: /dev/ttyS0
 ```
 
 ## Calibration


### PR DESCRIPTION


**Description:**
The serial device "address" was incorrect. The correct name is /dev/ttyS0

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
