### PR TITLE
Fix link to qcow2 image

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -210,7 +210,7 @@ If you can not find your machine type in the list, you should pick the `qemu` re
 [vmdk]: https://github.com/home-assistant/operating-system/releases/download/3.13/hassos_ova-3.13.vmdk.gz
 [vhdx]: https://github.com/home-assistant/operating-system/releases/download/3.13/hassos_ova-3.13.vhdx.gz
 [vdi]: https://github.com/home-assistant/operating-system/releases/download/3.13/hassos_ova-3.13.vdi.gz
-[qcow2]: https://github.com/home-assistant/operating-system/releases/download/4.5/hassos_ova-4.5.vdi.gz
+[qcow2]: https://github.com/home-assistant/operating-system/releases/download/4.5/hassos_ova-4.5.qcow2.gz
 [Virtual Appliance]: https://github.com/home-assistant/operating-system/releases/download/4.5/hassos_ova-4.5.ova
 [linux]: https://github.com/home-assistant/supervised-installer
 [local]: http://homeassistant.local:8123


### PR DESCRIPTION
## Proposed change

Small correction to the URL of one of the images.



## Type of change

URL fix

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [-] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
