### PR TITLE
Add Sleepiq services

### DIFF
--- a/source/_integrations/sleepiq.markdown
+++ b/source/_integrations/sleepiq.markdown
@@ -42,7 +42,17 @@ password:
 
 SleepIQ exposes a few services to control your Sleep Number bed via automations:
 
+### Service `sleepiq.set_sleep_number`
+
 This changes a bed's sleep number to the specified value. This value should be a multiple of 5 between 5 and 100. Other values will work, but they will be rounded to the nearest multiple of 5 by the Sleep Number API.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `sleep_number` | no | The new sleep number, as a multiple of 5 between 5 and 100.
+| `bed` | yes | The name of the bed. If unspecified, affects all beds. Case-insensitive.
+| `side` | yes | The side to change. If unspecified, both sides will change. Case-insensitive.
+
+**Example:**
 
 ```yaml
 - service: sleepiq.set_sleep_number
@@ -52,22 +62,16 @@ This changes a bed's sleep number to the specified value. This value should be a
     side: 'right'
 ```
 
-{% configuration %}
-  sleep_number:
-    required: true
-    description: The new sleep number, as a multiple of 5 between 5 and 100.
-    type: integer
-  bed:
-    required: false
-    description: The name of the bed. If unspecified, affects all beds. Case-insensitive.
-    type: string
-  side:
-    required: false
-    description: The side to change. If unspecified, both sides will change. Case-insensitive.
-    type: string
-{% endconfiguration %}
+### Service `sleepiq.set_to_favorite_sleep_number`
 
 This service changes a side's sleep number to its "favorite" preset.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `bed` | yes | The name of the bed. If unspecified, affects all beds. Case-insensitive.
+| `side` | yes | The side to change. If unspecified, both sides will change. Case-insensitive.
+
+**Example:**
 
 ```yaml
 - service: sleepiq.set_to_favorite_sleep_number
@@ -75,14 +79,3 @@ This service changes a side's sleep number to its "favorite" preset.
     bed: 'Master Bedroom'
     side: 'left'
 ```
-
-{% configuration %}
-  bed:
-    required: false
-    description: The name of the bed. If unspecified, affects all beds. Case-insensitive.
-    type: string
-  side:
-    required: false
-    description: The side to change. If unspecified, both sides will change. Case-insensitive.
-    type: string
-{% endconfiguration %}

--- a/source/_integrations/sleepiq.markdown
+++ b/source/_integrations/sleepiq.markdown
@@ -37,3 +37,52 @@ password:
   required: true
   type: string
 {% endconfiguration %}
+
+## Services
+
+SleepIQ exposes a few services to control your Sleep Number bed via automations:
+
+This changes a bed's sleep number to the specified value. This value should be a multiple of 5 between 5 and 100. Other values will work, but they will be rounded to the nearest multiple of 5 by the Sleep Number API.
+
+```yaml
+- service: sleepiq.set_sleep_number
+  data:
+    sleep_number: 45
+    bed: 'Master Bedroom'
+    side: 'right'
+```
+
+{% configuration %}
+  sleep_number:
+    required: true
+    description: The new sleep number, as a multiple of 5 between 5 and 100.
+    type: integer
+  bed:
+    required: false
+    description: The name of the bed. If unspecified, affects all beds. Case-insensitive.
+    type: string
+  side:
+    required: false
+    description: The side to change. If unspecified, both sides will change. Case-insensitive.
+    type: string
+{% endconfiguration %}
+
+This service changes a side's sleep number to its "favorite" preset.
+
+```yaml
+- service: sleepiq.set_to_favorite_sleep_number
+  data:
+    bed: 'Master Bedroom'
+    side: 'left'
+```
+
+{% configuration %}
+  bed:
+    required: false
+    description: The name of the bed. If unspecified, affects all beds. Case-insensitive.
+    type: string
+  side:
+    required: false
+    description: The side to change. If unspecified, both sides will change. Case-insensitive.
+    type: string
+{% endconfiguration %}


### PR DESCRIPTION
**Description:**

Added services "set_sleep_number" and "set_to_favorite_sleep_number" to the SleepIQ component. This allows for changing the sleep number of a Sleep Number bed via automations.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30722

## Checklist:

- [ x ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
