### PR TITLE
modbus: add description of parameter "delay"

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -53,6 +53,11 @@ timeout:
   required: false
   default: 3
   type: integer
+delay:
+  description: Time to sleep in seconds after connecting and before sending messagees. Some modbus-tcp servers needs a short delay typically 1-2 seconds in order to prepare the communication. If a server accepts connecting, but there are no response to the requests send, this parameter might help.
+  required: false
+  default: 0
+  type: integer
 {% endconfiguration %}
 
 ### Serial connection

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -54,7 +54,7 @@ timeout:
   default: 3
   type: integer
 delay:
-  description: Time to sleep in seconds after connecting and before sending messagees. Some modbus-tcp servers needs a short delay typically 1-2 seconds in order to prepare the communication. If a server accepts connecting, but there are no response to the requests send, this parameter might help.
+  description: Time to sleep in seconds after connecting and before sending messages. Some modbus-tcp servers need a short delay typically 1-2 seconds in order to prepare the communication. If a server accepts connecting, but there is no response to the requests send, this parameter might help.
   required: false
   default: 0
   type: integer


### PR DESCRIPTION
#11911  Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Using "delay" causes a pause after connect() and before first send()
allowing the server to prepare.

More Information in the core PR, with the actual code.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
I am not a native English speaker, so feel free to correct the text.

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/32557
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
