### PR TITLE
Added migration documentation to scripts

### DIFF
--- a/source/_docs/scripts/editor.markdown
+++ b/source/_docs/scripts/editor.markdown
@@ -20,3 +20,23 @@ script: !include scripts.yaml
 ```
 
 The content that was under `script:` should now be moved to `scripts.yaml` to be editable.
+
+## Migrating your scripts to `scripts.yaml`
+
+If you want to migrate your old scripts to use the editor, you'll have to copy them to `scripts.yaml`. Make sure that `scripts.yaml` is named entries! For each automation that you copy over, you'll have to add an key per script. This can be any string as long as it's unique.
+
+For example, the below script will turn on a scene.
+
+```yaml
+# Example scripts.yaml entry
+'my_unique_id':  # <-- Required for editor to work, for automations created with the editor the id will be automatically generated.
+  alias: Turn on a scene 'arrive_home'
+  sequence:
+    - service: scene.turn_on
+      data:
+        entity_id: scene.arrive_home
+```
+
+<div class='note'>
+Any comments in the YAML file will be lost and templates will be reformatted when you update an script via the editor.
+</div>


### PR DESCRIPTION
**Description:**

Added "Migrating your scripts to `scripts.yaml`"-section to the documentation.

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
