### PR TITLE
Remove nonexistent default value of "initial" configuration variable for input_text.

### DIFF
--- a/source/_integrations/input_text.markdown
+++ b/source/_integrations/input_text.markdown
@@ -54,7 +54,6 @@ input_text:
         description: Initial value when Home Assistant starts.
         required: false
         type: string
-        default: empty
       icon:
         description: Icon to display in front of the input element in the frontend.
         required: false


### PR DESCRIPTION
**Description:**
`initial:` configuration parameter for `input_text` does not have a default value of an empty string. It looks like it never had, so removing it to not confuse the users.

**Pull request in home-assistant (if applicable):** Not directly: home-assistant/home-assistant#30663

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
