### PR TITLE
Add config flow and restore_light_state to ISY994

### DIFF
--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -13,6 +13,7 @@ ha_category:
 ha_release: 0.28
 ha_iot_class: Local Push
 ha_domain: isy994
+ha_config_flow: true
 ---
 
 The ISY994 is a home automation controller that is capable of controlling Insteon and X10 devices. Some models of the ISY994 can even control Z-Wave devices.
@@ -32,7 +33,7 @@ There is currently support for the following device types within Home Assistant:
 
 Home Assistant is capable of communicating with any binary sensor, cover, fan, light, lock, sensor and switch that is configured on the controller. Using the programs on the controller, custom binary sensors, cover, fan, lock, and switches can also be created.
 
-To integrate your ISY994 controller with Home Assistant, Go to the integrations page in your configuration and click on new integration -> Universal Devices ISY994.
+To integrate your ISY994 controller with Home Assistant, Go to the **integrations page** in your configuration and click on new **integration** -> **Universal Devices ISY994**.
 
 You may also configure the integration manually by adding the following section to your `configuration.yaml` file:
 

--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -75,6 +75,7 @@ restore_light_state:
   description: If disabled (default behavior), lights turned ON from Home Assistant without a `brightness` parameter set, will turn on to the `on_level` set within the physical device. For example, on Insteon devices this would be the same brightness as if the switch/device was turned ON. If this setting is enabled, lights that are turned on from Home Assistant will go to the last known brightness value. Both the `on_level` and `last_brightness` values are available as attributes if needed for device-specific customization.
   required: false
   type: boolean
+  default: false
 {% endconfiguration %}
 
 Once the ISY controller is configured, it will automatically import any binary sensors, covers, fans, lights, locks, sensors and switches it can locate.

--- a/source/_integrations/isy994.markdown
+++ b/source/_integrations/isy994.markdown
@@ -32,7 +32,9 @@ There is currently support for the following device types within Home Assistant:
 
 Home Assistant is capable of communicating with any binary sensor, cover, fan, light, lock, sensor and switch that is configured on the controller. Using the programs on the controller, custom binary sensors, cover, fan, lock, and switches can also be created.
 
-To integrate your ISY994 controller with Home Assistant, add the following section to your `configuration.yaml` file:
+To integrate your ISY994 controller with Home Assistant, Go to the integrations page in your configuration and click on new integration -> Universal Devices ISY994.
+
+You may also configure the integration manually by adding the following section to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
@@ -69,6 +71,10 @@ tls:
   description: This entry should reflect the version of TLS that the ISY controller is using for HTTPS encryption. This value can be either 1.1 or 1.2. If this value is not set, it is assumed to be version 1.1. This is the default for most users. ISY994 Pro users may likely be using 1.2. When using HTTPS in the host entry, it is best practice to set this value.
   required: false
   type: string
+restore_light_state:
+  description: If disabled (default behavior), lights turned ON from Home Assistant without a `brightness` parameter set, will turn on to the `on_level` set within the physical device. For example, on Insteon devices this would be the same brightness as if the switch/device was turned ON. If this setting is enabled, lights that are turned on from Home Assistant will go to the last known brightness value. Both the `on_level` and `last_brightness` values are available as attributes if needed for device-specific customization.
+  required: false
+  type: boolean
 {% endconfiguration %}
 
 Once the ISY controller is configured, it will automatically import any binary sensors, covers, fans, lights, locks, sensors and switches it can locate.
@@ -119,7 +125,7 @@ All `isy994_control` events will have an `entity_id` and `control` parameter in 
 
 All Insteon scenes configured in the ISY994 will show up as a `switch` in Home Assistant, as they do not support dimming or setting specific brightness settings as Home Assisstant's `light` component.
 
-Insteon Secondary Keypad buttons and Remote buttons are added to Home Assistant to allow support for using Control Events in Automations; however, these devices cannot be directly controlled (turned on/off) and may report incorrect states. Secondary Keypad buttons may be controlled using ISY Scenes (refer to ISY Documentation for more details).
+Insteon Secondary Keypad buttons and Remote buttons are added to Home Assistant to allow support for using Control Events in Automations. These devices are added as `sensors` since they cannot be directly controlled (turned on/off); their state is the last ON level command they sent, in a range from `0` (Off) to `255` (On 100%).  Note: these devices may report incorrect states before being used after a reboot of the ISY. Secondary Keypad buttons may be turned on or off using ISY Scenes (refer to ISY Documentation for more details).
 
 ### Creating Custom Devices using ISY Programs
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update method for adding the integration to include using the new config flow via the integrations page.

Add the `restore_light_state` parameter: The ISY994 integration now includes a restore_light_state option. In 0.109.0, a change was made to restore a light's brightness to the previous state when turned on with no brightness parameter. This was, in part, to fix an issue where the light would turn on to full brightness when no parameters were given, regardless of the physical device's On Level brightness setting. Using the On Level is now supported and this is being made the default behavior to keep it the same as turning on the physical switch. To keep the current behavior and use Home Assistant's last brightness, set the restore_light_state is set to True or enable the option in the new config flow options.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35413
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
