### PR TITLE
Added Virgin Media's Hub 3 a UK variant of Router

### DIFF
--- a/source/_integrations/arris_tg2492lg.markdown
+++ b/source/_integrations/arris_tg2492lg.markdown
@@ -9,7 +9,9 @@ ha_release: 0.109
 
 This platform allows you to detect presence by looking at connected devices to an Arris TG2492LG router.
 
-This is one of the routers provided by [Ziggo](https://www.ziggo.nl/), a cable operator in the Netherlands, to their customers as the Ziggo Connectbox.
+This is one of the routers provided by:
+* [Ziggo](https://www.ziggo.nl/), a cable operator in the Netherlands, to their customers as the Ziggo Connectbox.
+* [Virgin Media](https://www.virginmedia.com/), a cable operator in the United Kingdom, to their customers as the Hub 3.
 
 <div class='note warning'>
 The router prevents the admin user from logging in twice. This can cause problems with accessing the router's configuration pages while this platform is active.


### PR DESCRIPTION
## Proposed change
In the UK this router is provided by Virgin Media as the Hub 3.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
