### PR TITLE
Remove empty entity_id from light doc

### DIFF
--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -24,7 +24,7 @@ Most lights do not support all attributes. You can check the integration documen
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`s of lights. Else targets all.
+| `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Set `entity_id: all` to target all lights.
 | `transition` | yes | Number that represents the time (in seconds) the light should take to transition to the new state.
 | `profile` | yes | String with the name of one of the [built-in profiles](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/light/light_profiles.csv) (relax, energize, concentrate, reading) or one of the custom profiles defined in `light_profiles.csv` in the current working directory.  Light profiles define an xy color and a brightness. If a profile is given and a brightness then the profile brightness will be overwritten.
 | `hs_color` | yes | A list containing two floats representing the hue and saturation of the color you want the light to be. Hue is scaled 0-360, and saturation is scaled 0-100.
@@ -82,7 +82,7 @@ Turns one or multiple lights off.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`s of lights. Else targets all.
+| `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Set `entity_id: all` to target all lights.
 | `transition` | yes | Integer that represents the time the light should take to transition to the new state in seconds.
 
 ### Service `light.toggle`


### PR DESCRIPTION
**Description:**

Leaving entity_id empty to target all has been deprecated, and is now non-functional since 0.103: https://github.com/home-assistant/home-assistant/pull/29178

In this commit, I patch the light doc page (probably the most visited one). Let me know if you want me to do this for all integrations. I was not 100% sure if this change is across all integrations.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
