### PR TITLE
Needs to be fuel_types: instead of fuel_type:

### DIFF
--- a/source/_integrations/tankerkoenig.markdown
+++ b/source/_integrations/tankerkoenig.markdown
@@ -30,7 +30,7 @@ To enable this platform, add the following lines to your `configuration.yaml`:
 tankerkoenig:
   api_key: YOUR_API_KEY
   radius: 1
-  fuel_type:
+  fuel_types:
     - "diesel"
 ```
 


### PR DESCRIPTION
Error in example configuration.

This will lead to an invalid configuration.
