### PR TITLE
Added location where learned codes can be found

### DIFF
--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -116,6 +116,9 @@ script:
 
 In the above example, two codes will be captured for the power command, and will be sent alternately each time the command is called.
 
+#### Where the learned codes are stored
+The learned commands are stored in folder \configuration\.storage in a file called broadlink_remote_xxxxxxxxxxx_codes.json. From here you can copy the codes for use in e.g. a Broadlink switch. Warning: files in the .storage folder should never be edited manually, so just view the file.
+
 ### Send command
 
 Use the `remote.send_command` service to send commands.

--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -116,8 +116,9 @@ script:
 
 In the above example, two codes will be captured for the power command, and will be sent alternately each time the command is called.
 
-#### Where the learned codes are stored
-The learned commands are stored in folder \configuration\.storage in a file called broadlink_remote_xxxxxxxxxxx_codes.json. From here you can copy the codes for use in e.g. a Broadlink switch. Warning: files in the .storage folder should never be edited manually, so just view the file.
+#### Learned codes storage location
+
+The learned commands are stored in folder `\configuration\.storage` in a file called `broadlink_remote_xxxxxxxxxxx_codes.json`. From here, you can copy the codes for use in e.g., a Broadlink switch. Warning: files in the .storage folder should never be edited manually, so just view the file.
 
 ### Send command
 


### PR DESCRIPTION
At the moment, the full codes are not published elsewhere it seems (bugs?). Eventually this file location should be removed again, but for now this info will help people.

## Proposed change
Adds info about the file in .storage where the learned codes can be found for users.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
