### PR TITLE
Mention homekit_controller air quality support

### DIFF
--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -13,6 +13,7 @@ ha_category:
   - Binary Sensor
   - Sensor
   - Fan
+  - Health
 ha_release: 0.68
 ha_iot_class: Local Polling
 ---
@@ -36,6 +37,7 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor (HomeKit motion, contact and smoke sensors)
 - Sensor (HomeKit humidity, temperature, co2 and light level sensors)
 - Fan
+- Air Quality
 
 HomeKit IP accessories for these device types may work with some caveats:
 


### PR DESCRIPTION
**Description:**

Mention support for homekit air quality sensors.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30510

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].