### PR TITLE
Update sonos.markdown

### DIFF
--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -30,7 +30,7 @@ The queue is not snapshotted and must be left untouched until the restore. Using
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | The speakers to snapshot. To target all sonos devices, use `all`.
+| `entity_id` | no | The speakers to snapshot. To target all Sonos devices, use `all`.
 | `with_group` | yes | Should we also snapshot the group layout and the state of other speakers in the group, defaults to true.
 
 ### Service `sonos.restore`
@@ -49,7 +49,7 @@ A cloud queue cannot be restarted. This includes queues started from within Spot
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of `entity_id`s that should have their snapshot restored. To target all sonos devices, use `all`.
+| `entity_id` | no | String or list of `entity_id`s that should have their snapshot restored. To target all Sonos devices, use `all`.
 | `with_group` | yes | Should we also restore the group layout and the state of other speakers in the group, defaults to true.
 
 ### Service `sonos.join`

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -30,7 +30,7 @@ The queue is not snapshotted and must be left untouched until the restore. Using
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | The speakers to snapshot. To target all sonos devices, use `all`.
+| `entity_id` | no | The speakers to snapshot. To target all sonos devices, use `all`.
 | `with_group` | yes | Should we also snapshot the group layout and the state of other speakers in the group, defaults to true.
 
 ### Service `sonos.restore`
@@ -49,7 +49,7 @@ A cloud queue cannot be restarted. This includes queues started from within Spot
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of `entity_id`s that should have their snapshot restored. To target all sonos devices, use `all`.
+| `entity_id` | no | String or list of `entity_id`s that should have their snapshot restored. To target all sonos devices, use `all`.
 | `with_group` | yes | Should we also restore the group layout and the state of other speakers in the group, defaults to true.
 
 ### Service `sonos.join`

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -30,7 +30,7 @@ The queue is not snapshotted and must be left untouched until the restore. Using
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | The speakers to snapshot.
+| `entity_id` | yes | The speakers to snapshot. To target all sonos devices, use `all`.
 | `with_group` | yes | Should we also snapshot the group layout and the state of other speakers in the group, defaults to true.
 
 ### Service `sonos.restore`
@@ -49,7 +49,7 @@ A cloud queue cannot be restarted. This includes queues started from within Spot
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of `entity_id`s that should have their snapshot restored.
+| `entity_id` | yes | String or list of `entity_id`s that should have their snapshot restored. To target all sonos devices, use `all`.
 | `with_group` | yes | Should we also restore the group layout and the state of other speakers in the group, defaults to true.
 
 ### Service `sonos.join`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Sonos integration doesn't accept usage of `snapshot` and `restore` without `entity_id` after 0.105.0.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant/issues/31650

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
