### PR TITLE
Update rmvtransport.markdown

### DIFF
--- a/source/_integrations/rmvtransport.markdown
+++ b/source/_integrations/rmvtransport.markdown
@@ -59,9 +59,9 @@ next_departure:
       required: false
       type: [string, integer]
     products:
-      description: "One or more modes of transport `['U-Bahn', 'Tram', 'Bus', 'S-Bahn', 'RB', 'RE', 'EC', 'IC', 'ICE']`."
+      description: "One or more modes of transport `['U-Bahn', 'Tram', 'Bus', 'S', 'RB', 'RE', 'EC', 'IC', 'ICE']`."
       required: false
-      default: ['U-Bahn', 'Tram', 'Bus', 'S-Bahn', 'RB', 'RE', 'EC', 'IC', 'ICE']
+      default: ['U-Bahn', 'Tram', 'Bus', 'S', 'RB', 'RE', 'EC', 'IC', 'ICE']
       type: [string]
     time_offset:
       description: Do not display departures leaving sooner than this number of minutes. Useful if you are a couple of minutes away from the stop.
@@ -97,7 +97,7 @@ sensor:
           - 'RB'
           - 'RE'
           - 'Bus'
-          - 'S-Bahn'
+          - 'S'
       - station: 3006907
         products: 'Bus'
         destinations: ['Wiesbaden Dernsches Gelände', 'Mainz Hauptbahnhof']
@@ -105,7 +105,7 @@ sensor:
       - station: 3006904
         lines: 'S8'
         max_journeys: 5
-        products: 'S-Bahn'
+        products: 'S'
 ```
 
 The first sensor will return S-Bahn, bus, RB and RE trains departures from Frankfurt Hauptbahnhof to Frankfurt Airport or Stadium that are at least 5 minutes away.


### PR DESCRIPTION
**Description:**
For S-Bahn the product is 'S' not 'S-Bahn'. See https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/rmvtransport/sensor.py

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
