### PR TITLE
Update homekit.markdown: URL encode space char

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -459,7 +459,7 @@ To use the HomeKit integration with to different Home Assistant instances on the
 
 #### Specific entity doesn't work
 
-Although we try our best, some entities don't work with the HomeKit integration yet. The result will be that either pairing fails completely or all Home Assistant accessories will stop working. Use the filter to identify which entity is causing the issue. It's best to try pairing and step by step including more entities. If it works unpair and repeat until you find the one that is causing the issues. To help others and the developers, please open a new issue here: [home-assistant/issues/new](https://github.com/home-assistant/home-assistant/issues/new?labels=component: homekit)
+Although we try our best, some entities don't work with the HomeKit integration yet. The result will be that either pairing fails completely or all Home Assistant accessories will stop working. Use the filter to identify which entity is causing the issue. It's best to try pairing and step by step including more entities. If it works unpair and repeat until you find the one that is causing the issues. To help others and the developers, please open a new issue here: [home-assistant/issues/new](https://github.com/home-assistant/home-assistant/issues/new?labels=component:%20homekit)
 
 #### Accessories are all listed as not responding
 


### PR DESCRIPTION
**Description:**

Fix URL formatting for new issues.

The current un-encoded space character shows markdown formatting on https://www.home-assistant.io/integrations/homekit/#specific-entity-doesnt-work
<img width="719" alt="Screen Shot 2019-12-26 at 8 28 07 PM" src="https://user-images.githubusercontent.com/483223/71501327-c2c45c80-281e-11ea-89ed-89efe9daa6d5.png">

Using `%20` instead should fix the markdown rendering to be a link instead (that's what I see when I preview the MD file in GitHub).

It looks like unprivileged users can't label new issues, so I'm not sure the `label` url parameter does anything, but at a minimum this should fix the formatting of the link.

**Pull request in home-assistant (if applicable):** Not Applicable

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. **Fixes, changes and adjustments for the current release should be created against `current`.**
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
