### PR TITLE
No longer loaded by default

### DIFF
--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -47,7 +47,7 @@ Zeroconf discoverable integrations [Axis](/integrations/axis/)/[ESPHome](/integr
 
 </div>
 
-`discovery` is included in the default configuration. To load this component manually, add the following lines to your `configuration.yaml` file:
+To load this integration, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
`discovery:` isn't included in the default configuration any more...

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
