### PR TITLE
Added opening and closing states to the MQTT cover

### DIFF
--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -12,8 +12,8 @@ The `mqtt` cover platform allows you to control an MQTT cover (such as blinds, a
 
 ## Configuration
 
-The device state (`open` or `closed`) will be updated only after a new message is published on `state_topic` matching `state_open` or `state_closed`. If these messages are published with the `retain` flag set, the cover will receive an instant state update after subscription and Home Assistant will display the correct state on startup. Otherwise, the initial state displayed in Home Assistant will be `unknown`.
-`state_topic` can only manage `state_open` and `state_closed`. No percentage positions etc.
+The device state (`open`, `opening`, `closed` or `closing`) will be updated only after a new message is published on `state_topic` matching `state_open`, `state_opening`, `state_closed` or `state_closing`. If these messages are published with the `retain` flag set, the cover will receive an instant state update after subscription and Home Assistant will display the correct state on startup. Otherwise, the initial state displayed in Home Assistant will be `unknown`.
+`state_topic` can only manage `state_open`, `state_opening`, `state_closed` and `state_closing`. No percentage positions etc.
 
 For this purpose is `position_topic` which can set state of the cover and position.
 Default setting are 0 means the device is `closed` and all other intermediate positions means the device is `open`.
@@ -70,11 +70,21 @@ state_open:
   required: false
   type: string
   default: open
+state_opening:
+  description: The payload that represents the opening state.
+  required: false
+  type: string
+  default: opening
 state_closed:
   description: The payload that represents the closed state.
   required: false
   type: string
   default: closed
+state_closing:
+  description: The payload that represents the closing state.
+  required: false
+  type: string
+  default: closing
 position_topic:
   description: The MQTT topic subscribed to receive cover position messages. If `position_topic` is set `state_topic` is ignored.
   required: false
@@ -242,7 +252,9 @@ cover:
     payload_close: "CLOSE"
     payload_stop: "STOP"
     state_open: "open"
+    state_opening: "opening"
     state_closed: "closed"
+    state_closing: "closing"
     payload_available: "online"
     payload_not_available: "offline"
     optimistic: false
@@ -297,7 +309,9 @@ cover:
     payload_close: "CLOSE"
     payload_stop: "STOP"
     state_open: "open"
+    state_opening: "opening"
     state_closed: "closed"
+    state_closing: "closing"
     payload_available: "online"
     payload_not_available: "offline"
     optimistic: false


### PR DESCRIPTION
Updated the MQTT cover documentation with support for the opening and closing states.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updated the MQTT cover documentation with the additional opening and closing states I've added in a PR.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant/pull/31259
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
