### PR TITLE
BraviaTV integration: add information about deregistering HA on the TV

### DIFF
--- a/source/_integrations/braviatv.markdown
+++ b/source/_integrations/braviatv.markdown
@@ -18,6 +18,12 @@ Almost all [Sony Bravia TV 2013 and newer](https://info.tvsideview.sony.net/en_w
 
 You can setup the Sony Bravia TV via **Configuration** >> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select Sony Bravia TV.
 
+<div class="note warning">
+
+If the PIN code is not shown on the TV screen during setup, you need to unregister `Home Assistant` on the TV, go to: **Settings** -> **Network** -> **Remote device settings** -> **Deregister remote device** (names of menu items on different TV models may be slightly different).
+
+</div>
+
 If you have following configuration in your `configuration.yaml` file it will be imported to the Integrations:
 
 ```yaml
@@ -39,7 +45,11 @@ name:
   type: string
 {% endconfiguration %}
 
+<div class="note warning">
+
 A new setup via `configuration.yaml` file is not possible.
+
+</div>
 
 ## Extra configuration for the integration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR:
- adds missing information about deregistering Home Assistant on the TV
- adds `div` `note warning` to the information about new setup via `configuration.yaml`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
