### PR TITLE
Updating vera docs to use config flow in related pr.

### DIFF
--- a/source/_integrations/vera.markdown
+++ b/source/_integrations/vera.markdown
@@ -32,20 +32,11 @@ There is currently support for the following device types within Home Assistant:
 and will be automatically added when HA connects to your Vera controller.
 
 ## Configuration
+<div class='note info'>
 
-To use Vera devices in your installation, add the following to your `configuration.yaml` file using the IP and port number of your Vera controller:
+The Vera integration is configured exclusively through the front-end. Manual setup through `configuration.yaml` is deprecated.
 
-```yaml
-vera:
-  vera_controller_url: http://192.168.1.161:3480/
-```
-
-{% configuration %}
-vera_controller_url:
-  description: The URL for your Vera device.
-  required: true
-  type: string
-{% endconfiguration %}
+</div>
 
 <div class='note'>
 
@@ -53,22 +44,14 @@ vera_controller_url:
 
 </div>
 
-### Configure devices
-
-By default your switches will be added to Home Assistant as switches, however, if some of them are light switches, you can tell Home Assistant this using the optional `lights` parameter as shown below.
-
-Vera imports detailed Z-Wave devices into Home Assistant. This can include system devices and other devices that you don't use; you can tell Home Assistant not to load these devices using the `exclude:` parameter as shown below.
+1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'Vera' and click 'Configure'.
+2. Enter the url for the controller and click 'Submit'.
+    * By default your switches will be added to Home Assistant as switches, however, if some of them are light switches, you can tell Home Assistant this by providing a list of light ids.
+    * Vera imports detailed Z-Wave devices into Home Assistant. This can include system devices and other devices that you don't use; you can tell Home Assistant not to load these devices by providing a list of device ids.
 
 You can find the Vera device id either via the advanced properties of the device in the Vera UI or by checking the `Vera Device Id` attribute on each device imported into Home Assistant (under the developer tools).
 
-```yaml
-vera:
-  vera_controller_url: http://192.168.1.161:3480/
-  # Optional to exclude devices - this is a list of vera device ids
-  exclude: [ 13, 14, 16, 20, 23, 72, 73, 74, 75, 76, 77, 78, 88, 89, 99]
-  # Optional to import switches as lights - this is a list of vera device ids
-  lights: [15, 17, 19, 21, 22, 24, 26, 43, 64, 70, 87]
-```
+
 
 ### Using Z-Wave devices in automation
 

--- a/source/_integrations/vera.markdown
+++ b/source/_integrations/vera.markdown
@@ -42,8 +42,12 @@ and will be automatically added when HA connects to your Vera controller.
 
 1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'Vera' and click 'Configure'.
 2. Enter the url for the controller and click 'Submit'.
-    * By default your switches will be added to Home Assistant as switches, however, if some of them are light switches, you can tell Home Assistant this by providing a list of light ids.
-    * Vera imports detailed Z-Wave devices into Home Assistant. This can include system devices and other devices that you don't use; you can tell Home Assistant not to load these devices by providing a list of device ids.
+
+## Options
+Once the Vera integration is configured, you can set additional options in the integration, click the gear icon.
+
+- Vera switch device - By default your switches will be added to Home Assistant as switches, however, if some of them are light switches, you can tell Home Assistant this by providing a list of light ids.
+- Vera device ids to exclude - Vera imports detailed Z-Wave devices into Home Assistant. This can include system devices and other devices that you don't use; you can tell Home Assistant not to load these devices by providing a list of device ids.
 
 You can find the Vera device id either via the advanced properties of the device in the Vera UI or by checking the `Vera Device Id` attribute on each device imported into Home Assistant (under the developer tools).
 

--- a/source/_integrations/vera.markdown
+++ b/source/_integrations/vera.markdown
@@ -34,12 +34,6 @@ and will be automatically added when HA connects to your Vera controller.
 
 ## Configuration
 
-<div class='note info'>
-
-The Vera integration is configured exclusively through the front-end. Manual setup through `configuration.yaml` is deprecated.
-
-</div>
-
 <div class='note'>
 
   It is recommended to assign a static IP address to your Vera Controller. This ensures that it won't change IP addresses, so you won't have to change the `vera_controller_url` if it reboots and comes up with a different IP address. See your router's manual for details on how to set this up. If you need the MAC address of your Vera, check the label on the bottom.

--- a/source/_integrations/vera.markdown
+++ b/source/_integrations/vera.markdown
@@ -33,6 +33,7 @@ There is currently support for the following device types within Home Assistant:
 and will be automatically added when HA connects to your Vera controller.
 
 ## Configuration
+
 <div class='note info'>
 
 The Vera integration is configured exclusively through the front-end. Manual setup through `configuration.yaml` is deprecated.
@@ -51,8 +52,6 @@ The Vera integration is configured exclusively through the front-end. Manual set
     * Vera imports detailed Z-Wave devices into Home Assistant. This can include system devices and other devices that you don't use; you can tell Home Assistant not to load these devices by providing a list of device ids.
 
 You can find the Vera device id either via the advanced properties of the device in the Vera UI or by checking the `Vera Device Id` attribute on each device imported into Home Assistant (under the developer tools).
-
-
 
 ### Using Z-Wave devices in automation
 

--- a/source/_integrations/vera.markdown
+++ b/source/_integrations/vera.markdown
@@ -13,6 +13,7 @@ ha_category:
   - Switch
   - Climate
 ha_release: pre 0.7
+ha_config_flow: true
 ha_domain: vera
 ---
 

--- a/source/_integrations/vera.markdown
+++ b/source/_integrations/vera.markdown
@@ -41,7 +41,7 @@ and will be automatically added when HA connects to your Vera controller.
 </div>
 
 1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'Vera' and click 'Configure'.
-2. Enter the url for the controller and click 'Submit'.
+2. Enter the URL for the controller and click 'Submit'.
 
 ## Options
 Once the Vera integration is configured, you can set additional options in the integration, click the gear icon.


### PR DESCRIPTION
**Description:**
Changing documentation to prefer config flow instead of configuration.yml.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#29880

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
