### PR TITLE
Modified example for view.visible property to include visible list example

### DIFF
--- a/source/lovelace/views.markdown
+++ b/source/lovelace/views.markdown
@@ -81,6 +81,9 @@ View config:
       icon: mdi:bulb
     - entity: switch.decorative_lights
       image: /local/lights.png
+  visible:
+    - user: dxxxx0363xxxx504b99xxxxac4xxxx8f
+    - user: axxxx0578xxxxaw45f3xxxx2qsxxxx5e
 ```
 
 ## Paths


### PR DESCRIPTION
It looks like an original example for `visible` property is not complete: it does not actually include `visible` property by itself neither as a boolean nor as a list.
Now example really includes an example of a view `visible` property as a list.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
