### PR TITLE
Update sensor.modbus.markdown

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -124,6 +124,7 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - NU8070
 - U6000
 - U6300
+- RU7100
 - RU7172
 
 #### Models tested but not yet working

--- a/source/_integrations/sensor.modbus.markdown
+++ b/source/_integrations/sensor.modbus.markdown
@@ -104,7 +104,7 @@ registers:
       default: 0
       type: integer
     data_type:
-      description: Response representation (int, uint, float, custom). If float selected, value will be converted to IEEE 754 floating point format.
+      description: Response representation (int, uint, float, string, custom). If float selected, value will be converted to IEEE 754 floating point format.
       required: false
       default: int
       type: string


### PR DESCRIPTION
Add support for string data_type to allow reading of ascii text from holding registers.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35269
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/34943

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
