### PR TITLE
Update zha.markdown to mention recently added group support

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -34,6 +34,8 @@ There is currently support for the following device types within Home Assistant:
 - Sensor
 - Switch
 
+There is also support for grouping of lights, switches, and fans (i.e. support for commanding device groups as entities).
+
 ## ZHA exception and deviation handling
 
 Zigbee devices that deviate from or do not fully conform to the standard specifications set by the [Zigbee Alliance](https://zigbeealliance.org) may require the development of custom [ZHA Device Handlers](https://github.com/dmulcahey/zha-device-handlers) (ZHA custom quirks handler implementation) to for all their functions to work properly with the ZHA integration in Home Assistant. These ZHA Device Handlers for Home Assistant can thus be used to parse custom messages to and from Zigbee devices.


### PR DESCRIPTION
## Proposed change
Just add a short mentioning of device grouping support into entities since it has been a highly requested feature popularized by the Philips Hue Bridge (with its "light groups") that has been missing from the ZHA integration component and was recently added and is already available in the current branch.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

Not done by me but added by @dmulcahey via all these pull requests:
- https://github.com/home-assistant/frontend/pull/4384
- https://github.com/home-assistant/frontend/pull/4382
- https://github.com/home-assistant/frontend/pull/4466
- https://github.com/home-assistant/frontend/pull/4380
- https://github.com/home-assistant/frontend/pull/4376
- https://github.com/home-assistant/frontend/pull/4365
- https://github.com/home-assistant/core/pull/33196
- https://github.com/home-assistant/core/pull/33207
- https://github.com/home-assistant/core/pull/33291
- https://github.com/home-assistant/core/pull/28823
- https://github.com/home-assistant/core/pull/29641
- https://github.com/home-assistant/core/pull/30183
- https://github.com/home-assistant/core/pull/30433
- https://github.com/home-assistant/core/pull/33378
- https://github.com/home-assistant/core/pull/31260

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
