### PR TITLE
Add config flow to Netgear

### DIFF
--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -17,7 +17,7 @@ There are two ways to integrate NETGEAR in Home Assistant.
 
 ### Via the frontend
 
-Menu: *Configuration* -> *Integrations*. Search for "NETGEAR", click submit try to autodetect the URL of the router, fill the configuration form, click submit.
+Menu: *Configuration* -> *Integrations*. Search for "NETGEAR", fill the configuration form, click submit.
 
 ### Via the configuration file
 

--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -13,11 +13,11 @@ This platform allows you to detect presence by looking at connected devices to a
 
 ## Configuration
 
-There are two ways to integrate Netgear in Home Assistant.
+There are two ways to integrate NETGEAR in Home Assistant.
 
 ### Via the frontend
 
-Menu: *Configuration* -> *Integrations*. Search for "Netgear", click submit try to autodetect the URL of the router, fill the configuration form, click submit.
+Menu: *Configuration* -> *Integrations*. Search for "NETGEAR", click submit try to autodetect the URL of the router, fill the configuration form, click submit.
 
 ### Via the configuration file
 

--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -40,6 +40,11 @@ port:
   required: false
   default: 5000
   type: integer
+ssl:
+  description: Determine if HTTPS should be used.
+  required: false
+  default: false
+  type: boolean
 username:
   description: The username of a user with administrative privileges.
   required: false
@@ -49,14 +54,6 @@ password:
   description: The password for your given admin account.
   required: true
   type: string
-devices:
-  description: If provided only specified devices will be reported. Can be MAC address or the device name as reported in the NETGEAR UI.
-  required: false
-  type: list
-exclude:
-  description: Devices to exclude from the scan. Can be MAC address or the device name as reported in the NETGEAR UI.
-  required: false
-  type: list
 {% endconfiguration %}
 
 

--- a/source/_integrations/netgear.markdown
+++ b/source/_integrations/netgear.markdown
@@ -6,17 +6,22 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: pre 0.7
 ha_domain: netgear
+ha_config_flow: true
 ---
 
 This platform allows you to detect presence by looking at connected devices to a [NETGEAR](https://www.netgear.com/) device.
 
-<div class='note'>
+## Configuration
 
-A recent updates of Orbi APs introduced a bug which takes several hours to detects presence on your local network. The current workaround is to force this integration to use the Orbi's API v2 by adding the `accesspoints:` node to your configuration.
+There are two ways to integrate Netgear in Home Assistant.
 
-</div>
+### Via the frontend
 
-To use this device tracker in your installation, add the following to your `configuration.yaml` file:
+Menu: *Configuration* -> *Integrations*. Search for "Netgear", click submit try to autodetect the URL of the router, fill the configuration form, click submit.
+
+### Via the configuration file
+
+Add the following section to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -26,12 +31,8 @@ device_tracker:
 ```
 
 {% configuration %}
-url:
-  description: The base URL, e.g., `http://routerlogin.com:5000` for example. If not provided `host` and `port` are used. If none provided autodetection of the URL will be used.
-  required: false
-  type: string
 host:
-  description: The IP address of your router, e.g., `192.168.1.1`.
+  description: The IP address of your router, e.g., `192.168.1.1`. If none provided autodetection of the URL will be used, like `http://routerlogin.net`.
   required: false
   type: string
 port:
@@ -53,18 +54,11 @@ devices:
   required: false
   type: list
 exclude:
-  description: Devices to exclude from the scan.
-  required: false
-  type: list
-accesspoints:
-  description: Also track devices on the specified APs. Only supports MAC address.
+  description: Devices to exclude from the scan. Can be MAC address or the device name as reported in the NETGEAR UI.
   required: false
   type: list
 {% endconfiguration %}
 
-When `accesspoints` is specified an extra device will be reported for each device connected to the APs specified here, as `MY-LAPTOP on RBS40`. `Router` will be reported as AP name for the main AP. Only tested with Orbi.
-
-The use of `devices` or `exclude` is recommended when using `accesspoints` to avoid having a lot of entries.
 
 List of models that are known to use port 80:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add config flow to Netgear in home-assistant/core#34779

Tested on Orbi RBK23, there were also some outdated doc.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#34779
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
