### PR TITLE
Add support for images from Brands

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -5,6 +5,8 @@
   <div class='brand-logo-container section'>
     {%- if page.logo -%}
       <img src='/images/supported_brands/{{ page.logo }}' />
+    {%- else -%}
+      <img src='https://brands.home-assistant.io/{{ page.ha_domain }}/logo.png' srcset='https://brands.home-assistant.io/{{ page.ha_domain }}/logo@2x.png 2x' />
     {%- endif -%}
   </div>
 

--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -95,7 +95,7 @@ var allComponents = [
         {% capture category %}"{{ ha_category | slugify | downcase }}"{% endcapture %}
         {% assign categories = categories | push: category %}
       {%- endfor -%}
-      {url:"{{ component.url }}", title:"{{component.title}}", cat: [{{categories|join: ","}}], featured: {% if component.featured %}true{% else %}false{% endif %}, v: "{{major_version}}.{{minor_version}}", logo: "{{component.logo}}"},
+      {url:"{{ component.url }}", title:"{{component.title}}", cat: [{{categories|join: ","}}], featured: {% if component.featured %}true{% else %}false{% endif %}, v: "{{major_version}}.{{minor_version}}", logo: "{{component.logo}}", domain: "{{component.ha_domain}}"},
     {% endif -%}
   {%- endfor -%}
   false
@@ -144,7 +144,7 @@ allComponents.pop(); // remove placeholder element at the end
         components: [],
         image: function () {
           if (this.logo === '') {
-            return '';
+            return '<img src="https://brands.home-assistant.io/' + this.domain + '/logo.png" srcset="https://brands.home-assistant.io/' + this.domain + '/logo@2x.png 2x">';
           } else {
             return '<img data-src="/images/supported_brands/' + this.logo + '">';
           }


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds in support for loading up images from:

<https://brands.home-assistant.io>


If an integration has a `logo` defined in the frontmatter, that will take precedence, until we have resolved/migrated all brands.

Note: this PR does not move images yet, not does it add `ha_domain`. So all current images will still show. Only the missing images will now show a placeholder. In a followup PR, I will add the `ha_domain` and start removing migrated images and `logo` frontmatter.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
