### PR TITLE
Removed Samsung TV

### DIFF
--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -30,7 +30,6 @@ Home Assistant can discover and automatically configure [zeroconf](https://en.wi
  * [Roku media player](/integrations/roku#media-player)
  * [SABnzbd downloader](/integrations/sabnzbd)
  * [Samsung SyncThru Printer](/integrations/syncthru)
- * [Samsung TVs](/integrations/samsungtv)
  * [Sonos speakers](/integrations/sonos)
  * [Telldus Live](/integrations/tellduslive/)
  * [Wink](/integrations/wink/)
@@ -54,7 +53,7 @@ To load this integration, add the following lines to your `configuration.yaml` f
 discovery:
   ignore:
     - sonos
-    - samsung_tv
+    - samsung_printer
   enable:
     - homekit
 ```
@@ -93,7 +92,6 @@ Valid values for ignore are:
  * `roku`: Roku media player
  * `sabnzbd`: SABnzbd downloader
  * `samsung_printer`: Samsung SyncThru Printer
- * `samsung_tv`: Samsung TVs
  * `sonos`: Sonos speakers
  * `songpal` : Songpal
  * `tellstick`: Telldus Live


### PR DESCRIPTION
As of 0.105 Samsung TV uses ssdp now, apparently

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
