### PR TITLE
On->on & Off->off

### DIFF
--- a/source/_integrations/binary_sensor.markdown
+++ b/source/_integrations/binary_sensor.markdown
@@ -15,33 +15,33 @@ Binary sensors gather information about the state of devices which have a "digit
 The way these sensors are displayed in the frontend can be modified in the [customize section](/getting-started/customizing-devices/). The following device classes are supported for binary sensors:
 
 - **None**: Generic on/off. This is the default and doesn't need to be set.
-- **battery**: `On` means low, `Off` means normal
-- **cold**: `On` means cold, `Off` means normal
-- **connectivity**: `On` means connected, `Off` means disconnected
-- **door**: `On` means open, `Off` means closed
-- **garage_door**: `On` means open, `Off` means closed
-- **gas**: `On` means gas detected, `Off` means no gas (clear)
-- **heat**: `On` means hot, `Off` means normal
-- **light**: `On` means light detected, `Off` means no light
-- **lock**: `On` means open (unlocked), `Off` means closed (locked)
-- **moisture**: `On` means moisture detected (wet), `Off` means no moisture (dry)
-- **motion**: `On` means motion detected, `Off` means no motion (clear)
-- **moving**: `On` means moving, `Off` means not moving (stopped)
-- **occupancy**: `On` means occupied, `Off` means not occupied (clear)
-- **opening**: `On` means open, `Off` means closed
-- **plug**: `On` means device is plugged in, `Off` means device is unplugged
-- **power**: `On` means power detected, `Off` means no power
-- **presence**: `On` means home, `Off` means away
-- **problem**: `On` means problem detected, `Off` means no problem (OK)
-- **safety**: `On` means unsafe, `Off` means safe
-- **smoke**: `On` means smoke detected, `Off` means no smoke (clear)
-- **sound**: `On` means sound detected, `Off` means no sound (clear)
-- **vibration**: `On` means vibration detected, `Off` means no vibration (clear)
-- **window**: `On` means open, `Off` means closed
+- **battery**: `on` means low, `off` means normal
+- **cold**: `on` means cold, `off` means normal
+- **connectivity**: `on` means connected, `off` means disconnected
+- **door**: `on` means open, `off` means closed
+- **garage_door**: `on` means open, `off` means closed
+- **gas**: `on` means gas detected, `off` means no gas (clear)
+- **heat**: `on` means hot, `off` means normal
+- **light**: `on` means light detected, `off` means no light
+- **lock**: `on` means open (unlocked), `off` means closed (locked)
+- **moisture**: `on` means moisture detected (wet), `off` means no moisture (dry)
+- **motion**: `on` means motion detected, `off` means no motion (clear)
+- **moving**: `on` means moving, `off` means not moving (stopped)
+- **occupancy**: `on` means occupied, `off` means not occupied (clear)
+- **opening**: `on` means open, `off` means closed
+- **plug**: `on` means device is plugged in, `off` means device is unplugged
+- **power**: `on` means power detected, `off` means no power
+- **presence**: `on` means home, `off` means away
+- **problem**: `on` means problem detected, `off` means no problem (OK)
+- **safety**: `on` means unsafe, `off` means safe
+- **smoke**: `on` means smoke detected, `off` means no smoke (clear)
+- **sound**: `on` means sound detected, `off` means no sound (clear)
+- **vibration**: `on` means vibration detected, `off` means no vibration (clear)
+- **window**: `on` means open, `off` means closed
 
 For analog sensors please check the [integration overview](/integrations/#sensor).
 
 <p class='img'>
 <img src='/images/screenshots/binary_sensor_classes_icons.png' />
-Example of various device classes icons in `On` and `Off` state.
+Example of various device classes icons in `on` and `off` state.
 </p>


### PR DESCRIPTION
just because they are not the same if used as state value.
stumbled upon it when discussing why this automation (https://community.home-assistant.io/t/integrating-rf-devices-with-sonoff-rf-bridge-on-tasmota-firmware/42484/112?u=ahmadk) doesn't work.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
