### PR TITLE
Added bonus template sensors to convert kilograms to pounds

### DIFF
--- a/source/_integrations/withings.markdown
+++ b/source/_integrations/withings.markdown
@@ -89,6 +89,9 @@ profiles:
 
 In a text editor, replace ```USER_PROFILE_NAME``` in the template sensors below with your withings User Profile Name defined in the Withings integration configuration. 
 
+
+{% raw %}
+
 ```yaml
 # Example configuration.yaml entry
 sensors:
@@ -97,7 +100,7 @@ sensors:
       withings_weight_lbs_USER_PROFILE_NAME:
         friendly_name: "withings weight_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: {% raw %}"{{ (states('sensor.withings_weight_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
+        value_template: "{{ (states('sensor.withings_weight_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
         icon_template: mdi:weight-pound
 
   - platform: template
@@ -105,7 +108,7 @@ sensors:
       withings_bone_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings bone_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: {% raw %}"{{ (states('sensor.withings_bone_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
+        value_template: "{{ (states('sensor.withings_bone_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
         icon_template: mdi:weight-pound
         
   - platform: template
@@ -113,7 +116,7 @@ sensors:
       withings_fat_free_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings fat_free_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: {% raw %}"{{ (states('sensor.withings_fat_free_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
+        value_template: "{{ (states('sensor.withings_fat_free_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
         icon_template: mdi:weight-pound
         
   - platform: template
@@ -121,7 +124,7 @@ sensors:
       withings_fat_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings fat_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: {% raw %}"{{ (states('sensor.withings_fat_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
+        value_template: "{{ (states('sensor.withings_fat_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
         icon_template: mdi:weight-pound
         
   - platform: template
@@ -129,6 +132,8 @@ sensors:
       withings_muscle_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings muscle_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: {% raw %}"{{ (states('sensor.withings_muscle_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
+        value_template: "{{ (states('sensor.withings_muscle_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
         icon_template: mdi:weight-pound
 ```
+
+{% endraw %}

--- a/source/_integrations/withings.markdown
+++ b/source/_integrations/withings.markdown
@@ -97,7 +97,7 @@ sensors:
       withings_weight_lbs_USER_PROFILE_NAME:
         friendly_name: "withings weight_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: "{{ (states('sensor.withings_weight_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: {% raw %}"{{ (states('sensor.withings_weight_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
         icon_template: mdi:weight-pound
 
   - platform: template
@@ -105,7 +105,7 @@ sensors:
       withings_bone_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings bone_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: "{{ (states('sensor.withings_bone_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: {% raw %}"{{ (states('sensor.withings_bone_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
         icon_template: mdi:weight-pound
         
   - platform: template
@@ -113,7 +113,7 @@ sensors:
       withings_fat_free_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings fat_free_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: "{{ (states('sensor.withings_fat_free_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: {% raw %}"{{ (states('sensor.withings_fat_free_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
         icon_template: mdi:weight-pound
         
   - platform: template
@@ -121,7 +121,7 @@ sensors:
       withings_fat_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings fat_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: "{{ (states('sensor.withings_fat_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: {% raw %}"{{ (states('sensor.withings_fat_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
         icon_template: mdi:weight-pound
         
   - platform: template
@@ -129,6 +129,6 @@ sensors:
       withings_muscle_mass_lbs_USER_PROFILE_NAME:
         friendly_name: "withings muscle_mass_lbs_USER_PROFILE_NAME"
         unit_of_measurement: 'lbs'
-        value_template: "{{ (states('sensor.withings_muscle_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        value_template: {% raw %}"{{ (states('sensor.withings_muscle_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"{% endraw %}
         icon_template: mdi:weight-pound
 ```

--- a/source/_integrations/withings.markdown
+++ b/source/_integrations/withings.markdown
@@ -84,3 +84,51 @@ profiles:
   required: true
   type: map
 {% endconfiguration %}
+
+## Bonus: Template Sensors to Convert Kilograms to Pounds
+
+In a text editor, replace ```USER_PROFILE_NAME``` in the template sensors below with your withings User Profile Name defined in the Withings integration configuration. 
+
+```yaml
+# Example configuration.yaml entry
+sensors:
+  - platform: template
+    sensors:
+      withings_weight_lbs_USER_PROFILE_NAME:
+        friendly_name: "withings weight_lbs_USER_PROFILE_NAME"
+        unit_of_measurement: 'lbs'
+        value_template: "{{ (states('sensor.withings_weight_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        icon_template: mdi:weight-pound
+
+  - platform: template
+    sensors:
+      withings_bone_mass_lbs_USER_PROFILE_NAME:
+        friendly_name: "withings bone_mass_lbs_USER_PROFILE_NAME"
+        unit_of_measurement: 'lbs'
+        value_template: "{{ (states('sensor.withings_bone_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        icon_template: mdi:weight-pound
+        
+  - platform: template
+    sensors:
+      withings_fat_free_mass_lbs_USER_PROFILE_NAME:
+        friendly_name: "withings fat_free_mass_lbs_USER_PROFILE_NAME"
+        unit_of_measurement: 'lbs'
+        value_template: "{{ (states('sensor.withings_fat_free_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        icon_template: mdi:weight-pound
+        
+  - platform: template
+    sensors:
+      withings_fat_mass_lbs_USER_PROFILE_NAME:
+        friendly_name: "withings fat_mass_lbs_USER_PROFILE_NAME"
+        unit_of_measurement: 'lbs'
+        value_template: "{{ (states('sensor.withings_fat_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        icon_template: mdi:weight-pound
+        
+  - platform: template
+    sensors:
+      withings_muscle_mass_lbs_USER_PROFILE_NAME:
+        friendly_name: "withings muscle_mass_lbs_USER_PROFILE_NAME"
+        unit_of_measurement: 'lbs'
+        value_template: "{{ (states('sensor.withings_muscle_mass_kg_USER_PROFILE_NAME') | float * 2.20462262185) | round(2) }}"
+        icon_template: mdi:weight-pound
+```


### PR DESCRIPTION
added bonus template sensors to convert kilograms to pounds. This will save users from having to re-invent the wheel on their own.

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
