### PR TITLE
Link to source/alerts based on ha_domain

### DIFF
--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -1,6 +1,4 @@
-{%- assign github_main_repo = 'https://github.com/home-assistant/home-assistant/blob/dev/homeassistant' -%}
 <section class="aside-module grid__item one-whole lap-one-half">
-  {%- include edit_github.html -%}
 
   <div class='brand-logo-container section'>
     {%- if page.logo -%}
@@ -10,13 +8,11 @@
     {%- endif -%}
   </div>
 
-  {%- assign file_parts = page.url | split: '/' | last | split: '.' -%}
-  {%- assign imp_name = file_parts | last -%}
-  {%- assign imp_url = imp_name | prepend: '/components/' | append: '/' -%}
-
-  <div class="section">
-    <kb-alert-link integration="{{ imp_name }}"></kb-alert-link>
-  </div>
+  {%- if page.ha_domain -%}
+    <div class="section">
+      <kb-alert-link integration="{{ page.ha_domain }}"></kb-alert-link>
+    </div>
+  {%- endif -%}
 
   {%- if page.ha_iot_class -%}
     <div class='section'>
@@ -52,9 +48,11 @@
     </div>
   {%- endif -%}
 
-  <div class='section'>
-    Source: <a href='{{github_main_repo}}{{imp_url}}'>{{imp_url}}</a>
-  </div>
+  {%- if page.ha_domain -%}
+    <div class='section'>
+      Source: <a href='https://github.com/home-assistant/core/tree/dev/homeassistant/components/{{ page.ha_domain }}'>View on GitHub</a>
+    </div>
+  {%- endif -%}
 
   {%- if page.ha_category.first -%}
     <div class='section'>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Changes in this PR:

- Removed additional variable assignment on top of page
- Change new core code base repository location
- Link to GitHub source based on `ha_domain` instead of guessing the URL
- Change GitHub link to be humanly readable ("View on GitHub" instead of `/components/adguard`)
- Removed the additional "Edit page on GitHub" link. There is already one. 2 almost next to each other might be a bit too much 😉 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
