### PR TITLE
HS110 clarifications regarding sensors

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -30,7 +30,7 @@ The following devices are known to work with this component.
 - HS100
 - HS103
 - HS105
-- HS110
+- HS110 (The only device capable or reporting energy usage data to template sensors)
 
 ### Strip (Multi-Plug)
 
@@ -129,7 +129,7 @@ tplink:
 
 ## Extracting Energy Sensor data
 
-In order to get the power consumption readings from supported devices, you'll have to create a [template sensor](/integrations/switch.template/).
+In order to get the power consumption readings from a TP-Link HS110 device, you'll have to create a [template sensor](/integrations/switch.template/).
 In the example below, change all of the `my_tp_switch`'s to match your device's entity ID.
 
 {% raw %}


### PR DESCRIPTION
Hi all - my first proposed change, and it's minor. I ran into this issue where I misread the original and believed other devices (HS103's in my case) were supported for everything (control and sensors) when it's really just the HS110 that can create sensors. Anyway, I thought I would make it more clear for anyone else who may have misread it like I did. Cheers!

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
