### PR TITLE
lights changed to light

### DIFF
--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -89,7 +89,7 @@ example:
 To improve readability, you can source out certain domains from your main configuration file with the `!include`-syntax.
 
 ```yaml
-lights: !include lights.yaml
+light: !include lights.yaml
 ```
 
 More information about this feature can also be found at [splitting configuration](/docs/configuration/splitting_configuration/).


### PR DESCRIPTION
## Proposed change
The YAML documentation page contains a typo. lights: should in fact be light:
This is an obvious obstacle for beginners which we can easily solve