### PR TITLE
Add service information to homeassistant integration

### DIFF
--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -96,10 +96,10 @@ There are four `homeassistant` services that aren't tied to any single domain, t
 * `homeassistant.toggle` - Turns off an entity that is on, or turns on an entity that is off (that supports being turned on and off)
 * `homeassistant.update_entity` - Request the update of an entity, rather than waiting for the next scheduled update, for example [google travel time] sensor, a [template sensor], or a [light]
 
-Complete service details and examples can be found on the [homeassistant services] page.
+Complete service details and examples can be found on the [Home Assistant integration][homeassistant-integration-services] page.
 
 [templating]: /topics/templating/
 [google travel time]: /integrations/google_travel_time/
 [template sensor]: /integrations/template/
 [light]: /integrations/light/
-[homeassistant services]: /integrations/homeassistant#services
+[homeassistant-integration-services]: /integrations/homeassistant#services

--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -96,7 +96,10 @@ There are four `homeassistant` services that aren't tied to any single domain, t
 * `homeassistant.toggle` - Turns off an entity that is on, or turns on an entity that is off (that supports being turned on and off)
 * `homeassistant.update_entity` - Request the update of an entity, rather than waiting for the next scheduled update, for example [google travel time] sensor, a [template sensor], or a [light]
 
+Complete service details and examples can be found on the [homeassistant services] page.
+
 [templating]: /topics/templating/
 [google travel time]: /integrations/google_travel_time/
 [template sensor]: /integrations/template/
 [light]: /integrations/light/
+[homeassistant services]: /integrations/homeassistant#services

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -8,27 +8,27 @@ ha_qa_scale: internal
 
 The Home Assistant integration provides generic implementations like the generic `homeassistant.turn_on`.
 
-### Services
+## Services
 
-the `homeassistant` integration provides services for controlling Home Assistant itself, as well as generic controls for any entity
+The `homeassistant` integration provides services for controlling Home Assistant itself, as well as generic controls for any entity.
 
-#### Service `homeassistant.check_config`
+### Service `homeassistant.check_config`
 
-Reads the config files and checks them for correctness, but **does not** load them into home assistant. Creates a persistant notification and log entry if errors are found.
+Reads the config files and checks them for correctness, but **does not** load them into Home Assistant. Creates a persistent notification and log entry if errors are found.
 
-#### Service `homeassistant.check_config`
+### Service `homeassistant.reload_core_config`
 
 Loads the main config file (`configuration.yaml`) and all linked files. Once loaded the new configuration is applied.
 
-#### Service `homeassistant.restart`
+### Service `homeassistant.restart`
 
 Restarts the Home Assistant instance (also reloading the configuration on start).
 
-#### Service `homeassistant.stop`
+### Service `homeassistant.stop`
 
 Stops the Home Assistant instance. Home Assistant must be restarted from the Host device to run again.
 
-#### Service `homeassistant.set_location`
+### Service `homeassistant.set_location`
 
 Update the location of the Home Assistant default zone (usually "Home").
 
@@ -37,7 +37,7 @@ Update the location of the Home Assistant default zone (usually "Home").
 | `latitude`                |       no | Latitude of your location.                            |
 | `longitude`               |       no | Longitude of your location.                           |
 
-##### Example
+#### Example
 
 ```yaml
 action:
@@ -47,7 +47,7 @@ action:
     longitude: 117.22743
 ```
 
-#### Service `homeassistant.toggle` 
+### Service `homeassistant.toggle` 
 
 Generic service to toggle devices on/off under any domain. Same usage as the light.turn_on, switch.turn_on, etc. services.
 
@@ -55,7 +55,7 @@ Generic service to toggle devices on/off under any domain. Same usage as the lig
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |       no | The entity_id of the device to toggle on/off.         |
 
-##### Example
+#### Example
 
 ```yaml
 action:
@@ -72,7 +72,7 @@ Generic service to turn devices on under any domain. Same usage as the light.tur
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |       no | The entity_id of the device to turn on.               |
 
-##### Example
+#### Example
 
 ```yaml
 action:
@@ -81,7 +81,7 @@ action:
     entity_id: light.living_room
 ```
 
-#### Service `homeassistant.turn_off` 
+### Service `homeassistant.turn_off` 
 
 Generic service to turn devices off under any domain. Same usage as the light.turn_on, switch.turn_on, etc. services.
 
@@ -89,7 +89,7 @@ Generic service to turn devices off under any domain. Same usage as the light.tu
 |---------------------------|----------|-------------------------------------------------------|
 | `entity_id`               |       no | The entity_id of the device to turn off.              |
 
-##### Example
+#### Example
 
 ```yaml
 action:
@@ -98,15 +98,15 @@ action:
     entity_id: light.living_room
 ```
 
-#### Service `homeassistant.update_entity` 
+### Service `homeassistant.update_entity` 
 
 Force one or more entities to update its data rather than wait for the next scheduled update.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |       no | One or multiple entity_ids to update. Can be a list.  |
+| `entity_id`               |       no | One or multiple entity_ids to update. It can be a list.  |
 
-##### Example
+#### Example
 
 ```yaml
 action:

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -14,7 +14,7 @@ the `homeassistant` integration provides services for controlling Home Assistant
 
 #### Service `homeassistant.check_config`
 
-Reads the config files and checks them for correctness, but **DOES NOT** load them into home assistant. Creates a persistant notification and log entry if errors are found.
+Reads the config files and checks them for correctness, but **does not** load them into home assistant. Creates a persistant notification and log entry if errors are found.
 
 #### Service `homeassistant.check_config`
 

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -3,6 +3,116 @@ title: "Core integration"
 description: "Description of the homeassistant integration."
 logo: home-assistant.png
 ha_release: 0.0
+ha_qa_scale: internal
 ---
 
 The Home Assistant integration provides generic implementations like the generic `homeassistant.turn_on`.
+
+### Services
+
+the `homeassistant` integration provides services for controlling Home Assistant itself, as well as generic controls for any entity
+
+#### Service `homeassistant.check_config`
+
+Reads the config files and checks them for correctness, but **DOES NOT** load them into home assistant. Creates a persistant notification and log entry if errors are found.
+
+#### Service `homeassistant.check_config`
+
+Loads the main config file (`configuration.yaml`) and all linked files. Once loaded the new configuration is applied.
+
+#### Service `homeassistant.restart`
+
+Restarts the Home Assistant instance (also reloading the configuration on start).
+
+#### Service `homeassistant.stop`
+
+Stops the Home Assistant instance. Home Assistant must be restarted from the Host device to run again.
+
+#### Service `homeassistant.set_location`
+
+Update the location of the Home Assistant default zone (usually "Home").
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `latitude`                |       no | Latitude of your location.                            |
+| `longitude`               |       no | Longitude of your location.                           |
+
+##### Example
+
+```yaml
+action:
+  service: homeassistant.set_location
+  data:
+    latitude: 32.87336
+    longitude: 117.22743
+```
+
+#### Service `homeassistant.toggle` 
+
+Generic service to toggle devices on/off under any domain. Same usage as the light.turn_on, switch.turn_on, etc. services.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |       no | The entity_id of the device to toggle on/off.         |
+
+##### Example
+
+```yaml
+action:
+  service: homeassistant.toggle
+  data:
+    entity_id: light.living_room
+```
+
+#### Service `homeassistant.turn_on` 
+
+Generic service to turn devices on under any domain. Same usage as the light.turn_on, switch.turn_on, etc. services.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |       no | The entity_id of the device to turn on.               |
+
+##### Example
+
+```yaml
+action:
+  service: homeassistant.turn_on
+  data:
+    entity_id: light.living_room
+```
+
+#### Service `homeassistant.turn_off` 
+
+Generic service to turn devices off under any domain. Same usage as the light.turn_on, switch.turn_on, etc. services.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |       no | The entity_id of the device to turn off.              |
+
+##### Example
+
+```yaml
+action:
+  service: homeassistant.turn_off
+  data:
+    entity_id: light.living_room
+```
+
+#### Service `homeassistant.update_entity` 
+
+Force one or more entities to update its data rather than wait for the next scheduled update.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |       no | One or multiple entity_ids to update. Can be a list.  |
+
+##### Example
+
+```yaml
+action:
+  service: homeassistant.update_entity
+  data:
+    entity_id:
+    - light.living_room
+    - switch.coffe_pot
+```

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -53,7 +53,7 @@ Generic service to toggle devices on/off under any domain. Same usage as the lig
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |       no | The entity_id of the device to toggle on/off.         |
+| `entity_id`               |       yes | The entity_id of the device to toggle on/off.         |
 
 #### Example
 
@@ -70,7 +70,7 @@ Generic service to turn devices on under any domain. Same usage as the light.tur
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |       no | The entity_id of the device to turn on.               |
+| `entity_id`               |       yes | The entity_id of the device to turn on.               |
 
 #### Example
 
@@ -87,7 +87,7 @@ Generic service to turn devices off under any domain. Same usage as the light.tu
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |       no | The entity_id of the device to turn off.              |
+| `entity_id`               |       yes | The entity_id of the device to turn off.              |
 
 #### Example
 


### PR DESCRIPTION
**Description:**
Add service information to homeassistant integration

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
