### PR TITLE
Small typo in description Stookalert

### DIFF
--- a/source/_integrations/stookalert.markdown
+++ b/source/_integrations/stookalert.markdown
@@ -26,7 +26,7 @@ binary_sensor:
 
 {% configuration %}
 province:
-  description: a province to use for the binary sensor's state. Currently only provinces in the Netherlands are supported. Valid values are `Drenthe`, `Flevoland`, `Friesland`, `Gelderland`, `Groningen`, `Limburg`, `Noord-Brabant`, `Noord-Holland`, `Overijssel`, `Utrecht`, `Zeeland` or `Zuid-Holland`.
+  description: A province to use for the binary sensor's state. Currently only provinces in the Netherlands are supported. Valid values are `Drenthe`, `Flevoland`, `Friesland`, `Gelderland`, `Groningen`, `Limburg`, `Noord-Brabant`, `Noord-Holland`, `Overijssel`, `Utrecht`, `Zeeland` or `Zuid-Holland`.
   required: true
   type: string
 name:


### PR DESCRIPTION
**Description:**
Typo in description: a -> A.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
