### PR TITLE
Correct SimpliSafe website link

### DIFF
--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -8,7 +8,7 @@ ha_category:
   - Lock
 ---
 
-The `simplisafe` integration integrates [SimpliSafe home security](https://simplisafe.com/smart-lock)  (V2 and V3) systems into Home Assistant. Multiple SimpliSafe accounts can be accommodated.
+The `simplisafe` integration integrates [SimpliSafe home security](https://simplisafe.com) (V2 and V3) systems into Home Assistant. Multiple SimpliSafe accounts can be accommodated.
 
 There is currently support for the following device types within Home Assistant:
 

--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -8,7 +8,7 @@ ha_category:
   - Lock
 ---
 
-The `simplisafe` integration integrates SimpliSafe home security (V2 and V3) systems into Home Assistant. Multiple SimpliSafe accounts can be accommodated.
+The `simplisafe` integration integrates [SimpliSafe home security](https://simplisafe.com/smart-lock)  (V2 and V3) systems into Home Assistant. Multiple SimpliSafe accounts can be accommodated.
 
 There is currently support for the following device types within Home Assistant:
 

--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -8,7 +8,7 @@ ha_category:
   - Lock
 ---
 
-The `simplisafe` integration integrates [SimpliSafe home security](https://simplisafe.com/smart-lock)  (V2 and V3) systems into Home Assistant. Multiple SimpliSafe accounts can be accommodated.
+The `simplisafe` integration integrates SimpliSafe home security (V2 and V3) systems into Home Assistant. Multiple SimpliSafe accounts can be accommodated.
 
 There is currently support for the following device types within Home Assistant:
 


### PR DESCRIPTION
**Description:**

https://github.com/home-assistant/home-assistant.io/pull/11563 makes a somewhat nonsensical change to the SimpliSafe docs (turns "SimpliSafe home security" into a link to the SimpliSafe lock). Not sure what the intention is, but this isn't correct. This PR uses the base SimpliSafe URL.

**Pull request in home-assistant (if applicable):** N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
