### PR TITLE
Add TP06 model to dyson docs

### DIFF
--- a/source/_integrations/dyson.markdown
+++ b/source/_integrations/dyson.markdown
@@ -169,3 +169,4 @@ Note: currently only the 2018 dyson fans are supported(TP04 and DP04).
 - Pure Cool link (desk and tower)
 - Pure Hot+cool link (see climate part) for thermal control
 - Pure Cool 2018 Models (TP04 and DP04)
+- Pure Cool Cryptomic (TP06)


### PR DESCRIPTION
Add TP06 to list of supported models


**Pull request in home-assistant (if applicable):** https://github.com/home-assistant/home-assistant/pull/30611
## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
