### PR TITLE
Add unit_of_measurement to climate.mqtt docs

### DIFF
--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -166,6 +166,10 @@ precision:
   required: false
   type: float
   default: 0.1 for Celsius and 1.0 for Fahrenheit.
+unit_of_measurement:
+  description: Defines the units of measurement of the sensor, if any.
+  required: false
+  type: string
 fan_mode_command_topic:
   description: The MQTT topic to publish commands to change the fan mode.
   required: false


### PR DESCRIPTION
**Description:**
For https://github.com/home-assistant/home-assistant/issues/30600


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30602

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
