### PR TITLE
Fix MQTT trigger automation_type documentation.

### DIFF
--- a/source/_integrations/device_trigger.mqtt.markdown
+++ b/source/_integrations/device_trigger.mqtt.markdown
@@ -19,7 +19,7 @@ The discovery topic needs to be: `<discovery_prefix>/device_automation/[<node_id
 
 {% configuration %}
 automation_type:
-  description: The type of automation, must be 'device_trigger'.
+  description: The type of automation, must be 'trigger'.
   required: true
   type: string
 payload:


### PR DESCRIPTION
## Proposed change
The MQTT trigger documentation states that the `automation_type` has to be `device_trigger` but this triggers an exception:

```
2020-02-29 16:14:34 ERROR (MainThread) [homeassistant.util.logging] Exception in async_discover when dispatching 'mqtt_discovery_new_device_automation_mqtt': ({'automation_type': 'device_trigger', 'type': 'action', 'subtype': 'brightness_down_click', 'payload': 'brightness_down_click', 'topic': 'zigbee2mqtt/my_remote/action', 'device': {'identifiers': ['zigbee2mqtt_0x000b57fffecb472d'], 'name': 'my_remote', 'sw_version': 'Zigbee2mqtt 1.11.0-dev', 'model': 'TRADFRI remote control (E1524/E1810)', 'manufacturer': 'IKEA'}, 'platform': 'mqtt'},)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/mqtt/device_automation.py", line 32, in async_discover
    config = PLATFORM_SCHEMA(discovery_payload)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 432, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: value is not allowed for dictionary value @ data['automation_type']
```

When looking at the code I found out it has to be `trigger` (https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mqtt/device_automation.py#L40). 

@emontnemery please confirm that this is expected

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Not relevant

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
