### PR TITLE
Added refresh rate for picture entity

### DIFF
--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -49,6 +49,7 @@ refresh_rate:
   required: false
   description: "Refresh rate of the image in seconds."
   type: string
+  default: 10
 name:
   required: false
   description: Overwrite entity name.

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -48,7 +48,7 @@ aspect_ratio:
 refresh_rate:
   required: false
   description: "Refresh rate of the image in seconds."
-  type: number
+  type: string
 name:
   required: false
   description: Overwrite entity name.

--- a/source/_lovelace/picture-entity.markdown
+++ b/source/_lovelace/picture-entity.markdown
@@ -45,6 +45,10 @@ aspect_ratio:
   required: false
   description: "Forces the height of the image to be a ratio of the width. You may enter a value such as: `16x9`, `16:9`, `1.78`."
   type: string
+refresh_rate:
+  required: false
+  description: "Refresh rate of the image in seconds."
+  type: number
 name:
   required: false
   description: Overwrite entity name.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The hui-image used in picture-entity card has a hard-coded refresh rate of 10 seconds.  To provide more flexibility in the image refresh rate a new user-configurable attribute has been added to the picture-entity card.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/5466


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
