### PR TITLE
Revert "Documentation for Sleepiq Lights integration"

### DIFF
--- a/source/_integrations/sleepiq.markdown
+++ b/source/_integrations/sleepiq.markdown
@@ -5,13 +5,12 @@ ha_category:
   - Health
   - Sensor
   - Binary Sensor
-  - Light
 ha_release: 0.29
 ha_iot_class: Local Polling
 ha_domain: sleepiq
 ---
 
-The SleepIQ implementation lets you view sensor data from [SleepIQ by SleepNumber](https://www.sleepnumber.com/sleepiq-sleep-tracker). In particular, it lets you see the occupancy and current SleepNumber (ie current firmness) of each side of a SleepNumber bed. Control of the lights included in the FlexFit platform is available as well.
+The SleepIQ implementation lets you view sensor data from [SleepIQ by SleepNumber](https://www.sleepnumber.com/sleepiq-sleep-tracker). In particular, it lets you see the occupancy and current SleepNumber (ie current firmness) of each side of a SleepNumber bed.
 
 ## Setup
 


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#11929

As it was accidentally merged at the time, meanwhile the parent PR was closed stale.

https://github.com/home-assistant/core/pull/31322