### PR TITLE
Adjust example

### DIFF
--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -119,34 +119,39 @@ automation:
 To dynamically set the `input_datetime` you can call
 `input_datetime.set_datetime`. The values for `date` and `time` must be in a certain format for the call to be successful. (See service description above.)
 If you have a `datetime` object you can use its `strftime` method. Of if you have a timestamp you can use the `timestamp_custom` filter.
-The following example can be used in an automation rule:
+The following example shows the different methods in an automation rule:
 
 {% raw %}
 ```yaml
 # Example configuration.yaml entry
-# Sets input_datetime to '05:30' when an input_boolean is turned on.
+# Shows different ways to set input_datetime when an input_boolean is turned on
 automation:
   trigger:
     platform: state
     entity_id: input_boolean.example
     to: 'on'
   action:
+  # Sets time to '05:30:00
   - service: input_datetime.set_datetime
     entity_id: input_datetime.bedroom_alarm_clock_time
     data:
       time: '05:30:00'
+   # Sets time to time from datetime object (current time in this example)
   - service: input_datetime.set_datetime
     entity_id: input_datetime.another_time
     data_template:
       time: "{{ now().strftime('%H:%M:%S') }}"
+  # Sets date to date from timestamp (current date in this example)
   - service: input_datetime.set_datetime
     entity_id: input_datetime.another_date
     data_template:
       date: "{{ as_timestamp(now())|timestamp_custom('%Y-%m-%d') }}"
+  # Sets date and time to date and time from datetime object (current date and time in this example)
   - service: input_datetime.set_datetime
     entity_id: input_datetime.date_and_time
     data_template:
       datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+  # Sets date and time to date and time from timestamp (current date and time in this example)
   - service: input_datetime.set_datetime
     data_template:
       entity_id: input_datetime.date_and_time


### PR DESCRIPTION
Example comment is a bit confusing by saying it sets the input_datetime to 05:30, however the actual examples shows different ways to set the input_datetime, not only setting it to 05:30

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
