### PR TITLE
Add config flow and device registry to fritzbox integration 

### DIFF
--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -42,9 +42,7 @@ YAML configuration is still around for people that prefer YAML, but it's depreca
 # Example configuration.yaml entry
 fritzbox:
   devices:
-    - host: fritz.box
-      username: admin
-      password: YOUR_PASSWORD
+    - password: YOUR_PASSWORD
 ```
 
 {% configuration %}

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -30,11 +30,13 @@ There is currently support for the following device types within Home Assistant:
 - [FRITZ!DECT 301](https://en.avm.de/products/fritzdect/fritzdect-301/)
 - [Eurotronic Comet DECT](https://eurotronic.org/produkte/elektronische-heizkoerperthermostate/sparmatic-comet/)
 
-## Setup
+## Configuration
 
-Go to the integrations page in your configuration and click on **new integration** -> **AVM FRITZ!Box**. If you have enabled SSDP discovery, it’s likely that you just have to confirm the detected device with username and password.
+To add the AVM FRITZ!Box integration to your installation, go to **Configuration** -> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select **AVM FRITZ!Box**.
 
-### YAML configuration
+If you have enabled SSDP discovery, it’s likely that you just have to confirm the detected device with username and password.
+
+### Configuration via YAML
 
 YAML configuration is still around for people that prefer YAML, but it's deprecated and you should not use it anymore.
 

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -48,20 +48,24 @@ fritzbox:
 ```
 
 {% configuration %}
-host:
-  description: The hostname or IP address of the FRITZ!Box.
-  required: false
-  type: string
-  default: fritz.box
-username:
-  description: The username for Smart Home access.
-  required: false
-  type: string
-  default: admin
-password:
-  description: The password of the user.
-  required: true
-  type: string
+devices:
+  description: A list of FRITZ!Box devices.
+  type: map
+  keys:
+  host:
+    description: The hostname or IP address of the FRITZ!Box.
+    required: false
+    type: string
+    default: fritz.box
+  username:
+    description: The username for Smart Home access.
+    required: false
+    type: string
+    default: admin
+  password:
+    description: The password of the user.
+    required: true
+    type: string
 {% endconfiguration %}
 
 ## Switch & Thermostat

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -32,11 +32,11 @@ There is currently support for the following device types within Home Assistant:
 
 ## Setup
 
-Go to the integrations page in your configuration and click on new integration -> AVM FRITZ!Box. If you have enabled SSDP discovery, it’s likely that you just have to confirm the detected device with username and password.
+Go to the integrations page in your configuration and click on **new integration** -> **AVM FRITZ!Box**. If you have enabled SSDP discovery, it’s likely that you just have to confirm the detected device with username and password.
 
 ### YAML configuration
 
-YAML configuration is still around for people that prefer YAML. It's deprecated and you should not use it anymore.
+YAML configuration is still around for people that prefer YAML, but it's deprecated and you should not use it anymore.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -36,7 +36,7 @@ Go to the integrations page in your configuration and click on new integration -
 
 ### YAML configuration
 
-YAML configuration is around for people that prefer YAML. To use this integration, add the following to your `configuration.yaml` file:
+YAML configuration is still around for people that prefer YAML. It's deprecated and you should not use it anymore.
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -41,9 +41,10 @@ YAML configuration is still around for people that prefer YAML, but it's depreca
 ```yaml
 # Example configuration.yaml entry
 fritzbox:
-  - host: fritz.box
-    username: admin
-    password: YOUR_PASSWORD
+  devices:
+    - host: fritz.box
+      username: admin
+      password: YOUR_PASSWORD
 ```
 
 {% configuration %}

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -32,33 +32,35 @@ There is currently support for the following device types within Home Assistant:
 
 ## Setup
 
+Go to the integrations page in your configuration and click on new integration -> AVM FRITZ!Box. If you have enabled SSDP discovery, it’s likely that you just have to confirm the detected device with username and password.
+
+### YAML configuration
+
+YAML configuration is around for people that prefer YAML. To use this integration, add the following to your configuration.yaml file:
+
 ```yaml
 # Example configuration.yaml entry
 fritzbox:
-  devices:
-    - host: fritz.box
-      username: YOUR_USERNAME
-      password: YOUR_PASSWORD
+  - host: fritz.box
+    username: admin
+    password: YOUR_PASSWORD
 ```
 
 {% configuration %}
-devices:
-  description: A list of FRITZ!Box devices.
+host:
+  description: The hostname or IP address of the FRITZ!Box.
+  required: false
+  type: string
+  default: fritz.box
+username:
+  description: The username for Smart Home access.
+  required: false
+  type: string
+  default: admin
+password:
+  description: The password of the user.
   required: true
-  type: map
-  keys:
-    host:
-      description: The hostname or IP address of the FRITZ!Box.
-      required: true
-      type: string
-    username:
-      description: The username for Smart Home access.
-      required: true
-      type: string
-    password:
-      description: The password of the user.
-      required: true
-      type: string
+  type: string
 {% endconfiguration %}
 
 ## Switch & Thermostat

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -52,20 +52,20 @@ devices:
   description: A list of FRITZ!Box devices.
   type: map
   keys:
-  host:
-    description: The hostname or IP address of the FRITZ!Box.
-    required: false
-    type: string
-    default: fritz.box
-  username:
-    description: The username for Smart Home access.
-    required: false
-    type: string
-    default: admin
-  password:
-    description: The password of the user.
-    required: true
-    type: string
+    host:
+      description: The hostname or IP address of the FRITZ!Box.
+      required: false
+      type: string
+      default: fritz.box
+    username:
+      description: The username for Smart Home access.
+      required: false
+      type: string
+      default: admin
+    password:
+      description: The password of the user.
+      required: true
+      type: string
 {% endconfiguration %}
 
 ## Switch & Thermostat

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -36,7 +36,7 @@ Go to the integrations page in your configuration and click on new integration -
 
 ### YAML configuration
 
-YAML configuration is around for people that prefer YAML. To use this integration, add the following to your configuration.yaml file:
+YAML configuration is around for people that prefer YAML. To use this integration, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add config flow and device registry to fritzbox integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/31240
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
