### PR TITLE
Updated the appdaemon repository. The current version is not valid.

### DIFF
--- a/source/_docs/ecosystem/appdaemon/running.markdown
+++ b/source/_docs/ecosystem/appdaemon/running.markdown
@@ -11,13 +11,13 @@ As configured, `AppDaemon` comes with a single HelloWorld App that will send a g
 Assuming you have set the config up as described above for Docker, you can run it with the command:
 
 ```bash
-$ docker run -d -v <Path to Config>/conf:/conf --name appdaemon appdaemon:latest
+$ docker run -d -v <Path to Config>/conf:/conf --name appdaemon acockburn/appdaemon:latest
 ```
 
 In the example above you would use:
 
 ```bash
-$ docker run -d -v /Users/foo/ha-config:/conf --name appdaemon appdaemon:latest
+$ docker run -d -v /Users/foo/ha-config:/conf --name appdaemon acockburn/appdaemon:latest
 ```
 
 Where you place the `conf` and `conf/apps` directory is up to you - it can be in downloaded repository, or anywhere else on the host, as long as you use the correct mapping in the `docker run` command.


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
