### PR TITLE
Documentation for Natural Resources Wales river level sensor integration

### DIFF
--- a/source/_integrations/natural_resources_wales.markdown
+++ b/source/_integrations/natural_resources_wales.markdown
@@ -3,7 +3,7 @@ title: Natural Resources Wales
 description: Instructions on how to use the Natural Resources Wales river levels sensor in Home Assistant.
 ha_category:
   - Weather
-ha_release: 0.109
+ha_release: "0.110"
 ha_iot_class: Local Polling
 ha_domain: natural_resources_wales
 ---

--- a/source/_integrations/natural_resources_wales.markdown
+++ b/source/_integrations/natural_resources_wales.markdown
@@ -1,0 +1,43 @@
+---
+title: Natural Resources Wales
+description: Instructions on how to use the Natural Resources Wales river levels sensor in Home Assistant.
+ha_category:
+  - Weather
+ha_release: 0.109
+ha_iot_class: Local Polling
+ha_domain: natural_resources_wales
+---
+
+The `Natural Resources Wales` integration provides sensors for the river level monitoring stations in Wales using the [National Resources Wales River Levels API](https://api-portal.naturalresources.wales/docs/services/).
+
+## Configuration
+
+To obtain an API key to access the river levels data first go to the [National Resources Wales API portal](https://api-portal.naturalresources.wales/) and create an account. Next go to the [River Levels API Data](https://api-portal.naturalresources.wales/products/5775297acff72d1aac51beab/) product page and subscribe to obtain your API key.
+
+Subscribers will be able to run 10 calls/minute up to a maximum of 2880 calls/day after which access is denied.
+
+To enable this sensor, add the following lines to your `configuration.yaml`:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: natural_resources_wales
+    api_key: YOUR_API_KEY_HERE
+```
+
+{% configuration %}
+scan_interval:
+  description: Interval (in seconds) for polling. Values below 30 will result in access to the API being denied.
+  required: false
+  type: integer
+  default: 60
+monitored_stations:
+  description: Array of station IDs to add to Home Assistant. By default every station is added.
+  required: false
+  type: [list, string]
+language:
+  description: The language to use for the sensor properties. EN or CY.
+  required: false
+  type: string
+  default: EN
+{% endconfiguration %}

--- a/source/_integrations/natural_resources_wales.markdown
+++ b/source/_integrations/natural_resources_wales.markdown
@@ -36,7 +36,7 @@ monitored_stations:
   required: false
   type: [list, string]
 language:
-  description: The language to use for the sensor properties. EN or CY.
+  description: The language to use for the sensor properties. `EN` or `CY`.
   required: false
   type: string
   default: EN

--- a/source/_integrations/natural_resources_wales.markdown
+++ b/source/_integrations/natural_resources_wales.markdown
@@ -12,7 +12,7 @@ The `Natural Resources Wales` integration provides sensors for the river level m
 
 ## Configuration
 
-To obtain an API key to access the river levels data first go to the [National Resources Wales API portal](https://api-portal.naturalresources.wales/) and create an account. Next go to the [River Levels API Data](https://api-portal.naturalresources.wales/products/5775297acff72d1aac51beab/) product page and subscribe to obtain your API key.
+To obtain an API key to access the river levels data first go to the [National Resources Wales API portal](https://api-portal.naturalresources.wales/) and create an account. Next, go to the [River Levels API Data](https://api-portal.naturalresources.wales/products/5775297acff72d1aac51beab/) product page and subscribe to obtain your API key.
 
 Subscribers will be able to run 10 calls/minute up to a maximum of 2880 calls/day after which access is denied.
 
@@ -27,7 +27,7 @@ sensor:
 
 {% configuration %}
 scan_interval:
-  description: Interval (in seconds) for polling. Values below 30 will result in access to the API being denied.
+  description: Interval (in seconds) for polling. Values below 30 will result in exceeding the allowed calls/day limit.
   required: false
   type: integer
   default: 60


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for Natural Resources Wales river level sensor integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34887
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1532

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
