### PR TITLE
Add light to velbus integration

### DIFF
--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -8,6 +8,7 @@ ha_category:
   - Climate
   - Sensor
   - Switch
+  - Light
 ha_iot_class: Local Push
 ha_release: "0.50"
 ---
@@ -21,6 +22,7 @@ There is currently support for the following device types within Home Assistant:
 - Sensor
 - Switch
 - Cover
+- Light
 
 ## Configuration
 
@@ -35,7 +37,7 @@ velbus:
   port: 'PORT_STRING'
 ```
 
-## Port Sstring
+## Port String
 
 The port string used in the user interface or the configuration file can have 2 formats:
 


### PR DESCRIPTION
**Description:**

 Add light to velbus integration

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30323

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
