### PR TITLE
Add Elexa Guardian docs

### DIFF
--- a/source/_integrations/guardian.markdown
+++ b/source/_integrations/guardian.markdown
@@ -1,0 +1,56 @@
+---
+title: Guardian
+description: Instructions on how to integrate SimpliSafe into Home Assistant.
+ha_release: 0.110.0
+ha_category:
+  - Binary Sensor
+  - Sensor
+  - Switch
+ha_config_flow: true
+ha_codeowners:
+  - '@bachya'
+ha_domain: guardian
+---
+
+The `guardian` integration integrates
+[Elexa Guardian water valve controllers](https://getguardian.com) into Home Assistant.
+
+There is currently support for the following device types within Home Assistant:
+
+- **Binary Sensor**: reports the status of the onboard leak detector and access point
+- **Sensor**: reports on the device's detected temperature and uptime
+- **Switch**: allows the user to open and close the valve
+
+## Configuration
+
+This integration can be configured via the Home Assistant UI by navigating to
+`Configuration > Integrations`. If you have the `zeroconf` integration enabled, Home Assistant
+will automatically discover any Guardian devices already connected to the network.
+
+## Services
+
+### `guardian.disable_ap`
+
+Disable the device's onboard access point.
+
+### `guardian.enable_ap`
+
+Enable the device's onboard access point.
+
+### `guardian.reboot`
+
+Reboot the device.
+
+### `guardian.reset_valve_diagnostics`
+
+Fully (and irrecoverably) reset all valve diagnostics.
+
+### `guardian.upgrade_firmware`
+
+Upgrade the device firmware.
+
+| Service Data Attribute | Optional | Description                                      |
+| ---------------------- | -------- | ------------------------------------------------ |
+| `url`                    | yes      | The URL of the server hosting the firmware file. |
+| `port`                   | yes      | The port on which the firmware file is served.   |
+| `filename`               | yes      | The firmware filename.                           |

--- a/source/_integrations/guardian.markdown
+++ b/source/_integrations/guardian.markdown
@@ -1,7 +1,7 @@
 ---
 title: Guardian
 description: Instructions on how to integrate SimpliSafe into Home Assistant.
-ha_release: "0.110"
+ha_release: "0.111"
 ha_category:
   - Binary Sensor
   - Sensor

--- a/source/_integrations/guardian.markdown
+++ b/source/_integrations/guardian.markdown
@@ -1,7 +1,7 @@
 ---
 title: Guardian
 description: Instructions on how to integrate SimpliSafe into Home Assistant.
-ha_release: 0.110.0
+ha_release: "0.110"
 ha_category:
   - Binary Sensor
   - Sensor
@@ -24,8 +24,9 @@ There is currently support for the following device types within Home Assistant:
 ## Configuration
 
 This integration can be configured via the Home Assistant UI by navigating to
-`Configuration > Integrations`. If you have the `zeroconf` integration enabled, Home Assistant
-will automatically discover any Guardian devices already connected to the network.
+**Configuration** -> **Integrations**. If you have the `zeroconf` integration enabled,
+Home Assistant will automatically discover any Guardian devices already connected to the
+network.
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds documentation for the forthcoming Elexa Guardian integration.
## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34627
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1489
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
