### PR TITLE
Update docs to reflect change from platform level to config level entry for vizio component

### DIFF
--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Media Player
 ha_release: 0.49
 ha_iot_class: Local Polling
+ha_config_flow: true
 ha_codeowners:
   - '@raman325'
 ---

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -79,9 +79,8 @@ To add your Vizio TV to your installation, add the following to your `configurat
 
 ```yaml
 # Example configuration.yaml entry
-media_player:
-  - platform: vizio
-    host: IP_ADDRESS
+vizio:
+  - host: IP_ADDRESS
     access_token: AUTH_TOKEN
 ```
 


### PR DESCRIPTION
**Description:**
`vizio` has been moved to a top level config entry so that Config Flow support could be added. The docs have been updated to reflect that

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30653

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
