### PR TITLE
Remove hidden property from xiaomi_miio.remote integration

### DIFF
--- a/source/_integrations/remote.xiaomi_miio.markdown
+++ b/source/_integrations/remote.xiaomi_miio.markdown
@@ -47,11 +47,6 @@ timeout:
   required: false
   type: integer
   default: 30
-hidden:
-  description: Hide the entity from UI. There is currently no reason to show the entity in UI as turning it off or on does nothing.
-  required: false
-  type: boolean
-  default: true
 commands:
   description: A list of commands
   required: false
@@ -74,7 +69,6 @@ remote:
     token: YOUR_TOKEN
     slot: 1
     timeout: 30
-    hidden: false
     commands:
       activate_towel_heater:
         command:


### PR DESCRIPTION
**Description:**

Removes the `hidden` property from the `xiaomi_miio` integration. This hidden property was relevant in the era before Lovelace.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30727

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
