### PR TITLE
Update Icon to Tab-Icon to avoid anchor duplication

### DIFF
--- a/source/lovelace/dashboards-and-views.markdown
+++ b/source/lovelace/dashboards-and-views.markdown
@@ -264,9 +264,9 @@ Picture card configuration:
     navigation_path: /lovelace/living_room
 ```
 
-## Tab-icon
+## View icon
 
-If you define a tab-icon, the icon instead of the title will be displayed, the title will then be used as a tool-tip.
+If you define a view icon, the icon instead of the title will be displayed, the title will then be used as a tool-tip.
 
 #### Example
 

--- a/source/lovelace/dashboards-and-views.markdown
+++ b/source/lovelace/dashboards-and-views.markdown
@@ -264,9 +264,9 @@ Picture card configuration:
     navigation_path: /lovelace/living_room
 ```
 
-## Icon
+## Tab-icon
 
-If you define an icon the title will be used as a tool-tip.
+If you define a tab-icon, the icon instead of the title will be displayed, the title will then be used as a tool-tip.
 
 #### Example
 


### PR DESCRIPTION
## Proposed change
The anchor for `icon` is already used on this page, so the second appearence was changed from `Icon` to `Tab-icon`. 
Also the text was changed to be more detailed about the function and use of `tab-icon`.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
