### PR TITLE
Update authentication.markdown to add user password reset on hassio command line

### DIFF
--- a/source/_docs/authentication.markdown
+++ b/source/_docs/authentication.markdown
@@ -86,6 +86,14 @@ While you should hopefully be storing your passwords in a password manager, if y
 
 When you start Home Assistant next, you'll be required to set up authentication again.
 
+### Lost user password
+
+1. login to the homeassistant docker or console
+2. hass --script auth -c /config change_password <user> <password>
+3. Restart HA
+
+You can use “hass --script auth -c /config list” command to list the users
+
 ### Error: invalid client id or redirect url
 
 <img src='/images/docs/authentication/error-invalid-client-id.png' alt='Screenshot of Error: invalid client id or redirect url'>


### PR DESCRIPTION
This will add procedure on how to reset a user password using the hassio commandline as seen here https://community.home-assistant.io/t/password-lost/66288/15?u=accelle

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
