### PR TITLE
Remove Amcrest deprecated sensors and switches

### DIFF
--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -7,7 +7,6 @@ ha_category:
   - Binary Sensor
   - Camera
   - Sensor
-  - Switch
 ha_iot_class: Local Polling
 ha_release: 0.49
 ---
@@ -19,7 +18,6 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor
 - Camera
 - Sensor
-- Switch (deprecated)
 
 ## Configuration
 
@@ -117,34 +115,12 @@ sensors:
   type: list
   default: None
   keys:
-    motion_detector:
-      description: >
-        Return `true`/`false` when motion is detected.  
-        
-        **Note:** The motion_detector sensor is deprecated and will be removed in a future release.
-        Use **binary_sensors** option **motion_detected** instead.
     sdcard:
       description: Return the SD card usage by reporting the total and used space.
     ptz_preset:
       description: >
         Return the number of PTZ preset positions
         configured for the given camera.
-switches:
-  description: >
-    Switches to display in the frontend.  
-    
-    **Note:** Switches are deprecated and will be removed in a future release.  
-    Use services and attributes instead.  
-    
-    The following switches can be monitored:
-  required: false
-  type: list
-  default: None
-  keys:
-    motion_detection:
-      description: Enable/disable motion detection setting.
-    motion_recording:
-      description: Enable/disable recording on motion detection setting.
 control_light:
   description: >
     Automatically control the camera's indicator light, turning it on if the audio or video streams are enabled, and turning it off if both streams are disabled.
@@ -254,7 +230,3 @@ amcrest:
 ```
 
 To check if your Amcrest camera is supported/tested, visit the [supportability matrix](https://github.com/tchellomello/python-amcrest#supportability-matrix) link from the `python-amcrest` project.
-
-<div class='note warning'>
-In previous versions, switch devices in setups with multiple cameras, would not have specific entity ID causing them to change randomly after each Home Assistant restart. The current version adds the name of the camera at the end of the switch entity ID, making it more specific and consistent and causes the name option to be required in a multi-camera system. This behavior matches the sensor behavior of the Amcrest component. Because of this, older automations may require updates to the entity ID.
-</div>


### PR DESCRIPTION
**Description:**
Remove Amcrest deprecated sensors & switches.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30308

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
