### PR TITLE
Added troubleshooting info

### DIFF
--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -68,7 +68,9 @@ After you have set up the above:
 - Add a new **Spotify** integration.
 - Follow the steps shown to authenticate Home Assistant with your Spotify account.
 
-> If you receive an `INVALID_CLIENT: Invalid redirect URI` error while trying to authenticate with your Spotify account, make sure to check the Redirect URI in the address bar after adding the new integration. Compare this value with the Redirect URL defined in the Spotify Developer Portal.
+<div class='note'>
+  If you receive an `INVALID_CLIENT: Invalid redirect URI` error while trying to authenticate with your Spotify account, make sure to check the Redirect URI in the address bar after adding the new integration. Compare this value with the Redirect URL defined in the Spotify Developer Portal.
+</div>
 
 ## URI Links For Playlists
 

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -69,7 +69,9 @@ After you have set up the above:
 - Follow the steps shown to authenticate Home Assistant with your Spotify account.
 
 <div class='note'>
+  
   If you receive an `INVALID_CLIENT: Invalid redirect URI` error while trying to authenticate with your Spotify account, make sure to check the Redirect URI in the address bar after adding the new integration. Compare this value with the Redirect URL defined in the Spotify Developer Portal.
+
 </div>
 
 ## URI Links For Playlists

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -68,6 +68,8 @@ After you have set up the above:
 - Add a new **Spotify** integration.
 - Follow the steps shown to authenticate Home Assistant with your Spotify account.
 
+> If you receive an `INVALID_CLIENT: Invalid redirect URI` error while trying to authenticate with your Spotify account, make sure to check the Redirect URI in the address bar after adding the new integration. Compare this value with the Redirect URL defined in the Spotify Developer Portal.
+
 ## URI Links For Playlists
 
 You can send playlists to Spotify using the `"media_content_type": "playlist"`, which are part of the


### PR DESCRIPTION
The `INVALID_CLIENT: Invalid redirect URI` error can occur when the URL, for example, contains a port number. This can happen if the port number is set in the Base_URL attribute of the HTTP integration.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
