### PR TITLE
Update UI configuration

### DIFF
--- a/source/_integrations/konnected.markdown
+++ b/source/_integrations/konnected.markdown
@@ -95,7 +95,7 @@ The settings UI starts by having you configure the general behavior of each zone
 
 #### Using Settings UI to Configure Additional Panel Behavior
 
-Once all zones are configured you'll be presented with configuration for additional panel behaviors.
+Once all zones are configured you'll be presented with the configuration for additional panel behaviors.
 
 **Blink panel LED on when sending state change:** The desired LED behavior for the panel.
 

--- a/source/_integrations/konnected.markdown
+++ b/source/_integrations/konnected.markdown
@@ -99,7 +99,7 @@ Once all zones are configured you'll be presented with configuration for additio
 
 **Blink panel LED on when sending state change:** The desired LED behavior for the panel
 
-**Override default Home Assistant API host panel URL:** The Konnected Alarm Panel post sensor states back to the Home Assistant API.  If this value is unchecked the panel will default postbacks using `base_url` in the `http` component. If you've set `base_url` to an external hostname, then you'll want to check this field and set the **Override API host url** to your _local_ IP address and port (e.g., `http://192.168.1.101:8123`).
+**Override default Home Assistant API host panel URL:** The Konnected Alarm Panel post sensor states back to the Home Assistant API.  If this value is unchecked the panel will default postbacks using `base_url` in the `http` component. If you've set `base_url` to an external hostname, then you'll want to check this field and set the **Override API host URL** to your _local_ IP address and port (e.g., `http://192.168.1.101:8123`).
 
 **Override API host URL (optional):** The host info to use if you checked **Override default Home Assistant API host panel URL** in the step above.  This is ignored if **Override default Home Assistant API host panel URL** is unchecked.
 

--- a/source/_integrations/konnected.markdown
+++ b/source/_integrations/konnected.markdown
@@ -93,6 +93,16 @@ The settings UI starts by having you configure the general behavior of each zone
 
 **Configure additional states for this zone:** Selecting "No" will complete configuration for the zone and proceed to options for the next zone. Select "Yes" if you need to create additional output states for this zone.  
 
+#### Using Settings UI to Configure Additional Panel Behavior
+
+Once all zones are configured you'll be presented with configuration for additional panel behaviors.
+
+**Blink panel LED on when sending state change:** The desired LED behavior for the panel
+
+**Override default Home Assistant API host panel url:** The Konnected Alarm Panel post sensor states back to the Home Assistant API.  If this value is unchecked the panel will default postbacks using `base_url` in the `http` component. If you've set `base_url` to an external hostname, then you'll want to check this field and set the **Override API host url** to your _local_ IP address and port (e.g., `http://192.168.1.101:8123`).
+
+**Override API host url (optional):** The host info to use if you checked **Override default Home Assistant API host panel url** in the step above.  This is ignored if **Override default Home Assistant API host panel url** is unchecked.
+
 ### YAML Configuration
 
 If you prefer you can utilize a `konnected` section in the `configuration.yaml` file that specifies the Konnected devices on the network and the sensors or actuators attached to them. If using `configuration.yaml` the configuration will be one-time imported when going through the Configuration Flow for the panel. **Note that you must still complete the UI based setup before the integration will be configured and entities created/accessible.**
@@ -326,7 +336,7 @@ Konnected runs on an ESP8266 board with the NodeMCU firmware. It is commonly use
 
 ### 0.108
 
-- Multiple output states for a zone.
+- Multiple output states for a zone. Details on configuring additional panel behaviors via the UI.
 
 ### 0.106
 

--- a/source/_integrations/konnected.markdown
+++ b/source/_integrations/konnected.markdown
@@ -101,7 +101,7 @@ Once all zones are configured you'll be presented with the configuration for add
 
 **Override default Home Assistant API host panel URL:** The Konnected Alarm Panel post sensor states back to the Home Assistant API.  If this value is unchecked the panel will default postbacks using `base_url` in the `http` component. If you've set `base_url` to an external hostname, then you'll want to check this field and set the **Override API host URL** to your _local_ IP address and port (e.g., `http://192.168.1.101:8123`).
 
-**Override API host URL (optional):** The host info to use if you checked **Override default Home Assistant API host panel URL** in the step above.  This is ignored if **Override default Home Assistant API host panel URL** is unchecked.
+**Override API host URL (optional):** The host info to use if you checked **Override default Home Assistant API host panel URL** in the step above. This is ignored if **Override default Home Assistant API host panel URL** is unchecked.
 
 ### YAML Configuration
 

--- a/source/_integrations/konnected.markdown
+++ b/source/_integrations/konnected.markdown
@@ -99,9 +99,9 @@ Once all zones are configured you'll be presented with configuration for additio
 
 **Blink panel LED on when sending state change:** The desired LED behavior for the panel
 
-**Override default Home Assistant API host panel url:** The Konnected Alarm Panel post sensor states back to the Home Assistant API.  If this value is unchecked the panel will default postbacks using `base_url` in the `http` component. If you've set `base_url` to an external hostname, then you'll want to check this field and set the **Override API host url** to your _local_ IP address and port (e.g., `http://192.168.1.101:8123`).
+**Override default Home Assistant API host panel URL:** The Konnected Alarm Panel post sensor states back to the Home Assistant API.  If this value is unchecked the panel will default postbacks using `base_url` in the `http` component. If you've set `base_url` to an external hostname, then you'll want to check this field and set the **Override API host url** to your _local_ IP address and port (e.g., `http://192.168.1.101:8123`).
 
-**Override API host url (optional):** The host info to use if you checked **Override default Home Assistant API host panel url** in the step above.  This is ignored if **Override default Home Assistant API host panel url** is unchecked.
+**Override API host URL (optional):** The host info to use if you checked **Override default Home Assistant API host panel URL** in the step above.  This is ignored if **Override default Home Assistant API host panel URL** is unchecked.
 
 ### YAML Configuration
 

--- a/source/_integrations/konnected.markdown
+++ b/source/_integrations/konnected.markdown
@@ -97,7 +97,7 @@ The settings UI starts by having you configure the general behavior of each zone
 
 Once all zones are configured you'll be presented with configuration for additional panel behaviors.
 
-**Blink panel LED on when sending state change:** The desired LED behavior for the panel
+**Blink panel LED on when sending state change:** The desired LED behavior for the panel.
 
 **Override default Home Assistant API host panel URL:** The Konnected Alarm Panel post sensor states back to the Home Assistant API.  If this value is unchecked the panel will default postbacks using `base_url` in the `http` component. If you've set `base_url` to an external hostname, then you'll want to check this field and set the **Override API host URL** to your _local_ IP address and port (e.g., `http://192.168.1.101:8123`).
 


### PR DESCRIPTION
Add details on additional Konnected panel behavior settings in the UI

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This change adds doc details related non-zone specific UI settings for Konnected Alarm Panels.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/33481
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
