### PR TITLE
Document zeroconf_default_interface

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -86,6 +86,7 @@ homekit:
         description: By default, zeroconf will attempt to bind to all interfaces. For systems running using network isolation or similar, this may result HomeKit not being seen on the network. Change this option to `true` if HomeKit cannot be discovered.
         required: true
         type: boolean
+        default: false
       advertise_ip:
         description: If you need to override the IP address used for mDNS advertisement. (For example, using network isolation in Docker and together with an mDNS forwarder like `avahi-daemon` in reflector mode)
         required: false

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -82,10 +82,14 @@ homekit:
         required: false
         type: boolean
         default: false
+      zeroconf_default_interface:
+        description: By default, zeroconf will attempt to bind to all interfaces. For systems running using network isolation or similar, this may result in homekit not being seen on the network. Change this option to `true` if homekit cannot be discovered.
+        required: true
+        type: boolean
       advertise_ip:
         description: If you need to override the IP address used for mDNS advertisement. (For example, using network isolation in Docker and together with an mDNS forwarder like `avahi-daemon` in reflector mode)
         required: false
-        type: string
+        type: string        
       filter:
         description: Filters for entities to be included/excluded from HomeKit. ([Configure Filter](#configure-filter))
         required: false
@@ -331,6 +335,8 @@ To avoid any errors, after you have successfully paired your Home Assistant Brid
 ## Docker Network Isolation
 
 The `advertise_ip` option can be used to run this integration even inside an ephemeral Docker container with network isolation enabled, e.g., not using the host network.
+
+You may also need to set `zeroconf_default_interface` to `true`.
 
 To use `advertise_ip`, add the option to your `homekit` configuration:
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -83,7 +83,7 @@ homekit:
         type: boolean
         default: false
       zeroconf_default_interface:
-        description: By default, zeroconf will attempt to bind to all interfaces. For systems running using network isolation or similar, this may result in homekit not being seen on the network. Change this option to `true` if homekit cannot be discovered.
+        description: By default, zeroconf will attempt to bind to all interfaces. For systems running using network isolation or similar, this may result HomeKit not being seen on the network. Change this option to `true` if HomeKit cannot be discovered.
         required: true
         type: boolean
       advertise_ip:

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -343,6 +343,7 @@ To use `advertise_ip`, add the option to your `homekit` configuration:
 ```yaml
 homekit:
   advertise_ip: "STATIC_IP_OF_YOUR_DOCKER_HOST"
+  zeroconf_default_interface: true
 ```
 
 Restart your Home Assistant instance. This feature requires running an mDNS forwarder on your Docker host, e.g., `avahi-daemon` in reflector mode. This kind of setup most likely requires `safe_mode` during the bridge setup.

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -89,7 +89,7 @@ homekit:
       advertise_ip:
         description: If you need to override the IP address used for mDNS advertisement. (For example, using network isolation in Docker and together with an mDNS forwarder like `avahi-daemon` in reflector mode)
         required: false
-        type: string        
+        type: string
       filter:
         description: Filters for entities to be included/excluded from HomeKit. ([Configure Filter](#configure-filter))
         required: false


### PR DESCRIPTION
## Proposed change
Homekit can fail to be discoverable because the
zeroconf default is to bind to all interfaces
(InterfaceChoice.All). This does not work
on some systems and (InterfaceChoice.Default) which
binds to 0.0.0.0 is needed for homekit zeroconf
to function.

A new option is available for homekit

zeroconf_default_interface: true



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/33999
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
