### PR TITLE
Add Zone Management Section to Monoprice docs

### DIFF
--- a/source/_integrations/monoprice.markdown
+++ b/source/_integrations/monoprice.markdown
@@ -22,6 +22,11 @@ Select the serial port to which Monoprice amplifier is connected, and name the s
 
 Sources can also be later edited from the integration options (gear icon in the top right when selecting the integration). In order to remove an existing source, you'll need to replace it with a space (simply removing its name will still keep it in place). Note that editing sources will remove the snapshot you may have saved.
 
+## Zone Management
+
+Devices and entities are created for each of the possible 18 zones, and can be enabled, disabled, and renamed through regular Home Assisant methods.
+By default, the first 6 zones (11..16) are enabled, while the other 12 zones possible through extensions (21..26, and 31..36) are disabled.
+
 ## Services
 
 ### Service `monoprice.snapshot`

--- a/source/_integrations/monoprice.markdown
+++ b/source/_integrations/monoprice.markdown
@@ -24,8 +24,8 @@ Sources can also be later edited from the integration options (gear icon in the 
 
 ## Zone Management
 
-Devices and entities are created for each of the possible 18 zones, and can be enabled, disabled, and renamed through regular Home Assisant methods.
-By default, the first 6 zones (11..16) are enabled, while the other 12 zones possible through extensions (21..26, and 31..36) are disabled.
+Devices and entities are created for each of the possible 18 zones, and can be enabled, disabled and renamed through regular Home Assisant methods.
+By default, the first 6 zones (11..16) are enabled, while the 12 extension zones (21..26, and 31..36) are disabled.
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
A new section about Zone management (which changed significantly with the move to config entries). This was an inadvertent omission on my part when I initially updated the docs.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/30337
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
