### PR TITLE
Increase prominence of whitelist_external_dirs note

### DIFF
--- a/source/_integrations/filesize.markdown
+++ b/source/_integrations/filesize.markdown
@@ -8,7 +8,13 @@ ha_release: 0.64
 ha_domain: filesize
 ---
 
-The `filesize` sensor for displaying the size in MB of a file. Note that paths must be added to [whitelist_external_dirs](/docs/configuration/basic/).
+The `filesize` sensor is for displaying the size in MB of a file.
+
+<div class='note'>
+
+File paths must also be added to [whitelist_external_dirs](/docs/configuration/basic/) in your `configuration.yaml`.
+
+</div>
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed change
The note regarding `whitelist_external_dirs` in the File Size sensor docs wasn't obvious enough to me. Since this is required for Hass.io for example I've made this more obvious.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
