### PR TITLE
:books: Update confirmation in Installation Script

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -166,9 +166,8 @@ Debian/Ubuntu:
 
 ```bash
 sudo -i
-apt-get install -y software-properties-common
 apt-get update
-apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
+apt-get install -y software-properties-common apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
 systemctl disable ModemManager
 curl -fsSL get.docker.com | sh
 ```

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -166,7 +166,7 @@ Debian/Ubuntu:
 
 ```bash
 sudo -i
-apt-get install software-properties-common
+apt-get install -y software-properties-common
 apt-get update
 apt-get install -y apparmor-utils apt-transport-https avahi-daemon ca-certificates curl dbus jq network-manager socat
 systemctl disable ModemManager


### PR DESCRIPTION
If a user were to copy paste the commands, I believe it will fail as there is no confirmation on the initial `software-properties-common` install.

## Proposed change
Add's `-y` flag so copy paste would work.  One other thought, could this maybe be optimised to a single line install?



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
