### PR TITLE
Spell Zigbee consistently, with lowercase "b"

### DIFF
--- a/source/_integrations/tradfri.markdown
+++ b/source/_integrations/tradfri.markdown
@@ -13,7 +13,7 @@ ha_category:
   - Switch
 ---
 
-The `tradfri` integration allows you to connect your IKEA Trådfri Gateway to Home Assistant. The gateway can control compatible Zigbee-based lights (certified ZigBee Light Link products) connected to it. Home Assistant will automatically discover the gateway's presence on your local network if `discovery:` is present in your `configuration.yaml` file.
+The `tradfri` integration allows you to connect your IKEA Trådfri Gateway to Home Assistant. The gateway can control compatible Zigbee-based lights (certified Zigbee Light Link products) connected to it. Home Assistant will automatically discover the gateway's presence on your local network if `discovery:` is present in your `configuration.yaml` file.
 
 You will be prompted to configure the gateway through the Home Assistant interface. The configuration process is very simple: when prompted, enter the security key printed on the sticker on the bottom of the IKEA Trådfri Gateway, then click *configure*.
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -122,7 +122,7 @@ Go to the **Configuration** page and select the **ZHA** integration that was add
 
 Click on **ADD DEVICES** to start a scan for new devices.
 
-Reset your ZigBee devices according to the device instructions provided by the manufacturer (e.g.,  turn on/off lights up to 10 times, switches usually have a reset button/pin).
+Reset your Zigbee devices according to the device instructions provided by the manufacturer (e.g.,  turn on/off lights up to 10 times, switches usually have a reset button/pin).
 
 ## Troubleshooting
 
@@ -145,7 +145,7 @@ Follow the instructions on [https://github.com/vanviegen/hue-thief/](https://git
 
 ### ZHA Start up issue with Home-Assistant Docker/Hass.io installs on linux hosts
 
-On Linux hosts ZHA can fail to start during HA startup or restarts because the zigbee USB device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.
+On Linux hosts ZHA can fail to start during HA startup or restarts because the Zigbee USB device is being claimed by the host's modemmanager service. To fix this disable the modemmanger on the host system.
 
 To remove modemmanager from an Debian/Ubuntu host run this command:
 


### PR DESCRIPTION

**Description:**
https://zigbeealliance.org/developer_resources/zigbee-specification/
"Please note that this uses old branding, Zigbee is always a lowercase
 B, not a capital. This change occurred shortly after the official
 release of this document."

Also other docs at https://zigbeealliance.org/solution_type/zigbee/,
https://github.com/zigpy/zigpy/issues/111


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
