### PR TITLE
Update signal_messenger.markdown

### DIFF
--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -32,9 +32,9 @@ notify:
   - name: signal
     platform: signal_messenger
     url: "http://127.0.0.1:8080" # the URL where the Signal Messenger REST API is listening 
-    number: YOUR_PHONE_NUMBER # the sender number
+    number: "YOUR_PHONE_NUMBER" # the sender number
     recipients: # one or more recipients
-      - RECIPIENT1
+      - "RECIPIENT1"
 ```
 
 {% configuration %}


### PR DESCRIPTION
Configuration entry must have quotation marks around phone numbers. e.g. "+123456789"

**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
