### PR TITLE
Fix Netgear LTE notify service default name

### DIFF
--- a/source/_integrations/netgear_lte.markdown
+++ b/source/_integrations/netgear_lte.markdown
@@ -71,7 +71,7 @@ notify:
     name:
       description: The name of the notification service.
       required: false
-      default: `netgear_lte`
+      default: "`netgear_lte`"
       type: string
 sensor:
   description: Configuration options for sensors.

--- a/source/_integrations/netgear_lte.markdown
+++ b/source/_integrations/netgear_lte.markdown
@@ -71,7 +71,7 @@ notify:
     name:
       description: The name of the notification service.
       required: false
-      default: notify
+      default: `netgear_lte`
       type: string
 sensor:
   description: Configuration options for sensors.


### PR DESCRIPTION
**Description:**

https://github.com/home-assistant/home-assistant/blob/0.103.4/homeassistant/components/netgear_lte/__init__.py#L62

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
