### PR TITLE
Remove configuration.yaml docs for WWLLN

### DIFF
--- a/source/_integrations/wwlln.markdown
+++ b/source/_integrations/wwlln.markdown
@@ -24,58 +24,23 @@ is available as the state of each entity.
 </p>
 
 New data is fetched every 10 minutes. Because data from the WWLLN may vary in terms
-of how real-time it is, the default `window` parameter is set to 1 hour to ensure that as
-many strikes are caught as possible.
+of how real-time it is, the default `window` option (which can be configured via the UI)
+is set to 1 hour to ensure that as many strikes are caught as possible.
 
 ## Configuration
 
-To retrieve data from the WWLLN, edit your `configuration.yaml` file manually or use the "Integrations" feature in the GUI, you find it under Configurations - Integrations.
-
-To manually add the component, add the following to your `configuration.yaml`:
-
-```yaml
-wwlln:
-```
-
-{% configuration %}
-latitude:
-  description: The latitude you want to monitor; defaults to the value defined in `configuration.yaml`.
-  required: false
-  type: float
-longitude:
-  description: The longitude you want to monitor; defaults to the value defined in `configuration.yaml`.
-  required: false
-  type: float
-radius:
-  description: The radius around your location to monitor; defaults to 25 km or mi (depending on the unit system defined in your `configuration.yaml`).
-  required: false
-  type: integer
-window:
-  description: The amount of time before now for which strikes should be considered "active" and shown in the UI. Note that a window of less than 1 hour may cause Home Assistant to miss events.
-  required: false
-  type: time
-  default: 10 minutes
-{% endconfiguration %}
+This integration can be configured via the Home Assistant UI by navigating to
+**Configuration** -> **Integrations**. 
 
 ## State Attributes
 
 The following state attributes are available for each entity in addition to
 the standard ones:
 
-| Attribute        | Description                                                                   |
-| ---------------- | ----------------------------------------------------------------------------- |
-| latitude         | Latitude of the lightning strike.                                             |
-| longitude        | Longitude of the lightning strike.                                            |
-| source           | `wwlln` to be used in conjunction with the `geo_location` automation trigger. |
-| external_id      | The external ID used in the feed to identify the lightning strike in the feed.      |
-| publication_date | Date and time when this event occurred.                                       |
-
-## Full Configuration
-
-```yaml
-# Example configuration.yaml entry
-wwlln:
-  radius: 100
-  latitude: 37.39
-  longitude: -5.99
-```
+| Attribute        | Description                                                                    |
+| ---------------- | ------------------------------------------------------------------------------ |
+| latitude         | Latitude of the lightning strike.                                              |
+| longitude        | Longitude of the lightning strike.                                             |
+| source           | `wwlln` to be used in conjunction with the `geo_location` automation trigger.      |
+| external_id      | The external ID used in the feed to identify the lightning strike in the feed. |
+| publication_date | Date and time when this event occurred.                                        |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR removes `configuration.yaml` docs for WWLLN.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34825
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
