### PR TITLE
Add another TV to Samsung TV supported devices

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -75,6 +75,7 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - D6300SF
 - D6500
 - D6505
+- D6900 (WOL did not work)
 - D7000
 - D8000
 - EH5300
@@ -114,7 +115,7 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - UE6199UXZG (port must be set to 8001, On/Off, Forward/Backward, Volume control, but no Play button)
 - UE65KS8005 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
 - UE49KU6470 (port must be set to 8001, On/Off, Forward/Backward, Volume are OK, but no Play button)
-- UE46ES5500 (partially supported, turn on doesn't works)
+- UE46ES5500 (partially supported, turn on doesn't work)
 
 #### Models tested but not yet working
 


### PR DESCRIPTION
Added PS51D6900 TV to the supported Samsung TV list.

**Description:**

Not much more to say. Manual setup worked with my TV, but I couldn't get WOL to work.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
