### PR TITLE
Adding definition of logfile variable to rc.d script

### DIFF
--- a/source/_docs/installation/freenas.markdown
+++ b/source/_docs/installation/freenas.markdown
@@ -118,6 +118,7 @@ rcvar=${name}_enable
 
 pidfile_child="/var/run/${name}.pid"
 pidfile="/var/run/${name}_daemon.pid"
+logfile="/var/log/${name}.log"
 
 load_rc_config ${name}
 : ${homeassistant_enable:="NO"}


### PR DESCRIPTION
With this instruction a have an error after starting service:
```
# sysrc homeassistant_enable="YES"
homeassistant_enable:  -> YES
# service homeassistant start
install: : No such file or directory
Starting homeassistant.
daemon: open: Permission denied
/usr/local/etc/rc.d/homeassistant: WARNING: failed to start homeassistant
```
There is needs to define logfile variable in rc.d script

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
