### PR TITLE
Add model RU7172, cleanup model list

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -97,11 +97,11 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - F6500
 - F7000
 - F8000BF
-- K5579 (On/Off, Forward/Backward, Volume control, but no Play button)
+- K5579
 - K5600AK (partially supported, turn on works but state is not updated)
 - K6500AF
-- KS7005 (MAC address must be provided, On/Off, Volume are OK, no channel change)
-- KS7502 (turn on doesn't work, turn off works fine)
+- KS7005 (no channel change)
+- KS7502 (On doesn't work, Off works fine)
 - KS8000
 - KS8005
 - KS8500
@@ -109,21 +109,19 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - KU6100
 - KU6290
 - KU6400U
+- KU6470
 - KU7000
 - M5620
 - MU6170UXZG
-- NU7090 (On/Off, MAC must be specified for Power On)
+- MU6179
+- MU6199
+- NU7090 (On/Off)
 - NU7400
 - NU8000
+- NU8070
 - U6000
 - U6300
-- UE46ES5500 (partially supported, turn on doesn't work)
-- UE46D7000
-- UE49KU6470 (On/Off, Forward/Backward, Volume are OK, but no Play button)
-- UE55MU6179
-- UE55NU8070
-- UE6199UXZG (On/Off, Forward/Backward, Volume control, but no Play button)
-- UE65KS8005 (On/Off, Forward/Backward, Volume are OK, but no Play button)
+- RU7172
 
 #### Models tested but not yet working
 


### PR DESCRIPTION
## Proposed change
- added model `RU7172`
- removed all `no play button` comments
- removed all `UExx`, as stated above the list
- changed `UE6199UXZG` to `MU6199`, because it was a typo (#4325)
- removed all `MAC must be specified for turn on`, because this is mentioned in the docu anyway


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
