### PR TITLE
📚 Rename Hass.io on main docs page

### DIFF
--- a/source/docs/index.markdown
+++ b/source/docs/index.markdown
@@ -10,7 +10,7 @@ The documentation covers beginner to advanced topics around the installation, se
     <div class='img-container'>
       <img src='https://brands.home-assistant.io/homeassistant/icon.png' />
     </div>
-    <div class='title'>Hass.io</div>
+    <div class='title'>Installation</div>
   </a>
   <a class='option-card' href='/docs/configuration/'>
     <div class='img-container'>


### PR DESCRIPTION
Makes sense to me to have the section as Installation rather than Hass.io (as it then matches the Configuration next step).  Any comments are welcome.

Appreciate the links/sub folder still needs to be fixed.

## Proposed change

Rename Hassio label



## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
