### PR TITLE
remove suppress_warning from configuration definition of vizio component

### DIFF
--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -97,11 +97,6 @@ device_class:
   required: false
   type: string
   default: tv
-suppress_warning:
-  description: Set to `true` to disable self-signed certificate warnings.
-  required: false
-  default: false
-  type: string
 {% endconfiguration %}
 
 ## Notes and limitations


### PR DESCRIPTION
**Description:**
Removes `suppress_warning` from the configuration definition of the `vizio` component. This is related to an associated PR as listed below

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30536

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
