### PR TITLE
Remove reference to old configuration parameter for iqvia

### DIFF
--- a/source/_integrations/iqvia.markdown
+++ b/source/_integrations/iqvia.markdown
@@ -23,8 +23,7 @@ Data measured includes:
 ## Configuring the Platform
 
 To integrate `iqvia` into Home Assistant, add the following section to your
-`configuration.yaml` file (adjusting the `monitored_conditions` list to your
-liking):
+`configuration.yaml` file:
 
 ```yaml
 iqvia:


### PR DESCRIPTION
## Proposed change

Remove mention of `monitored_conditions` from [documentation](https://www.home-assistant.io/integrations/iqvia/).

## Type of change


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
