### PR TITLE
Deprecate history_graph integration

### DIFF
--- a/source/_integrations/history_graph.markdown
+++ b/source/_integrations/history_graph.markdown
@@ -10,6 +10,11 @@ ha_codeowners:
   - '@andrey-git'
 ---
 
+<div class='note'>
+  This integration is deprecated and pending removal in Home Assistant 0.107.0,
+  as it was only used by the old states UI (not our current Lovelace UI).
+</div>
+
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/history_graph.png' />
 </p>


### PR DESCRIPTION
**Description:**

The history_graph integration has been deprecated and pending for removal in Home Assistant 0.107.0. This integration was used for the old states UI.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30835

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
