### PR TITLE
Sync config flow with codebase

### DIFF
--- a/source/_integrations/brother.markdown
+++ b/source/_integrations/brother.markdown
@@ -6,6 +6,7 @@ ha_category:
   - System Monitor
 ha_release: 0.104
 ha_iot_class: Local Polling
+ha_config_flow: true
 ---
 
 The `Brother Printer` integration allows you to read current data from your local Brother printer.

--- a/source/_integrations/elgato.markdown
+++ b/source/_integrations/elgato.markdown
@@ -7,6 +7,7 @@ ha_category:
 ha_release: 0.104
 ha_iot_class: Local Polling
 ha_qa_scale: platinum
+ha_config_flow: true
 ---
 
 The [Elgato Key Light](https://www.elgato.com/en/gaming/key-light) sets the

--- a/source/_integrations/gios.markdown
+++ b/source/_integrations/gios.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Health
 ha_release: 0.104
 ha_iot_class: Cloud Polling
+ha_config_flow: true
 ---
 
 The `gios` integration uses the [GIOŚ](http://powietrze.gios.gov.pl/pjp/current) web service as a source for air quality data for your location.

--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -7,6 +7,7 @@ ha_category:
   - Sensor
 ha_iot_class: Cloud Polling
 ha_release: '0.10'
+ha_config_flow: true
 ---
 
 The `icloud` integration allows you to detect presence using the [iCloud](https://www.icloud.com/) service. iCloud allows users to track their location on iOS devices.

--- a/source/_integrations/local_ip.markdown
+++ b/source/_integrations/local_ip.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Network
 ha_iot_class: Local Polling
 ha_release: 0.105
+ha_config_flow: true
 ---
 
 The `local_ip` sensor will expose the local (LAN) IP address of your Home Assistant instance. This can be useful when your instance has a static public hostname (for example, if you use the Nabu Casa service), but have a dynamically allocated local LAN address (for example, configured via DHCP).

--- a/source/_integrations/sentry.markdown
+++ b/source/_integrations/sentry.markdown
@@ -6,6 +6,7 @@ ha_category:
   - System Monitor
 ha_iot_class: Cloud Polling
 ha_release: 0.104
+ha_config_flow: true
 ---
 
 The `sentry` integration integrates with [Sentry](https://sentry.io/) to capture both logged errors as well as unhandled exceptions in Home Assistant.

--- a/source/_integrations/tesla.markdown
+++ b/source/_integrations/tesla.markdown
@@ -12,6 +12,7 @@ ha_category:
   - Switch
 ha_release: 0.53
 ha_iot_class: Cloud Polling
+ha_config_flow: true
 ---
 
 The `Tesla` integration offers integration with the [Tesla](https://auth.tesla.com/login) cloud service and provides presence detection as well as sensors such as charger state and temperature.


### PR DESCRIPTION
**Description:**

Sync config flow marker on `next` with Home Assistant on `dev`.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
