### PR TITLE
Update Freenas docs

### DIFF
--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -13,13 +13,6 @@ Enter the Home Assistant jail. If you don't know which name you have given the j
 iocage exec HomeAssistant
 ```
 
-Create the user and group that Home Assistant will run as. The user/group ID of `8123` can be replaced if this is already in use in your environment.
-
-```bash
-pw groupadd -n homeassistant -g 8123
-echo 'homeassistant:8123:8123::::::/bin/csh:' | adduser -f -
-```
-
 Install the sugessted packages and virtualenv:
 
 ```bash
@@ -29,6 +22,13 @@ pkg install -y autoconf bash ca_root_nss gmake pkgconf python37 python37
 python3.7 -m ensurepip
 pip3 install --upgrade pip
 pip3 install --upgrade virtualenv
+```
+
+Create the user and group that Home Assistant will run as. The user/group ID of `8123` can be replaced if this is already in use in your environment.
+
+```bash
+pw groupadd -n homeassistant -g 8123
+echo 'homeassistant:8123:8123::::::/usr/local/bin/bash:' | adduser -f -
 ```
 
 Create the installation directory:
@@ -44,7 +44,7 @@ Install Home Assistant itself:
 su homeassistant
 cd /usr/local/share/homeassistant
 virtualenv -p python3.7 .
-source ./bin/activate.csh
+source ./bin/activate
 pip3 install homeassistant
 ```
 
@@ -310,7 +310,7 @@ Then, enter the `venv`:
 ```bash
 su homeassistant
 cd /usr/local/share/homeassistant
-source ./bin/activate.csh
+source ./bin/activate
 ```
 
 Upgrade Home Assistant:

--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -18,7 +18,7 @@ Install the suggested packages and virtualenv:
 ```bash
 pkg update
 pkg upgrade
-pkg install -y autoconf bash ca_root_nss gmake pkgconf python37  py37-sqlite3
+pkg install -y autoconf bash ca_root_nss gmake pkgconf python37 py37-sqlite3
 python3.7 -m ensurepip
 pip3 install --upgrade pip
 pip3 install --upgrade virtualenv
@@ -108,7 +108,7 @@ vi /usr/local/etc/rc.d/homeassistant
 #       UnChange: `sysrc -x homeassistant_config_dir`
 
 # -------------------------------------------------------
-# Copy this file to '/usr/local/etc/rc.d/homeassistant' 
+# Copy this file to '/usr/local/etc/rc.d/homeassistant'
 # `chmod +x /usr/local/etc/rc.d/homeassistant`
 # `sysrc homeassistant_enable=yes`
 # `service homeassistant start`
@@ -253,8 +253,8 @@ vi /etc/devfs.rules
 
 Add the following lines 
 ```bash
-[devfsrules_jail_allow_usb=7]  
-add path 'cu\*' mode 0660 group 8123 unhide 
+[devfsrules_jail_allow_usb=7]
+add path 'cu\*' mode 0660 group 8123 unhide
 ```
 
 Reload devfs

--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -20,12 +20,12 @@ pw groupadd -n homeassistant -g 8123
 echo 'homeassistant:8123:8123::::::/bin/csh:' | adduser -f -
 ```
 
-Install the necessary Python packages and virtualenv:
+Install the sugessted packages and virtualenv:
 
 ```bash
 pkg update
 pkg upgrade
-pkg install -y python37 py37-sqlite3 ca_root_nss
+pkg install -y autoconf bash ca_root_nss gmake pkgconf python37 python37
 python3.7 -m ensurepip
 pip3 install --upgrade pip
 pip3 install --upgrade virtualenv

--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -82,29 +82,37 @@ vi /usr/local/etc/rc.d/homeassistant
 ```bash
 #!/bin/sh
 #
-# Based upon work by tprelog at https://www.ixsystems.com/community/resources/fn-11-2-iocage-home-assistant-jail-plugins-for-node-red-mosquitto-amazon-dash-tasmoadmin.102/
+# Based upon work by tprelog at https://github.com/tprelog/iocage-homeassistant/blob/11.3-RELEASE/overlay/usr/local/etc/rc.d/homeassistant
 #
 # PROVIDE: homeassistant
 # REQUIRE: LOGIN
 # KEYWORD: shutdown
 #
-# homeassistant_enable:    Set to YES to enable the homeassistant service.
-#            Default: NO
-# homeassistant_user:    The user account used to run the homeassistant daemon.
-#            This is optional, however do not specifically set this to an
-#            empty string as this will cause the daemon to run as root.
-#            Default: homeassistant
-# homeassistant_group:    The group account used to run the homeassistant daemon.
-#            This is optional, however do not specifically set this to an
-#            empty string as this will cause the daemon to run with group wheel.
-#            Default: homeassistant
-# homeassistant_config_dir:    Directory where config files are located.
-#            Default: /home/homeassistant/.homeassistant
-# homeassistant_install_dir:    Directory where Home Assistant is installed.
-#            Default: /usr/local/share/homeassistant
+# homeassistant_user: The user account used to run the homeassistant daemon.
+#		This is optional, however do not specifically set this to an
+#		empty string as this will cause the daemon to run as root.
+#		Default: homeassistant
+# homeassistant_group: The group account used to run the homeassistant daemon.
+#		This is optional, however do not specifically set this to an
+#		empty string as this will cause the daemon to run with group wheel.
+#		Default: homeassistant
 #
-# sysrc homeassistant_enable=yes
-# service homeassistant start
+# homeassistant_venv: Directory where homeassistant virtualenv is installed.
+#       Default:  "/usr/local/share/homeassistant"
+#       Change:   `sysrc homeassistant_venv="/srv/homeassistant"`
+#       UnChange: `sysrc -x homeassistant_venv`
+#
+# homeassistant_config_dir: Directory where homeassistant config is located.
+#       Default:  "/home/homeassistant/.homeassistant"
+#       Change:   `sysrc homeassistant_config_dir="/home/hass/homeassistant"`
+#       UnChange: `sysrc -x homeassistant_config_dir`
+
+# -------------------------------------------------------
+# Copy this file to '/usr/local/etc/rc.d/homeassistant' 
+# `chmod +x /usr/local/etc/rc.d/homeassistant`
+# `sysrc homeassistant_enable=yes`
+# `service homeassistant start`
+# -------------------------------------------------------
 
 . /etc/rc.subr
 name=homeassistant
@@ -118,37 +126,78 @@ load_rc_config ${name}
 : ${homeassistant_user:="homeassistant"}
 : ${homeassistant_group:="homeassistant"}
 : ${homeassistant_config_dir:="/home/homeassistant/.homeassistant"}
-: ${homeassistant_install_dir:="/usr/local/share/homeassistant"}
+: ${homeassistant_venv:="/usr/local/share/homeassistant"}
 
 command="/usr/sbin/daemon"
+extra_commands="check_config restart test upgrade"
+
 start_precmd=${name}_precmd
-homeassistant_precmd()
-{
-    rc_flags="-f -P ${pidfile} -p ${pidfile_child} ${homeassistant_install_dir}/bin/hass --config ${homeassistant_config_dir} ${rc_flags}"
-
-    if [ ! -e "${pidfile_child}" ]; then
-            install -g ${homeassistant_group} -o ${homeassistant_user} -- /dev/null "${pidfile_child}";
-    fi
-
-    if [ ! -e "${pidfile}" ]; then
-            install -g ${homeassistant_group} -o ${homeassistant_user} -- /dev/null "${pidfile}";
-    fi
-
+homeassistant_precmd() {
+    rc_flags="-f -o ${logfile} -P ${pidfile} -p ${pidfile_child} ${homeassistant_venv}/bin/hass --config ${homeassistant_config_dir} ${rc_flags}"
+    [ ! -e "${pidfile_child}" ] && install -g ${homeassistant_group} -o ${homeassistant_user} -- /dev/null "${pidfile_child}"
+    [ ! -e "${pidfile}" ] && install -g ${homeassistant_group} -o ${homeassistant_user} -- /dev/null "${pidfile}"
+    [ -e "${logfile}" ] && rm -f -- "${logfile}"
+    install -g ${homeassistant_group} -o ${homeassistant_user} -- /dev/null "${logfile}"
     if [ ! -d "${homeassistant_config_dir}" ]; then
-            install -d -g ${homeassistant_group} -o ${homeassistant_user} -- "${homeassistant_config_dir}";
+      install -d -g ${homeassistant_group} -o ${homeassistant_user} -m 775 -- "${homeassistant_config_dir}"
     fi
-
-    echo "Performing check on Home Assistant configuration:"
-    eval "${homeassistant_install_dir}/bin/hass" --config "${homeassistant_config_dir}" --script check_config
 }
 
 stop_postcmd=${name}_postcmd
-homeassistant_postcmd()
-{
+homeassistant_postcmd() {
     rm -f -- "${pidfile}"
     rm -f -- "${pidfile_child}"
 }
 
+upgrade_cmd="${name}_upgrade"
+homeassistant_upgrade() {
+    service ${name} stop
+    su ${homeassistant_user} -c '
+      source ${@}/bin/activate || exit 1
+      pip3 install --upgrade homeassistant
+      deactivate
+    ' _ ${homeassistant_venv} || exit 1
+    [ $? == 0 ] && homeassistant_check_config && service ${name} start
+}
+
+check_config_cmd="${name}_check_config"
+homeassistant_check_config() {
+    [ ! -e "${homeassistant_config_dir}/configuration.yaml" ] && return 0
+    echo "Performing check on Home Assistant configuration:"
+    #eval "${homeassistant_venv}/bin/hass --config ${homeassistant_config_dir} --script check_config"
+    su ${homeassistant_user} -c '
+      source ${1}/bin/activate || exit 2
+      hass --config ${2} --script check_config || exit 3
+      deactivate
+    ' _ ${homeassistant_venv} ${homeassistant_config_dir}
+}
+
+restart_cmd="${name}_restart"
+homeassistant_restart() {
+    homeassistant_check_config || exit 1
+    echo "Restarting Home Assistant"
+    service ${name} stop
+    service ${name} start
+}
+
+test_cmd="${name}_test"
+homeassistant_test() {
+    echo -e "\nTesting virtualenv...\n"
+    [ ! -d "${homeassistant_venv}" ] && echo -e " NO DIRECTORY: ${homeassistant_venv}\n" && exit
+    [ ! -f "${homeassistant_venv}/bin/activate" ] && echo -e " NO FILE: ${homeassistant_venv}/bin/activate\n" && exit
+
+    ## switch users / activate virtualenv / get version
+    su "${homeassistant_user}" -c '
+      source ${1}/bin/activate || exit 2
+      echo " $(python --version)" || exit 3
+      echo " Home Assistant $(pip3 show homeassistant | grep Version | cut -d" " -f2)" || exit 4
+      deactivate
+    ' _ ${homeassistant_venv}
+
+    [ $? != 0 ] && echo "exit $?"
+}
+
+load_rc_config ${name}
 run_rc_command "$1"
 ```
 

--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -13,12 +13,12 @@ Enter the Home Assistant jail. If you don't know which name you have given the j
 iocage exec HomeAssistant
 ```
 
-Install the sugessted packages and virtualenv:
+Install the suggested packages and virtualenv:
 
 ```bash
 pkg update
 pkg upgrade
-pkg install -y autoconf bash ca_root_nss gmake pkgconf python37 python37
+pkg install -y autoconf bash ca_root_nss gmake pkgconf python37  py37-sqlite3
 python3.7 -m ensurepip
 pip3 install --upgrade pip
 pip3 install --upgrade virtualenv

--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -13,15 +13,12 @@ Enter the Home Assistant jail. If you don't know which name you have given the j
 iocage exec HomeAssistant
 ```
 
-Install the suggested packages and virtualenv:
+Install the suggested packages:
 
 ```bash
 pkg update
 pkg upgrade
 pkg install -y autoconf bash ca_root_nss gmake pkgconf python37 py37-sqlite3
-python3.7 -m ensurepip
-pip3 install --upgrade pip
-pip3 install --upgrade virtualenv
 ```
 
 Create the user and group that Home Assistant will run as. The user/group ID of `8123` can be replaced if this is already in use in your environment.
@@ -38,13 +35,14 @@ mkdir -p /usr/local/share/homeassistant
 chown -R homeassistant:homeassistant /usr/local/share/homeassistant
 ```
 
-Install Home Assistant itself:
+Create the virtualenv and install Home Assistant itself:
 
 ```bash
 su homeassistant
 cd /usr/local/share/homeassistant
-virtualenv -p python3.7 .
+python3.7 -m venv .
 source ./bin/activate
+pip3 install --upgrade pip
 pip3 install homeassistant
 ```
 


### PR DESCRIPTION
**Description:**

I've an updated version of the rc.d script which has not made it to my FreeNAS resource that the current script is based upon. It does need bash installed though. 

And why not just use bash anyways? At least for the HA user. It helps keep things in line with other virtualenv instruction. I'm not trying to offend anyone but you don't see `activate.csh`, in docs for other things like AppDaemon or HASS-Configurator for example. I think in the end it's just easier to make a small change here to avoid frustration when people are trying follow a Linux guide down the road.

I suggested a few other pkgs to install from the start as well. I'm all about minimum required but having these few extras, I think will go a long way to ease some frustration when starting to add your components into HA.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
