### PR TITLE
Add multiple TVs example to webostv

### DIFF
--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -106,7 +106,7 @@ webostv:
 Please note, the above provides a minimal example, however, all options are
 available for each individual TV.
 
-### Turn on action
+## Turn on action
 
 Home Assistant is able to turn on a LG webOS Smart TV if you specify an action, like HDMI-CEC or WakeOnLan.
 
@@ -133,11 +133,11 @@ notify:
 
 Any other [actions](/docs/automation/action/) to power on the device can be configured.
 
-### Sources
+## Sources
 
 To obtain complete list of available sources currently configured on the TV, once the webOS TV is configured and linked, while its powered on head to the **Developer Tools** > **States**, find your `media_player.<name>` and use the sources listed in `source_list:` remembering to split them per line into your `sources:` configuration.
 
-### Change channel through play_media service
+## Change channel through play_media service
 
 The `play_media` service can be used in a script to switch to the specified tv channel. It selects the best matching channel according to the `media_content_id` parameter:
 
@@ -161,32 +161,32 @@ data:
   media_content_type: "channel"
 ```
 
-### Next/Previous buttons
+## Next/Previous buttons
 
 The behaviour of the next and previous buttons is different depending on the active source:
 
 - if the source is 'LiveTV' (television): next/previous buttons act as channel up/down
 - otherwise: next/previous buttons act as next/previous track
 
-### Generic commands and buttons
+## Services
 
 Available services: `button`, `command`
 
-#### Service `webostv.button`
+### Service `webostv.button`
 
 | Service data attribute | Optional | Description                                                                                                                                                                                                                                                                            |
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | Target a specific webostv media player.                                                                                                                                                                                                                                                |
 | `button`               | no       | Name of the button. Known possible values are `LEFT`, `RIGHT`, `DOWN`, `UP`, `HOME`, `BACK`, `ENTER`, `DASH`, `INFO`, `ASTERISK`, `CC`, `EXIT`, `MUTE`, `RED`, `GREEN`, `BLUE`, `VOLUMEUP`, `VOLUMEDOWN`, `CHANNELUP`, `CHANNELDOWN`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9` |
 
-#### Service `webostv.command`
+### Service `webostv.command`
 
 | Service data attribute | Optional | Description                                                                                                                                                                          |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `entity_id`            | no       | Target a specific webostv media player.                                                                                                                                              |
 | `command`              | no       | Endpoint for the command, e.g. `media.controls/rewind`.  The full list of known endpoints is available at <https://github.com/bendavid/aiopylgtv/blob/master/aiopylgtv/endpoints.py> |
 
-#### Example
+### Example
 
 ```yaml
 script:

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -18,14 +18,13 @@ There is currently support for the following device types within Home Assistant:
 - [Media Player](#media-player)
 - [Notifications](#notifications)
 
-
 To begin with enable *LG Connect Apps* feature in *Network* settings of the TV [instructions](https://www.lg.com/uk/support/product-help/CT00008334-1437131798537-others).
 
 Once basic configuration is added to your `configuration.yaml` file. A notification should be visible in the frontend's **Notification** section. Follow the instructions and accept the pairing request on your TV.
 
 Pairing information will be saved to a configuration file `webostv.conf` in the Home Assistant configuration directory. This process is IP address-sensitive, in case the IP address of your TV would change in future.
 
-### Configuration
+## Configuration
 
 To add a TV to your installation, add the following to your `configuration.yaml` file:
 
@@ -63,7 +62,7 @@ customize:
       type: list
 {% endconfiguration %}
 
-### Example
+### Full configuration example
 
 A full configuration example will look like the sample below:
 
@@ -83,13 +82,29 @@ webostv:
       - youtube
       - makotv
       - netflix
-        
+
 media_player:
 
 notify:
 ```
 
 Avoid using `[ ]` in the `name:` of your device.
+
+### Using multiple TVs
+
+It is also possible to use multiple TVs with this integration.
+
+```yaml
+# Example configuration.yaml entry with multiple TVs
+webostv:
+  - name: Living Room TV
+    host: 192.168.1.100
+  - name: Bedroom TV
+    host: 192.168.1.101
+```
+
+Please note, the above provides a minimal example, however, all options are
+available for each individual TV.
 
 ### Turn on action
 
@@ -150,8 +165,8 @@ data:
 
 The behaviour of the next and previous buttons is different depending on the active source:
 
- - if the source is 'LiveTV' (television): next/previous buttons act as channel up/down
- - otherwise: next/previous buttons act as next/previous track
+- if the source is 'LiveTV' (television): next/previous buttons act as channel up/down
+- otherwise: next/previous buttons act as next/previous track
 
 ### Generic commands and buttons
 
@@ -159,18 +174,18 @@ Available services: `button`, `command`
 
 #### Service `webostv.button`
 
-| Service data attribute | Optional | Description                                             |
-|------------------------|----------|---------------------------------------------------------|
-| `entity_id`            |       no | Target a specific webostv media player.                 |
-| `button`               |       no | Name of the button. Known possible values are `LEFT`, `RIGHT`, `DOWN`, `UP`, `HOME`, `BACK`, `ENTER`, `DASH`, `INFO`, `ASTERISK`, `CC`, `EXIT`, `MUTE`, `RED`, `GREEN`, `BLUE`, `VOLUMEUP`, `VOLUMEDOWN`, `CHANNELUP`, `CHANNELDOWN`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9` |
-        
+| Service data attribute | Optional | Description                                                                                                                                                                                                                                                                            |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `entity_id`            | no       | Target a specific webostv media player.                                                                                                                                                                                                                                                |
+| `button`               | no       | Name of the button. Known possible values are `LEFT`, `RIGHT`, `DOWN`, `UP`, `HOME`, `BACK`, `ENTER`, `DASH`, `INFO`, `ASTERISK`, `CC`, `EXIT`, `MUTE`, `RED`, `GREEN`, `BLUE`, `VOLUMEUP`, `VOLUMEDOWN`, `CHANNELUP`, `CHANNELDOWN`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9` |
+
 #### Service `webostv.command`
 
-| Service data attribute | Optional | Description                                             |
-|------------------------|----------|---------------------------------------------------------|
-| `entity_id`            |       no | Target a specific webostv media player.                 |
-| `command`              |       no | Endpoint for the command, e.g. `media.controls/rewind`.  The full list of known endpoints is available at https://github.com/bendavid/aiopylgtv/blob/master/aiopylgtv/endpoints.py |
-        
+| Service data attribute | Optional | Description                                                                                                                                                                          |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `entity_id`            | no       | Target a specific webostv media player.                                                                                                                                              |
+| `command`              | no       | Endpoint for the command, e.g. `media.controls/rewind`.  The full list of known endpoints is available at <https://github.com/bendavid/aiopylgtv/blob/master/aiopylgtv/endpoints.py> |
+
 #### Example
 
 ```yaml


### PR DESCRIPTION
**Description:**

Adds an example on how to use multiple TVs to the `webostv` integration. 
This question was asked quite a bit the past view days, in several locations, including this issue: home-assistant/home-assistant#30879.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
