### PR TITLE
Update to explain preset_mode variables

### DIFF
--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -130,7 +130,7 @@ A _preset_ is an override of the target temperature defined in the
 currently active climate. The temperature targeted in the preset mode may be
 explicitly set (temperature preset), it may be derived from a reference
 climate (home, away, sleep, etc.), or it may be derived from a vacation
-defined by the thermostat. All holds are temporary. Temperature and
+defined by the thermostat. The preset_modes list on Ecobee thermostat is defined as smart1 through smartx.  The numbers enumerate the valid modes that have been defined in the list.  All holds are temporary. Temperature and
 climate holds expire when the thermostat transitions to the next climate
 defined in its program. A vacation hold starts at the beginning of the
 defined vacation period and expires when the vacation period ends.


### PR DESCRIPTION
Ecobee preset_mode is not the name of the preset mode but instead smart1 through smartx.  Forums and PR back in 0.97 updated this ability for the API but the documentation was not reflecting that important note.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
