### PR TITLE
Sync current docs with codebase release 0.104.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,6 +46,7 @@ source/_integrations/blink.markdown @fronzbot
 source/_integrations/bmw_connected_drive.markdown @gerard33
 source/_integrations/braviatv.markdown @robbiet480
 source/_integrations/broadlink.markdown @danielhiversen @felipediel
+source/_integrations/brother.markdown @bieniu
 source/_integrations/brunt.markdown @eavanvalkenburg
 source/_integrations/bt_smarthub.markdown @jxwolstenholme
 source/_integrations/buienradar.markdown @mjj4791 @ties
@@ -80,6 +81,7 @@ source/_integrations/ecobee.markdown @marthoc
 source/_integrations/ecovacs.markdown @OverloadUT
 source/_integrations/egardia.markdown @jeroenterheerdt
 source/_integrations/eight_sleep.markdown @mezz64
+source/_integrations/elgato.markdown @frenck
 source/_integrations/elv.markdown @majuss
 source/_integrations/emby.markdown @mezz64
 source/_integrations/emulated_hue.markdown @NobleKangaroo
@@ -113,6 +115,7 @@ source/_integrations/geniushub.markdown @zxdavb
 source/_integrations/geo_rss_events.markdown @exxamalte
 source/_integrations/geonetnz_quakes.markdown @exxamalte
 source/_integrations/geonetnz_volcano.markdown @exxamalte
+source/_integrations/gios.markdown @bieniu
 source/_integrations/gitter.markdown @fabaff
 source/_integrations/glances.markdown @fabaff @engrbm87
 source/_integrations/gntp.markdown @robbiet480
@@ -145,6 +148,7 @@ source/_integrations/huawei_lte.markdown @scop
 source/_integrations/huawei_router.markdown @abmantis
 source/_integrations/hue.markdown @balloob
 source/_integrations/iaqualink.markdown @flz
+source/_integrations/icloud.markdown @Quentame
 source/_integrations/ign_sismologia.markdown @exxamalte
 source/_integrations/incomfort.markdown @zxdavb
 source/_integrations/influxdb.markdown @fabaff
@@ -154,6 +158,7 @@ source/_integrations/input_number.markdown @home-assistant/core
 source/_integrations/input_select.markdown @home-assistant/core
 source/_integrations/input_text.markdown @home-assistant/core
 source/_integrations/integration.markdown @dgomes
+source/_integrations/intesishome.markdown @jnimmo
 source/_integrations/ios.markdown @robbiet480
 source/_integrations/iperf3.markdown @rohankapoorcom
 source/_integrations/ipma.markdown @dgomes
@@ -165,6 +170,7 @@ source/_integrations/juicenet.markdown @jesserockz
 source/_integrations/kaiterra.markdown @Michsior14
 source/_integrations/keba.markdown @dannerph
 source/_integrations/keenetic_ndms2.markdown @foxel
+source/_integrations/kef.markdown @basnijholt
 source/_integrations/keyboard_remote.markdown @bendavid
 source/_integrations/knx.markdown @Julius2342
 source/_integrations/kodi.markdown @armills
@@ -176,6 +182,7 @@ source/_integrations/life360.markdown @pnbruckner
 source/_integrations/linky.markdown @Quentame
 source/_integrations/linux_battery.markdown @fabaff
 source/_integrations/liveboxplaytv.markdown @pschmitt
+source/_integrations/local_ip.markdown @issacg
 source/_integrations/logger.markdown @home-assistant/core
 source/_integrations/logi_circle.markdown @evanjd
 source/_integrations/luci.markdown @fbradyirl @mzdrale
@@ -224,6 +231,7 @@ source/_integrations/obihai.markdown @dshokouhi
 source/_integrations/ohmconnect.markdown @robbiet480
 source/_integrations/ombi.markdown @larssont
 source/_integrations/onboarding.markdown @home-assistant/core
+source/_integrations/onewire.markdown @garbled1
 source/_integrations/opentherm_gw.markdown @mvn23
 source/_integrations/openuv.markdown @bachya
 source/_integrations/openweathermap.markdown @fabaff
@@ -236,6 +244,7 @@ source/_integrations/pcal9535a.markdown @Shulyaka
 source/_integrations/persistent_notification.markdown @home-assistant/core
 source/_integrations/philips_js.markdown @elupus
 source/_integrations/pi_hole.markdown @fabaff @johnluetke
+source/_integrations/pilight.markdown @trekky12
 source/_integrations/plaato.markdown @JohNan
 source/_integrations/plant.markdown @ChristianKuehnel
 source/_integrations/plex.markdown @jjlawren
@@ -257,6 +266,7 @@ source/_integrations/rainmachine.markdown @bachya
 source/_integrations/random.markdown @fabaff
 source/_integrations/repetier.markdown @MTrab
 source/_integrations/rfxtrx.markdown @danielhiversen
+source/_integrations/ring.markdown @balloob
 source/_integrations/rmvtransport.markdown @cgtobi
 source/_integrations/roomba.markdown @pschmitt
 source/_integrations/saj.markdown @fredericvl
@@ -266,11 +276,13 @@ source/_integrations/scrape.markdown @fabaff
 source/_integrations/script.markdown @home-assistant/core
 source/_integrations/sense.markdown @kbickar
 source/_integrations/sensibo.markdown @andrey-git
+source/_integrations/sentry.markdown @dcramer
 source/_integrations/serial.markdown @fabaff
 source/_integrations/seventeentrack.markdown @bachya
 source/_integrations/shell_command.markdown @home-assistant/core
 source/_integrations/shiftr.markdown @fabaff
 source/_integrations/shodan.markdown @fabaff
+source/_integrations/signal_messenger.markdown @bbernhard
 source/_integrations/simplisafe.markdown @bachya
 source/_integrations/sinch.markdown @bendikrb
 source/_integrations/slide.markdown @ualex73
@@ -292,11 +304,13 @@ source/_integrations/sql.markdown @dgomes
 source/_integrations/starline.markdown @anonym-tsk
 source/_integrations/statistics.markdown @fabaff
 source/_integrations/stiebel_eltron.markdown @fucm
+source/_integrations/stookalert.markdown @fwestenberg
 source/_integrations/stream.markdown @hunterjm
 source/_integrations/stt.markdown @pvizeli
 source/_integrations/suez_water.markdown @ooii
 source/_integrations/sun.markdown @Swamp-Ig
 source/_integrations/supla.markdown @mwegrzynek
+source/_integrations/surepetcare.markdown @benleb
 source/_integrations/swiss_hydrological_data.markdown @fabaff
 source/_integrations/swiss_public_transport.markdown @fabaff
 source/_integrations/switchbot.markdown @danielhiversen
@@ -309,14 +323,15 @@ source/_integrations/tado.markdown @michaelarnauts
 source/_integrations/tahoma.markdown @philklei
 source/_integrations/tautulli.markdown @ludeeus
 source/_integrations/tellduslive.markdown @fredrike
-source/_integrations/template.markdown @PhracturedBlue
-source/_integrations/tesla.markdown @zabuldon
+source/_integrations/template.markdown @PhracturedBlue @tetienne
+source/_integrations/tesla.markdown @zabuldon @alandtse
 source/_integrations/tfiac.markdown @fredrike @mellado
 source/_integrations/thethingsnetwork.markdown @fabaff
 source/_integrations/threshold.markdown @fabaff
 source/_integrations/tibber.markdown @danielhiversen
 source/_integrations/tile.markdown @bachya
 source/_integrations/time_date.markdown @fabaff
+source/_integrations/tmb.markdown @alemuro
 source/_integrations/todoist.markdown @boralyl
 source/_integrations/toon.markdown @frenck
 source/_integrations/tplink.markdown @rytilahti
@@ -350,10 +365,12 @@ source/_integrations/waqi.markdown @andrey-git
 source/_integrations/watson_tts.markdown @rutkai
 source/_integrations/weather.markdown @fabaff
 source/_integrations/weblink.markdown @home-assistant/core
+source/_integrations/webostv.markdown @bendavid
 source/_integrations/websocket_api.markdown @home-assistant/core
 source/_integrations/wemo.markdown @sqldiablo
 source/_integrations/withings.markdown @vangorra
 source/_integrations/wled.markdown @frenck
+source/_integrations/workday.markdown @fabaff
 source/_integrations/worldclock.markdown @fabaff
 source/_integrations/wwlln.markdown @bachya
 source/_integrations/xbox_live.markdown @MartinHjelmare

--- a/source/_integrations/brother.markdown
+++ b/source/_integrations/brother.markdown
@@ -7,6 +7,8 @@ ha_category:
 ha_release: 0.104
 ha_iot_class: Local Polling
 ha_config_flow: true
+ha_codeowners:
+  - '@bieniu'
 ---
 
 The `Brother Printer` integration allows you to read current data from your local Brother printer.

--- a/source/_integrations/elgato.markdown
+++ b/source/_integrations/elgato.markdown
@@ -8,6 +8,9 @@ ha_release: 0.104
 ha_iot_class: Local Polling
 ha_qa_scale: platinum
 ha_config_flow: true
+ha_codeowners:
+  - '@frenck'
+ha_quality_scale: platinum
 ---
 
 The [Elgato Key Light](https://www.elgato.com/en/gaming/key-light) sets the

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -1,5 +1,5 @@
 ---
-title: Honeywell evohome / Total Connect Comfort
+title: Honeywell Total Connect Comfort (Europe)
 description: Instructions on how to integrate a Honeywell evohome/TCC system with Home Assistant.
 logo: honeywell.png
 ha_category:

--- a/source/_integrations/gios.markdown
+++ b/source/_integrations/gios.markdown
@@ -7,6 +7,8 @@ ha_category:
 ha_release: 0.104
 ha_iot_class: Cloud Polling
 ha_config_flow: true
+ha_codeowners:
+  - '@bieniu'
 ---
 
 The `gios` integration uses the [GIOŚ](http://powietrze.gios.gov.pl/pjp/current) web service as a source for air quality data for your location.

--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -8,6 +8,8 @@ ha_category:
 ha_iot_class: Cloud Polling
 ha_release: '0.10'
 ha_config_flow: true
+ha_codeowners:
+  - '@Quentame'
 ---
 
 The `icloud` integration allows you to detect presence using the [iCloud](https://www.icloud.com/) service. iCloud allows users to track their location on iOS devices.

--- a/source/_integrations/intesishome.markdown
+++ b/source/_integrations/intesishome.markdown
@@ -5,6 +5,8 @@ logo: intesishome.png
 ha_category: Climate
 ha_release: 0.104
 ha_iot_class: Cloud Push
+ha_codeowners:
+  - '@jnimmo'
 ---
 
 The `IntesisHome` climate platform lets you control [IntesisHome](https://www.intesishome.com) and [Airconwithme](https://www.airconwithme.com) devices. IntesisHome provides integrations with air conditioners, including Panasonic, Daikin, Fujitsu, Toshiba, LG and more.

--- a/source/_integrations/kef.markdown
+++ b/source/_integrations/kef.markdown
@@ -6,6 +6,8 @@ ha_category:
   - Media Player
 ha_iot_class: Local Polling
 ha_release: 0.104
+ha_codeowners:
+  - '@basnijholt'
 ---
 
 The `kef` platform allows you to control the [KEF LS50 Wireless](https://international.kef.com/products/ls50-wireless) and [KEF LSX](https://international.kef.com/products/lsx) speakers from Home Assistant.

--- a/source/_integrations/local_ip.markdown
+++ b/source/_integrations/local_ip.markdown
@@ -7,6 +7,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 0.104
 ha_config_flow: true
+ha_codeowners:
+  - '@issacg'
 ---
 
 The `local_ip` sensor will expose the local (LAN) IP address of your Home Assistant instance. This can be useful when your instance has a static public hostname (for example, if you use the Nabu Casa service), but have a dynamically allocated local LAN address (for example, configured via DHCP).

--- a/source/_integrations/onewire.markdown
+++ b/source/_integrations/onewire.markdown
@@ -6,6 +6,8 @@ ha_category:
   - DIY
 ha_release: 0.12
 ha_iot_class: Local Polling
+ha_codeowners:
+  - '@garbled1'
 ---
 
 The `onewire` platform supports sensors which are using the One wire (1-wire) bus for communication.

--- a/source/_integrations/pilight.markdown
+++ b/source/_integrations/pilight.markdown
@@ -9,6 +9,8 @@ ha_category:
   - Switch
 ha_release: 0.26
 ha_iot_class: Local Push
+ha_codeowners:
+  - '@trekky12'
 ---
 
 [Pilight](https://www.pilight.org/) is a modular and open source solution to communicate with 433 MHz devices and runs on various small form factor computers. A lot of common [protocols](https://manual.pilight.org/protocols/index.html) are already available.

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -12,6 +12,8 @@ ha_category:
 ha_release: 0.42
 ha_iot_class: Cloud Polling
 ha_config_flow: true
+ha_codeowners:
+  - '@balloob'
 ---
 
 The `ring` implementation allows you to integrate your [Ring.com](https://ring.com/) devices in Home Assistant.

--- a/source/_integrations/sentry.markdown
+++ b/source/_integrations/sentry.markdown
@@ -7,6 +7,8 @@ ha_category:
 ha_iot_class: Cloud Polling
 ha_release: 0.104
 ha_config_flow: true
+ha_codeowners:
+  - '@dcramer'
 ---
 
 The `sentry` integration integrates with [Sentry](https://sentry.io/) to capture both logged errors as well as unhandled exceptions in Home Assistant.

--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -5,6 +5,8 @@ logo: signal_messenger.png
 ha_category:
   - Notifications
 ha_release: 0.104
+ha_codeowners:
+  - '@bbernhard'
 ---
 
 The `signal_messenger` integration uses the [Signal Messenger REST API](https://github.com/bbernhard/signal-cli-rest-api) to deliver notifications from Home Assistant to your Android or iOs device.

--- a/source/_integrations/stookalert.markdown
+++ b/source/_integrations/stookalert.markdown
@@ -1,12 +1,14 @@
 ---
-title: "Stookalert"
-description: "Instructions on how to use Stookalert data within Home Assistant"
+title: RIVM Stookalert
+description: Instructions on how to use Stookalert data within Home Assistant
 logo: stookalert.png
 ha_category:
   - Binary Sensor
   - Environment
 ha_release: 0.104
 ha_iot_class: Cloud Polling
+ha_codeowners:
+  - '@fwestenberg'
 ---
 
 The `stookalert` sensor platform queries the [RIVM stookalert](https://www.rivm.nl/stookalert) API for unfavorable weather conditions or poor air quality. With a Stookalert, the RIVM calls on people not to burn wood. This can prevent health problems in people in the area.

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -7,6 +7,8 @@ ha_category:
   - Sensor
 ha_release: 0.104
 ha_iot_class: Cloud Polling
+ha_codeowners:
+  - '@benleb'
 ---
 
 The `surepetcare` component allows you to get information on your Sure Petcare Connect Pet or Cat Flap.

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -9,6 +9,7 @@ logo: home-assistant.png
 ha_quality_scale: internal
 ha_codeowners:
   - '@PhracturedBlue'
+  - '@tetienne'
 ---
 
 The `template` platform supports sensors which get their values from other entities.

--- a/source/_integrations/tesla.markdown
+++ b/source/_integrations/tesla.markdown
@@ -15,6 +15,7 @@ ha_iot_class: Cloud Polling
 ha_config_flow: true
 ha_codeowners:
   - '@zabuldon'
+  - '@alandtse'
 ---
 
 The `Tesla` integration offers integration with the [Tesla](https://auth.tesla.com/login) cloud service and provides presence detection as well as sensors such as charger state and temperature.

--- a/source/_integrations/tmb.markdown
+++ b/source/_integrations/tmb.markdown
@@ -1,11 +1,13 @@
 ---
-title: "Transports Metropolitans de Barcelona"
-description: "Instructions on how to integrate TMB iBus sensor within Home Assistant."
+title: Transports Metropolitans de Barcelona
+description: Instructions on how to integrate TMB iBus sensor within Home Assistant.
 logo: tmb.png
 ha_category:
   - Transport
 ha_release: 0.104
 ha_iot_class: Local Polling
+ha_codeowners:
+  - '@alemuro'
 ---
 
 This sensor will provide you the remaining time, in minutes, for the next bus in a specific stop by using the [iBus service](https://www.tmb.cat/en/barcelona/tmb-ibus).

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -7,6 +7,8 @@ ha_category:
   - Notifications
 ha_iot_class: Local Polling
 ha_release: 0.18
+ha_codeowners:
+  - '@bendavid'
 ---
 
 The `webostv` platform allows you to control a [LG](https://www.lg.com/) webOS Smart TV.

--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -7,6 +7,8 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 0.41
 ha_quality_scale: internal
+ha_codeowners:
+  - '@fabaff'
 ---
 
 The `workday` binary sensor indicates, whether the current day is a workday or not. It allows specifying, which days of the week counts as workdays and also


### PR DESCRIPTION
**Description:**

Syncs up documentation with the codebase, Home Asssistant 0.104.0

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
