### PR TITLE
Add missing parameter to config section and add note about breaking change for vizio component

### DIFF
--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -90,6 +90,11 @@ host:
   description: IP address of your device.
   required: true
   type: string
+name:
+  description: Nickname for your device that will be used to generate the device's entity ID. If multiple Vizio devices are configured, the value must be unique for each entry.
+  required: false
+  type: string
+  default: Vizio SmartCast
 access_token:
   description: Authentication token you received in the last step of the pairing process (if applicable).
   required: false


### PR DESCRIPTION
**Description:**
A parameter (`name`) was missing from the configuration section of the docs. I also added a note about a breaking change that will get introduced that requires the parameter to be unique for each config entry.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#30653

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html