### PR TITLE
Add option for configure a custom "turn_off_action" (lg_netcast integration)

### DIFF
--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -37,6 +37,10 @@ turn_on_action:
   description: Defines an [action](/docs/automation/action/) to turn the TV on.
   required: false
   type: string
+turn_off_action:
+  description: Defines an [action](/docs/automation/action/) to switch the TV off.
+  required: false
+  type: string
 {% endconfiguration %}
 
 To get the access token for your TV configure the `lg_netcast` platform in Home Assistant without the `access_token`.
@@ -58,6 +62,10 @@ media_player:
     host: 192.168.0.20
     turn_on_action:
       service: switch.turn_on
+      data:
+        entity_id: switch.tv_switch
+    turn_off_action:
+      service: switch.turn_off
       data:
         entity_id: switch.tv_switch
 ```

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -38,7 +38,7 @@ turn_on_action:
   required: false
   type: string
 turn_off_action:
-  description: Defines an [action](/docs/automation/action/) to switch the TV off. This ovverides the default to set the TV in standby.
+  description: Defines an [action](/docs/automation/action/) to switch the TV off. This overides the default to set the TV in standby.
   required: false
   type: string
 {% endconfiguration %}

--- a/source/_integrations/lg_netcast.markdown
+++ b/source/_integrations/lg_netcast.markdown
@@ -38,7 +38,7 @@ turn_on_action:
   required: false
   type: string
 turn_off_action:
-  description: Defines an [action](/docs/automation/action/) to switch the TV off.
+  description: Defines an [action](/docs/automation/action/) to switch the TV off. This ovverides the default to set the TV in standby.
   required: false
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
lg_netcast integration config parameter update
https://github.com/home-assistant/core/pull/34342

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation update for my HA-Core PR (linked below). 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34342
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
