### PR TITLE
Remove obsolete homebridge_* settings

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -27,6 +27,7 @@ Under the *Configuration* menu you'll find the *Customization* menu. If this men
 homeassistant:
   customize: !include customize.yaml
 ```
+
 #### Possible values
 
 {% configuration customize %}
@@ -34,17 +35,8 @@ friendly_name:
   description: Name of the entity as displayed in the UI.
   required: false
   type: string
-homebridge_name:
-  description: Name of the entity in `HomeBridge`.
-  required: false
-  type: string
 hidden:
   description: Set to `true` to hide the entity.
-  required: false
-  type: boolean
-  default: false
-homebridge_hidden:
-  description: Set to `true` to hide the entity from `HomeBridge`.
   required: false
   type: boolean
   default: false
@@ -133,7 +125,6 @@ homeassistant:
     "scene.month_*_colors":
       hidden: true
       emulated_hue_hidden: false
-      homebridge_hidden: true
 ```
 
 ### Reloading customize

--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -76,13 +76,14 @@ When providing `select_source` as a command, it is recommended to also provide t
 
 ## Usage examples
 
-#### Chromecast & Kodi control with switches
+### Chromecast & Kodi control with switches
 
 In this example, a switch is available to control the power of the television. Switches are also available to turn the volume up, turn the volume down, and mute the audio. These could be command line switches or any other entity in Home Assistant. The `turn_on` and `turn_off` commands will be redirected to the television, and the volume commands will be redirected to an audio receiver. The `select_source` command will be passed directly to an A/V receiver.
 
 The children are a Chromecast and a Kodi player. If the Chromecast is playing, the Universal Media Player will reflect its status. If the Chromecast is idle and Kodi is playing, the universal media player will change to reflect its status.
 
 {% raw %}
+
 ```yaml
 media_player:
   platform: universal
@@ -129,6 +130,7 @@ media_player:
     source: media_player.receiver|source
     source_list: media_player.receiver|source_list
 ```
+
 {% endraw %}
 
 #### Kodi CEC-TV control
@@ -139,24 +141,19 @@ We store the state of the attached TV in a hidden [input boolean](/integrations/
 
 Because the input boolean used to store the TV state is only changing when using the Home Assistant `turn_on` and `turn_off` actions, and Kodi could be controlled by so many ways, we also define some automations to update this Input Boolean when needed.
 
-In an Apple HomeKit scene, we can now expose this universal media player as an on/off switch in Homebridge, and, that way, use Siri to turn on and off the TV.
-
 The complete configuration is:
 
 {% raw %}
+
 ```yaml
 homeassistant:
   customize:
     input_boolean.kodi_tv_state:
       hidden: true
-      homebridge_hidden: true
     media_player.kodi:
       hidden: true
-      homebridge_hidden: true
     media_player.kodi_tv:
       friendly_name: Kodi
-      homebridge_name: Kodi
-      homebridge_media_player_switch: on_off
 
 input_boolean:
   kodi_tv_state:
@@ -236,4 +233,5 @@ automation:
   - service: media_player.turn_off
     entity_id: media_player.kodi_tv
 ```
+
 {% endraw %}


### PR DESCRIPTION
**Description:**

Remove the custom attributes for HomeBridge.
The thing has been deprecated since 2018: <https://github.com/home-assistant/homebridge-homeassistant>

Nothing in our active backend uses them. It is just the documentation that still has them. This PR removes it.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
