### PR TITLE
change service call description

### DIFF
--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -26,7 +26,7 @@ The service `persistent_notification.create` takes in `message`, `title`, and `n
 | `title`                |      yes | Title of the notification. Accepts [templates](/topics/templating/).
 | `notification_id`      |      yes | If `notification_id` is given, it will overwrite the notification if there already was a notification with that ID.
 
-In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) with static content it could look like.
+Here is how an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) with static content could look like.
 
 ```yaml
 action:
@@ -36,7 +36,7 @@ action:
     title: "Custom subject"
 ```
 
-or if you want to show some runtime information
+If you want to show some runtime information, you have to use [templates](/topics/templating/ inside `data_template`.
 
 {% raw %}
 

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -26,7 +26,7 @@ The service `persistent_notification.create` takes in `message`, `title`, and `n
 | `title`                |      yes | Title of the notification. Accepts [templates](/topics/templating/).
 | `notification_id`      |      yes | If `notification_id` is given, it will overwrite the notification if there already was a notification with that ID.
 
-In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) with static content it could look like
+In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) with static content it could look like.
 
 ```yaml
 action:

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -38,6 +38,8 @@ action:
 
 or if you want to show some runtime information
 
+{% raw %}
+
 ```yaml
 action:
   service: persistent_notification.create
@@ -46,6 +48,8 @@ action:
       Thermostat is {{ state_attr('climate.thermostat', 'hvac_action') }}
     message: "Temperature {{ state_attr('climate.thermostat', 'current_temperature') }}"
 ```
+
+{% endraw %}
 
 The service `persistent_notification.dismiss` requires a `notification_id`.
 

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -22,13 +22,11 @@ The service `persistent_notification.create` takes in `message`, `title`, and `n
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `message`              |       no | Body of the notification.
-| `title`                |      yes | Title of the notification.
+| `message`              |       no | Body of the notification. Accepts [templates](/topics/templating/).
+| `title`                |      yes | Title of the notification. Accepts [templates](/topics/templating/).
 | `notification_id`      |      yes | If `notification_id` is given, it will overwrite the notification if there already was a notification with that ID.
 
-The `persistent_notification` integration supports specifying [templates](/topics/templating/) for both the `message` and the `title`. This will allow you to use the current state of Home Assistant in your notifications.
-
-In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this with a customized subject.
+In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) with static content it could look like
 
 ```yaml
 action:
@@ -36,6 +34,17 @@ action:
   data:
     message: "Your message goes here"
     title: "Custom subject"
+```
+
+or if you want to show some runtime information
+
+```yaml
+action:
+  service: persistent_notification.create
+  data_template:
+    title: >
+      Thermostat is {{ state_attr('climate.thermostat', 'hvac_action') }}
+    message: "Temperature {{ state_attr('climate.thermostat', 'current_temperature') }}"
 ```
 
 The service `persistent_notification.dismiss` requires a `notification_id`.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Based on this topic - https://community.home-assistant.io/t/changing-input-number-doesnt-work/183335

I think it's better to have notes about templates in the service data description rather than separately (so easy to miss it)
I also added an example with templates just to give users a practical idea as this "This will allow you to use the current state of Home Assistant in your notifications" sounds very abstract ;)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
