### PR TITLE
Added instructions to pick qemu targets if no specific target

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -199,7 +199,7 @@ curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/mast
 
 See the [hassio-installer](https://github.com/home-assistant/hassio-installer) GitHub page for an up-to-date listing of supported machine types.
 
-If you can not find your machine type in the list, you should pick the qemu release. i.e. qemux86-64 for a normal 64-bit Linux distribution, or qemuarm-64 for most modern ARM based target like Raspberry Pi clones, or TV boxes.
+If you can not find your machine type in the list, you should pick the `qemu` release. i.e., `qemux86-64` for a normal 64-bit Linux distribution, or `qemuarm-64` for most modern ARM-based target like Raspberry Pi clones, or TV boxes.
 
 <div class='note'>
 When you use this installation method, the core SSH add-on may not function correctly. If that happens, use the community SSH add-on. Some of the documentation might not work for your installation either.

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -199,6 +199,8 @@ curl -sL "https://raw.githubusercontent.com/home-assistant/hassio-installer/mast
 
 See the [hassio-installer](https://github.com/home-assistant/hassio-installer) GitHub page for an up-to-date listing of supported machine types.
 
+If you can not find your machine type in the list, you should pick the qemu release. i.e. qemux86-64 for a normal 64-bit Linux distribution, or qemuarm-64 for most modern ARM based target like Raspberry Pi clones, or TV boxes.
+
 <div class='note'>
 When you use this installation method, the core SSH add-on may not function correctly. If that happens, use the community SSH add-on. Some of the documentation might not work for your installation either.
 </div>


### PR DESCRIPTION
Based on Frenck's response to my issue here:
https://github.com/home-assistant/hassio-installer/issues/74
I suggest to clarify the documentation with the above text

## Proposed change
Clarify that the qemu "machines" should be considered the generic targets. I am one of those that can get a great TV box way cheaper than a Raspberry Pi 4. For less than the price of 4GB Pi 4, I can get a TV Box, quad-core, 2GHz, 4GB, 128GB eMMC, case and PSU included. So I assume/hope these nice boxes will get more popular with those that do not need 2x HDMI or the GPIO header.

## Type of change
Documentation update.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

https://github.com/home-assistant/hassio-installer/issues/74

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
