### PR TITLE
Fixed sentence in acupsd.markdown

### DIFF
--- a/source/_integrations/apcupsd.markdown
+++ b/source/_integrations/apcupsd.markdown
@@ -10,7 +10,7 @@ ha_release: 0.13
 ha_iot_class: Local Polling
 ---
 
-[APCUPSd](http://www.apcupsd.org/) status information can be integrated into Home Assistant when the Network Information Server (NIS) [is configured](http://www.apcupsd.org/manual/manual.html#nis-server-client-configuration-using-the-net-driver) is enabled on the APC device.
+[APCUPSd](http://www.apcupsd.org/) status information can be integrated into Home Assistant when the Network Information Server (NIS) [is configured](http://www.apcupsd.org/manual/manual.html#nis-server-client-configuration-using-the-net-driver) on the APC device.
 
 There is currently support for the following device types within Home Assistant:
 


### PR DESCRIPTION
Removed unnecessary "is enabled" in line 13.

Alternatively, replacing the "is enabled" by "and enabled" would also work.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
