### PR TITLE
Entity Component to no longer generate automatic groups

### DIFF
--- a/source/_cookbook/automation_for_rainy_days.markdown
+++ b/source/_cookbook/automation_for_rainy_days.markdown
@@ -17,7 +17,7 @@ automation:
         to: 'rain'
     condition:
       - condition: state
-        entity_id: group.all_devices
+        entity_id: all
         state: 'home'
       - condition: time
         after: '14:00'

--- a/source/_cookbook/automation_sun.markdown
+++ b/source/_cookbook/automation_sun.markdown
@@ -14,7 +14,7 @@ automation:
     offset: "-00:45:00"
   condition:
     condition: state
-    entity_id: group.all_devices
+    entity_id: all
     state: home
   action:
     service: light.turn_on

--- a/source/_cookbook/ifttt.manything.markdown
+++ b/source/_cookbook/ifttt.manything.markdown
@@ -21,7 +21,7 @@ automation:
     # if we leave the house during the day.
     trigger:
       - platform: state
-        entity_id: group.all_devices
+        entity_id: all
         to: 'not_home'
     condition:
       - platform: state
@@ -36,7 +36,7 @@ automation:
     # when we get home unless it's nighttime.
     trigger:
       - platform: state
-        entity_id: group.all_devices
+        entity_id: all
         to: 'home'
     condition:
       - condition: state
@@ -59,9 +59,9 @@ For ManyThing support, you need to set up an `on` and `off` event.
 
 You can use the developer tools to test your [Maker Service](https://ifttt.com/maker_webhooks) trigger. To do this, open the Home Assistant UI, open the sidebar, click on the first icon in the developer tools. This should get you to the 'Call Service' screen. Fill in the following values:
 
-Field | Value
------ | -----
-domain | `ifttt`
-service | `trigger`
-Service Data | `{"event": "manything_on"}`
+| Field        | Value                       |
+| ------------ | --------------------------- |
+| domain       | `ifttt`                     |
+| service      | `trigger`                   |
+| Service Data | `{"event": "manything_on"}` |
 

--- a/source/_docs/automation/examples.markdown
+++ b/source/_docs/automation/examples.markdown
@@ -20,13 +20,13 @@ automation:
         event: sunset
         offset: '-01:00:00'
       - platform: state
-        entity_id: group.all_devices
+        entity_id: all
         to: 'home'
     condition:
       # Prefix the first line of each condition configuration
       # with a '-'' to enter multiple
       - condition: state
-        entity_id: group.all_devices
+        entity_id: all
         state: 'home'
       - condition: time
         after: '16:00:00'
@@ -40,7 +40,7 @@ automation:
   - alias: 'Rule 2 - Away Mode'
     trigger:
       platform: state
-      entity_id: group.all_devices
+      entity_id: all
       to: 'not_home'
     action:
       service: light.turn_off

--- a/source/_docs/ecosystem/appdaemon/api.markdown
+++ b/source/_docs/ecosystem/appdaemon/api.markdown
@@ -1650,7 +1650,7 @@ for tracker in trackers:
 
 ### everyone_home()
 
-A convenience function to determine if everyone is home. Use this in preference to getting the state of `group.all_devices()` as it avoids a race condition when using state change callbacks for device trackers.
+A convenience function to determine if everyone is home.
 
 #### Synopsis
 
@@ -1669,7 +1669,7 @@ if self.everyone_home():
 ```
 ### anyone_home()
 
-A convenience function to determine if one or more person is home. Use this in preference to getting the state of `group.all_devices()` as it avoids a race condition when using state change callbacks for device trackers.
+A convenience function to determine if one or more person is home.
 
 #### Synopsis
 
@@ -1689,7 +1689,7 @@ if self.anyone_home():
 ```
 ### noone_home()
 
-A convenience function to determine if no people are at home. Use this in preference to getting the state of group.all_devices() as it avoids a race condition when using state change callbacks for device trackers.
+A convenience function to determine if no people are at home.
 
 #### Synopsis
 

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -117,17 +117,17 @@ Force a refresh of the Blink system.
 Trigger a camera to take a new still image.
 
 | Service Data Attribute | Optional | Description                            |
-|------------------------|----------|----------------------------------------|
-| `name`                 |     no   | Name of camera to take new image with. |
+| ---------------------- | -------- | -------------------------------------- |
+| `name`                 | no       | Name of camera to take new image with. |
 
 ### `blink.save_video`
 
 Save the last recorded video of a camera to a local file. Note that in most cases, Home Assistant will need to know that the directory is writable via the `whitelist_external_dirs` in your `configuration.yaml` file (see example below).
 
 | Service Data Attribute | Optional | Description                              |
-|------------------------|----------|------------------------------------------|
-| `name`                 |    no    | Name of camera containing video to save. |
-| `filename`             |    no    | Location of save file.                   |
+| ---------------------- | -------- | ---------------------------------------- |
+| `name`                 | no       | Name of camera containing video to save. |
+| `filename`             | no       | Location of save file.                   |
 
 
 ```yaml
@@ -176,7 +176,7 @@ Here, this example assumes your blink module is named `My Sync Module` and that 
   alias: Arm Blink When Away
   trigger:
       platform: state
-      entity_id: group.all_devices
+      entity_id: all
       to: 'not_home'
   action:
       service: alarm_control_panel.alarm_arm_away
@@ -192,7 +192,7 @@ Similar to the previous example, this automation will disarm blink when arriving
   alias: Disarm Blink When Home
   trigger:
       platform: state
-      entity_id: group.all_devices
+      entity_id: all
       to: 'home'
   action:
       service: alarm_control_panel.alarm_disarm

--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -102,8 +102,6 @@ google_assistant:
     light.living_room:
       expose: false
       room: LIVING_ROOM
-    group.all_automations:
-      expose: false
 ```
 
 {% configuration %}
@@ -195,10 +193,6 @@ Currently, the following domains are available to be used with Google Assistant,
 - vacuum (dock/start/stop/pause)
 - sensor (temperature setting for temperature sensors and humidity setting for humidity sensors)
 - Alarm Control Panel (arm/disarm)
-
-<div class='note warning'>
-  The domain `groups` contains groups containing all items, such as `group.all_automations`. When telling Google Assistant to shut down everything, this will lead in this example to disabling all automations.
-</div>
 
 ### Secure Devices
 

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -60,18 +60,6 @@ control:
   type: string
 {% endconfiguration %}
 
-## Default groups
-
-Some integrations automatically create special groups containing integration entities. These groups are named like `group.all_...`, for example:
-
-- `group.all_switches`
-- `group.all_lights`
-- `group.all_devices`
-- `group.all_scripts`
-- `group.all_automations`
-
-You can see list of these groups in  **States** <img src='/images/screenshots/developer-tool-states-icon.png' class='no-shadow' height='38' /> page of the **Developer Tools**.
-
 ## Group behavior
 
 By default when any member of a group is `on` then the group will also be `on`. Similarly with a device tracker, when any member of the group is `home` then the group is `home`. If you set the `all` option to `true` though, this behavior is inverted and all members of the group have to be `on` for the group to turn on as well.
@@ -147,41 +135,4 @@ Notice in the example below that in order to refer to the group "Living Room", y
     entities:
       - group.living_room
       - group.bedroom
-```
-
-Default groups appear in the HOME tab, if not overridden by user views and groups. Default groups are hidden by default, so you must [customize](/docs/configuration/customizing-devices/) them to be visible in your custom groups and views.
-
-```yaml
-# Example configuration.yaml to include default groups in custom view
-customize:
-  group.all_automations:
-    hidden: false
-  group.all_scripts:
-    hidden: false
-group:
-  automation_view:
-    name: Automation
-    view: true
-    entities:
-      - group.all_automations
-      - group.all_scripts
-```
-
-## Customize group order
-You can also order your groups using [customize](/docs/configuration/customizing-devices/) with `order: ` if they don't show up in the order you want them in.
-
-```yaml
-# Example configuration.yaml to order groups with order:
-customize:
-  group.all_automations:
-    order: 1
-  group.all_scripts:
-    order: 2
-group:
-  automation_view:
-    name: Automation
-    view: true
-    entities:
-      - group.all_automations
-      - group.all_scripts
 ```

--- a/source/_posts/2015-09-19-alarm-sonos-and-itunes-support.markdown
+++ b/source/_posts/2015-09-19-alarm-sonos-and-itunes-support.markdown
@@ -43,11 +43,11 @@ automation:
       event: sunset
       offset: "-01:00:00"
     - platform: state
-      entity_id: group.all_devices
+      entity_id: all
       state: home
   condition:
     - platform: state
-      entity_id: group.all_devices
+      entity_id: all
       state: home
     - platform: time
       after: "16:00:00"


### PR DESCRIPTION
**Description:**

Entity integrations will no longer automatically maintain the hidden groups with all of their entities. The following groups are no longer automatically created and maintained: 

 - `group.all_automations`
 - `group.calendar`
 - `group.all_covers`
 - `group.all_devices`
 - `group.all_fans`
 - `group.all_lights`
 - `group.all_locks`
 - `group.all_plants`
 - `group.remember_the_milk_accounts` (???)
 - `group.all_remotes`
 - `group.all_scripts`
 - `group.all_switches`
 - `group.all_vacuum_cleaners`

The automation and script config panels have been updated to show and manage all automations/scripts. If you want to show cards in your UI with all entities for a single domain, use the [auto-entities](https://github.com/thomasloven/lovelace-auto-entities) card. If you want to target all entities in a service call, use `'all'` as value for `entity_id`.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#23789

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
