### PR TITLE
Mark HomematicIP Cloud with platinum QS 

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -14,6 +14,7 @@ ha_category:
 ha_iot_class: Cloud Push
 ha_release: 0.66
 ha_config_flow: true
+ha_quality_scale: platinum
 ha_codeowners:
   - '@SukramJ'
 ---
@@ -288,6 +289,8 @@ Push button devices are only available with a battery sensor. This is due to a l
 It's not possible to detect a key press event on these devices at the moment.
 
   * Remote Control - 8 buttons (*HmIP-RC8*)
+  * Wall-mount Remote Control for brand switches - 2-button (*HmIP-BRC2*)
+  * Motion Detector for 55mm frames - indoor (HmIP-SMI55)(Push button)
   * Wall-mount Remote Control - 2-button (*HmIP-WRC2*)
   * Wall-mount Remote Control - 6-button (*HmIP-WRC6*)
   * Key Ring Remote Control - 4 buttons (*HmIP-KRC4*)


### PR DESCRIPTION
## Proposed change
- Mark HomematicIP Cloud with QS platinum (already confirmed in [#31133](https://github.com/home-assistant/home-assistant/pull/31133)
- Add devices

## Type of change
<!--
    What types of changes does your PR introduce to our documention/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#31133](https://github.com/home-assistant/home-assistant/pull/31133))
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
