### PR TITLE
Add tunnel timeout to support websocket connections

### DIFF
--- a/source/_docs/ecosystem/haproxy.markdown
+++ b/source/_docs/ecosystem/haproxy.markdown
@@ -57,7 +57,8 @@ defaults
 	timeout connect 5000
 	timeout client  50000
 	timeout server  50000
-	timeout http-request 5s  #protection from Slowloris attacks
+	timeout tunnel  60000    # long enough for websocket pings every 55 seconds
+	timeout http-request 5s  # protection from Slowloris attacks
 
 frontend www-http
 	bind *:80
@@ -68,7 +69,7 @@ frontend www-https
 	bind *:443 ssl crt /etc/haproxy/certs/MYCERT.pem
 	acl hass-acl hdr(host) -i SUBDOMAIN.DOMAIN.COM
 	use_backend hass-backend if hass-acl
-	
+
 backend hass-backend
 	server hass <Home Assistant Server IP>:8123
 


### PR DESCRIPTION
HomeAssistant uses a 55 second interval to send heartbeats to the Lovelace UI over WebSockets. If the tunnel timeout is not set, the WebSocket connection from the browser to the server is reset every 50 seconds because of the defaults currently defined. When the connection resets, it reconnects automatically, and causes the page to reload. Any unsaved data in forms is lost.

This commit updates the documentation example for HAProxy, and adds a sane default of 60 seconds to the HAProxy configuration for tunneled connections, so that the frontend WebSocket connection doesn't time out every 50 seconds.

I have tested this setting in my configuration as it is seen in this commit.

55 second interval: https://github.com/home-assistant/home-assistant/blob/9c551ae85d68a8c82c706d6e2cf044cfd5533054/homeassistant/components/websocket_api/http.py#L111
tunnel timeout documentation: https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4-timeout%20tunnel

Related: home-assistant/home-assistant-js-websocket#108