### PR TITLE
Change references to Hass.io to Home Assistant

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -1,9 +1,11 @@
 ---
-title: "Installing Hass.io"
-description: "Instructions on how to install Hass.io."
+title: "Installing Home Assistant"
+description: "Instructions on how to install Home Assistant."
 ---
 
-The following will take you through the steps required to install Hass.io.
+> *Note: As part of the official [Changing the Home Assistant Brand][brand-change] initiative, "Hass.io" has will now be reffered to as "Home Assistant". "Home Assistant" includes both the "Home Assistant Core" as well as the Home Assistant "Supervisor".*
+
+The following will take you through the steps required to install Home Assistant.
 
 1. Download the appropriate install option:
 
@@ -32,7 +34,7 @@ The following will take you through the steps required to install Hass.io.
      - [Raspberry Pi Zero-W][pi0-w]
      - [Raspberry Pi 2][pi2]
 
-2. Install Hass.io:
+2. Install Home Assistant:
 
    - Flash the downloaded image to an SD card using [balenaEtcher][balenaEtcher]. If using a Pi we recommend at least a 32 GB SD card to avoid running out of space. On Virtual machine platforms, provide at least 32 GB of disk space for the VM.
    - Load the appliance image into your virtual machine software. Choose 64-bit Linux and UEFI boot.
@@ -51,7 +53,7 @@ The following will take you through the steps required to install Hass.io.
 
 6. You will be able to reach your installation at `http://hassio.local:8123` (if your router supports mDNS, otherwise see below).
 
-7. It is important to provide yourself proper access, including the Hass.io CLI tools. Both the [Samba add-on][samba] and the [SSH add-on][ssh] should be the first add-ons you should install, before making changes to the configuration in the `/config/` folder. From the UI choose **Hass.io**, which is located in the sidebar and then the add-on store.
+7. It is important to provide yourself proper access, including the Home Assistant CLI tools. Both the [Samba add-on][samba] and the [SSH add-on][ssh] should be the first add-ons you should install, before making changes to the configuration in the `/config/` folder. From the UI choose **Supervisor**, which is located in the sidebar and then the add-on store.
 
 <div class='note'>
 
@@ -67,39 +69,39 @@ If you are using a Raspberry Pi please remember to ensure you're using an [appro
 
 Now you can [configure][configure] your install.
 
-## Updating a Hass.io installation
+## Updating a Home Assistant installation
 
-Best practice for updating a Hass.io installation:
+Best practice for updating a Home Assistant installation:
 
-1. Backup your installation, using the snapshot functionality Hass.io offers.
+1. Backup your installation, using the snapshot functionality Supervisor offers.
 2. Check the release notes for breaking changes on [Home Assistant release notes](https://github.com/home-assistant/home-assistant/releases). Be sure to check all release notes between the version you are running and the one you are upgrading to. Use the search function in your browser (`CTRL + f`) and search for **Breaking Changes**.
 3. Check your configuration using the [Check Home Assistant configuration](/addons/check_config/) add-on.
 4. If the check passes, you can safely update. If not, update your configuration accordingly.
-5. Select _Dashboard_ from the _Hass.io_ menu, and then select _Update_.
+5. Select _Dashboard_ from the _Supervisor_ menu, and then select _Update_.
 
-## Run a specific version on Hass.io
+## Run a specific version of Home Assistant
 
-SSH to your Hass.io system, or connect to the console, and run:
+SSH to your Home Assistant system, or connect to the console, and run:
 
 ```bash
 hassio ha update --version=0.XX.X
 ```
 
-## Run the beta version on Hass.io
+## Run the beta version of Home Assistant
 
 If you would like to test next release before anyone else, you can install the beta version released every three weeks:
 
-1. Backup your installation, using the snapshot functionality Hass.io offers.
+1. Backup your installation, using the snapshot functionality Supervisor offers.
 2. Check the [Home Assistant RC release notes](https://rc.home-assistant.io/latest-release-notes/) for breaking changes. Be sure to check all release notes between the version you are running and the one you are upgrading to. Use the search function in your browser (`CTRL + f`) and search for **Breaking Changes**.
-3. Select _System_ tab from the _Hass.io_ menu, then select _Join Beta Channel_ under _Hass.io supervisor_, then select _Reload_.
-4. Select _Dashboard_ tab from the _Hass.io_ menu, and then select _Update_.
+3. Select _System_ tab from the _Supervisor_ menu, then select _Join Beta Channel_ under _Supervisor_, then select _Reload_.
+4. Select _Dashboard_ tab from the _Supervisor_ menu, and then select _Update_.
 
 ## Alternative: install on a generic Linux host
 
-For advanced users, it is also possible to try Hass.io on your [Linux server or inside a virtual machine][linux].
+For advanced users, it is also possible to try Home Assistant on your [Linux server or inside a virtual machine][linux].
 Examples given here are tested on Ubuntu and Arch Linux, but the instructions should work as a guideline for installing on other Linux distrubutions.
 
-The packages you need to have available on your system that will run Hass.io may vary.
+The packages you need to have available on your system that will run Home Assistant may vary.
 
 ### Debian/Ubuntu
 
@@ -197,14 +199,15 @@ curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/mast
 - `qemux86`
 - `qemux86-64`
 
-See the [hassio-installer](https://github.com/home-assistant/hassio-installer) GitHub page for an up-to-date listing of supported machine types.
+See the [Home Assistant Installer](https://github.com/home-assistant/hassio-installer) GitHub page for an up-to-date listing of supported machine types.
 
 <div class='note'>
 When you use this installation method, the core SSH add-on may not function correctly. If that happens, use the community SSH add-on. Some of the documentation might not work for your installation either.
 </div>
 
-A detailed guide about running Hass.io as a virtual machine is available in the [blog][hassio-vm].
+A detailed guide about running Home Assistant as a virtual machine is available in the [blog][hassio-vm].
 
+[brand-change]: /blog/2020/01/29/changing-the-home-assistant-brand/
 [balenaEtcher]: https://www.balena.io/etcher
 [Virtual Appliance]: https://github.com/home-assistant/hassos/blob/dev/Documentation/boards/ova.md
 [hassos-network]: https://github.com/home-assistant/hassos/blob/dev/Documentation/network.md


### PR DESCRIPTION
## Proposed change
I made a pass at rewording the Hass.io installation page to use the new branding of Home Assistant instead of Hass.io. I even included a brief explanation at the top of the page introducing the branding change, which includes a link to the blog post explaining the change.

I suspect you may not want to make the naming changes one page at a time. I'm wondering if a separate branch of the site needs to be worked on so the changes can be made all at once (including reorganizing the paths to exclude references to hassio)?


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
