### PR TITLE
Update link to available speedtest.net servers.

### DIFF
--- a/source/_integrations/speedtestdotnet.markdown
+++ b/source/_integrations/speedtestdotnet.markdown
@@ -21,7 +21,7 @@ Most Speedtest.net servers require TCP port 8080 outbound to function. Without t
 
 ## Configuration
 
-For the `server_id` check the list of [available servers](http://www.speedtestserver.com).
+For the `server_id` check the list of [available servers](https://speedtest.net/speedtest-servers.php).
 
 To add Speedtest.net sensors to your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
The current site no longer seems to list servers, instead it provides cli help.

## Proposed change
The current site no longer seems to list servers, instead it provides cli help.
The proposed site is from the provider, but is only a hard to read XML file.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
