### PR TITLE
Fixed indentation on example

### DIFF
--- a/source/_integrations/telegram.markdown
+++ b/source/_integrations/telegram.markdown
@@ -288,9 +288,9 @@ action:
       document:
         file: /tmp/whatever.odf
         caption: Document Title xy
-    keyboard:
-      - '/command1, /command2'
-      - '/command3, /command4'
+      keyboard:
+        - '/command1, /command2'
+        - '/command3, /command4'
 ```
 
 {% configuration %}


### PR DESCRIPTION
keyboard was inside the incorrect data structure.

## Proposed change
Move the "keyboard" key inside the second level "data" structure.

## Type of change
Typo

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Wrong indentation for one of the keys.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
