### PR TITLE
Update lets_encrypt.markdown

### DIFF
--- a/source/_docs/ecosystem/certificates/lets_encrypt.markdown
+++ b/source/_docs/ecosystem/certificates/lets_encrypt.markdown
@@ -259,13 +259,10 @@ Make sure you are in the home directory for the Home Assistant user:
 cd
 ```
 
-We will now make a directory for the certbot software, download it and give it the correct permissions:
+We will now install the certbot software:
 
 ```text
-mkdir certbot
-cd certbot/
-wget https://dl.eff.org/certbot-auto
-chmod a+x certbot-auto
+sudo apt-get install certbox -y
 ```
 
 You might need to stop Home Assistant before continuing with the next step. You can do this via the Web-UI or use the following command if you are running on Raspbian:
@@ -278,7 +275,7 @@ You can restart Home Assistant after the next step using the same command and re
 Now we will run the certbot program to get our SSL certificate. You will need to include your email address and your DuckDNS URL in the appropriate places:
 
 ```text
-./certbot-auto certonly --standalone --preferred-challenges http-01 --email your@email.address -d examplehome.duckdns.org
+sudo certbot certonly --standalone --preferred-challenges http-01 --email your@email.address -d examplehome.duckdns.org
 ```
 
 Once the program has run it will generate a certificate and other files and place them in a folder `/etc/letsencrypt/` .
@@ -296,6 +293,7 @@ Our Home Assistant user needs access to files within the letsencrypt folder, so 
 ```bash
 sudo chmod 755 /etc/letsencrypt/live/
 sudo chmod 755 /etc/letsencrypt/archive/
+sudo chmod -R 777 /etc/letsencrypt/
 ```
 
 Did all of that go without a hitch? Wahoo! Your Let's Encrypt certificate is now ready to be used with Home Assistant. Move to step 5 to put it all together


### PR DESCRIPTION
certbot-auto appears to no longer be the preferred method to install certs, certbot is now the recommended method (https://github.com/certbot/certbot/issues/6933#issuecomment-481243457)

I've also added an additional chmod that I had to add to allow Home Assistant to read the cert files, as otherwise I got the error:

Invalid config for [http]: file not readable for dictionary value @ data['http']['ssl_key'].

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
