### PR TITLE
Update docs to reflect device_class changes for vizio component

### DIFF
--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -79,9 +79,8 @@ To add your Vizio TV to your installation, add the following to your `configurat
 
 ```yaml
 # Example configuration.yaml entry
-media_player:
-  - platform: vizio
-    host: IP_ADDRESS
+vizio:
+  - host: IP_ADDRESS
     access_token: AUTH_TOKEN
 ```
 

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -102,12 +102,12 @@ device_class:
 volume_step:
   description: The number of steps that the volume will be increased or decreased by at a time.
   required: false
-  type: int
+  type: integer
   default: 1
 timeout:
   description: The number of seconds that the Vizio component will wait for a response from the device before timing out.
   required: false
-  type: int
+  type: integer
   default: 5
 {% endconfiguration %}
 

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Media Player
 ha_release: 0.49
 ha_iot_class: Local Polling
+ha_config_flow: true
 ha_codeowners:
   - '@raman325'
 ---
@@ -41,7 +42,7 @@ and note its IP address. If using the IP address by itself does not work, you ma
 
 ## Pairing
 
-Before adding your device to Home Assistant, you may need to pair it manually. In particular, it is unclear how a sound bar would notify you of a valid auth token. In this case, it might be best to first skip the pairing process entirely, specify a `device_class` of `soundbar` in your configuration, and try interacting with the entity to see if you have any success. If the media player controls aren't working, and if specifying different ports as mentioned above doesn't work, you will need to find a way to obtain the auth token during this process.
+Before adding your device to Home Assistant, you may need to pair it manually. In particular, it is unclear how a sound bar would notify you of a valid auth token. In this case, it might be best to first skip the pairing process entirely, specify a `device_class` of `speaker` in your configuration, and try interacting with the entity to see if you have any success. If the media player controls aren't working, and if specifying different ports as mentioned above doesn't work, you will need to find a way to obtain the auth token during this process.
 
 To obtain an auth token, follow these steps:
 
@@ -50,7 +51,7 @@ Make sure that your device is on before continuing.
 | Parameter       | Description          |
 |:----------------|:---------------------|
 | `ip`            | IP address (possibly including port) obtained from the previous section |
-| `device_type`   | The type of device you are connecting to. Options are `tv` or `soundbar` |
+| `device_type`   | The type of device you are connecting to. Options are `tv` or `speaker` |
 
 Enter the following command to initiate pairing:
 
@@ -94,10 +95,20 @@ access_token:
   required: false
   type: string
 device_class:
-  description: The class of your device. Valid options are `tv` or `soundbar`
+  description: The class of your device. Valid options are `tv` or `speaker`
   required: false
   type: string
   default: tv
+volume_step:
+  description: The number of steps that the volume will be increased or decreased by at a time.
+  required: false
+  type: int
+  default: 1
+timeout:
+  description: The number of seconds that the Vizio component will wait for a response from the device before timing out.
+  required: false
+  type: int
+  default: 5
 {% endconfiguration %}
 
 ## Notes and limitations

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -104,11 +104,6 @@ volume_step:
   required: false
   type: integer
   default: 1
-timeout:
-  description: The number of seconds that the Vizio component will wait for a response from the device before timing out.
-  required: false
-  type: integer
-  default: 5
 {% endconfiguration %}
 
 ## Notes and limitations


### PR DESCRIPTION
**Description:** Made a breaking change to the available `device_class` options to use the device classes defined in `media_player`. This has the benefit of making all `vizio` devices compatible with Alexa and Google Assistant.


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30802

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
