### PR TITLE
Improve cache busting

### DIFF
--- a/plugins/cache_buster.rb
+++ b/plugins/cache_buster.rb
@@ -1,0 +1,10 @@
+module Jekyll
+  module CacheBuster
+    require 'digest/md5'
+    def cache_buster(file_name)
+      [file_name, '?', Digest::MD5.hexdigest(File.read(File.join('./source', file_name)))].join
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::CacheBuster)

--- a/source/_includes/javascripts/scripts.html
+++ b/source/_includes/javascripts/scripts.html
@@ -5,7 +5,7 @@ g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js
 s.parentNode.insertBefore(g,s)}(document,'script'));
 </script>
 
-<script src="/javascripts/prism.js?{{ site.time | date: '%s' }}" type="text/javascript"></script>
+<script src="{{ '/javascripts/prism.js' | cache_buster }}" type="text/javascript"></script>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>

--- a/source/_includes/site/head.html
+++ b/source/_includes/site/head.html
@@ -28,8 +28,8 @@
     <meta name="twitter:description" content="{{ page.description | default: site.description | strip_html | truncate: 200 }}">
     <meta name="twitter:image" content="{{ page.og_image | default: "/images/default-social.png" | prepend: site.url }}">
 
-        <link href="/stylesheets/prism.css?{{ site.time | date: '%s' }}" rel="stylesheet">
-        <link href="/stylesheets/screen.css?{{ site.time | date: '%s' }}" media="screen, projection, print" rel="stylesheet">
+    <link href="{{ '/stylesheets/prism.css' | cache_buster }}" rel="stylesheet">
+    <link href="{{ '/stylesheets/screen.css' | cache_buster }}" media="screen, projection, print" rel="stylesheet">
     <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{ site.title }}" type="application/atom+xml">
     <link rel='shortcut icon' href='/images/favicon.ico' />
     <link rel='icon' type='image/png' href='/images/favicon-192x192.png' sizes='192x192' />


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR replaced the previously used CSS/JS caching busting method (which was a timestamp). Instead, I wrote a tiny Jekyll plugin, that hashes the css/js file used and uses that hash instead of the time.

As a result, if the css/js doesn't change, the hash doesn't change.

- It allows us to use CloudFlare caching more efficiently as it will not invalidate every deploy.
- Deployment processing is faster, previously all files in our site changed because the date changed. The hash doesn't change that often, so fewer files to deploy during sync.


## Type of change
<!--
    What types of changes does your PR introduce to our documention/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
