### PR TITLE
Clarified that scan_interval uses seconds

### DIFF
--- a/source/_integrations/tankerkoenig.markdown
+++ b/source/_integrations/tankerkoenig.markdown
@@ -60,9 +60,9 @@ radius:
   default: 2
   type: integer
 scan_interval:
-  description: The time interval to poll the server for new data. You should not put values lower than 5 minutes here; otherwise you risk your API key being blocked.
+  description: The time interval in seconds to poll the server for new data. You should not put values lower than 5 minutes here; otherwise you risk your API key being blocked.
   required: false
-  default: 0:30
+  default: 1800 (30min)
   type: time
 stations:
   description: List of additional fuel stations to create entities for.


### PR DESCRIPTION
The previously given default value of "30" could lead to the assumption that scan_interval was meassured in minutes and not seconds, which would block the users API Key very fast as the API would be polled twice a minute.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue: #12454 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
