### PR TITLE
Update ring.markdown

### DIFF
--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -31,31 +31,11 @@ This component does NOT allow for live viewing of your Ring camera within Home A
 
 ## Configuration
 
-Go to the integrations page in your config and click on new integration -> Ring.
+Go to the integrations page in your config and click on new integration -> Ring.  Please note, this requires 0.104 to appear.
 
 ## YAML configuration
 
-YAML configuration is around for people that prefer YAML, but it's not preferred! The YAML method does not work with two-factor authentication and it requires you to store your username/password. The normal method only requires you to enter username/password once.
-
-To enable device linked in your [Ring.com](https://ring.com/) account, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-ring:
-  username: YOUR_USERNAME
-  password: YOUR_PASSWORD
-```
-
-{% configuration %}
-username:
-  description: The username for accessing your Ring account.
-  required: true
-  type: string
-password:
-  description: The password for accessing your Ring account.
-  required: true
-  type: string
-{% endconfiguration %}
+YAML configuration no longer works with the updates Ring has done to their backend.
 
 ## Binary Sensor
 


### PR DESCRIPTION
Added that it appears you need 0.104 for the UI method to work and that the YAML no longer works (I had it setup that way, broke after the issue with the footage being viewed came out).

**Description:**

YAML method no longer works and the UI method does not appear in 0.103.6.


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
