### PR TITLE
Removing Windows

### DIFF
--- a/source/_docs/installation.markdown
+++ b/source/_docs/installation.markdown
@@ -94,12 +94,6 @@ These guides are provided as-is. Some of these install methods are more limited 
     </div>
     <div class='title'>CentOS/RHEL</div>
   </a>
-  <a class='option-card' href='/docs/installation/windows/'>
-    <div class='img-container'>
-      <img src='/images/supported_brands/windows.png' />
-    </div>
-    <div class='title'>Windows</div>
-  </a>
   <a class='option-card' href='/docs/installation/macos/'>
     <div class='img-container'>
       <img src='/images/supported_brands/apple.png' />


### PR DESCRIPTION
We get a regular trickle of folks installing on Windows, who're then stuck on things like auto-starting, and almost everything else.

As much as I don't like removing community provided guides, I think this one needs to disappear.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
