### PR TITLE
add becker integration doc

### DIFF
--- a/source/_integrations/becker.markdown
+++ b/source/_integrations/becker.markdown
@@ -21,16 +21,13 @@ The becker cover configuration consist in a new becker platform in your cover co
 
 ```yaml
 # Example configuration.yaml entry
-cover:
-  - platform: becker
-    device: "/dev/serial/by-id/usb-BECKER-ANTRIEBE_GmbH_CDC_RS232_v125_Centronic-if00"
-    covers:
-      kitchen:
-        friendly_name: "Kitchen Cover"
-        channel: "1"
-      bedroom:
-        friendly_name: "Bedroom Cover"
-        channel: "2"
+becker:
+  device: "/dev/serial/by-id/usb-BECKER-ANTRIEBE_GmbH_CDC_RS232_v125_Centronic-if00"
+  covers:
+    - name: "Kitchen Cover"
+      channel: "1"
+    - name: "Bedroom Cover"
+      channel: "2"
 ```
 
 {% configuration %}
@@ -44,8 +41,8 @@ covers:
   required: true
   type: list
   keys:
-    friendly_name:
-      description: Override the name to use in the frontend.
+    name:
+      description: Name to use for the device.
       required: false
       type: string
     channel:
@@ -58,3 +55,7 @@ covers:
 If a channel consists of only numbers, please make sure to surround it with quotes.
 This is a known limitation in YAML, because the device ID will be interpreted as a number otherwise.
 </div>
+
+## Services
+
+This integration introduce a new service *becker.pair" allowing you to pair a cover/shutter with your centronic stick from the UI, scripts or automations

--- a/source/_integrations/becker.markdown
+++ b/source/_integrations/becker.markdown
@@ -3,7 +3,7 @@ title: Velux
 description: Instructions on how to integrate Becker Covers via Becker Centronic USB Strick with Home Assistant.
 ha_category:
   - Cover
-ha_release: 
+ha_release: 0.110
 ha_codeowners:
   - '@nicolasberthel'
 ha_domain: becker

--- a/source/_integrations/becker.markdown
+++ b/source/_integrations/becker.markdown
@@ -1,6 +1,6 @@
 ---
 title: Velux
-description: Instructions on how to integrate Becker Covers via Becker Centronic USB Strick with Home Assistant.
+description: Instructions on how to integrate Becker Covers via Becker Centronic USB Stick with Home Assistant.
 ha_category:
   - Cover
 ha_release: 0.110
@@ -9,7 +9,7 @@ ha_codeowners:
 ha_domain: becker
 ---
 
-Becker Cover Integration for for Home Assistant allows you to control your Becker Covers via a centronic USB Stick
+Becker Cover Integration for Home Assistant allows you to control your Becker Covers via a centronic USB Stick.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -58,4 +58,4 @@ This is a known limitation in YAML, because the device ID will be interpreted as
 
 ## Services
 
-This integration introduce a new service *becker.pair" allowing you to pair a cover/shutter with your centronic stick from the UI, scripts or automations
+This integration introduces a new service `becker.pair` allowing you to pair a cover/shutter with your centronic stick from the UI, scripts or automations.

--- a/source/_integrations/becker.markdown
+++ b/source/_integrations/becker.markdown
@@ -1,5 +1,5 @@
 ---
-title: Velux
+title: Becker
 description: Instructions on how to integrate Becker Covers via Becker Centronic USB Stick with Home Assistant.
 ha_category:
   - Cover

--- a/source/_integrations/becker.markdown
+++ b/source/_integrations/becker.markdown
@@ -1,0 +1,60 @@
+---
+title: Velux
+description: Instructions on how to integrate Becker Covers via Becker Centronic USB Strick with Home Assistant.
+ha_category:
+  - Cover
+ha_release: 
+ha_codeowners:
+  - '@nicolasberthel'
+ha_domain: becker
+---
+
+Becker Cover Integration for for Home Assistant allows you to control your Becker Covers via a centronic USB Stick
+
+There is currently support for the following device types within Home Assistant:
+
+- Cover
+
+## Configuration
+
+The becker cover configuration consist in a new becker platform in your cover configuration:
+
+```yaml
+# Example configuration.yaml entry
+cover:
+  - platform: becker
+    device: "/dev/serial/by-id/usb-BECKER-ANTRIEBE_GmbH_CDC_RS232_v125_Centronic-if00"
+    covers:
+      kitchen:
+        friendly_name: "Kitchen Cover"
+        channel: "1"
+      bedroom:
+        friendly_name: "Bedroom Cover"
+        channel: "2"
+```
+
+{% configuration %}
+device:
+  description: The path to access centronic stick.
+  default: /dev/serial/by-id/usb-BECKER-ANTRIEBE_GmbH_CDC_RS232_v125_Centronic-if00
+  required: false
+  type: string
+covers:
+  description: The list of covers you want to control
+  required: true
+  type: list
+  keys:
+    friendly_name:
+      description: Override the name to use in the frontend.
+      required: false
+      type: string
+    channel:
+      description: The channel used to control the cover. Pay attention to surround the channel number with strings
+      required: true
+      type: string
+{% endconfiguration %}
+
+<div class='note warning'>
+If a channel consists of only numbers, please make sure to surround it with quotes.
+This is a known limitation in YAML, because the device ID will be interpreted as a number otherwise.
+</div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation for new integration for becker covers


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35288
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
