### PR TITLE
Updated list of Lovelace cards that support actions

### DIFF
--- a/source/lovelace/actions.markdown
+++ b/source/lovelace/actions.markdown
@@ -7,9 +7,10 @@ Some Lovelace cards have support for tap actions. These actions define what will
 
 Actions can be enabled on:
 
-- [Entity](/lovelace/entities/)
-- [Entity Button](/lovelace/entity-button/)
+- [Button](/lovelace/button/)
+- [Entities](/lovelace/entities/)
 - [Glance](/lovelace/glance/)
+- [Light](/lovelace/light/)
 - [Picture](/lovelace/picture/)
 - [Picture Element](/lovelace/picture-elements/)
 - [Picture Entity](/lovelace/picture-entity/)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Reasons for following changes:

* Support for hold action and double tap action was added to Light card, but not mentioned here.
* Entity Button card was renamed to Button a few versions ago
* Renamed "Entity" card to "Entities" as that is the proper name, and there's an actual Entity card now (which doesn't support actions). So it was wrong.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
