### PR TITLE
Update lock.mqtt example with state_locked and state_unlocked

### DIFF
--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -88,11 +88,21 @@ payload_available:
   required: false
   type: string
   default: online
+payload_lock:
+  description: The payload that represents enabled/locked state.
+  required: false
+  type: string
+  default: LOCK
 payload_not_available:
   description: The payload that represents the unavailable state.
   required: false
   type: string
   default: offline
+payload_unlock:
+  description: The payload that represents disabled/unlocked state.
+  required: false
+  type: string
+  default: UNLOCK
 qos:
   description: The maximum QoS level of the state topic.
   required: false
@@ -149,6 +159,8 @@ lock:
     name: Frontdoor
     state_topic: "home-assistant/frontdoor/"
     command_topic: "home-assistant/frontdoor/set"
+    payload_lock: "LOCK"
+    payload_unlock: "UNLOCK"
     state_locked: "LOCK"
     state_unlocked: "UNLOCK"
     optimistic: false

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -149,8 +149,8 @@ lock:
     name: Frontdoor
     state_topic: "home-assistant/frontdoor/"
     command_topic: "home-assistant/frontdoor/set"
-    state_lock: "LOCK"
-    state_unlock: "UNLOCK"
+    state_locked: "LOCK"
+    state_unlocked: "UNLOCK"
     optimistic: false
     qos: 1
     retain: true

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -88,21 +88,11 @@ payload_available:
   required: false
   type: string
   default: online
-payload_lock:
-  description: The payload that represents enabled/locked state.
-  required: false
-  type: string
-  default: LOCK
 payload_not_available:
   description: The payload that represents the unavailable state.
   required: false
   type: string
   default: offline
-payload_unlock:
-  description: The payload that represents disabled/unlocked state.
-  required: false
-  type: string
-  default: UNLOCK
 qos:
   description: The maximum QoS level of the state topic.
   required: false
@@ -159,8 +149,8 @@ lock:
     name: Frontdoor
     state_topic: "home-assistant/frontdoor/"
     command_topic: "home-assistant/frontdoor/set"
-    payload_lock: "LOCK"
-    payload_unlock: "UNLOCK"
+    state_lock: "LOCK"
+    state_unlock: "UNLOCK"
     optimistic: false
     qos: 1
     retain: true


### PR DESCRIPTION
Had an issue with my HASS not working with locks. Turns out the docs didn't reflect the new "state_lock" and "state_unlock" payload breaking change mentioned here: https://www.home-assistant.io/blog/2020/01/15/release-104/#breaking-changes

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
