### PR TITLE
Update pulseaudio_loopback pulsectl lib (#34965)

### DIFF
--- a/source/_integrations/pulseaudio_loopback.markdown
+++ b/source/_integrations/pulseaudio_loopback.markdown
@@ -41,27 +41,17 @@ name:
 host:
   description: The IP address or host name of the PulseAudio server.
   required: false
-  default: localhost
+  default: Use client configuration in /etc/pulse
   type: string
 port:
   description: The port that Pulseaudio is listening on.
   required: false
-  default: 4712
-  type: integer
-buffer_size:
-  description: How much data to load from Pulseaudio at once.
-  required: false
-  default: 1024
-  type: integer
-tcp_timeout:
-  description: How long to wait for a response from Pulseaudio before giving up.
-  required: false
-  default: 3
+  default: 4713
   type: integer
 {% endconfiguration %}
 
 <div class='note warning'>
 
-This integration relies on raw TCP commands to PulseAudio. In order for PulseAudio to accept commands with this component, `module-cli-protocol` must be loaded on the PulseAudio server.
+This integration relies on raw TCP commands to PulseAudio. In order for PulseAudio to accept commands with this component, `module-native-protocol` must be loaded on the PulseAudio server.
 
 </div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update documentation with changes for updated pulseaudio_loopback integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34965
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
