### PR TITLE
Fix configuration and example in template alarm_control_panel

### DIFF
--- a/source/_integrations/alarm_control_panel.template.markdown
+++ b/source/_integrations/alarm_control_panel.template.markdown
@@ -31,57 +31,71 @@ To enable a Template Alarm Control Panel in your installation, add the following
 # Example configuration.yaml entry
 alarm_control_panel:
   - platform: template
-    name: Safe Alarm Panel
-    value_template: "{{ states('alarm_control_panel.real_alarm') }}"
-    arm_away:
-      service: alarm_control_panel.alarm_arm_away
-      data:
-        entity_id: alarm_control_panel.real_alarm
-        code: !secret alarm_code
-    arm_home:
-      service: alarm_control_panel.alarm_arm_home
-      data:
-        entity_id: alarm_control_panel.real_alarm
-        code: !secret alarm_code
-    disarm:
-      - condition: state
-        entity_id: device_tracker.paulus
-        state: 'home'
-      - service: alarm_control_panel.alarm_arm_home
-        data:
-          entity_id: alarm_control_panel.real_alarm
-          code: !secret alarm_code
+    panels:
+      safe_alarm_panel:
+        value_template: "{{ states('alarm_control_panel.real_alarm') }}"
+        arm_away:
+          service: alarm_control_panel.alarm_arm_away
+          data:
+            entity_id: alarm_control_panel.real_alarm
+            code: !secret alarm_code
+        arm_home:
+          service: alarm_control_panel.alarm_arm_home
+          data:
+            entity_id: alarm_control_panel.real_alarm
+            code: !secret alarm_code
+        disarm:
+          - condition: state
+            entity_id: device_tracker.paulus
+            state: 'home'
+          - service: alarm_control_panel.alarm_arm_home
+            data:
+              entity_id: alarm_control_panel.real_alarm
+              code: !secret alarm_code
 ```
 
 {% endraw %}
 
 {% configuration %}
-  name:
-    description: Name to use in the frontend.
-    required: false
-    type: string
-    default: Template Alarm Control Panel
-  value_template:
-    description: "Defines a template to set the state of the alarm panel. Only the states `armed_away`, `armed_home`, `armed_night`, `disarmed`, `triggered` and `unavailable` are used."
-    required: false
-    type: template
-  disarm:
-    description: Defines an action to run when the alarm is disarmed.
-    required: false
-    type: action
-  arm_away:
-    description: Defines an action to run when the alarm is armed to away mode.
-    required: false
-    type: action
-  arm_home:
-    description: Defines an action to run when the alarm is armed to home mode.
-    required: false
-    type: action
-  arm_night:
-    description: Defines an action to run when the alarm is armed to night mode.
-    required: false
-    type: action
+panels:
+  description: List of your panels.
+  required: true
+  type: map
+  keys:
+    alarm_control_panel_name:
+      description: The slug of the panel.
+      required: true
+      type: map
+      keys:
+        name:
+          description: Name to use in the frontend.
+          required: false
+          type: string
+          default: Template Alarm Control Panel
+        value_template:
+          description: "Defines a template to set the state of the alarm panel. Only the states `armed_away`, `armed_home`, `armed_night`, `disarmed`, `triggered` and `unavailable` are used."
+          required: false
+          type: template
+        disarm:
+          description: Defines an action to run when the alarm is disarmed.
+          required: false
+          type: action
+        arm_away:
+          description: Defines an action to run when the alarm is armed to away mode.
+          required: false
+          type: action
+        arm_home:
+          description: Defines an action to run when the alarm is armed to home mode.
+          required: false
+          type: action
+        arm_night:
+          description: Defines an action to run when the alarm is armed to night mode.
+          required: false
+          type: action
 {% endconfiguration %}
+
+
+
 
 ## Considerations
 


### PR DESCRIPTION
## Proposed change

The configuration for template_alarm_control_panel currently doesn't work.  It is similar to the template sensor and template binary sensor, which I based the changes from.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
- [x] ADDED: None of the above - this is a new feature still in beta with incorrect documentation.
## Additional information
see [template sensor](https://github.com/home-assistant/home-assistant.io/blob/current/source/_integrations/template.markdown) and [template binary sensor](https://github.com/home-assistant/home-assistant.io/blob/current/source/_integrations/binary_sensor.template.markdown).  Note they have sightly different configuration sections, but I followed the binary sensor example as it seemed more comprehensive.

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant/pull/30487
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
