### PR TITLE
Cleanup, doc hierarchy, and ordering

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -55,8 +55,15 @@ broadcast_address:
   type: string
 {% endconfiguration %}
 
-Currently known supported models:
+### Supported models
+If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.io/tree/current/source/_integrations/samsungtv.markdown).
 
+#### Naming
+The first letter (U, P, L, H & K) represent the screen type, e.g., LED or Plasma. The second letter represents the region, E is Europe, N is North America and A is Asia & Australia. The two numbers following that represent the screen size. If you add your model remember to remove these first 4 characters before adding to the list.
+
+For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North American, 55 inch TV, and the model number listed below would be the remainder: `NU7100`.
+
+#### Models tested and working
 - C7700
 - D5500
 - D6100
@@ -103,8 +110,7 @@ Currently known supported models:
 - UE49KU6470 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
 - UE46ES5500 (partially supported, turn on doesn't works)
 
-Currently tested but not working models:
-
+#### Models tested but not yet working
 - J5200 - Unable to see state and unable to control
 - J5500 - State is always "on" and unable to control (but port 8001 *is* open)
 - J6200 - State is always "on" and unable to control (but port 8001 *is* open)
@@ -125,11 +131,10 @@ Currently tested but not working models:
 
 None of the 2014 (H) and 2015 (J) model series (e.g., J5200) will work, since Samsung have used a different (encrypted) type of interface for these.
 
-If your model is not on the list then give it a test, if everything works correctly then add it to the list on
-[GitHub](https://github.com/home-assistant/home-assistant.io/tree/current/source/_integrations/samsungtv.markdown).
-The first letter (U, P, L, H & K) represent the screen type, e.g., LED or Plasma. The second letter represents the region, E is Europe, N is North America and A is Asia & Australia. The two numbers following that represent the screen size.
-If you add your model remember to remove these first 4 characters before adding to the list.
 
+### Usage
+
+#### Changing channels
 Changing channels can be done by calling the `media_player.play_media` service
 with the following payload:
 
@@ -140,8 +145,8 @@ with the following payload:
   "media_content_type": "channel"
 }
 ```
-
-Currently the ability to select a source is not implemented.
+#### Selecting a source
+Source selection is not yet implemented.
 
 ### Hass.io
 

--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -56,14 +56,17 @@ broadcast_address:
 {% endconfiguration %}
 
 ### Supported models
+
 If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.io/tree/current/source/_integrations/samsungtv.markdown).
 
 #### Naming
+
 The first letter (U, P, L, H & K) represent the screen type, e.g., LED or Plasma. The second letter represents the region, E is Europe, N is North America and A is Asia & Australia. The two numbers following that represent the screen size. If you add your model remember to remove these first 4 characters before adding to the list.
 
 For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North American, 55 inch TV, and the model number listed below would be the remainder: `NU7100`.
 
 #### Models tested and working
+
 - C7700
 - D5500
 - D6100
@@ -111,6 +114,7 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - UE46ES5500 (partially supported, turn on doesn't works)
 
 #### Models tested but not yet working
+
 - J5200 - Unable to see state and unable to control
 - J5500 - State is always "on" and unable to control (but port 8001 *is* open)
 - J6200 - State is always "on" and unable to control (but port 8001 *is* open)
@@ -131,10 +135,10 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 
 None of the 2014 (H) and 2015 (J) model series (e.g., J5200) will work, since Samsung have used a different (encrypted) type of interface for these.
 
-
 ### Usage
 
 #### Changing channels
+
 Changing channels can be done by calling the `media_player.play_media` service
 with the following payload:
 
@@ -146,6 +150,7 @@ with the following payload:
 }
 ```
 #### Selecting a source
+
 Source selection is not yet implemented.
 
 ### Hass.io


### PR DESCRIPTION
**Description:**
Added hierarchical headings for TV support, working, not working lists, put naming info first to assist with finding your TV on the list

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
