### PR TITLE
Update nuheat for new climate platform

### DIFF
--- a/source/_integrations/nuheat.markdown
+++ b/source/_integrations/nuheat.markdown
@@ -136,28 +136,19 @@ Returns the maximum supported temperature by the thermostat
 
 The following services are provided by the NuHeat Thermostat: `set_temperature`, `set_hvac_mode`, `set_preset_mode`, `resume_program`.
 
-The services `fan_min_on_time`, `set_aux_heat`, `set_away_mode`, `set_humidity`, `set_fan_mode`, and `set_swing_mode` offered by the [Climate component](/integrations/climate/) are not implemented for this thermostat.
+### Service `climate.set_hvac_mode` ([Climate component](/integrations/climate/))
 
-### Service `set_temperature`
+NuHeat Thermostats do not have an off concept. Setting the temperature to `min_temp` and changing the mode to `heat` will cause the device to enter a `Permanent Hold` preset and will stop the thermostat from turning on unless you happen to live in a freezing climate.
 
-Puts the thermostat into an indefinite hold at the given temperature.
+### Service `climate.set_temperature` ([Climate component](/integrations/climate/))
 
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Use `entity_id: all` to target all.
-| `temperature` | no | Desired target temperature (when not in auto mode)
+If the thermostat is in auto mode, it puts the thermostat into a temporary hold at the given temperature.
 
-Only the target temperatures relevant for the current operation mode need to
-be provided.
+If the thermostat is in heat mode, it puts the thermostat into a permanent hold at the given temperature.
 
-### Service `set_preset_mode`
+### Service `climate.set_preset_mode` ([Climate component](/integrations/climate/))
 
-Sets the thermostat's preset mode. Without a preset mode set it run the thermostat's programmed schedule, "temperature" (to indefinitely hold the thermostat's current target temperature), or "temporary_temperature" (to hold the thermostat's current target temperature until the thermostat's next scheduled event).
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Use `entity_id: all` to target all.
-| `hold_mode` | no | New value of hold mode.
+The following presets are available: `Run Schedule`, `Temporary Hold`, `Permanent Hold`.
 
 ### Service `nuheat.resume_program`
 

--- a/source/_integrations/nuheat.markdown
+++ b/source/_integrations/nuheat.markdown
@@ -136,7 +136,7 @@ Returns the maximum supported temperature by the thermostat
 
 The following services are provided by the NuHeat Thermostat: `set_temperature`, `set_hvac_mode`, `set_preset_mode`, `resume_program`.
 
-### Service `climate.set_hvac_mode` ([Climate component](/integrations/climate/))
+### Service `climate.set_hvac_mode` ([Climate integration](/integrations/climate/))
 
 NuHeat Thermostats do not have an off concept. Setting the temperature to `min_temp` and changing the mode to `heat` will cause the device to enter a `Permanent Hold` preset and will stop the thermostat from turning on unless you happen to live in a freezing climate.
 

--- a/source/_integrations/nuheat.markdown
+++ b/source/_integrations/nuheat.markdown
@@ -140,7 +140,7 @@ The following services are provided by the NuHeat Thermostat: `set_temperature`,
 
 NuHeat Thermostats do not have an off concept. Setting the temperature to `min_temp` and changing the mode to `heat` will cause the device to enter a `Permanent Hold` preset and will stop the thermostat from turning on unless you happen to live in a freezing climate.
 
-### Service `climate.set_temperature` ([Climate component](/integrations/climate/))
+### Service `climate.set_temperature` ([Climate integration](/integrations/climate/))
 
 If the thermostat is in auto mode, it puts the thermostat into a temporary hold at the given temperature.
 

--- a/source/_integrations/nuheat.markdown
+++ b/source/_integrations/nuheat.markdown
@@ -146,7 +146,7 @@ If the thermostat is in auto mode, it puts the thermostat into a temporary hold 
 
 If the thermostat is in heat mode, it puts the thermostat into a permanent hold at the given temperature.
 
-### Service `climate.set_preset_mode` ([Climate component](/integrations/climate/))
+### Service `climate.set_preset_mode` ([Climate integration](/integrations/climate/))
 
 The following presets are available: `Run Schedule`, `Temporary Hold`, `Permanent Hold`.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Remove docs for pre climate 1.0 items that no longer exist

Add notes about removal of the off mode as it doesn't actually work since nuheat doesn't implement it.

Implement missing set_hvac_mode for nuheat

Fix hvac_mode as it was really implementing hvac_action



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/32714
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
