### PR TITLE
Fix can't add multiple iCloud accounts (remove account name)

### DIFF
--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -56,10 +56,6 @@ password:
   description: Your iCloud account password.
   required: true
   type: string
-account_name:
-  description: A friendly name for your iCloud account. If this isn't given, it will use the part before the `@` of the username.
-  required: false
-  type: string
 max_interval:
   description: Maximum interval in minutes between subsequent location updates. This tracker uses dynamic intervals for requesting location updates. When the iPhone is stationary, the interval will eventually be set to `max_interval` to save battery. When the iPhone starts moving again, the interval will be dynamically updated to 1 min. Note that updating interval to 1 min might be delayed by maximum `max_interval` minutes. Minimum value is 1 min.
   required: false


### PR DESCRIPTION
**Description:**

Following parent PR.

**Pull request in home-assistant:** home-assistant/home-assistant#30898

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
