### PR TITLE
remove api_password option from http: config

### DIFF
--- a/source/_docs/ecosystem/certificates/tls_domain_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_domain_certificate.markdown
@@ -57,7 +57,6 @@ The [`http`](/integrations/http/) section must contain the full path to the need
 
 ```yaml
 http:
-  api_password: YOUR_SECRET_PASSWORD
   base_url: https://mydomain.com:8123
   ssl_certificate: /etc/letsencrypt/live/mydomain.com/fullchain.pem
   ssl_key: /etc/letsencrypt/live/mydomain.com/privkey.pem


### PR DESCRIPTION
remove api_password option from http: config because the option are deprecated since 0.90 release of HomeAssistant.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
