### PR TITLE
Added PTZ GotoPreset support

### DIFF
--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -76,7 +76,7 @@ If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your ca
 | `zoom` | Zoom. Allowed values: `ZOOM_IN`, `ZOOM_OUT`, `NONE`
 | `distance` | Distance coefficient. Sets how much PTZ should be executed in one request. Allowed values: floating point numbers, 0 to 1. Default : 0.1
 | `speed` | Speed coefficient. Sets how fast PTZ will be executed. Allowed values: floating point numbers, 0 to 1. Default : 0.5
-  `preset` | PTZ preset profile token. Sets the preset profile token which is executed with GotoPreset.
+| `preset` | PTZ preset profile token. Sets the preset profile token which is executed with GotoPreset.
 | `move_mode` | PTZ moving mode. Allowed values: `ContinuousMove`, `RelativeMove`, `AbsoluteMove`, `GotoPreset`. Default :`RelativeMove`
 | `continuous_duration` | Set ContinuousMove delay in seconds before stoping the move. Allowed values: floating point numbers or integer. Default : 0.5
 

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -76,7 +76,8 @@ If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your ca
 | `zoom` | Zoom. Allowed values: `ZOOM_IN`, `ZOOM_OUT`, `NONE`
 | `distance` | Distance coefficient. Sets how much PTZ should be executed in one request. Allowed values: floating point numbers, 0 to 1. Default : 0.1
 | `speed` | Speed coefficient. Sets how fast PTZ will be executed. Allowed values: floating point numbers, 0 to 1. Default : 0.5
-| `move_mode` | PTZ moving mode. Allowed values: `ContinuousMove`, `RelativeMove`, `AbsoluteMove`. Default :`RelativeMove`
+  `preset` | PTZ preset profile token. Sets the preset profile token which is executed with GotoPreset.
+| `move_mode` | PTZ moving mode. Allowed values: `ContinuousMove`, `RelativeMove`, `AbsoluteMove`, `GotoPreset`. Default :`RelativeMove`
 | `continuous_duration` | Set ContinuousMove delay in seconds before stoping the move. Allowed values: floating point numbers or integer. Default : 0.5
 
 If you are running into trouble with this sensor, please refer to the [Troubleshooting section](/integrations/ffmpeg/#troubleshooting).


### PR DESCRIPTION
## Proposed change
Support for moving onvif camera's to presets was missing.
With this change one can execute a GotoPreset command via OnVif to move/pan/tilt/zoom a camera to a preset by specifying the GotoPreset profile token.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Related to https://github.com/home-assistant/core/pull/34420

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
