### PR TITLE
Mention support for smoke sensors

### DIFF
--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -32,7 +32,7 @@ There is currently support for the following device types within Home Assistant:
 - Light (HomeKit lights)
 - Lock (HomeKit lock)
 - Switch (HomeKit switches)
-- Binary Sensor (HomeKit motion sensors and contact sensors)
+- Binary Sensor (HomeKit motion, contact and smoke sensors)
 - Sensor (HomeKit humidity, temperature, co2 and light level sensors)
 
 HomeKit IP accessories for these device types may work with some caveats:


### PR DESCRIPTION
**Description:**

home-assistant/home-assistant#30269 adds support for homekit smoke sensors. This PR updates the documentation to reflect this.


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30269

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
