### PR TITLE
Add effect service to WLED integration

### DIFF
--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -63,4 +63,20 @@ The integration will create a number of switches:
 
 ## Services
 
-This integration currently does not offer any additional services.
+Currently, the WLED integration provides one service for controlling effect.
+More services for other WLED features are expected to be added in the future.
+
+### Service `wled.effect`
+
+This service allows for controlling the WLED effect.
+
+| Service Data Attribute | Required | Description                                                                                                     |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `entity_id`            | no       | A WLED entity ID, or list entity IDs, to apply the effect to. Use `entity_id: all` to target all WLED entities. |
+| `effect`               | no       | Name or ID of the WLED light effect.                                                                            |
+| `intensity`            | no       | Intensity of the effect.                                                                                        |
+| `speed`                | no       | Speed of the effect. Number between `0` (slow) and `255` (fast).                                                |
+| `reverse`              | no       | Reverse the effect. Either `true` to reverse or `false` otherwise.                                              |
+
+A list of all available effects (and the behavior of the intensity for each
+effect) [is documented in the WLED Wiki](https://github.com/Aircoookie/WLED/wiki/List-of-effects-and-palettes#effects).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds a `wled.effect` service to the WLED integration.

This allows the user to finetune the effects running on the WLED light (or set the light into a specific effect state, before turning it on.

Allows controlling:

- The effect (using an effect name or ID)
- The speed of the effect
- The intensity of the effect
- Reverse the effect

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/33026
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
