### PR TITLE
Replace all 'Else targets all.' occurrences.

### DIFF
--- a/source/_integrations/cover.markdown
+++ b/source/_integrations/cover.markdown
@@ -35,7 +35,7 @@ Available services: `cover.open_cover`, `cover.close_cover`, `cover.stop_cover`,
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 
 ### Service `cover.set_cover_position`
 
@@ -43,7 +43,7 @@ Set cover position of one or multiple covers.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `position` | no | Integer between 0 and 100.
 
 #### Automation example 
@@ -66,7 +66,7 @@ Set cover tilt position of one or multiple covers.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `tilt_position` | no | Integer between 0 and 100.
 
 #### Automation example 

--- a/source/_integrations/cover.markdown
+++ b/source/_integrations/cover.markdown
@@ -35,7 +35,7 @@ Available services: `cover.open_cover`, `cover.close_cover`, `cover.stop_cover`,
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all.
 
 ### Service `cover.set_cover_position`
 
@@ -43,7 +43,7 @@ Set cover position of one or multiple covers.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all.
 | `position` | no | Integer between 0 and 100.
 
 #### Automation example 
@@ -66,7 +66,7 @@ Set cover tilt position of one or multiple covers.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all.
 | `tilt_position` | no | Integer between 0 and 100.
 
 #### Automation example 

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -195,7 +195,7 @@ Resumes the currently active schedule.
 
 | Service data attribute | Optional | Description                                                                                            |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all. |
+| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all. |
 | `resume_all`           | no       | true or false                                                                                          |
 
 ### Service `ecobee.set_fan_min_on_time`
@@ -204,5 +204,5 @@ Sets the minimum amount of time that the fan will run per hour.
 
 | Service data attribute | Optional | Description                                                                                            |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all. |
+| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all. |
 | `fan_min_on_time`      | no       | integer (e.g. 5)                                                                                       |

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -195,7 +195,7 @@ Resumes the currently active schedule.
 
 | Service data attribute | Optional | Description                                                                                            |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all. |
+| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Use `entity_id: all` to target all. |
 | `resume_all`           | no       | true or false                                                                                          |
 
 ### Service `ecobee.set_fan_min_on_time`
@@ -204,5 +204,5 @@ Sets the minimum amount of time that the fan will run per hour.
 
 | Service data attribute | Optional | Description                                                                                            |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all. |
+| `entity_id`            | yes      | String or list of strings that point at `entity_id`'s of climate devices to control. Use `entity_id: all` to target all. |
 | `fan_min_on_time`      | no       | integer (e.g. 5)                                                                                       |

--- a/source/_integrations/foscam.markdown
+++ b/source/_integrations/foscam.markdown
@@ -64,7 +64,7 @@ If your Foscam camera supports PTZ, you will be able to pan or tilt your camera.
 
 | Service data attribute | Description |
 | -----------------------| ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all. |
+| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
 | `movement` | 	Direction of the movement. Allowed values: `up`, `down`, `left`, `right`, `top_left`, `top_right`, `bottom_left`, `bottom_right` |
 | `travel_time` | (Optional) Travel time in seconds. Allowed values: float from 0 to 1. Default: 0.125 |
 

--- a/source/_integrations/foscam.markdown
+++ b/source/_integrations/foscam.markdown
@@ -64,7 +64,7 @@ If your Foscam camera supports PTZ, you will be able to pan or tilt your camera.
 
 | Service data attribute | Description |
 | -----------------------| ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Else targets all. |
+| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all. |
 | `movement` | 	Direction of the movement. Allowed values: `up`, `down`, `left`, `right`, `top_left`, `top_right`, `bottom_left`, `bottom_right` |
 | `travel_time` | (Optional) Travel time in seconds. Allowed values: float from 0 to 1. Default: 0.125 |
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -27,7 +27,7 @@ Change the light to a new state.
 
 | Service data attribute | Description |
 | ---------------------- | ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of lights. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | String or list of strings that point at `entity_id`s of lights. Use `entity_id: all` to target all.
 | `transition` | Duration (in seconds) for the light to fade to the new state.
 | `zones` | List of integers for the zone numbers to affect (each LIFX Z strip has 8 zones, starting at 0).
 | `infrared` | Automatic infrared level (0..255) when light brightness is low (for compatible bulbs).
@@ -72,7 +72,7 @@ Run a flash effect by changing to a color and then back.
 
 | Service data attribute | Description |
 | ---------------------- | ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of lights. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | String or list of strings that point at `entity_id`s of lights. Use `entity_id: all` to target all.
 | `color_name` | A color name such as `red` or `green`.
 | `rgb_color` | A list containing three integers representing the RGB color you want the light to be.
 | `brightness` | Integer between 0 and 255 for how bright the color should be.
@@ -87,7 +87,7 @@ Run an effect with colors looping around the color wheel. All participating ligh
 
 | Service data attribute | Description |
 | ---------------------- | ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of lights. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | String or list of strings that point at `entity_id`s of lights. Use `entity_id: all` to target all.
 | `brightness` | Number between 0 and 255 indicating brightness of the effect. Leave this out to maintain the current brightness of each participating light.
 | `period` | Duration (in seconds) between starting a new color change.
 | `transition` | Duration (in seconds) where lights are actively changing color.
@@ -101,7 +101,7 @@ Run an effect that does nothing, thereby stopping any other effect that might be
 
 | Service data attribute | Description |
 | ---------------------- | ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of lights. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | String or list of strings that point at `entity_id`s of lights. Use `entity_id: all` to target all.
 
 
 ## Advanced configuration

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -27,7 +27,7 @@ Change the light to a new state.
 
 | Service data attribute | Description |
 | ---------------------- | ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of lights. Else targets all.
+| `entity_id` | String or list of strings that point at `entity_id`s of lights. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `transition` | Duration (in seconds) for the light to fade to the new state.
 | `zones` | List of integers for the zone numbers to affect (each LIFX Z strip has 8 zones, starting at 0).
 | `infrared` | Automatic infrared level (0..255) when light brightness is low (for compatible bulbs).
@@ -72,7 +72,7 @@ Run a flash effect by changing to a color and then back.
 
 | Service data attribute | Description |
 | ---------------------- | ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of lights. Else targets all.
+| `entity_id` | String or list of strings that point at `entity_id`s of lights. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `color_name` | A color name such as `red` or `green`.
 | `rgb_color` | A list containing three integers representing the RGB color you want the light to be.
 | `brightness` | Integer between 0 and 255 for how bright the color should be.
@@ -87,7 +87,7 @@ Run an effect with colors looping around the color wheel. All participating ligh
 
 | Service data attribute | Description |
 | ---------------------- | ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of lights. Else targets all.
+| `entity_id` | String or list of strings that point at `entity_id`s of lights. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `brightness` | Number between 0 and 255 indicating brightness of the effect. Leave this out to maintain the current brightness of each participating light.
 | `period` | Duration (in seconds) between starting a new color change.
 | `transition` | Duration (in seconds) where lights are actively changing color.
@@ -101,7 +101,7 @@ Run an effect that does nothing, thereby stopping any other effect that might be
 
 | Service data attribute | Description |
 | ---------------------- | ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of lights. Else targets all.
+| `entity_id` | String or list of strings that point at `entity_id`s of lights. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 
 
 ## Advanced configuration

--- a/source/_integrations/lock.markdown
+++ b/source/_integrations/lock.markdown
@@ -61,4 +61,4 @@ Go to the **Developer Tools**, then to **Call Service** in the frontend, and cho
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on specific lock. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id`            |      yes | Only act on specific lock. Use `entity_id: all` to target all.

--- a/source/_integrations/lock.markdown
+++ b/source/_integrations/lock.markdown
@@ -61,4 +61,4 @@ Go to the **Developer Tools**, then to **Call Service** in the frontend, and cho
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id`            |      yes | Only act on specific lock. Else targets all.
+| `entity_id`            |      yes | Only act on specific lock. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.

--- a/source/_integrations/nuheat.markdown
+++ b/source/_integrations/nuheat.markdown
@@ -144,7 +144,7 @@ Puts the thermostat into an indefinite hold at the given temperature.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `temperature` | no | Desired target temperature (when not in auto mode)
 
 Only the target temperatures relevant for the current operation mode need to
@@ -156,7 +156,7 @@ Sets the thermostat's preset mode. Without a preset mode set it run the thermost
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `hold_mode` | no | New value of hold mode.
 
 ### Service `nuheat.resume_program`
@@ -165,4 +165,4 @@ Resumes the currently active schedule.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.

--- a/source/_integrations/nuheat.markdown
+++ b/source/_integrations/nuheat.markdown
@@ -144,7 +144,7 @@ Puts the thermostat into an indefinite hold at the given temperature.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Use `entity_id: all` to target all.
 | `temperature` | no | Desired target temperature (when not in auto mode)
 
 Only the target temperatures relevant for the current operation mode need to
@@ -156,7 +156,7 @@ Sets the thermostat's preset mode. Without a preset mode set it run the thermost
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Use `entity_id: all` to target all.
 | `hold_mode` | no | New value of hold mode.
 
 ### Service `nuheat.resume_program`
@@ -165,4 +165,4 @@ Resumes the currently active schedule.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Use `entity_id: all` to target all.

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -65,7 +65,7 @@ If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your ca
 
 | Service data attribute | Description |
 | -----------------------| ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all.
 | `tilt` | Tilt direction. Allowed values: `UP`, `DOWN`, `NONE`
 | `pan` | Pan direction. Allowed values: `RIGHT`, `LEFT`, `NONE`
 | `zoom` | Zoom. Allowed values: `ZOOM_IN`, `ZOOM_OUT`, `NONE`

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -65,7 +65,7 @@ If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your ca
 
 | Service data attribute | Description |
 | -----------------------| ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Else targets all.
+| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `tilt` | Tilt direction. Allowed values: `UP`, `DOWN`, `NONE`
 | `pan` | Pan direction. Allowed values: `RIGHT`, `LEFT`, `NONE`
 | `zoom` | Zoom. Allowed values: `ZOOM_IN`, `ZOOM_OUT`, `NONE`

--- a/source/_integrations/vacuum.markdown
+++ b/source/_integrations/vacuum.markdown
@@ -30,7 +30,7 @@ Start a new cleaning task. For the Xiaomi Vacuum and Neato use `vacuum.start` in
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.turn_off`
 
@@ -38,7 +38,7 @@ Stop the current cleaning task and return to the dock. For the Xiaomi Vacuum and
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.start_pause`
 
@@ -46,7 +46,7 @@ Start, pause or resume a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.start`
 
@@ -54,7 +54,7 @@ Start or resume a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.pause`
 
@@ -62,7 +62,7 @@ Pause a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.stop`
 
@@ -70,7 +70,7 @@ Stop the current activity of the vacuum.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.return_to_base`
 
@@ -78,7 +78,7 @@ Tell the vacuum to return home.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.locate`
 
@@ -86,7 +86,7 @@ Locate the vacuum cleaner robot.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.clean_spot`
 
@@ -94,7 +94,7 @@ Tell the vacuum cleaner to do a spot clean-up.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.set_fan_speed`
 
@@ -102,7 +102,7 @@ Set the fan speed of the vacuum. The `fanspeed` can be a label, as `balanced` or
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 | `fan_speed`               |       no | Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium', or by percentage, between 0 and 100. |
 
 #### Service `vacuum.send_command`
@@ -111,6 +111,6 @@ Send a platform-specific command to the vacuum cleaner.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 | `command`                 |       no | Command to execute.                                   |
 | `params`                  |      yes | Parameters for the command.                           |

--- a/source/_integrations/vacuum.markdown
+++ b/source/_integrations/vacuum.markdown
@@ -30,7 +30,7 @@ Start a new cleaning task. For the Xiaomi Vacuum and Neato use `vacuum.start` in
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.turn_off`
 
@@ -38,7 +38,7 @@ Stop the current cleaning task and return to the dock. For the Xiaomi Vacuum and
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.start_pause`
 
@@ -46,7 +46,7 @@ Start, pause or resume a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.start`
 
@@ -54,7 +54,7 @@ Start or resume a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.pause`
 
@@ -62,7 +62,7 @@ Pause a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.stop`
 
@@ -70,7 +70,7 @@ Stop the current activity of the vacuum.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.return_to_base`
 
@@ -78,7 +78,7 @@ Tell the vacuum to return home.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.locate`
 
@@ -86,7 +86,7 @@ Locate the vacuum cleaner robot.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.clean_spot`
 
@@ -94,7 +94,7 @@ Tell the vacuum cleaner to do a spot clean-up.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.set_fan_speed`
 
@@ -102,7 +102,7 @@ Set the fan speed of the vacuum. The `fanspeed` can be a label, as `balanced` or
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 | `fan_speed`               |       no | Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium', or by percentage, between 0 and 100. |
 
 #### Service `vacuum.send_command`
@@ -111,6 +111,6 @@ Send a platform-specific command to the vacuum cleaner.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Else targets all.        |
+| `entity_id`               |      yes | Only act on specific vacuum. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.        |
 | `command`                 |       no | Command to execute.                                   |
 | `params`                  |      yes | Parameters for the command.                           |

--- a/source/_integrations/water_heater.markdown
+++ b/source/_integrations/water_heater.markdown
@@ -32,7 +32,7 @@ Sets target temperature of water heater device.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `temperature` | no | New target temperature for water heater
 | `operation_mode` | yes | Operation mode to set the temperature to. This defaults to current_operation mode if not set, or set incorrectly.
 
@@ -57,7 +57,7 @@ Set operation mode for water heater device
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `operation_mode` | no | New value of operation mode
 
 #### Automation example
@@ -80,7 +80,7 @@ Turn away mode on or off for water heater device
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Else targets all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
 | `away_mode` | no | New value of away mode. 'on'/'off' or True/False
 
 #### Automation example

--- a/source/_integrations/water_heater.markdown
+++ b/source/_integrations/water_heater.markdown
@@ -32,7 +32,7 @@ Sets target temperature of water heater device.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Use `entity_id: all` to target all.
 | `temperature` | no | New target temperature for water heater
 | `operation_mode` | yes | Operation mode to set the temperature to. This defaults to current_operation mode if not set, or set incorrectly.
 
@@ -57,7 +57,7 @@ Set operation mode for water heater device
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Use `entity_id: all` to target all.
 | `operation_mode` | no | New value of operation mode
 
 #### Automation example
@@ -80,7 +80,7 @@ Turn away mode on or off for water heater device
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Either `entity_id` or `area` must be specified. Use `entity_id: all` to target all.
+| `entity_id` | yes | String or list of strings that point at `entity_id`'s of water heater devices to control. Use `entity_id: all` to target all.
 | `away_mode` | no | New value of away mode. 'on'/'off' or True/False
 
 #### Automation example


### PR DESCRIPTION
**Description:**

Please read on, I have 2 questions for further changes related to this PR.

I simply did a 'replace all' in all files:
Replace "Else targets all." with "Either `entity_id` or `area` must be specified. Use `entity_id:all` to target all."

There are 2 previous PRs, where @frenck 's comments/actions are contradictory: 
In #11578 a change was accepted where entity_id was made non-optional for the light integration.
In #11602 which was a similar change to the light docs, @frenck commented that entity_id is optional, since area can also be specified.

**1. Is this the way we want to do this?** If so, I will also apply it to the light documentation.
**2. Shall I also add an `area` parameter** to every integration that has an `entity_id` parameter?


## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html

