### PR TITLE
Add a note for pure Android boxes that also may work

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -12,6 +12,12 @@ ha_codeowners:
 
 The `androidtv` platform allows you to control an Android TV device or [Amazon Fire TV](https://www.amazon.com/b/?node=8521791011) device.
 
+<div class='note info'>
+  
+Some regular and pure Android boxes (not Android TV ones) allow this integration enabling just "USB debugging", with exactly the same control over network (ethernet or wifi) as this integration intents for Android TV implementation. Your mileage may vary.
+
+</div>
+
 ## Device preparation
 
 To set up your device, you will need to find its IP address and enable ADB debugging. For Android TV devices, please consult the documentation for your device.


### PR DESCRIPTION
## Proposed change
Some Android boxes, running pure Android implementation (for tablets), allow this integration to work as intended, enabling "USB debugging" option. No "Network debugging" is available through the configuration menu, but these activates in parallel the one needed over network connection as-well.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Tested on a chinese H96 Pro Plus (S912 chipset), with regular android 7.1.2 implementation, and Home Assistant Core "Python ADB" config:

```yaml
media_player:
  - platform: androidtv
    name: S912
    host: 192.168.XX.YY
```

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
