### PR TITLE
Switch order of Python and ADB server instructions

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -159,17 +159,17 @@ This integration works by sending ADB commands to your Android TV / Fire TV devi
 When connecting to your device for the first time, a dialog will appear on your Android TV / Fire TV asking you to approve the connection. Check the box that says "always allow connections from this device" and hit OK.
 </div>
 
-### 1. ADB Server
+### 1. Python ADB Implementation
 
-You can use an ADB server to connect to your Android TV and Fire TV devices.
-
-For Hass.io users, you can install the [Android Debug Bridge](https://github.com/hassio-addons/addon-adb/blob/master/README.md) addon. Using this approach, Home Assistant will send the ADB commands to the server, which will then send them to the Android TV / Fire TV device and report back to Home Assistant. To use this option, add the `adb_server_ip` option to your configuration. If you are running the server on the same machine as Home Assistant, you can use `127.0.0.1` for this value.
-
-### 2. Python ADB Implementation
-
-The second option is to connect to your device using the `adb-shell` Python package. As of Home Assistant 0.101, if a key is needed for authentication and it is not provided by the `adbkey` configuration option, then Home Assistant will generate a key for you.
+The default approach is to connect to your device using the `adb-shell` Python package. As of Home Assistant 0.101, if a key is needed for authentication and it is not provided by the `adbkey` configuration option, then Home Assistant will generate a key for you.
 
 Prior to Home Assistant 0.101, this approach did not work well for newer devices. Efforts have been made to resolve these issues, but if you experience problems then you should use the ADB server option.
+
+### 2. ADB Server
+
+The second option is to use an ADB server to connect to your Android TV and Fire TV devices.
+
+For Hass.io users, you can install the [Android Debug Bridge](https://github.com/hassio-addons/addon-adb/blob/master/README.md) addon. Using this approach, Home Assistant will send the ADB commands to the server, which will then send them to the Android TV / Fire TV device and report back to Home Assistant. To use this option, add the `adb_server_ip` option to your configuration. If you are running the server on the same machine as Home Assistant, you can use `127.0.0.1` for this value.
 
 ## ADB Troubleshooting
 

--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -61,7 +61,7 @@ adbkey:
   required: false
   type: string
 adb_server_ip:
-  description: The IP address of the ADB server. If this is provided, the integration will utilize an [ADB server](#1-adb-server) to communicate with the device.
+  description: The IP address of the ADB server. If this is provided, the integration will utilize an [ADB server](#2-adb-server) to communicate with the device.
   required: false
   type: string
 adb_server_port:
@@ -187,7 +187,7 @@ If the setup for your Android TV or Fire TV device fails, then there is probably
 
 6. If your device drops off WiFi, breaking the ADB connection and causing the entity to become unavailable in Home Assistant, you could install a wake lock utility (such as [Wakelock](https://github.com/d4rken/wakelock-revamp)) to prevent this from happening. Some users have reported this problem with Xiaomi Mi Box devices.
 
-7. If you are using the [Python ADB implementation](#2-python-adb-implementation) approach, as mentioned above, there may be some issues with newer devices. In this case, you should use the [ADB server](#1-adb-server) approach instead.
+7. If you are using the [Python ADB implementation](#1-python-adb-implementation) approach, as mentioned above, there may be some issues with newer devices. In this case, you should use the [ADB server](#2-adb-server) approach instead.
 
 ## Services
 


### PR DESCRIPTION
**Description:**

Put the Python ADB section before the ADB server section. This approach is easier to setup and easier to debug, and users should only option for the ADB server approach if the Python ADB approach is unsuccessful / unreliable. 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
