### PR TITLE
Add documentation for zabbix item sensors

### DIFF
--- a/source/_components/sensor.zabbix.markdown
+++ b/source/_components/sensor.zabbix.markdown
@@ -1,8 +1,8 @@
 ---
 layout: page
 title: "Zabbix Sensor"
-description: "Instructions on how to integrate Zabbix Triggers sensors within Home Assistant."
-date: 2016-12-13 22:57
+description: "Instructions on how to integrate Zabbix Triggers and Item sensors within Home Assistant."
+date: 2020-01-20 11:57
 sidebar: true
 comments: false
 sharing: true
@@ -13,11 +13,13 @@ ha_release: 0.37
 ha_iot_class: "Local Polling"
 ---
 
-The `zabbix` sensor platform let you monitor the current count of active triggers for your [Zabbix](http://www.zabbix.com/) monitoring instance.
+The `zabbix` sensor platform let you monitor the current count of active triggers for your [Zabbix](http://www.zabbix.com/) monitoring instance, as well as loading items to fetch their latest value as sensors.
 
 <p class='note'>
 You must have the [Zabbix component](/components/zabbix/) configured to use those sensors.
 </p>
+
+## Trigger Count Sensors
 
 To set it up, add the following information to your `configuration.yaml` file:
 
@@ -33,7 +35,7 @@ sensor:
 
 {% configuration %}
 triggers:
-  description: Specifies that this sensor is for Zabbix 'triggers'. In the future there will be other Zabbix sensors.
+  description: Specifies that this sensor is for Zabbix 'triggers'.
   required: true
   type: string
 name:
@@ -48,5 +50,34 @@ individual:
   description: A 'true'/'false' to specify whether we should show individual sensors when a list of hostids is provided.  If false, the sensor state will be the count of all triggers for the specified hosts (or all hosts within the Zabbix instance, if hostids isn't provided).
   required: false
   type: boolean
-  {% endconfiguration %}
+{% endconfiguration %}
 
+## Item Value Sensors
+
+To set it up, add the following information to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: zabbix
+    items:
+      - id: 12345
+        name: Important Host Disk Usage
+      - id: 67890
+        name: Other Host CPU Usage
+```
+
+{% configuration %}
+items:
+  description: Specifies that this sensor is for Zabbix 'items'.
+  required: true
+  type: string
+name:
+  description: Allows you to specify the name for the Sensor, otherwise the item name, as stored in Zabbix, is used.
+  required: false
+  type: string
+id:
+  description: This is a single Zabbix itemid to retrieve the data for.
+  required: true
+  type: string
+{% endconfiguration %}

--- a/source/_components/sensor.zabbix.markdown
+++ b/source/_components/sensor.zabbix.markdown
@@ -2,7 +2,6 @@
 layout: page
 title: "Zabbix Sensor"
 description: "Instructions on how to integrate Zabbix Triggers and Item sensors within Home Assistant."
-date: 2020-01-20 11:57
 sidebar: true
 comments: false
 sharing: true


### PR DESCRIPTION
**Description:**
Add documentation for zabbix item sensors.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#31006

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
