### PR TITLE
Markdown Card: User Variable

### DIFF
--- a/source/_lovelace/markdown.markdown
+++ b/source/_lovelace/markdown.markdown
@@ -82,6 +82,7 @@ card:
 
 {% endraw %}
 
+
 A special template variable - `user` is set up for the `content` of the card. It contains the currently logged in user.
 
 For example:

--- a/source/_lovelace/markdown.markdown
+++ b/source/_lovelace/markdown.markdown
@@ -15,32 +15,32 @@ Screenshot of the markdown card.
 
 {% configuration %}
 type:
-  required: true
-  description: markdown
-  type: string
+required: true
+description: markdown
+type: string
 content:
-  required: true
-  description: "Content to render as [Markdown](https://commonmark.org/help/). May contain [templates](/docs/configuration/templating/)."
-  type: string
+required: true
+description: "Content to render as [Markdown](https://commonmark.org/help/). May contain [templates](/docs/configuration/templating/)."
+type: string
 title:
-  required: false
-  description: The card title.
-  type: string
-  default: none
+required: false
+description: The card title.
+type: string
+default: none
 card_size:
-  required: false
-  type: integer
-  default: none
-  description: The algorithm for placing cards aesthetically in Lovelace may have problems with the Markdown card if it contains templates. You can use this value to help it estimate the height of the card in units of 50 pixels (approximately 3 lines of text in default size). (e.g., `4`)
+required: false
+type: integer
+default: none
+description: The algorithm for placing cards aesthetically in Lovelace may have problems with the Markdown card if it contains templates. You can use this value to help it estimate the height of the card in units of 50 pixels (approximately 3 lines of text in default size). (e.g., `4`)
 entity_id:
-  required: false
-  type: [string, list]
-  default: none
-  description: "A list of entity IDs so a template in `content:` only reacts to the state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities."
+required: false
+type: [string, list]
+default: none
+description: "A list of entity IDs so a template in `content:` only reacts to the state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities."
 theme:
-  required: false
-  description: "Set to any theme within `themes.yaml`"
-  type: string
+required: false
+description: "Set to any theme within `themes.yaml`"
+type: string
 {% endconfiguration %}
 
 ## Example
@@ -68,7 +68,7 @@ entities:
   - light.ceiling_lights
   - light.kitchen_lights
 state_filter:
-  - 'on'
+  - "on"
 card:
   type: markdown
   content: |
@@ -78,6 +78,21 @@ card:
     {%- endfor %}
 
     And the door is {% if is_state('binary_sensor.door', 'on') %} open {% else %} closed {% endif %}.
+```
+
+{% endraw %}
+
+
+A special template variable - `user` is set up for the `content` of the card. It contains the currently logged in user.
+
+For example:
+
+{% raw %}
+
+```yaml
+type: markdown
+content: |
+  Hello, {{user}}
 ```
 
 {% endraw %}

--- a/source/_lovelace/markdown.markdown
+++ b/source/_lovelace/markdown.markdown
@@ -15,32 +15,32 @@ Screenshot of the markdown card.
 
 {% configuration %}
 type:
-required: true
-description: markdown
-type: string
+  required: true
+  description: markdown
+  type: string
 content:
-required: true
-description: "Content to render as [Markdown](https://commonmark.org/help/). May contain [templates](/docs/configuration/templating/)."
-type: string
+  required: true
+  description: "Content to render as [Markdown](https://commonmark.org/help/). May contain [templates](/docs/configuration/templating/)."
+  type: string
 title:
-required: false
-description: The card title.
-type: string
-default: none
+  required: false
+  description: The card title.
+  type: string
+  default: none
 card_size:
-required: false
-type: integer
-default: none
-description: The algorithm for placing cards aesthetically in Lovelace may have problems with the Markdown card if it contains templates. You can use this value to help it estimate the height of the card in units of 50 pixels (approximately 3 lines of text in default size). (e.g., `4`)
+  required: false
+  type: integer
+  default: none
+  description: The algorithm for placing cards aesthetically in Lovelace may have problems with the Markdown card if it contains templates. You can use this value to help it estimate the height of the card in units of 50 pixels (approximately 3 lines of text in default size). (e.g., `4`)
 entity_id:
-required: false
-type: [string, list]
-default: none
-description: "A list of entity IDs so a template in `content:` only reacts to the state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities."
+  required: false
+  type: [string, list]
+  default: none
+  description: "A list of entity IDs so a template in `content:` only reacts to the state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities."
 theme:
-required: false
-description: "Set to any theme within `themes.yaml`"
-type: string
+  required: false
+  description: "Set to any theme within `themes.yaml`"
+  type: string
 {% endconfiguration %}
 
 ## Example
@@ -68,7 +68,7 @@ entities:
   - light.ceiling_lights
   - light.kitchen_lights
 state_filter:
-  - "on"
+  - 'on'
 card:
   type: markdown
   content: |
@@ -81,7 +81,6 @@ card:
 ```
 
 {% endraw %}
-
 
 A special template variable - `user` is set up for the `content` of the card. It contains the currently logged in user.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds docs for new variable

![image](https://user-images.githubusercontent.com/18730868/78143403-3799ca80-73fc-11ea-9313-7956dc403731.png)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/5393
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
