### PR TITLE
Fix the NS API and product name

### DIFF
--- a/source/_integrations/nederlandse_spoorwegen.markdown
+++ b/source/_integrations/nederlandse_spoorwegen.markdown
@@ -10,7 +10,7 @@ ha_release: 0.57
 
 This sensor will provide you with time table information of the [Nederlandse Spoorwegen](https://www.ns.nl/) train service in the Netherlands.
 
-To obtain an API key, create an account on the [NS API-Portaal](https://apiportal.ns.nl/) and obtain an API key for the `RetrieveTripInformationPublicAPI` API.
+To obtain an API key, create an account on the [NS API-Portaal](https://apiportal.ns.nl/) and obtain an API key for the `Reisinformatie` API which is part of the `Ns-App` product.
 
 The `nederlandse_spoorwegen` integration can be configured using `configuration.yaml` as shown below:
 


### PR DESCRIPTION
## Proposed change
The NS company deprecates an API on 31-01-2020. This PR guides the user to the correct new API.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/home-assistant#30971
- This PR fixes or closes issue:

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
