### PR TITLE
Deprecate weblink integration

### DIFF
--- a/source/_integrations/weblink.markdown
+++ b/source/_integrations/weblink.markdown
@@ -14,7 +14,10 @@ The `weblink` integration allows you to display links in the Home Assistant fron
 
 <div class='note'>
 
-The below documentation applies to the classic "States" user interface. Starting with Home Assistant 0.86, Lovelace is the new default interface. For information on configuring weblinks in Lovelace please follow [these instructions](/lovelace/entities/#weblink) instead.
+The below documentation applies to the classic "States" user interface.
+The `weblink` integration has been **deprecated** and pending for removal in Home Assistant 0.107.0.
+
+Starting with Home Assistant 0.86, Lovelace is the new default interface. For information on configuring weblinks in Lovelace please follow [these instructions](/lovelace/entities/#weblink) instead.
 
 </div>
 


### PR DESCRIPTION
**Description:**

The `weblink` integration is now deprecated and pending removal in Home Assistant 0.107.0. This integration only works with the old states UI.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30834

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
