### PR TITLE
Add documentation for securing emulated_hue

### DIFF
--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -106,6 +106,14 @@ entities:
   description: Customization for entities.
   required: false
   type: list
+client_username:
+  description: Custom client `username` send out by `emulated_hue` during paring process. This may be used too prevent malicious apps from bypassing paring process due to default `username` being public. This option is especially useful if the paring process is actually enabled with `link_button_entity` option.
+  required: false
+  type: string
+link_button_entity:
+  description: ID of on/off entity (like `input_boolean`) that represents "link button state". When the entity is *ON*, `emulated_hue` accepts any paring request. If it is *OFF*, `emulated_hue` rejects any paring request in the same way as Hue Bridge does. If this option is omitted, `emulated_hue` behaves as if the "link button" was always *ON*.
+  required: false
+  type: string
 {% endconfiguration %}
 
 A full configuration sample looks like the one below.
@@ -128,6 +136,8 @@ emulated_hue:
       name: "Bedside Lamp"
     light.ceiling_lights:
       hidden: true
+  link_button_entity: input_boolean.hue_link_button
+  client_username: "30197ed87b6fb3d7c2a8c1fcdcdb3291"
 ```
 
 The following are attributes that can be applied in the `entities` section:
@@ -158,7 +168,7 @@ No further actions are required
 
 #### Python venv
 
-An additional step is required to run Home Assistant as a non-root user and use port 80. 
+An additional step is required to run Home Assistant as a non-root user and use port 80.
 
 ##### Linux
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds documentation for the linked feature in main `home-assistant` codebase. Those changes are hand-in-hand with the `home-assistant` changes and should be merged in only alongside `home-assistant` changes.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant/pull/31595
- This PR fixes or closes issue: -

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
