### PR TITLE
Use reduced privilege user

### DIFF
--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -86,11 +86,11 @@ host:
   required: true
   type: string
 username:
-  description: The username on openwrt. Set above as `hassio`.
+  description: The username on OpenWrt. Set above as `hassio`.
   required: true
   type: string
 password:
-  description: The password for the openwrt account.
+  description: The password for the OpenWrt account.
   required: true
   type: string
 dhcp_software:

--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -17,18 +17,18 @@ Before this scanner can be used you have to install the ubus RPC package on Open
 opkg install rpcd-mod-file
 ```
 
-For OpenWrt version 18.06.x the package uhttpd-mod-ubus should also be installed:
+For OpenWrt version 18.06 and higher, the package uhttpd-mod-ubus should also be installed:
 
 ```bash
 opkg install uhttpd-mod-ubus
 ```
 
-And create a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/user.json`.
+And create a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/hassio.json`.
 
 ```json
 {
-  "user": {
-    "description": "Read only user access role",
+  "hassio": {
+    "description": "Read only user access role for hassio",
     "read": {
       "ubus": {
         "*": [ "*" ]
@@ -38,6 +38,22 @@ And create a read-only user to be used by setting up the ACL file `/usr/share/rp
     "write": {}
   }
 }
+```
+
+Generate the password hash for a new password with 
+
+```bash
+uhttpd -m YOUR_PASSWORD
+```
+
+and add a new user called 'hassio' with the password we just hashed by adding a new entry in the file `/etc/config/rpcd`
+
+```json
+
+config login
+        option username 'hassio'
+        option password '$1$XXXXXXXXXXXXXXXXXXXXXXX'
+        list read 'hassio'
 ```
 
 Restart the services.
@@ -60,8 +76,8 @@ After this is done, add the following to your `configuration.yaml` file:
 device_tracker:
   - platform: ubus
     host: ROUTER_IP_ADDRESS
-    username: YOUR_ADMIN_USERNAME
-    password: YOUR_ADMIN_PASSWORD
+    username: hassio
+    password: YOUR_PASSWORD
 ```
 
 {% configuration %}
@@ -70,11 +86,11 @@ host:
   required: true
   type: string
 username:
-  description: The username of an user with administrative privileges, usually `root`.
+  description: The username on openwrt. Set above as `hassio`.
   required: true
   type: string
 password:
-  description: The password for your given admin account.
+  description: The password for the openwrt account.
   required: true
   type: string
 dhcp_software:


### PR DESCRIPTION
## Proposed change

Document creating a new rpcd user with read-only privileges to avoid needing to supply your admin password.

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - ~~I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.~~
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
