### PR TITLE
Update pvoutput.markdown

### DIFF
--- a/source/_integrations/pvoutput.markdown
+++ b/source/_integrations/pvoutput.markdown
@@ -56,19 +56,19 @@ sensor:
   - platform: template
     sensors:
       power_consumption:
-        value_template: {% raw %}'{% if is_state_attr("sensor.pvoutput", "power_consumption", "NaN") %}0{% else %}{{ state_attr('sensor.pvoutput', 'power_consumption') }}{% endif %}'{% endraw %}
+              value_template: '{% if is_state_attr("sensor.pvoutput", "power_consumption", "NaN") %}0{% else %}{{ state_attr("sensor.pvoutput", "power_consumption") }}{% endif %}'
         friendly_name: 'Using'
         unit_of_measurement: 'Watt'
       energy_consumption:
-        value_template: {% raw %}'{{ "%0.1f"|format(state_attr('sensor.pvoutput', 'energy_consumption')|float/1000) }}'{% endraw %}
+        value_template: '{{ "%0.1f"|format(state_attr("sensor.pvoutput", "energy_consumption")|float/1000) }}'
         friendly_name: 'Used'
         unit_of_measurement: 'kWh'
       power_generation:
-        value_template: {% raw %}'{% if is_state_attr("sensor.pvoutput", "power_generation", "NaN") %}0{% else %}{{ state_attr('sensor.pvoutput', 'power_generation') }}{% endif %}'{% endraw %}
+        value_template: '{% if is_state_attr("sensor.pvoutput", "power_generation", "NaN") %}0{% else %}{{ state_attr("sensor.pvoutput", "power_generation") }}{% endif %}'
         friendly_name: 'Generating'
         unit_of_measurement: 'Watt'
       energy_generation:
-        value_template: {% raw %}'{% if is_state_attr("sensor.pvoutput", "energy_generation", "NaN") %}0{% else %}{{ "%0.2f"|format(state_attr('sensor.pvoutput', 'energy_generation')|float/1000) }}{% endif %}'{% endraw %}
+        value_template: '{% if is_state_attr("sensor.pvoutput", "energy_generation", "NaN") %}0{% else %}{{ "%0.2f"|format(state_attr("sensor.pvoutput", "energy_generation")|float/1000) }}{% endif %}'
         friendly_name: 'Generated'
         unit_of_measurement: 'kWh'
 ```

--- a/source/_integrations/pvoutput.markdown
+++ b/source/_integrations/pvoutput.markdown
@@ -47,6 +47,8 @@ It's recommended to set `scan_interval:` according to a value greater than 60 se
 
 To format the PVoutput sensor it's recommended to use the [template component](/topics/templating/). For example:
 
+{% raw %}
+
 ```yaml
 sensor:
   - platform: pvoutput
@@ -72,3 +74,5 @@ sensor:
         friendly_name: 'Generated'
         unit_of_measurement: 'kWh'
 ```
+
+{% endraw %}


### PR DESCRIPTION
Replaced some single quotes with double quotes in the pvoutput template. Current template throwing errors similar to these (line numbers will vary based on configuration.yaml file:
```
Configuration invalid 
CHECK CONFIG
Error loading /config/configuration.yaml: while parsing a block mapping
  in "/config/configuration.yaml", line 408, column 9
expected <block end>, but found '<scalar>'
  in "/config/configuration.yaml", line 408, column 56
```
Updated template configuration fixes these errors.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
