### PR TITLE
Minor samsungTV cleanup.  Most especially that the TV must be on before launching HA

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -17,14 +17,14 @@ The `samsungtv` platform allows you to control a [Samsung Smart TV](https://www.
 ### Setup
 
 Go to the integrations page in your configuration and click on new integration -> Samsung TV.
-If you have enabled [ssdp](/integrations/ssdp) discovery and your TV is on, it's likely that you just have to confirm the detected device.
+If your TV is on and you have enabled [ssdp](/integrations/ssdp) discovery, it's likely that you just have to confirm the detected device.
 
 When the TV is first connected, you will need to accept Home Assistant on the TV to allow communication.
 
 ### YAML Configuration
 
 YAML configuration is around for people that prefer YAML.
-To use a TV add the following to your `configuration.yaml` file:
+To use this integration, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -46,6 +46,8 @@ turn_on_action:
   required: false
   type: list
 {% endconfiguration %}
+
+After saving the yaml configuration, the TV must be turned on _before_ launching Home Assistant in order for the TV to be registered the first time.
 
 #### Wake up TV
 
@@ -74,7 +76,7 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 
 #### Models tested and working
 
-- C7700
+- C7700 (on doesn't work)
 - D5500
 - D6100
 - D6300SF

--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -17,7 +17,7 @@ The `samsungtv` platform allows you to control a [Samsung Smart TV](https://www.
 ### Setup
 
 Go to the integrations page in your configuration and click on new integration -> Samsung TV.
-If your TV is on and you have enabled [ssdp](/integrations/ssdp) discovery, it's likely that you just have to confirm the detected device.
+If your TV is on and you have enabled [SSDP](/integrations/ssdp) discovery, it's likely that you just have to confirm the detected device.
 
 When the TV is first connected, you will need to accept Home Assistant on the TV to allow communication.
 
@@ -47,7 +47,7 @@ turn_on_action:
   type: list
 {% endconfiguration %}
 
-After saving the yaml configuration, the TV must be turned on _before_ launching Home Assistant in order for the TV to be registered the first time.
+After saving the YAML configuration, the TV must be turned on _before_ launching Home Assistant in order for the TV to be registered the first time.
 
 #### Wake up TV
 


### PR DESCRIPTION

## Proposed change
In order for Home Assistant to initially recognize and register a yaml configured samsungTV, the TV must be on before launching/restarting HA.

@escoand requested an additional note in the documentation

Feel free to adjust wording as you see fit.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:  N/A
- This PR fixes or closes issue:  N/A

## Checklist

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
