### PR TITLE
Add missing MAC address randomization warning

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -130,6 +130,19 @@ Optional:
 
 </div>
 
+<div class='note warning'>
+
+   With NetworkManager, your MAC address will reset during the Wi-Fi scanning (usually, on every reboot). To prevent this, you need to add
+
+```
+[device]
+wifi.scan-rand-mac-address=no
+```
+
+to `/etc/NetworkManager/NetworkManager.conf` _([Source](https://unix.stackexchange.com/a/395201/102128))_.
+
+</div>
+
 ### Arch Linux
 
 - `apparmor`

--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -134,7 +134,7 @@ Optional:
 
    With NetworkManager, your MAC address will reset during the Wi-Fi scanning (usually, on every reboot). To prevent this, you need to add
 
-```
+```ini
 [device]
 wifi.scan-rand-mac-address=no
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Because this page mentions the `network-manager` package, and because it changes the MAC address on every reboot by default, we should mention how to disable this behaviour, for people that do want to "control the host network setup over the UI".

Preview: https://deploy-preview-12342--home-assistant-docs.netlify.com/hassio/installation/#debianubuntu

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
