### PR TITLE
Specify Raspberry Pi version

### DIFF
--- a/source/_integrations/fastdotcom.markdown
+++ b/source/_integrations/fastdotcom.markdown
@@ -75,6 +75,6 @@ action:
 
 ## Notes
 
-- When running on Raspberry Pi, the maximum speed is limited by its 100 Mbit/s LAN adapter.
+- When running on Raspberry Pi 3 or older, the maximum speed is limited by its 100 Mbit/s LAN adapter.
 - The sensor will return the maximum measured speed during a 15-second test.
 - Speed tests consume data depending on your internet speed, make sure to consider this if your internet connection has limited bandwidth.


### PR DESCRIPTION
**Description:**
Specify which Raspberry Pi versions have 100Mbit/s ehternet because version 4 has 1Gbit/s ethernet.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
