### PR TITLE
Mention the possibility of missing energy sensor

### DIFF
--- a/source/_integrations/melcloud.markdown
+++ b/source/_integrations/melcloud.markdown
@@ -47,7 +47,7 @@ token:
 
 ## Air-to-Air device
 
-An Air-to-Air heat pump provides `climate` and `sensor` platforms.
+An Air-to-Air heat pump provides `climate` and `sensor` platforms. Device capabilities can limit the available parameters and sensors.
 
 ### Climate
 
@@ -63,4 +63,4 @@ The following parameters can be controlled for the `climate` platform entities:
 The following attributes are available for `sensor` platform entities:
 
 - Room temperature
-- Energy - The total consumed energy in kWh.
+- Energy - The total consumed energy in kWh. **Not supported by all models.**


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Relatively recent devices do not necessarily have the energy metering capabilities which can be surprising. The possibility of lacking properties due to device capabilities as well as the possibility of missing energy sensor in bold.

I believe this is correctly targeted at `next`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/home-assistant#31831

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
