### PR TITLE
Fix Lovelace `resources` name in 0.107 blog post

### DIFF
--- a/source/_posts/2020-03-18-release-107.markdown
+++ b/source/_posts/2020-03-18-release-107.markdown
@@ -70,7 +70,7 @@ Lovelace configuration panel, and YAML dashboards can be set up in
 `configuration.yaml`, see [the documentation](/lovelace/yaml-mode/).
 
 This awesome new feature comes with a deprecation if you use Lovelace in
-manual YAML mode: You need to move the `resource` section from
+manual YAML mode: You need to move the `resources` section from
 your `ui-lovelace.yaml` to the `lovelace:` section in `configuration.yaml`.
 It is not a breaking change yet; we still load them from the previous location
 if we didn't find anything in the `lovelace:` section, however, this fallback


### PR DESCRIPTION
## Proposed change

Fix a typo on the 0.107 release notes page, the `resources` section for `lovelace:` was misspelled.  (https://www.home-assistant.io/lovelace/yaml-mode/)



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
