### PR TITLE
Remove deprecated hide_entity for automations

### DIFF
--- a/source/_docs/automation/examples.markdown
+++ b/source/_docs/automation/examples.markdown
@@ -63,7 +63,6 @@ automation:
 
 # Send a notification via Pushover with the event of a Xiaomi cube. Custom event from the Xiaomi component.
   - alias: 'Xiaomi Cube Action'
-    hide_entity: false
     initial_state: false
     trigger:
       platform: event

--- a/source/_integrations/automation.markdown
+++ b/source/_integrations/automation.markdown
@@ -11,15 +11,11 @@ ha_codeowners:
 ---
 
 Please see the [docs section](/docs/automation/) for in-depth
-documentation on how to use the automation component.
+documentation on how to use the automation integration.
 
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/automation-switches.png' />
 </p>
-
-This allows one to reload the automation without restarting Home Assistant
-itself. If you don't want to see the automation rule in your frontend use
-`hide_entity: true` to hide it.
 
 You can also use `initial_state: 'false'` so that the automation
 is not automatically turned on after a Home Assistant reboot.
@@ -27,7 +23,6 @@ is not automatically turned on after a Home Assistant reboot.
 ```yaml
 automation:
   - alias: Door alarm
-    hide_entity: true
     initial_state: true
     trigger:
       - platform: state

--- a/source/_integrations/flic.markdown
+++ b/source/_integrations/flic.markdown
@@ -94,7 +94,6 @@ To help detect and debug flic button clicks, you can use this automation that se
 ```yaml
 automation:
   - alias: FLIC Html5 notify on every click
-    hide_entity: false
     trigger:
       platform: event
       event_type: flic_click

--- a/source/_integrations/rova.markdown
+++ b/source/_integrations/rova.markdown
@@ -79,12 +79,12 @@ sensor:
 To have your Home Assistant installation remind you of upcoming waste collections, combine the `rova` platform with some [Automations](/docs/automation/) and a [notification platform](/integrations/notify/).
 
 {% raw %}
+
 ```yaml
 # Example configuration.yaml entry for Rova waste collection reminder
 automation:
   - id: rova-garbage-bio-reminder
     alias: 'Send Rova Bio waste collection reminder'
-    hide_entity: true
     trigger:
       - platform: time
         at: '19:00:00'
@@ -98,6 +98,7 @@ automation:
         data:
           message: 'Reminder: put out biowaste bin'
 ```
+
 {% endraw %}
 
 <div class='note warning'>

--- a/source/_integrations/telegram_chatbot.markdown
+++ b/source/_integrations/telegram_chatbot.markdown
@@ -223,7 +223,6 @@ Simple ping pong example.
 
 ```yaml
 alias: 'Telegram bot that reply pong to ping'
-hide_entity: true
 trigger:
   platform: event
   event_type: telegram_command
@@ -301,7 +300,6 @@ Text repeater:
 {% raw %}
 ```yaml
 - alias: 'Telegram bot that repeats text'
-  hide_entity: true
   trigger:
     platform: event
     event_type: telegram_text
@@ -323,7 +321,6 @@ Message editor:
 {% raw %}
 ```yaml
 - alias: 'Telegram bot that edits the last sent message'
-  hide_entity: true
   trigger:
     platform: event
     event_type: telegram_callback
@@ -355,7 +352,6 @@ Keyboard editor:
 {% raw %}
 ```yaml
 - alias: 'Telegram bot that edits the keyboard'
-  hide_entity: true
   trigger:
     platform: event
     event_type: telegram_callback
@@ -380,7 +376,6 @@ Only acknowledges the 'NO' answer:
 {% raw %}
 ```yaml
 - alias: 'Telegram bot that simply acknowledges'
-  hide_entity: true
   trigger:
     platform: event
     event_type: telegram_callback
@@ -399,7 +394,6 @@ Telegram callbacks also support arguments and commands the same way as normal me
 {% raw %}
 ```yaml
 - alias: 'Telegram bot repeats arguments on callback query'
-  hide_entity: true
   trigger:
     platform: event
     event_type: telegram_callback

--- a/source/_posts/2016-09-29-async-sleepiq-emoncms-stocks.markdown
+++ b/source/_posts/2016-09-29-async-sleepiq-emoncms-stocks.markdown
@@ -28,7 +28,7 @@ As you might have noticed, this release has been delayed by 5 days. This was due
 
 ### Hide automation rules
 
-Since 0.28 [automation rules](/blog/2016/09/10/notify-group-reload-api-pihole/#reload-automation-rules) can be reloaded directly from the frontend. By default all automation rules are shown. If you want to [hide an automation rule](/getting-started/automation-create-first/), use `hide_entity: true`.
+Since 0.28 [automation rules](/blog/2016/09/10/notify-group-reload-api-pihole/#reload-automation-rules) can be reloaded directly from the frontend.
 
 ### All changes
 


### PR DESCRIPTION
**Description:**

The `hide_entity` configuration option on an automation is now deprecated and will be removed in Home Assistant 0.107. With Lovelace now being the standard, this option has become obsolete. Please ensure your automations are not using this option.

This PR already removes it from the documentation to prevent anyone from starting to using it.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30799

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
