### PR TITLE
Open GitHub link in new tab

### DIFF
--- a/source/_includes/edit_github.html
+++ b/source/_includes/edit_github.html
@@ -1,4 +1,4 @@
 {% assign url_parts = page.url | split: '/' %}
 {% if page.hide_github_edit != true %}
-<div class='edit-github'><a href='{{ site.NLY_REPOSITORY_URL }}/tree/{{ site.NLY_HEAD }}/source/{{ page.path }}'>Edit this page on GitHub</a></div>
+<div class='edit-github'><a target="_blank" rel="noopener noreferrer" href='{{ site.NLY_REPOSITORY_URL }}/tree/{{ site.NLY_HEAD }}/source/{{ page.path }}'>Edit this page on GitHub</a></div>
 {% endif %}


### PR DESCRIPTION
## Proposed change

The link to edit the source of a documentation page on GitHub should be opened in a new tab, as that is common practice and makes sense in this case.

Replaces #12364

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

Meta: Change to the webpage code itself

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
