### PR TITLE
Add small note to alarmdotcom panel

### DIFF
--- a/source/_integrations/alarmdotcom.markdown
+++ b/source/_integrations/alarmdotcom.markdown
@@ -40,3 +40,7 @@ code:
   required: false
   type: integer
 {% endconfiguration %}
+
+<div class='note warning'>
+  Please make sure that your alarm.com language is set to English before open any issue.
+</div>


### PR DESCRIPTION
**Description:**

Alarm.com integration does not work in some conditions especially if the alarm.com language is set to another language instead of English.

## Checklist:

- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
