### PR TITLE
Updated vacuum.xiaomi_miio.markdown to warn of access token method

### DIFF
--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -218,17 +218,6 @@ The following table shows the units of measurement for each attribute:
 
 ### Xiaomi Home app (Xiaomi Aqara Gateway, android?)
 
-<div class='note'>
-
-This method yielded an incorrect token on the 22nd of April, 2020 when used with:
-1. Xiaomi Gateway
-2. Xiaomi Mi Robot Vacuum
-3. Xiaomi IR Remote
-
-Using the alternate method with Mi Home `v5.4.49`, there were 3 different tokens listed for each of the above devices. The token yielded by this method matched the token for the Xiaomi Gateway in the text file. After using the correct token from the Mi Home `v5.4.49` method, the devices started to work again. 
-
-</div>
-
 1. Install the Xiaomi Home app.
 2. Sign In/make an account.
 3. Make sure you set your region to: Mainland China (Seems to be the longest line with Chines characters) under settings -> Region (language can later be set on English).
@@ -238,6 +227,8 @@ Using the alternate method with Mi Home `v5.4.49`, there were 3 different tokens
 7. Tap the version number (Plug-in version 2.77.1 as of January 2020) at the bottom of the screen repeatedly.
 8. You should now see 2 extra options listed in English, this means you enabled developer mode. [if not, try all steps again!].
 9. Under "Hub info" there is quite some text in JSON format, this includes the "token" that you need.
+
+Note: If you have multiple devices needing a token, e.g. Xiaomi Mi Robot Vacuum and a Xiaomi IR Remote, the above method may not work. The Xiaomi Home app will display a token, though it isn't the correct one. The alternative method using "Mi Home `v5.4.49`" will provide the correct token. 
 
 ### Alternative methods
 

--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -228,7 +228,7 @@ The following table shows the units of measurement for each attribute:
 8. You should now see 2 extra options listed in English, this means you enabled developer mode. [if not, try all steps again!].
 9. Under "Hub info" there is quite some text in JSON format, this includes the "token" that you need.
 
-Note: If you have multiple devices needing a token, e.g. Xiaomi Mi Robot Vacuum and a Xiaomi IR Remote, the above method may not work. The Xiaomi Home app will display a token, though it isn't the correct one. The alternative method using "Mi Home `v5.4.49`" will provide the correct token. 
+Note: If you have multiple devices needing a token, e.g., Xiaomi Mi Robot Vacuum and a Xiaomi IR Remote, the above method may not work. The Xiaomi Home app will display a token, though it isn't the correct one. The alternative method using "Mi Home v5.4.49" will provide the correct token. 
 
 ### Alternative methods
 

--- a/source/_integrations/vacuum.xiaomi_miio.markdown
+++ b/source/_integrations/vacuum.xiaomi_miio.markdown
@@ -218,6 +218,17 @@ The following table shows the units of measurement for each attribute:
 
 ### Xiaomi Home app (Xiaomi Aqara Gateway, android?)
 
+<div class='note'>
+
+This method yielded an incorrect token on the 22nd of April, 2020 when used with:
+1. Xiaomi Gateway
+2. Xiaomi Mi Robot Vacuum
+3. Xiaomi IR Remote
+
+Using the alternate method with Mi Home `v5.4.49`, there were 3 different tokens listed for each of the above devices. The token yielded by this method matched the token for the Xiaomi Gateway in the text file. After using the correct token from the Mi Home `v5.4.49` method, the devices started to work again. 
+
+</div>
+
 1. Install the Xiaomi Home app.
 2. Sign In/make an account.
 3. Make sure you set your region to: Mainland China (Seems to be the longest line with Chines characters) under settings -> Region (language can later be set on English).


### PR DESCRIPTION
The latest version of Mi Home does not provide the correct token to use with the Robot Vacuum nor the IR Remote.
The token retrieved by tapping 2.77.1 is only for the Gateway and not any child devices.
Added warning message but realistically this new method should be removed once further testing confirms it is not correct.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
