### PR TITLE
Added documentation for the bmp280 integration

### DIFF
--- a/source/_integrations/bmp280.markdown
+++ b/source/_integrations/bmp280.markdown
@@ -39,7 +39,7 @@ i2c_address:
 
 ## Setting up the I2C interface on the host device
 
-To get more information on how to set up the I2C interface on your Raspberry Pi, please refer to the [BME680 sensor integration](../bme680/#directions-for-installing-smbus-support-on-raspberry-pi).
+To get more information on how to set up the I2C interface on your Raspberry Pi, please refer to the [BME680 sensor integration](/integrations/bme680/#directions-for-installing-smbus-support-on-raspberry-pi).
 
 ## Choosing the appropriate I2C address
 

--- a/source/_integrations/bmp280.markdown
+++ b/source/_integrations/bmp280.markdown
@@ -1,7 +1,7 @@
 ---
 title: Bosch BMP280 Environmental Sensor
 description: Instructions on how to integrate a BMP280 sensor into Home Assistant.
-ha_release: 0.105
+ha_release: 0.108
 logo: raspberry-pi.png
 ha_category:
   - DIY
@@ -17,11 +17,12 @@ This integration has been tested on a Raspberry Pi 4B, but it should work on any
 
 ## Configuration
 
-To use your BMP280 sensor in your installation, you have to enable I2C on your host device then add the following to your `configuration.yaml` file:
+To use a BMP280 sensor in your installation, you have to enable I2C on your host device then configure the integration using the following example:
 
 ```yaml
 sensor:
   - platform: bmp280
+  - i2c_address: 0x77
 ```
 
 {% configuration %}
@@ -31,9 +32,8 @@ name:
   default: BMP280
   type: string
 i2c_address:
-  description: I2C address of the sensor. It is either 0x76 or 0x77, depending on your wiring configuration.
-  required: false
-  default: 0x77
+  description: I2C address of the sensor. It is either 0x76 or 0x77, depending on your actual wiring configuration.
+  required: true
   type: integer
 {% endconfiguration %}
 
@@ -43,6 +43,6 @@ To get more information on how to set up the I2C interface on your Raspberry Pi,
 
 ## Choosing the appropriate I2C address
 
-Please note that the I2C address of this device depends on the state of the `SDO` pin. If it is pulled down (to the `GND` rail) it will be `0x76`, if it's pulled up (to the `VCC` rail) it will be `0x77`. 
+Please note that the I2C address of this device depends on the state of the `SDO` pin. If it is pulled down (to the `GND` rail) it will be `0x76`, if it's pulled up (to the `VCC` rail) it will be `0x77`.
 
 If you leave it floating then the address will be unpredictable or even worse, it can change over time. So it is recommended to hook up this pin to either the positive or the negative rail of your host device.

--- a/source/_integrations/bmp280.markdown
+++ b/source/_integrations/bmp280.markdown
@@ -3,7 +3,8 @@ title: Bosch BMP280 Environmental Sensor
 description: Instructions on how to integrate a BMP280 sensor into Home Assistant.
 ha_release: 0.105
 logo: raspberry-pi.png
-ha_category: DIY
+ha_category:
+  - DIY
 ha_iot_class: Local Polling
 ha_quality_scale: silver
 ha_code_owners:

--- a/source/_integrations/bmp280.markdown
+++ b/source/_integrations/bmp280.markdown
@@ -43,6 +43,6 @@ To get more information on how to set up the I2C interface on your Raspberry Pi,
 
 ## Choosing the appropriate I2C address
 
-Please note that the actual I2C address of this device depends on the state of the `SD0` pin. If its pulled down (to the `GND` rail) it will be `0x77`, if it's pulled up (to the `VCC` pin) it will be `0x76`. 
+Please note that the I2C address of this device depends on the state of the `SDO` pin. If it is pulled down (to the `GND` rail) it will be `0x76`, if it's pulled up (to the `VCC` rail) it will be `0x77`. 
 
 If you leave it floating then the address will be unpredictable or even worse, it can change over time. So it is recommended to hook up this pin to either the positive or the negative rail of your host device.

--- a/source/_integrations/bmp280.markdown
+++ b/source/_integrations/bmp280.markdown
@@ -1,0 +1,47 @@
+---
+title: Bosch BMP280 Environmental Sensor
+description: Instructions on how to integrate a BMP280 sensor into Home Assistant.
+ha_release: 0.105
+logo: raspberry-pi.png
+ha_category: DIY
+ha_iot_class: Local Polling
+ha_quality_scale: silver
+ha_code_owners:
+  - '@belidzs'
+---
+
+The `bmp280` sensor platform allows you to read temperature and pressure values of a [Bosch BMP280 Environmental sensor](https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/pressure-sensors-bmp280-1.html) connected via [I2C](https://en.wikipedia.org/wiki/I²C) bus (SDA, SCL pins).
+
+This integration has been tested on a Raspberry Pi 4B, but it should work on any device which is supported by [CircuitPython](https://circuitpython.org/).
+
+## Configuration
+
+To use your BMP280 sensor in your installation, you have to enable I2C on your host device then add the following to your `configuration.yaml` file:
+
+```yaml
+sensor:
+  - platform: bmp280
+```
+
+{% configuration %}
+name:
+  description: The name of the sensor.
+  required: false
+  default: BMP280
+  type: string
+i2c_address:
+  description: I2C address of the sensor. It is either 0x76 or 0x77, depending on your wiring configuration.
+  required: false
+  default: 0x77
+  type: integer
+{% endconfiguration %}
+
+## Setting up the I2C interface on the host device
+
+To get more information on how to set up the I2C interface on your Raspberry Pi, please refer to the [BME680 sensor integration](../bme680/#directions-for-installing-smbus-support-on-raspberry-pi).
+
+## Choosing the appropriate I2C address
+
+Please note that the actual I2C address of this device depends on the state of the `SD0` pin. If its pulled down (to the `GND` rail) it will be `0x77`, if it's pulled up (to the `VCC` pin) it will be `0x76`. 
+
+If you leave it floating then the address will be unpredictable or even worse, it can change over time. So it is recommended to hook up this pin to either the positive or the negative rail of your host device.


### PR DESCRIPTION
**Description:**
Added documentation for the BMP280 integration. 

I can't provide the PR for the integration itself yet as I'm required to provide the number of this PR. There's a bit of a chicken and the egg problem here.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
