### PR TITLE
Correct sighthound.markdown

### DIFF
--- a/source/_integrations/sighthound.markdown
+++ b/source/_integrations/sighthound.markdown
@@ -10,9 +10,9 @@ ha_iot_class: Cloud Polling
 
 Adds integration for person detection with [Sighthound Cloud](https://www.sighthound.com/products/cloud). The Sighthound Developer tier (free for non-commercial use) allows 5000 requests per month. If you need more requests per month you will need to sign up for a production account (i.e., Basic or Pro account).
 
-This integration adds an image processing entity where the state of the entity is the number of people detected in an image. For each person detected, an `image_processing.person_detected` event is fired. The event data includes the entity_id of the image processing entity firing the event, and the bounding box around the detected person. 
+This integration adds an image processing entity where the state of the entity is the number of people detected in an image. For each person detected, an `sighthound.person_detected` event is fired. The event data includes the entity_id of the image processing entity firing the event, and the bounding box around the detected person. 
 
-**Note** that in order to prevent accidentally using up your requets to Sighthound, by default the component will not automatically scan images, but requires you to call the `image_processing.scan` service e.g. using an automation triggered by motion. Alternativley, periodic scanning can be enabled by configuring a `scan_interval`.
+**Note** that in order to prevent accidentally using up your requets to Sighthound, by default the component will not automatically scan images, but requires you to call the `image_processing.scan` service e.g. using an automation triggered by motion.
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed change
Fixes incorrectly named event, and removes reference to `scan_interval` which is not functional.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
