### PR TITLE
Add feature history map

### DIFF
--- a/source/_lovelace/map.markdown
+++ b/source/_lovelace/map.markdown
@@ -42,6 +42,11 @@ dark_mode:
   description: Enable a dark theme for the map.
   type: boolean
   default: false
+hours_to_show:
+  required: false
+  description: Shows a path of previous locations. Hours to show as path on the map.
+  type: integer
+  default: 0
 {% endconfiguration %}
 
 <div class='note'>
@@ -73,4 +78,11 @@ geo_location_sources:
   - nsw_rural_fire_service_feed
 entities:
   - zone.home
+```
+
+```yaml
+type: map
+entities:
+  - device_tracker.demo_paulus
+hours_to_show: 48
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
HA displays historical data everywhere. Most of the time as timelines in line charts. But there is no option to show historical location data. So this PR add a feature to the standard `hui-map-card` and provides the option to show the history of a `sensor.<device-name>_geocoded_location` entity, which all android and iOS devices provide.

Example:
![hui-map-card-history-feature](https://user-images.githubusercontent.com/18525285/77456253-44fef580-6dfb-11ea-816f-bb491c81686e.jpg)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
https://github.com/home-assistant/frontend/pull/5331

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
