### PR TITLE
Adding documentation for Synology SRM Sensor

### DIFF
--- a/source/_integrations/synology_srm.markdown
+++ b/source/_integrations/synology_srm.markdown
@@ -151,12 +151,12 @@ sensor:
   - platform: template
     sensors:
       wan_download:
-        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.rx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
+        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core_system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.rx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
         friendly_name: Download
         unit_of_measurement: Mbit/s
         icon_template: 'mdi:download'
       wan_upload:
-        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.tx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
+        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core_system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.tx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
         friendly_name: Upload
         unit_of_measurement: Mbit/s
         icon_template: 'mdi:upload'

--- a/source/_integrations/synology_srm.markdown
+++ b/source/_integrations/synology_srm.markdown
@@ -29,7 +29,7 @@ device_tracker:
 
 {% configuration %}
 host:
-  description: The Synology SRM router host or IP address, e.g., `192.168.1.1` or `router.mydomain.local`
+  description: "The Synology SRM router host or IP address, e.g., `192.168.1.1` or `router.mydomain.local`"
   required: true
   type: string
 port:

--- a/source/_integrations/synology_srm.markdown
+++ b/source/_integrations/synology_srm.markdown
@@ -1,15 +1,20 @@
+
 ---
 title: Synology SRM
 description: Instructions on how to integrate Synology SRM routers into Home Assistant.
 logo: synology.png
 ha_category:
   - Presence Detection
+  - System Monitor
 ha_release: 0.87
 ha_codeowners:
   - '@aerialls'
+  - '@i00'
 ---
 
 This platform allows you to detect presence by looking at connected devices to a [Synology SRM](https://www.synology.com/en-us/srm) router.
+
+You can also configure a sensor to obtain information about the router.
 
 ## Configuration
 
@@ -53,6 +58,102 @@ verify_ssl:
   default: false
   type: boolean
 {% endconfiguration %}
+
+## Sensor
+
+The state of the Synology SRM sensor contains the external IP address for the router - however this is only set if the monitored_conditions is not specified or contains core.ddns_extip.
+
+The sensors attributes are filled with other information obtained from the router.
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: synology_srm
+    host: SynologyRouter.local
+    password: !secret SynologyRouter
+    monitored_conditions:
+      - core.ddns_extip
+      - core.system_utilization
+```
+
+{% configuration %}
+host:
+  description: The Synology SRM router host or IP address, e.g., `192.168.1.1` or `router.mydomain.local`
+  required: true
+  type: string
+port:
+  description: The port to connect to the Synology SRM router.
+  required: false
+  default: 8001
+  type: integer
+username:
+  description: The username of a user with administrative privileges.
+  required: false
+  default: admin
+  type: string
+password:
+  description: The password for your given admin account.
+  required: true
+  type: string
+ssl:
+  description: Use HTTPS instead of HTTP to connect.
+  required: false
+  default: true
+  type: boolean
+verify_ssl:
+  description: Enable or disable SSL certificate verification.
+  required: false
+  default: false
+  type: boolean
+name:
+  description: Allows a custom name to be set for the sensor - it is recommended that this be set when more than one router is being monitored. 
+  required: false
+  default: synology_srm
+  type: string
+monitored_conditions:
+    description: This specifies what information is obtained from the router and stored in the entity's attributes.
+  required: false
+  default: core.ddns_extip
+  type: string
+  keys:
+    base.encryption
+    base.info
+    core.ddns_extip
+    core.ddns_record
+    core.system_utilization
+    core.network_nsm_device
+    mesh.network_wanstatus
+    mesh.network_wifidevice
+    mesh.system_info
+{% endconfiguration %}
+
+### Example
+
+The following will create two entities that will store the routers current WAN traffic:
+
+```yaml
+sensor:
+  - platform: synology_srm
+    host: SynologyRouter.local
+    password: !secret SynologyRouter
+    monitored_conditions:
+      - core.ddns_extip
+      - core.system_utilization
+  - platform: template
+    sensors:
+      wan_download:
+        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.rx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
+        friendly_name: Download
+        unit_of_measurement: Mbit/s
+        icon_template: 'mdi:download'
+      wan_upload:
+        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.tx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
+        friendly_name: Upload
+        unit_of_measurement: Mbit/s
+        icon_template: 'mdi:upload'
+```
+
+## Notes
 
 It's not possible to create another account in SRM with admin permissions. You'll need to use your admin account (or the one you renamed at creation) for this connection.
 

--- a/source/_integrations/synology_srm.markdown
+++ b/source/_integrations/synology_srm.markdown
@@ -115,15 +115,24 @@ monitored_conditions:
   default: core.ddns_extip
   type: list
   keys:
-    base.encryption
-    base.info
-    core.ddns_extip
-    core.ddns_record
-    core.system_utilization
-    core.network_nsm_device
-    mesh.network_wanstatus
-    mesh.network_wifidevice
-    mesh.system_info
+    base.encryption:
+      description: Base encryption
+    base.info:
+      description: Base info
+    core.ddns_extip:
+      description: Core ddns external IP
+    core.ddns_record:
+       description: Core ddns record
+    core.system_utilization:
+      description: Core system utilization
+    core.network_nsm_device:
+      description: Core network nsm device
+    mesh.network_wanstatus:
+      description: Mesh network wan status
+    mesh.network_wifidevice:
+      description: Mesh network Wi-Fi device
+    mesh.system_info:
+      description: Mesh system info
 {% endconfiguration %}
 
 ### Example

--- a/source/_integrations/synology_srm.markdown
+++ b/source/_integrations/synology_srm.markdown
@@ -130,6 +130,7 @@ monitored_conditions:
 
 The following will create two entities that will store the routers current WAN traffic:
 
+{% raw %}
 ```yaml
 sensor:
   - platform: synology_srm
@@ -141,16 +142,17 @@ sensor:
   - platform: template
     sensors:
       wan_download:
-        value_template: {% raw %}"{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.rx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"{% endraw %}
+        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.rx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
         friendly_name: Download
         unit_of_measurement: Mbit/s
         icon_template: 'mdi:download'
       wan_upload:
-        value_template: {% raw %}"{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.tx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"{% endraw %}
+        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.tx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
         friendly_name: Upload
         unit_of_measurement: Mbit/s
         icon_template: 'mdi:upload'
 ```
+{% endraw %}
 
 ## Notes
 

--- a/source/_integrations/synology_srm.markdown
+++ b/source/_integrations/synology_srm.markdown
@@ -1,4 +1,3 @@
-
 ---
 title: Synology SRM
 description: Instructions on how to integrate Synology SRM routers into Home Assistant.
@@ -24,7 +23,7 @@ To use this device tracker in your installation, add the following to your `conf
 # Example configuration.yaml entry
 device_tracker:
   - platform: synology_srm
-    host: 192.168.1.254
+    host: IP_ADDRESS
     password: YOUR_ADMIN_PASSWORD
 ```
 
@@ -69,8 +68,8 @@ The sensors attributes are filled with other information obtained from the route
 # Example configuration.yaml entry
 sensor:
   - platform: synology_srm
-    host: SynologyRouter.local
-    password: !secret SynologyRouter
+    host: IP_ADDRESS
+    password: PASSWORD
     monitored_conditions:
       - core.ddns_extip
       - core.system_utilization
@@ -111,10 +110,10 @@ name:
   default: synology_srm
   type: string
 monitored_conditions:
-    description: This specifies what information is obtained from the router and stored in the entity's attributes.
+  description: This specifies what information is obtained from the router and stored in the entity's attributes.
   required: false
   default: core.ddns_extip
-  type: string
+  type: list
   keys:
     base.encryption
     base.info

--- a/source/_integrations/synology_srm.markdown
+++ b/source/_integrations/synology_srm.markdown
@@ -141,12 +141,12 @@ sensor:
   - platform: template
     sensors:
       wan_download:
-        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.rx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
+        value_template: {% raw %}"{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.rx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"{% endraw %}
         friendly_name: Download
         unit_of_measurement: Mbit/s
         icon_template: 'mdi:download'
       wan_upload:
-        value_template: "{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.tx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"
+        value_template: {% raw %}"{% set i = namespace() %}{% set i.i = 0 %}{% for item in states.sensor.synology_srm.attributes.core.system_utilization.network if item.device|regex_match('^(usbnet|ppp)', ignorecase=true) %}{% set i.i = i.i + item.tx %}{% endfor %}{{ ((i.i / 1024 / 1024) * 8)|round(2) }}"{% endraw %}
         friendly_name: Upload
         unit_of_measurement: Mbit/s
         icon_template: 'mdi:upload'


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update the documentation for the Synology SRM Component to include details of the new sensor that lists information about the router.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
**Not 100% sure if this is classified as a new integration I have said so since the integration search on HA lists the multiple ha_categories separately**
## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant/pull/31523
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
