### PR TITLE
Simpler method to get chat_id for telegram bot

### DIFF
--- a/source/_integrations/telegram.markdown
+++ b/source/_integrations/telegram.markdown
@@ -18,9 +18,9 @@ The requirements are:
 - You need to configure a [Telegram bot in Home Assistant](/integrations/telegram_chatbot) and define there your API key and the allowed chat ids to interact with.
 - The `chat_id` of an allowed user. 
 
-**Method 1.** You can get your id by sending any message to the [GetIDs Bot](https://t.me/getidsbot). Also you can add bot to the group and get group's chat_id.
+**Method 1:** You can get your `chat_id` by sending any message to the [GetIDs bot](https://t.me/getidsbot).
 
-**Method 2.** To retrieve your `chat_id` you can visit `https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` or to use `$ curl -X GET https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` **after** you have sent the bot a message. Replace `YOUR_API_TOKEN` with your actual token.
+**Method 2:** To retrieve your `chat_id` you can visit `https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` or to use `$ curl -X GET https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` **after** you have sent the bot a message. Replace `YOUR_API_TOKEN` with your actual token.
 
 The result set will include your chat ID as `id` in the `chat` section:
 
@@ -51,7 +51,7 @@ The result set will include your chat ID as `id` in the `chat` section:
 }
 ```
 
-**Method 3.** Another way to get your chat ID directly is described below. Start your Python interpreter from the command-line:
+**Method 3:** Another way to get your chat ID directly is described below. Start your Python interpreter from the command-line:
 
 ```python
 $ python3

--- a/source/_integrations/telegram.markdown
+++ b/source/_integrations/telegram.markdown
@@ -16,9 +16,11 @@ The requirements are:
 
 - You need a [Telegram bot](https://core.telegram.org/bots). Please follow those [instructions](https://core.telegram.org/bots#6-botfather) to create one and get the token for your bot. Keep in mind that bots are not allowed to contact users. You need to make the first contact with your user. Meaning that you need to send a message to the bot from your user.
 - You need to configure a [Telegram bot in Home Assistant](/integrations/telegram_chatbot) and define there your API key and the allowed chat ids to interact with.
-- The `chat_id` of an allowed user.
+- The `chat_id` of an allowed user. 
 
-The quickest way to retrieve your `chat_id` is visiting `https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` or to use `$ curl -X GET https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` **after** you have sent the bot a message. Replace `YOUR_API_TOKEN` with your actual token.
+**Method 1.** You can get your id by sending any message to the [GetIDs Bot](https://t.me/getidsbot). Also you can add bot to the group and get group's chat_id.
+
+**Method 2.** To retrieve your `chat_id` you can visit `https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` or to use `$ curl -X GET https://api.telegram.org/botYOUR_API_TOKEN/getUpdates` **after** you have sent the bot a message. Replace `YOUR_API_TOKEN` with your actual token.
 
 The result set will include your chat ID as `id` in the `chat` section:
 
@@ -49,7 +51,7 @@ The result set will include your chat ID as `id` in the `chat` section:
 }
 ```
 
-Another way to get your chat ID directly is described below. Start your Python interpreter from the command-line:
+**Method 3.** Another way to get your chat ID directly is described below. Start your Python interpreter from the command-line:
 
 ```python
 $ python3


### PR DESCRIPTION
**Description:**

I was struggling with getting id some time ago but found this bot and this is the easiest method to get chat_id.
Notice that chat_id is the same for all bots, but you should contact them first

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
