### PR TITLE
Remove deprecation warnings from 0.42

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -22,12 +22,6 @@ automation:
       mood: happy
 ```
 
-<div class='note warning'>
-
-Starting 0.42, it is no longer possible to listen for event `homeassistant_start`. Use the 'homeassistant' platform below instead.
-
-</div>
-
 ### Home Assistant trigger
 
 Triggers when Home Assistant starts up or shuts down.

--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -8,62 +8,49 @@ The core of Home Assistant is the event bus. The event bus allows any integratio
 
 Home Assistant contains a few built-in events that are used to coordinate between various components.
 
-### Event `homeassistant_start`
-Event `homeassistant_start` is fired when all integrations from the configuration have been initialized. This is the event that will start the timer firing off `time_changed` events.
-
-<div class='note warning'>
-
-  Starting 0.42, it is no longer possible to listen for event `homeassistant_start`. Use the 'homeassistant' [platform](/docs/automation/trigger) instead.
-
-</div>
-
-### Event `homeassistant_stop`
-Event `homeassistant_stop` is fired when Home Assistant is shutting down. It should be used to close any open connection or release any resources.
-
-
 ### Event `state_changed`
 Event `state_changed` is fired when a state changes. Both `old_state` and `new_state` are state objects. [Documentation about state objects.](/topics/state_object/)
 
-Field | Description
------ | -----------
-`entity_id` | Entity ID of the changed entity. Example: `light.kitchen`
-`old_state` | The previous state of the entity before it changed. This field is omitted if the entity is new.
-`new_state` | The new state of the entity. This field is omitted if the entity is removed from the state machine.
+| Field       | Description                                                                                         |
+| ----------- | --------------------------------------------------------------------------------------------------- |
+| `entity_id` | Entity ID of the changed entity. Example: `light.kitchen`                                           |
+| `old_state` | The previous state of the entity before it changed. This field is omitted if the entity is new.     |
+| `new_state` | The new state of the entity. This field is omitted if the entity is removed from the state machine. |
 
 
 ### Event `time_changed`
 Event `time_changed` is fired every second by the timer and contains the current time.
 
-Field | Description
------ | -----------
-`now` | A [datetime object](https://docs.python.org/3.4/library/datetime.html#datetime.datetime) containing the current time in UTC.
+| Field | Description                                                                                                                  |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `now` | A [datetime object](https://docs.python.org/3.4/library/datetime.html#datetime.datetime) containing the current time in UTC. |
 
 
 ### Event `service_registered`
 Event `service_registered` is fired when a new service has been registered within Home Assistant.
 
-Field | Description
------ | -----------
-`domain` | Domain of the service. Example: `light`.
-`service` | The service to call. Example: `turn_on`
+| Field     | Description                              |
+| --------- | ---------------------------------------- |
+| `domain`  | Domain of the service. Example: `light`. |
+| `service` | The service to call. Example: `turn_on`  |
 
 
 ### Event `call_service`
 Event `call_service` is fired to call a service.
 
-Field | Description
------ | -----------
-`domain` | Domain of the service. Example: `light`.
-`service` | The service to call. Example: `turn_on`
-`service_data` | Dictionary with the service call parameters. Example: `{ 'brightness': 120 }`.
-`service_call_id` | String with a unique call id. Example: `23123-4`.
+| Field             | Description                                                                    |
+| ----------------- | ------------------------------------------------------------------------------ |
+| `domain`          | Domain of the service. Example: `light`.                                       |
+| `service`         | The service to call. Example: `turn_on`                                        |
+| `service_data`    | Dictionary with the service call parameters. Example: `{ 'brightness': 120 }`. |
+| `service_call_id` | String with a unique call id. Example: `23123-4`.                              |
 
 ### Event `service_executed`
 Event `service_executed` is fired by the service handler to indicate the service is done.
 
-Field | Description
------ | -----------
-`service_call_id` | String with the unique call id of the service call that was executed. Example: `23123-4`.
+| Field             | Description                                                                               |
+| ----------------- | ----------------------------------------------------------------------------------------- |
+| `service_call_id` | String with the unique call id of the service call that was executed. Example: `23123-4`. |
 
 <div class='note warning'>
 
@@ -75,15 +62,15 @@ Field | Description
 
 Event `platform_discovered` is fired when a new platform has been discovered by the [`discovery`](/integrations/discovery/) component.
 
-Field | Description
------ | -----------
-`service` | The platform that is discovered. Example: `zwave`.
-`discovered` | Dictionary containing discovery information. Example: `{ "host": "192.168.1.10", "port": 8889}`.
+| Field        | Description                                                                                      |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| `service`    | The platform that is discovered. Example: `zwave`.                                               |
+| `discovered` | Dictionary containing discovery information. Example: `{ "host": "192.168.1.10", "port": 8889}`. |
 
 
 ### Event `component_loaded`
 Event `component_loaded` is fired when a new integration has been loaded and initialized.
 
-Field | Description
------ | -----------
-`component` | Domain of the integration that has just been initialized. Example: `light`.
+| Field       | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `component` | Domain of the integration that has just been initialized. Example: `light`. |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

0.42 is kinda in the past...

## Type of change
<!--
    What types of changes does your PR introduce to our documention/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
