### PR TITLE
Change `entity_id` to required

### DIFF
--- a/source/_integrations/vacuum.markdown
+++ b/source/_integrations/vacuum.markdown
@@ -30,7 +30,7 @@ Start a new cleaning task. For the Xiaomi Vacuum and Neato use `vacuum.start` in
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.turn_off`
 
@@ -38,7 +38,7 @@ Stop the current cleaning task and return to the dock. For the Xiaomi Vacuum and
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.start_pause`
 
@@ -46,7 +46,7 @@ Start, pause or resume a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.start`
 
@@ -54,7 +54,7 @@ Start or resume a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.pause`
 
@@ -62,7 +62,7 @@ Pause a cleaning task.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.stop`
 
@@ -70,7 +70,7 @@ Stop the current activity of the vacuum.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.return_to_base`
 
@@ -78,7 +78,7 @@ Tell the vacuum to return home.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.locate`
 
@@ -86,7 +86,7 @@ Locate the vacuum cleaner robot.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.clean_spot`
 
@@ -94,16 +94,16 @@ Tell the vacuum cleaner to do a spot clean-up.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 
 #### Service `vacuum.set_fan_speed`
 
-Set the fan speed of the vacuum. The `fanspeed` can be a label, as `balanced` or `turbo`, or be a number; it depends on the `vacuum` platform.
+Set the fan speed of the vacuum. `fan_speed` can be a label like `balanced` or `turbo`, or a number; it depends on the `vacuum` platform.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
-| `fan_speed`               |       no | Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium', or by percentage, between 0 and 100. |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `fan_speed`               |       no | Platform-dependent vacuum cleaner fan speed, with speed steps like `medium` or by percentage, between 0 and 100. |
 
 #### Service `vacuum.send_command`
 
@@ -111,6 +111,6 @@ Send a platform-specific command to the vacuum cleaner.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | Only act on specific vacuum. Use `entity_id: all` to target all.        |
 | `command`                 |       no | Command to execute.                                   |
 | `params`                  |      yes | Parameters for the command.                           |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
`entity_id` was still marked as optional in each service call.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

No additional info.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
