### PR TITLE
Update plugwise platform

### DIFF
--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -20,10 +20,10 @@ The platform supports [Anna](https://www.plugwise.com/en_US/products/anna), [Ada
 
 Platforms available - depending on your Smile and setup are include:
 
+ - `binary_sensor`
  - `climate`
  - `light`
  - `sensor`
- - `water_heater`
 
 The password can be found on the bottom of your Smile, it should consist of 6 characters. To find your IP address use the Plugwise App: 
 
@@ -31,13 +31,21 @@ The password can be found on the bottom of your Smile, it should consist of 6 ch
  - Go to the (lower) 'Settings'-icon (&#9776;) and choose 'Preferences'. 
  - Choose 'System' then 'Networking' and your IP address will be shown.
 
+## Devices
+
+This integration will show all devices present in your Plugwise configuration. In addition you will see a 'Smile' device representing your central Plugwise gateway (i.e. the Smile, Smile P1 or Adam).
+
+For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom' these will show up as individual devices. For setups where an auxiliary heater (or heater/cooler) is present there will be an additional device representing it called 'Auxiliary'.
+
+Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna or Smile will be assigned to your gateway device. Auxiliary Heater(/Cooler) measurements such as 'boiler_temperature' will be assigned to the Auxiliary device.
+
 ## Configuration
 
 To set up this integration, click Configuration in the sidebar and then click Integrations. Add a new integration using the "+" button in the lower right corner and look for 'Plugwise'. Click configure and you will be presented with a dialog requesting the Smile ID or password of your Smile and it's IP address. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
 Depending on your `climate` setup a `water_heater` will be added when there is information available about such devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s.
 
-Repeat the above procedure for each Smile (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
+Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 
 ### Service
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -31,38 +31,36 @@ The password can be found on the bottom of your Smile, it should consist of 6 ch
  - Go to the (lower) 'Settings'-icon (&#9776;) and choose 'Preferences'. 
  - Choose 'System' then 'Networking' and your IP address will be shown.
 
-## Devices
+## Entities
 
-This integration will show all devices present in your Plugwise configuration. In addition you will see a 'Smile' device representing your central Plugwise gateway (i.e. the Smile, Smile P1 or Adam).
+This integration will show all Plugwise devices present in your Plugwise configuration. In addition you will see a 'Smile' device representing your central Plugwise gateway (i.e. the Smile, Smile P1 or Adam).
 
 For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom' these will show up as individual devices. For setups where an auxiliary heater (or heater/cooler) is present there will be an additional device representing it called 'Auxiliary'.
 
-Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna or Smile will be assigned to your gateway device. Auxiliary Heater(/Cooler) measurements such as 'boiler_temperature' will be assigned to the Auxiliary device.
+Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna or Smile will be assigned to your gateway device. Auxiliary Heater(/Cooler) measurements such as 'boiler_temperature' will be assigned to the Auxiliary entity.
 
 ## Configuration
 
 To set up this integration, click Configuration in the sidebar and then click Integrations. Add a new integration using the "+" button in the lower right corner and look for 'Plugwise'. Click configure and you will be presented with a dialog requesting the Smile ID or password of your Smile and it's IP address. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
-Depending on your `climate` setup a `water_heater` will be added when there is information available about such devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s.
+Depending on your `climate` setup an auxiliary entitiy will be added when there is information available about such Plugwise devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 
-### Service
+### Services
 
-#### Update Smile data (custom service)
+#### Update Smile data
 
-Service: `plugwise.update`
-
-This service has no options or parameters. Calling it will refresh all available data from all connected Smiles.
-
-Example:
+Forced update of data from your Smile can be triggered by calling the generic `homeassistant.update_entity` service with your Smile entity as the target.
 
 ```yaml
-# Force update for all smiles
+# Example script change the temperature
 script:
-  plugwise_force_update:
+  force_adam_update:
     sequence:
-      - service: plugwise.update
+      - service: homeassistant.update_entity
+        data:
+          entity_id: climate.anna
 ```
 
 #### Set HVAC mode (schedule)
@@ -136,8 +134,7 @@ Adam (zone_control):
  - v3.0
  - v2.3
 
- - Devices supported are Floor, Koen, Lisa, Plug and Tom
- - For Plug remember each plug must have its own, unique, location-name, otherwise it will not show up
+ - Devices supported are Floor, Koen, Lisa, Plug and Tom - note a Koen always comes with a plug (the active part)
 
 Anna (thermostat):
 
@@ -147,5 +144,6 @@ Anna (thermostat):
 
 Smile P1 (DSMR):
 
+ - v4.0
  - v3.3
  - v2.5

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -121,7 +121,7 @@ script:
 
 ### Supported devices
 
-The current implementation of the python module includes:
+The current implementation of the Python module (Plugwise-Smile) includes:
 
 Adam (zone_control):
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -7,7 +7,7 @@ ha_category:
   - Switch
   - Water_heater
 ha_iot_class: Local Polling
-ha_release: 0.109
+ha_release: 0.98
 ha_codeowners:
   - '@CoMPaTech'
   - '@bouwew'


### PR DESCRIPTION
## Proposed change
Updating documentation with according initial https://github.com/home-assistant/core/pull/33691 (and/or additional PRs, see PR for request to separate) - component has changed to both async in backend and using config_flow instead of configuration file directives. Co-authored between @bouwew and @CoMPaTech Creating documentation PR to keep up with any changes to the PR

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

Brands already adjusted as per https://github.com/home-assistant/brands/pull/816

## Additional information

- https://github.com/home-assistant/core/pull/33691
- https://github.com/home-assistant/brands/pull/816
- This PR fixes or closes issue: 

## Checklist

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
