### PR TITLE
Update the docs for the new notification service

### DIFF
--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -7,6 +7,7 @@ ha_category:
   - Presence Detection
   - Lock
   - Sensor
+  - Notifications
 ha_release: 0.64
 ha_iot_class: Cloud Polling
 ha_codeowners:
@@ -26,6 +27,7 @@ This integration provides the following platforms:
 - Device tracker: The location of your car.
 - Lock: Control the lock of your car.
 - Sensors: Mileage, remaining range, remaining fuel, charging time remaining (electric cars), charging status (electric cars), remaining range electric (electric cars).
+- Notifications: Send messages or Points of Interest (POI) to your car from Home Assistant.
 - Services: Turn on air condition, sound the horn, flash the lights and update the state. More details can be found [here](/integrations/bmw_connected_drive/#services).
 
 ## Configuration
@@ -70,6 +72,44 @@ bmw_connected_drive:
       type: boolean
       default: false
 {% endconfiguration %}
+
+## Notifications
+
+The `bmw_connected_drive` integration offers a notification service. Using this service you can send messages or Points of Interest (POI) to your vehicle. In your vehicle you can select this POI and the navigation will automatically start using the POI as destination.
+The name of the service is `notify.bmw_connected_drive_<your_vehicle>`.
+
+### Examples
+
+A few examples on how to use the notification service.
+
+#### Send a text message to your vehicle
+
+```yaml
+...
+action:
+  service: notify.bmw_connected_drive_<your_vehicle>
+  data:
+    title: Message from Home Assistant # optional, will default to "Home Assistant" when left empty
+    message: The text of the message you want to send to your vehicle
+```
+
+#### Send a Point of Interest to your vehicle
+
+```yaml
+...
+action:
+  service: notify.NOTIFIER_NAME
+  data:
+    message: The name of the POI # this is shown on the iDrive dashboard
+    data:
+      location:
+        latitude: 48.177024
+        longitude: 11.559107
+        street: Street name  # Optional
+        city: City name  # Optional
+        postal_code: Postal Code  # Optional
+        country: Country  # Optional
+```
 
 ## Services
 

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -98,7 +98,7 @@ action:
 ```yaml
 ...
 action:
-  service: notify.NOTIFIER_NAME
+  service: notify.bmw_connected_drive_<your_vehicle>
   data:
     message: The name of the POI # this is shown on the iDrive dashboard
     data:

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -75,7 +75,7 @@ bmw_connected_drive:
 
 ## Notifications
 
-The `bmw_connected_drive` integration offers a notification service. Using this service you can send messages or Points of Interest (POI) to your vehicle. In your vehicle you can select this POI and the navigation will automatically start using the POI as destination.
+The `bmw_connected_drive` integration offers a notification service. Using this service you can send messages or Points of Interest (POI) to your vehicle. In your vehicle you can select this POI and the navigation will automatically start using the POI as a destination.
 The name of the service is `notify.bmw_connected_drive_<your_vehicle>`.
 
 ### Examples

--- a/source/_integrations/bmw_connected_drive.markdown
+++ b/source/_integrations/bmw_connected_drive.markdown
@@ -27,7 +27,7 @@ This integration provides the following platforms:
 - Device tracker: The location of your car.
 - Lock: Control the lock of your car.
 - Sensors: Mileage, remaining range, remaining fuel, charging time remaining (electric cars), charging status (electric cars), remaining range electric (electric cars).
-- Notifications: Send messages or Points of Interest (POI) to your car from Home Assistant.
+- Notifications: Send messages or Points of Interest (POI) to your car.
 - Services: Turn on air condition, sound the horn, flash the lights and update the state. More details can be found [here](/integrations/bmw_connected_drive/#services).
 
 ## Configuration


### PR DESCRIPTION
## Proposed change

In https://github.com/home-assistant/core/pull/33484 a new notification service for BMW is introduced. This PR updates the documentation according to that.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/33484
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
