### PR TITLE
Add UE55NU8070 as supported to samsungtv.markdown

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -121,6 +121,7 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - UE65KS8005 (On/Off, Forward/Backward, Volume are OK, but no Play button)
 - UE49KU6470 (On/Off, Forward/Backward, Volume are OK, but no Play button)
 - UE46ES5500 (partially supported, turn on doesn't work)
+- UE55NU8070
 
 #### Models tested but not yet working
 


### PR DESCRIPTION
## Proposed change
Add the Samsung UE55NU8070 model as a supported model to the samsungtv.markdown file

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
None.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
