### PR TITLE
Remove legacy api_password occurances

### DIFF
--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -10,7 +10,6 @@ For integrations that you want to use in Home Assistant, you add code in your `c
 
 The following example entry assumes that you would like to set up the [notify component](/integrations/notify) with the [pushbullet platform](/integrations/pushbullet).
 
-
 ```yaml
 notify:
   platform: pushbullet
@@ -66,11 +65,12 @@ sensor:
 ## Including values
 
 ### Environmental variables
+
 You can include values from your system's environment variables with `!env_var`. Note that this will only work in a scenario where it is possible to specify these. Hass.io users are recommended to use `!include` statements instead.
 
 ```yaml
-http:
-  api_password: !env_var PASSWORD
+example:
+  password: !env_var PASSWORD
 ```
 
 #### Default value
@@ -78,8 +78,8 @@ http:
 If an environment variable is not set, you can fallback to a default value.
 
 ```yaml
-http:
-  api_password: !env_var PASSWORD default_password
+example:
+  password: !env_var PASSWORD default_password
 ```
 
 ### Including entire files
@@ -102,7 +102,7 @@ If you see the following message:
 found character '\t' that cannot start any token
 ```
 
-This means that you've mistakenly entered a tab character, instead of spaces. 
+This means that you've mistakenly entered a tab character, instead of spaces.
 
 ### Upper and lower case
 

--- a/source/_docs/tools/credstash.markdown
+++ b/source/_docs/tools/credstash.markdown
@@ -14,8 +14,8 @@ $ hass --script credstash --help
 To store a password in credstash, replace your password or API key with `!secret` and an identifier in `configuration.yaml` file.
 
 ```yaml
-http:
-  api_password: !secret http_password
+example:
+  password: !secret example_password
 ```
 
 Create an entry in your credstash store.

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -32,10 +32,6 @@ http:
 ```
 
 {% configuration %}
-api_password:
-  description: "**Deprecated since 0.90 release. Configuration moved to [Legacy API password auth provider](/docs/authentication/providers/#legacy-api-password).** Protect the Home Assistant API with a password - this password can also be used to log in to the frontend. Where your client or other software supports it, you should use [long lasting access token](/docs/authentication/#your-account-profile) instead, as [shown in the REST API](https://developers.home-assistant.io/docs/en/external_api_rest.html) and [websocket API](https://developers.home-assistant.io/docs/en/external_api_websocket.html) documentation."
-  required: false
-  type: string
 server_host:
   description: "Only listen to incoming requests on specific IP/host. By default it will accept all IPv4 connections. Use `server_host: ::0` if you want to listen to (and only) IPv6."
   required: false


### PR DESCRIPTION
**Description:**

Removes some occurrences of the old `api_password`, that has been removed from Home Assistant already.

fixes #11764

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
