### PR TITLE
Update HEOS documentation style

### DIFF
--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -47,17 +47,15 @@ A connection to a single device enables control for all devices on the network. 
 
 Use the sign-in service to sign the connected controller into a HEOS account so that it can retrieve and play HEOS favorites and playlists. An error message is logged if sign-in is unsuccessful. Example service data payload:
 
-```json
-{
-  "username": "example@example.com",
-  "password": "password"
-}
+```yaml
+username: "example@example.com"
+password: "password"
 ```
 
-| Attribute              | Description
-| ---------------------- | ---------------------------------------------------------|
-| `username`             | The username or email of the HEOS account. [Required]
-| `password`             | The password of the HEOS account. [Required]
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `username`             | no       | The username or email of the HEOS account.
+| `password`             | no       | The password of the HEOS account.
 
 ### Service `heos.sign_out`
 
@@ -69,73 +67,65 @@ Use the sign-out service to sign the connected controller out of a HEOS account.
 
 You can play a HEOS favorite by number or name with the `media_player.play_media` service. Example service data payload:
 
-```json
-{
-  "entity_id": "media_player.office",
-  "media_content_type": "favorite",
-  "media_content_id": "1"
-}
+```yaml
+entity_id: media_player.office
+media_content_type: "favorite"
+media_content_id: "1"
 ```
 
-| Attribute              | Description
-| ---------------------- | ---------------------------------------------------------|
-| `entity_id`            | `entity_id` of the player
-| `media_content_type`   | Set to the value `favorite`
-| `media_content_id`     | The nubmer (i.e., `1`) or name (i.e., `Thumbprint Radio`) of the HEOS favorite
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            | yes      |  `entity_id` of the player(s)
+| `media_content_type`   | no       | Set to the value `favorite`
+| `media_content_id`     | no       | (i.e., `1`) or name (i.e., `Thumbprint Radio`) of the HEOS favorite
 
 #### Play Playlist
 
 You can play a HEOS playlist with the `media_player.play_media` service. Example service data payload:
 
-```json
-{
-  "entity_id": "media_player.office",
-  "media_content_type": "playlist",
-  "media_content_id": "Awesome Music"
-}
+```yaml
+entity_id: media_player.office
+media_content_type: "playlist"
+media_content_id: "Awesome Music"
 ```
 
-| Attribute              | Description
-| ---------------------- | ---------------------------------------------------------|
-| `entity_id`            | `entity_id` of the player
-| `media_content_type`   | Set to the value `playlist`
-| `media_content_id`     | The name of the HEOS playlist
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            | yes      | `entity_id` of the player(s)
+| `media_content_type`   | no       | Set to the value `playlist`
+| `media_content_id`     | no       | The name of the HEOS playlist
 
 #### Play Quick Select
 
 You can play a HEOS Quick Select by nubmer or name with the `media_player.play_media` service. Example service data payload:
 
-```json
-{
-  "entity_id": "media_player.office",
-  "media_content_type": "quick_select",
-  "media_content_id": "1"
-}
+```yaml
+entity_id: media_player.office
+media_content_type: "quick_select"
+media_content_id": "1"
 ```
 
-| Attribute              | Description
-| ---------------------- | ---------------------------------------------------------|
-| `entity_id`            | `entity_id` of the player
-| `media_content_type`   | Set to the value `quick_select`
-| `media_content_id`     | The quick select number (i.e., `1`) or name (i.e., `Quick Select 1`)
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            | yes      | `entity_id` of the player(s)
+| `media_content_type`   | no       | Set to the value `quick_select`
+| `media_content_id`     | no       | The quick select number (i.e., `1`) or name (i.e., `Quick Select 1`)
 
 #### Play URL
 
 You can play a URL through a HEOS media player using the `media_player.play_media` service. The HEOS player must be able to reach the URL. Example service data payload:
 
-```json
-{
-  "entity_id": "media_player.office",
-  "media_content_type": "url",
-  "media_content_id": "http://path.to/stream.mp3"
-}
+```yaml
+entity_id: media_player.office
+media_content_type: "url"
+media_content_id: "http://path.to/stream.mp3"
 ```
 
-| Attribute              | Description
-| ---------------------- | ---------------------------------------------------------|
-| `entity_id`            | `entity_id` of the player to play the URL
-| `media_content_type`   | Set to the value `url`
-| `media_content_id`     | The full URL to the stream
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            | yes      | `entity_id` of the player(s) to play the URL
+| `media_content_type`   | no       | Set to the value `url`
+| `media_content_id`     | no       | The full URL to the stream
 
 ## Notes
 


### PR DESCRIPTION
- Use YAML instead of JSON in examples
- Add additional column in tables to clarify whether an attribute is required or not for a service call.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The HEOS docs currently use JSON for examples and don't make it clear whether attributes in service calls are optional or not. This change has been suggested in #12373 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
https://github.com/home-assistant/home-assistant.io/pull/12373
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
