### PR TITLE
Fan integration xiaomi_miio - Troubleshooting Unable to find device error messages

### DIFF
--- a/source/_integrations/fan.xiaomi_miio.markdown
+++ b/source/_integrations/fan.xiaomi_miio.markdown
@@ -496,5 +496,3 @@ Turn the dry mode off.
 Check if the device is in the same subnet as the Home Assistant instance. Otherwise, you should configure your router/firewall to put this device in the same VLAN as the Home Assistant instance.
 
 If it's not possible to use VLANs for some reason, your last resort may be using NAT translation, between the IPs.
-
-On OPNSense (may be similar to PFSense), go to Firewall -> Outbound -> Activate `Hybrid outbound NAT rule generation` -> Save -> Add -> Interface `THE_ONE_WHERE_IS_THE_DEVICE` -> Source address `THE_HA_IP_ADDRESS/32`-> Destination address `THE_DEVICE_IP_ADDRESS/32` -> Translation / target `THE_INTERFACE_ADDRESS_WHERE_THE_DEVICE_IS` -> Save.

--- a/source/_integrations/fan.xiaomi_miio.markdown
+++ b/source/_integrations/fan.xiaomi_miio.markdown
@@ -491,7 +491,7 @@ Turn the dry mode off.
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
 
-### Troubleshooting `Unable to find device` error messages
+## Troubleshooting `Unable to find device` error messages
 
 Check if the device is in the same subnet as the Home Assistant instance. Otherwise, you should configure your router/firewall to put this device in the same VLAN as the Home Assistant instance.
 

--- a/source/_integrations/fan.xiaomi_miio.markdown
+++ b/source/_integrations/fan.xiaomi_miio.markdown
@@ -493,7 +493,7 @@ Turn the dry mode off.
 
 ### Troubleshooting `Unable to find device` error messages
 
-Check if the device is in the same subnet as the Home Assitant instance. Otherwise, you should configure your router/firewall to put this device in the same VLAN as the Home Assistant instance.
+Check if the device is in the same subnet as the Home Assistant instance. Otherwise, you should configure your router/firewall to put this device in the same VLAN as the Home Assistant instance.
 
 If it's not possible to use VLANs for some reason, your last resort may be using NAT translation, between the IPs.
 

--- a/source/_integrations/fan.xiaomi_miio.markdown
+++ b/source/_integrations/fan.xiaomi_miio.markdown
@@ -490,3 +490,11 @@ Turn the dry mode off.
 | Service data attribute    | Optional | Description                                             |
 |---------------------------|----------|---------------------------------------------------------|
 | `entity_id`               |       no | Only act on a specific Xiaomi miIO fan entity.          |
+
+### Troubleshooting `Unable to find device` error messages
+
+Check if the device is in the same subnet as the Home Assitant instance. Otherwise, you should configure your router/firewall to put this device in the same VLAN as the Home Assistant instance.
+
+If it's not possible to use VLANs for some reason, your last resort may be using NAT translation, between the IPs.
+
+On OPNSense (may be similar to PFSense), go to Firewall -> Outbound -> Activate `Hybrid outbound NAT rule generation` -> Save -> Add -> Interface `THE_ONE_WHERE_IS_THE_DEVICE` -> Source address `THE_HA_IP_ADDRESS/32`-> Destination address `THE_DEVICE_IP_ADDRESS/32` -> Translation / target `THE_INTERFACE_ADDRESS_WHERE_THE_DEVICE_IS` -> Save.


### PR DESCRIPTION
## Proposed change
How to solve connection errors on different subnets, for some Xiaomi devices unable to perceive UDP traffic outside of their own subnet IP range. Such as the Xiaomi Air Purifier 2S device.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/34305

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
