### PR TITLE
Link media_player was wrong

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -81,7 +81,7 @@ Device class is currently supported by the following components:
 * [Binary Sensor](/integrations/binary_sensor/)
 * [Sensor](/integrations/sensor/)
 * [Cover](/integrations/cover/)
-* [Media Player](integrations/media_player/)
+* [Media Player](/integrations/media_player/)
 
 ### Manual customization
 


### PR DESCRIPTION
## Proposed change
Link media_player was wrong



## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
