### PR TITLE
add testing notes for Q9F

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -130,10 +130,10 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - MU6125 - Unable to see state and unable to control (Tested on UE58MU6125 on port 8001 and 8801)
 - MU6300 - Port set to 8001, turning on works, status not working reliably, turning off is not permanent (it comes back on)
 - MU6400 - Unable to see state and unable to control (using latest 1270 firmware. Had limited functionality on previous firmware)
-- Q60 – turning on works, turning off does not work, State is always "off".
+- Q60 – Turning on works, turning off does not work, State is always "off".
 - Q6F – Port set to 8001, turning on works, turning off does not work, status not working reliably.
 - Q7F - State is always "off" and unable to control via port 8001.
-- Q9F - turning on works, turning off does not work. State is correct. Nothing else works. Port 8001
+- Q9F - Turning on works, turning off does not work. State is correct. Nothing else works. Port 8001.
 
 None of the 2014 (H) and 2015 (J) model series (e.g., J5200) will work, since Samsung have used a different (encrypted) type of interface for these.
 

--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -133,6 +133,7 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - Q60 – turning on works, turning off does not work, State is always "off".
 - Q6F – Port set to 8001, turning on works, turning off does not work, status not working reliably.
 - Q7F - State is always "off" and unable to control via port 8001.
+- Q9F - turning on works, turning off does not work. State is correct. Nothing else works. Port 8001
 
 None of the 2014 (H) and 2015 (J) model series (e.g., J5200) will work, since Samsung have used a different (encrypted) type of interface for these.
 


### PR DESCRIPTION
**Description:**
Add testing notes for Samsung Q9F.
Power On works.
State is correct.
No other services function.

## Checklist:

- [ x ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
