### PR TITLE
ZCL AnalogOutput Cluster support

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -10,6 +10,7 @@ ha_category:
   - Lock
   - Sensor
   - Switch
+  - Input Number
 ha_release: 0.44
 ha_iot_class: Local Polling
 featured: true
@@ -26,6 +27,7 @@ There is currently support for the following device types within Home Assistant:
 - Lock
 - Switch
 - Fan
+- Input Number
 
 ## ZHA exception and deviation handling
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -10,7 +10,6 @@ ha_category:
   - Lock
   - Sensor
   - Switch
-  - Input Number
 ha_release: 0.44
 ha_iot_class: Local Polling
 featured: true


### PR DESCRIPTION
**Description:**

Account for changes in HA PR. AnalogOutput cluster uses `input_number` for value input.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30211

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
