### PR TITLE
Remove auto_hide from emby integration

### DIFF
--- a/source/_integrations/emby.markdown
+++ b/source/_integrations/emby.markdown
@@ -42,9 +42,4 @@ port:
   required: false
   default: 8096 (No SSL),  8920 (SSL)
   type: integer
-auto_hide:
-  description: Automatically hide devices that are unavailable from the Home Assistant Interface.
-  required: false
-  default: false
-  type: boolean
 {% endconfiguration %}


### PR DESCRIPTION
**Description:**

This removes the `auto_hide` configuration option from the Emby media player platform, as a result the `hidden` property is removed.

This is from a pre-Lovelace era. It now results in a player to be unavailable, which is expected behavior. Showing it or not, is not up to the integration/platform, but to the frontend/UI.


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30729

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
