### PR TITLE
Update list of supported Denon AVR receivers

### DIFF
--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -40,6 +40,8 @@ Known supported devices:
 - Other Denon AVR receivers (untested)
 - Marantz receivers (experimental)
 
+If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.github.io/tree/current/source/_integrations/denonavr.markdown).
+
 <div class='note warning'>
 If you have something else using the IP controller for your Denon AVR 3808CI, such as your URC controller, it will not work! There is either a bug or security issue with some models where only one device could be controlling the IP functionality.
 </div>

--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -40,7 +40,7 @@ Known supported devices:
 - Other Denon AVR receivers (untested)
 - Marantz receivers (experimental)
 
-If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.github.io/tree/current/source/_integrations/denonavr.markdown).
+If your model is not on the list then give it a test, if everything works correctly then add it to the list by clicking on the **Edit this page on Github** link above.
 
 <div class='note warning'>
 If you have something else using the IP controller for your Denon AVR 3808CI, such as your URC controller, it will not work! There is either a bug or security issue with some models where only one device could be controlling the IP functionality.

--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -40,7 +40,7 @@ Known supported devices:
 - Other Denon AVR receivers (untested)
 - Marantz receivers (experimental)
 
-If your model is not on the list then give it a test, if everything works correctly then add it to the list by clicking on the **Edit this page on Github** link above.
+If your model is not on the list then give it a test, if everything works correctly then add it to the list by clicking on the **Edit this page on GitHub** link above.
 
 <div class='note warning'>
 If you have something else using the IP controller for your Denon AVR 3808CI, such as your URC controller, it will not work! There is either a bug or security issue with some models where only one device could be controlling the IP functionality.

--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -19,12 +19,14 @@ Known supported devices:
 - Denon AVR-X1500H
 - Denon AVR-X2000
 - Denon AVR-X2100W
+- Denon AVR-X3400H
 - Denon AVR-X4100W
 - Denon AVR-X4300H
 - Denon AVR-X4500H
 - Denon AVR-1912
 - Denon AVR-2312CI
 - Denon AVR-3311CI
+- Denon AVR-3312
 - Denon AVR-4810
 - Denon AVR-S750H
 - Marantz M-CR510


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add the following Denon AVR receivers to the list of supported receivers:

* Denon AVR-X3400H
* Denon AVR-3312

Also added a note about contributing similar to the notes in other sections


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

I have tested both receivers with all services to ensure correct functionality

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - **I made a change to the existing documentation and used the `current` branch.**
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
