### PR TITLE
Update tplink.markdown

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -39,7 +39,7 @@ The following devices are known to work with this component.
 
 - HS107 (indoor 2-outlet)
 - HS300 (powerstrip 6-outlet)
-- HS303 (powerstrip 3-outlet)
+- KP303 (powerstrip 3-outlet)
 - KP400 (outdoor 2-outlet)
 - KP200 (indoor 2-outlet)
 


### PR DESCRIPTION
**Description:**
I got the device model number wrong in #11805, it's KP303, not HS303, apologies.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
