### PR TITLE
Rename frontmatter ha_qa_scale to ha_quality_scale to match codebase

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -22,16 +22,16 @@
     </div>
   {%- endif -%}
 
-  {%- if page.ha_qa_scale -%}
+  {%- if page.ha_quality_scale -%}
     <div class='section'>
       Quality Scale: <a href='/docs/quality_scale/'>
-        {%- if page.ha_qa_scale == 'platinum' -%}
+        {%- if page.ha_quality_scale == 'platinum' -%}
           🏆 (platinum)
-        {%- elsif page.ha_qa_scale == 'gold' -%}
+        {%- elsif page.ha_quality_scale == 'gold' -%}
           🥇 (gold)
-        {%- elsif page.ha_qa_scale == 'silver' -%}
+        {%- elsif page.ha_quality_scale == 'silver' -%}
           🥈 (silver)
-        {%- elsif page.ha_qa_scale == 'internal' -%}
+        {%- elsif page.ha_quality_scale == 'internal' -%}
           🏠 (internal)
         {%- endif -%}
       </a>

--- a/source/_integrations/alarm_control_panel.markdown
+++ b/source/_integrations/alarm_control_panel.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to integrate Alarm Control Panels into Home Ass
 logo: home-assistant.png
 ha_category:
   - Alarm
-ha_qa_scale: internal
 ha_release: 0.7.3
+ha_quality_scale: internal
 ---
 
 Home Assistant can give you an interface with is similar to a classic alarm system.

--- a/source/_integrations/alert.markdown
+++ b/source/_integrations/alert.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Automation
 ha_release: 0.38
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `alert` integration is designed to notify you when problematic issues arise.

--- a/source/_integrations/api.markdown
+++ b/source/_integrations/api.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup the RESTful API within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Other
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 The `api` integration exposes a RESTful API and allows one to interact with a Home Assistant instance that is running headless. This integration depends on the [`http` integration](/integrations/http/).

--- a/source/_integrations/auth.markdown
+++ b/source/_integrations/auth.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Other
 ha_release: 0.73
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 This integration creates the endpoints for the [authentication system](/docs/authentication/) that is built into Home Assistant.

--- a/source/_integrations/automation.markdown
+++ b/source/_integrations/automation.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup automation within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Automation
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 Please see the [docs section](/docs/automation/) for in-depth

--- a/source/_integrations/bayesian.markdown
+++ b/source/_integrations/bayesian.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Utility
 ha_iot_class: Local Polling
 ha_release: 0.53
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `bayesian` binary sensor platform observes the state from multiple sensors and uses [Bayes' rule](https://en.wikipedia.org/wiki/Bayes%27_theorem) to estimate the probability that an event has occurred given the state of the observed sensors. If the estimated posterior probability is above the `probability_threshold`, the sensor is `on` otherwise it is `off`.

--- a/source/_integrations/binary_sensor.markdown
+++ b/source/_integrations/binary_sensor.markdown
@@ -4,8 +4,8 @@ description: Instructions on how-to setup binary sensors with Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Binary Sensor
-ha_qa_scale: internal
 ha_release: 0.9
+ha_quality_scale: internal
 ---
 
 Binary sensors gather information about the state of devices which have a "digital" return value (either 1 or 0). These can be switches, contacts, pins, etc. These sensors only have two states: **0/off/low/closed/false** and **1/on/high/open/true**. Knowing that there are only two states allows Home Assistant to represent these sensors in a better way in the frontend according to their functionality.

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.12
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `template` platform supports binary sensors which get their values from

--- a/source/_integrations/browser.markdown
+++ b/source/_integrations/browser.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup the browser integration with Home Assi
 logo: home-assistant.png
 ha_category:
   - Utility
-ha_qa_scale: internal
 ha_release: pre 0.7
+ha_quality_scale: internal
 ---
 
 The `browser` integration provides a service to open URLs in the default browser on the host machine.

--- a/source/_integrations/camera.markdown
+++ b/source/_integrations/camera.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to integrate cameras within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Camera
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 The camera integration allows you to use IP cameras with Home Assistant.

--- a/source/_integrations/climate.markdown
+++ b/source/_integrations/climate.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup climate control devices within Home As
 logo: home-assistant.png
 ha_category:
   - Climate
-ha_qa_scale: internal
 ha_release: 0.19
+ha_quality_scale: internal
 ---
 
 The Climate integration allows you to control and monitor HVAC (heating, ventilating, and air conditioning) devices and thermostats.

--- a/source/_integrations/config.markdown
+++ b/source/_integrations/config.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Front End
 ha_release: 0.39
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `config` integration is designed to display panels in the frontend to configure and manage parts of Home Assistant.

--- a/source/_integrations/configurator.markdown
+++ b/source/_integrations/configurator.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to integrate the configurator in your component
 logo: home-assistant.png
 ha_category:
   - Other
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 <div class='note'>

--- a/source/_integrations/conversation.markdown
+++ b/source/_integrations/conversation.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to have conversations with your Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Voice
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 The conversation integration allows you to converse with Home Assistant. You can either converse by pressing the microphone in the frontend (supported browsers only (no iOS)) or by calling the `conversation/process` service with the transcribed text.

--- a/source/_integrations/counter.markdown
+++ b/source/_integrations/counter.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Automation
 ha_release: 0.53
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `counter` integration allows one to count occurrences fired by automations.

--- a/source/_integrations/cover.group.markdown
+++ b/source/_integrations/cover.group.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.66
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `group` platform can create a cover that combines several cover entities into one.

--- a/source/_integrations/cover.markdown
+++ b/source/_integrations/cover.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to integrate covers into Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Cover
-ha_qa_scale: internal
 ha_release: 0.27
+ha_quality_scale: internal
 ---
 
 Home Assistant can give you an interface to control covers such as rollershutters, blinds, and garage doors.

--- a/source/_integrations/cover.template.markdown
+++ b/source/_integrations/cover.template.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.48
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `template` platform can create covers that combine integrations and provides

--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -8,8 +8,8 @@ ha_category:
   - Switch
 ha_release: 0.59
 ha_iot_class: Local Polling
-ha_qa_scale: platinum
 ha_config_flow: true
+ha_quality_scale: platinum
 ---
 
 The `daikin` integration integrates Daikin air conditioning systems into Home Assistant.

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -12,8 +12,8 @@ ha_category:
   - Switch
 ha_release: 0.61
 ha_iot_class: Local Push
-ha_qa_scale: platinum
 ha_config_flow: true
+ha_quality_scale: platinum
 ---
 
 [deCONZ](https://www.dresden-elektronik.de/funk/software/deconz.html) by [dresden elektronik](https://www.dresden-elektronik.de) is a software that communicates with ConBee/RaspBee Zigbee gateways and exposes Zigbee devices that are connected to the gateway.

--- a/source/_integrations/demo.markdown
+++ b/source/_integrations/demo.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to use the Platform demos with Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Other
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 The `demo` platform allows you to use integrations which are providing a demo of their implementation. The demo entities are dummies but show you how the actual platform looks like. This way you can run own demonstration instance like the online [Home Assistant demo](/demo/) or `hass --demo-mode` but combined with your own real/functional platforms.

--- a/source/_integrations/device_automation.markdown
+++ b/source/_integrations/device_automation.markdown
@@ -3,8 +3,8 @@ title: Device Automation
 logo: home-assistant.png
 ha_category:
   - Automation
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 Device Automations is a plugin for the automation integration to allow other integrations to provide device specific triggers, conditions and actions.

--- a/source/_integrations/device_sun_light_trigger.markdown
+++ b/source/_integrations/device_sun_light_trigger.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to automate your lights with Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Automation
-ha_qa_scale: internal
 ha_release: pre 0.7
+ha_quality_scale: internal
 ---
 
 Home Assistant has a built-in integration called `device_sun_light_trigger` to help you automate your lights. The integration will:

--- a/source/_integrations/device_tracker.markdown
+++ b/source/_integrations/device_tracker.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup device tracking within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Presence Detection
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 The device tracker allows you to track devices in Home Assistant. This can happen by querying your wireless router or by having applications push location info.

--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup Home Assistant to discover new devices
 logo: home-assistant.png
 ha_category:
   - Other
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 Home Assistant can discover and automatically configure [zeroconf](https://en.wikipedia.org/wiki/Zero-configuration_networking)/[mDNS](https://en.wikipedia.org/wiki/Multicast_DNS) and [uPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play) devices on your network. Currently the `discovery` integration can detect:

--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Downloading
 ha_release: pre 0.7
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `downloader` integration provides a service to download files. It will raise an error and not continue to set itself up when the download directory does not exist. The directory needs to be writable for the user that is running Home Assistant.

--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Hub
 ha_release: 0.27
 ha_iot_class: Local Push
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 <div class='note warning'>

--- a/source/_integrations/fan.markdown
+++ b/source/_integrations/fan.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup Fan devices within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Fan
-ha_qa_scale: internal
 ha_release: 0.27
+ha_quality_scale: internal
 ---
 
 The `fan` integration is built for the controlling of fan devices.

--- a/source/_integrations/fan.template.markdown
+++ b/source/_integrations/fan.template.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.69
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `template` platform creates fans that combine integrations and provides the

--- a/source/_integrations/filter.markdown
+++ b/source/_integrations/filter.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.65
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `filter` platform enables sensors that process the states of other entities.

--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -5,7 +5,7 @@ ha_category:
   - Automation
 ha_release: 0.21
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `flux` switch platform will change the temperature of your lights similar to the way flux works on your computer, using circadian rhythm. They will be bright during the day, and gradually fade to a red/orange at night. The `flux` switch restores its last state after startup.

--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -6,7 +6,7 @@ ha_category:
   - System Monitor
 ha_iot_class: Local Polling
 ha_release: 0.67
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 This integration adds [Watchdog](https://pythonhosted.org/watchdog/) file system monitoring, publishing events on the Home Assistant bus on the creation/deletion/modification of files within configured folders. The monitored `event_type` are:

--- a/source/_integrations/frontend.markdown
+++ b/source/_integrations/frontend.markdown
@@ -4,8 +4,8 @@ description: Offers a frontend to Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Other
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 This offers the official frontend to control Home Assistant. This integration is by default enabled, unless you've disabled or removed the [`default_config:`](https://www.home-assistant.io/integrations/default_config/) line from your configuration. If that is the case, the following example shows you how to enable this integration manually:

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup groups within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Organization
-ha_qa_scale: internal
 ha_release: pre 0.7
+ha_quality_scale: internal
 ---
 
 Groups allow the user to combine multiple entities into one. 

--- a/source/_integrations/history.markdown
+++ b/source/_integrations/history.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - History
 ha_release: pre 0.7
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `history` integration will track everything that is going on within Home

--- a/source/_integrations/history_graph.markdown
+++ b/source/_integrations/history_graph.markdown
@@ -5,7 +5,7 @@ ha_category:
   - History
 logo: home-assistant.png
 ha_release: 0.55
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 <p class='img'>

--- a/source/_integrations/history_stats.markdown
+++ b/source/_integrations/history_stats.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Utility
 ha_iot_class: Local Polling
 ha_release: 0.39
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `history_stats` sensor platform provides quick statistics about another integration or platforms, using data from the [history](/integrations/history/).

--- a/source/_integrations/homeassistant.markdown
+++ b/source/_integrations/homeassistant.markdown
@@ -3,7 +3,7 @@ title: Home Assistant Core Integration
 description: Description of the homeassistant integration.
 logo: home-assistant.png
 ha_release: 0.0
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The Home Assistant integration provides generic implementations like the generic `homeassistant.turn_on`.

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -8,7 +8,7 @@ ha_category:
   - Sensor
 ha_release: pre 0.7
 ha_iot_class: Local Push
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `http` integration serves all files and data required for the Home Assistant frontend. You only need to add this to your configuration file if you want to change any of the default settings.

--- a/source/_integrations/hue.markdown
+++ b/source/_integrations/hue.markdown
@@ -6,10 +6,10 @@ ha_category:
   - Hub
   - Light
 ha_iot_class: Local Polling
-ha_qa_scale: platinum
 featured: true
 ha_release: '0.60'
 ha_config_flow: true
+ha_quality_scale: platinum
 ---
 
 Philips Hue support is integrated into Home Assistant as a hub that can drive the light and sensor platforms. The preferred way to set up the Philips Hue platform is by enabling the [discovery component](/integrations/discovery/).

--- a/source/_integrations/input_boolean.markdown
+++ b/source/_integrations/input_boolean.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to integrate the Input Boolean integration into
 logo: home-assistant.png
 ha_category:
   - Automation
-ha_qa_scale: internal
 ha_release: 0.11
+ha_quality_scale: internal
 ---
 
 The `input_boolean` integration allows the user to define boolean values that can be controlled via the frontend and can be used within conditions of automation. This can for example be used to disable or enable certain automations.

--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Automation
 ha_release: 0.55
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `input_datetime` integration allows the user to define date and time values

--- a/source/_integrations/input_number.markdown
+++ b/source/_integrations/input_number.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Automation
 ha_release: 0.55
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `input_number` integration allows the user to define values that can be controlled via the frontend and can be used within conditions of automation. The frontend can display a slider, or a numeric input box. Changes to the slider or numeric input box generate state events. These state events can be utilized as `automation` triggers as well.

--- a/source/_integrations/input_select.markdown
+++ b/source/_integrations/input_select.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Automation
 ha_release: 0.13
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `input_select` integration allows the user to define a list of values that can be selected via the frontend and can be used within conditions of automation. When a user selects a new item, a state transition event is generated. This state event can be used in an `automation` trigger.

--- a/source/_integrations/input_text.markdown
+++ b/source/_integrations/input_text.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Automation
 ha_release: 0.53
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `input_text` integration allows the user to define values that can be controlled via the frontend and can be used within conditions of automation. Changes to the value stored in the text box generate state events. These state events can be utilized as `automation` triggers as well. It can also be configured in password mode (obscured text).

--- a/source/_integrations/integration.markdown
+++ b/source/_integrations/integration.markdown
@@ -7,7 +7,7 @@ ha_category:
 ha_release: 0.87
 ha_iot_class: Local Push
 logo: integral.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `integration` platform provides the [Riemann sum](https://en.wikipedia.org/wiki/Riemann_sum) of the values provided by a source sensor. The Riemann sum is an approximation of an **integral** by a finite sum. The integration sensors is updated upon changes of the **source**. Fast sampling source sensors provide better results. In this implementation, the default is the Trapezoidal method, but Left and Right methods can optionally be used.

--- a/source/_integrations/intent_script.markdown
+++ b/source/_integrations/intent_script.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Intent
 ha_release: '0.50'
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `intent_script` integration allows users to configure actions and responses to intents. Intents can be fired by any integration that supports it. Examples are [Alexa](/integrations/alexa/) (Amazon Echo), [Dialogflow](/integrations/dialogflow/) (Google Assistant) and [Snips](/integrations/snips/).

--- a/source/_integrations/light.group.markdown
+++ b/source/_integrations/light.group.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.65
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The group light platform lets you combine multiple lights into one entity. All child lights of a light group can still be used as usual, but controlling the state of the grouped light will forward the command to each child light.

--- a/source/_integrations/light.markdown
+++ b/source/_integrations/light.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup your lights with Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Light
-ha_qa_scale: internal
 ha_release: pre 0.7
+ha_quality_scale: internal
 ---
 
 This integration allows you to track and control various light bulbs. Read the integration documentation for your particular light hardware to learn how to enable it.

--- a/source/_integrations/light.switch.markdown
+++ b/source/_integrations/light.switch.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.83
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The light switch platform lets you control an existing switch, allowing you

--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.46
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `template` platform creates lights that combine integrations and provides the

--- a/source/_integrations/lock.markdown
+++ b/source/_integrations/lock.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup your locks with Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Lock
-ha_qa_scale: internal
 ha_release: 0.9
+ha_quality_scale: internal
 ---
 
 Keeps track which locks are in your environment, their state and allows you to control them.

--- a/source/_integrations/lock.template.markdown
+++ b/source/_integrations/lock.template.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.81
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `template` platform creates locks that combines components.

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to enable the logger integration for Home Assis
 logo: home-assistant.png
 ha_category:
   - Utility
-ha_qa_scale: internal
 ha_release: 0.8
+ha_quality_scale: internal
 ---
 
 The `logger` integration lets you define the level of logging activities in Home

--- a/source/_integrations/luftdaten.markdown
+++ b/source/_integrations/luftdaten.markdown
@@ -7,8 +7,8 @@ ha_category:
   - Sensor
 ha_release: 0.82
 ha_iot_class: Cloud Polling
-ha_qa_scale: gold
 ha_config_flow: true
+ha_quality_scale: gold
 ---
 
 The `luftdaten` integration will query the open data API of [luftdaten.info](https://luftdaten.info/) to monitor air quality and other weather data from a specific (self build) sensor station.

--- a/source/_integrations/manual.markdown
+++ b/source/_integrations/manual.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Alarm
 ha_release: 0.7.6
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `manual` alarm control panel platform enables you to set manual alarms in Home Assistant.

--- a/source/_integrations/map.markdown
+++ b/source/_integrations/map.markdown
@@ -4,8 +4,8 @@ description: Offers a map to show tracked devices.
 logo: home-assistant.png
 ha_category:
   - Other
-ha_qa_scale: internal
 ha_release: 0.56
+ha_quality_scale: internal
 ---
 
 This offers a map on the frontend to display the location of tracked devices. To set up tracked devices, look at the [device tracker](/integrations/device_tracker/) documentation. This integration is by default enabled, unless you've disabled or removed the [`default_config:`](https://www.home-assistant.io/integrations/default_config/) line from your configuration. If that is the case, the following example shows you how to enable this integration manually:

--- a/source/_integrations/media_extractor.markdown
+++ b/source/_integrations/media_extractor.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Media Player
 ha_release: 0.49
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `media_extractor` integration gets a stream URL and sends it to a media player entity. This integration can extract entity specific streams if configured accordingly.

--- a/source/_integrations/media_player.markdown
+++ b/source/_integrations/media_player.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup your media players with Home Assistant
 logo: home-assistant.png
 ha_category:
   - Media Player
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 Interacts with media players on your network.

--- a/source/_integrations/min_max.markdown
+++ b/source/_integrations/min_max.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Utility
 ha_iot_class: Local Polling
 ha_release: 0.31
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `min_max` sensor platform consumes the state from other sensors to determine the minimum, maximum, latest (last) and the mean of the collected states. The sensor will always show you the lowest/highest/latest value which was received from all monitored sensors. If you have spikes in your values, it's recommended to filter/equalize your values with a [statistics sensor](/integrations/statistics) first.

--- a/source/_integrations/mobile_app.markdown
+++ b/source/_integrations/mobile_app.markdown
@@ -5,8 +5,8 @@ logo: home-assistant.png
 ha_category:
   - Other
 ha_release: 0.89
-ha_qa_scale: internal
 ha_config_flow: true
+ha_quality_scale: internal
 ---
 
 The Mobile App integration allows Home Assistant mobile apps to easily integrate with Home Assistant.

--- a/source/_integrations/mold_indicator.markdown
+++ b/source/_integrations/mold_indicator.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Environment
 ha_release: '0.20'
 ha_iot_class: Local Polling
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The Mold Indicator sensor integration consumes information of two temperature sensors and a humidity sensor to give an indication for possible mold growth in your home. In case of bad ventilation and insulation, the indoor humidity may lead to condensation on cold surfaces as the windows or even walls. Condensation or a high relative humidity near those cold surfaces leads to a higher risk for mold growth. This sensor integration estimates the temperature at a pre-calibrated critical point in the room (the coldest surface) and calculates the relative humidity of the air at that point. If the sensor value rises above approximately 70 percent, mold growth might occur and the room should be ventilated. At 100%, the air humidity condensates at the critical point.

--- a/source/_integrations/moon.markdown
+++ b/source/_integrations/moon.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Environment
 ha_iot_class: Local Polling
 ha_release: 0.38
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `moon` integration tracks the phases of the moon.

--- a/source/_integrations/notify.group.markdown
+++ b/source/_integrations/notify.group.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Notifications
 ha_release: 0.26
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `group` notification platform allows you to combine multiple `notify` platforms into a single service.

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to add user notifications to Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Notifications
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 The `notify` integration makes it possible to send notifications to a wide variety of platforms. To use it you have to setup at least one notification target (notifier), check the [integrations list](/integrations/#notifications) for one that fits your use case.

--- a/source/_integrations/onboarding.markdown
+++ b/source/_integrations/onboarding.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Other
 ha_release: 0.73
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 This integration creates the endpoints for the onboarding that is built into Home Assistant. There are no configuration options for this integration directly.

--- a/source/_integrations/otp.markdown
+++ b/source/_integrations/otp.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Utility
 ha_iot_class: Local Polling
 ha_release: 0.49
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `otp` sensor generates One-Time Passwords according to [RFC6238](https://tools.ietf.org/html/rfc6238) that is compatible with most OTP generators available, including Google Authenticator. You can use this when building custom security solutions and want to use "rolling codes", that change every 30 seconds.

--- a/source/_integrations/panel_custom.markdown
+++ b/source/_integrations/panel_custom.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Front End
 ha_release: 0.26
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `panel_custom` support allows you to add additional panels to your Home Assistant frontend. The panels are listed in the sidebar if wished and can be highly customized. See the developer documentation on [instructions how to build your own panels](https://developers.home-assistant.io/docs/en/frontend_creating_custom_panels.html).

--- a/source/_integrations/panel_iframe.markdown
+++ b/source/_integrations/panel_iframe.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Front End
 ha_release: 0.25
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `panel_iframe` support allows you to add additional panels to your Home Assistant frontend. The panels are listed in the sidebar and can contain external resources like the web frontend of your router, your monitoring system, or your media server.

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Other
 ha_release: 0.23
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `persistent_notification` integration can be used to show a notification on the frontend that has to be dismissed by the user.

--- a/source/_integrations/person.markdown
+++ b/source/_integrations/person.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to set up people tracking within Home Assistant
 logo: home-assistant.png
 ha_category:
   - Presence Detection
-ha_qa_scale: internal
 ha_release: 0.88
+ha_quality_scale: internal
 ---
 
 The person integration allows connecting [device tracker](/integrations/device_tracker/) entities to one or more person entities. The state updates of a connected device tracker will set the state of the person. When multiple device trackers are used, the state of person will be determined in this order:

--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -7,7 +7,7 @@ ha_category:
   - Binary Sensor
   - Presence Detection
 ha_release: 0.43
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 There is currently support for the following device types within Home Assistant:

--- a/source/_integrations/plant.markdown
+++ b/source/_integrations/plant.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Environment
 ha_release: 0.44
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 This`plant`component lets you merge moisture, conductivity, light intensity, temperature and battery level for a plant into a single UI element. It also supports setting minimum and maximum values for each measurement and will change its state to "problem" if it is not within those limits.

--- a/source/_integrations/point.markdown
+++ b/source/_integrations/point.markdown
@@ -10,7 +10,7 @@ ha_category:
 ha_release: 0.83
 ha_config_flow: true
 ha_iot_class: Cloud Polling
-ha_qa_scale: gold
+ha_quality_scale: gold
 ---
 
 The Point hub enables integration with the [Minut Point](https://minut.com/). To connect with Point, you will have to [sign up for a developer account](https://minut.com/community/developers/) and get a `client_id` and `client_secret` with the `callback url` configured as your Home Assistant `base_url` + `/api/minut`, e.g. `http://localhost:8123/api/minut`. The `client_id` and `client_secret` should be used as below.

--- a/source/_integrations/proximity.markdown
+++ b/source/_integrations/proximity.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Automation
 ha_release: 0.13
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `proximity` integration allows you to monitor the proximity of devices to a particular [zone](/integrations/zone/) and the direction of travel. The result is an entity created in Home Assistant which maintains the proximity data.

--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Automation
 ha_release: 0.47
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 This integration allows you to write Python scripts that are exposed as services in Home Assistant. Each Python file created in the `<config>/python_scripts/` folder will be exposed as a service. The content is not cached so you can easily develop: edit file, save changes, call service. The scripts are run in a sandboxed environment. The following variables are available in the sandbox:

--- a/source/_integrations/random.markdown
+++ b/source/_integrations/random.markdown
@@ -8,7 +8,7 @@ ha_category:
   - Binary Sensor
 ha_iot_class: Local Polling
 ha_release: 0.32
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `random` integration simply creates random values or state. This can be useful if you want to test automation rules or run an interactive demo. It generates a new state every time it is polled.

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - History
 ha_release: pre 0.7
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `recorder` integration is responsible for storing details in a database, which then are handled by the [`history` integration](/integrations/history/).

--- a/source/_integrations/rss_feed_template.markdown
+++ b/source/_integrations/rss_feed_template.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Front End
 ha_release: 0.44
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `rss_feed_template` integration can export any information from Home Assistant as a static RSS feed. This can be used to display that information on many types of devices using an RSS reader. While native apps for Home Assistant are not widely available, native RSS readers exist for almost any platform.

--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup scenes within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Organization
-ha_qa_scale: internal
 ha_release: 0.15
+ha_quality_scale: internal
 ---
 
 You can create scenes that capture the states you want certain entities to be. For example, a scene can specify that light A should be turned on and light B should be bright red.

--- a/source/_integrations/script.markdown
+++ b/source/_integrations/script.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup scripts within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Automation
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 The `script` integration allows users to specify a sequence of actions to be executed by Home Assistant. These are run when you turn the script on. The script integration will create an entity for each script and allow them to be controlled via services.

--- a/source/_integrations/season.markdown
+++ b/source/_integrations/season.markdown
@@ -6,7 +6,7 @@ ha_category:
 logo: home-assistant.png
 ha_iot_class: Local Polling
 ha_release: 0.53
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `season` sensor will display the current astronomical or meteorological season (Spring, Summer, Autumn, Winter) based on the user's setting in the configuration file.

--- a/source/_integrations/sensor.markdown
+++ b/source/_integrations/sensor.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup your sensors with Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Sensor
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 Sensors are gathering information about states and conditions.

--- a/source/_integrations/sensor.websocket_api.markdown
+++ b/source/_integrations/sensor.websocket_api.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Utility
 ha_release: 0.33
 ha_iot_class: Local Push
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `websocket_api` sensor platform shows how many clients are connected to the stream API.

--- a/source/_integrations/shell_command.markdown
+++ b/source/_integrations/shell_command.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to integrate Shell commands into Home Assistant
 ha_category:
   - Automation
 logo: home-assistant.png
-ha_qa_scale: internal
 ha_release: 0.7.6
+ha_quality_scale: internal
 ---
 
 This integration can expose regular shell commands as services. Services can be called from a [script] or in [automation].

--- a/source/_integrations/shopping_list.markdown
+++ b/source/_integrations/shopping_list.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Intent
 ha_release: '0.50'
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `shopping_list` integration allows you to keep track of shopping list items. Includes the ability to add items via your voice using the sentence "Add eggs to my shopping list".

--- a/source/_integrations/simulated.markdown
+++ b/source/_integrations/simulated.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Utility
 ha_iot_class: Local Polling
 ha_release: 0.65
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `simulated` sensor platform provides a simulated sensor that generates a time-varying signal `V(t)` given by the [function](https://en.wikipedia.org/wiki/Sine_wave):

--- a/source/_integrations/statistics.markdown
+++ b/source/_integrations/statistics.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Utility
 ha_iot_class: Local Polling
 ha_release: '0.30'
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `statistics` sensor platform consumes the state from other sensors. It exports the `mean` value as state and the following values as attributes: `count`, `mean`, `median`, `stdev`, `variance`, `total`, `min_value`, `max_value`, `min_age`, `max_age`, `change`, `average_change` and `change_rate`. If it's a binary sensor then only state changes are counted.

--- a/source/_integrations/stream.markdown
+++ b/source/_integrations/stream.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Other
 ha_release: '0.90'
 ha_iot_class: Local Push
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `stream` integration provides a way to proxy live streams through Home Assistant. The integration currently only supports proxying H.264 source streams to the HLS format and requires at least FFmpeg >= 3.2.

--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to track the sun within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Environment
-ha_qa_scale: internal
 ha_release: pre 0.7
+ha_quality_scale: internal
 ---
 
 The sun integration will use your current location to track if the sun is above or

--- a/source/_integrations/switch.markdown
+++ b/source/_integrations/switch.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to set up your switches with Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Switch
-ha_qa_scale: internal
 ha_release: 0.7
+ha_quality_scale: internal
 ---
 
 Keeps track which switches are in your environment, their state and allows you to control them.

--- a/source/_integrations/switch.template.markdown
+++ b/source/_integrations/switch.template.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.13
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `template` platform creates switches that combines components.

--- a/source/_integrations/system_health.markdown
+++ b/source/_integrations/system_health.markdown
@@ -4,8 +4,8 @@ description: System Health integration will report system info and allow to run 
 logo: home-assistant.png
 ha_category:
   - Other
-ha_qa_scale: internal
 ha_release: 0.87
+ha_quality_scale: internal
 ---
 
 The System Health integration provides an API to offer information on the system and its components. It also allows to run diagnostic tools to diagnose problems.

--- a/source/_integrations/system_log.markdown
+++ b/source/_integrations/system_log.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Other
 ha_release: 0.58
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `system_log` integration stores information about all logged errors and warnings in Home Assistant. All collected information is accessible directly in the frontend, just navigate to the `Info` section under `Developer Tools`. In order to not overload Home Assistant with log data, only the 50 last errors and warnings will be stored. Older entries are automatically discarded from the log. It is possible to change the number of stored log entries using the parameter `max_entries`.

--- a/source/_integrations/tellduslive.markdown
+++ b/source/_integrations/tellduslive.markdown
@@ -11,8 +11,8 @@ ha_category:
   - Switch
 ha_release: 0.11
 ha_config_flow: true
-ha_qa_scale: gold
 ha_iot_class: Cloud Polling
+ha_quality_scale: gold
 ---
 
 The `tellduslive` integration let you connect to [Telldus Live](https://live.telldus.com). It's cloud platform that connects to your Tellstick Net or Tellstick ZNet connected gear at home.

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.12
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `template` platform supports sensors which get their values from other entities.

--- a/source/_integrations/threshold.markdown
+++ b/source/_integrations/threshold.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Utility
 ha_iot_class: Local Polling
 ha_release: 0.34
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `threshold` binary sensor platform observes the state of another sensor. If the value is below (`lower`) or higher (`upper`) than the given threshold then state of the threshold sensor is changed. It support also a range if `lower` and `upper` are given.

--- a/source/_integrations/tibber.markdown
+++ b/source/_integrations/tibber.markdown
@@ -7,8 +7,8 @@ ha_category:
   - Sensor
   - Notifications
 ha_release: 0.8
-ha_qa_scale: silver
 ha_iot_class: Cloud Polling
+ha_quality_scale: silver
 ---
 
 The `tibber` integration provides a sensor with the current electricity price if you are a [Tibber](https://tibber.com/) customer.

--- a/source/_integrations/time_date.markdown
+++ b/source/_integrations/time_date.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Calendar
 ha_iot_class: Local Push
 ha_release: pre 0.7
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The time and date (`time_date`) sensor platform adds one or more sensors to your Home Assistant state machine.

--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Automation
 ha_release: 0.57
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `timer` integration aims to simplify automations based on (dynamic) durations.

--- a/source/_integrations/tod.markdown
+++ b/source/_integrations/tod.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.89
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `tod` platform supports binary sensors which get their values by checking if the current time is within defined time ranges.

--- a/source/_integrations/trend.markdown
+++ b/source/_integrations/trend.markdown
@@ -6,7 +6,7 @@ ha_category:
 logo: home-assistant.png
 ha_release: 0.28
 ha_iot_class: Local Push
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `trend` platform allows you to create sensors which show the trend of

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -8,8 +8,8 @@ ha_category:
   - Switch
 ha_release: 0.81
 ha_iot_class: Local Polling
-ha_qa_scale: platinum
 ha_config_flow: true
+ha_quality_scale: platinum
 ---
 
 [UniFi](https://unifi-sdn.ubnt.com/) by [Ubiquiti Networks, inc.](https://www.ubnt.com/) is a software that binds gateways, switches and wireless access points together with one graphical front end.

--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to create a universal media player in Home Assi
 logo: home-assistant.png
 ha_category:
   - Media Player
-ha_qa_scale: internal
 ha_release: 0.11
+ha_quality_scale: internal
 ---
 
 Universal Media Players combine multiple existing entities in Home Assistant into one media player entity. This is used for creating a single entity that controls an entire media center.

--- a/source/_integrations/updater.markdown
+++ b/source/_integrations/updater.markdown
@@ -4,8 +4,8 @@ description: Detecting when Home Assistant updates are available.
 logo: home-assistant.png
 ha_category:
   - Binary Sensor
-ha_qa_scale: internal
 ha_release: 0.8
+ha_quality_scale: internal
 ---
 
 The `updater` binary sensor will check daily for new releases. The state will be "on" when an update is available. Otherwise, the state will be "off". The newer version, as well as the link to the release notes, are attributes of the updater. As [Hass.io](/hassio/) has its own schedule for release it doesn't make sense to use this binary sensor on Hass.io.

--- a/source/_integrations/uptime.markdown
+++ b/source/_integrations/uptime.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_iot_class: Local Push
 logo: home-assistant.png
 ha_release: 0.56
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `uptime` sensor platform displays the time since the last Home Assistant restart.

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_release: 0.87
 ha_iot_class: Local Push
 logo: energy_meter.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `utility meter` integration provides functionality to track consumptions of various utilities (e.g., energy, gas, water, heating).

--- a/source/_integrations/vacuum.template.markdown
+++ b/source/_integrations/vacuum.template.markdown
@@ -5,7 +5,7 @@ ha_category: Vacuum
 ha_release: 0.96
 ha_iot_class: Local Push
 logo: home-assistant.png
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `template` platform creates vacuums that combine integrations and provides the

--- a/source/_integrations/version.markdown
+++ b/source/_integrations/version.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_iot_class: Local Push
 logo: home-assistant.png
 ha_release: 0.52
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `version` sensor platform that can display the current Home Assistant versions.

--- a/source/_integrations/weather.markdown
+++ b/source/_integrations/weather.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup your Weather platforms with Home Assis
 logo: home-assistant.png
 ha_category:
   - Weather
-ha_qa_scale: internal
 ha_release: 0.32
+ha_quality_scale: internal
 ---
 
 The `weather` platforms gather meteorological information from web services and display the conditions and other details about the weather at the given location. Read the integration documentation for your particular weather provider to learn how to set it up.

--- a/source/_integrations/weblink.markdown
+++ b/source/_integrations/weblink.markdown
@@ -5,7 +5,7 @@ logo: home-assistant.png
 ha_category:
   - Front End
 ha_release: 0.13
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `weblink` integration allows you to display links in the Home Assistant frontend.

--- a/source/_integrations/websocket_api.markdown
+++ b/source/_integrations/websocket_api.markdown
@@ -4,8 +4,8 @@ description: Instructions on how to setup the WebSocket API within Home Assistan
 logo: home-assistant.png
 ha_category:
   - Other
-ha_qa_scale: internal
 ha_release: 0.34
+ha_quality_scale: internal
 ---
 
 The `websocket_api` integration set up a WebSocket API and allows one to interact with a Home Assistant instance that is running headless. This integration depends on the [`http` component](/integrations/http/).

--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -8,8 +8,8 @@ ha_category:
   - Switch
 ha_release: 0.102
 ha_iot_class: Local Polling
-ha_qa_scale: platinum
 ha_config_flow: true
+ha_quality_scale: platinum
 ---
 
 [WLED](https://github.com/Aircoookie/WLED) is a fast and feature-rich

--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Utility
 ha_iot_class: Local Polling
 ha_release: 0.41
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `workday` binary sensor indicates, whether the current day is a workday or not. It allows specifying, which days of the week counts as workdays and also

--- a/source/_integrations/worldclock.markdown
+++ b/source/_integrations/worldclock.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Calendar
 ha_iot_class: Local Push
 ha_release: pre 0.7
-ha_qa_scale: internal
+ha_quality_scale: internal
 ---
 
 The `worldclock` sensor platform simply displays the current time in a different time zone.

--- a/source/_integrations/zeroconf.markdown
+++ b/source/_integrations/zeroconf.markdown
@@ -3,9 +3,9 @@ title: Zero-configuration networking (zeroconf)
 description: Exposes Home Assistant using the Zeroconf protocol.
 ha_category:
   - Network
-ha_qa_scale: internal
 ha_release: 0.18
 logo: home-assistant.png
+ha_quality_scale: internal
 ---
 
 The `zeroconf` integration will scan the network for supported devices and services. Discovered integrations will show up in the discovered section on the integrations page in the config panel. It will also make Home Assistant discoverable for other services in the network. Zeroconf is also sometimes known as Bonjour, Rendezvous, and Avahi.

--- a/source/_integrations/zone.markdown
+++ b/source/_integrations/zone.markdown
@@ -4,9 +4,9 @@ description: Instructions on how to set up zones within Home Assistant.
 logo: home-assistant.png
 ha_category:
   - Organization
-ha_qa_scale: internal
 ha_release: 0.69
 ha_config_flow: true
+ha_quality_scale: internal
 ---
 
 Zones allow you to specify certain regions on earth (for now). When a device tracker sees a device to be within a zone, the state will take the name from the zone. Zones can also be used as a [trigger](/getting-started/automation-trigger/#zone-trigger) or [condition](/getting-started/automation-condition/#zone-condition) inside automation setups.


### PR DESCRIPTION
**Description:**

This renames the `ha_qa_scale` frontmatter to `ha_quality_scale`.
This is more descriptive and also matches the recently added `quality_scale` added to the manifests in the Home Assistant codebase.

A PR to update the developer docs will follow.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
