### PR TITLE
Update list of tp-link kasa supported devices

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -39,6 +39,7 @@ The following devices are known to work with this component.
 
 - HS107 (indoor 2-outlet)
 - HS300 (powerstrip 6-outlet)
+- HS303 (powerstrip 3-outlet)
 - KP400 (outdoor 2-outlet)
 - KP200 (indoor 2-outlet)
 


### PR DESCRIPTION
**Description:**
Update list of supported devices to include 'HS303 (powerstrip 3-outlet)'. I've confirmed this is working.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
