### PR TITLE
Add configurable min and max volume option for yamaha media player component

### DIFF
--- a/source/_integrations/yamaha.markdown
+++ b/source/_integrations/yamaha.markdown
@@ -51,6 +51,16 @@ zone_names:
   description: Mapping of zone names to custom ones, allowing one to rename e.g., `Main_Zone` to `Family Room`.
   required: false
   type: list
+volume_min:
+  description: Minimum volume of the device in decibels.
+  required: false
+  type: float
+  default: -100.0
+volume_max:
+  description: Maximum volume of the device in decibels.
+  required: false
+  type: float
+  default: 0.0
 {% endconfiguration %}
 
 ### Discovery notes


### PR DESCRIPTION
**Description:**
Yamaha receivers tend to have configurable max volumes. As a result, if a user decided to lower their receiver's max volume within its settings the home assistant volume slider maxes out before 100%. On my RX-A3000 the minimum volume is -80dB. As a result this also causes an issue where the bottom portion of the volume slider hits minimum before 0% (and logs error messages in hassio). This change allows users to specify their own custom min and max volumes (dB numeric values). I have left the default as -100.0dB to 0dB for backwards compatibility however my particular research shows -80.0dB to 16.5dB is more correct for yamaha's default. Note this change maintains the linear nature of the volume slider, long term it's unclear if the volume slider should interact differently based on the logarithmic scale the receiver uses. Behavior here is unchanged for this commit intentionally. Tested as a custom component on my receiver with various min and max volumes. Issue #21218 is related but for the yamaha_musiccast integration, this fix is only applicable for the yamaha integration but the change should be similar.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30283

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
