### PR TITLE
add camera password line to sample config

### DIFF
--- a/source/_integrations/uvc.markdown
+++ b/source/_integrations/uvc.markdown
@@ -29,6 +29,7 @@ camera:
   - platform: uvc
     nvr: IP_ADDRESS
     key: API_KEY
+    password: CAMERA_PASSWORD
 ```
 
 {% configuration %}


### PR DESCRIPTION


**Description:**

The need for the camera password line is explained in the uvc doc, but it is not included in the sample config for copypasting. Without it, the integration works but imagery does not show.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
