### PR TITLE
Add documentation about occupancy groups to Lutron caseta

### DIFF
--- a/source/_integrations/lutron.markdown
+++ b/source/_integrations/lutron.markdown
@@ -75,7 +75,7 @@ After setup, scenes will appear in Home Assistant using the area, keypad and but
 
 ## Occupancy Sensors
 
-Any configured Powr Savr occuancy sensors will be added as occupancy binary sensors. Lutron reports occupancy for an area, rather than reporting individual sensors. Sensitivity and timeouts are controlled on the sensors themselves, not in software.
+Any configured Powr Savr occupancy sensors will be added as occupancy binary sensors. Lutron reports occupancy for an area, rather than reporting individual sensors. Sensitivity and timeouts are controlled on the sensors themselves, not in software.
 
 ## Example Automations
 

--- a/source/_integrations/lutron_caseta.markdown
+++ b/source/_integrations/lutron_caseta.markdown
@@ -9,6 +9,7 @@ ha_category:
   - Scene
   - Switch
   - Fan
+  - Binary Sensor
 ha_release: 0.41
 ha_iot_class: Local Polling
 ha_domain: lutron_caseta
@@ -25,6 +26,7 @@ The currently supported Caseta devices are:
 - Scenes as [scenes](#scene)
 - Lutron shades as [covers](#cover)
 - Lutron smart [fan](#fan) speed control
+- Lutron Occupancy/Vacancy [sensors](#sensor)
 
 When configured, the `lutron_caseta` integration will automatically discover the currently supported devices as setup in the Lutron Smart Bridge. The name assigned in the Lutron mobile app will be used to form the `entity_id` used in Home Assistant. e.g., a dimmer called 'Lamp' in a room called 'Bedroom' becomes `light.bedroom_lamp` in Home Assistant.
 
@@ -115,3 +117,17 @@ After setup, fans will appear in Home Assistant using an `entity_id` based on th
 For more information on working with fans in Home Assistant, see the [Fans component](/components/fan/).
 
 Available services: `fan.turn_on`, `fan.turn_off`, and `fan.set_speed`.
+
+## Sensor
+
+Occupancy sensors can be added to a Lutron Caseta system to trigger events when an area becomes vacant and, optionally, occupied. However, Lutron systems report occupancy and vacancy statuses only in *occupancy groups* -- that is, groups of one or more sensors.
+
+Occupancy groups will appear in Home Assistant using an `entity_id` based on the area name in which the first sensor of the group is located. For example, one or more sensors in the Master Bathroom will appear in Home Assistant as `binary_sensor.master_bathroom_occupancy`.
+
+An occupancy group is considered occupied if any of the sensors in the group are currently in an "occupied" state. Specifically, this means that motion has been detected more recently than that sensor's particular timeout setting. Only after all sensors in an occupancy group report being vacant does the occupancy group itself report being vacant.
+
+Lutron Caseta occupancy sensors support 4 different timeouts and 3 different sensitivity levels, but those are only controllable from the devices themselves and cannot be set from either Home Assistant or even the Caseta mobile app.
+
+Because Lutron Caseta devices automatically report state to Home Assistant (rather than relying on polling), occupancy status updates occur almost instantaneously.
+
+For more information on working with binary sensors in Home Assistant, see the [Binary Sensors Component](/components/binary_sensor/)

--- a/source/_integrations/lutron_caseta.markdown
+++ b/source/_integrations/lutron_caseta.markdown
@@ -15,11 +15,11 @@ ha_iot_class: Local Polling
 ha_domain: lutron_caseta
 ---
 
-[Lutron](http://www.lutron.com/) is an American lighting control company. They have several lines of home automation devices that manage light switches, dimmers, occupancy sensors, HVAC controls, etc. The `lutron_caseta` integration in Home Assistant is responsible for communicating with the Lutron Caseta Smart Bridge for the [Caseta](https://www.casetawireless.com/) product line of dimmers, switches and shades.
+[Lutron](http://www.lutron.com/) is an American lighting control company. They have several lines of home automation devices that manage light switches, dimmers, occupancy sensors, HVAC controls, etc. The `lutron_caseta` integration in Home Assistant is responsible for communicating with the Lutron Caseta Smart Bridge for the [Caseta](https://www.casetawireless.com/) product line of dimmers, switches, shades, and sensors. It will also communicate with the Lutron Radio RA2 Main Repeater for the [RA2 Select](http://www.lutron.com/en-US/Products/Pages/WholeHomeSystems/RA2Select/Overview.aspx) product line of dimmers, switches, shades, and sensors.
 
-This integration only supports the [Caseta](https://www.casetawireless.com/) line of products. Both Smart Bridge (L-BDG2-WH) and Smart Bridge PRO (L-BDGPRO2-WH) models are supported. For the RadioRA 2 product line, see the [Lutron component](/integrations/lutron/).
+This integration only supports the [Caseta](https://www.casetawireless.com/) line of products. The Smart Bridge (L-BDG2-WH), Smart Bridge PRO (L-BDGPRO2-WH), and RA2 Select (RR-SEL-REP2-BL) models are supported. For the RadioRA 2 and HomeWorks QS product lines, see the [Lutron component](/integrations/lutron/).
 
-The currently supported Caseta devices are:
+The currently supported Caseta and RA2 Select devices are:
 
 - Wall and plug-in dimmers as [lights](#light)
 - Wall switches as [switches](#switch)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/33032
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
