### PR TITLE
Add Controls to Media Control Card

### DIFF
--- a/source/_lovelace/media-control.markdown
+++ b/source/_lovelace/media-control.markdown
@@ -26,6 +26,21 @@ entity:
   required: true
   description: "A media player `entity_id`."
   type: string
+show_controls_power:
+  required: false
+  description: "Show power controls?"
+  type: boolean
+  default: true
+show_controls_playback:
+  required: false
+  description: "Show playback controls?"
+  type: boolean
+  default: false
+show_controls_volume:
+  required: false
+  description: "Show volume controls?"
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 ## {% linkable_title Example %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds controls to the media control card to show power, playback and volume controls.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/5303

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
