### PR TITLE
Update documentation for new ZHA config entry flow

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -79,32 +79,36 @@ Use the plus button in the bottom right to add a new integration called **ZHA**.
 
 In the popup:
 
-- USB Device Path - on a Linux system will be something like `/dev/ttyUSB0` or `/dev/ttyACM0`
-- Radio type - select device type `ezsp`, `deconz`, `ti_cc`, `xbee` or `zigate`
+- Serial Device Path - List of detected serial ports on the system. You need to pick one to which your
+radio is connected
 - Submit
+
+Press `Submit` and the integration will try to detect radio type automatically. If unsuccessful, you will get
+a new pop-up asking for a radio type. In the pop-up:
+
+- Radio Type
 
 | Radio Type | Zigbee Radio Hardware |
 | ------------- | ------------- |
-| `ezsp`  | EmberZNet based radios, Telegesis ETRX357USB*** (using EmberZNet firmware)  |
-| `deconz` | ConBee, ConBee II |
+| `deconz` | ConBee, ConBee II, RaspBi |
+| `ezsp`  | EmberZNet based radios, HUSBZB-1, Telegesis ETRX357USB*** (using EmberZNet firmware)  |
+| `ti_cc` | Texas Instruments ZNB based radios: CC2531, CC2530 |
 | `xbee` | Digi XBee Series 2, 2C, 3  |
+| `zigate` | ZiGate based radio | 
 
-- Press `Submit` to save changes.
+- Submit
 
-The success dialog will appear or an error will be displayed in the popup. An error is likely if Home Assistant can't access the USB device or your device is not up to date. Refer to [Troubleshooting](#troubleshooting) below for more information.
+Press `Submit` to save radio type and you will get a new form asking for port settings specific for this
+radio type. In the pop-up:
+- Serial device path
+- port speed (not applicable for all radios)
+- data flow control (not applicable for all radios)
 
-## Configuration - Manual
+Most devices need at very least the serial device path, like `/dev/ttyUSB0`, but it is recommended to use
+device path from `/dev/serial/by-id` folder,
+eg `/dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_C0F003D3-if01-port0`
 
-To configure the component, select ZHA on the Integrations page and provide the path to your Zigbee USB stick.
-
-Or, you can manually configure `zha` section in `configuration.yaml`. The path to the database which will persist your network data is required.
-
-```yaml
-# Example configuration.yaml entry
-zha:
-  usb_path: /dev/ttyUSB2
-  database_path: /home/homeassistant/.homeassistant/zigbee.db
-```
+Press `Submit` The success dialog will appear or an error will be displayed in the popup. An error is likely if Home Assistant can't access the USB device or your device is not up to date. Refer to [Troubleshooting](#troubleshooting) below for more information.
 
 If you are use ZiGate, you have to use some special usb_path configuration:
 
@@ -113,20 +117,6 @@ If you are use ZiGate, you have to use some special usb_path configuration:
 - Wifi Zigate : `socket://[IP]:[PORT]` for example `socket://192.168.1.10:9999`
 
 {% configuration %}
-radio_type:
-  description: One of `deconz`, `ezsp`, `ti_cc`, `xbee` or `zigate`.
-  required: false
-  type: string
-  default: ezsp
-usb_path:
-  description: Path to the serial device for the radio.
-  required: true
-  type: string
-baudrate:
-  description: Baud rate of the serial device.
-  required: false
-  type: integer
-  default: 57600
 database_path:
   description: _Full_ path to the database which will keep persistent network data.
   required: true
@@ -136,6 +126,10 @@ enable_quirks:
   required: false
   type: boolean
   default: true
+zigpy_config:
+  description: Advanced zigpy configuration and should be used only when directed by maintainers
+  required: false
+  type: dict
 {% endconfiguration %}
 
 To add new devices to the network, call the `permit` service on the `zha` domain. Do this by clicking the Service icon in Developer tools and typing `zha.permit` in the **Service** dropdown box. Next, follow the device instructions for adding, scanning or factory reset.

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -126,10 +126,6 @@ enable_quirks:
   required: false
   type: boolean
   default: true
-zigpy_config:
-  description: Advanced zigpy configuration and should be used only when directed by maintainers
-  required: false
-  type: dict
 {% endconfiguration %}
 
 To add new devices to the network, call the `permit` service on the `zha` domain. Do this by clicking the Service icon in Developer tools and typing `zha.permit` in the **Service** dropdown box. Next, follow the device instructions for adding, scanning or factory reset.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update documentation for new config flow for ZHA integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35161
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
