### PR TITLE
CDO update of zha.markdown

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -21,7 +21,7 @@ ha_codeowners:
 ---
 
 [Zigbee Home Automation](https://zigbee.org/zigbee-for-developers/applicationstandards/zigbeehomeautomation/)
-integration for Home Assistant allows you to connect many off-the-shelf Zigbee based devices to Home Assistant, using one of the available Zigbee radio modules that is compatible with [Zigpy](https://github.com/zigpy/zigpy) (an open source Python library implementing a Zigbee stack, which in turn relies on separate libraries which can each interface a with Zigbee radio module a different manufacturer).
+integration for Home Assistant allows you to connect many off-the-shelf Zigbee based devices to Home Assistant, using one of the available Zigbee radio modules that is compatible with [zigpy](https://github.com/zigpy/zigpy) (an open source Python library implementing a Zigbee stack, which in turn relies on separate libraries which can each interface a with Zigbee radio module a different manufacturer).
 
 There is currently support for the following device types within Home Assistant:
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -21,17 +21,17 @@ ha_codeowners:
 ---
 
 [Zigbee Home Automation](https://zigbee.org/zigbee-for-developers/applicationstandards/zigbeehomeautomation/)
-integration for Home Assistant allows you to connect many off-the-shelf Zigbee based devices to Home Assistant, using one of the available Zigbee radio modules compatible with [zigpy](https://github.com/zigpy/zigpy) (an open source Python library implementing a Zigbee stack, which in turn relies on separate libraries which can each interface a with Zigbee radio module a different manufacturer).
+integration for Home Assistant allows you to connect many off-the-shelf Zigbee based devices to Home Assistant, using one of the available Zigbee radio modules that is compatible with [Zigpy](https://github.com/zigpy/zigpy) (an open source Python library implementing a Zigbee stack, which in turn relies on separate libraries which can each interface a with Zigbee radio module a different manufacturer).
 
 There is currently support for the following device types within Home Assistant:
 
 - Binary Sensor
-- Sensor
+- Cover
+- Fan
 - Light
 - Lock
+- Sensor
 - Switch
-- Fan
-- Cover
 
 ## ZHA exception and deviation handling
 


### PR DESCRIPTION
**Description:**

Change to alphabetical order when sorting the list with supported ZHA device types, same as in Z-Wave documentation.

https://www.home-assistant.io/integrations/zwave vs https://www.home-assistant.io/integrations/zha/

CDO, it's like OCD but all the letters are in the alphabetical order, AS THEY SHOULD BE!

**Pull request in home-assistant (if applicable):** Not applicable

## Checklist:

Note! I did the PR against the `next` branch instead of the `current` branch because PR #11695 which adds "Cover" to that list where sort order changed is only in the `next` branch and not the `current` branch.

- [X] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
