### PR TITLE
Update netgear.markdown

### DIFF
--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -69,5 +69,6 @@ The use of `devices` or `exclude` is recommended when using `accesspoints` to av
 List of models that are known to use port 80:
 - Nighthawk X4S - AC2600 (R7800)
 - Orbi
+- XR500
 
 See the [device tracker integration page](/integrations/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
## Proposed change
Tested with my XR500 Router and it worked only on Port 80


## Type of change
1 line of  text

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
