### PR TITLE
Add trunk and frunk locks to Tesla docs

### DIFF
--- a/source/_integrations/nws.markdown
+++ b/source/_integrations/nws.markdown
@@ -13,62 +13,12 @@ The `nws` platform uses the [National Weather Service](https://www.weather.gov) 
 
 ## Configuration
 
+To add `nws` to your installation, go to **Configuration** >> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select **National Weather Service (NWS)**. Multiple entries can be configured, but a unique set of latitude and longitude must be supplied for each.
+
 According to the [API documentation](https://www.weather.gov/documentation/services-web-api/), a string is required for the API key, and an email address is suggested to be included within the string.
 
-To add NWS to your installation using the closest station, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-nws:
-  api_key: YOUR_API_KEY
-```
-
-To specify a station, for example, KADW (Andrews Air Force Base), use the following:
-
-```yaml
-# Example configuration.yaml entry
-nws:
- api_key: YOUR_API_KEY
- station: KADW
-```
-
-A list of nearby stations is printed to the log with level `DEBUG` if no station is supplied. Stations can also be found on the [NOAA website](https://www.cnrfc.noaa.gov/metar.php). Codes with only three characters, for example, `ADW` should be prefixed with the letter K, `KADW`.
-
-Multiple entries can be configured, but a unique set of latitude and longitude must be supplied for each:
-
-```yaml
-# Example configuration.yaml entry
-nws:
- - api_key: YOUR_API_KEY
-   latitude: 38.5
-   longitude: -76.5
- - api_key: YOUR_API_KEY
-   latitude: 39
-   longitude: -76.5
-```
+Providing a METAR station code is optional, and if not supplied, the closest station to the latitude and longitude will be chosen. A list of nearby stations is printed to the log with level `DEBUG` if no station is supplied. Stations can also be found on the [NOAA website](https://www.cnrfc.noaa.gov/metar.php). Codes with only three characters, for example, `ADW` should be prefixed with the letter K, `KADW`.
 
 Two weather entities are created for each entry in the configuration: one for hourly forecasts and one for day and night forecasts. The time supplied for each forecast is the start time for the forecast.
-
-{% configuration %}
-api_key:
-  description: "Your API key. Any string, but an email address is suggested to be included."
-  required: true
-  type: string
-latitude:
-  description: "Manually specify latitude. By default, the value will be taken from the Home Assistant configuration."
-  required: false
-  type: float
-  default: "Provided by Home Assistant configuration."
-longitude:
-  description: Manually specify longitude. By default, the value will be taken from the Home Assistant configuration.
-  required: false
-  type: float
-  default: "Provided by Home Assistant configuration."
-station:
-  description: "METAR station code."
-  required: false
-  type: string
-  default: "Closest station to `latitude` and `longitude` as returned by NWS API."
-{% endconfiguration %}
 
 Details about the API are available in the [NWS API documentation](https://www.weather.gov/documentation/services-web-api). The [pynws](https://github.com/MatthewFlamm/pynws) library is used to retrieve data.

--- a/source/_integrations/tesla.markdown
+++ b/source/_integrations/tesla.markdown
@@ -25,7 +25,7 @@ This integration provides the following platforms:
 - Binary sensors - such as parking and charger connection.
 - Sensors - such as Battery level, Inside/Outside temperature, odometer, estimated range, and charging rate.
 - Device tracker - to track location of your car
-- Lock - Door lock and charger door lock. Enables you to control Tesla's door and charger door lock
+- Lock - Door lock, rear trunk lock, front trunk (frunk) lock and charger door lock. Enables you to control Tesla's doors, trunks and charger door
 - Climate - HVAC control. Allow you to control (turn on/off, set target temperature) your Tesla's HVAC system. Also enables preset modes to enable or disable max defrost mode `defrost` or `normal` operation mode.
 - Switch - Charger and max range switch to allow you to start/stop charging and set max range charging. Update switch to allow you to disable polling of vehicles to conserve battery. Sentry mode switch to enable or disable Sentry mode.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Append the trunk and frunk locks to the list of locks. Supported in version 0.8.0 of teslajsonpy.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34343
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
