### PR TITLE
Emoncms API now provides a Unit of Measurement

### DIFF
--- a/source/_integrations/emoncms.markdown
+++ b/source/_integrations/emoncms.markdown
@@ -31,7 +31,7 @@ api_key:
   required: true
   type: string
 url:
-  description: "The base URL of Emoncms, use <https://emoncms.org> for the cloud based version. For self hosted Emoncms or EmonPi you may need a URL of `http://x.x.x.x/emoncms`."
+  description: "The base URL of Emoncms, use <https://emoncms.org> for the cloud-based version. For self-hosted Emoncms or EmonPi you may need a URL of `http://x.x.x.x/emoncms`."
   required: true
   type: string
 id:

--- a/source/_integrations/emoncms.markdown
+++ b/source/_integrations/emoncms.markdown
@@ -21,17 +21,20 @@ sensor:
   id: 1
 ```
 
+As of Feb 2020 including the option `use_emoncms_unit` will discover all sensors from Emoncms and use the unit of measurement specified in the Feed in Emoncms.  Tested with [Emoncms](https://github.com/emoncms/emoncms) V10.1.13.
+
 ## Configuration variables
 
 - `api_key` (*Required*): The read API key for your Emoncms user.
-- `url` (*Required*): The base URL of Emoncms, use <https://emoncms.org> for the cloud based version.
+- `url` (*Required*): The base URL of Emoncms, use <https://emoncms.org> for the cloud based version. For self hosted Emoncms or EmonPi you may need a URL of <http://x.x.x.x/emoncms>.
 - `id` (*Required*): Positive integer identifier for the sensor. Must be unique if you specify multiple Emoncms sensors.
 - `include_only_feed_id` (*Optional*): Positive integer list of Emoncms feed IDs. Only the feeds with feed IDs specified here will be displayed. Can not be specified if `exclude_feed_id` is specified.
 - `exclude_feed_id` (*Optional*): Positive integer list of Emoncms feed IDs. All the feeds will be displayed as sensors except the ones listed here. Can not be specified if `include_only_feed_id` is specified.
 - `sensor_names` (*Optional*): Dictionary of names for the sensors created that are created based on feed ID. The dictionary consists of `feedid: name` pairs. Sensors for feeds with their feed ID mentioned here will get the chosen name instead of the default name
 - `value_template` (*Optional*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to alter the feed value.
 - `scan_interval` (*Optional*): Defines the update interval of the sensor in seconds.
-- `unit_of_measurement` (*Optional*): Defines the unit of measurement of for all the sensors. default is "W".
+- `unit_of_measurement` (*Optional*): Defines the unit of measurement of for all the sensors. Default is "W".
+- `use_emoncms_unit` (*Optional*): Boolean. Causes integration to use the unit of measurement specified in the Emoncms Feed API payload. If no unit is set by Emoncms, no unit will be added to the sensor. A unit set in `unit_of_measurement` is ignored when this is True.  Default is *False*
 
 ## Default naming scheme
 
@@ -44,6 +47,17 @@ If `sensor_names` is used, any feeds with defined names will get those names exa
 ### Examples
 
 In this section you find some more examples of how this sensor can be used.
+
+Minimal configuration. All Feeds are added as sensors with the unit of measurement being set by the Emoncms Feed.
+
+```yaml
+sensor:
+  platform: emoncms
+  api_key: API_KEY
+  url: https://emoncms.org
+  id: 1
+  use_emoncms_unit: True
+```
 
 Display only feeds with their feed IDs specified in `include_only_feed_id`.
 
@@ -69,7 +83,7 @@ sensor:
     api_key: API_KEY
     url: https://emoncms.org
     id: 1
-    unit_of_measurement: "KWH"
+    unit_of_measurement: "kWh"
     exclude_feed_id:
       - 107
       - 105
@@ -84,7 +98,7 @@ sensor:
     api_key: API_KEY
     url: https://emoncms.org
     id: 1
-    unit_of_measurement: "KW"
+    unit_of_measurement: "kW"
     include_only_feed_id:
       - 5
       - 120
@@ -126,7 +140,7 @@ sensor:
       - 107
       - 106
   - platform: emoncms
-    api_key:  put your emoncms read api key here
+    api_key:  API_KEY
     url: https://emoncms.org
     id: 2
     scan_interval: 60

--- a/source/_integrations/emoncms.markdown
+++ b/source/_integrations/emoncms.markdown
@@ -31,7 +31,7 @@ api_key:
   required: true
   type: string
 url:
-  description: "The base URL of Emoncms, use <https://emoncms.org> for the cloud based version. For self hosted Emoncms or EmonPi you may need a URL of <http://x.x.x.x/emoncms>."
+  description: "The base URL of Emoncms, use <https://emoncms.org> for the cloud based version. For self hosted Emoncms or EmonPi you may need a URL of `http://x.x.x.x/emoncms`."
   required: true
   type: string
 id:

--- a/source/_integrations/emoncms.markdown
+++ b/source/_integrations/emoncms.markdown
@@ -25,16 +25,50 @@ As of Feb 2020 including the option `use_emoncms_unit` will discover all sensors
 
 ## Configuration variables
 
-- `api_key` (*Required*): The read API key for your Emoncms user.
-- `url` (*Required*): The base URL of Emoncms, use <https://emoncms.org> for the cloud based version. For self hosted Emoncms or EmonPi you may need a URL of <http://x.x.x.x/emoncms>.
-- `id` (*Required*): Positive integer identifier for the sensor. Must be unique if you specify multiple Emoncms sensors.
-- `include_only_feed_id` (*Optional*): Positive integer list of Emoncms feed IDs. Only the feeds with feed IDs specified here will be displayed. Can not be specified if `exclude_feed_id` is specified.
-- `exclude_feed_id` (*Optional*): Positive integer list of Emoncms feed IDs. All the feeds will be displayed as sensors except the ones listed here. Can not be specified if `include_only_feed_id` is specified.
-- `sensor_names` (*Optional*): Dictionary of names for the sensors created that are created based on feed ID. The dictionary consists of `feedid: name` pairs. Sensors for feeds with their feed ID mentioned here will get the chosen name instead of the default name
-- `value_template` (*Optional*): Defines a [template](/docs/configuration/templating/#processing-incoming-data) to alter the feed value.
-- `scan_interval` (*Optional*): Defines the update interval of the sensor in seconds.
-- `unit_of_measurement` (*Optional*): Defines the unit of measurement of for all the sensors. Default is "W".
-- `use_emoncms_unit` (*Optional*): Boolean. Causes integration to use the unit of measurement specified in the Emoncms Feed API payload. If no unit is set by Emoncms, no unit will be added to the sensor. A unit set in `unit_of_measurement` is ignored when this is True.  Default is *False*
+{% configuration %}
+api_key:
+  description: The read API key for your Emoncms user.
+  required: true
+  type: string
+url:
+  description: "The base URL of Emoncms, use <https://emoncms.org> for the cloud based version. For self hosted Emoncms or EmonPi you may need a URL of <http://x.x.x.x/emoncms>."
+  required: true
+  type: string
+id:
+  description: Positive integer identifier for the sensor. Must be unique if you specify multiple Emoncms sensors.
+  required: true
+  type: integer
+include_only_feed_id:
+  description: Positive integer list of Emoncms feed IDs. Only the feeds with feed IDs specified here will be displayed. Can not be specified if `exclude_feed_id` is specified.
+  required: false
+  type: list
+exclude_feed_id:
+  description: Positive integer list of Emoncms feed IDs. All the feeds will be displayed as sensors except the ones listed here. Can not be specified if `include_only_feed_id` is specified.
+  required: false
+  type: list
+sensor_names:
+  description: Dictionary of names for the sensors created that are created based on feed ID. The dictionary consists of `feedid: name` pairs. Sensors for feeds with their feed ID mentioned here will get the chosen name instead of the default name.
+  required: false
+  type: [integer, list]
+value_template:
+  description: Defines a [template](/docs/configuration/templating/#processing-incoming-data) to alter the feed value.
+  required: false
+  type: template
+scan_interval:
+  description: Defines the update interval of the sensor in seconds.
+  required: false
+  type: integer
+unit_of_measurement:
+  description: Defines the unit of measurement of for all the sensors.
+  required: false
+  default: W
+  type: string
+use_emoncms_unit:
+  description: Causes integration to use the unit of measurement specified in the Emoncms Feed API payload. If no unit is set by Emoncms, no unit will be added to the sensor. A unit set in `unit_of_measurement` is ignored when this is `True`.
+  required: false
+  default: false
+  type: boolean
+{% endconfiguration %}
 
 ## Default naming scheme
 

--- a/source/_integrations/emoncms.markdown
+++ b/source/_integrations/emoncms.markdown
@@ -21,7 +21,7 @@ sensor:
   id: 1
 ```
 
-As of Feb 2020 including the option `use_emoncms_unit` will discover all sensors from Emoncms and use the unit of measurement specified in the Feed in Emoncms.  Tested with [Emoncms](https://github.com/emoncms/emoncms) V10.1.13.
+As of Feb 2020 including the option `use_emoncms_unit` will discover all sensors from Emoncms and use the unit of measurement specified in the Feed in Emoncms. Tested with [Emoncms](https://github.com/emoncms/emoncms) V10.1.13.
 
 ## Configuration variables
 
@@ -47,7 +47,7 @@ exclude_feed_id:
   required: false
   type: list
 sensor_names:
-  description: Dictionary of names for the sensors created that are created based on feed ID. The dictionary consists of `feedid: name` pairs. Sensors for feeds with their feed ID mentioned here will get the chosen name instead of the default name.
+  description: "Dictionary of names for the sensors created that are created based on feed ID. The dictionary consists of `feedid: name` pairs. Sensors for feeds with their feed ID mentioned here will get the chosen name instead of the default name."
   required: false
   type: [integer, list]
 value_template:
@@ -64,7 +64,7 @@ unit_of_measurement:
   default: W
   type: string
 use_emoncms_unit:
-  description: Causes integration to use the unit of measurement specified in the Emoncms Feed API payload. If no unit is set by Emoncms, no unit will be added to the sensor. A unit set in `unit_of_measurement` is ignored when this is `True`.
+  description: Causes integration to use the unit of measurement specified in the Emoncms Feed API payload. If no unit is set by Emoncms, no unit will be added to the sensor. A unit set in `unit_of_measurement` is ignored when this is `true`.
   required: false
   default: false
   type: boolean
@@ -90,7 +90,7 @@ sensor:
   api_key: API_KEY
   url: https://emoncms.org
   id: 1
-  use_emoncms_unit: True
+  use_emoncms_unit: true
 ```
 
 Display only feeds with their feed IDs specified in `include_only_feed_id`.

--- a/source/_integrations/emoncms.markdown
+++ b/source/_integrations/emoncms.markdown
@@ -21,7 +21,7 @@ sensor:
   id: 1
 ```
 
-As of Feb 2020 including the option `use_emoncms_unit` will discover all sensors from Emoncms and use the unit of measurement specified in the Feed in Emoncms. Tested with [Emoncms](https://github.com/emoncms/emoncms) V10.1.13.
+As of Feb 2020 including the option `use_emoncms_unit` will discover all sensors from Emoncms and use the unit of measurement specified in the feed from Emoncms. Tested with [Emoncms](https://github.com/emoncms/emoncms) V10.1.13.
 
 ## Configuration variables
 

--- a/source/_integrations/emoncms.markdown
+++ b/source/_integrations/emoncms.markdown
@@ -21,7 +21,7 @@ sensor:
   id: 1
 ```
 
-As of Feb 2020 including the option `use_emoncms_unit` will discover all sensors from Emoncms and use the unit of measurement specified in the feed from Emoncms. Tested with [Emoncms](https://github.com/emoncms/emoncms) V10.1.13.
+As of Feb 2020, the integration will discover all sensors from Emoncms and will use the unit of measurement specified in the Feed from Emoncms, in preference to the one set in the configuration. Tested with [Emoncms](https://github.com/emoncms/emoncms) V10.1.13 - `unit` was added to the API around version V9.9.1.
 
 ## Configuration variables
 
@@ -59,15 +59,10 @@ scan_interval:
   required: false
   type: integer
 unit_of_measurement:
-  description: Defines the unit of measurement of for all the sensors.
+  description: Defines the unit of measurement to be used for any sensor where the unit is *not* set in Emoncms. If no unit is set in Emoncms or in the configuration, the default (W) will be used.
   required: false
   default: W
   type: string
-use_emoncms_unit:
-  description: Causes integration to use the unit of measurement specified in the Emoncms Feed API payload. If no unit is set by Emoncms, no unit will be added to the sensor. A unit set in `unit_of_measurement` is ignored when this is `true`.
-  required: false
-  default: false
-  type: boolean
 {% endconfiguration %}
 
 ## Default naming scheme
@@ -82,7 +77,7 @@ If `sensor_names` is used, any feeds with defined names will get those names exa
 
 In this section you find some more examples of how this sensor can be used.
 
-Minimal configuration. All Feeds are added as sensors with the unit of measurement being set by the Emoncms Feed.
+Minimal configuration. All Feeds are added as sensors with the unit of measurement being set by the Emoncms Feed or the default unit.
 
 ```yaml
 sensor:
@@ -90,7 +85,6 @@ sensor:
   api_key: API_KEY
   url: https://emoncms.org
   id: 1
-  use_emoncms_unit: true
 ```
 
 Display only feeds with their feed IDs specified in `include_only_feed_id`.


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update to add a variable to use the Unit of measurment included in the Emoncms API call.

Minor other enhancements.

As a user is required to add a variable to make the change this should be regarded as non-breaking.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant/pull/32042
- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant/issues/31251

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
