### PR TITLE
Add lg_netcast turn_on_action configuration variable

### DIFF
--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -5,7 +5,7 @@ logo: lg.png
 ha_category:
   - Media Player
 ha_iot_class: Local Polling
-ha_release: '0.20'
+ha_release: 0.20
 ---
 
 The `lg_netcast` platform allows you to control a LG Smart TV running NetCast 3.0 (LG Smart TV models released in 2012) and NetCast 4.0 (LG Smart TV models released in 2013). For the new LG WebOS TV's use the [webostv](/integrations/webostv#media-player) platform.
@@ -16,7 +16,7 @@ To add a LG TV to your installation, add the following to your `configuration.ya
 # Example configuration.yaml entry
 media_player:
   - platform: lg_netcast
-    host: 192.168.0.20
+    host: IP_ADDRESS
     turn_on_action:
       service: switch.turn_on
       data:
@@ -48,5 +48,20 @@ After starting Home Assistant the TV will display the access token on screen.
 Just add the token to your configuration and restart Home Assistant and the media player integration for your LG TV will show up.
 
 <div class='note'>
-The access token will not change until you factory reset your TV.
+  The access token will not change until you factory reset your TV.
 </div>
+
+## Advanced configuration
+
+The example below shows how you can use the `turn_on_action`
+
+```yaml
+# Example configuration.yaml entry
+media_player:
+  - platform: lg_netcast
+    host: 192.168.0.20
+    turn_on_action:
+      service: switch.turn_on
+      data:
+        entity_id: switch.tv_switch
+```

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -17,6 +17,10 @@ To add a LG TV to your installation, add the following to your `configuration.ya
 media_player:
   - platform: lg_netcast
     host: 192.168.0.20
+    turn_on_action:
+      service: switch.turn_on
+      data:
+        entity_id: switch.tv_switch
 ```
 
 {% configuration %}
@@ -32,6 +36,10 @@ name:
   description: The name you would like to give to the LG Smart TV.
   required: false
   default: LG TV Remote
+  type: string
+turn_on_action:
+  description: Defines an [action](/docs/automation/action/) to turn the TV on.
+  required: false
   type: string
 {% endconfiguration %}
 

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -17,10 +17,6 @@ To add a LG TV to your installation, add the following to your `configuration.ya
 media_player:
   - platform: lg_netcast
     host: IP_ADDRESS
-    turn_on_action:
-      service: switch.turn_on
-      data:
-        entity_id: switch.tv_switch
 ```
 
 {% configuration %}


### PR DESCRIPTION
## Proposed change

Adds `turn_on_action`

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant/pull/31792
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
