### PR TITLE
Loose some fat on the VSCode dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,30 +1,22 @@
 {
-    "name": "home-assistant.io",
-    "dockerFile": "Dockerfile",
-    "appPort": [
-        4000
-    ],
-    "postCreateCommand": "bundle install",
-    "extensions": [
-        "davidanson.vscode-markdownlint",
-        "eamodio.gitlens",
-        "editorconfig.editorconfig",
-        "github.vscode-pull-request-github",
-        "mrmlnc.vscode-scss",
-        "ms-vsliveshare.vsliveshare",
-        "rebornix.Ruby",
-        "streetsidesoftware.code-spell-checker",
-        "yzhang.markdown-all-in-one"
-    ],
-    "settings": {
-        "editor.rulers": [80, 100, 120],
-        "editor.renderWhitespace": "boundary",
-        "errorLens.gutterIconsEnabled": true,
-        "errorLens.addAnnotationTextPrefixes": false,
-        "errorLens.enabledDiagnosticLevels": [
-            "error",
-            "warning"
-        ],
-        "terminal.integrated.shell.linux": "/bin/bash"
-    }
+  "name": "home-assistant.io",
+  "dockerFile": "Dockerfile",
+  "appPort": [4000],
+  "postCreateCommand": "bundle install",
+  "extensions": [
+    "davidanson.vscode-markdownlint",
+    "editorconfig.editorconfig",
+    "mrmlnc.vscode-scss",
+    "rebornix.Ruby",
+    "streetsidesoftware.code-spell-checker",
+    "yzhang.markdown-all-in-one"
+  ],
+  "settings": {
+    "editor.rulers": [80, 100, 120],
+    "editor.renderWhitespace": "boundary",
+    "errorLens.gutterIconsEnabled": true,
+    "errorLens.addAnnotationTextPrefixes": false,
+    "errorLens.enabledDiagnosticLevels": ["error", "warning"],
+    "terminal.integrated.shell.linux": "/bin/bash"
+  }
 }


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Removes:

- `github.vscode-pull-request-github`
- `eamodio.gitlens`
- `ms-vsliveshare.vsliveshare`

It will make the VSCode container spin up faster and is less opinionated. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
