### PR TITLE
Add attribute parameter to label-state

### DIFF
--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -316,6 +316,11 @@ entity:
   required: true
   description: Entity id
   type: string
+attribute:
+  required: false
+  description: If present, the corresponding attribute will be shown,
+   instead of the entity's state
+  type: string
 prefix:
   required: false
   description: Text before entity state.
@@ -900,6 +905,13 @@ elements:
     style:
       top: 82%
       left: 79%
+  - type: state-label
+    entity: climate.kitchen
+    attribute: current_temperature
+    suffix: "°C"
+    style:
+      top: 33%
+      left: 15%
   - type: service-button
     title: Turn lights off
     style:


### PR DESCRIPTION
Add an optional parameter "attribute" to the label-state element in
picture elements

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add the possibility to set "attribute" as a parameter to the picture-elements state-label type,
so that instead of showing the state, a specific attribute can be shown instead, but the actions
still refer to the original entity.

Can be used to e.g. show the current temperature instead of the desired one in a label, but still be able to control it with a simple click.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant-polymer/pull/4953
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
