### PR TITLE
Update Serial sensor platform : Add full options 

### DIFF
--- a/source/_integrations/serial.markdown
+++ b/source/_integrations/serial.markdown
@@ -44,7 +44,7 @@ baudrate:
   default: 9600 Bps
   type: integer
 bytesize:
-  description: Number of data bits. Possible values: 5=FIVEBITS, 6=SIXBITS, 7=SEVENBITS, 8=EIGHTBITS
+  description: "Number of data bits. Possible values: `5=FIVEBITS`, `6=SIXBITS`, `7=SEVENBITS`, `8=EIGHTBITS`."
   required: false
   default: EIGHTBITS
   type: integer

--- a/source/_integrations/serial.markdown
+++ b/source/_integrations/serial.markdown
@@ -49,7 +49,7 @@ bytesize:
   default: EIGHTBITS
   type: integer
 parity:
-  description: Enable parity checking. Possible values: PARITY_NONE, PARITY_EVEN, PARITY_ODD PARITY_MARK, PARITY_SPACE
+  description: "Enable parity checking. Possible values: `PARITY_NONE`, `PARITY_EVEN`, `PARITY_ODD PARITY_MARK`, `PARITY_SPACE`."
   required: false
   default: PARITY_NONE
   type: string

--- a/source/_integrations/serial.markdown
+++ b/source/_integrations/serial.markdown
@@ -43,6 +43,36 @@ baudrate:
   required: false
   default: 9600 Bps
   type: integer
+bytesize:
+  description: Number of data bits. Possible values: 5=FIVEBITS, 6=SIXBITS, 7=SEVENBITS, 8=EIGHTBITS
+  required: false
+  default: EIGHTBITS
+  type: integer
+parity:
+  description: Enable parity checking. Possible values: PARITY_NONE, PARITY_EVEN, PARITY_ODD PARITY_MARK, PARITY_SPACE
+  required: false
+  default: PARITY_NONE
+  type: string
+stopbits:
+  description: Number of stop bits. Possible values: 1=STOPBITS_ONE, 1.5=STOPBITS_ONE_POINT_FIVE, 2=STOPBITS_TWO
+  required: false
+  default: STOPBITS_ONE
+  type: float
+xonxoff: 
+  description: Enable software flow control.
+  required: false
+  default: False
+  type: boolean
+rtscts:
+  description: Enable hardware (RTS/CTS) flow control.
+  required: false
+  default: False
+  type: boolean
+dsrdtr:
+  description: Enable hardware (DSR/DTR) flow control.
+  required: false
+  default: False
+  type: boolean
 value_template:
   description: "Defines a [template](/docs/configuration/templating/#processing-incoming-data) to extract a value from the serial line."
   required: false

--- a/source/_integrations/serial.markdown
+++ b/source/_integrations/serial.markdown
@@ -49,9 +49,9 @@ bytesize:
   default: 8
   type: integer
 parity:
-  description: "Enable parity checking. Possible values: `PARITY_NONE`, `PARITY_EVEN`, `PARITY_ODD PARITY_MARK`, `PARITY_SPACE`."
+  description: "Enable parity checking. Possible values: `N=PARITY_NONE`, `E=PARITY_EVEN`, `O=PARITY_ODD`, `M=PARITY_MARK`, `S=PARITY_SPACE`."
   required: false
-  default: PARITY_NONE
+  default: "N"
   type: string
 stopbits:
   description: "Number of stop bits. Possible values: `1=STOPBITS_ONE`, `1.5=STOPBITS_ONE_POINT_FIVE`, `2=STOPBITS_TWO`."

--- a/source/_integrations/serial.markdown
+++ b/source/_integrations/serial.markdown
@@ -46,7 +46,7 @@ baudrate:
 bytesize:
   description: "Number of data bits. Possible values: `5=FIVEBITS`, `6=SIXBITS`, `7=SEVENBITS`, `8=EIGHTBITS`."
   required: false
-  default: EIGHTBITS
+  default: 8
   type: integer
 parity:
   description: "Enable parity checking. Possible values: `PARITY_NONE`, `PARITY_EVEN`, `PARITY_ODD PARITY_MARK`, `PARITY_SPACE`."

--- a/source/_integrations/serial.markdown
+++ b/source/_integrations/serial.markdown
@@ -54,7 +54,7 @@ parity:
   default: PARITY_NONE
   type: string
 stopbits:
-  description: Number of stop bits. Possible values: 1=STOPBITS_ONE, 1.5=STOPBITS_ONE_POINT_FIVE, 2=STOPBITS_TWO
+  description: "Number of stop bits. Possible values: `1=STOPBITS_ONE`, `1.5=STOPBITS_ONE_POINT_FIVE`, `2=STOPBITS_TWO`."
   required: false
   default: STOPBITS_ONE
   type: float

--- a/source/_integrations/serial.markdown
+++ b/source/_integrations/serial.markdown
@@ -56,7 +56,7 @@ parity:
 stopbits:
   description: "Number of stop bits. Possible values: `1=STOPBITS_ONE`, `1.5=STOPBITS_ONE_POINT_FIVE`, `2=STOPBITS_TWO`."
   required: false
-  default: STOPBITS_ONE
+  default: 1
   type: float
 xonxoff: 
   description: Enable software flow control.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

With PR : https://github.com/home-assistant/core/pull/34962
Improve Serial sensor platform with full options for configuring the serial port.
bytesize, parity, stopbits, xonxoff, rtscts, dsrdtr.

The default values are unchanged so it is 100% compatible with previous config.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/core/pull/34962
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
