### PR TITLE
Add Braava support to iRobot Roomba component

### DIFF
--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -13,14 +13,14 @@ ha_codeowners:
 ha_domain: roomba
 ---
 
-The `roomba` integration allows you to control your [iRobot Roomba](https://www.irobot.com/roomba) and [Braava Jet](https://www.irobot.com/braava) robot.
+The `roomba` integration allows you to control your [iRobot Roomba](https://www.irobot.com/roomba) vacuum or [iRobot Braava](https://www.irobot.com/braava) m-series mop.
 
 <p class='img'>
 <img src='/images/screenshots/more-info-dialog-roomba.png' />
 </p>
 
 <div class='note'>
-This platform has been tested and is confirmed to be working with the iRobot Roomba 980, 890, and Braava m6 models, but should also work fine with any Wi-Fi enabled Roomba and Braava like the 690 or the 960.
+This platform has been tested and is confirmed to be working with the iRobot Roomba s9+, Roomba 980, Roomba 890, and Braava jet m6 models, but should also work fine with any Wi-Fi enabled Roomba or Braava like the 690 or the 960.
 </div>
 
 ## Configuration

--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -1,24 +1,26 @@
 ---
 title: iRobot Roomba
-description: Instructions on how to integrate your Wi-Fi enabled Roomba within Home Assistant.
+description: Instructions on how to integrate your Wi-Fi enabled Roomba and Braava within Home Assistant.
 ha_category:
   - Vacuum
+ha_iot_class: Local Push
 ha_release: 0.51
 ha_conflig_flow: true
 ha_codeowners:
   - '@pschmitt'
   - '@cyr-ius'
+  - '@shenxn'
 ha_domain: roomba
 ---
 
-The `roomba` integration allows you to control your [iRobot Roomba](https://www.irobot.com/For-the-Home/Vacuuming/Roomba.aspx) vacuum.
+The `roomba` integration allows you to control your [iRobot Roomba](https://www.irobot.com/roomba) and [Braava Jet](https://www.irobot.com/braava) robot.
 
 <p class='img'>
 <img src='/images/screenshots/more-info-dialog-roomba.png' />
 </p>
 
 <div class='note'>
-This platform has been tested and is confirmed to be working with the iRobot Roomba 980 and 890 models, but should also work fine with any Wi-Fi enabled Roomba like the 690 or the 960.
+This platform has been tested and is confirmed to be working with the iRobot Roomba 980, 890, and Braava m6 models, but should also work fine with any Wi-Fi enabled Roomba and Braava like the 690 or the 960.
 </div>
 
 ## Configuration


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update the documentation since iRobot Braava support has been added to the roomba integration. This PR also updated the tested device list.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#33616](https://github.com/home-assistant/core/pull/33616)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
