### PR TITLE
Add a bit on device triggers in /automation/trigger

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -389,14 +389,14 @@ automation:
     event: enter # or "leave"
 ```
 
-### Device trigger
+### Device triggers
 
-Device triggers encompass a set of events which are defined by an integration. This includes, for example, state changes of sensors as well as button events from remotes.
+Device triggers encompass a set of events that are defined by an integration. This includes, for example, state changes of sensors as well as button events from remotes.
 [MQTT device triggers](/integrations/device_trigger.mqtt/) are set up through autodiscovery.
 
-In contrast to state triggers, device trigger are tied to a device and not necessarily an entity.
+In contrast to state triggers, device triggers are tied to a device and not necessarily an entity.
 To use a device trigger, set up an automation through the browser frontend.
-If you would like to use a device trigger for an automation which is not managed through the browser frontend, you can copy the YAML from the trigger widget in the frontend and paste it into your automation's trigger list.
+If you would like to use a device trigger for an automation that is not managed through the browser frontend, you can copy the YAML from the trigger widget in the frontend and paste it into your automation's trigger list.
 
 ### Multiple triggers
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -389,6 +389,15 @@ automation:
     event: enter # or "leave"
 ```
 
+### Device trigger
+
+Device triggers encompass a set of events which are defined by an integration. This includes, for example, state changes of sensors as well as button events from remotes.
+[MQTT device triggers](/integrations/device_trigger.mqtt/) are set up through autodiscovery.
+
+In contrast to state triggers, device trigger are tied to a device and not necessarily an entity.
+To use a device trigger, set up an automation through the browser frontend.
+If you would like to use a device trigger for an automation which is not managed through the browser frontend, you can copy the YAML from the trigger widget in the frontend and paste it into your automation's trigger list.
+
 ### Multiple triggers
 
 It is possible to specify multiple triggers for the same rule. To do so just prefix the first line of each trigger with a dash (-) and indent the next lines accordingly. Whenever one of the triggers fires, [processing](#what-are-triggers) of your automation rule begins.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Alleviates #13272 by adding a section on device triggers in the documentation for automation triggers.
We might want to have something more in-depth here, but this is better than nothing.

In writing this I also noticed that the documentation does not explain the concept of devices (and their distinction from entities).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #13272

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
