### PR TITLE
Correct MQTT Lock Default States

### DIFF
--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -55,12 +55,12 @@ state_locked:
   description: The value that represents the lock to be in locked state
   required: false
   type: string
-  default: locked
+  default: LOCKED
 state_unlocked:
   description: The value that represents the lock to be in unlocked state
   required: false
   type: string
-  default: unlocked
+  default: UNLOCKED
 optimistic:
   description: Flag that defines if lock works in optimistic mode.
   required: false


### PR DESCRIPTION
Updated the defaults to match the states changed in https://github.com/home-assistant/home-assistant/pull/29808

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
