### PR TITLE
duration is (supposedly) an optional attr

### DIFF
--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -55,7 +55,7 @@ Listen to the specified topic matcher and dumps all received messages within a s
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `topic` | no | Topic to dump. Can contain a wildcard (`#` or `+`).
-| `duration` | no | Duration in seconds that we will listen for messages. Default is 5 seconds.
+| `duration` | yes | Duration in seconds that we will listen for messages. Default is 5 seconds.
 
 ```yaml
 topic: openzwave/#


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
duration is (supposedly) an optional attr if it says something about default in the description

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
