### PR TITLE
Update miflora documentation: add go_unavailable_timeout

### DIFF
--- a/source/_integrations/miflora.markdown
+++ b/source/_integrations/miflora.markdown
@@ -144,6 +144,6 @@ An automation example to report a battery failure:
     to: unavailable
   action:
   - data_template:
-      message: "Flower 1 Moisture is {{states('sensor.kiwi_moisture') }}"
+      message: "Flower 1 moisture is {{states('sensor.flower1_moisture') }} for more than 24 hours"
     service: notify.notifier_telegram_someone
 ```

--- a/source/_integrations/miflora.markdown
+++ b/source/_integrations/miflora.markdown
@@ -99,6 +99,11 @@ adapter:
   required: false
   default: hci0
   type: string
+go_unavailable_timeout:
+  description: "Timeout to report this device as unavailable. This option hides a bad link quality"
+  required: false
+  default: 7200
+  type: time_period
 {% endconfiguration %}
 
 <div class='note warning'>
@@ -119,10 +124,26 @@ sensor:
     name: Flower 1
     force_update: true    
     median: 3
+    go_unavailable_timeout: 43200
     monitored_conditions:
       - moisture
       - light
       - temperature
       - conductivity
       - battery
+```
+An automation example to report a battery failure:
+
+```yaml
+- id: flower1_moisture_unavailable_check
+  alias: Flower 1 sensors available
+  trigger:
+  - entity_id: sensor.flower1_moisture
+    for: 24:00:00
+    platform: state
+    to: unavailable
+  action:
+  - data_template:
+      message: "Flower 1 Moisture is {{states('sensor.kiwi_moisture') }}"
+    service: notify.notifier_telegram_someone
 ```

--- a/source/_integrations/miflora.markdown
+++ b/source/_integrations/miflora.markdown
@@ -144,6 +144,6 @@ An automation example to report a battery failure:
     to: unavailable
   action:
   - data_template:
-      message: "Flower 1 moisture is {{states('sensor.flower1_moisture') }} for more than 24 hours"
+      message: "Flower 1 moisture is unavailable for more than 24 hours"
     service: notify.notifier_telegram_someone
 ```

--- a/source/_integrations/miflora.markdown
+++ b/source/_integrations/miflora.markdown
@@ -103,7 +103,7 @@ go_unavailable_timeout:
   description: "Timeout to report this device as unavailable. This option hides a bad link quality"
   required: false
   default: 7200
-  type: time_period
+  type: integer
 {% endconfiguration %}
 
 <div class='note warning'>


### PR DESCRIPTION
## Proposed change
Add documentation for go_unavailable_timeout in miflora/sensors.py


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- This PR is related to https://github.com/home-assistant/home-assistant/pull/31156

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

