### PR TITLE
Consecutive volume steps delay in webostv

### DIFF
--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -210,8 +210,10 @@ script:
           entity_id:  media_player.lg_webos_smart_tv
           command: "media.controls/rewind"
 ```
+
 ## Consecutive volume steps delay
-In the case where an sound output that only support relative volume stepping is used, the receiving speaker may have issues dealing several volume step commands arriving at the same time. Therefore it's possible configure a time delay so that at least the configured amount of time has elapsed between two consecutive volume steps before the second one is fired. The configured value is in milliseconds.
+
+In the case where a sound output that only supports relative volume stepping is used, the receiving speaker may have issues dealing with several volume step commands arriving at the same time. Therefore it's possible to configure a time delay so that at least the configured amount of time has elapsed between two consecutive volume steps before the second one is fired. The configured value is in milliseconds.
 
 ```yaml
 # Example

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -210,6 +210,18 @@ script:
           entity_id:  media_player.lg_webos_smart_tv
           command: "media.controls/rewind"
 ```
+## Consecutive volume steps delay
+In the case where an sound output that only support relative volume stepping is used, the receiving speaker may have issues dealing several volume step commands arriving at the same time. Therefore it's possible configure a time delay so that at least the configured amount of time has elapsed between two consecutive volume steps before the second one is fired. The configured value is in milliseconds.
+
+```yaml
+# Example
+webostv:
+  host: 192.168.0.10
+  name: Living Room TV
+  consecutive_volume_steps_delay: 300
+
+media_player:
+```
 
 ## Notifications
 


### PR DESCRIPTION
Added section about Consecutive volume steps delay in webostv

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This documentation is related to a new feature in the webostv component. In the case where an sound output that only support relative volume stepping is used, the receiving speaker may have issues dealing several volume step commands arriving at the same time. Therefore should be possible to configure a time delay so that at least the configured amount of time has elapsed between two consecutive volume steps before the second one is fired.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- [Link to parent pull request in the codebase](https://github.com/home-assistant/core/pull/35367) 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
