### PR TITLE
Update pi_hole.markdown

### DIFF
--- a/source/_integrations/pi_hole.markdown
+++ b/source/_integrations/pi_hole.markdown
@@ -44,7 +44,7 @@ verify_ssl:
   type: boolean
   default: true
 api_key:
-  description: API Key for interacting with the Pi-hole. This is not required if you want to just query the Pi-hole for usage statistics.
+  description: API Key for interacting with the Pi-hole. This is not required if you want to just query the Pi-hole for usage statistics.  API Key may need to be set to null ( "" ) when using the Pi Hole addon for HASSIO
   required: false
   type: string
   default: None
@@ -57,7 +57,8 @@ api_key:
 pi_hole:
   host: 'localhost:4865'
   ssl: false
-  verify_ssl: false
+  verify_ssl: false 
+  api_key: ""
 ```
 
 ## Services


### PR DESCRIPTION
See https://github.com/hassio-addons/addon-pi-hole/issues/99.  API Key needs to be set to null due to another issue in the pihole addon.  

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#11620

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
