### PR TITLE
Sets Lovelace button entity configuration variable to optional

### DIFF
--- a/source/_lovelace/button.markdown
+++ b/source/_lovelace/button.markdown
@@ -22,7 +22,7 @@ type:
   description: button
   type: string
 entity:
-  required: true
+  required: false
   description: Home Assistant entity ID.
   type: string
 name:
@@ -94,7 +94,6 @@ tap_action:
   service: script.turn_on
   service_data:
     entity_id: script.turn_off_lights
-entity: script.turn_off_lights
 ```
 
 <p class='img'>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Since the change https://github.com/home-assistant/frontend/pull/4581, the `entity` is not required anymore for the Lovelace `button`, but documentation still says it does: https://www.home-assistant.io/lovelace/button/#entity

This updated the documentation by replacing the "(Required)" label with "(Optional)" and also updates the sample to show this change.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: (not applied)
- This PR fixes or closes issue: #12452 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
