### PR TITLE
Update nmap parameter to use -sn instead of -sP

### DIFF
--- a/source/_integrations/nmap_tracker.markdown
+++ b/source/_integrations/nmap_tracker.markdown
@@ -95,7 +95,7 @@ And you can set up the device tracker as
 ```yaml
 - platform: nmap_tracker
   hosts: 192.168.1.1-25
-  scan_options: " --privileged -sP "
+  scan_options: " --privileged -sn "
 ```
 
 See the [device tracker integration page](/integrations/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
## Proposed change

In previous releases of Nmap -sn was known as -sP

The usage of -sn instead of -sP was made 10 years ago in nmap 5.22, it is time to update nmap_tracker documentation 
Ref: https://github.com/nmap/nmap/commit/2e7208d2d1bc9a8593bbf61fcb50725ae2434c9b

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- I didn't find any usage of nmap -sP the codebase. So need of a code change.

## Checklist

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
