### PR TITLE
Add documentation regarding the mediaroom  media_content_type

### DIFF
--- a/source/_integrations/mediaroom.markdown
+++ b/source/_integrations/mediaroom.markdown
@@ -50,23 +50,42 @@ If the STB is on the same network segment as Home Assistant, it can determine wh
 
 ## Examples
 
-### Example `press_button` script
 
-The `play_media` function can be used in scripts to change channels and emulate button pressing from a remote control.
+### Example scripts
+
+The `play_media` function can be used in scripts to change channels:
 
 {% raw %}
 ```yaml
-# Example play_media script
+# Example play_media script to change channel
+#
+change_channel:
+  sequence:
+    service: media_player.play_media
+    data_template:
+      entity_id: media_player.mediaroom_stb
+      media_content_id: "{{ channel_number }}"
+      media_content_type: "channel"
+```
+{% endraw %}
+
+The `play_media` function can also be used to trigger actions on the set-up-box such opening the videoclub:
+
+{% raw %}
+```yaml
+# Example play_media script to trigger an action
 #
 press_button:
   sequence:
     service: media_player.play_media
     data_template:
       entity_id: media_player.mediaroom_stb
-      media_content_id: "{{ value }}"
-      media_content_type: "channel"
+      media_content_id: "{{ action }}"
+      media_content_type: "mediaroom"
 ```
 {% endraw %}
+
+Check [here](https://github.com/dgomes/pymediaroom) for the list of possible media_content_id's
 
 ### Example configuration with 2 STB
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added new example to the `mediaroom` component in order to reflect changes introduced by https://github.com/home-assistant/core/pull/34625


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34625
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
