### PR TITLE
Add UE55MU6179 to supported to samsungtv.markdown

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -120,6 +120,7 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - UE46ES5500 (partially supported, turn on doesn't work)
 - UE46D7000
 - UE49KU6470 (On/Off, Forward/Backward, Volume are OK, but no Play button)
+- UE55MU6179
 - UE55NU8070
 - UE6199UXZG (On/Off, Forward/Backward, Volume control, but no Play button)
 - UE65KS8005 (On/Off, Forward/Backward, Volume are OK, but no Play button)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add UE55MU6179 to supported devices for sammsung tv integration.
All features are working on this tv. Checked features On/Off, Forward/Backward, Volume control, Play/Stop

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
