### PR TITLE
Update atag docs

### DIFF
--- a/source/_integrations/atag.markdown
+++ b/source/_integrations/atag.markdown
@@ -18,19 +18,15 @@ The integration implements the following platforms:
 
 ## Configuration
 
-The Atag integration can be enabled directly from Home Assistant. Navigate to `configuration`, then `integrations` and click `add`. Click `Atag` to initiate the configuration. Only the IP Address has to be provided, but be sure to add your email address if you experience connectivity issues.
+The Atag integration can be enabled directly from Home Assistant. Navigate to `configuration`, then `integrations` and click `add`. Click `Atag` to initiate the configuration.
 
 {% configuration %}
 host:
   description: Atag hostname or IP address.
   required: true
   type: string
-email:
-  description: Email registered in the Atag App.
-  required: false
-  type: string
 port:
-  description: Port to reach the Atag API. Only needed if connecting through alternative routes.
+  description: API Port. Only change if you are connecting indirectly (e.g. through reverse proxy)
   required: false
   type: integer
 {% endconfiguration %}
@@ -45,13 +41,18 @@ This integration supports the following services (see [Climate](/integrations/cl
 
 - [`set_temperature`](/integrations/climate/#service-climateset_temperature)
 - [`set_hvac_mode`](/integrations/climate/#service-climateset_hvac_mode)
-  - `heat` for regular thermostat mode
+  - `heat` for thermostat mode
   - `auto` for weather-based mode
-  - `off` to disable control from Home Assistant
+- [`set_preset_mode`](/integrations/climate/#service-climateset_preset_mode)
+  - `Manual` enable manual operation
+  - `Auto` enable schedule based operation
+  - `Extend` delay the next scheduled temperature update by the default extend period
+  - `away` enable the vacation mode for 1 day or until another preset is activated
+  - `boost` enable fireplace mode
 
 <div class='note'>
-HVAC mode provides returns regular or weather-based mode (i.e., not manual, auto, extend, fireplace).
-The hold modes (manual, auto, extend) are currently available as a sensor only. Setting these modes is planned for a future update.
+`HVAC mode Auto` (Weather based) should not be confused with `Preset mode Auto` (Sheduled, thermostat mode).
+Currently selection of custom timeframes in Extend, Away and boost modes is not supported. The default settings can be changed on the device.
 </div>
 
 ## Water Heater
@@ -66,12 +67,11 @@ The following sensors will be added to Home Assistant:
 
 ### Sensors enabled by default
 
-- `outside_temp`
-- `outside_temp_avg`
-- `weather_status`
-- `operation_mode`
-- `ch_water_pressure`
-- `dhw_water_temp`
-- `dhw_water_pres`
+- `average_outside_temperature`
 - `burning_hours`
-- `flame_level`
+- `ch_return_temperature`
+- `ch_water_pressure`
+- `ch_water_temperature`
+- `flame`
+- `outside_temperature`
+- `weather_status`


### PR DESCRIPTION
## Proposed change
Missed this when updating the PR yesterday. Changes in the main PR need to be reflected in the docs as well:
- add preset modes
- remove OFF mode
- renamed sensors

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
