### PR TITLE
Update modbus text, with warning (relevant for V1.08)

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -156,14 +156,18 @@ modbus:
 ## Log warning (v1.0.8 and onwards)
 
 Pymodbus (which is the implementation library) was updated and issues a warning:
+
  - "Not Importing deprecated clients. Dependency Twisted is not Installed"
+
 This warning can be safely ignored, and have no influence on how the integration
 works!
 
 ## Opening an issue
+
 When opening an issue, please add your current configuration (or a scaled down version), with at least:
- - the modbus configuration lines
- - the entity (sensor etc) lines
+
+ - the Modbus configuration lines
+ - the entity (sensor, etc.) lines
 
 In order for the developers better to identify the problem, please add the
 following lines to configuration.yaml:
@@ -174,7 +178,8 @@ logger:
     homeassistant.components.modbus: debug
     pymodbus.client: debug
 ```
-and restart HA, reproduce the problem, and include the log in the issue.
+
+and restart Home Assistant, reproduce the problem, and include the log in the issue.
 
 ## Building on top of Modbus
 

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -153,6 +153,29 @@ modbus:
 | address   | Address of the Register (e.g., 138) |
 | value     | A single value or an array of 16-bit values. Single value will call modbus function code 6. Array will call modbus function code 16. Array might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |
 
+## Log warning (v1.0.8 and onwards)
+
+Pymodbus (which is the implementation library) was updated and issues a warning:
+ - "Not Importing deprecated clients. Dependency Twisted is not Installed"
+This warning can be safely ignored, and have no influence on how the integration
+works!
+
+## Opening an issue
+When opening an issue, please add your current configuration (or a scaled down version), with at least:
+ - the modbus configuration lines
+ - the entity (sensor etc) lines
+
+In order for the developers better to identify the problem, please add the
+following lines to configuration.yaml:
+
+```yaml
+logger:
+  logs:
+    homeassistant.components.modbus: debug
+    pymodbus.client: debug
+```
+and restart HA, reproduce the problem, and include the log in the issue.
+
 ## Building on top of Modbus
 
  - [Modbus Binary Sensor](/integrations/binary_sensor.modbus/)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
pymodbus issues a silly warning, that confuses our users, text is therefore updated to inform users that the warning has no effect on the integration.

Also added a section about how to make a communication debug log, which helps solve issues.

This change is relevant for version 1.0.8 and later.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
