### PR TITLE
Add docs in vaccum.xiaomi_miio.markdown with how to clean a specific room

### DIFF
--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -179,6 +179,35 @@ automation:
           - 26496
 ```
 
+### Service `vacuum.send_command`
+
+Send a platform-specific command to the vacuum cleaner.
+
+| Service data attribute    | Optional | Description                                               |
+|---------------------------|----------|-----------------------------------------------------------|
+| `entity_id`               |      yes | Only act on a specific robot                              |
+| `command`                 |       no | Command to execute, e.g. app_segment_clean, get_room_mapping.|
+| `params`                  |      yes | Parameters for the command.                               |
+
+Example script of `vacuum.send_command` to clean a specific room, use:
+
+```yaml
+vacuum_kitchen:
+  alias: "Clean the kitchen"
+  sequence:
+    - service: vacuum.send_command
+      data:
+        entity_id: vacuum.xiaomi_vacuum_cleaner
+        command: app_segment_clean
+        params: [18]
+```
+
+Where params specify room numbers. For multiple rooms params can be specified like [17,18]. Valid room numbers can be retrieved using miio command line tool. It will only give room numbers and not the room names. To get the room names one can just test the app_segment_clean command and see which room it cleans. 
+
+```bash
+miio protocol call <ip of the vacuum> get_room_mapping
+```
+
 ## Attributes
 
 In addition to [all of the attributes provided by the `vacuum` component](/integrations/vacuum/#attributes),

--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -318,7 +318,7 @@ The information output is:
 
 ## Example on how to clean a specific room
 
-Example script using [`vacuum.send_command`](https://www.home-assistant.io/integrations/vacuum/) to clean a specific room:
+Example script using [`vacuum.send_command`](/integrations/vacuum/) to clean a specific room:
 
 ```yaml
 vacuum_kitchen:
@@ -331,9 +331,9 @@ vacuum_kitchen:
         params: [18]
 ```
 
-Where params specify room numbers. For multiple rooms params can be specified like [17,18].
+Where params specify room numbers, for multiple rooms, params can be specified like `[17,18]`.
 
-Valid room numbers can be retrieved using miio command line tool. It will only give room numbers and not the room names. To get the room names one can just test the app_segment_clean command and see which room it cleans. 
+Valid room numbers can be retrieved using miio command-line tool. It will only give room numbers and not the room names. To get the room names, one can just test the app_segment_clean command and see which room it cleans. 
 
 ```bash
 miio protocol call <ip of the vacuum> get_room_mapping

--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -179,35 +179,6 @@ automation:
           - 26496
 ```
 
-### Service `vacuum.send_command`
-
-Send a platform-specific command to the vacuum cleaner.
-
-| Service data attribute    | Optional | Description                                               |
-|---------------------------|----------|-----------------------------------------------------------|
-| `entity_id`               |      yes | Only act on a specific robot                              |
-| `command`                 |       no | Command to execute, e.g. app_segment_clean, get_room_mapping.|
-| `params`                  |      yes | Parameters for the command.                               |
-
-Example script of `vacuum.send_command` to clean a specific room, use:
-
-```yaml
-vacuum_kitchen:
-  alias: "Clean the kitchen"
-  sequence:
-    - service: vacuum.send_command
-      data:
-        entity_id: vacuum.xiaomi_vacuum_cleaner
-        command: app_segment_clean
-        params: [18]
-```
-
-Where params specify room numbers. For multiple rooms params can be specified like [17,18]. Valid room numbers can be retrieved using miio command line tool. It will only give room numbers and not the room names. To get the room names one can just test the app_segment_clean command and see which room it cleans. 
-
-```bash
-miio protocol call <ip of the vacuum> get_room_mapping
-```
-
 ## Attributes
 
 In addition to [all of the attributes provided by the `vacuum` component](/integrations/vacuum/#attributes),
@@ -343,6 +314,30 @@ The information output is:
 - `Model ID`- The model id if it could be determined, this indicates what type of device it is.
 - `Address` - The IP that the device has on the network.
 - `Token` - The token of the device or `???` if it could not be automatically determined.
+
+
+## Example on how to clean a specific room
+
+Example script using [`vacuum.send_command`](https://www.home-assistant.io/integrations/vacuum/) to clean a specific room:
+
+```yaml
+vacuum_kitchen:
+  alias: "Clean the kitchen"
+  sequence:
+    - service: vacuum.send_command
+      data:
+        entity_id: vacuum.xiaomi_vacuum_cleaner
+        command: app_segment_clean
+        params: [18]
+```
+
+Where params specify room numbers. For multiple rooms params can be specified like [17,18].
+
+Valid room numbers can be retrieved using miio command line tool. It will only give room numbers and not the room names. To get the room names one can just test the app_segment_clean command and see which room it cleans. 
+
+```bash
+miio protocol call <ip of the vacuum> get_room_mapping
+```
 
 ## Retrieving Zoned Cleaning Coordinates
 


### PR DESCRIPTION
…w to clean a specific room

It specifies how the command send_command can be used for Xiaomi vacuums.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
