### PR TITLE
Update stream.markdown

### DIFF
--- a/source/_integrations/stream.markdown
+++ b/source/_integrations/stream.markdown
@@ -33,7 +33,7 @@ Both `duration` and `lookback` options are suggestions, but should be consistent
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `stream_source`        |      no  | The input source for the stream, e.g., `rtsp://my.stream.feed:554`. |
-| `filename`             |      no  | The file name string. Variable is `entity_id`, e.g., `/tmp/my_stream.mp4`. |
+| `filename`             |      no  | The file name string. e.g., `/tmp/my_stream.mp4`. |
 | `duration`             |      yes | Target recording length (in seconds). Default: 30 |
 | `lookback`             |      yes | Target lookback period (in seconds) to include in addition to duration.  Only available if there is currently an active HLS stream for `stream_source`. Default: 0 |
 


### PR DESCRIPTION
**Description:**
Looking at the integrations [code](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/stream/__init__.py#L198), there does not seem to be any replacements or formatting occurring in the filename.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
