### PR TITLE
Remove QNAP logo due to brands

### DIFF
--- a/source/_integrations/qnap.markdown
+++ b/source/_integrations/qnap.markdown
@@ -1,7 +1,6 @@
 ---
 title: QNAP
 description: Instructions on how to integrate the QNAP sensor within Home Assistant.
-logo: qnap.png
 ha_category:
   - System Monitor
 ha_release: 0.38


### PR DESCRIPTION
## Proposed change
Removing logo as is in brands repo

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html