### PR TITLE
Clarification on external access for Alexa intents and smart home skills

### DIFF
--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -19,7 +19,7 @@ The built-in Alexa integration allows you to integrate Home Assistant into Alexa
 
 - Amazon Developer Account. You can sign on [here](https://developer.amazon.com).
 - An [AWS account](https://aws.amazon.com/free/) is need if you want to use Alexa Custom Skill API. Part of your Alexa Custom Skill will be hosted on [AWS Lambda](https://aws.amazon.com/lambda/pricing/). However you don't need worry the cost, AWS Lambda allow free to use up to 1 millions requests and 1GB outbound data transfer per month.
-- The Alexa Custom Skill API also needs your Home Assistant instance can be accessed from Internet. We strongly suggest you host HTTPS server and use validation certificate. Read more on [our blog](/blog/2015/12/13/setup-encryption-using-lets-encrypt/) about how to set up encryption for Home Assistant. When running Hass.io using the [Duck DNS](/addons/duckdns/) add-on is the easiest method.
+- The Alexa Custom Skill API also needs your Home Assistant instance to be accessible from the internet via HTTPS on port 443 using a certificate signed by [an Amazon approved certificate authority](https://ccadb-public.secure.force.com/mozilla/IncludedCACertificateReport), this is so account linking can take place. Read more on [our blog](/blog/2015/12/13/setup-encryption-using-lets-encrypt/) about how to set up encryption for Home Assistant. When running Hass.io using the [Duck DNS](/addons/duckdns/) add-on is the easiest method.
 
 ### Create Your Amazon Alexa Custom Skill
 
@@ -94,8 +94,9 @@ Alexa can link your Amazon account to your Home Assistant account. Therefore Hom
 - Find the skill you just created and click `Edit` in the `Actions` column.
 - Click `ACCOUNT LINKING` in the left navigation bar of build page
 - Input all information required. Assuming your Home Assistant can be accessed by https://[YOUR HOME ASSISTANT URL:PORT]
-  * `Authorization URI`: https://[YOUR HOME ASSISTANT URL:PORT]/auth/authorize
-  * `Access Token URI`: https://[YOUR HOME ASSISTANT URL:PORT]/auth/token
+  * `Authorization URI`: https://[YOUR HOME ASSISTANT URL]/auth/authorize
+  * `Access Token URI`: https://[YOUR HOME ASSISTANT URL]/auth/token
+    - Note: you must use a valid/trusted SSL Certificate and port 443 for account linking to work
   * `Client ID`:
     - https://pitangui.amazon.com/ if you are in US
     - https://layla.amazon.com/ if you are in EU

--- a/source/_integrations/alexa.smart_home.markdown
+++ b/source/_integrations/alexa.smart_home.markdown
@@ -37,7 +37,7 @@ For Home Assistant Cloud Users, documentation can be found [here](https://www.na
 
 - Amazon Developer Account. You can sign on [here](https://developer.amazon.com).
 - An [AWS account](https://aws.amazon.com/free/) is need if you want to use Smart Home Skill API. Part of your Smart Home Skill will be hosted on [AWS Lambda](https://aws.amazon.com/lambda/pricing/). However you don't need worry the cost, AWS Lambda allow free to use up to 1 millions requests and 1GB outbound data transfer per month.
-- Smart Home API also needs your Home Assistant instance can be accessed from Internet. We strongly suggest you host HTTPS server and use validation certificate. Read more on [our blog](/blog/2015/12/13/setup-encryption-using-lets-encrypt/) about how to set up encryption for Home Assistant. When running Hass.io using the [Duck DNS](/addons/duckdns/) add-on is the easiest method.
+- The Smart Home API also needs your Home Assistant instance to be accessible from the internet via HTTPS on port 443 using a certificate signed by [an Amazon approved certificate authority](https://ccadb-public.secure.force.com/mozilla/IncludedCACertificateReport), this is so account linking can take place. Read more on [our blog](/blog/2015/12/13/setup-encryption-using-lets-encrypt/) about how to set up encryption for Home Assistant. When running Hass.io using the [Duck DNS](/addons/duckdns/) add-on is the easiest method.
 
 ### Create Your Amazon Alexa Smart Home Skill
 
@@ -171,8 +171,8 @@ Alexa can link your Amazon account to your Home Assistant account. Therefore Hom
 - Find the skill you just created, click `Edit` link in the `Actions` column.
 - Click `ACCOUNT LINKING` in the left navigation bar of build page
 - Input all information required. Assuming your Home Assistant can be accessed by https://[YOUR HOME ASSISTANT URL:PORT]
-  * `Authorization URI`: https://[YOUR HOME ASSISTANT URL:PORT]/auth/authorize
-  * `Access Token URI`: https://[YOUR HOME ASSISTANT URL:PORT]/auth/token
+  * `Authorization URI`: https://[YOUR HOME ASSISTANT URL]/auth/authorize
+  * `Access Token URI`: https://[YOUR HOME ASSISTANT URL]/auth/token
     - Note: you must use a valid/trusted SSL Certificate and port 443 for account linking to work
   * `Client ID`:
     - https://pitangui.amazon.com/ if you are in US


### PR DESCRIPTION
Clarifies that your Home Assistant instance must be accessible from the
internet via HTTPS on port 443, using a valid certificate to use account
linking.

**Description:** Whilst a note about using HTTPS on port 443 was added to the smart home documentation it wasn't added to the custom intent documentation. This adds the note about using HTTPS/443 to the custom intent documentation, and rewords the bit about external access in the requirements section of each to be more specific, following comments on the [gist that is linked in the custom intent documentation](https://gist.github.com/lpomfrey/97381cf4316553b03622c665ae3a47da)

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
