### PR TITLE
Add documentation for pilight dimmer as light

### DIFF
--- a/source/_integrations/pilight.markdown
+++ b/source/_integrations/pilight.markdown
@@ -22,7 +22,7 @@ There is currently support for the following device types within Home Assistant:
 - [Binary Sensor](#binary-sensor)
 - [Sensor](#sensor)
 - [Switch](#switch)
-- [Dimmer](#dimmer)
+- [Light](#light)
 
 ## Configuration
 
@@ -305,9 +305,9 @@ switch:
           state: 'off'
 ```
 
-## Dimmer
+## Light
 
-Pilight dimmer devices, which can have different brightness values can be used as light component. 
+Pilight dimmer devices, which can have different brightness values, can be used as a light. 
 The configuration parameters are the same for dimmers and switches. 
 
 {% configuration %}
@@ -350,7 +350,6 @@ light:
           unit: 10
           state: 'off'
 ```
-
 
 ## Troubleshooting
 

--- a/source/_integrations/pilight.markdown
+++ b/source/_integrations/pilight.markdown
@@ -22,6 +22,7 @@ There is currently support for the following device types within Home Assistant:
 - [Binary Sensor](#binary-sensor)
 - [Sensor](#sensor)
 - [Switch](#switch)
+- [Dimmer](#dimmer)
 
 ## Configuration
 
@@ -303,6 +304,53 @@ switch:
           id: 34
           state: 'off'
 ```
+
+## Dimmer
+
+Pilight dimmer devices, which can have different brightness values can be used as light component. 
+The configuration parameters are the same for dimmers and switches. 
+
+{% configuration %}
+lights:
+  description: The list that contains all command lights.
+  required: true
+  type: string
+  keys:
+    entry:
+      description: Name of the command light, which are the same like for switches. Multiple entries are possible.
+      required: true
+      type: list
+{% endconfiguration %}
+
+### Example
+
+```yaml
+light:
+  - platform: pilight
+    lights:
+      test2:
+        on_code:
+          protocol: kaku_dimmer
+          id: 23298822
+          unit: 10
+          'on': 1
+        off_code:
+          protocol: kaku_dimmer
+          id: 23298822
+          unit: 10
+          'off': 1
+        on_code_receive:
+          protocol: kaku_dimmer
+          id: 23298822
+          unit: 10
+          state: 'on'
+        off_code_receive:
+          protocol: kaku_dimmer
+          id: 23298822
+          unit: 10
+          state: 'off'
+```
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
**Description:**
Add configuration parameters for pilight dimmer as light component

**Pull request in home-assistant:** home-assistant/home-assistant#30107

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
