### PR TITLE
Docs DenonAVR Config Flow

### DIFF
--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -46,28 +46,11 @@ If your model is not on the list then give it a test, if everything works correc
 If you have something else using the IP controller for your Denon AVR 3808CI, such as your URC controller, it will not work! There is either a bug or security issue with some models where only one device could be controlling the IP functionality.
 </div>
 
-To add a Denon Network Receiver to your installation, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-media_player:
-  - platform: denonavr
-    host: IP_ADDRESS
-    name: NAME
-    show_all_sources: true
-    timeout: POSITIVE INTEGER
-    zones:
-      - zone: Zone2 / Zone3
-        name: NAME
-```
+To add a Denon Network Receiver to your installation, click Configuration in the sidebar, then click Integrations. Denon and Marantz receivers schould be discovered automatically and schould show up in the overvieuw. Hit configure and go through the steps to specify the optional settings. If your receiver does not show up automatically, click the + icon in the lower right. Then search for "denonavr" and enter the setup.
 
 {% configuration %}
 host:
   description: IP address of the device, e.g., 192.168.1.32. If not set, auto-discovery is used.
-  required: false
-  type: string
-name:
-  description: Name of the device. If not set, friendlyName of the receiver is used.
   required: false
   type: string
 show_all_sources:
@@ -80,19 +63,16 @@ timeout:
   required: false
   default: 2
   type: integer
-zones:
-  description: List of additional zones to be activated. They are displayed as additional media players with the same functionality Main Zone of the device supports.
+zone1:
+  description: Specifies if zone 1 should be activated. Zones are displayed as additional media players with the same functionality as the Main Zone of the device supports.
   required: false
-  type: list
-  keys:
-    zone:
-      description: Zone which should be activated. Valid options are `Zone2` and `Zone3`.
-      required: true
-      type: string
-    name:
-      description: Name of the zone. If not set the name of the main device + zone as a suffix is taken.
-      required: false
-      type: string
+  default: false
+  type: boolean
+zone2:
+  description: Specifies if zone 2 should be activated. Zones are displayed as additional media players with the same functionality as the Main Zone of the device supports.
+  required: false
+  default: false
+  type: boolean
 {% endconfiguration %}
 
 A few notes:

--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -46,7 +46,7 @@ If your model is not on the list then give it a test, if everything works correc
 If you have something else using the IP controller for your Denon AVR 3808CI, such as your URC controller, it will not work! There is either a bug or security issue with some models where only one device could be controlling the IP functionality.
 </div>
 
-To add a Denon Network Receiver to your installation, click Configuration in the sidebar, then click Integrations. Denon and Marantz receivers schould be discovered automatically and schould show up in the overvieuw. Hit configure and go through the steps to specify the optional settings. If your receiver does not show up automatically, click the + icon in the lower right. Then search for "denonavr" and enter the setup.
+To add a Denon Network Receiver to your installation, click Configuration in the sidebar, then click Integrations. Denon and Marantz receivers should be discovered automatically and should show up in the overview. Hit configure and go through the steps to specify the optional settings. If your receiver does not show up automatically, click the + icon in the lower right. Then search for "denonavr" and enter the setup.
 
 {% configuration %}
 host:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update the docs for the new Config Flow instead of Yaml configuration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35255
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
