### PR TITLE
Add note to Badges regarding Panel mode

### DIFF
--- a/source/lovelace/views.markdown
+++ b/source/lovelace/views.markdown
@@ -22,7 +22,7 @@ views:
       type: string
     badges:
       required: false
-      description: List of entities IDs or `badge` objects to display as badges.
+      description: List of entities IDs or `badge` objects to display as badges. Note: Badges do not show when view is in panel mode.
       type: list
     cards:
       required: false
@@ -144,7 +144,7 @@ views:
 
 ## Panel
 
-Setting panel true sets the view to panel mode. In this mode the first card is rendered full-width, other cards in the view will not be rendered. This mode is good when using cards like `map`, `stack` or `picture-elements`.
+Setting panel true sets the view to panel mode. In this mode the first card is rendered full-width, other cards in the view will not be rendered. This mode is good when using cards like `map`, `stack` or `picture-elements`. Note that badges will not appear in Panel Mode.
 
 #### Example
 

--- a/source/lovelace/views.markdown
+++ b/source/lovelace/views.markdown
@@ -22,7 +22,7 @@ views:
       type: string
     badges:
       required: false
-      description: List of entities IDs or `badge` objects to display as badges. Note: Badges do not show when view is in panel mode.
+      description: List of entities IDs or `badge` objects to display as badges. Note that badges do not show when view is in panel mode.
       type: list
     cards:
       required: false


### PR DESCRIPTION
Clarify that badges do not show when view is in panel mode.

## Proposed change
Just a clarification that Badges are ignored in Panel Mode views.  I've never really used them before so this was new to me.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.



- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
