### PR TITLE
Fix SynologyDSM sensor unknown for 15 min

### DIFF
--- a/source/_integrations/synologydsm.markdown
+++ b/source/_integrations/synologydsm.markdown
@@ -130,9 +130,6 @@ monitored_conditions:
       description: Displays the maximum temperature of all disks in the volume (creates a new entry for each volume).
 {% endconfiguration %}
 
-<div class='note'>
-After booting Home Assistant it can take up to 15 minutes for the sensors to show up. This is due to the fact that sensors are created after Home Assistant has fully been initialized.
-</div>
 
 <div class='note warning'>
 This sensor will wake up your Synology NAS if it's in hibernation mode.


### PR DESCRIPTION
**Description:**

Removing the need to wait 15 min to get SynologyDSM sensors.

**Pull request in home-assistant :** home-assistant/home-assistant#30720

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html