### PR TITLE
Add note about hosting files in www folder

### DIFF
--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -162,6 +162,12 @@ If you want to use Home Assistant to host or serve static files then create a di
 
 </div>
 
+<div class='note warning'>
+
+  Files served from the `www`/`local` folder, aren't protected by the Home Assistant authentication. Files stored in this folder, if the URL is known, can be accessed by anybody without authentication.
+
+</div>
+
 ## Binary Sensor
 
 The HTTP binary sensor is dynamically created with the first request that is made to its URL. You don't have to define it in the configuration first.


### PR DESCRIPTION
**Description:**

This PR adds a note about files services from the `www`/`local` aren't protected by Home Assistant's auth.

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
