### PR TITLE
Add reset_energy_counter service to Homematic IP Cloud

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -168,6 +168,7 @@ Within this delay the device registration should be completed in the App, otherw
 - `homematicip_cloud.deactivate_vacation`: Deactivates the vacation mode immediately.
 - `homematicip_cloud.set_active_climate_profile`: Set the active climate profile index.
 - `homematicip_cloud.dump_hap_config`: Dump the configuration of the Homematic IP Access Point(s).
+- `homematicip_cloud.reset_energy_counter`: Reset energy counter of measuring actuators.
 
 ### Service Examples
 

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -252,6 +252,16 @@ action:
     anonymize: True
 ```
 
+Reset energy counter of measuring actuators.
+
+```yaml
+...
+action:
+  service: homematicip_cloud.reset_energy_counter
+  data:
+    entity_id: switch.livingroom
+```
+
 
 ## Additional info
 


### PR DESCRIPTION
**Description:**
Add reset_energy_counter service to Homematic IP Cloud

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30256

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
