### PR TITLE
Linking beta versions install instructions across documentation

### DIFF
--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -50,6 +50,8 @@ pip3 install homeassistant==0.XX.X
 
 #### Run the beta version
 
+For specific instructions for the Home Assistante Core versions, see: https://www.home-assistant.io/hassio/installation/#run-the-beta-version-on-home-assistant
+
 If you would like to test the next release before anyone else, you can install the beta version released every two weeks:
 
 ```bash

--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -50,7 +50,7 @@ pip3 install homeassistant==0.XX.X
 
 #### Run the beta version
 
-For specific instructions for the Home Assistante Core versions, see: https://www.home-assistant.io/hassio/installation/#run-the-beta-version-on-home-assistant
+For specific instructions on the standard Home Assistante Core instances, see: https://www.home-assistant.io/hassio/installation/#run-the-beta-version-on-home-assistant
 
 If you would like to test the next release before anyone else, you can install the beta version released every two weeks:
 


### PR DESCRIPTION
## Proposed change
The instructions for installing the beta versions are scattered across some docs, increasing the difficulty for the basic user that wants to tests an upper HA version.

Linking the docs should solve the issue.

## Type of change
- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
