### PR TITLE
Added VSX-528 as a supported device

### DIFF
--- a/source/_integrations/pioneer.markdown
+++ b/source/_integrations/pioneer.markdown
@@ -121,3 +121,23 @@ sources:
   'MHL': '48'
   'Game': '49'
 ```
+
+#### VSX-528
+
+```yaml
+sources:
+  'CD': '01'
+  'Tuner': '02'
+  'DVD': '04'
+  'TV': '05'
+  'Sat/Cbl': '06'
+  'DVR/BDR': '15'
+  'iPod/USB': '17'
+  'HDMI/MHL': '48'
+  'BD': '25'
+  'Adapter': '33'
+  'Netradio': '38'
+  'Media Server': '44'
+  'Favorites': '45'
+  'Game': '49'
+```

--- a/source/_integrations/pioneer.markdown
+++ b/source/_integrations/pioneer.markdown
@@ -125,6 +125,7 @@ sources:
 #### VSX-528
 
 ```yaml
+port: 8102
 sources:
   'CD': '01'
   'Tuner': '02'


### PR DESCRIPTION
## Proposed change
Adds support for Pioneer VSX-528 including the correct & tested sources mapping.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant/pull/31023
- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant/pull/31023

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html