### PR TITLE
🔨 Add defaults and config variable - DSMR

### DIFF
--- a/source/_integrations/dsmr.markdown
+++ b/source/_integrations/dsmr.markdown
@@ -54,17 +54,24 @@ sensor:
 
 {% configuration %}
   port:
-    description: "Serial port to which Smartmeter is connected (default: /dev/ttyUSB0 (connected to USB port)). For remote (i.e., ser2net) connections, use TCP port number to connect to (i.e., 2001)."
+    description: "Serial port to which Smartmeter is connected via USB. For remote (i.e., ser2net) connections, use TCP port number to connect to (i.e., 2001)."
     required: false
     type: string
+    default: "/dev/ttyUSB0"
   host:
-    description: "Host to which Smartmeter is connected (default: '' (connected via serial or USB, see **port**)). For remote connections, use IP address of host to connect to (i.e., 192.168.1.13)."
+    description: "Host to which Smartmeter is connected via serial or USB, see **port**. For remote connections, use IP address of host to connect to (i.e., 192.168.1.13)."
     required: false
     type: string
   dsmr_version:
-    description: "Version of DSMR used by meter. Choices: 2.2, 4, 5, 5B (For Belgian Meter). Defaults to 2.2."
+    description: "Version of DSMR used by meter. Choices: `2.2`, `4`, `5`, `5B` (For Belgian Meter)."
     required: false
     type: string
+    default: "2.2"
+  reconnect_interval:
+    description: The reconnect interval in seconds when the connection is lost with the Smartmeter.
+    required: false
+    type: integer
+    default: 30
   precision:
     description: Defines the precision of the calculated values, through the argument of round().
     required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR sets the default options in a separate variable and adds the `reconnect_interval` option to the documentation of the DSMR integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
