### PR TITLE
Add battery status to bluetooth_le tracker

### DIFF
--- a/source/_integrations/bluetooth_le_tracker.markdown
+++ b/source/_integrations/bluetooth_le_tracker.markdown
@@ -38,6 +38,11 @@ track_new_devices:
   required: false
   default: false
   type: boolean
+track_battery:
+  description: Whether the integration should try to read the battery status for tracked devices.
+  required: false
+  default: false
+  type: boolean
 interval_seconds:
   description: Seconds between each scan for new devices.
   required: false
@@ -47,6 +52,8 @@ interval_seconds:
 
 As some BT LE devices change their MAC address regularly, a new device is only discovered when it has been seen 5 times.
 Some BTLE devices (e.g., fitness trackers) are only visible to the devices that they are paired with. In this case, the BTLE tracker won't see this device.
+
+Enabling the battery tracking might decrease the duration of the battery, since the status will be checked on every scan.
 
 ## Rootless Setup
 

--- a/source/_integrations/bluetooth_le_tracker.markdown
+++ b/source/_integrations/bluetooth_le_tracker.markdown
@@ -53,7 +53,7 @@ interval_seconds:
 As some BT LE devices change their MAC address regularly, a new device is only discovered when it has been seen 5 times.
 Some BTLE devices (e.g., fitness trackers) are only visible to the devices that they are paired with. In this case, the BTLE tracker won't see this device.
 
-Enabling the battery tracking might decrease the duration of the battery, since the status will be checked on every scan.
+Enabling the battery tracking might slightly decrease the duration of the battery, but since this is only done at most once a day, this shouldn't be noticeable. Not all devices offer battery status information; if the information is not available, the integration will only try once at startup.
 
 ## Rootless Setup
 


### PR DESCRIPTION
Added a parameter to enable the Bluetooth LE device tracker to check
the battery status of tracked devices.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Most Bluetooth LE tracked devices are battery based devices. In order to be able to change the battery before it dies, it would be nice if the battery charge status could be read from Home Assistant.
There is a standard GATT characteristic to read the battery status from a BLE device (if the device implements it).
Enhanced the bluetooth_le device tracker to try to read this value from connected devices.
In order to not tax the device battery needlessly, reading its state is disabled by default.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/33222
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
