### PR TITLE
Logger available namespaces

### DIFF
--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -88,7 +88,11 @@ where **namespace** is the *<component_namespace>* currently logging.
 {% endconfiguration %}
 
 In the example, do note the difference between 'glances_api' and 'homeassistant.components.glances' namespaces, 
-both of which are at root. They are logged by different APIs.
+both of which are at root. They are logged by different APIs. 
+
+If you want to know the namespaces in your own environment then check your log files on startup. 
+You will see INFO log messages from homeassistant.loader stating `loaded <component> from <namespace>`. 
+Those are the namespaces available for you to set a `log level` against. 
 
 ### Log Levels
 
@@ -146,3 +150,6 @@ the [SSH add-on](/addons/ssh/):
 ```bash
 $ tail -f /config/home-assistant.log
 ```
+
+Docker users can see the logs directly from the host command line with `docker logs my_container_id` - 
+check the options available with `--help`.

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -151,5 +151,11 @@ the [SSH add-on](/addons/ssh/):
 $ tail -f /config/home-assistant.log
 ```
 
-Docker users can see the logs directly from the host command line with `docker logs my_container_id` - 
-check the options available with `--help`.
+On Docker you can use your host command line directly - follow the logs dynamically with:
+
+```bash
+# follow the log dynamically
+docker logs --follow  MY_CONTAINER_ID
+```
+
+To see other options use `--help` instead, or simply leave with no options to display the entire log.


### PR DESCRIPTION
**Description:**

Explained how users can know against which namespaces they may declare a loglevel, and also mention docker command to view logs

**Pull request in home-assistant (if applicable):** none - doc only PR

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
