### PR TITLE
Remove multiple login methods from mikrotik

### DIFF
--- a/source/_integrations/mikrotik.markdown
+++ b/source/_integrations/mikrotik.markdown
@@ -83,11 +83,9 @@ arp_ping:
 {% endconfiguration %}
 
 <div class='note info'>
-  
-  As of version 6.43 of RouterOS Mikrotik introduced a new login method (plain) in addition to the old login method (token). With Version 6.45.1 the old token login method got deprecated.
-  In order to support both login mechanisms, the new config option `login_method` has been introduced. If this option is not set, the component will try to login with the plain method first and the token method if that fails.
-  That can cause log entries on the router like `login failure for user homeassistant from 192.168.23.10 via api` but doesn't keep the component from working. 
-  To get rid of these entries, set the `login_method` to `plain` for Routers with OS versions > 6.43 or `token` for routers with OS versions < 6.43.
+
+  As of version 6.43 of RouterOS Mikrotik introduced a new login method (`plain`) in addition to the old login method (`token`). With Version 6.45.1 the old `token` login method got deprecated.
+  In order to support both login mechanisms, the new config option `login_method` has been introduced.
 
 </div>
 


### PR DESCRIPTION
**Description:**
- remove trying one login method after another since this has been dropped by [librouteros](https://github.com/luqasz/librouteros), see the [changelog for 3.0.0](https://github.com/luqasz/librouteros/blob/master/CHANGELOG.rst#300)

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30800<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
