### PR TITLE
Remove parts about port_mapping and optional sensors

### DIFF
--- a/source/_integrations/upnp.markdown
+++ b/source/_integrations/upnp.markdown
@@ -14,8 +14,6 @@ ha_domain: upnp
 
 The `upnp` integration enables you to collect network statistics from your router such as bytes in/out and packets in/out. This information is provided by the [UPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play)/[Internet Gateway Device (IGD) Protocol](https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol) if enabled on your router.
 
-The IGD can automatically create port forwarding mappings on your router for Home Assistant, exposing your installation to the internet. The mapping will never automatically expire. Upon stopping Home Assistant, the mapping will be removed from your router.
-
 There is currently support for the following device types within Home Assistant:
 
 - **Sensor** - Allows to get the network statistics from your router such as bytes in/out and packets in/out.
@@ -27,46 +25,24 @@ Please note that UPnP or NAT-PMP needs to be enabled on your router for this int
 To integrate this into Home Assistant, add the following section to your `configuration.yaml` file:
 
 ```yaml
-# Example configuration.yaml entry with custom external portal
+# Example configuration.yaml entry
 upnp:
-  port_mapping: true
-  ports:
-    hass: 8000
-    8080: 8080
 ```
 
-With the default settings only the sensors are added for statistics. If you wish to have port mapping done through IGD, add the option **port_mapping** and **ports**.
-
 {% configuration %}
-port_mapping:
-  description: If the integration should try to map ports.
-  required: false
-  type: boolean
-  default: false
-sensors:
-  description: If the integration should enable the UPnP sensors.
-  required: false
-  type: boolean
-  default: true
 local_ip:
   description: The local IP address of the computer running Home Assistant.
   required: false
   type: string
   default: Try to auto-detect IP of host.
-ports:
-  description: Map of ports to map from internal to external. Pass 'hass' as internal port to use the port Home Assistant runs on. Note that you have to enable port_mapping if you wish to map ports.
-  required: false
-  type: map
-  default: Open same port on external router as that Home Assistant runs locally and forwards it.
 {% endconfiguration %}
 
 ## Troubleshooting
 
-If Home Assistant is not able to discover UPnP sensors, it may be because the local IP address was not auto-detected correctly. To prevent this, you may add the `local_ip` option to your UPnP configuration:
+If Home Assistant is not able to discover the UPnP device, it may be because the local IP address of the computer running Home Assistant was not auto-detected correctly. To prevent this, you may add the `local_ip` option to your UPnP configuration:
 
 ```yaml
-# Example configuration.yaml with UPnP sensors enabled and local_ip set
+# Example configuration.yaml with local_ip set
 upnp:
-  sensors: true
   local_ip: 192.168.1.2
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

`upnp`-component was simplified, update docs to reflect this.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35191
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
