### PR TITLE
Remove iOS from docs navigation tree

### DIFF
--- a/source/_includes/asides/docs_navigation.html
+++ b/source/_includes/asides/docs_navigation.html
@@ -194,57 +194,6 @@
         </ul>
       </li>
       <li>
-        <b>{% active_link /docs/ecosystem/ios/ iOS %}</b>
-        <ul>
-          <li>
-            {% active_link /docs/ecosystem/ios/notifications/basic/ Basic
-            notifications %}
-          </li>
-          <ul>
-            <li>
-              {% active_link /docs/ecosystem/ios/notifications/sounds/ Sounds %}
-            </li>
-            <li>
-              {% active_link /docs/ecosystem/ios/notifications/architecture/
-              Architecture %}
-            </li>
-            <li>
-              {% active_link
-              /docs/ecosystem/ios/notifications/privacy_security_rate_limits/
-              Privacy, rate limiting and security %}
-            </li>
-          </ul>
-          <li>Advanced notifications</li>
-          <ul>
-            <li>
-              {% active_link /docs/ecosystem/ios/notifications/attachments/
-              Attachments %}
-            </li>
-            <li>
-              {% active_link
-              /docs/ecosystem/ios/notifications/content_extensions/ Dynamic
-              content %}
-            </li>
-            <li>
-              {% active_link /docs/ecosystem/ios/notifications/actions/
-              Actionable notifications %}
-            </li>
-            <li>
-              {% active_link
-              /docs/ecosystem/ios/notifications/requesting_location_updates/
-              Requesting location updates %}
-            </li>
-          </ul>
-          <li>
-            {% active_link /docs/ecosystem/ios/location/ Location Tracking %}
-          </li>
-          <li>
-            {% active_link /docs/ecosystem/ios/integration/ Integration with
-            other apps %}
-          </li>
-        </ul>
-      </li>
-      <li>
         {% active_link /docs/ecosystem/ Ecosystem %}
         <ul>
           <li>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Removes the iOS menu items from the documentation navigation tree.
All pages are already redirected to the new home of the companion apps.
Furthermore, the button/link is listed on the index page of the docs section.

This will trim down the large menu we have there.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
