### PR TITLE
Update for V1.4 API

### DIFF
--- a/source/_integrations/hydrawise.markdown
+++ b/source/_integrations/hydrawise.markdown
@@ -41,7 +41,7 @@ scan_interval:
   default: 30
 {% endconfiguration %}
 
-To get your API access token log into your [Hydrawise account](https://app.hydrawise.com/config/login) and in the 'My Account Details' section under Account Settings click 'Generate API Key'. Enter that key in your configuration file as the `API_KEY`.
+To get your API access token log into your [Hydrawise account](https://app.hydrawise.com/config/login) and in the 'My Account Details' section under Account Settings click 'Generate API Key'. Enter that key in your configuration file as `YOUR_API_KEY`.
 
 ## Binary Sensor
 
@@ -62,11 +62,13 @@ monitored_conditions:
   keys:
     is_watering:
       description: The binary sensor is `on` when the zone is actively watering.
-    rain_sensor:
-      description: Is `on` when the rain_sensor (if installed on the controller) is active (wet).
     status:
       description: This will indicate `on` when there is a connection to the Hydrawise cloud. It is not an indication of whether the irrigation controller hardware is online.
 {% endconfiguration %}
+
+<div class='note warning'>
+The Hydrawise API removed the ability to read the rain sensor status. Therefore it is no longer suppored by the Hydrawise integration to Home Assistant.
+</div>
 
 ## Sensor
 
@@ -88,7 +90,7 @@ monitored_conditions:
     watering_time:
       description: The amount of time left if the zone is actively watering. Otherwise the time is 0.
     next_cycle:
-      description: The day and time when the next scheduled automatic watering cycle will start. If the zone is suspended then the value will be `NS` to indicate Not Scheduled.
+      description: The day and time when the next scheduled automatic watering cycle will start. If the zone is suspended then the value will be `not_scheduled`.
   {% endconfiguration %}
 
 ## Switch
@@ -124,6 +126,10 @@ monitored_conditions:
 When `auto_watering` is `on` the irrigation zone will follow the Smart Watering schedule set through the Hydrawise [mobile or web app](https://www.hydrawise.com). When the `auto_watering` switch is `off` the zone's Smart Watering schedule is suspended for 1 year.
 
 When `manual_watering` is `on` the zone will run for the amount of time set by `watering_minutes`.
+
+<div class='note warning'>
+Due to changes in the Hydrawise API the status of the Auto Watering switches has changed. Under normal conditions the Auto Watering switches correctly reflect the Smart Watering schedule on the Hydrawise mobile or web app. However, if a rain sensor is connected to the system and it is active (rain detected), or the zone is running the Auto Watering switch will turn off. After both of those conditions are removed the switch will again show the correct Auto Watering condition.
+</div>
 
 ```yaml
 # An example that enables all the switches, and sets the manual watering time to 20 minutes.

--- a/source/_integrations/hydrawise.markdown
+++ b/source/_integrations/hydrawise.markdown
@@ -90,7 +90,7 @@ monitored_conditions:
     watering_time:
       description: The amount of time left if the zone is actively watering. Otherwise the time is 0.
     next_cycle:
-      description: The day and time when the next scheduled automatic watering cycle will start. If the zone is suspended then the value will be `not_scheduled`.
+      description: The day and time when the next scheduled automatic watering cycle will start.
   {% endconfiguration %}
 
 ## Switch


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is the updated documentation for the Hydrawise integration. It reflects the changes being made in the Hydrawise PR to Home-Assistant/Core.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34448
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
