### PR TITLE
Add scan_interval info to Android TV integration

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -101,6 +101,10 @@ turn_off_command:
   type: string
 {% endconfiguration %}
 
+<div class='note'>
+By default the device is polled for state changes every 10 seconds. You can increase this interval by specifying [`scan_interval`](/docs/configuration/platform_options/#scan-interval).
+</div>
+
 ### Full Configuration
 
 ```yaml


### PR DESCRIPTION
## Proposed change

There was no mention that the integration is polling the device every 10 seconds by default. Luckily this can be changed by the `scan_interval` option.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
