### PR TITLE
Clarify which name to put in devices

### DIFF
--- a/source/_integrations/automatic.markdown
+++ b/source/_integrations/automatic.markdown
@@ -54,7 +54,7 @@ devices:
 {% endconfiguration %}
 <div class='note'>
   
-The device name must be the name given by Automatic -ahem- *automatically*. This is typically the model year, make and model. This is *not* the nickname you have give the vehicle in the `vehicles` section of the app's settings.
+The device name must be the name given by Automatic automatically. This is typically the model year, make and model. This is *not* the nickname you have to give the vehicle in the `vehicles` section of the app's settings.
   
 </div>  
 

--- a/source/_integrations/automatic.markdown
+++ b/source/_integrations/automatic.markdown
@@ -52,6 +52,11 @@ devices:
   required: false
   type: list
 {% endconfiguration %}
+<div class='note'>
+  
+The device name must be the name given by Automatic -ahem- *automatically*. This is typically the model year, make and model. This is *not* the nickname you have give the vehicle in the `vehicles` section of the app's settings.
+  
+</div>  
 
 Home Assistant will also fire events when an update is received from Automatic. These can be used to trigger automations, as shown in the example below. A list of available event types can be found in the [Automatic Real-Time Events documentation](https://developer.automatic.com/api-reference/#real-time-events).
 

--- a/source/_integrations/automatic.markdown
+++ b/source/_integrations/automatic.markdown
@@ -52,6 +52,7 @@ devices:
   required: false
   type: list
 {% endconfiguration %}
+
 <div class='note'>
   
 The device name must be the name given by Automatic automatically. This is typically the model year, make and model. This is *not* the nickname you have to give the vehicle in the `vehicles` section of the app's settings.


### PR DESCRIPTION
When setting up Automatic, I found it confusing which name to put in the `devices` section, and put the nickname in, which broke the integration. Added a note to clarify for future users.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
