### PR TITLE
added detail of Brave browser in Linux

### DIFF
--- a/source/_docs/frontend/browsers.markdown
+++ b/source/_docs/frontend/browsers.markdown
@@ -46,6 +46,8 @@ We would appreciate if you help to keep this page up-to-date and add feedback.
 | [surf]                | 0.7            | works      |                          |
 | [Chrome]              | 71.0.3578.98   | works      |                          |
 | [Waterfox]            | 56.2.6         | fails      |                          |
+| [Brave]               | 1.5.115        | fails      | loads but then "page unresponsive" |
+
 
 ## Android
 
@@ -70,6 +72,7 @@ There are reports that devices running with iOS prior to iOS 10, especially old 
 | :-------------------- |:---------------|:-----------|:-------------------------|
 | [LG webOS TV Built-in]| 2019-2020      | fails      | loads empty page         |
 
+[Brave]: https://brave.com/
 [Chrome]: https://www.google.com/chrome/
 [Chromium]: https://www.chromium.org/
 [Conkeror]: http://conkeror.org/


### PR DESCRIPTION
HomeAssistant loads when using Brave in Linux, but page then becomes unresponsive and has to be 'hard closed', after a single interaction

## Proposed change
added Brave browser, HA doesn't work for me in Linux with that 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted minor missing information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
