### PR TITLE
Add warning to SolarEdge local documentation

### DIFF
--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -14,7 +14,7 @@ ha_domain: solaredge_local
 
 <div class='note'>
 
-Recent firmeware updates have disabled the local API on many inverters.  Please enter the IP address of your inverter in a browser before attempting to use this component.  If the local API is enabled, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu.  See [this issue](https://github.com/jbuehl/solaredge/issues/124) and [this issue](https://github.com/drobtravels/solaredge-local/issues/24) for additional details.
+Recent firmeware updates have disabled the local API on many inverters. Please enter the IP address of your inverter in a browser before attempting to use this component. If the local API is enabled, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. See [this issue](https://github.com/jbuehl/solaredge/issues/124) and [this issue](https://github.com/drobtravels/solaredge-local/issues/24) for additional details.
   
 If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -12,22 +12,19 @@ ha_codeowners:
 ha_domain: solaredge_local
 ---
 
-<div class='note'>
-
-Recent firmeware updates have disabled the local API on many inverters. Please enter the IP address of your inverter in a browser before attempting to use this component. If the local API is enabled, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. See [this issue](https://github.com/jbuehl/solaredge/issues/124) and [this issue](https://github.com/drobtravels/solaredge-local/issues/24) for additional details.
-  
-If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
-
-</div>
-
 The `solaredge_local` platform uses the local API available on some SolarEdge Inverters to allow you to get details from your SolarEdge solar power setup and integrate these into your Home Assistant installation.
 
 Only specific models support the local API. The local API is available on inverters that do not have an LCD character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection". These inverters also have a part number that ends with a 4. For example: SEXXK-XXXXXBXX4 or SEXXXXH-XXXXXBXX4
 
 You can check if the local API works by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. 
 
+<div class='note'>
 
+Recent firmware updates have disabled the local API on many inverters. Please enter the IP address of your inverter in a browser before attempting to use this component. If the local API is enabled, you'll see a web page with the SolarEdge logo and a "Commissioning" menu. See [this issue](https://github.com/jbuehl/solaredge/issues/124) and [this issue](https://github.com/drobtravels/solaredge-local/issues/24) for additional details.
+  
+If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
 
+</div>
 
 ## Configuration
 

--- a/source/_integrations/solaredge_local.markdown
+++ b/source/_integrations/solaredge_local.markdown
@@ -12,17 +12,21 @@ ha_codeowners:
 ha_domain: solaredge_local
 ---
 
+<div class='note'>
+
+Recent firmeware updates have disabled the local API on many inverters.  Please enter the IP address of your inverter in a browser before attempting to use this component.  If the local API is enabled, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu.  See [this issue](https://github.com/jbuehl/solaredge/issues/124) and [this issue](https://github.com/drobtravels/solaredge-local/issues/24) for additional details.
+  
+If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
+
+</div>
+
 The `solaredge_local` platform uses the local API available on some SolarEdge Inverters to allow you to get details from your SolarEdge solar power setup and integrate these into your Home Assistant installation.
 
 Only specific models support the local API. The local API is available on inverters that do not have an LCD character screen. You can also  check the datasheets if in the section "Additional Features", sub-section "Inverter Commissioning" is present the following line "With the SetApp mobile application using built-in Wi-Fi access point for local connection". These inverters also have a part number that ends with a 4. For example: SEXXK-XXXXXBXX4 or SEXXXXH-XXXXXBXX4
 
 You can check if the local API works by finding the IP address of your inverter and visiting it in a browser. If it supports the local API, you'll see a HTML page with the SolarEdge logo and a "Commissioning" menu. 
 
-<div class='note'>
-  
-If your inverter does not support the local API, you can use the [cloud based version](/integrations/solaredge/)
 
-</div>
 
 
 ## Configuration


### PR DESCRIPTION
This integration no longer functions with recent firmware updates.  It may continue work long term on inverters which do not receive firmware updates

More details in [this issue](https://github.com/drobtravels/solaredge-local/issues/24)

## Proposed change

Add warning and reference to issue with more details so users can quickly determine if this integration will work for them.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ X]This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
