### PR TITLE
Add missing rtsp_transport option to onvif camera

### DIFF
--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -52,9 +52,9 @@ profile:
   type: integer
   default: 0
 rtsp_transport:
-  description: RTSP transport protocols.
+  description: RTSP transport protocols. The possible options are: `tcp`, `udp`, `udp_multicast`, `http`.
   required: false
-  type: string - one of "tcp", "udp", "udp_multicast", "http"
+  type: string
   default: tcp
 extra_arguments:
   description: "Extra options to pass to `ffmpeg`, e.g., image quality or video filter options. More details in [`ffmpeg` component](/integrations/ffmpeg)."

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -51,6 +51,11 @@ profile:
   required: false
   type: integer
   default: 0
+rtsp_transport:
+  description: RTSP transport protocols.
+  required: false
+  type: string - one of "tcp", "udp", "udp_multicast", "http"
+  default: tcp
 extra_arguments:
   description: "Extra options to pass to `ffmpeg`, e.g., image quality or video filter options. More details in [`ffmpeg` component](/integrations/ffmpeg)."
   required: false

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -51,6 +51,11 @@ profile:
   required: false
   type: integer
   default: 0
+rtsp_transport:
+  description: RTSP transport protocols.
+  required: false
+  type: one of "tcp", "udp", "udp_multicast", "http"
+  default: tcp
 extra_arguments:
   description: "Extra options to pass to `ffmpeg`, e.g., image quality or video filter options. More details in [`ffmpeg` component](/integrations/ffmpeg)."
   required: false

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -52,7 +52,7 @@ profile:
   type: integer
   default: 0
 rtsp_transport:
-  description: RTSP transport protocols. The possible options are: `tcp`, `udp`, `udp_multicast`, `http`.
+  description: "RTSP transport protocols. The possible options are: `tcp`, `udp`, `udp_multicast`, `http`."
   required: false
   type: string
   default: tcp


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add missing option


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
