### PR TITLE
added note about name variable

### DIFF
--- a/source/_integrations/history_stats.markdown
+++ b/source/_integrations/history_stats.markdown
@@ -47,7 +47,7 @@ state:
   required: true
   type: string
 name:
-  description: Name displayed on the frontend.
+  description: Name displayed on the frontend. Note that it is used by Home Assistant to generate sensor's `object_id` so it is advisable to choose a unique one and change name for frontend using [customization](https://www.home-assistant.io/docs/configuration/customizing-devices/#friendly_name) or via [Lovelace](https://www.home-assistant.io/lovelace/entities/#name).
   required: false
   default: unnamed statistics
   type: string

--- a/source/_integrations/history_stats.markdown
+++ b/source/_integrations/history_stats.markdown
@@ -47,7 +47,7 @@ state:
   required: true
   type: string
 name:
-  description: Name displayed on the frontend. Note that it is used by Home Assistant to generate sensor's `object_id` so it is advisable to choose a unique one and change name for frontend using [customization](https://www.home-assistant.io/docs/configuration/customizing-devices/#friendly_name) or via [Lovelace](https://www.home-assistant.io/lovelace/entities/#name).
+  description: Name displayed on the frontend. Note that it is used by Home Assistant to generate sensor's `object_id` so it is advisable to choose a unique one and change name for frontend using [customization](../../docs/configuration/customizing-devices/#friendly_name) or via [Lovelace](../../lovelace/entities/#name).
   required: false
   default: unnamed statistics
   type: string

--- a/source/_integrations/history_stats.markdown
+++ b/source/_integrations/history_stats.markdown
@@ -47,7 +47,7 @@ state:
   required: true
   type: string
 name:
-  description: Name displayed on the frontend. Note that it is used by Home Assistant to generate sensor's `object_id` so it is advisable to choose a unique one and change name for frontend using [customization](../../docs/configuration/customizing-devices/#friendly_name) or via [Lovelace](../../lovelace/entities/#name).
+  description: Name displayed on the frontend. Note that it is used by Home Assistant to generate sensor's `object_id` so it is advisable to choose a unique one and change name for frontend using [customization](/docs/configuration/customizing-devices/#friendly_name) or via [Lovelace](/lovelace/entities/#name).
   required: false
   default: unnamed statistics
   type: string


### PR DESCRIPTION
I though that name is just for frontend and spent some time finding out where my sensor had gone when I had changed its name.
Hope it will save others' time.
Actually, I don't think this component's approach is great - would be much more intuitive to have name as a key of a dictionary (as with template sensors, for example) and a friendly_name for UI.
Unfortunately, there are many of similar components - perhaps they are older than current template sensor's implementation?

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
