### PR TITLE
Songpal code improvement

### DIFF
--- a/source/_integrations/songpal.markdown
+++ b/source/_integrations/songpal.markdown
@@ -58,6 +58,6 @@ For a list of available settings and their values use [`songpal sound`](https://
 
 | Service data attribute | Optional | Description                                      |
 |------------------------|----------|--------------------------------------------------|
-| `entity_id`            |      yes | Target entity, leave unset for all devices       |
+| `entity_id`            |       no | Target entity. To target all songpal devices, use `all` |
 | `name`                 |       no | Configuration variable, e.g., `nightmode`         |
 | `value`                |       no | New configuration value, e.g., `on`               |

--- a/source/_integrations/songpal.markdown
+++ b/source/_integrations/songpal.markdown
@@ -58,6 +58,6 @@ For a list of available settings and their values use [`songpal sound`](https://
 
 | Service data attribute | Optional | Description                                      |
 |------------------------|----------|--------------------------------------------------|
-| `entity_id`            |       no | Target entity. To target all songpal devices, use `all` |
+| `entity_id`            |      yes | Target entity. To target all songpal devices, use `all` |
 | `name`                 |       no | Configuration variable, e.g., `nightmode`         |
 | `value`                |       no | New configuration value, e.g., `on`               |

--- a/source/_integrations/songpal.markdown
+++ b/source/_integrations/songpal.markdown
@@ -6,6 +6,7 @@ ha_category:
 ha_iot_class: Local Push
 ha_release: 0.65
 ha_config_flow: true
+ha_quality_scale: gold
 ha_codeowners:
   - '@rytilahti'
   - '@shenxn'


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- The `songpal/set_sound_setting` now uses service registration helper to register so the `entity_id` need to be set as `all` instead of left unset to call the service on all songpal devices.
- The integration now reaches gold quality scale.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#35318
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
