### PR TITLE
Added SAN to the example openssl command

### DIFF
--- a/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
@@ -23,8 +23,10 @@ Change to your Home Assistant [configuration directory](/getting-started/configu
 The certificate **must** be `.pem` extension.
 
 ```bash
-openssl req -sha256 -newkey rsa:4096 -nodes -keyout privkey.pem -x509 -days 730 -out fullchain.pem
+openssl req -sha256 -addext "subjectAltName = IP:X.X.X.X" -newkey rsa:4096 -nodes -keyout privkey.pem -x509 -days 730 -out fullchain.pem
 ```
+
+Where the `X.X.X.X` must be replaced with the IP address of your local machine running Home Assistant (E.G.: 192.168.1.20).
 
 For details about the parameters, please check the OpenSSL documentation. Provide the requested information during the generation process.
 

--- a/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
@@ -26,7 +26,7 @@ The certificate **must** be `.pem` extension.
 openssl req -sha256 -addext "subjectAltName = IP:X.X.X.X" -newkey rsa:4096 -nodes -keyout privkey.pem -x509 -days 730 -out fullchain.pem
 ```
 
-Where the `X.X.X.X` must be replaced with the IP address of your local machine running Home Assistant (e.g.,: `192.168.1.20`).
+Where the `X.X.X.X` must be replaced with the IP address of your local machine running Home Assistant (e.g., `192.168.1.20`).
 
 For details about the parameters, please check the OpenSSL documentation. Provide the requested information during the generation process.
 

--- a/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
+++ b/source/_docs/ecosystem/certificates/tls_self_signed_certificate.markdown
@@ -26,7 +26,7 @@ The certificate **must** be `.pem` extension.
 openssl req -sha256 -addext "subjectAltName = IP:X.X.X.X" -newkey rsa:4096 -nodes -keyout privkey.pem -x509 -days 730 -out fullchain.pem
 ```
 
-Where the `X.X.X.X` must be replaced with the IP address of your local machine running Home Assistant (E.G.: 192.168.1.20).
+Where the `X.X.X.X` must be replaced with the IP address of your local machine running Home Assistant (e.g.,: `192.168.1.20`).
 
 For details about the parameters, please check the OpenSSL documentation. Provide the requested information during the generation process.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This ensures that the Home Assistant Companion on Android 10 and iOS 13 (this is what I tested) will correctly connect to the local Home Assistant instance without blocking the connection due to an SSL error.

This is due to compliance with RFC 2818, which states that support for CN fallback (that is the only parameter we are allowed to set with the current openssl command in the docs) is deprecated and only SAN should be used to establish whether a certificate is valid for a certain host or not.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
