### PR TITLE
Add expected format for offset in title

### DIFF
--- a/source/_integrations/caldav.markdown
+++ b/source/_integrations/caldav.markdown
@@ -106,7 +106,7 @@ custom_calendars:
 
 ### Sensor attributes
 
- - **offset_reached**: If set in the event title and parsed out will be on/off once the offset in the title in minutes is reached. So the title Very important meeting !!-10 would trigger this attribute to be on 10 minutes before the event starts.
+ - **offset_reached**: If set in the event title and parsed out will be on/off once the offset in the title in minutes is reached. So the title Very important meeting !!-10 would trigger this attribute to be on 10 minutes before the event starts. This should be in the format of `HH:MM` or `MM`.
  - **all_day**: `True/False` if this is an all day event. Will be `False` if there is no event found.
  - **message**: The event title with the `search` values extracted. So in the above example for `offset_reached` the message would be set to Very important meeting
  - **description**: The event description.


### PR DESCRIPTION
Added the expected format for offset in event title to help prevent mistakes

## Proposed change
There is no detailed information about how to write the offset in the event title. E.g. if you use three digit numbers like 300 they are shortened to two digits without any notice. This change helps users to better understand the format.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
