### PR TITLE
Wording change to explanation of the actions

### DIFF
--- a/source/_integrations/cover.template.markdown
+++ b/source/_integrations/cover.template.markdown
@@ -74,23 +74,23 @@ cover:
         required: false
         type: string
       open_cover:
-        description: Defines an action to run when the cover is opened. If [`open_cover`](#open_cover) is specified, [`close_cover`](#close_cover) must also be specified. At least one of [`open_cover`](#open_cover) and [`set_cover_position`](#set_cover_position) must be specified.
+        description: Defines an action to open the cover. If [`open_cover`](#open_cover) is specified, [`close_cover`](#close_cover) must also be specified. At least one of [`open_cover`](#open_cover) and [`set_cover_position`](#set_cover_position) must be specified.
         required: inclusive
         type: action
       close_cover:
-        description: Defines an action to run when the cover is closed.
+        description: Defines an action to close the cover.
         required: inclusive
         type: action
       stop_cover:
-        description: Defines an action to run when the cover is stopped.
+        description: Defines an action to stop the cover.
         required: false
         type: action
       set_cover_position:
-        description: Defines an action to run when the cover is set to a specific value (between `0` and `100`).
+        description: Defines an action to set to a cover position (between `0` and `100`).
         required: false
         type: action
       set_cover_tilt_position:
-        description: Defines an action to run when the cover tilt is set to a specific value (between `0` and `100`).
+        description: Defines an action to set the tilt of a cover (between `0` and `100`).
         required: false
         type: action
       optimistic:


### PR DESCRIPTION
The wording of the action configuration variables was misleading. The way it reads is that the action will happen once the cover is in that position. I should read as the actions will cause the cover to be in those positions.
Ex. : open_cover "Defines an action to run when the cover is opened."
Most people would read that to mean once the condition is satisfied of the cover being open, the action will then run. It should be that the action will cause the cover to open. I made these changes to the 5 action variables to hopefully make that clearer as it confused me when I was looking to create a cover template.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
