### PR TITLE
RFLink now supports * and ? anywhere in ignore_devices strings

### DIFF
--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -48,7 +48,7 @@ wait_for_ack:
   default: true
   type: boolean
 ignore_devices:
-  description: List of device id's to ignore. Supports wildcards (`*`) at the end.
+  description: List of device id's to ignore. Supports wildcards (`*`, `?`).
   required: false
   type: [list, string]
 reconnect_interval:
@@ -136,10 +136,6 @@ rflink:
 ```
 
 This configuration will ignore the button `1` of the `newkaku` device with ID `000001`, all devices of the `digitech` protocol and all switches of the `kaku` protocol device with codewheel ID `1`.
-
-<div class='note'>
-Wildcards only work at the end of the ID, not in the middle or front!
-</div>
 
 ### Device support
 


### PR DESCRIPTION
**Description:**

See related HA PR.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30268

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
