### PR TITLE
Updates vacuum.xioami_miio docs

### DIFF
--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -189,23 +189,29 @@ In addition to [all of the attributes provided by the `vacuum` component](/integ
 - `main_brush_left`
 - `side_brush_left`
 - `filter_left`
+- `sensor_dirty_left`
 - `cleaning_count`
 - `total_cleaned_area`
 - `total_cleaning_time`
+- `clean_start`
+- `clean_end`
 
 The following table shows the units of measurement for each attribute:
 
-| Attribute                 | Unit of measurement | Description                                           |
-|---------------------------|---------------------|-------------------------------------------------------|
-| `do_not_disturb`          |                     | DND mode on / off                                     |
-| `cleaning_time`           | minutes             | Last / actual cleaning time in minutes                |
-| `cleaned_area`            | square meter        | Last / actual cleaned area in square meters           |
-| `main_brush_left`         | hours               | Hours left until a change of the main brush is needed |
-| `side_brush_left`         | hours               | Hours left until a change of the side brush is needed |
-| `filter_left`             | hours               | Hours left until a change of the filter is needed     |
-| `cleaning_count`          |                     | Number of total cleaning cycles                       |
-| `total_cleaned_area`      | square meter        | Total cleaned area in square meters                   |
-| `total_cleaning_time`     | minutes             | Total cleaning time in minutes                        |
+| Attribute                 | Unit of measurement | Description                                                    |
+|---------------------------|---------------------|----------------------------------------------------------------|
+| `do_not_disturb`          |                     | DND mode on / off                                              |
+| `cleaning_time`           | minutes             | Last / actual cleaning time in minutes                         |
+| `cleaned_area`            | square meter        | Last / actual cleaned area in square meters                    |
+| `main_brush_left`         | hours               | Hours left until a change of the main brush is needed          |
+| `side_brush_left`         | hours               | Hours left until a change of the side brush is needed          |
+| `filter_left`             | hours               | Hours left until a change of the filter is needed              |
+| `sensor_dirty_left`       | hours               | Hours left until the wall and cliff sensors should be cleaned  |
+| `cleaning_count`          |                     | Number of total cleaning cycles                                |
+| `total_cleaned_area`      | square meter        | Total cleaned area in square meters                            |
+| `total_cleaning_time`     | minutes             | Total cleaning time in minutes                                 |
+| `clean_start`             | datetime            | The last date/time the vacuum started cleaning (offset naive)  |
+| `clean_end`               | datetime            | The last date/time the vacuum finished cleaning (offset naive) |
 
 ## Retrieving the Access Token
 
@@ -224,7 +230,7 @@ This token (32 hexadecimal characters) is required for the Xiaomi Mi Robot Vacuu
 
 ### Android (not rooted)
 
-> If using an Android device to retrieve the Access Token only `v5.4.49` of Mi Home is confirmed working (December 2019).  
+> If using an Android device to retrieve the Access Token only `v5.4.49` of Mi Home is confirmed working (December 2019).
 
 1. To begin, set up your Robovac with the latest version of Mi Home on your primary Android device as you normally would.
 2. Using `v5.4.49` of Mi Home locate a text file under the `Smarthome/logs` folder where the 32 character token is stored.
@@ -333,11 +339,36 @@ vacuum_kitchen:
 
 Where params specify room numbers, for multiple rooms, params can be specified like `[17,18]`.
 
-Valid room numbers can be retrieved using miio command-line tool. It will only give room numbers and not the room names. To get the room names, one can just test the app_segment_clean command and see which room it cleans. 
+Valid room numbers can be retrieved using miio command-line tool. It will only give room numbers and not the room names. To get the room names, one can just test the app_segment_clean command and see which room it cleans.
 
 ```bash
 miio protocol call <ip of the vacuum> get_room_mapping
 ```
+
+## Example on how to reset maintenance hours (brushes, filter, sensors)
+
+The vacuum entity stores attribute values for when brushes, filters and sensors need to be
+cleaned or replaced (`main_brush_left`, `side_brush_left`, `filter_left` and
+`sensor_dirty_left`).  The values are measured in hours. Once the parts are cleaned
+or replaced you can then reset those values on the vacuum.  Here is an example script using
+[`vacuum.send_command`](/integrations/vacuum/) to reset the hours for the main brush:
+
+```yaml
+reset_main_brush_left:
+  alias: "Reset hours for main brush replacement"
+  sequence:
+    - service: vacuum.send_Command
+      data:
+        entity_id: vacuum.xiaomi_vacuum_cleaner
+        command: reset_consumable
+        params: ['main_brush_work_time']
+```
+
+Allowed `params` for the `reset_consumable` command:
+* `['main_brush_work_time']`
+* `['side_brush_work_time']`
+* `['filter_work_time']`
+* `['sensor_dirty_time']`
 
 ## Retrieving Zoned Cleaning Coordinates
 


### PR DESCRIPTION
**Description:**

Added some missing device state attributes.  Also added an example on how to reset the counter for consumables (filter, brushes and sensors).



## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
