### PR TITLE
Add Device Class info for customization

### DIFF
--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -73,7 +73,6 @@ Currently only supported on [Sonos](/integrations/sonos), [Spotify](/integration
 | `entity_id`            |       no | Target a specific media player. For example `media_player.spotify`|
 | `shuffle`              |       no | `true`/`false` for enabling/disabling shuffle        |
 
-
 ### Device Class
 
 The way media players are displayed in the frontend can be modified in the [customize section](/getting-started/customizing-devices/). The following device classes are supported for media players:

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -72,3 +72,11 @@ Currently only supported on [Sonos](/integrations/sonos), [Spotify](/integration
 | ---------------------- | -------- | ---------------------------------------------------- |
 | `entity_id`            |       no | Target a specific media player. For example `media_player.spotify`|
 | `shuffle`              |       no | `true`/`false` for enabling/disabling shuffle        |
+
+
+### Device Class
+
+The way media players are displayed in the frontend can be modified in the [customize section](/getting-started/customizing-devices/). The following device classes are supported for media players:
+
+- **tv**: Device is a television type device.
+- **speaker**: Device is speaker or stereo type device.


### PR DESCRIPTION
**Description:**
Add Device Class info for customization

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
