### PR TITLE
add home as WorkingDirectory

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -27,6 +27,7 @@ After=network-online.target
 [Service]
 Type=simple
 User=%i
+WorkingDirectory=/home/%i/.homeassistant
 ExecStart=/usr/bin/hass
 
 [Install]


### PR DESCRIPTION
## Proposed change

Find issue with an integration that used urlretrieve to download file.
Running HASS without this option in systemd make it fails to work.
Adding WorkingDirectory in systemd files resolve user right issue.

## Type of change
DOCS

- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
https://github.com/max5962/essence/issues/1
https://github.com/max5962/prixCarburant-home-assistant/issues/2

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
