### PR TITLE
changed mac to mac_address in docs

### DIFF
--- a/source/_integrations/wake_on_lan.markdown
+++ b/source/_integrations/wake_on_lan.markdown
@@ -61,11 +61,11 @@ To enable this switch in your installation, add the following to your `configura
 # Example configuration.yaml entry
 switch:
   - platform: wake_on_lan
-    mac: MAC_ADDRESS
+    mac_address: MAC_ADDRESS
 ```
 
 {% configuration %}
-mac:
+mac_address:
   description: "The MAC address to send the wake up command to, e.g, `00:01:02:03:04:05`."
   required: true
   type: string


### PR DESCRIPTION
**Description:**
docs were outdated. I changed mac to mac_address for switch with wake on lan platform.
But I didn't change the service part, because i don't know if it also needs to be updated.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
