### PR TITLE
Fix latest-release-notes redirect

### DIFF
--- a/source/latest-release-notes/index.html
+++ b/source/latest-release-notes/index.html
@@ -1,7 +1,8 @@
 ---
 ---
 
-{% assign recent_release_post = site.categories['Release-Notes'].first %}
+{% assign posts = site.categories['Release-Notes'] | where_exp: "post", "post.title contains site.current_minor_version" %}
+{% assign recent_release_post = posts.first %}
 
 <script>
   document.location = '{{ recent_release_post.url }}{{ site.patch_version_notes }}';


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

We recently posted the release notes for Android, causing the latest release notes now to link to that.

This PR adds a little hacky but a working fix for that, by ensuring the release notes that are being redirected to, actually contains the current minor version in the release notes post title).

fixes #11909

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
