### PR TITLE
Clarify number of entities required to create a group entity

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -33,7 +33,7 @@ There is currently support for the following device types within Home Assistant:
 - Sensor
 - Switch
 
-There is also support for grouping of lights, switches, and fans (i.e. support for commanding device groups as entities).
+There is also support for grouping of lights, switches, and fans (i.e. support for commanding device groups as entities).  At least two entities must be added to a group before the group entity is created.
 
 ## ZHA exception and deviation handling
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -33,7 +33,7 @@ There is currently support for the following device types within Home Assistant:
 - Sensor
 - Switch
 
-There is also support for grouping of lights, switches, and fans (i.e. support for commanding device groups as entities).  At least two entities must be added to a group before the group entity is created.
+There is also support for grouping of lights, switches, and fans (i.e. support for commanding device groups as entities). At least two entities must be added to a group before the group entity is created.
 
 ## ZHA exception and deviation handling
 


### PR DESCRIPTION
## Proposed change
Clarify that two entities must be added to a group before the group entity is created.



## Type of change


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
n/a



## Checklist


- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
