### PR TITLE
Add assume_state option at xiaomi_tv platform

### DIFF
--- a/source/_integrations/xiaomi_tv.markdown
+++ b/source/_integrations/xiaomi_tv.markdown
@@ -36,6 +36,11 @@ name:
   required: false
   default: Xiaomi TV
   type: string
+assume_state:
+  description: Assume the state of tv or not.
+  required: false
+  default: true
+  type: boolean
 {% endconfiguration %}
 
 If you do not set a host in the configuration file, local TVs will automatically be discovered.
@@ -51,5 +56,6 @@ media_player:
 ```
 
 <div class='note info'>
-The platform will never turn your TV off. Instead, it will be put to sleep and woken up. This can be useful, because the selected source of the TV will remain the same. It will essentially turn your TV into a dumb TV.
+If the `assume_state` (default) is `true` the platform will never turn your TV off. Instead, it will be put to sleep and woken up. This can be useful because the selected source of the TV will remain the same. It will essentially turn your TV into a dumb TV.
+If the `assume_state` is `false` your TV will turn off and not able to turn on again using this module. You have to power the TV on using IR, Bluetooth remote control or HDMI-CEC.
 </div>


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30645

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
