### PR TITLE
Update utility_meter.markdown

### DIFF
--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -170,19 +170,19 @@ So, tracking daily and monthly consumption for each sensor, will require setting
 
 ```yaml
 utility_meter:
-  daily_power_offpeak:
+  daily_energy_offpeak:
     source: sensor.energy_consumption_tarif_1
     cycle: daily
-  daily_power_peak:
+  daily_energy_peak:
     source: sensor.energy_consumption_tarif_2
     cycle: daily
   daily_gas:
     source: sensor.gas_consumption
     cycle: daily
-  monthly_power_offpeak:
+  monthly_energy_offpeak:
     source: sensor.energy_consumption_tarif_1
     cycle: monthly
-  monthly_power_peak:
+  monthly_energy_peak:
     source: sensor.energy_consumption_tarif_2
     cycle: monthly
   monthly_gas:
@@ -197,13 +197,13 @@ Additionally, you can add template sensors to compute daily and monthly total us
 sensor:
   - platform: template
     sensors:
-      daily_power:
-        friendly_name: Daily Power
+      daily_energy:
+        friendly_name: Daily Energy
         unit_of_measurement: kWh
-        value_template: "{{ states('sensor.daily_power_offpeak')|float + states('sensor.daily_power_peak')|float }}"
-      monthly_power:
-        friendly_name: Monthly Power
+        value_template: "{{ states('sensor.daily_energy_offpeak')|float + states('sensor.daily_energy_peak')|float }}"
+      monthly_energy:
+        friendly_name: Monthly Energy
         unit_of_measurement: kWh
-        value_template: "{{ states('sensor.monthly_power_offpeak')|float + states('sensor.monthly_power_peak')|float }}"
+        value_template: "{{ states('sensor.monthly_energy_offpeak')|float + states('sensor.monthly_energy_peak')|float }}"
 ```
 {% endraw %}


### PR DESCRIPTION
Pedantic: Energy (kWh or Joule) is not power (W or J/s), correct naming of variables

## Proposed change
<!--
   Changed incorrect labeling of energies as power. Should not change functionality.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
