### PR TITLE
OPNSense uses by default https on its webGUI

### DIFF
--- a/source/_integrations/opnsense.markdown
+++ b/source/_integrations/opnsense.markdown
@@ -23,7 +23,7 @@ to your configuration.yaml:
 
 ```yaml
 opnsense:
-  url: http://router/api
+  url: https://router/api
   api_secret: API_SECRET
   api_key: API_KEY
 ```


### PR DESCRIPTION
## Proposed change
Changing the proposed http url to https, as by opnsense default.


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
