### PR TITLE
Improve docs for MQTT state vacuum state_topic and value_template.

### DIFF
--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -358,10 +358,6 @@ supported_features:
   required: false
   type: [string, list]
   default: "`start`, `stop`, `return_home`, `status`, `battery`, `clean_spot`"
-value_template:
-  description: "Defines a [template](/topics/templating/) to extract a state update from the `state_topic` payload. The ouput of the template must be a valid JSON in the format accepted by [`state_topic`](#state_topic). This is very similar to the [`json_attributes_template`](/integrations/sensor.mqtt/#json-attributes-template-configuration)".
-  required: false
-  type: string
 {% endconfiguration %}
 
 ### State configuration example

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -350,7 +350,7 @@ set_fan_speed_topic:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive state messages from the vacuum. Messages received on the `state_topic` must be a valid JSON dictionary, with a mandatory `state` key and optionally `battery_level` and `fan_speed` keys as shown in the [example](#state-mqtt-protocol).
+  description: "The MQTT topic subscribed to receive state messages from the vacuum. Messages received on the `state_topic` must be a valid JSON dictionary, with a mandatory `state` key and optionally `battery_level` and `fan_speed` keys as shown in the [example](#state-mqtt-protocol)."
   required: false
   type: string
 supported_features:
@@ -359,7 +359,7 @@ supported_features:
   type: [string, list]
   default: "`start`, `stop`, `return_home`, `status`, `battery`, `clean_spot`"
 value_template:
-  description: "Defines a [template](/topics/templating/) to extract a state update from the `state_topic` payload. The ouput of the template must be a valid JSON in the format accepted by [`state_topic`](#state_topic). This is very similar to the [json_attributes_template](/integrations/sensor.mqtt/#json-attributes-template-configuration)".
+  description: "Defines a [template](/topics/templating/) to extract a state update from the `state_topic` payload. The ouput of the template must be a valid JSON in the format accepted by [`state_topic`](#state_topic). This is very similar to the [`json_attributes_template`](/integrations/sensor.mqtt/#json-attributes-template-configuration)".
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -359,7 +359,7 @@ supported_features:
   type: [string, list]
   default: "`start`, `stop`, `return_home`, `status`, `battery`, `clean_spot`"
 value_template:
-  description: "Defines a [template](/topics/templating/) to extract a state update from the `state_topic` payload. The ouput of the template must be a valid JSON in the format accepted by [`state_topic`](#state_topic)."
+  description: "Defines a [template](/topics/templating/) to extract a state update from the `state_topic` payload. The ouput of the template must be a valid JSON in the format accepted by [`state_topic`](#state_topic). This is very similar to the [json_attributes_template](/integrations/sensor.mqtt/#json-attributes-template-configuration)".
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -220,11 +220,12 @@ vacuum:
 ```
 {% endraw %}
 
-## Legacy MQTT Protocol
+### Legacy MQTT Protocol
 
 The above configuration for this integration expects an MQTT protocol like the following.
+See also [Shared MQTT Protocol](#shared-mqtt-protocol).
 
-### Legacy Basic Commands
+#### Legacy Basic Commands
 
 MQTT topic: `vacuum/command`
 
@@ -238,7 +239,7 @@ Possible MQTT payloads:
 - `locate` - Locate the vacuum (typically by playing a song)
 - `start_pause` - Toggle the vacuum between cleaning and stopping
 
-### Status/Sensor Updates
+#### Status/Sensor Updates
 
 MQTT topic: `vacuum/state`
 
@@ -349,7 +350,7 @@ set_fan_speed_topic:
   required: false
   type: string
 state_topic:
-  description: The MQTT topic subscribed to receive state messages from the vacuum. State topic is extracting JSON if no `value_template` is defined.
+  description: The MQTT topic subscribed to receive state messages from the vacuum. Messages received on the `state_topic` must be a valid JSON dictionary, with a mandatory `state` key and optionally `battery_level` and `fan_speed` keys as shown in the [example](#state-mqtt-protocol).
   required: false
   type: string
 supported_features:
@@ -358,7 +359,7 @@ supported_features:
   type: [string, list]
   default: "`start`, `stop`, `return_home`, `status`, `battery`, `clean_spot`"
 value_template:
-  description: "Defines a [template](/topics/templating/) to extract possible states from the vacuum."
+  description: "Defines a [template](/topics/templating/) to extract a state update from the `state_topic` payload. The ouput of the template must be a valid JSON in the format accepted by [`state_topic`](#state_topic)."
   required: false
   type: string
 {% endconfiguration %}
@@ -395,11 +396,12 @@ vacuum:
 ```
 {% endraw %}
 
-## State MQTT Protocol
+### State MQTT Protocol
 
 The above configuration for this integration expects an MQTT protocol like the following.
+See also [Shared MQTT Protocol](#shared-mqtt-protocol).
 
-### State Basic Commands
+#### State Basic Commands
 
 MQTT topic: `vacuum/command`
 
@@ -412,7 +414,7 @@ Possible MQTT payloads:
 - `clean_spot` - Initialize a spot cleaning cycle
 - `locate` - Locate the vacuum (typically by playing a song)
 
-### Send Custom Command
+#### Send Custom Command
 
 Vacuum send_command allows three parameters:
 
@@ -448,7 +450,7 @@ Service trigger example:
 
 MQTT topic: `vacuum/send_command`
 
-### Status/Sensor Updates
+#### Status/Sensor Updates
 
 MQTT topic: `vacuum/state`
 
@@ -522,6 +524,8 @@ Service trigger example:
 ```
 
 MQTT topic: `vacuum/send_command`
+
+## Usage examples
 
 ### Usage with cloudless Xiaomi vacuums
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Improve docs for MQTT state vacuum `state_topic` and remove documentation of `value_template` which is not working and has been removed (https://github.com/home-assistant/core/pull/33536).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Related to core PR https://github.com/home-assistant/core/pull/33536
## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
