### PR TITLE
Add breaking change for google assistant

### DIFF
--- a/source/_posts/2020-01-15-release-104.markdown
+++ b/source/_posts/2020-01-15-release-104.markdown
@@ -371,11 +371,7 @@ Make sure to fill in all fields of the issue template, that is helping us a lot!
 
   One possible scenario is if you have set an automation using the state of one lock to trigger an action on other lock(s). This change would cause the action to trigger on `locking` if it was previously triggering on `unlocking`. - ([@davet2001] - [#30663]) ([binary_sensor docs])
 
-- __Google Assistant__ - The `api_key` setting for manual installs is now deprecated and will be removed in 0.105.  To correct this issue you will need to remove this from the `configuration.yaml` and follow the steps in the docs for the `service_account` setting.  Look for the following step to correct this issue. - ([@elupus] - [#30402]) ([google_assistant docs])
-
-```
-If you want to support actively reporting of state to Google’s server (config option report_state) and support google_assistant.request_sync, you need to generate a service account.
-```
+- __Google Assistant__ - The `api_key` for manual installs is now deprecated and will be removed in 0.105.  To correct this you will need to remove `api_key` from the `configuration.yaml` and switch to using `service_account` instead. - ([@elupus] - [#30402]) ([google_assistant docs])
 
 ## Beta Fixes
 

--- a/source/_posts/2020-01-15-release-104.markdown
+++ b/source/_posts/2020-01-15-release-104.markdown
@@ -371,13 +371,11 @@ Make sure to fill in all fields of the issue template, that is helping us a lot!
 
   One possible scenario is if you have set an automation using the state of one lock to trigger an action on other lock(s). This change would cause the action to trigger on `locking` if it was previously triggering on `unlocking`. - ([@davet2001] - [#30663]) ([binary_sensor docs])
 
-- __Google Assistant__ - The `api_key` setting for manual installs is now deprecated and will be removed in 0.105.  To correct this issue you will need to remove this from the `configuration.yaml` and follow the steps in the docs for the `service_account` setting.  Look for the following step to correct this issue:
+- __Google Assistant__ - The `api_key` setting for manual installs is now deprecated and will be removed in 0.105.  To correct this issue you will need to remove this from the `configuration.yaml` and follow the steps in the docs for the `service_account` setting.  Look for the following step to correct this issue. - ([@elupus] - [#30402]) ([google_assistant docs])
 
 ```
 If you want to support actively reporting of state to Google’s server (config option report_state) and support google_assistant.request_sync, you need to generate a service account.
 ```
-
-([@elupus] - [#30402]) ([google_assistant docs])
 
 ## Beta Fixes
 

--- a/source/_posts/2020-01-15-release-104.markdown
+++ b/source/_posts/2020-01-15-release-104.markdown
@@ -371,6 +371,14 @@ Make sure to fill in all fields of the issue template, that is helping us a lot!
 
   One possible scenario is if you have set an automation using the state of one lock to trigger an action on other lock(s). This change would cause the action to trigger on `locking` if it was previously triggering on `unlocking`. - ([@davet2001] - [#30663]) ([binary_sensor docs])
 
+- __Google Assistant__ - The `api_key` setting for manual installs is now deprecated and will be removed in 0.105.  To correct this issue you will need to remove this from the `configuration.yaml` and follow the steps in the docs for the `service_account` setting.  Look for the following step to correct this issue:
+
+```
+If you want to support actively reporting of state to Google’s server (config option report_state) and support google_assistant.request_sync, you need to generate a service account.
+```
+
+([@elupus] - [#30402]) ([google_assistant docs])
+
 ## Beta Fixes
 
 - Fix upnp raw sensor state formatting when None ([@pnbruckner] - [#30444]) ([upnp docs]) (beta fix)


### PR DESCRIPTION
**Description:**

We missed a breaking change in the PR that is causing some confusion, will need to submit a separate PR to mention the deprecated key.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#N/A

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
