### PR TITLE
Release note fragment improvements

### DIFF
--- a/source/_posts/2020-02-05-release-105.markdown
+++ b/source/_posts/2020-02-05-release-105.markdown
@@ -483,7 +483,7 @@ Hats over your heart for these shuttered integrations. Pour one out for:
 
 - __Hook__ *Removed* - The `hook` integration has been removed due to the shutdown of the connected service. All servers that have been providing this service will be turned off on 31 Jan 2020. - ([@springstan] - [#31046])
 
-## Release 0.105.1 - February 5
+## <a id="release-0.105.1"></a>Release 0.105.1 - February 5
 
 - Check for known Hue vulnerability ([@balloob] - [#31494]) ([hue docs])
 - Move program_mode check ([@aneisch] - [#31501]) ([radiotherm docs])
@@ -506,7 +506,7 @@ Hats over your heart for these shuttered integrations. Pour one out for:
 [radiotherm docs]: /integrations/radiotherm/
 [sonos docs]: /integrations/sonos/
 
-## Release 0.105.2 - February 6
+## <a id="release-0.105.2"></a>Release 0.105.2 - February 6
 
 - 0.105.0 ([@frenck] - [#31489]) ([abode docs]) ([adguard docs]) ([airly docs])
 - Fix automation sun import ([@balloob] - [#31521]) ([automation docs])
@@ -547,7 +547,7 @@ Hats over your heart for these shuttered integrations. Pour one out for:
 [webostv docs]: /integrations/webostv/
 [zone docs]: /integrations/zone/
 
-## Release 0.105.3 - February 10
+## <a id="release-0.105.3"></a>Release 0.105.3 - February 10
 
 - Bump ZHA dependencies. ([@Adminiuga] - [#31555]) ([zha docs])
 - Resolve August integration makes too many requests and hits rate limits ([@bdraco] - [#31558]) ([august docs])
@@ -588,7 +588,7 @@ Hats over your heart for these shuttered integrations. Pour one out for:
 [nws docs]: /integrations/nws/
 [zha docs]: /integrations/zha/
 
-## Release 0.105.4 - February 14
+## <a id="release-0.105.4"></a>Release 0.105.4 - February 14
 
 - Guard writing automation/scene/script config ([@balloob] - [#31568]) ([config docs])
 - For vizio integration, set unique ID early to prevent multiple zeroconf discovery items for the same device to appear ([@raman325] - [#31686]) ([vizio docs])
@@ -628,7 +628,7 @@ Hats over your heart for these shuttered integrations. Pour one out for:
 [spotify docs]: /integrations/spotify/
 [vizio docs]: /integrations/vizio/
 
-## Release 0.105.5 - February 17
+## <a id="release-0.105.5"></a>Release 0.105.5 - February 17
 
 - Upgrade bimmer_connected to 0.7.0 ([@gerard33] - [#31894]) ([bmw_connected_drive docs])
 - Report which data causes JSON serialization error ([@balloob] - [#31901])

--- a/source/latest-release-notes/index.html
+++ b/source/latest-release-notes/index.html
@@ -5,5 +5,5 @@
 {% assign recent_release_post = posts.first %}
 
 <script>
-  document.location = '{{ recent_release_post.url }}{{ site.patch_version_notes }}';
+  document.location = '{{ recent_release_post.url }}' + (document.location.hash || '{{ site.patch_version_notes }}');
 </script>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This adds ability to preserve a fragment identifier possibly in the URL when accessing `/latest-release-notes/#something`, and adds identifiers for 0.105.x releases.

We can take advantage of this in the HA release note links, will file a related UI PR.

Somewhat torn whether this is current or next material, but can obviously rebase on request.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
