### PR TITLE
Update AlarmDecoder Docs

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -34,7 +34,6 @@ alarmdecoder:
     host: 192.168.1.20
     port: 10000
   panel_display: false
-  autobypass: false
   zones:
     01:
       name: 'Smoke Detector'

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -81,9 +81,14 @@ panel_display:
   default: false
   type: boolean
 autobypass:
-  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#'). This will require your code to be entered."
+  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#'). This will require your code to be entered even if `code_arm_required` is set to `false`."
   required: false
   default: false
+  type: boolean
+code_arm_required:
+  description: "If this is set to `false`, you will not need to enter your code to arm the system."
+  required: false
+  default: true
   type: boolean
 zones:
   description: "AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/integrations/alarmdecoder) docs. *Note: If no zones are specified, Home Assistant will not load any binary_sensor integrations.*"
@@ -130,7 +135,7 @@ There are several attributes available on the alarm panel to give you more infor
 - `programming_mode`: Set to `true` if your system is in programming mode.
 - `ready`: Set to `true` if your system is ready to be armed. Any faults, including motions sensors, will make this value `false`.
 - `zone_bypassed`: Set to `true` if your system is currently bypassing a zone.
-- `code_arm_required`: Set to `false`.
+- `code_arm_required`: Set to the value specified in your config.
 
 ## Services
 

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -135,7 +135,7 @@ There are several attributes available on the alarm panel to give you more infor
 - `programming_mode`: Set to `true` if your system is in programming mode.
 - `ready`: Set to `true` if your system is ready to be armed. Any faults, including motions sensors, will make this value `false`.
 - `zone_bypassed`: Set to `true` if your system is currently bypassing a zone.
-- `code_arm_required`: Set to the value specified in your config.
+- `code_arm_required`: Set to the value specified in your configuration.
 
 ## Services
 

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -34,6 +34,7 @@ alarmdecoder:
     host: 192.168.1.20
     port: 10000
   panel_display: false
+  autobypass: false
   zones:
     01:
       name: 'Smoke Detector'
@@ -81,7 +82,7 @@ panel_display:
   default: false
   type: boolean
 autobypass:
-  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#')."
+  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#'). This will require your code to be entered."
   required: false
   default: false
   type: boolean
@@ -130,6 +131,7 @@ There are several attributes available on the alarm panel to give you more infor
 - `programming_mode`: Set to `true` if your system is in programming mode.
 - `ready`: Set to `true` if your system is ready to be armed. Any faults, including motions sensors, will make this value `false`.
 - `zone_bypassed`: Set to `true` if your system is currently bypassing a zone.
+- `code_arm_required`: Set to `false`.
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR updates the AlarmDecoder documentation to reflect the changes outlined in this PR: https://github.com/home-assistant/home-assistant/pull/32390.

Once that PR is merged, AlarmDecoder users will no longer need to enter a code to arm their systems. A code will still be necessary to use the auto-bypass feature, though.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant/pull/32390
- This PR fixes or closes issue: n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
