### PR TITLE
Rename zwave_mqtt to ozw

### DIFF
--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -1,6 +1,6 @@
 ---
-title: Z-Wave over MQTT
-description: Instructions on how to integrate Z-Wave over MQTT with Home Assistant.
+title: OpenZWave (beta)
+description: Instructions on how to integrate OpenZWave with Home Assistant.
 ha_category:
   - Switch
 ha_release: "0.110"
@@ -10,15 +10,15 @@ ha_codeowners:
   - '@cgarwood'
   - '@marcelveldt'
   - '@MartinHjelmare'
-ha_domain: zwave_mqtt
+ha_domain: ozw
 ---
 
 This integration allows you to utilize OpenZWave's qt-openzwave daemon to control a Z-Wave network over MQTT.
 
 ## Requirements
 
-- MQTT server and the [MQTT integration](/integrations/mqtt/) set up in Home Assistant
-- [qt-openzwave daemon](https://github.com/OpenZWave/qt-openzwave)
+- MQTT server and the [MQTT integration](/integrations/mqtt/) set up in Home Assistant.
+- [qt-openzwave daemon](https://github.com/OpenZWave/qt-openzwave).
 - Supported Z-Wave dongle compatible with OpenZWave 1.6. See this [list](/docs/z-wave/controllers/#supported-z-wave-usb-sticks--hardware-modules) of controllers.
 
 ## Configuration
@@ -28,28 +28,38 @@ Home Assistant frontend.
 
 Menu: **Configuration** -> **Integrations**.
 
-Click on the `+` sign to add an integration and click on **Z-Wave over MQTT**.
-After completing the configuration flow, the Z-Wave over MQTT
-integration will be available.
+Click on the `+` sign to add an integration and click on **OpenZWave (beta)**.
+After completing the configuration flow, the OpenZWave integration will be
+available.
 
 ### Secure network key
 
-The secure network key is set in the settings for the qt-openzwave daemon and not in the integration configuration.
+The secure network key is set in the settings for the qt-openzwave daemon and
+not in the integration configuration.
 
 ## Services
 
 ### Service `zwave_mqtt.add_node`
 
-This service will set the controller into inclusion mode and should be used to add a device (node) to the Z-Wave network. Call the service and then perform the device-specific procedure, according to the device manual, to add your device to the network. Make sure the controller is connected to the host where the QT-OpenZwave daemon is running, when performing this operation.
+This service will set the controller into inclusion mode and should be used to
+add a device (node) to the Z-Wave network. Call the service and then perform
+the device-specific procedure, according to the device manual, to add your
+device to the network. Make sure the controller is connected to the host where
+the QT-OpenZwave daemon is running, when performing this operation.
 
 | Service Data Attribute | Required | Description                                                                                                                                                                                                                                      |
 | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `secure`               | no       | Add the new node with secure communications. [Secure network key must be set](#secure-network-key). This process will fallback to add_node (unsecure) for unsupported devices. Note that unsecure devices can't directly talk to secure devices. |
+| `secure`               | no       | Add the new node with secure communications. [Secure network key must be set](#secure-network-key). This process will fallback to add_node (unsecure) for unsupported devices. Note that insecure devices can't directly talk to secure devices. |
 | `instance_id`          | no       | The OZW Instance/Controller to use, defaults to 1.                                                                                                                                                                                               |
 
 ### Service `zwave_mqtt.remove_node`
 
-This service will set the controller into exclusion mode and should be used to remove a device (node) from the Z-Wave network. Call the service and then perform the device-specific procedure, according to the device manual, to remove your device from the network. Make sure the controller is connected to the host where the QT-OpenZwave daemon is running, when performing this operation.
+This service will set the controller into exclusion mode and should be used to
+remove a device (node) from the Z-Wave network. Call the service and then
+perform the device-specific procedure, according to the device manual,
+to remove your device from the network. Make sure the controller is connected
+to the host where the QT-OpenZwave daemon is running, when performing
+this operation.
 
 | Service Data Attribute | Required | Description                                        |
 | ---------------------- | -------- | -------------------------------------------------- |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Renames the new "Z-Wave over MQTT" integration to "OpenZWave".
Domain changed from `zwave_mqtt` to `ozw`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35631
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1614
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
