### PR TITLE
Rewrite Plex play_media service descriptions

### DIFF
--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -110,39 +110,79 @@ By default the Plex integration will create Media Player entities for all local,
 
 ### Service `play_media`
 
-Plays a song, playlist, TV episode, or video on a connected client.
+Plays a song, album, artist, playlist, TV show/season/episode, movie, or video on a connected client.
+
+Required fields within the `media_content_id` payloads are marked as such, others are optional.
 
 #### Music
 
-| Service data attribute | Optional | Description                                                                                            | Example                                                                                                                                                       |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | `entity_id` of the client                                                                              | media_player.theater_plex                                                                                                                                     |
-| `media_content_id`     | no       | Quote escaped JSON with `library_name`, `artist_name`, `album_name`, `track_name`, `shuffle` (0 or 1). | { \\"library_name\\" : \\"My Music\\", \\"artist_name\\" : \\"Adele\\", \\"album_name\\" : \\"25\\", \\"track_name\\" : \\"hello\\", \\"shuffle\\": \\"0\\" } |
-| `media_content_type`   | no       | Type of media to play, in this case `MUSIC`                                                            | MUSIC                                                                                                                                                         |
+| Service data attribute | Description                                                                                                                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `entity_id`            | `entity_id` of the client                                                                                                                                                                            |
+| `media_content_id`     | Quoted JSON containing:<br/><ul><li>`library_name` (Required)</li><li>`artist_name` (Required)</li><li>`album_name`</li><li>`track_name`</li><li>`track_number`</li><li>`shuffle` (0 or 1)</li></ul> |
+| `media_content_type`   | `MUSIC`                                                                                                                                                                                              |
+
+##### Examples:
+```yaml
+entity_id: media_player.plex_player
+media_content_type: MUSIC
+media_content_id: '{ "library_name": "Music", "artist_name": "Adele", "album_name": "25", "track_name": "Hello" }'
+```
+```yaml
+entity_id: media_player.plex_player
+media_content_type: MUSIC
+media_content_id: '{ "library_name": "Music", "artist_name": "Stevie Wonder", "shuffle": "1" }'
+```
 
 #### Playlist
 
-| Service data attribute | Optional | Description                                                  | Example                                                                  |
-| ---------------------- | -------- | ------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| `entity_id`            | no       | `entity_id` of the client                                    | media_player.theater_plex                                                |
-| `media_content_id`     | no       | Quote escaped JSON with `playlist_name`, `shuffle` (0 or 1). | { \\"playlist_name\\" : \\"The Best of Disco\\" \\"shuffle\\": \\"0\\" } |
-| `media_content_type`   | no       | Type of media to play, in this case `PLAYLIST`               | PLAYLIST                                                                 |
+| Service data attribute | Description                                                                                         |
+| ---------------------- | --------------------------------------------------------------------------------------------------- |
+| `entity_id`            | `entity_id` of the client                                                                           |
+| `media_content_id`     | Quoted JSON containing:<br/><ul><li>`playlist_name` (Required)</li><li>`shuffle` (0 or 1)</li></ul> |
+| `media_content_type`   | `PLAYLIST`                                                                                          |
+
+##### Example:
+```yaml
+entity_id: media_player.plex_player
+media_content_type: PLAYLIST
+media_content_id: '{ "playlist_name": "The Best of Disco", "shuffle": "1" }'
+```
 
 #### TV Episode
 
-| Service data attribute | Optional | Description                                                                                                 | Example                                                                                                                                                    |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | `entity_id` of the client                                                                                   | media_player.theater_plex                                                                                                                                  |
-| `media_content_id`     | no       | Quote escaped JSON with `library_name`, `show_name`, `season_number`, `episode_number`, `shuffle` (0 or 1). | { \\"library_name\\" : \\"Adult TV\\", \\"show_name\\" : \\"Rick and Morty\\", \\"season_number\\" : 2, \\"episode_number\\" : 5, \\"shuffle\\": \\"0\\" } |
-| `media_content_type`   | no       | Type of media to play, in this case `EPISODE`                                                               | EPISODE                                                                                                                                                    |
+| Service data attribute | Description                                                                                                                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `entity_id`            | `entity_id` of the client                                                                                                                                                          |
+| `media_content_id`     | Quoted JSON containing:<br/><ul><li>`library_name` (Required)</li><li>`show_name` (Required)</li><li>`season_number`</li><li>`episode_number`</li><li>`shuffle` (0 or 1)</li></ul> |
+| `media_content_type`   | `EPISODE`                                                                                                                                                                          |
+
+##### Examples:
+```yaml
+entity_id: media_player.plex_player
+media_content_type: EPISODE
+media_content_id: '{ "library_name": "Adult TV", "show_name": "Rick and Morty", "season_number": 2, "episode_number": 5 }'
+```
+```yaml
+entity_id: media_player.plex_player
+media_content_type: EPISODE
+media_content_id: '{ "library_name": "Kid TV", "show_name": "Sesame Street", "shuffle": "1" }'
+```
 
 #### Video
 
-| Service data attribute | Optional | Description                                                               | Example                                                                                             |
-| ---------------------- | -------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | `entity_id` of the client                                                 | media_player.theater_plex                                                                           |
-| `media_content_id`     | no       | Quote escaped JSON with `library_name`, `video_name`, `shuffle` (0 or 1). | { \\"library_name\\" : \\"Adult Movies\\", \\"video_name\\" : \\"Blade\\", \\"shuffle\\": \\"0\\" } |
-| `media_content_type`   | no       | Type of media to play, in this case `VIDEO`                               | VIDEO                                                                                               |
+| Service data attribute | Description                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `entity_id`            | `entity_id` of the client                                                                               |
+| `media_content_id`     | Quoted JSON containing:<br/><ul><li>`library_name` (Required)</li><li>`video_name` (Required)</li></ul> |
+| `media_content_type`   | `VIDEO`                                                                                                 |
+
+##### Example:
+```yaml
+entity_id: media_player.plex_player
+media_content_type: VIDEO
+media_content_id: '{ "library_name": "Adult Movies", "video_name": "Blade" }'
+```
 
 ### Compatibility
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The `play_media` service description was very busy and hard to read, and used outdated notation for escaping JSON payloads. This splits the service description and examples to make them more readable (and copy & paste-able!).

The fields in the JSON payload were also not all required and are now marked accordingly.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
