### PR TITLE
Add recorder vars db_max_retries and db_retry_wait

### DIFF
--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -8,7 +8,7 @@ ha_release: pre 0.7
 ha_quality_scale: internal
 ---
 
-The `recorder` , which then are handled by the [`history` integration](/integrations/history/).
+The `recorder` integration is responsible for storing details in a database, which then are handled by the [`history` integration](/integrations/history/).
 
 Home Assistant uses [SQLAlchemy](https://www.sqlalchemy.org/), which is an Object Relational Mapper (ORM). This means that you can use **any** SQL backend for the recorder that is supported by SQLAlchemy, like [MySQL](https://www.mysql.com/), [MariaDB](https://mariadb.org/), [PostgreSQL](https://www.postgresql.org/), or [MS SQL Server](https://www.microsoft.com/en-us/sql-server/).
 

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -34,10 +34,12 @@ recorder:
     db_max_retries:
       description: The max amount of times, the recorder retries to connect to the database.
       required: false
+      default: 10
       type: int
     db_retry_wait:
       description: The time in seconds, that the recorder sleeps when trying to connect to the database.
       required: false
+      default: 3
       type: int
     purge_keep_days:
       description: Specify the number of history days to keep in recorder database after a purge.
@@ -188,6 +190,7 @@ If you are using the default `FULL` recovery model for MS SQL Server you will ne
 ### Database startup
 
 If you are running a database server instance on the same server as Home Assistant then you must ensure that this service starts before Home Assistant. For a Linux instance running Systemd (Raspberry Pi, Debian, Ubuntu and others) then you should edit the service file.
+To help facilitate this, db_max_retry and db_retry_wait variables have been added to ensure the recorder retries the connection to your database enough times, for your database to start up.
 
 ```bash
 sudo nano /etc/systemd/system/home-assistant@homeassistant.service

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -35,12 +35,12 @@ recorder:
       description: The max amount of times, the recorder retries to connect to the database.
       required: false
       default: 10
-      type: int
+      type: integer
     db_retry_wait:
       description: The time in seconds, that the recorder sleeps when trying to connect to the database.
       required: false
       default: 3
-      type: int
+      type: integer
     purge_keep_days:
       description: Specify the number of history days to keep in recorder database after a purge.
       required: false

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -8,7 +8,7 @@ ha_release: pre 0.7
 ha_quality_scale: internal
 ---
 
-The `recorder` integration is responsible for storing details in a database, which then are handled by the [`history` integration](/integrations/history/).
+The `recorder` , which then are handled by the [`history` integration](/integrations/history/).
 
 Home Assistant uses [SQLAlchemy](https://www.sqlalchemy.org/), which is an Object Relational Mapper (ORM). This means that you can use **any** SQL backend for the recorder that is supported by SQLAlchemy, like [MySQL](https://www.mysql.com/), [MariaDB](https://mariadb.org/), [PostgreSQL](https://www.postgresql.org/), or [MS SQL Server](https://www.microsoft.com/en-us/sql-server/).
 
@@ -31,6 +31,14 @@ recorder:
       description: The URL that points to your database.
       required: false
       type: string
+    db_max_retries:
+      description: The max amount of times, the recorder retries to connect to the database.
+      required: false
+      type: int
+    db_retry_wait:
+      description: The time in seconds, that the recorder sleeps when trying to connect to the database.
+      required: false
+      type: int
     purge_keep_days:
       description: Specify the number of history days to keep in recorder database after a purge.
       required: false


### PR DESCRIPTION
## Proposed change
Essentially, i'm proposing to add:

    db_retry_wait:
    db_max_retries:

to the recorder component. These are necessary because currently the retry count and sleep time is fixed to 10 retries, and 3 seconds sleep. I want to change that, so that its a variable.

The need came from an issue i had where my mariadb were consistently so slow to start, that my Home assistant container made its 10 retries and moved on. Testing shows that a completely new mariadb is about 2 mins to start up, so i was trying to figure out a way to force HA to check a bit more.
Proposed fixed were scripting the deploy, wrapping Home Assistant in a wait-for-it or dockerize container and using that to wait, but this seems like the best solution that benefits most people.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant/pull/31561
- This PR fixes or closes issue: none.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
