### PR TITLE
Add complete Vizio configuration.yaml entry example

### DIFF
--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -175,6 +175,29 @@ apps:
               default: null
 {% endconfiguration %}
 
+```yaml
+# Complete configuration.yaml entry
+vizio:
+  - host: "DEVICE_IP:DEVICE_PORT"
+    access_token: AUTH_TOKEN
+    name: MY_VIZIO_DEVICE
+    device_class: tv
+    volume_step: 1
+    apps:
+      include:
+        - APP_1
+        - APP_2
+      exclude:
+        - APP_1
+        - APP_2
+      additional_configs:
+        - name: MY_CUSTOM_APP
+          config:
+            APP_ID: 9
+            NAME_SPACE: 9
+            MESSAGE: MY_MESSAGE
+```
+
 ### Obtaining an app configuration
 
 If there is an app you want to be able to launch from Home Assistant that isn't detected by default, you will need to specify the app configuration in `configuration.yaml`. This configuration can be obtained from the `app_id` state attribute when an unknown app is running on your device.


### PR DESCRIPTION
## Proposed change
A user mentioned in home-assistant/core#34913 that they were having trouble understanding how to build their config entry for `vizio` so I've included a complete example. This can go in `current` since it is not tied to new functionality



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
