### PR TITLE
Prevent failure when reloading fail2ban

### DIFF
--- a/source/_cookbook/fail2ban.markdown
+++ b/source/_cookbook/fail2ban.markdown
@@ -87,8 +87,7 @@ filter = ha
 logpath = /home/homeassistant/.homeassistant/home-assistant.log
 
 # 3600 seconds = 1 hour
-bantime = 3600
-bantime = 30 # during testing it is useful to have a short ban interval, comment out this line later
+bantime = 30 # during testing it is useful to have a short ban interval, change this to 3600 later
 
 # Maximum amount of login attempts before IP is blocked
 maxretry = 3


### PR DESCRIPTION
**Description:** fail2ban complains about a double `bantime` directive when reloading the service, suggest people change the value later rather than include two statements in the configuration file

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#11814

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
