### PR TITLE
Nextcloud - Clarifying the needed admin privileges

### DIFF
--- a/source/_integrations/nextcloud.markdown
+++ b/source/_integrations/nextcloud.markdown
@@ -16,9 +16,9 @@ The `nextcloud` integration pulls summary [Nextcloud](https://nextcloud.com/) in
 
 ## Configuration
 
-This integration requires access to the monitor API of a Nextcloud instance (This is generally an admin user).
+This integration requires access to the monitor API of a Nextcloud instance  Therefore, the account on where you should generate an App password from the Nextcloud web UI, must have `Administrator` privileges. 
 
-You should also generate an App password from the Nextcloud web UI: **Settings** > **Security** > **Devices & sessions** > **Create new app password**.
+To create the needed App password follow this path on your Nextcloud instance: **Settings** > **Security** > **Devices & sessions** > **Create new app password**.
 
 Once you have generated the App password, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
## Proposed change
Proposing a better text to clarify the needed admin privileges from the account on where the App pass is generated.

## Type of change
- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/34115

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
