### PR TITLE
Working directory bis

### DIFF
--- a/source/_docs/autostart/systemd.markdown
+++ b/source/_docs/autostart/systemd.markdown
@@ -46,6 +46,7 @@ After=network-online.target
 [Service]
 Type=simple
 User=%i
+WorkingDirectory=/home/%i/.homeassistant
 ExecStart=/srv/homeassistant/bin/hass -c "/home/%i/.homeassistant"
 
 [Install]


### PR DESCRIPTION
sorry @frenck same as #13337
Didn't see they were two sections in docs

## Proposed change
Find issue with an integration that used urlretrieve to download file.
Running HASS without this option in systemd make it fails to work.
Adding WorkingDirectory in systemd files resolve user right issue.

## Type of change
DOCS

- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information
This PR fixes or closes issue:
https://github.com/max5962/essence/issues/1
https://github.com/max5962/prixCarburant-home-assistant/issues/2

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
