### PR TITLE
Correct spelling of HDMI-CEC

### DIFF
--- a/source/_addons/cec_scan.markdown
+++ b/source/_addons/cec_scan.markdown
@@ -1,6 +1,6 @@
 ---
 title: "CEC Scanner"
-description: "Scan HDMI CEC devices."
+description: "Scan HDMI-CEC devices."
 ---
 
-Help you to discover the HDMI CEC address. Start the add-on and look into the log to see all connected device on HDMI.
+Help you to discover the HDMI-CEC address. Start the add-on and look into the log to see all connected device on HDMI.

--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -134,12 +134,12 @@ Restart Home Assistant, and you should now be able to use `play_url` as before.
 
 ### My Apple TV turns on when I restart Home Assistant
 
-The Apple TV will automatically turn on if a request is sent to it, e.g., if a button is pressed, something is streamed to it via AirPlay or if current state (currently playing) is accessed. This is how Apple has designed it, and it will cause problems if you are using HDMI CEC. Every time Home Assistant is started, a new request is sent to the device to figure out what is currently playing. When using CEC, this will wake up your TV and other devices you have configured.
+The Apple TV will automatically turn on if a request is sent to it, e.g., if a button is pressed, something is streamed to it via AirPlay or if current state (currently playing) is accessed. This is how Apple has designed it, and it will cause problems if you are using HDMI-CEC. Every time Home Assistant is started, a new request is sent to the device to figure out what is currently playing. When using CEC, this will wake up your TV and other devices you have configured.
 
 So, if your TV is randomly turning on, this is probably the reason. As stated, this is by design, and there is no real fix for it. There's also no known way to turn off the Apple TV via the protocol used for communication. You have the following options:
 
 - Do not use this platform
-- Disable HDMI CEC on your Apple TV
+- Disable HDMI-CEC on your Apple TV
 - Use "fake standby"
 
 The first two points are quite obvious. Fake standby is a concept implemented in this platform that disables all requests to the device and makes it appear as being "off" in the web interface. This will make sure that the device is not woken up, but it will of course not show any information or allow you to control it. It is however easy to turn it on (or off) in the web interface or to use an automation with `turn_on`. To make it more useful, you can write automations that turn it on or off depending on some other device, like the input source on your receiver.
@@ -156,9 +156,9 @@ Turning the device on/off in the user interface will *not* turn the physical dev
 
 To play media on an Apple TV with device authentication enabled (e.g., ATV4 with tvOS 10.2+), Home Assistant must be properly authenticated. This method starts the process and presents the credentials needed for playback as a persistent notification. Please see guide above for usage.
 
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`s of Apple TVs.
+| Service data attribute | Optional | Description                                                        |
+| ---------------------- | -------- | ------------------------------------------------------------------ |
+| `entity_id`            | yes      | String or list of strings that point at `entity_id`s of Apple TVs. |
 
 ### Service `apple_tv_scan`
 

--- a/source/_integrations/hdmi_cec.markdown
+++ b/source/_integrations/hdmi_cec.markdown
@@ -1,6 +1,6 @@
 ---
 title: HDMI-CEC
-description: Instructions on how to interact with HDMI CEC via Home Assistant.
+description: Instructions on how to interact with HDMI-CEC via Home Assistant.
 ha_category:
   - Automation
 logo: hdmi.png

--- a/source/_posts/2017-01-28-face-coffee-wink.markdown
+++ b/source/_posts/2017-01-28-face-coffee-wink.markdown
@@ -29,12 +29,12 @@ Although the old method is not insecure, the new method is a lot more secure. Up
 ### New customization options
 [@Andrey-git] has added some great new options to the customize functionality. It is now possible to specify customizations as a wildcard for entities or for a specific domain.
 
-### Major Wink and HDMI CEC improvements
+### Major Wink and HDMI-CEC improvements
 [@w1ll1am23] did an amazing job fixing a ton of bugs and issues with the Wink integration. Biggest improvement is that it now is able to automatically refresh the authentication tokens. This means that if you have your email address and password in your `configuration.yaml` file, no `client_id` and `client_secret` are needed, and token which was generated with the generator located in the [Wink][wink] documentation.
 
 The new Wink support will cause renaming of all the binary sensors and will also create new sensors for devices that weren't previously detected or supported in the older version.
 
-Thanks to [@konikvranik] the [HDMI CEC][cec] integration got a huge update with a lot of improvements. This update should make it easier to work with HDMI CEC and give you more control.
+Thanks to [@konikvranik] the [HDMI-CEC][cec] integration got a huge update with a lot of improvements. This update should make it easier to work with HDMI-CEC and give you more control.
 
 ### First Coffee Maker supported
 [@stu-gott] has added support for the first coffee maker in Home Assistant: [Mr. Coffee Smart Optimal Brew][coffee]. Happy brewing!
@@ -93,7 +93,7 @@ Thanks to [@konikvranik] the [HDMI CEC][cec] integration got a huge update with 
 - Light - Zwave: Use only supported features for devices ([@turbokongen])
 - Media player - Kodi: Support for volume stepping ([@armills])
 - Media player- roku: Use `is_screensaver`, update IDLE state, and use device name ([@robbiet480], [@xhostplus])
-- Switch - HDMI CEC: Support for devices and commands ([@konikvranik])
+- Switch - HDMI-CEC: Support for devices and commands ([@konikvranik])
 - Lock - Zwave: Improvements to Zwave lock platform ([@turbokongen])
 - TTS: Invalidate broken file cache entries ([@stu-gott])
 - Light - Hue: Improvements ([@robbiet480])

--- a/source/_posts/2017-02-03-hassbian-toybox.markdown
+++ b/source/_posts/2017-02-03-hassbian-toybox.markdown
@@ -16,7 +16,7 @@ Changes from previous image are big and small but lets start with the interestin
 A set of script written to add extra functionality to your Raspberry Pi installation. 
 This scripts are run as the `pi` user and installs a set of tools or packages.
 Currently includes:
- - Install Libcec. Adds local [HDMI CEC support][cec].
+ - Install Libcec. Adds local [HDMI-CEC support][cec].
  - Install Mossquitto. Installs the latest Mosquitto package and client tools from the Mosquitto projects official repository. Now includes websocket support.
  - Install OpenZWave. Installs OpenZWave and prepares for using a USB or GPIO ZWave controller.
  - Install Samba. Installs the Samba packages and shares your configuration over smb to be available to edit on any computer without the need for separate file transfer software. This share is unsecured and it's usage is not recommended if your installation is publicly available.

--- a/source/_posts/2017-02-25-config-panel-and-state-restoration.markdown
+++ b/source/_posts/2017-02-25-config-panel-and-state-restoration.markdown
@@ -160,7 +160,7 @@ And a final shout out to [Pascal][@pvizeli]. He keeps improving the performance 
 - Lock - Nuki: Reduce battery drain on Nuki Lock ([@pschmitt])
 - Notify - Webostv: Only try to pair notify.webostv when not paired ([@andersonshatch])
 - KNX: Fix slow status updates from the knx bus ([@keerts])
-- HDMI CEC: HDMI_CEC customization [Breaking change] ([@balloob], [@andrey-git])
+- HDMI-CEC: HDMI_CEC customization [Breaking change] ([@balloob], [@andrey-git])
 - Sensor - Moon: Remove unit of measurement ([@fabaff])
 - Z-Wave: Add initial Z-Wave config panel ([@balloob])
 - History: Allow printing the number of states returned by history and time it took to extract and add day ([@andrey-git])

--- a/source/_posts/2017-04-30-hassbian-1.21-its-about-time.markdown
+++ b/source/_posts/2017-04-30-hassbian-1.21-its-about-time.markdown
@@ -21,7 +21,7 @@ To allow you to customize your installation further, we have included a tool cal
 
   - Install Hue. Configures the Python executable to allow usage of low numbered ports for use with Emulated Hue component that's used with Amazon Echo, Google Home and Mycroft.ai.
  - Install Mosquitto MQTT server. Installs the latest Mosquitto package and client tools from the Mosquitto projects official repository. Now includes websocket support.
- - Install Libcec. Adds local [HDMI CEC support][cec].
+ - Install Libcec. Adds local [HDMI-CEC support][cec].
  - Install Open Z-Wave-pip. Installs Python Open Z-Wave from a pip package. This is the quickest and recommended way of installing Z-Wave support but does not OZWCP pre-installed.
  - Install Open Z-Wave. Installs Python Open Z-Wave and OZWCP from git.
  - Install Samba. Allows anyone on your network to edit your configuration from any computer. This share is unsecured and it's usage is not recommended if you share your network with others.


### PR DESCRIPTION
**Description:**

Corrects the spelling of HDMI-CEC across the docs.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
