### PR TITLE
Update Amcrest:markdown

### DIFF
--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -92,7 +92,7 @@ authentication:
   required: false
   type: string
   default: basic
-scan_interval:
+scan_interval: (Obsolete from 108.5)
   description: Defines the update interval of the sensor in seconds.
   required: false
   type: integer
@@ -142,6 +142,11 @@ Newer Amcrest firmware may not work, then `rtsp` is recommended instead.
 **Note:** If you set the `stream_source` option to `rtsp`,
 make sure to follow the steps mentioned at [FFmpeg](/integrations/ffmpeg/)
 documentation to install the `ffmpeg`.
+
+**Note:** From 108.5 a new motion detection mechanism has been implemented for Amcrest cameras
+to improve speed response, whilst lowering network demands. Some cameras have a 
+propreitary bug in the firmware (V2.420.0009.0.R.20151106) and will return a 500 Bad Response
+error and are incompatible with Motion Detection.
 
 ## Services
 

--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -92,8 +92,8 @@ authentication:
   required: false
   type: string
   default: basic
-scan_interval: (Obsolete from 108.5)
-  description: Defines the update interval of the sensor in seconds.
+scan_interval:
+  description: Defines the update interval of the sensor in seconds. This setting is fixed from HA version 108.5 and scan_interval has no effect
   required: false
   type: integer
   default: 10

--- a/source/_integrations/amcrest.markdown
+++ b/source/_integrations/amcrest.markdown
@@ -145,7 +145,7 @@ documentation to install the `ffmpeg`.
 
 **Note:** From 108.5 a new motion detection mechanism has been implemented for Amcrest cameras
 to improve speed response, whilst lowering network demands. Some cameras have a 
-propreitary bug in the firmware (V2.420.0009.0.R.20151106) and will return a 500 Bad Response
+proprietary bug in the firmware (V2.420.0009.0.R.20151106) and will return a 500 Bad Response
 error and are incompatible with Motion Detection.
 
 ## Services


### PR DESCRIPTION
## Proposed change
Following new code mechanisms by @pnbrucker the scan_interval is now obsolete as the camera polling has been replaced by a new event mechanism. Also added a note that the new mechanism does not work with a certain block of FW.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
