### PR TITLE
Add timeout parameter

### DIFF
--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -48,6 +48,11 @@ surepetcare:
     description: The Sure Petcare IDs of the Pets to show
     required: false
     type: list
+  timeout:
+    description: "Timeout in seconds for request to the Sure Petcare API."
+    required: false
+    default: 15
+    type: int
   scan_interval:
     description: "Minimum time interval between updates. Supported formats: `scan_interval: 'HH:MM:SS'`, `scan_interval: 'HH:MM'` and Time period dictionary (see example below)."
     required: false

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -52,7 +52,7 @@ surepetcare:
     description: "Timeout in seconds for request to the Sure Petcare API."
     required: false
     default: 15
-    type: int
+    type: integer
   scan_interval:
     description: "Minimum time interval between updates. Supported formats: `scan_interval: 'HH:MM:SS'`, `scan_interval: 'HH:MM'` and Time period dictionary (see example below)."
     required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
add timeout parameter


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34944
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/32583 & https://github.com/home-assistant/core/issues/33515

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
