### PR TITLE
Add useful logging example

### DIFF
--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -47,6 +47,12 @@ logger:
     # log level for MQTT integration
     homeassistant.components.mqtt: warning
     
+    # log level for all python scripts
+    homeassistant.components.python_script: warning
+    
+    # individual log level for this python script
+    homeassistant.components.python_script.my_new_script.py: debug
+    
     # log level for SmartThings lights
     homeassistant.components.smartthings.light: info
 


### PR DESCRIPTION
I never knew it's possible to set per-script log level for python scripts so I think it's worth at least to add such an example to this page

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
