### PR TITLE
Changed the temp and range options

### DIFF
--- a/source/_integrations/enocean.markdown
+++ b/source/_integrations/enocean.markdown
@@ -258,29 +258,29 @@ sensor:
 The temperature sensor supports these additional configuration properties.
 
 {% configuration %}
-temp_min:
+min_temp:
   description: The minimal temperature in °C your sensor supports.
   required: false
   type: integer
   default: 0
-temp_max:
+max_temp:
   description: The maximum temperature in °C your sensor supports.
   required: false
   type: integer
   default: 40
-range_min:
-  description: The range value your sensor reports for `temp_min`
+range_from:
+  description: The range value your sensor reports for `min_temp`
   required: false
   type: integer
   default: 255
-range_max:
-  description: The range value your sensor reports for `temp_max`
+range_to:
+  description: The range value your sensor reports for `max_temp`
   required: false
   type: integer
   default: 0
 {% endconfiguration %}
 
-Note that the default configuration values of _range_min_ and _range_max_ are not typos, the range is backwards for most sensors.
+Note that the default configuration values of _range_from_ and _range_to_ are not typos, the range is backwards for most sensors.
 However, some EEPs have a different, inverted range, which goes from 0 to 250. This includes the following EEPs:
 
 - **A5-04-01**
@@ -296,8 +296,8 @@ sensor:
     platform: enocean
     id: [0x01,0x90,0x84,0x3C]
     device_class: temperature
-    range_min: 0
-    range_max: 250
+    range_from: 0
+    range_to: 250
 ```
 
 ## Switch


### PR DESCRIPTION
changed the option description min_temp/max_temp/range_from/range_to to right one like in the source code.

**Description:**

Changed the documentation to the option parameters in source code.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
