### PR TITLE
Add avahi explanation to Cast and Discovery docs

### DIFF
--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -70,3 +70,20 @@ Cast devices can only be discovered and connected to if they are on the same sub
 - Enable source NAT to make requests from Home Assistant to the Chromecast appear to come from the same subnet as the Chromecast.
 
 Setups with cast devices on a different subnet than Home Assistant are not recommended and not supported.
+
+### Cast devices and Home Assistant in Docker without using net=host
+
+If you run Home Assistant in Docker and for some reason do not want to use `--net=host`, you might see that Home Assistant fails to connect to your cast devices. To solve this, you can configure avahi-reflector on your host to make mDNS / UPnP work:
+
+``` 
+# Install the Avavhi-daemon
+sudo apt-get install avahi-daemon
+
+# Turn on the reflector. Go into /etc/avahi/avahi-daemon.conf and change the reflector section to:
+ [reflector]
+ enable-reflector=yes
+ reflect-ipv=no
+
+# (re)start the Avahi daemon to reload config
+sudo service avahi-daemon restart
+```

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -75,6 +75,7 @@ Setups with cast devices on a different subnet than Home Assistant are not recom
 
 If you run Home Assistant in Docker and for some reason do not want to use `--net=host`, you might see that Home Assistant fails to connect to your cast devices. To solve this, you can configure avahi-reflector on your host to make mDNS / UPnP work:
 
+{% raw %}
 ``` 
 # Install the Avavhi-daemon
 sudo apt-get install avahi-daemon
@@ -87,3 +88,4 @@ sudo apt-get install avahi-daemon
 # (re)start the Avahi daemon to reload config
 sudo service avahi-daemon restart
 ```
+{% endraw %}

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -73,7 +73,7 @@ Setups with cast devices on a different subnet than Home Assistant are not recom
 
 ### Cast devices and Home Assistant in Docker without using net=host
 
-If you run Home Assistant in Docker and for some reason do not want to use `--net=host`, you might see that Home Assistant fails to connect to your cast devices. To solve this, you can configure avahi-reflector on your host to make mDNS / UPnP work:
+If you run Home Assistant in Docker and for some reason do not want to use `--net=host`, you might see that Home Assistant fails to connect to your cast devices. To solve this, you can configure avahi-reflector on your host to make mDNS work:
 
 {% raw %}
 ``` 

--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -107,12 +107,27 @@ Valid values for enable are:
 Home Assistant must be on the same network as the devices for UPnP discovery to work.
 If running Home Assistant in a [Docker container](/docs/installation/docker/) use switch `--net=host` to put it on the host's network.
 
+If for some reason you do not want to use `--net=host` you can also configure avahi-reflector on your host to make mDNS / UPnP work:
+
+``` 
+# Install the Avahi-daemon
+sudo apt-get install avahi-daemon
+
+# Turn on the reflector. Go into /etc/avahi/avahi-daemon.conf and change the reflector section to:
+ [reflector]
+ enable-reflector=yes
+ reflect-ipv=no
+
+# (re)start the Avahi daemon to reload config
+sudo service avahi-daemon restart
+```
+
 ### Windows
 
 #### 64-bit Python
 There is currently a <a href='https://bitbucket.org/al45tair/netifaces/issues/17/dll-fails-to-load-windows-81-64bit'>known issue</a> with running this integration on a 64-bit version of Python and Windows.
 
-### could not install dependency netdisco
+### Could not install dependency netdisco
 
 If you see `Not initializing discovery because could not install dependency netdisco==0.6.1` in the logs, you will need to install the `python3-dev` or `python3-devel` package on your system manually (eg. `sudo apt-get install python3-dev` or `sudo dnf -y install python3-devel`). On the next restart of Home Assistant, the discovery should work. If you still get an error, check if you have a compiler (`gcc`) available on your system.
 

--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -107,8 +107,10 @@ Valid values for enable are:
 Home Assistant must be on the same network as the devices for UPnP discovery to work.
 If running Home Assistant in a [Docker container](/docs/installation/docker/) use switch `--net=host` to put it on the host's network.
 
-If for some reason you do not want to use `--net=host` you can also configure avahi-reflector on your host to make mDNS / UPnP work:
+### mDNS
+If for some reason you do not want to use `--net=host` you can also configure avahi-reflector on your host to make mDNS work:
 
+{% raw %}
 ``` 
 # Install the Avahi-daemon
 sudo apt-get install avahi-daemon
@@ -121,6 +123,7 @@ sudo apt-get install avahi-daemon
 # (re)start the Avahi daemon to reload config
 sudo service avahi-daemon restart
 ```
+{% endraw %}
 
 ### Windows
 

--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -108,7 +108,7 @@ Home Assistant must be on the same network as the devices for UPnP discovery to 
 If running Home Assistant in a [Docker container](/docs/installation/docker/) use switch `--net=host` to put it on the host's network.
 
 ### mDNS
-If for some reason you do not want to use `--net=host` you can also configure avahi-reflector on your host to make mDNS work:
+If for some reason you do not want to use `--net=host` when running Home Assistant in a Docker container, you can also configure avahi-reflector on your host to make mDNS work:
 
 {% raw %}
 ``` 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding explanation on how to set-up Avahi for Docker users that do not want to use the `--net:host` option. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Related issue: https://github.com/home-assistant/core/issues/34874

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
