### PR TITLE
Merge Dark Sky docs

### DIFF
--- a/source/_integrations/darksky.markdown
+++ b/source/_integrations/darksky.markdown
@@ -26,6 +26,8 @@ You need an API key which is free but requires [registration](https://darksky.ne
 
 There are two ways you can integrate Dark Sky into Home Assistant: as a sensor and a weather entity. The [sensor](/integrations/sensor) entity allows you to add the conditions you'd like to monitor and returns a value that you can add to various styles of Lovelace cards. In contrast, the weather entity allows you to set up a [weather forecast card](/lovelace/weather-forecast/#configuration-variables) that displays a 5-day forecast with some additional data. 
 
+### Sensor
+
 To add Dark Sky to your installation as a sensor, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -239,6 +241,8 @@ All language options are described in this table that you can use for the dark s
 While the platform is called "darksky" the sensors will show up in Home Assistant as "dark_sky" (eg: sensor.dark_sky_summary).
 </div>  
 
+### Weather
+
 To add Dark Sky to your installation as a weather entity, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -279,6 +283,5 @@ mode:
   type: string
   default: hourly
 {% endconfiguration %}
-
 
 More details about the API are available in the [Dark Sky API documentation](https://darksky.net/dev/docs).

--- a/source/_integrations/darksky.markdown
+++ b/source/_integrations/darksky.markdown
@@ -24,7 +24,9 @@ You need an API key which is free but requires [registration](https://darksky.ne
 
 ## Configuration
 
-To add Dark Sky to your installation, add the following to your `configuration.yaml` file:
+There are two ways you can integrate Dark Sky into Home Assistant: as a sensor and a weather entity. The [sensor](/integrations/sensor) entity allows you to add the conditions you'd like to monitor and returns a value that you can add to various styles of Lovelace cards. In contrast, the weather entity allows you to set up a [weather forecast card](/lovelace/weather-forecast/#configuration-variables) that displays a 5-day forecast with some additional data. 
+
+To add Dark Sky to your installation as a sensor, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -235,6 +237,48 @@ All language options are described in this table that you can use for the dark s
 
 <div class='note warning'>
 While the platform is called "darksky" the sensors will show up in Home Assistant as "dark_sky" (eg: sensor.dark_sky_summary).
-</div>
+</div>  
+
+To add Dark Sky to your installation as a weather entity, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+weather:
+  - platform: darksky
+    api_key: YOUR_API_KEY
+```
+
+{% configuration %}
+api_key:
+  description: "Your API key for [Dark Sky](https://darksky.net/dev/)."
+  required: true
+  type: string
+latitude:
+  description: Manually specify latitude. By default the value will be taken from the Home Assistant configuration.
+  required: false
+  type: float
+  default: Provided by Home Assistant configuration
+longitude:
+  description: Manually specify longitude. By default the value will be taken from the Home Assistant configuration.
+  required: false
+  type: float
+  default: Provided by Home Assistant configuration
+units:
+  description: "Manually specify unit system. Valid values are: `auto`, `us`, `si`, `ca`, `uk` and `uk2`."
+  required: false
+  type: string
+  default: "`si` if Home Assistant unit system is metric, `us` if imperial."
+name:
+  description: Name to use in the frontend.
+  required: false
+  type: string
+  default: Dark Sky
+mode:
+  description: "The forecast type. Can be `hourly` or `daily`."
+  required: false
+  type: string
+  default: hourly
+{% endconfiguration %}
+
 
 More details about the API are available in the [Dark Sky API documentation](https://darksky.net/dev/docs).


### PR DESCRIPTION
Attempting to merge Dark Sky documentation for simplification and clarity. If the PR is accepted, I'd like to remove /integrations/weather.darksky/ and just keep the current page (/integrations/darksky/)

## Proposed change
<!-- 
  The Dark Sky documents are split and not easy for a beginner to understand. I want to merge the documentation and provide greater detail, which would provide simplification and clarity. I am unsure how to add a screenshot, but that is something I want to include as well.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  I want to additionally delete the weather.darksky link if this PR is merged. I may need an example on how to add images for the final version of this page.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
