### PR TITLE
google_assistant: Add documentation for structure

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -98,6 +98,7 @@ google_assistant:
       aliases:
         - BRIGHT_LIGHTS
         - ENTRY_LIGHTS
+      structure: STRUCTURE_NAME_IN_GOOGLE_HOME
     light.living_room:
       expose: false
       room: LIVING_ROOM
@@ -171,6 +172,10 @@ entity_config:
           description: Allows for associating this device to a Room in Google Assistant.
           required: false
           type: string
+        structure:
+          description: Allows for associating this device to a Structure in Google Assistant and the Google Home app.
+          required: false
+          type: string
 {% endconfiguration %}
 
 ### Available domains
@@ -213,6 +218,10 @@ There is currently a limitation with this feature that requires a hard-coded set
 ### Room/Area support
 
 Entities that have not been explicitly assigned to rooms but have been placed in Home Assistant areas will return room hints to Google with the devices in those areas.
+
+### Structure support
+
+Entities that have not been explicitly assigned to a structure will not be placed into any rooms if multiple structures are defined in the Google Home app.
 
 ### Climate Operation Modes
 


### PR DESCRIPTION
This adds config documentation for support of the structure config option.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35625
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/35619

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
