### PR TITLE
Add MAC Address table OID for TP-Link Archer VR1600v

### DIFF
--- a/source/_integrations/snmp.markdown
+++ b/source/_integrations/snmp.markdown
@@ -40,6 +40,7 @@ The following OID examples pull the current MAC Address table from a router. Thi
 | OPNSense | 19.1 | `1.3.6.1.2.1.4.22.1.2` |
 | pfSense | 2.2.4 | `1.3.6.1.2.1.4.22.1.2` |
 | Ruckus | ZoneDirector 9.13.3 | `1.3.6.1.4.1.25053.1.2.2.1.1.3.1.1.1.6` |
+| TP-Link | Archer VR1600v | `1.3.6.1.2.1.3.1.1.2.16.1` |
 | TP-Link | Archer VR2600v | `1.3.6.1.2.1.3.1.1.2.19.1` |
 | TP-Link | Archer VR600 | `1.3.6.1.2.1.3.1.1.2` |
 | Ubiquiti | Edgerouter Lite v1.9.0 | `1.3.6.1.2.1.4.22.1.2` |


### PR DESCRIPTION
**Description:**

This is the standard router distributed by the TPG ISP in Australia, e.g. https://community.tpg.com.au/t5/Modems-and-Devices/How-to-set-up-your-TP-Link-VR1600v-modem/td-p/709 .

Demo for validation (`...` elision is mine):
```
$ snmpwalk -On -c public -v 2c 192.168.1.1 1.3.6.1.2.1.3.1.1.2.16.1
.1.3.6.1.2.1.3.1.1.2.16.1.192.168.1.101 = Hex-STRING: 9C E3 ... 
.1.3.6.1.2.1.3.1.1.2.16.1.192.168.1.102 = Hex-STRING: F0 18 ... 
.1.3.6.1.2.1.3.1.1.2.16.1.192.168.1.105 = STRING: "x(..."
.1.3.6.1.2.1.3.1.1.2.16.1.192.168.1.106 = Hex-STRING: 78 28 ...
```

**Pull request in home-assistant (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
