### PR TITLE
Add service to Velbus

### DIFF
--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -54,6 +54,32 @@ port:
   type: string
 {% endconfiguration %}
 
+### Service `velbus.sync_clock`
+
+You can use the service `velbus.sync clock` to synchronize the clock of the velbus modules to the clock of the machine running Home Assistant. This is the same as the 'sync clock' button at the VelbusLink software.
+
+### Service `velbus.set_memo_text`
+
+You can use the service `velbus.set_memo_text` to provide the memo text to be displayed at Velbus modules like VMBGPO(D) and VMBELO.
+
+| Service data attribute | Optional | Description                              |
+| ---------------------- | -------- | ---------------------------------------- |
+| `address`              | no       | The module address in decimal format, which is displayed at the device list at the integration page. |
+| `memo_text`            | yes      | Text to be displayed on module. When no memo text is supplied the memo text will be cleared. |
+
+Example:
+
+```yaml
+script:
+  trash_memo:
+    alias: Trash memo text
+    sequence:
+    - data:
+        address: 65
+        memo_text: "It's trash day"
+      service: velbus.set_memo_text
+```
+
 ## Example automation
 
 The Velbus integration allows you to link a Velbus button (i.e., a button of a [VMBGPOD](https://www.velbus.eu/products/view/?id=416302&lang=en) module) to a controllable entity of Home Assistant.

--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -54,6 +54,11 @@ port:
   type: string
 {% endconfiguration %}
 
+## Services
+
+- `velbus.sync clock`: Synchronize Velbus time to local clock.
+- `velbus.set_memo_text`: Show memo text on Velbus display modules.
+
 ### Service `velbus.sync_clock`
 
 You can use the service `velbus.sync clock` to synchronize the clock of the velbus modules to the clock of the machine running Home Assistant. This is the same as the 'sync clock' button at the VelbusLink software.

--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -56,7 +56,7 @@ port:
 
 ### Service `velbus.sync_clock`
 
-You can use the service `velbus.sync clock` to synchronize the clock of the velbus modules to the clock of the machine running Home Assistant. This is the same as the 'sync clock' button at the VelbusLink software.
+You can use the service `velbus.sync clock` to synchronize the clock of the Velbus modules to the clock of the machine running Home Assistant. This is the same as the 'sync clock' button at the VelbusLink software.
 
 ### Service `velbus.set_memo_text`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add description for both **_sync_clock_** and **_set_memo_text_** services of the Velbus integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
Service for _**sync_clock**_ is currently available in current release. The **_set_memo_text_** service will be available after applying the mentioned PR below.

- Link to parent pull request in the codebase: [#31222](https://github.com/home-assistant/home-assistant/pull/31222)
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
