### PR TITLE
Describe require_admin config option for history, logbook and map

### DIFF
--- a/source/_integrations/history.markdown
+++ b/source/_integrations/history.markdown
@@ -61,6 +61,11 @@ include:
       description: The list of domains to be included in the history.
       required: false
       type: list
+require_admin:
+  description: If admin access is required to see this iframe.
+  required: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 Without any `include` or `exclude` configuration the history displays graphs for

--- a/source/_integrations/history.markdown
+++ b/source/_integrations/history.markdown
@@ -62,7 +62,7 @@ include:
       required: false
       type: list
 require_admin:
-  description: If admin access is required to see this iframe.
+  description: If admin access is required to see this panel.
   required: false
   type: boolean
   default: false

--- a/source/_integrations/logbook.markdown
+++ b/source/_integrations/logbook.markdown
@@ -51,6 +51,11 @@ include:
       description: The list of domains to be included in creating logbook entries.
       required: false
       type: list
+require_admin:
+  description: If admin access is required to see this iframe.
+  required: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 If you want to exclude messages of some entities or domains from the logbook

--- a/source/_integrations/logbook.markdown
+++ b/source/_integrations/logbook.markdown
@@ -52,7 +52,7 @@ include:
       required: false
       type: list
 require_admin:
-  description: If admin access is required to see this iframe.
+  description: If admin access is required to see this panel.
   required: false
   type: boolean
   default: false

--- a/source/_integrations/map.markdown
+++ b/source/_integrations/map.markdown
@@ -18,10 +18,10 @@ map:
 {% configuration %}
 map:
   require_admin:
-  description: If admin access is required to see this iframe.
-  required: false
-  type: boolean
-  default: false
+    description: If admin access is required to see this iframe.
+    required: false
+    type: boolean
+    default: false
 {% endconfiguration %}
 
 <div class='note'>

--- a/source/_integrations/map.markdown
+++ b/source/_integrations/map.markdown
@@ -16,12 +16,11 @@ map:
 ```
 
 {% configuration %}
-map:
-  require_admin:
-    description: If admin access is required to see this iframe.
-    required: false
-    type: boolean
-    default: false
+require_admin:
+  description: If admin access is required to see this iframe.
+  required: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 <div class='note'>

--- a/source/_integrations/map.markdown
+++ b/source/_integrations/map.markdown
@@ -17,7 +17,7 @@ map:
 
 {% configuration %}
 require_admin:
-  description: If admin access is required to see this iframe.
+  description: If admin access is required to see this panel.
   required: false
   type: boolean
   default: false

--- a/source/_integrations/map.markdown
+++ b/source/_integrations/map.markdown
@@ -15,6 +15,15 @@ This offers a map on the frontend to display the location of tracked devices. To
 map:
 ```
 
+{% configuration %}
+map:
+  require_admin:
+  description: If admin access is required to see this iframe.
+  required: false
+  type: boolean
+  default: false
+{% endconfiguration %}
+
 <div class='note'>
 Devices that are currently at home won't show on the map.
 </div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The Lovelace interface enables setting panels to require admin rights of the user to display. While the iframe panel already had this feature enabled, the (default) map, logbook and history panels hadn't. This PR enables setting this (optional) parameter for these panels.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34821
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
