### PR TITLE
Use explicit links inside configuration blocks

### DIFF
--- a/source/_addons/google_assistant.markdown
+++ b/source/_addons/google_assistant.markdown
@@ -42,15 +42,15 @@ That's it. You should no be able to use the Google Voice assistant.
 
 {% configuration %}
 client_secrets:
-  description: The file downloaded from the [Google Actions Console][GActionsConsole], you can redownload them under the "Develop - Device registration" tab. By default the add-on look in the "hassio/share" folder.
+  description: The file downloaded from the [Google Actions Console](https://console.actions.google.com/), you can redownload them under the "Develop - Device registration" tab. By default the add-on look in the "hassio/share" folder.
   required: true
   type: string
 project_id:
-  description: The project id can be found in your "google_assistant.json" file or under project settings in the [Google Actions Console][GActionsConsole].
+  description: The project id can be found in your "google_assistant.json" file or under project settings in the [Google Actions Console](https://console.actions.google.com/).
   required: true
   type: string
 model_id:
-  description: The model id can also be found under the "Develop - Device registration tab" in the [Google Actions Console][GActionsConsole].
+  description: The model id can also be found under the "Develop - Device registration tab" in the [Google Actions Console](https://console.actions.google.com/).
   required: true
   type: string
 {% endconfiguration %}

--- a/source/_integrations/alert.markdown
+++ b/source/_integrations/alert.markdown
@@ -51,7 +51,7 @@ entity_id:
 title:
   description: >
     A title to be used for the notification if the notifier supports it
-    with [template][template] support.
+    with [template](/docs/configuration/templating/) support.
   required: false
   type: template
 state:
@@ -80,13 +80,13 @@ skip_first:
 message:
   description: >
     A message to be sent after an alert transitions from `off` to `on`
-    with [template][template] support.
+    with [template](/docs/configuration/templating/) support.
   required: false
   type: template
 done_message:
   description: >
-    A message sent after an alert transitions from `on` to `off` with 
-    [template][template] support. Is only sent if an alert notification 
+    A message sent after an alert transitions from `on` to `off` with
+    [template](/docs/configuration/templating/) support. Is only sent if an alert notification
     was sent for transitioning from `off` to `on`.
   required: false
   type: template
@@ -205,7 +205,7 @@ sent at 2:15, 2:45, 3:45, 4:45, etc., continuing every 60 minutes.
 ### Message Templates
 
 It may be desirable to have the alert notifications include information
-about the state of the entity. [Templates](/docs/configuration/templating/)
+about the state of the entity. [Templates][template]
 can be used in the message or name of the alert to make it more relevant.
 The following will show for a plant how to include the problem `attribute`
 of the entity.


### PR DESCRIPTION
**Description:**

The converter used in the configuration plugin is not aware of references declared outside of the block and therefore fails to render reference links. This replaces them with explicit links.

Resolves #11643

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
