### PR TITLE
Update synology.markdown

### DIFF
--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -17,7 +17,7 @@ There are 2 alternatives, when using Home Assistant on Synology NAS:
 
 Option 1 is described on the [Docker installation page](/docs/installation/docker/).
 
-Option 3 uses the Synology Based Virtual Machine Manager. You can import the VDI image to be found at the [Hass.io installation page](https://www.home-assistant.io/hassio/installation/). Download the image and add it to the image store. The go to "Virtual Machine" in the interface and create a new VM with the image you just added.
+Option 3 uses the Synology Based Virtual Machine Manager. You can import the VDI image to be found at the [Hass.io installation page](/hassio/installation/). Download the image and add it to the image store. The go to "Virtual Machine" in the interface and create a new VM with the image you just added.
 
 The main benefit from this method is that you can assign Home Assistant its own IP number, so there is no risk regarding TCP/UDP port conflicts. USB dongles an be connected to the VM without the need to install a driver in DSM.
 
@@ -242,4 +242,3 @@ $ sudo /volume1/homeassistant/hass-daemon restart
 ```bash
 $  /volume1/@appstore/py3k/usr/local/bin/python3 -m pip install --upgrade homeassistant
 ```
-

--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -13,8 +13,15 @@ Synology only provide Python 3.5.1, which is not compatible with Home Assistant 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
 1. using Docker
 2. directly running on DSM
+3. using Hass.io in a VM (if you have an Intel based Synology)
 
-Option 1 is described on the [Docker installation page](/docs/installation/docker/), whereas Option 2 is described below.
+Option 1 is described on the [Docker installation page](/docs/installation/docker/).
+
+Option 3 uses the Synology Based Virtual Machine Manager. You can import the VDI image to be found at the [Hass.io installation page](https://www.home-assistant.io/hassio/installation/). Download the image and add it to the image store. The go to "Virtual Machine" in the interface and create a new VM with the image you just added.
+
+The main benefit from this method is that you can assign Home Assistant its own IP number, so there is no risk regarding TCP/UDP port conflicts. USB dongles an be connected to the VM without the need to install a driver in DSM.
+
+Option 2 is described below.
 
 
 The following configuration has been tested on Synology 413j running DSM 6.0-7321 Update 1.


### PR DESCRIPTION
It is also possible to run Hass.io in a VM on Synology using the VDI image.

## Proposed change
It is now also possible to run Home Assistant (hass.io) in a VM if you have an Intel based Synology. This creates a third option. This works without any changes to startup commands or installation of USB drivers, e.g. to make RFLink dongles work.

Been running with a vm for a couple of months now, without incident.

Looks stable enough to add it to the documentation.
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - [X] I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
