### PR TITLE
Fixed incorrect  type of `client_secret` in Netatmo docs.

### DIFF
--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -45,7 +45,7 @@ client_id:
 client_secret:
   description: The `client secret` from your Netatmo app.
   required: true
-  type: integer
+  type: string
 {% endconfiguration %}
 
 Once that is configured you can enable it from the integrations page.


### PR DESCRIPTION
## Proposed change
Fixes incorrect type of `client_secret` in Netatmo docs. 



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant.io/pull/11770

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
