### PR TITLE
Add Proxmox Permissions Information

### DIFF
--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -100,3 +100,43 @@ proxmoxve:
 The integration will automatically create a binary sensor for each tracked virtual machine or container. The binary sensor will either be on if the VM's state is running or off if the VM's state is different.
 
 The created sensor will be called `binary_sensor.NODE_NAME_VMNAME_running`.
+
+## Proxmox Permissions
+
+To be able to retrieve the status of VMs and containers, the user used to connect must minimally have the `VM.Audit` privilege. Below is a guide to how to configure a new user with the minimum required permissions.
+
+### Create Home Assistant Role
+
+Before creating the user, we need to create a permissions role for the user.
+
+* Click `Datacenter`
+* Open `Permissions` and click `Roles`
+* Click the `Create` button above all the existing roles
+* name the new role (e.g. "home-assistant")
+* Click the arrow next to privileges and select `VM.Audit` in the dropdown
+* Click `Create`
+
+### Create Home Assistant User
+
+Creating a dedicated user for home assistant limited to only the role just created is the most secure method. These instructions use the `pve` realm for the user. This allows a connection, but ensures that the user is not authenticated for SSH connections. If you use the `pve` realm, just be sure to add `realm: pve` to your config.
+
+* Click `Datacenter`
+* Open `Permissions` and click `Users`
+* Click `Add`
+* Enter a username (e.g. "hass")
+* Enter a secure password (it can be complex as you will only need to copy/paste it into your Home Assistant configuration)
+* Set the realm to "Proxmox VE authentication server"
+* Ensure `Enabled` is checked and `Expire` is set to "never"
+* Click `Add`
+
+### Add User Permissions to Assets
+
+To apply the user and role just created, we need to give it permissions
+
+* Click `Datacenter`
+* Click `Permissions`
+* Open `Add` and click `User Permission`
+* Select "\" for the path
+* Select your hass user ("hass")
+* Select the Home Assistant role ("home-assistant")
+* Make sure `Propigate` is checked


### PR DESCRIPTION
**Description:**
Add information to the proxmoxve integration on how to securely enable a connection from Proxmox.

Solves #11431 

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
