### PR TITLE
Quotation marks are missing

### DIFF
--- a/source/_integrations/climate.markdown
+++ b/source/_integrations/climate.markdown
@@ -95,7 +95,7 @@ automation:
       data:
         entity_id: climate.kitchen
         temperature: 24
-        hvac_mode: heat
+        hvac_mode: "heat"
 ```
 
 ```yaml
@@ -110,7 +110,7 @@ automation:
         entity_id: climate.kitchen
         target_temp_high: 24
         target_temp_low: 20
-        hvac_mode: heat_cool
+        hvac_mode: "heat_cool"
 ```
 
 ### Service `climate.set_humidity`
@@ -179,7 +179,7 @@ automation:
     - service: climate.set_hvac_mode
       data:
         entity_id: climate.kitchen
-        hvac_mode: heat
+        hvac_mode: "heat"
 ```
 
 ### Service `climate.set_swing_mode`


### PR DESCRIPTION
The hvac_mode state should be entered with quotation marks, like "heat".

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
