### PR TITLE
Add Panel proxy

### DIFF
--- a/source/_integrations/panel_proxy.markdown
+++ b/source/_integrations/panel_proxy.markdown
@@ -3,7 +3,7 @@ title: Proxy Panel
 description: Instructions on how to add proxy using iFrames in the frontend of Home Assistant.
 ha_category:
   - Front End
-ha_release: 0.107
+ha_release: 0.109
 ha_quality_scale: internal
 ha_codeowners:
   - '@doudz'

--- a/source/_integrations/panel_proxy.markdown
+++ b/source/_integrations/panel_proxy.markdown
@@ -12,7 +12,7 @@ ha_domain: panel_proxy
 
 The `panel_proxy` support allows you to create a simple reverse proxy to other webapp in Home Assistant frontend. The panels are listed in the sidebar and can contain external resources like the web frontend of your router, your monitoring system, or your media server.
 
-This is similar to the directive proxy_pass of nginx for example.
+This is similar to the directive proxy_pass of NGINX for example.
 
 To enable proxy Panel in your installation, add the following to your `configuration.yaml` file:
 

--- a/source/_integrations/panel_proxy.markdown
+++ b/source/_integrations/panel_proxy.markdown
@@ -1,0 +1,67 @@
+---
+title: Proxy Panel
+description: Instructions on how to add proxy using iFrames in the frontend of Home Assistant.
+ha_category:
+  - Front End
+ha_release: 0.107
+ha_quality_scale: internal
+ha_codeowners:
+  - '@doudz'
+ha_domain: panel_proxy
+---
+
+The `panel_proxy` support allows you to create a simple reverse proxy to other webapp in Home Assistant frontend. The panels are listed in the sidebar and can contain external resources like the web frontend of your router, your monitoring system, or your media server.
+
+This is similar to the directive proxy_pass of nginx for example.
+
+To enable proxy Panel in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+panel_proxy:
+  router:
+    title: 'Router'
+    url: 'http://192.168.1.1/router'
+  fridge:
+    title: 'Fridge'
+    url: 'http://192.168.1.5/fridge'
+  otherapp:
+    title: 'Other App'
+    url: 'http://localhost:8080/otherapp'
+```
+
+{% configuration %}
+panel_proxy:
+  description: Enables the panel_proxy component. Only allowed once.
+  required: true
+  type: map
+  keys:
+    panel_name:
+      description: Name of the panel. Only allowed once.
+      required: true
+      type: map
+      keys:
+        title:
+          description: Friendly title for the panel. Will be used in the sidebar.
+          required: true
+          type: string
+        url:
+          description: The absolute URL.
+          required: true
+          type: string
+        icon:
+          description: Icon for entry.
+          required: false
+          type: icon
+        require_admin:
+          description: If admin access is required to see this iframe.
+          required: false
+          type: boolean
+          default: false
+{% endconfiguration %}
+
+<div class='note warning'>
+
+panel_name must be the mount point of the remote app, example otherapp => http://localhost:8080/otherapp
+
+</div>

--- a/source/_redirects
+++ b/source/_redirects
@@ -1665,7 +1665,6 @@
 /components/pandora /integrations/pandora
 /components/panel_custom /integrations/panel_custom
 /components/panel_iframe /integrations/panel_iframe
-/components/panel_proxy /integrations/panel_proxy
 /components/pencom /integrations/pencom
 /components/persistent_notification /integrations/persistent_notification
 /components/person /integrations/person

--- a/source/_redirects
+++ b/source/_redirects
@@ -1665,6 +1665,7 @@
 /components/pandora /integrations/pandora
 /components/panel_custom /integrations/panel_custom
 /components/panel_iframe /integrations/panel_iframe
+/components/panel_proxy /integrations/panel_proxy
 /components/pencom /integrations/pencom
 /components/persistent_notification /integrations/persistent_notification
 /components/person /integrations/person


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for panel_proxy integration.
panel_proxy allow create reverse proxy without setting up NGINX or similar


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34078
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
