### PR TITLE
Point to Telegram chatbot page from Telegram config example

### DIFF
--- a/source/_integrations/telegram.markdown
+++ b/source/_integrations/telegram.markdown
@@ -87,6 +87,10 @@ notify:
     chat_id: CHAT_ID_2
 ```
 
+Refer to the platforms mentioned in the
+[Telegram chatbot page](/integrations/telegram_chatbot/) for
+`telegram_bot` configuration.
+
 {% configuration %}
 name:
   description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.

--- a/source/_integrations/telegram_chatbot.markdown
+++ b/source/_integrations/telegram_chatbot.markdown
@@ -10,7 +10,7 @@ ha_iot_class: Cloud Push
 
 Use Telegram on your mobile or desktop device to send and receive messages or commands to/from your Home Assistant.
 
-This integration creates notification services to send, or edit previously sent, messages from a [Telegram Bot account](https://core.telegram.org/bots) configured either with the [polling](/integrations/telegram_polling) method or with the [webhooks](/integrations/telegram_webhooks) one, and trigger events when receiving messages.
+This integration creates notification services to send, or edit previously sent, messages from a [Telegram Bot account](https://core.telegram.org/bots) configured either with the [polling](/integrations/telegram_polling) platform or with the [webhooks](/integrations/telegram_webhooks) one, and trigger events when receiving messages.
 
 If you don't need to receive messages, you can use the [broadcast](/integrations/telegram_broadcast) platform instead.
 


### PR DESCRIPTION
**Description:**

Was a bit confused because the example config for the bot is not explained where it is presented in the Telegram (not bot) page, specifically the `platform: polling` entry. Also, fix one occurrence where a Telegram platform is referred to as "method" to use the word "platform".

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
