### PR TITLE
fixed small error in signal_messenger documentation

### DIFF
--- a/source/_integrations/signal_messenger.markdown
+++ b/source/_integrations/signal_messenger.markdown
@@ -79,5 +79,6 @@ action:
   service: notify.NOTIFIER_NAME
   data:
     message: "Alarm in the living room!"
-    attachment: "/tmp/surveillance_camera.jpg"
+    data:
+      attachment: "/tmp/surveillance_camera.jpg"
 ```


### PR DESCRIPTION
* 'data' section was missing

**Description:**

fixes a small documentation error in the signal_messenger integration (see https://github.com/home-assistant/home-assistant/issues/30838 for details)

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
