### PR TITLE
continue_on_timeout clarification

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -107,7 +107,6 @@ Wait until some things are complete. We support at the moment `wait_template` fo
 # Wait for sensor to trigger or 1 minute before continuing to execute.
 - wait_template: "{{ is_state('binary_sensor.entrance', 'on') }}"
   timeout: '00:01:00'
-  continue_on_timeout: 'true'
 ```
 {% endraw %}
 
@@ -133,7 +132,7 @@ It is also possible to use dummy variables, e.g., in scripts, when using `wait_t
 ```
 {% endraw %}
 
-You can also get the script to abort after the timeout by using `continue_on_timeout`
+You can also get the script to abort after the timeout by using optional `continue_on_timeout`
 
 {% raw %}
 ```yaml
@@ -143,6 +142,8 @@ You can also get the script to abort after the timeout by using `continue_on_tim
   continue_on_timeout: 'false'
 ```
 {% endraw %}
+
+Without `continue_on_timeout` the script will always continue.  
 
 ### Fire an Event
 


### PR DESCRIPTION
It was a bit unclear what happens if one omits continue_on_timeout (i.e what's its default value) so I decided to test it and fill the gap so others shouldn't do it again

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
