### PR TITLE
remove $ marks from code lines for copy/pasting

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -77,30 +77,30 @@ WantedBy=multi-user.target
 You need to reload `systemd` to make the daemon aware of the new configuration.
 
 ```bash
-$ sudo systemctl --system daemon-reload
+sudo systemctl --system daemon-reload
 ```
 
 To have Home Assistant start automatically at boot, enable the service.
 
 ```bash
-$ sudo systemctl enable home-assistant@YOUR_USER
+sudo systemctl enable home-assistant@YOUR_USER
 ```
 
 To disable the automatic start, use this command.
 
 ```bash
-$ sudo systemctl disable home-assistant@YOUR_USER
+sudo systemctl disable home-assistant@YOUR_USER
 ```
 
 To start Home Assistant now, use this command.
 ```bash
-$ sudo systemctl start home-assistant@YOUR_USER
+sudo systemctl start home-assistant@YOUR_USER
 ```
 
 You can also substitute the `start` above with `stop` to stop Home Assistant, `restart` to restart Home Assistant, and 'status' to see a brief status report as seen below.
 
 ```bash
-$ sudo systemctl status home-assistant@YOUR_USER
+sudo systemctl status home-assistant@YOUR_USER
 ● home-assistant@fab.service - Home Assistant for YOUR_USER
    Loaded: loaded (/etc/systemd/system/home-assistant@YOUR_USER.service; enabled; vendor preset: disabled)
    Active: active (running) since Sat 2016-03-26 12:26:06 CET; 13min ago
@@ -114,18 +114,18 @@ $ sudo systemctl status home-assistant@YOUR_USER
 To get Home Assistant's logging output, simple use `journalctl`.
 
 ```bash
-$ sudo journalctl -f -u home-assistant@YOUR_USER
+sudo journalctl -f -u home-assistant@YOUR_USER
 ```
 
 Because the log can scroll quite quickly, you can select to view only the error lines:
 ```bash
-$ sudo journalctl -f -u home-assistant@YOUR_USER | grep -i 'error'
+sudo journalctl -f -u home-assistant@YOUR_USER | grep -i 'error'
 ```
 
 When working on Home Assistant, you can easily restart the system and then watch the log output by combining the above commands using `&&`
 
 ```bash
-$ sudo systemctl restart home-assistant@YOUR_USER && sudo journalctl -f -u home-assistant@YOUR_USER
+sudo systemctl restart home-assistant@YOUR_USER && sudo journalctl -f -u home-assistant@YOUR_USER
 ```
 
 ### Automatically restarting Home Assistant on failure

--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -100,7 +100,7 @@ sudo systemctl start home-assistant@YOUR_USER
 You can also substitute the `start` above with `stop` to stop Home Assistant, `restart` to restart Home Assistant, and 'status' to see a brief status report as seen below.
 
 ```bash
-sudo systemctl status home-assistant@YOUR_USER
+$ sudo systemctl status home-assistant@YOUR_USER
 ● home-assistant@fab.service - Home Assistant for YOUR_USER
    Loaded: loaded (/etc/systemd/system/home-assistant@YOUR_USER.service; enabled; vendor preset: disabled)
    Active: active (running) since Sat 2016-03-26 12:26:06 CET; 13min ago


### PR DESCRIPTION
## Proposed change
Remove the `$` signs from each code block so that they can actually be copy+pasted into a terminal window.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
A pretty minor change, but seeing as pages like the [manual installation doc](https://www.home-assistant.io/docs/installation/raspberry-pi/) do this as well, it seems pretty reasonable to request.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
