### PR TITLE
Update proxmoxve.markdown

### DIFF
--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -126,8 +126,8 @@ Creating a dedicated user for Home Assistant, limited to only the role just crea
 * Open `Permissions` and click `Users`
 * Click `Add`
 * Enter a username (e.g.,  "hass")
-* Enter a secure password (it can be complex as you will only need to copy/paste it into your Home Assistant configuration)
 * Set the realm to "Proxmox VE authentication server"
+* Enter a secure password (it can be complex as you will only need to copy/paste it into your Home Assistant configuration)
 * Ensure `Enabled` is checked and `Expire` is set to "never"
 * Click `Add`
 


### PR DESCRIPTION
Improving the order of instructions in the "create home assistant user" section.

## Proposed change
The password field isn't visible until the realm is changed to PVE. moved the password step to after the realm change step.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
