### PR TITLE
Improve docs for the transmission integration

### DIFF
--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -43,7 +43,7 @@ transmission:
 
 {% configuration %}
 host:
-  description: "This is the IP address of your Transmission daemon, e.g., `192.168.1.1`."
+  description: "This is the IP address of your Transmission daemon, e.g., `192.168.1.1` or `https://example.com/transmission/rpc`."
   required: true
   type: string
 port:
@@ -123,20 +123,30 @@ Adds a new torrent to download. It can either be a URL (HTTP, HTTPS or FTP), mag
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `name`    | no | Name of the configured instance
+| `name`    | yes | Name of the configured instance (Default: "Transmission")
 | `torrent` | no | Torrent to download
+
+### Service `remove_torrent`
+
+Removes a torrent from the client.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `name`    | no | Name of the configured instance (Default: "Transmission")
+| `id` | no | ID of the torrent, can be found in the `torrent_info` attribute of the `*_torrents` sensors
+| `delete_data` | yes | Delete torrent data (Default: false)
 
 
 ## Templating
 
-### Sensor `started_torrents`
+### Attribute `torrent_info`
 
-The state attribute `torrent_info` contains information about the torrents that are currently downloading. You can see this information in **Developer Tools** -> **States** -> `sensor.transmission_started_torrents` -> **Attributes**, or by adding a Markdown Card to Lovelace.
+All `*_torrents` sensors e.g. `sensor.transmission_total_torrents` or `sensor.transmission_started_torrents` have a state attribute `torrent_info` that contains information about the torrents that are currently in a corresponding state. You can see this information in **Developer Tools** -> **States** -> `sensor.transmission_total_torrents` -> **Attributes**, or by adding a Markdown Card to Lovelace.
 
 {% raw %}
 ```yaml
 content: >
-  {% set payload = state_attr('sensor.transmission_started_torrents', 'torrent_info') %}
+  {% set payload = state_attr('sensor.transmission_total_torrents', 'torrent_info') %}
 
   {% for torrent in payload.items() %} {% set name = torrent[0] %} {% set data = torrent[1] %}
   

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -96,6 +96,7 @@ Possible events are:
 
 - transmission_downloaded_torrent
 - transmission_started_torrent
+- transmission_removed_torrent
 
 Inside of the event, there is the name of the torrent that is started or completed, as it is seen in the Transmission User Interface.
 


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add docs for `transmission.remove_torrent` service, fix wording, add `transmission_removed_torrent` event.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/34223

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
