### PR TITLE
Update nginx.markdown

### DIFF
--- a/source/_docs/ecosystem/nginx.markdown
+++ b/source/_docs/ecosystem/nginx.markdown
@@ -133,7 +133,7 @@ server {
     listen [::]:443 ssl default_server ipv6only=off; # if your nginx version is >= 1.9.5 you can also add the "http2" flag here
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
     # ssl on; # Uncomment if you are using nginx < 1.15.0
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
     ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;


### PR DESCRIPTION
Remove outdated TLSv1.0 and TLSv1.1

## Proposed change
Remove deprecated TLSv1.0 and TLSv1.1 from nginx proxy configuration. 

TLSv1.0 and TLSv1.1 seem to be non-supported anyway judging from an old pull-request (#15217), however the nginx proxy configuration was not updated accordingly. 

With this change the ssllabs.com test result changes from B to A+.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: n.a.
- Link to parent pull request in the Brands repository: n.a.
- This PR fixes or closes issue: n.a.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html