### PR TITLE
Removal of some stale Windows references

### DIFF
--- a/source/_docs/authentication.markdown
+++ b/source/_docs/authentication.markdown
@@ -95,7 +95,8 @@ You have to use a domain name, not IP address, to remote access Home Assistant o
 
 This is because we only allow an IP address as a client ID when your IP address is an internal network address (e.g., `192.168.0.1`) or loopback address (e.g., `127.0.0.1`).
 
-If you don't have a valid domain name for your Home Assistant instance, you can modify the `hosts` file on your computer to fake one. On Windows, edit the `C:\Windows\System32\Drivers\etc\hosts` file with administrator privilege, or on Linux the `/etc/hosts` file,  and add following entry:
+If you don't have a valid domain name for your Home Assistant instance, you can modify the `hosts` file on your computer to fake one.
+On Linux edit the `/etc/hosts` file, and add following entry:
 
 ```text
 12.34.56.78 homeassistant.home

--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -15,7 +15,6 @@ The location of the folder differs between operating systems:
 | Docker         | `/config`                  |
 | macOS          | `~/.homeassistant`         |
 | Linux          | `~/.homeassistant`         |
-| Windows        | `%APPDATA%/.homeassistant` |
 
 If you want to use a different folder for configuration, use the configuration command line parameter: `hass --config path/to/config`.
 

--- a/source/_docs/installation/python.markdown
+++ b/source/_docs/installation/python.markdown
@@ -19,13 +19,12 @@ hass --open-ui
 
 Running these commands will:
 
- - Install Home Assistant
- - Launch Home Assistant and serve the web interface on [http://localhost:8123](http://localhost:8123)
+- Install Home Assistant
+- Launch Home Assistant and serve the web interface on [http://localhost:8123](http://localhost:8123)
 
 Video tutorials of this process for various operating systems are available here:
 
- - [Windows 10](https://www.youtube.com/watch?v=X27eVvuqwnY)
- - [macOS](https://www.youtube.com/watch?v=hej6ipN86ls)
- - [Ubuntu 14.04](https://www.youtube.com/watch?v=SXaAG1lGNH0)
+- [macOS](https://www.youtube.com/watch?v=hej6ipN86ls)
+- [Ubuntu 14.04](https://www.youtube.com/watch?v=SXaAG1lGNH0)
 
 Keep in mind that the operating systems used and the software releases shown may be outdated.

--- a/source/_integrations/ffmpeg.markdown
+++ b/source/_integrations/ffmpeg.markdown
@@ -12,7 +12,8 @@ The `ffmpeg` integration allows other Home Assistant integrations to process vid
 <div class='note'>
 
 If you are running Home Assistant Core in a Python environment, you'll need have the `ffmpeg` binary in your system path.
-On Debian 8 or Raspbian (Jessie) you can install it from [debian-backports](https://backports.debian.org/Instructions/). If you want [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) support on a Raspberry Pi, you will need to build from source by yourself. Windows binaries are available on the [FFmpeg](http://www.ffmpeg.org/) website.
+On Debian 8 or Raspbian (Jessie) you can install it from [debian-backports](https://backports.debian.org/Instructions/). If you want [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) support on a Raspberry Pi, you will need to build from source by yourself.
+
 </div>
 
 ## Configuration

--- a/source/help/reporting_issues.markdown
+++ b/source/help/reporting_issues.markdown
@@ -4,33 +4,27 @@ description: "Reporting issues about Home Assistant"
 sidebar: false
 ---
 
-If you have an installation, a setup or a configuration issue please use our [Forum](https://community.home-assistant.io/) to get help. We have a big community which will help you if they can. 
+If you have an installation, a setup or a configuration issue please use our [Forum](https://community.home-assistant.io/) to get help. We have a big community which will help you if they can.
 
-If you found a bug then please report it in one of our [trackers](/help/#bugs-feature-requests-and-alike). To help you and our developers to identify the issue quickly, please fill out the provided template. The "weird" content you will see is there to render your entry in a nice format after submitting. It's just [markdown](https://guides.github.com/features/mastering-markdown/). 
+If you found a bug then please report it in one of our [trackers](/help/#bugs-feature-requests-and-alike). To help you and our developers to identify the issue quickly, please fill out the provided template. The "weird" content you will see is there to render your entry in a nice format after submitting. It's just [markdown](https://guides.github.com/features/mastering-markdown/).
 
-Use the command below to get the Home Assistant release you are running from a command-line.
+Please refer to the **Info** page, which is accessible in the **Developer tools** in the Home Assistant frontend.
 
-```bash
-$ hass --version
-```
-
-Otherwise check the **About** page which is accessible in the **Developer tools** of the Home Assistant frontend.
-
-### First Home Assistant release with the issue
+## First Home Assistant release with the issue
 
 Please provide the release which contains the issue.
 
-### Last working Home Assistant release (if known)
+## Last working Home Assistant release (if known)
 
 If possible, provide the latest release of which you know that the integration or platform was working. Home Assistant is evolving very fast and issues may already be addressed or be introduced by a recent change.
 
-### Operating environment (Hass.io/Docker/Windows/etc.)
+## Operating environment
 
-There are many different ways to run Home Assistant. In this section please mention which you are using, e.g., manual installation, [Hass.io](/hassio/), Hasbian or as container (Docker). It can help if you mention which operating system you are using because not all are supported on the same level.
+There are many different ways to run Home Assistant. In this section please mention which you are using, e.g., Home Assistant (using the Home Assistant Operating System), Home Assistant Supervised, Home Assistant Core in Docker or a manual installation of the Home Assistant Core. It can help if you mention which operating system you are using because not all are supported on the same level.
 
-### Integration/platform
+## Integration
 
-Please add the link to the documention of the integration/platform in question. E.g.,
+Please add the link to the documentation of the integration in question. E.g.,
 
 - issue with the `random` sensor: [/integrations/random#sensor](/integrations/random#sensor)
 - issue with the `hue` integration: [/integrations/hue/](/integrations/hue/)
@@ -43,7 +37,7 @@ There are integrations and platform which require additional steps (installing t
 
 ### Problem-relevant `configuration.yaml` entries
 
-To exclude configuration issues and allow the developers to quickly test, and perhaps reproduce, your issue, add the relevant part of your `configuration.yaml` file. This file is located in your [configuration folder](/docs/configuration/). 
+To exclude configuration issues and allow the developers to quickly test, and perhaps reproduce, your issue, add the relevant part of your `configuration.yaml` file. This file is located in your [configuration folder](/docs/configuration/).
 
 ```yaml
 sensor:
@@ -64,4 +58,3 @@ Traceback (most recent call last):
 ### Additional information
 
 This section can contain additional details or other observation. Often the little things can help as well.
-


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Removes some stale Windows references. Documentation for Windows venv setups has been removed quite a while ago. This cleans up some older references.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
