### PR TITLE
Add directions to enable ZHA debug logging

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -167,8 +167,6 @@ When reporting issues, please provide the following information in addition to i
 `Configuration` Panel -> `Zigbee Home Automation` -> Pick your Device -> `Zigbee Information`
 
 
-
-
 ### Debug logging
 
 To enable debug logging for ZHA component ard radio libraries, add the following [logger](https://www.home-assistant.io/integrations/logger/) configuration to `configuration.yaml`

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -155,21 +155,21 @@ Click on **ADD DEVICES** to start a scan for new devices.
 
 Reset your Zigbee devices according to the device instructions provided by the manufacturer (e.g.,  turn on/off lights up to 10 times, switches usually have a reset button/pin).
 
-
 ## Troubleshooting
 
 ### Reporting issues
 
 When reporting issues, please provide the following information in addition to information requested by issue template:
+
 1. Debug logs for the issue, see [debug logging](#debug-logging)
 2. Model of Zigbee radio being used
 3. If issue is related to a specific Zigbee device, provide device Zigbee signature. Signature is available at
 `Configuration` Panel -> `Zigbee Home Automation` -> Pick your Device -> `Zigbee Information`
 
-
 ### Debug logging
 
-To enable debug logging for ZHA component ard radio libraries, add the following [logger](https://www.home-assistant.io/integrations/logger/) configuration to `configuration.yaml`
+To enable debug logging for ZHA component ard radio libraries, add the following [logger](https://www.home-assistant.io/integrations/logger/) configuration to `configuration.yaml`:
+
 ```yaml
 logger:
   default: info
@@ -186,7 +186,6 @@ logger:
     zigpy_xbee.api: debug
     zigpy_zigate: debug
 ```
-
 
 ### Add Philips Hue bulbs that have previously been added to another bridge
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -155,7 +155,40 @@ Click on **ADD DEVICES** to start a scan for new devices.
 
 Reset your Zigbee devices according to the device instructions provided by the manufacturer (e.g.,  turn on/off lights up to 10 times, switches usually have a reset button/pin).
 
+
 ## Troubleshooting
+
+### Reporting issues
+
+When reporting issues, please provide the following information in addition to information requested by issue template:
+1. Debug logs for the issue, see [debug logging](#debug-logging)
+2. Model of Zigbee radio being used
+3. If issue is related to a specific Zigbee device, provide device Zigbee signature. Signature is available at
+`Configuration` Panel -> `Zigbee Home Automation` -> Pick your Device -> `Zigbee Information`
+
+
+
+
+### Debug logging
+
+To enable debug logging for ZHA component ard radio libraries, add the following [logger](https://www.home-assistant.io/integrations/logger/) configuration to `configuration.yaml`
+```yaml
+logger:
+  default: info
+  logs:
+    homeassistant.core: debug
+    homeassistant.components.zha: debug
+    bellows.zigbee.application: debug
+    bellows.ezsp: debug
+    zigpy: debug
+    zigpy_cc: debug
+    zigpy_deconz.zigbee.application: debug
+    zigpy_deconz.api: debug
+    zigpy_xbee.zigbee.application: debug
+    zigpy_xbee.api: debug
+    zigpy_zigate: debug
+```
+
 
 ### Add Philips Hue bulbs that have previously been added to another bridge
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add instructions on how to enable debug logging for ZHA and what additional information to provide when reporting issues for zha


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- git[ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
