### PR TITLE
Add docs for the Zerproc integration

### DIFF
--- a/source/_integrations/zerproc.markdown
+++ b/source/_integrations/zerproc.markdown
@@ -4,7 +4,7 @@ description: Instructions for integrating Zerproc bluetooth lights within Home A
 ha_category:
   - Light
 ha_iot_class: Local Polling
-ha_release: 0.110
+ha_release: "0.111"
 ha_domain: zerproc
 ---
 

--- a/source/_integrations/zerproc.markdown
+++ b/source/_integrations/zerproc.markdown
@@ -10,16 +10,18 @@ ha_domain: zerproc
 
 This integration discovers nearby Zerproc lights and adds them to Home Assistant.
 
-This integration requires pybluez to be installed. On Debian based installs, run
+## Setup
+
+This integration requires `pybluez` to be installed. On Debian based installs, run
 
 ```bash
 sudo apt install bluetooth
 ```
 
-Before you get started with this platform, please note that:
+Before you get started with this integration, please note that:
 
- - This platform is incompatible with Windows
- - This platform requires access to the Bluetooth stack, see [Rootless Setup section](#rootless-setup) for further information
+ - Not compatible with Windows
+ - Requires access to the Bluetooth stack, see [Rootless Setup section](#rootless-setup) for further information
 
 ## Configuration
 
@@ -33,7 +35,7 @@ The integration will scan for nearby devices, and is completed if any are found.
 
 ## Rootless Setup
 
-Normally accessing the Bluetooth stack is reserved for root, but running programs that are networked as root is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 and hcitool the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](https://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
+Normally accessing the Bluetooth stack is reserved for `root`, but running programs that are networked as `root` is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 and `hcitool` the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](https://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
 
 ```bash
 sudo apt-get install libcap2-bin

--- a/source/_integrations/zerproc.markdown
+++ b/source/_integrations/zerproc.markdown
@@ -1,0 +1,44 @@
+---
+title: Zerproc Bluetooth Lights
+description: Instructions for integrating Zerproc bluetooth lights within Home Assistant.
+ha_category:
+  - Light
+ha_iot_class: Local Polling
+ha_release: 0.110
+ha_domain: zerproc
+---
+
+This integration discovers nearby Zerproc lights and adds them to Home Assistant.
+
+This integration requires pybluez to be installed. On Debian based installs, run
+
+```bash
+sudo apt install bluetooth
+```
+
+Before you get started with this platform, please note that:
+
+ - This platform is incompatible with Windows
+ - This platform requires access to the Bluetooth stack, see [Rootless Setup section](#rootless-setup) for further information
+
+## Configuration
+
+This integration can be configured using the integrations page in Home Assistant.
+
+Menu: **Configuration** -> **Integrations**.
+
+Click on the `+` sign to add an integration and search for **Zerproc**.
+
+The integration will scan for nearby devices, and is completed if any are found. No additional configuration is required. The integration will perform a BLE scan every 60 seconds to search for new devices.
+
+## Rootless Setup
+
+Normally accessing the Bluetooth stack is reserved for root, but running programs that are networked as root is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 and hcitool the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](https://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
+
+```bash
+sudo apt-get install libcap2-bin
+sudo setcap 'cap_net_raw,cap_net_admin+eip' `readlink -f \`which python3\``
+sudo setcap 'cap_net_raw+ep' `readlink -f \`which hcitool\``
+```
+
+A restart of Home Assistant is required.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds docs for the new Zerproc integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35477
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1589
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
