### PR TITLE
Update input_datetime: reorder default values

### DIFF
--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -63,7 +63,7 @@ input_datetime:
         description: Set the initial value of this input, depending on `has_time` and `has_date`.
         required: false
         type: [datetime, time, date]
-        default: 1970-01-01 00:00 | 1970-01-01 | 00:00
+        default: 1970-01-01 00:00 | 00:00 | 1970-01-01
 {% endconfiguration %}
 
 ### Attributes


### PR DESCRIPTION
**Description:**
Default values in the same order as types

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
