### PR TITLE
Update trigger.markdown for consistency with automation_sun.markdown

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -216,7 +216,7 @@ automation:
   trigger:
     platform: numeric_state
     entity_id: sun.sun
-    value_template: "{{ state.attributes.elevation }}"
+    value_template: "{{ state_attr('sun.sun', 'elevation') }}"
     # Can be a positive or negative number
     below: -4.0
   action:


### PR DESCRIPTION
**Description:**
Looks like a similar change was made to `automation_sun.markdown` in #10532, attributed to #10315.

As someone trying to add an automation for the sun's elevation, the inconsistency was confusing. I don't know if other parts of this page should be updated in a similar way.

**Pull request in home-assistant (if applicable):** Not Applicable

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
