### PR TITLE
Moved logo to brands repository

### DIFF
--- a/source/_integrations/bmp280.markdown
+++ b/source/_integrations/bmp280.markdown
@@ -2,7 +2,6 @@
 title: Bosch BMP280 Environmental Sensor
 description: Instructions on how to integrate a BMP280 sensor into Home Assistant.
 ha_release: 0.108
-logo: raspberry-pi.png
 ha_category:
   - DIY
 ha_iot_class: Local Polling

--- a/source/_integrations/directv.markdown
+++ b/source/_integrations/directv.markdown
@@ -3,6 +3,7 @@ title: DirecTV
 description: Instructions on how to integrate DirecTV receivers into Home Assistant.
 ha_category:
   - Media Player
+  - Remote
 ha_release: 0.25
 ha_iot_class: Local Polling
 ha_domain: directv
@@ -59,3 +60,66 @@ Available services: turn_on, turn_off, media_play, media_pause, media_stop, medi
 | `entity_id`            |      yes | Target a specific media player. Defaults to all.                                                                                                                       |
 | `media_content_id`     |       no | The channel number to change to.                   |
 | `media_content_type`   |       no | A media type. Has to be `channel`.
+
+## Remote
+
+The DirecTV remote platform allows you to send remote control buttons to a DirecTV receiver. It is automatically set up when a DirecTV receiver is configured.
+
+At the moment, the following buttons are supported:
+
+- `power`
+- `poweron`
+- `poweroff`
+- `format`
+- `pause`
+- `rew`
+- `replay`
+- `stop`
+- `advance`
+- `ffwd`
+- `record`
+- `play`
+- `guide`
+- `active`
+- `list`
+- `exit`
+- `back`
+- `menu`
+- `info`
+- `up`
+- `down`
+- `left`
+- `right`
+- `select`
+- `red`
+- `green`
+- `yellow`
+- `blue`
+- `chanup`
+- `chandown`
+- `prev`
+- `0`
+- `1`
+- `2`
+- `3`
+- `4`
+- `5`
+- `6`
+- `7`
+- `8`
+- `9`
+- `dash`
+- `enter`
+
+A typical service call for press several buttons looks like this.
+
+```yaml
+service: remote.send_command
+data:
+  entity_id: remote.directv_entity
+  command:
+    - left
+    - left
+    - menu
+    - select
+```

--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -75,9 +75,9 @@ panel_iframe:
 
 ## Switch
 
-The `rachio` switch platform allows you to toggle zones connected to your [Rachio irrigation system](https://rachio.com/) on and off.
+The `rachio` switch platform allows you to toggle zones and Fixed schedules connected to your [Rachio irrigation system](https://rachio.com/) on and off.
 
-Once configured, a switch will be added for every zone that is enabled on every controller in the account provided, as well as a switch to toggle each controller's standby mode.
+Once configured, a switch will be added for every zone that is enabled on every controller in the account provided, a switch to start or stop every Fixed schedule on a controller, as well as a switch to toggle each controller's standby mode.
 
 ## Examples
 
@@ -94,6 +94,7 @@ irrigation:
   - group.zones_front
   - group.zones_back
   - switch.side_yard
+  - switch.every_day_6am
 
 zones_front:
   name: Front Yard


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Moved logo to brands repository as requested in https://github.com/home-assistant/brands/issues/135

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/936
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
