### PR TITLE
Add documentation for Modbus light and fan

### DIFF
--- a/source/_integrations/fan.modbus.markdown
+++ b/source/_integrations/fan.modbus.markdown
@@ -1,0 +1,139 @@
+---
+title: "Modbus Fan"
+description: "Instructions on how to integrate Modbus fans into Home Assistant."
+ha_category:
+  - Fan
+ha_release: 0.109
+ha_iot_class: Local Push
+ha_domain: modbus
+---
+
+The `modbus` fan platform allows you to control [Modbus](http://www.modbus.org/)-enabled fans. We support two types of Modbus fans — coil-based and register-based. Note that our implementation of Modbus register fan supports only holding registers, because input registers are not writable, and don't give us any control over connected fans.
+
+## Configuration
+
+To enable Modbus fans in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+fan:
+  platform: modbus
+  coils:
+    - name: Fan1
+      hub: hub1
+      slave: 1
+      coil: 13
+    - name: Fan2
+      slave: 2
+      coil: 14
+  registers:
+    - name: Fan3
+      hub: hub1
+      slave: 1
+      register: 11
+```
+
+{% configuration %}
+coils:
+  description: A list of relevant coils to read from/write to.
+  required: false
+  type: map
+  keys:
+    hub:
+      description: The name of the hub.
+      required: false
+      default: default
+      type: string
+    slave:
+      description: The number of the slave (can be omitted for tcp and udp Modbus).
+      required: true
+      type: integer
+    name:
+      description: Name of the switch.
+      required: true
+      type: string
+    coil:
+      description: Coil number.
+      required: true
+      type: integer
+registers:
+  description: A list of relevant registers to read from/write to.
+  required: false
+  type: map
+  keys:
+    hub:
+      description: The hub to use.
+      required: false
+      default: default
+      type: string
+    slave:
+      description: The number of the slave (can be omitted for tcp and udp Modbus).
+      required: true
+      type: integer
+    name:
+      description: Name of the switch.
+      required: true
+      type: string
+    register:
+      description: Register number.
+      required: true
+      type: integer
+    command_on:
+      description: Value to write to turn on the switch.
+      required: false
+      default: 1
+      type: integer
+    command_off:
+      description: Value to write to turn off the switch.
+      required: false
+      default: 0
+      type: integer
+    verify_state:
+      description: Define if is possible to readback the status of the switch.
+      required: false
+      default: true
+      type: boolean
+{% endconfiguration %}
+
+It's possible to change the default 30 seconds scan interval for the switch state updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.
+
+## Examples
+
+In this section, you find some real-life examples of how to use this fan.
+
+### Full configuration for a Modbus coil fan
+
+The example below shows a full configuration for a Modbus coil fan, for which the state is polled from Modbus every 10 seconds.
+
+```yaml
+fan:
+  platform: modbus
+  scan_interval: 10
+  coils:
+    - name: Fan1
+      hub: hub1
+      slave: 1
+      coil: 13
+    - name: Fan2
+      hub: hub1
+      slave: 2
+      coil: 14
+```
+
+### Full configuration for a Modbus register fan
+
+The example below shows a full configuration for a Modbus register fan, for which the state is polled from Modbus every 15 seconds.
+
+```yaml
+fan:
+  platform: modbus
+  scan_interval: 15
+  registers:
+    - name: Fan1
+      hub: hub1
+      slave: 1
+      register: 11
+      command_on: 1
+      command_off: 0,
+      verify_state: true
+```

--- a/source/_integrations/fan.modbus.markdown
+++ b/source/_integrations/fan.modbus.markdown
@@ -3,8 +3,8 @@ title: "Modbus Fan"
 description: "Instructions on how to integrate Modbus fans into Home Assistant."
 ha_category:
   - Fan
-ha_release: 0.109
-ha_iot_class: Local Push
+ha_release: 0.116
+ha_iot_class: Local Polling
 ha_domain: modbus
 ---
 
@@ -16,86 +16,68 @@ To enable Modbus fans in your installation, add the following to your `configura
 
 ```yaml
 # Example configuration.yaml entry
-fan:
-  platform: modbus
-  coils:
-    - name: Fan1
-      hub: hub1
-      slave: 1
-      coil: 13
-    - name: Fan2
-      slave: 2
-      coil: 14
-  registers:
-    - name: Fan3
-      hub: hub1
-      slave: 1
-      register: 11
+modbus:
+  - name: hub1
+    type: tcp
+    host: IP_ADDRESS
+    port: 502
+
+    fans:
+      - name: Fan1
+        slave: 1
+        coil: 0
+        scan_interval: 10
+      - name: Fan2
+        register: 0
+        command_on: 1
+        command_off: 0
+        scan_interval: 10
 ```
 
 {% configuration %}
-coils:
-  description: A list of relevant coils to read from/write to.
-  required: false
+fans:
+  description: The array contains a list of all your Modbus fans.
+  required: true
   type: map
   keys:
-    hub:
-      description: The name of the hub.
-      required: false
-      default: default
+    name:
+      description: Name of the fan.
+      required: true
       type: string
     slave:
       description: The number of the slave (can be omitted for tcp and udp Modbus).
-      required: true
+      required: false
+      default: 1
       type: integer
-    name:
-      description: Name of the switch.
-      required: true
-      type: string
     coil:
-      description: Coil number.
+      description: Coil address; can be omitted if a register attribute is specified. Coil and register attributes are mutually exclusive, and you need to always specify one of them.
       required: true
       type: integer
-registers:
-  description: A list of relevant registers to read from/write to.
-  required: false
-  type: map
-  keys:
-    hub:
-      description: The hub to use.
-      required: false
-      default: default
-      type: string
-    slave:
-      description: The number of the slave (can be omitted for tcp and udp Modbus).
-      required: true
-      type: integer
-    name:
-      description: Name of the switch.
-      required: true
-      type: string
     register:
-      description: Register number.
+      description: Holding register address; can be omitted if a coil attribute is specified. Coil and register attributes are mutually exclusive, and you need to always specify one of them.
       required: true
       type: integer
     command_on:
-      description: Value to write to turn on the switch.
+      description: Value to write to turn on the fan. This value can be specified only for register-based fans.
       required: false
       default: 1
       type: integer
     command_off:
-      description: Value to write to turn off the switch.
+      description: Value to write to turn off the fan. This value can be specified only for register-based fans.
       required: false
       default: 0
       type: integer
     verify_state:
-      description: Define if is possible to readback the status of the switch.
+      description: Define if is possible to readback the status of the fan.
       required: false
       default: true
       type: boolean
+    scan_interval:
+      description: Defines the update interval of the sensor in seconds.
+      required: false
+      type: integer
+      default: 15
 {% endconfiguration %}
-
-It's possible to change the default 30 seconds scan interval for the switch state updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.
 
 ## Examples
 
@@ -106,18 +88,21 @@ In this section, you find some real-life examples of how to use this fan.
 The example below shows a full configuration for a Modbus coil fan, for which the state is polled from Modbus every 10 seconds.
 
 ```yaml
-fan:
-  platform: modbus
-  scan_interval: 10
-  coils:
-    - name: Fan1
-      hub: hub1
-      slave: 1
-      coil: 13
-    - name: Fan2
-      hub: hub1
-      slave: 2
-      coil: 14
+modbus:
+  - name: hub1
+    type: tcp
+    host: IP_ADDRESS
+    port: 502
+
+    fans:
+      - name: Fan1
+        slave: 1
+        coil: 13
+        scan_interval: 10
+      - name: Fan2
+        slave: 2
+        coil: 14
+        scan_interval: 10
 ```
 
 ### Full configuration for a Modbus register fan
@@ -125,15 +110,18 @@ fan:
 The example below shows a full configuration for a Modbus register fan, for which the state is polled from Modbus every 15 seconds.
 
 ```yaml
-fan:
-  platform: modbus
-  scan_interval: 15
-  registers:
-    - name: Fan1
-      hub: hub1
-      slave: 1
-      register: 11
-      command_on: 1
-      command_off: 0,
-      verify_state: true
+modbus:
+  - name: hub1
+    type: tcp
+    host: IP_ADDRESS
+    port: 502
+
+    fans:
+      - name: Fan1
+        slave: 1
+        register: 11
+        command_on: 1
+        command_off: 0
+        verify_state: true
+        scan_interval: 15
 ```

--- a/source/_integrations/light.modbus.markdown
+++ b/source/_integrations/light.modbus.markdown
@@ -3,8 +3,8 @@ title: "Modbus Light"
 description: "Instructions on how to integrate Modbus lights into Home Assistant."
 ha_category:
   - Light
-ha_release: 0.109
-ha_iot_class: Local Push
+ha_release: 0.116
+ha_iot_class: Local Polling
 ha_domain: modbus
 ---
 
@@ -16,86 +16,68 @@ To enable Modbus lights in your installation, add the following to your `configu
 
 ```yaml
 # Example configuration.yaml entry
-light:
-  platform: modbus
-  coils:
-    - name: Light1
-      hub: hub1
-      slave: 1
-      coil: 13
-    - name: Light2
-      slave: 2
-      coil: 14
-  registers:
-    - name: Light3
-      hub: hub1
-      slave: 1
-      register: 11
+modbus:
+  - name: hub1
+    type: tcp
+    host: IP_ADDRESS
+    port: 502
+
+    lights:
+      - name: Light1
+        slave: 1
+        coil: 0
+        scan_interval: 10
+      - name: Light2
+        register: 0
+        command_on: 1
+        command_off: 0
+        scan_interval: 10
 ```
 
 {% configuration %}
-coils:
-  description: A list of relevant coils to read from/write to.
-  required: false
+lights:
+  description: The array contains a list of all your Modbus lights.
+  required: true
   type: map
   keys:
-    hub:
-      description: The name of the hub.
-      required: false
-      default: default
+    name:
+      description: Name of the light.
+      required: true
       type: string
     slave:
       description: The number of the slave (can be omitted for tcp and udp Modbus).
-      required: true
+      required: false
+      default: 1
       type: integer
-    name:
-      description: Name of the switch.
-      required: true
-      type: string
     coil:
-      description: Coil number.
+      description: Coil address; can be omitted if a register attribute is specified. Coil and register attributes are mutually exclusive, and you need to always specify one of them.
       required: true
       type: integer
-registers:
-  description: A list of relevant registers to read from/write to.
-  required: false
-  type: map
-  keys:
-    hub:
-      description: The hub to use.
-      required: false
-      default: default
-      type: string
-    slave:
-      description: The number of the slave (can be omitted for tcp and udp Modbus).
-      required: true
-      type: integer
-    name:
-      description: Name of the switch.
-      required: true
-      type: string
     register:
-      description: Register number.
+      description: Holding register address; can be omitted if a coil attribute is specified. Coil and register attributes are mutually exclusive, and you need to always specify one of them.
       required: true
       type: integer
     command_on:
-      description: Value to write to turn on the switch.
+      description: Value to write to turn on the light. This value can be specified only for register-based lights.
       required: false
       default: 1
       type: integer
     command_off:
-      description: Value to write to turn off the switch.
+      description: Value to write to turn off the light. This value can be specified only for register-based lights.
       required: false
       default: 0
       type: integer
     verify_state:
-      description: Define if is possible to readback the status of the switch.
+      description: Define if is possible to readback the status of the light.
       required: false
       default: true
       type: boolean
+    scan_interval:
+      description: Defines the update interval of the sensor in seconds.
+      required: false
+      type: integer
+      default: 15
 {% endconfiguration %}
-
-It's possible to change the default 30 seconds scan interval for the switch state updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.
 
 ## Examples
 
@@ -106,18 +88,21 @@ In this section, you find some real-life examples of how to use this light.
 The example below shows a full configuration for a Modbus coil light, for which the state is polled from Modbus every 10 seconds.
 
 ```yaml
-light:
-  platform: modbus
-  scan_interval: 10
-  coils:
-    - name: Light1
-      hub: hub1
-      slave: 1
-      coil: 13
-    - name: Light2
-      hub: hub1
-      slave: 2
-      coil: 14
+modbus:
+  - name: hub1
+    type: tcp
+    host: IP_ADDRESS
+    port: 502
+
+    lights:
+      - name: Light1
+        slave: 1
+        coil: 13
+        scan_interval: 10
+      - name: Light2
+        slave: 2
+        coil: 14
+        scan_interval: 10
 ```
 
 ### Full configuration for a Modbus register light
@@ -125,15 +110,18 @@ light:
 The example below shows a full configuration for a Modbus register light, for which the state is polled from Modbus every 15 seconds.
 
 ```yaml
-light:
-  platform: modbus
-  scan_interval: 15
-  registers:
-    - name: Light1
-      hub: hub1
-      slave: 1
-      register: 11
-      command_on: 1
-      command_off: 0,
-      verify_state: true
+modbus:
+  - name: hub1
+    type: tcp
+    host: IP_ADDRESS
+    port: 502
+
+    lights:
+      - name: Light1
+        slave: 1
+        register: 11
+        command_on: 1
+        command_off: 0
+        verify_state: true
+        scan_interval: 15
 ```

--- a/source/_integrations/light.modbus.markdown
+++ b/source/_integrations/light.modbus.markdown
@@ -1,0 +1,139 @@
+---
+title: "Modbus Light"
+description: "Instructions on how to integrate Modbus lights into Home Assistant."
+ha_category:
+  - Light
+ha_release: 0.109
+ha_iot_class: Local Push
+ha_domain: modbus
+---
+
+The `modbus` light platform allows you to control [Modbus](http://www.modbus.org/)-enabled lights. We support two types of Modbus lights — coil-based and register-based. Note that our implementation of Modbus register light supports only holding registers, because input registers are not writable, and don't give us any control over connected lights.
+
+## Configuration
+
+To enable Modbus lights in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+light:
+  platform: modbus
+  coils:
+    - name: Light1
+      hub: hub1
+      slave: 1
+      coil: 13
+    - name: Light2
+      slave: 2
+      coil: 14
+  registers:
+    - name: Light3
+      hub: hub1
+      slave: 1
+      register: 11
+```
+
+{% configuration %}
+coils:
+  description: A list of relevant coils to read from/write to.
+  required: false
+  type: map
+  keys:
+    hub:
+      description: The name of the hub.
+      required: false
+      default: default
+      type: string
+    slave:
+      description: The number of the slave (can be omitted for tcp and udp Modbus).
+      required: true
+      type: integer
+    name:
+      description: Name of the switch.
+      required: true
+      type: string
+    coil:
+      description: Coil number.
+      required: true
+      type: integer
+registers:
+  description: A list of relevant registers to read from/write to.
+  required: false
+  type: map
+  keys:
+    hub:
+      description: The hub to use.
+      required: false
+      default: default
+      type: string
+    slave:
+      description: The number of the slave (can be omitted for tcp and udp Modbus).
+      required: true
+      type: integer
+    name:
+      description: Name of the switch.
+      required: true
+      type: string
+    register:
+      description: Register number.
+      required: true
+      type: integer
+    command_on:
+      description: Value to write to turn on the switch.
+      required: false
+      default: 1
+      type: integer
+    command_off:
+      description: Value to write to turn off the switch.
+      required: false
+      default: 0
+      type: integer
+    verify_state:
+      description: Define if is possible to readback the status of the switch.
+      required: false
+      default: true
+      type: boolean
+{% endconfiguration %}
+
+It's possible to change the default 30 seconds scan interval for the switch state updates as shown in the [Platform options](/docs/configuration/platform_options/#scan-interval) documentation.
+
+## Examples
+
+In this section, you find some real-life examples of how to use this light.
+
+### Full configuration for a Modbus coil light
+
+The example below shows a full configuration for a Modbus coil light, for which the state is polled from Modbus every 10 seconds.
+
+```yaml
+light:
+  platform: modbus
+  scan_interval: 10
+  coils:
+    - name: Light1
+      hub: hub1
+      slave: 1
+      coil: 13
+    - name: Light2
+      hub: hub1
+      slave: 2
+      coil: 14
+```
+
+### Full configuration for a Modbus register light
+
+The example below shows a full configuration for a Modbus register light, for which the state is polled from Modbus every 15 seconds.
+
+```yaml
+light:
+  platform: modbus
+  scan_interval: 15
+  registers:
+    - name: Light1
+      hub: hub1
+      slave: 1
+      register: 11
+      command_on: 1
+      command_off: 0,
+      verify_state: true
+```

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -187,3 +187,5 @@ and restart Home Assistant, reproduce the problem, and include the log in the is
  - [Modbus Climate](/integrations/climate.modbus/)
  - [Modbus Sensor](/integrations/sensor.modbus/)
  - [Modbus Switch](/integrations/switch.modbus/)
+ - [Modbus Fan](/integrations/fan.modbus/)
+ - [Modbus Light](/integrations/light.modbus/)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This pull request adds documentation for new integrations, `Modbus fan` and `Modbus light`.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#33551
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
