### PR TITLE
Add description of manual config flow for Plex

### DIFF
--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -30,6 +30,8 @@ Local and secure connections are preferred when setting up an Integration. After
 
 </div>
 
+Alternatively, you can manually configure a Plex server connection by selecting the "Manual setup" option when configuring a Plex integration. This will allow you to specify the server connection options which will be validated before setup is completed. The available options are described in the **Configuration Variables** section below.
+
 The `plex` integration can also be configured via `configuration.yaml`:
 
 ```yaml

--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -30,7 +30,7 @@ Local and secure connections are preferred when setting up an Integration. After
 
 </div>
 
-Alternatively, you can manually configure a Plex server connection by selecting the "Manual setup" option when configuring a Plex integration. This will allow you to specify the server connection options which will be validated before setup is completed. The available options are described in the **Configuration Variables** section below.
+Alternatively, you can manually configure a Plex server connection by selecting the "Manual setup" option when configuring a Plex integration. This option is only available to users in "Advanced Mode". This will allow you to specify the server connection options which will be validated before setup is completed. The available options are described in the **Configuration Variables** section below.
 
 The `plex` integration can also be configured via `configuration.yaml`:
 

--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -22,7 +22,7 @@ There is currently support for the following device types within Home Assistant:
 
 If your Plex server has been claimed by a Plex account via the [claim interface](https://plex.tv/claim), Home Assistant will require authentication to connect.
 
-The preferred way to enable the Plex integration is via **Configuration** -> **Integrations**. You will be redirected to the [Plex](https://plex.tv) website to sign in with your Plex account. Once access is granted, Home Assistant will connect to the server linked to the associated account. If multiple Plex servers are available on the account, you will be prompted to complete the configuration by selecting the desired server on the Integrations page. Home Assistant will show as an authorized device on the [Plex Web](https://app.plex.tv/web/app) interface under **Settings** -> **Authorized Devices**.
+The Plex integration is set up via **Configuration** -> **Integrations**. You will be redirected to the [Plex](https://plex.tv) website to sign in with your Plex account. Once access is granted, Home Assistant will connect to the server linked to the associated account. If multiple Plex servers are available on the account, you will be prompted to complete the configuration by selecting the desired server on the Integrations page. Home Assistant will show as an authorized device on the [Plex Web](https://app.plex.tv/web/app) interface under **Settings** -> **Authorized Devices**.
 
 <div class='note info'>
 
@@ -30,85 +30,37 @@ Local and secure connections are preferred when setting up an Integration. After
 
 </div>
 
-Alternatively, you can manually configure a Plex server connection by selecting the "Manual setup" option when configuring a Plex integration. This option is only available to users in "Advanced Mode". This will allow you to specify the server connection options which will be validated before setup is completed. The available options are described in the **Configuration Variables** section below.
+### Integration Options
 
-The `plex` integration can also be configured via `configuration.yaml`:
+Several options are provided to adjust the behavior of `media_player` entities. These can be changed at **Plex** -> **Options** on the Integrations page.
 
-```yaml
-# Example configuration.yaml entry
-plex:
-  token: MYSECRETTOKEN
-```
+**Use episode art**: Display TV episode art instead of TV show art.
 
-<div class='note warning'>
+**Monitored users**: A list of accounts with access to the Plex server. Only selected users will create `media_player` entities.
 
-Only one Plex server can be configured when using `configuration.yaml`. To add more servers, set up via **Configuration** -> **Integrations**.
+**Ignore new managed/shared users**: Enable to ignore new Plex accounts granted access to the server.
 
-</div>
 
-{% configuration %}
-host:
-  description: The IP address or hostname of your Plex server.
-  required: false
-  type: string
-port:
-  description: The port of your Plex Server.
-  required: false
-  default: 32400
-  type: integer
-token:
-  description: A valid X-Plex-Token for your Plex server. If provided without `host` and `port`, a connection URL will be retreived from Plex.
-  required: false
-  type: string
-server:
-  description: Name of Plex server to use if multiple servers are associated with the token's Plex account. Only used if `token` is provided without `host` and `port`.
-  required: false
-  type: string
-ssl:
-  description: Use HTTPS to connect to Plex server, **NOTE:** host **must not** be an IP when this option is enabled.
-  required: false
-  default: false
-  type: boolean
-verify_ssl:
-  description: Verify the SSL certificate of your Plex server. You may need to disable this check if your local server enforces secure connections with the default certificate.
-  required: false
-  default: true
-  type: boolean
-media_player:
-  description: Options to set the default behavior of `media_player` entities for new Integrations. **NOTE:** These options are exposed as Configuration Options (**Integrations** -> **Configured** --> **Plex** --> **Gear Icon**). Configuration Options will take precedence.
-  required: false
-  type: map
-  keys:
-    use_episode_art:
-      description: Display TV episode art instead of TV show art.
-      required: false
-      default: false
-      type: boolean
-    ignore_new_shared_users:
-      description: Do not track Plex clients for newly added Plex users.
-      required: false
-      default: false
-      type: boolean
-{% endconfiguration %}
+### Manual Configuration
 
-```yaml
-# Complete configuration.yaml entry
-plex:
-  host: 192.168.1.100
-  port: 32400
-  token: MY_SECRET_TOKEN
-  ssl: true
-  verify_ssl: true
-  media_player:
-    use_episode_art: true
-    ignore_new_shared_users: false
-```
+Alternatively, you can manually configure a Plex server connection by selecting the "Configure Plex server manually" when configuring a Plex integration. This option is only available to users in "Advanced Mode". This will allow you to specify the server connection options which will be validated before setup is completed. The available options are described below:
+
+**Host**: The IP address or hostname of your Plex server. Optional if 'Token' is provided.
+
+**Port**: The port of your Plex Server.
+
+**Use SSL**: Use HTTPS to connect to Plex server.
+
+**Verify SSL certificate**: Verify the SSL certificate of your Plex server. May be used if connecting with an IP or if using a self-signed certificate.
+
+**Token**: A valid authorization token for your Plex server. If provided without 'Host', a connection URL will be retreived from Plex.
+
 
 ## Media Player
 
 The `plex` media_player platform will create Media Player entities for each connected client device. These entities will display media information, playback progress, and playback controls if supported by the device.
 
-By default the Plex integration will create Media Player entities for all local, managed, and shared users on the Plex server. To choose specific users to monitor or ignore, select them via the Configuration Options (**Integrations** -> **Configured** --> **Plex** --> **Gear Icon**).
+By default the Plex integration will create Media Player entities for all local, managed, and shared users on the Plex server. To choose specific users to monitor or ignore, adjust the "*Monitored users*" and "*Ignore new managed/shared users*" options described under [Integration Options](#integration-options).
 
 ### Service `play_media`
 
@@ -200,15 +152,7 @@ media_content_id: '{ "library_name": "Adult Movies", "video_name": "Blade" }'
 
 ### Notes
 
-* The `plex` integration supports multiple Plex servers. Additional connections can be configured under Configuration > Integrations.
-* When setting up a server via `configuration.yaml`, it is possible to get errors that look like the following.
-
-  ```txt
-  ERROR:plexapi:http://192.168.1.10:32400: ('Connection aborted.', BadStatusLine("''",))
-  INFO:homeassistant.components.media_player.plex:No server found at: http://192.168.1.10:32400
-  ```
-
-  If this occurs, check the setting `Server`>`Network`>`Secure connections` on your Plex Media Server: if it is set to `Preferred` or `Required`, you may need to manually set the `ssl` and `verify_ssl` configuration options to, respectively, `true` and `false`.
+* The `plex` integration supports multiple Plex servers. Additional connections can be configured under **Configuration** > **Integrations**.
 * Movies must be located under 'Movies' section in the Plex library to properly get 'playing' state.
 
 ## Sensor


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Describe manual configuration added to the Plex integration config flow.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34476
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
