### PR TITLE
Zooz device config documentation

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -191,131 +191,399 @@ Triple tap on|2|4
 5x tap off|1|6
 5x tap on|2|6
 
-### Zooz Scene Capable On/Off and Dimmer Wall Switches (Zen26 & Zen27 - Firmware 2.0+)
+### Zooz Scene Capable On/Off and Dimmer Wall Switches (Zen21v2 & Zen22v2 - Firmware 3.0+ and Zen26 & Zen27 - Firmware 2.0+)
 
 Many Zooz Zen26/27 switches that have been sold do not have firmware 2.0+. Contact Zooz to obtain the over the air firmware update instructions and new user manual for the switches.
 
 Once the firmware is updated, the the new configuration parameters will have to be added to the `zwcfg` file. Replace the existing `COMMAND_CLASS_CONFIGURATION` with the one of the following options (depending on your model of switch):
 
+Zen21v2 (On/Off Switch):
+```xml
+<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1">
+  <Instance index="1" />
+  <Value type="list" genre="config" instance="1" index="1" label="Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+    <Help>Normal mode: Upper paddle turns the light on, lower paddle turns the light off. Reverse mode: Upper paddle turns the light off, lower paddle turns the light on. Toggle mode: Either paddle toggles the light.</Help>
+    <Item label="Normal" value="0" />
+    <Item label="Reverse" value="1" />
+    <Item label="Toggle" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="2" label="LED Indication Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="1" size="1">
+    <Help>LED Indication light function. Normal has the LED Indication on when the switch is off, off when the switch is on.</Help>
+    <Item label="Normal" value="0" />
+    <Item label="Reverse" value="1" />
+    <Item label="Always Off" value="2" />
+    <Item label="Always On" value="3" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="3" label="Enable Auto Turn-Off Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="int" genre="config" instance="1" index="4" label="Auto Turn-Off Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+    <Help>Time, in minutes, for auto-off timer delay.</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="5" label="Enable Auto Turn-On Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="int" genre="config" instance="1" index="6" label="Auto Turn-On Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+    <Help>Set the time (in minutes) after which you want the switch to automatically turn on once it has been turned off.</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="7" label="Association Reports" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="15" vindex="15" size="1">
+    <Help>Choose which physical and Z-Wave triggers should prompt the switch to send a status change report to associated devices.</Help>
+    <Item label="none" value="0" />
+    <Item label="physical tap on ZEN21 only" value="1" />
+    <Item label="physical tap on connected 3-way switch only" value="2" />
+    <Item label="physical tap on ZEN21 or connected 3-way switch" value="3" />
+    <Item label="Z-Wave command from hub" value="4" />
+    <Item label="physical tap on ZEN21 or Z-Wave command from hub" value="5" />
+    <Item label="physical tap on connected 3-way switch or Z-Wave command from hub" value="6" />
+    <Item label="physical tap on ZEN21 / connected 3-way switch or Z-Wave command from hub" value="7" />
+    <Item label="timer only" value="8" />
+    <Item label="physical tap on ZEN21 or timer" value="9" />
+    <Item label="physical tap on connected 3-way switch or timer" value="10" />
+    <Item label="physical tap on ZEN21 / connected 3-way switch or timer" value="11" />
+    <Item label="Z-Wave command from hub or timer" value="12" />
+    <Item label="physical tap on ZEN21, Z-Wave command from hub, or timer" value="13" />
+    <Item label="physical tap on ZEN21 / connected 3-way switch, Z-Wave command from hub, or timer" value="14" />
+    <Item label="all of the above. (default)" value="15" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="8" label="On Off Status After Power Failure" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="1" size="1">
+    <Help>Status after power failure. Off: always turn light off. On: always turn light on. Restore: remember the latest state and restore that state.</Help>
+    <Item label="Off" value="0" />
+    <Item label="On" value="1" />
+    <Item label="Restore" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="9" label="Enable/Disable Scene Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+    <Help>Enable or Disable scene control functionality for quick double tap triggers (Available for select hubs only).</Help>
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="11" label="Smart Bulb Mode: Enable/Disable Paddle / Z-Wave Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+    <Help>Enable or disable local on/off control. If enabled, you’ll only be able to control the connected light via Z-Wave. Scenes and other functionality will still be available through paddles.</Help>
+    <Item label="physical paddle control disabled" value="0" />
+    <Item label="physical paddle control enabled (default)" value="1" />
+    <Item label="physical paddle and Z-Wave control disabled" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="12" label="3-Way Switch Type" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Help>Choose the type of 3-way switch you want to use with this dimmer in a 3-way set-up. Changing this setting can allow you to control brightness and dim the light from both 3-way locations. Use a regular momentary switch (like the Zooz ZAC99 accessory switch) if value is set to 2.</Help>
+    <Item label="regular mechanical 3-way on/off switch(default)" value="0" />
+    <Item label="momentary switch, click once to change status (light on or off)" value="1" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="13" label="Reporting behavior with disabled physical control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+    <Help>Set reporting behavior for disabled physical control.</Help>
+    <Item label="switch reports on/off status and changes LED indicator state even if physical and Z-Wave control is disabled (default)" value="0" />
+    <Item label="switch doesn&apos;t report on/off status or change LED indicator state when physical (and Z-Wave) control is disabled" value="1" />
+  </Value>
+</CommandClass>
+```
+
+Zen22v2 (Dimmer):
+```xml
+<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1">
+  <Instance index="1" />
+  <Value type="list" genre="config" instance="1" index="1" label="Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+    <Help>Normal mode: Upper paddle turns the light on, lower paddle turns the light off. Reverse mode: Upper paddle turns the light off, lower paddle turns the light on. Toggle mode: Either paddle toggles the light.</Help>
+    <Item label="Normal" value="0" />
+    <Item label="Reverse" value="1" />
+    <Item label="Toggle" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="2" label="LED Indication Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="1" size="1">
+    <Help>LED Indication light function. Normal has the LED Indication on when the switch is off, off when the switch is on.</Help>
+    <Item label="Normal" value="0" />
+    <Item label="Reverse" value="1" />
+    <Item label="Always Off" value="2" />
+    <Item label="Always On" value="3" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="3" label="Enable Auto Turn-Off Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="int" genre="config" instance="1" index="4" label="Auto Turn-Off Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+    <Help>Time, in minutes, for auto-off timer delay.</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="5" label="Enable Auto Turn-On Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="int" genre="config" instance="1" index="6" label="Auto Turn-On Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+    <Help>Set the time (in minutes) after which you want the switch to automatically turn on once it has been turned off.</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="7" label="Association Reports" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="15" vindex="15" size="1">
+    <Help>Choose which physical and Z-Wave triggers should prompt the switch to send a status change report to associated devices.</Help>
+    <Item label="none" value="0" />
+    <Item label="physical tap on ZEN22 only" value="1" />
+    <Item label="physical tap on connected 3-way switch only" value="2" />
+    <Item label="physical tap on ZEN22 or connected 3-way switch" value="3" />
+    <Item label="Z-Wave command from hub" value="4" />
+    <Item label="physical tap on ZEN22 or Z-Wave command from hub" value="5" />
+    <Item label="physical tap on connected 3-way switch or Z-Wave command from hub" value="6" />
+    <Item label="physical tap on ZEN22 / connected 3-way switch or Z-Wave command from hub" value="7" />
+    <Item label="timer only" value="8" />
+    <Item label="physical tap on ZEN22 or timer" value="9" />
+    <Item label="physical tap on connected 3-way switch or timer" value="10" />
+    <Item label="physical tap on ZEN22 / connected 3-way switch or timer" value="11" />
+    <Item label="Z-Wave command from hub or timer" value="12" />
+    <Item label="physical tap on ZEN22, Z-Wave command from hub, or timer" value="13" />
+    <Item label="physical tap on ZEN22 / connected 3-way switch, Z-Wave command from hub, or timer" value="14" />
+    <Item label="all of the above. (default)" value="15" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="8" label="On Off Status After Power Failure" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="1" size="1">
+    <Help>Status after power failure. Off: always turn light off. On: always turn light on. Restore: remember the latest state and restore that state.</Help>
+    <Item label="Off" value="0" />
+    <Item label="On" value="1" />
+    <Item label="Restore" value="2" />
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="9" label="Ramp Rate Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="99" value="0">
+    <Help>Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation). Values correspond to the number of seconds it take for the dimmer to reach full brightness or turn off when operated manually. This setting is for physical taps only, see parameter 17 to adjust Z-Wave ramp rate. Values: 1 – 99 (seconds). 0 – instant on/off. Default: 1</Help>
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="10" label="Minimum Brightness" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="1">
+    <Help>Set the minimum brightness level (in %) for your dimmer. You won’t be able to dim the light below the set value. Default: 1</Help>
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="11" label="Maximum Brightness" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="99">
+    <Help>Set the maximum brightness level (in %) for your dimmer. You won’t be able to add brightness to the light beyond the set value. Note: if Parameter 12 is set to value 0, Parameter 11 is automatically disabled. Default: 99</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="12" label="Double Tap Function" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Help>Double Tap action. When set to Full, turns light on to 100%. If set to Maximum Level, turns light on to % set in Parameter 11.</Help>
+    <Item label="Full" value="0" />
+    <Item label="Maximum Level" value="1" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="13" label="Enable/Disable Scene Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+    <Help>Enable or Disable scene control functionality for quick double tap triggers.</Help>
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="14" label="Enable/Disable Double-tap" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="2" size="1">
+    <Help>Enables/Disables the double-tap fucntion and assign brightness to single tap. Last level: single tap returns to last brightness level. Full/Max level: single tap returns to full/max level</Help>
+    <Item label="Enabled" value="0" />
+    <Item label="Disabled (last level)" value="1" />
+    <Item label="Disabled (full/max level)" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="15" label="Smart Bulb Mode: Enable/Disable Paddle / Z-Wave Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="1" size="1">
+    <Help>Enable or disable local on/off control. If enabled, you’ll only be able to control the connected light via Z-Wave. Scenes and other functionality will still be available through paddles.</Help>
+    <Item label="physical paddle control disabled" value="0" />
+    <Item label="physical paddle control enabled (default)" value="1" />
+    <Item label="physical paddle and Z-Wave control disabled" value="2" />
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="16" label="Physical Dimming Speed" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="4">
+    <Help>Set the time it takes to get from 0% to 100% brightness when pressing and holding the paddle (physical dimming). The number entered as value corresponds to the number of seconds. Default: 4</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="17" label="Zwave Ramp Rate Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+    <Help>Choose if you want to set the Z-Wave ramp rate independently of the physical ramp rate (using an appropriate command in your hub) or if you want them to match.</Help>
+    <Item label="Z-Wave ramp rate matches the physical ramp rate set in parameter 9" value="0" />
+    <Item label="Z-Wave ramp rate is set independently using appropriate Z-Wave commands (default)" value="1" />
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="18" label="Custom Brightness Level On" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="99" value="0">
+    <Help>Set the custom brightness level (instead of the last set brightness level) you want the dimmer to come on to when you single tap the upper paddle. Default: 0 - last brightness level</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="19" label="3-Way Switch Type" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="0" size="1">
+    <Help>Choose the type of 3-way switch you want to use with this dimmer in a 3-way set-up. Changing this setting can allow you to control brightness and dim the light from both 3-way locations. Use a regular momentary switch (like the Zooz ZAC99 accessory switch) if value is set to 2.</Help>
+    <Item label="regular mechanical 3-way on/off switch, use the connected 3-way switch to turn the light off or on to the last brightness level, dimming only available from the Zooz Z-Wave dimmer and from the hub (or through voice control if smart speaker is integrated with your Z-Wave hub) (default)" value="0" />
+    <Item label="regular mechanical 3-way on/off switch, tap the paddles once to change state (light on or off), tap the paddles twice quickly to turn light on to full brightness, tap the paddles quickly 3 times to enable a dimming sequence (the light will start dimming up and down in a loop) and tap the switch again to set the selected brightness level" value="1" />
+    <Item label="momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence)" value="2" />
+    <Item label="momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence but always reduce brightness after double click)" value="3" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="20" label="Zwave tap and hold Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Help>Choose how you&apos;d like the dimmer to report when paddles are tapped and held and physical / Z-Wave control is enabled or disabled.</Help>
+    <Item label="report each brightness level to hub when physical / Z-Wave control is disabled for physical dimming (final level only reported if physical / Z-Wave control is enabled)" value="0" />
+    <Item label="report final brightness level only for physical dimming, regardless of the physical / Z-Wave control mode" value="1" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="21" label="Reporting behavior with disabled physical control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+    <Help>Set reporting behavior for disabled physical control.</Help>
+    <Item label="switch reports on/off status and changes LED indicator state even if physical and Z-Wave control is disabled (default)" value="0" />
+    <Item label="switch doesn&apos;t report on/off status or change LED indicator state when physical (and Z-Wave) control is disabled" value="1" />
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="22" label="Night Light Mode" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="99" value="0">
+    <Help>Set the brightness level the dimmer will turn on to when off and when lower paddle is held DOWN for a second. Default: 20</Help>
+  </Value>
+</CommandClass>
+```
+
 Zen26 (On/Off Switch):
 ```xml
-<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1" request_flags="4" innif="true">
-	<Instance index="1" />
-	<Value type="list" genre="config" instance="1" index="1" label="Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
-		<Help>Normal mode: Upper paddle turns the light on, lower paddle turns the light off. Reverse will reverse those functions. Any will toggle the light regardless of which button is pushed.</Help>
-		<Item label="Normal" value="0" />
-		<Item label="Reverse" value="1" />
-		<Item label="Any" value="2" />
-	</Value>
-	<Value type="list" genre="config" instance="1" index="2" label="LED Indication Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="0" size="1">
-		<Help>LED Indication light function. Normal has the LED Indication on when the switch is off, off when the switch is on.</Help>
-		<Item label="Normal" value="0" />
-		<Item label="Reverse" value="1" />
-		<Item label="Always Off" value="2" />
-		<Item label="Always On" value="3" />
-	</Value>
-	<Value type="list" genre="config" instance="1" index="3" label="Enable Turn-Off Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
-		<Help>Enable or disable the auto turn-off timer function.</Help>
-		<Item label="Disabled (Default)" value="0" />
-		<Item label="Enabled" value="1" />
-	</Value>
-	<Value type="int" genre="config" instance="1" index="4" label="Turn-Off Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="1">
-		<Help>Time, in seconds, for auto-off timer delay. 60 (default).</Help>
-	</Value>
-	<Value type="list" genre="config" instance="1" index="5" label="Enable Turn-On Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
-		<Help>Enable or disable the auto turn-on timer function.</Help>
-		<Item label="Disabled (Default)" value="0" />
-		<Item label="Enabled" value="1" />
-	</Value>
-	<Value type="int" genre="config" instance="1" index="6" label="Turn-On Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="55">
-		<Help>Time, in minutes, for auto-on timer delay. 60 (default).</Help>
-	</Value>
-	<Value type="list" genre="config" instance="1" index="8" label="On Off Status After Power Failure" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="2" size="1">
-		<Help>Status after power on after power failure. OFF will always turn light off. ON will always turn light on. Restore will remember the latest state and restore that state.</Help>
-		<Item label="OFF" value="0" />
-		<Item label="ON" value="1" />
-		<Item label="Restore" value="2" />
-	</Value>
-	<Value type="list" genre="config" instance="1" index="10" label="Scene Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
-		<Help>Enable or disable scene control functionality for quick double tap triggers.</Help>
-		<Item label="Disabled (Default)" value="0" />
-		<Item label="Enabled" value="1" />
-	</Value>
-	<Value type="list" genre="config" instance="1" index="11" label="Enable/Disable Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
-		<Help>Enable or disable local on/off control. If enabled, you&apos;ll only be able to control the connected light via Z-Wave.</Help>
-		<Item label="Disabled" value="0" />
-		<Item label="Enabled (Default)" value="1" />
-	</Value>
+<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1">
+  <Instance index="1" />
+  <Value type="list" genre="config" instance="1" index="1" label="Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+    <Help>Normal mode: Upper paddle turns the light on, lower paddle turns the light off. Reverse mode: Upper paddle turns the light off, lower paddle turns the light on. Toggle mode: Either paddle toggles the light.</Help>
+    <Item label="Normal" value="0" />
+    <Item label="Reverse" value="1" />
+    <Item label="Toggle" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="2" label="LED Indication Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="1" size="1">
+    <Help>LED Indication light function. Normal has the LED Indication on when the switch is off, off when the switch is on.</Help>
+    <Item label="Normal" value="0" />
+    <Item label="Reverse" value="1" />
+    <Item label="Always Off" value="2" />
+    <Item label="Always On" value="3" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="3" label="Enable Auto Turn-Off Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="int" genre="config" instance="1" index="4" label="Auto Turn-Off Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+    <Help>Time, in minutes, for auto-off timer delay.</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="5" label="Enable Auto Turn-On Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="int" genre="config" instance="1" index="6" label="Auto Turn-On Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+    <Help>Set the time (in minutes) after which you want the switch to automatically turn on once it has been turned off.</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="7" label="Association Reports" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="15" vindex="15" size="1">
+    <Help>Choose which physical and Z-Wave triggers should prompt the switch to send a status change report to associated devices.</Help>
+    <Item label="none" value="0" />
+    <Item label="physical tap on ZEN26 only" value="1" />
+    <Item label="physical tap on connected 3-way switch only" value="2" />
+    <Item label="physical tap on ZEN26 or connected 3-way switch" value="3" />
+    <Item label="Z-Wave command from hub" value="4" />
+    <Item label="physical tap on ZEN26 or Z-Wave command from hub" value="5" />
+    <Item label="physical tap on connected 3-way switch or Z-Wave command from hub" value="6" />
+    <Item label="physical tap on ZEN26 / connected 3-way switch or Z-Wave command from hub" value="7" />
+    <Item label="timer only" value="8" />
+    <Item label="physical tap on ZEN26 or timer" value="9" />
+    <Item label="physical tap on connected 3-way switch or timer" value="10" />
+    <Item label="physical tap on ZEN26 / connected 3-way switch or timer" value="11" />
+    <Item label="Z-Wave command from hub or timer" value="12" />
+    <Item label="physical tap on ZEN26, Z-Wave command from hub, or timer" value="13" />
+    <Item label="physical tap on ZEN26 / connected 3-way switch, Z-Wave command from hub, or timer" value="14" />
+    <Item label="all of the above. (default)" value="15" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="8" label="On Off Status After Power Failure" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="1" size="1">
+    <Help>Status after power failure. Off: always turn light off. On: always turn light on. Restore: remember the latest state and restore that state.</Help>
+    <Item label="Off" value="0" />
+    <Item label="On" value="1" />
+    <Item label="Restore" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="10" label="Enable/Disable Scene Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+    <Help>Enable or Disable scene control functionality for quick double tap triggers (Available for select hubs only).</Help>
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="11" label="Smart Bulb Mode: Enable/Disable Paddle / Z-Wave Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+    <Help>Enable or disable local on/off control. If enabled, you’ll only be able to control the connected light via Z-Wave. Scenes and other functionality will still be available through paddles.</Help>
+    <Item label="physical paddle control disabled" value="0" />
+    <Item label="physical paddle control enabled (default)" value="1" />
+    <Item label="physical paddle and Z-Wave control disabled" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="13" label="Reporting behavior with disabled physical control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+    <Help>Set reporting behavior for disabled physical control.</Help>
+    <Item label="switch reports on/off status and changes LED indicator state even if physical and Z-Wave control is disabled (default)" value="0" />
+    <Item label="switch doesn&apos;t report on/off status or change LED indicator state when physical (and Z-Wave) control is disabled" value="1" />
+  </Value>
 </CommandClass>
 ```
 
 Zen27 (Dimmer):
 ```xml
-<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1" request_flags="4" innif="true">
-	<Instance index="1" />
-	<Value type="list" genre="config" instance="1" index="1" label="Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
-		<Help>Normal mode: Upper paddle turns the light on, lower paddle turns the light off. Reverse will reverse those functions. Any will toggle the light regardless of which button is pushed.</Help>
-		<Item label="Normal" value="0" />
-		<Item label="Reverse" value="1" />
-		<Item label="Any" value="2" />
-	</Value>
-	<Value type="list" genre="config" instance="1" index="2" label="LED Indication Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="0" size="1">
-		<Help>LED Indication light function. Normal has the LED Indication on when the switch is off, off when the switch is on.</Help>
-		<Item label="Normal" value="0" />
-		<Item label="Reverse" value="1" />
-		<Item label="Always Off" value="2" />
-		<Item label="Always On" value="3" />
-	</Value>
-	<Value type="list" genre="config" instance="1" index="3" label="Enable Auto Turn-Off Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
-		<Item label="Disabled" value="0" />
-		<Item label="Enabled" value="1" />
-	</Value>
-	<Value type="int" genre="config" instance="1" index="4" label="Auto Turn-Off Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
-		<Help>Time, in minutes, for auto-off timer delay.</Help>
-	</Value>
-	<Value type="list" genre="config" instance="1" index="5" label="Enable Auto Turn-On Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
-		<Item label="Disabled" value="0" />
-		<Item label="Enabled" value="1" />
-	</Value>
-	<Value type="int" genre="config" instance="1" index="6" label="Auto Turn-On Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
-		<Help>Time, in minutes, for auto-off timer delay.</Help>
-	</Value>
-	<Value type="list" genre="config" instance="1" index="8" label="On Off Status After Power Failure" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="2" size="1">
-		<Help>Status after power on after power failure. OFF will always turn light off. ON will always turn light on. Restore will remember the latest state and restore that state.</Help>
-		<Item label="OFF" value="0" />
-		<Item label="ON" value="1" />
-		<Item label="Restore" value="2" />
-	</Value>
-	<Value type="byte" genre="config" instance="1" index="9" label="Ramp Rate Control" units="seconds" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="3">
-		<Help>Adjust the ramp rate for your dimmer (fade-in / fade-out effect for on / off operation). Values correspond to the number of seconds it take for the dimmer to reach full brightness or turn off when operated manually.</Help>
-	</Value>
-	<Value type="byte" genre="config" instance="1" index="10" label="Minimum Brightness" units="%" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="99">
-		<Help>Set the minimum brightness level for your dimmer. You won&apos;t be able to dim the light below the set value.</Help>
-	</Value>
-	<Value type="byte" genre="config" instance="1" index="11" label="Maximum Brightness" units="%" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="99">
-		<Help>Set the maximum brightness level for your dimmer. You won&apos;t be able to add brightness to the light beyond the set value. Note: if Parameter 12 is set to value &quot;Full&quot;, Parameter 11 is automatically disabled.</Help>
-	</Value>
-	<Value type="list" genre="config" instance="1" index="12" label="Double Tap Function Brightness" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
-		<Help>Double Tap action. When set to Full, turns light on to 100%. If set to Maximum Level, turns light on to % set in Parameter 11.</Help>
-		<Item label="Full" value="0" />
-		<Item label="Maximum Level" value="1" />
-	</Value>				
-	<Value type="list" genre="config" instance="1" index="13" label="Scene Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
-		<Help>Enable or disable scene control functionality for quick double tap triggers.</Help>
-		<Item label="Disabled" value="0" />
-		<Item label="Enabled" value="1" />
-	</Value>
-	<Value type="list" genre="config" instance="1" index="14" label="Enable Double Tap Function" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
-		<Help>Enable the double tap or disable the double tap function and assign brightness level to single tap.</Help>
-		<Item label="Enabled" value="0" />
-		<Item label="Disabled - Single Tap To Last Brightness" value="1" />
-		<Item label="Disabled - Single Tap To Max Brightness" value="2" />
-	</Value>
-	<Value type="list" genre="config" instance="1" index="15" label="Enable/Disable Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
-		<Help>Enable or disable local on/off control. If enabled, light will only be able to be controlled via Z-Wave.</Help>
-		<Item label="Disabled" value="0" />
-		<Item label="Enabled" value="1" />
-	</Value>
+<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1">
+  <Instance index="1" />
+  <Value type="list" genre="config" instance="1" index="1" label="Paddle Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+    <Help>Normal mode: Upper paddle turns the light on, lower paddle turns the light off. Reverse mode: Upper paddle turns the light off, lower paddle turns the light on. Toggle mode: Either paddle toggles the light.</Help>
+    <Item label="Normal" value="0" />
+    <Item label="Reverse" value="1" />
+    <Item label="Toggle" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="2" label="LED Indication Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="3" vindex="1" size="1">
+    <Help>LED Indication light function. Normal has the LED Indication on when the switch is off, off when the switch is on.</Help>
+    <Item label="Normal" value="0" />
+    <Item label="Reverse" value="1" />
+    <Item label="Always Off" value="2" />
+    <Item label="Always On" value="3" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="3" label="Enable Auto Turn-Off Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="int" genre="config" instance="1" index="4" label="Auto Turn-Off Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+    <Help>Time, in minutes, for auto-off timer delay.</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="5" label="Enable Auto Turn-On Timer" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="int" genre="config" instance="1" index="6" label="Auto Turn-On Timer Duration" units="minutes" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="65535" value="60">
+    <Help>Set the time (in minutes) after which you want the switch to automatically turn on once it has been turned off.</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="7" label="Association Reports" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="15" vindex="15" size="1">
+    <Help>Choose which physical and Z-Wave triggers should prompt the switch to send a status change report to associated devices.</Help>
+    <Item label="none" value="0" />
+    <Item label="physical tap on ZEN27 only" value="1" />
+    <Item label="physical tap on connected 3-way switch only" value="2" />
+    <Item label="physical tap on ZEN27 or connected 3-way switch" value="3" />
+    <Item label="Z-Wave command from hub" value="4" />
+    <Item label="physical tap on ZEN27 or Z-Wave command from hub" value="5" />
+    <Item label="physical tap on connected 3-way switch or Z-Wave command from hub" value="6" />
+    <Item label="physical tap on ZEN27 / connected 3-way switch or Z-Wave command from hub" value="7" />
+    <Item label="timer only" value="8" />
+    <Item label="physical tap on ZEN27 or timer" value="9" />
+    <Item label="physical tap on connected 3-way switch or timer" value="10" />
+    <Item label="physical tap on ZEN27 / connected 3-way switch or timer" value="11" />
+    <Item label="Z-Wave command from hub or timer" value="12" />
+    <Item label="physical tap on ZEN27, Z-Wave command from hub, or timer" value="13" />
+    <Item label="physical tap on ZEN27 / connected 3-way switch, Z-Wave command from hub, or timer" value="14" />
+    <Item label="all of the above. (default)" value="15" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="8" label="On Off Status After Power Failure" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="2" size="1">
+    <Help>Status after power failure. Off: always turn light off. On: always turn light on. Restore: remember the latest state and restore that state.</Help>
+    <Item label="Off" value="0" />
+    <Item label="On" value="1" />
+    <Item label="Restore" value="2" />
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="9" label="Ramp Rate Control" units="seconds" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="1">
+    <Help>Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation). Values correspond to the number of seconds it take for the dimmer to reach full brightness or turn off when operated manually. This setting is for physical taps only, see parameter 17 to adjust Z-Wave ramp rate.</Help>
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="10" label="Minimum Brightness" units="%" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="1">
+    <Help>Set the minimum brightness level (in %) for your dimmer. You won&apos;t be able to dim the light below the set value.</Help>
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="11" label="Maximum Brightness" units="%" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="99">
+    <Help>Set the maximum brightness level (in %) for your dimmer. You won&apos;t be able to add brightness to the light beyond the set value. Note: if Parameter 12 is set to value &quot;Full&quot;, Parameter 11 is automatically disabled.</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="12" label="Double Tap Function" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Help>Double Tap action. When set to Full, turns light on to 100%. If set to Maximum Level, turns light on to % set in Parameter 11.</Help>
+    <Item label="Full" value="0" />
+    <Item label="Maximum Level" value="1" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="13" label="Enable/Disable Scene Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+    <Help>Enable or Disable scene control functionality for quick double tap triggers.</Help>
+    <Item label="Disabled" value="0" />
+    <Item label="Enabled" value="1" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="14" label="Enable/Disable Double-tap" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
+    <Help>Enables/Disables the double-tap function and assign brightness to single tap. Last level: single tap returns to last brightness level. Full/Max level: single tap returns to full/max level</Help>
+    <Item label="Enabled" value="0" />
+    <Item label="Disabled (last level)" value="1" />
+    <Item label="Disabled (full/max level)" value="2" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="15" label="Smart Bulb Mode: Enable/Disable Paddle / Z-Wave Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="1" size="1">
+    <Help>Enable or disable local on/off control. If enabled, you’ll only be able to control the connected light via Z-Wave. Scenes and other functionality will still be available through paddles.</Help>
+    <Item label="physical paddle control disabled" value="0" />
+    <Item label="physical paddle control enabled (default)" value="1" />
+    <Item label="physical paddle and Z-Wave control disabled" value="2" />
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="16" label="Physical Dimming Speed" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="99" value="4">
+    <Help>Set the time it takes to get from 0% to 100% brightness when pressing and holding the paddle (physical dimming). The number entered as value corresponds to the number of seconds. Default: 4</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="17" label="Zwave Ramp Rate Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+    <Help>Choose if you want to set the Z-Wave ramp rate independently of the physical ramp rate (using an appropriate command in your hub) or if you want them to match.</Help>
+    <Item label="Z-Wave ramp rate matches the physical ramp rate set in parameter 9" value="0" />
+    <Item label="Z-Wave ramp rate is set independently using appropriate Z-Wave commands (default)" value="1" />
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="18" label="Custom Brightness Level On" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="99" value="0">
+    <Help>Set the custom brightness level (instead of the last set brightness level) you want the dimmer to come on to when you single tap the upper paddle. Default: 0 - last brightness level</Help>
+  </Value>
+  <Value type="list" genre="config" instance="1" index="20" label="Zwave tap and hold Control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Help>Choose how you&apos;d like the dimmer to report when paddles are tapped and held and physical / Z-Wave control is enabled or disabled.</Help>
+    <Item label="report each brightness level to hub when physical / Z-Wave control is disabled for physical dimming (final level only reported if physical / Z-Wave control is enabled)" value="0" />
+    <Item label="report final brightness level only for physical dimming, regardless of the physical / Z-Wave control mode" value="1" />
+  </Value>
+  <Value type="list" genre="config" instance="1" index="21" label="Reporting behavior with disabled physical control" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
+    <Help>Set reporting behavior for disabled physical control.</Help>
+    <Item label="switch reports on/off status and changes LED indicator state even if physical and Z-Wave control is disabled (default)" value="0" />
+    <Item label="switch doesn&apos;t report on/off status or change LED indicator state when physical (and Z-Wave) control is disabled" value="1" />
+  </Value>
+  <Value type="byte" genre="config" instance="1" index="22" label="Night Light Mode" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="99" value="0">
+    <Help>Set the brightness level the dimmer will turn on to when off and when lower paddle is held DOWN for a second. Default: 20</Help>
+  </Value>
 </CommandClass>
 ```
 


### PR DESCRIPTION
## Proposed change
- Updated Zen26 and Zen27 config documentation for the latest firmware
- Added Zen21v2 and Zen22v2 config documentation for the latest firmware

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
https://www.support.getzooz.com/kb/article/316-zooz-on-off-switch-zen21-ver-3-04-advanced-settings/
https://www.support.getzooz.com/kb/article/319-zooz-dimmer-zen22-ver-3-07-advanced-settings/
https://www.support.getzooz.com/kb/article/315-zooz-s2-on-off-switch-zen26-ver-2-03-advanced-settings/
https://www.support.getzooz.com/kb/article/314-zooz-s2-dimmer-zen27-ver-2-08-advanced-settings/
https://github.com/OpenZWave/open-zwave/pull/2185

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
