### PR TITLE
Mention deconz breaking change in blog post for 0.104

### DIFF
--- a/source/_posts/2020-01-15-release-104.markdown
+++ b/source/_posts/2020-01-15-release-104.markdown
@@ -237,7 +237,7 @@ Make sure to fill in all fields of the issue template, that is helping us a lot!
 
 - __Hue__ - Hue will no longer import existing authentication from disk. It has not written this authentication to disk since March 2018. The config option has been deprecated and will be removed in 0.106. ([@balloob] - [#30000]) ([hue docs])
 
-- __Deconz__ - Due to changes to configuration handling, deconz groups will be assigned new identifiers in Home Assistant. As a result, deconz groups will be duplicated. Remove any group devices from the registry prior to upgrading or alternatively delete the obsolete entries after the upgrade to eliminate the duplicates. ([#30875]) ([deconz docs])
+- __deCONZ__ - Due to changes to configuration handling, deCONZ groups will be assigned new identifiers in Home Assistant. As a result, deCONZ groups will be duplicated. Remove any group devices from the registry prior to upgrading or alternatively delete the obsolete entries after the upgrade to eliminate the duplicates. ([#30875]) ([deconz docs])
 
 - __UPnP__ - UPnP/IGD units of measurement have been aligned with other integrations and common uses, they're now kB and kB/s instead of kbyte and kbyte/sec respectively. - ([@scop] - [#29552]) ([upnp docs])
 

--- a/source/_posts/2020-01-15-release-104.markdown
+++ b/source/_posts/2020-01-15-release-104.markdown
@@ -237,6 +237,8 @@ Make sure to fill in all fields of the issue template, that is helping us a lot!
 
 - __Hue__ - Hue will no longer import existing authentication from disk. It has not written this authentication to disk since March 2018. The config option has been deprecated and will be removed in 0.106. ([@balloob] - [#30000]) ([hue docs])
 
+- __Deconz__ - Due to changes to configuration handling, deconz groups will be assigned new identifiers in Home Assistant. As a result, deconz groups will be duplicated. Remove any group devices from the registry prior to upgrading or alternatively delete the obsolete entries after the upgrade to eliminate the duplicates. ([#30875]) ([deconz docs])
+
 - __UPnP__ - UPnP/IGD units of measurement have been aligned with other integrations and common uses, they're now kB and kB/s instead of kbyte and kbyte/sec respectively. - ([@scop] - [#29552]) ([upnp docs])
 
 - __Worx Landroid__ - The `worxlandroid` sensor has been changed to not return the hardcoded state values `manual-stop`, `charging`, `charging-complete`, `going-home`, `mowing`, instead use the states given from the Landroid to Home Assistant.


### PR DESCRIPTION
**Description:**
Adds a notice about a breaking change relating to deconz groups documented in https://github.com/home-assistant/home-assistant/issues/30875

## Checklist:
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
