### PR TITLE
Rename zwave_mqtt to ozw

### DIFF
--- a/source/_posts/2020-05-20-release-110.markdown
+++ b/source/_posts/2020-05-20-release-110.markdown
@@ -59,15 +59,15 @@ Screenshot of the HACS integration with its icon shown.
 
 [@timmo001]: https://github.com/timmo001
 
-## Z-Wave over MQTT integration
+## OpenZWave integration now in beta
 
-This release features the new Z-Wave over MQTT integration. It has been in
-testing as a custom integration by the community since last December and is now
+This release features the new OpenZwave integration. It has been in testing as
+a custom integration by the community since last December and is now
 ready for a wider audience.
 
 It is still early days for this integration, though; not all platforms and
 devices are supported yet and the setup process has prerequisites that raise
-the accessibility bar. See our [documentation](/integrations/zwave_mqtt/) for
+the accessibility bar. See our [documentation](/integrations/ozw/) for
 the current requirements and instructions.
 
 If you want to give it a shot, you should be comfortable with setting up custom
@@ -1476,4 +1476,4 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [zerproc docs]: /integrations/zerproc/
 [zha docs]: /integrations/zha/
 [zwave docs]: /integrations/zwave/
-[zwave_mqtt docs]: /integrations/zwave_mqtt/
+[zwave_mqtt docs]: /integrations/ozw/


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The zwave_mqtt integration has been renames to ozw (OpenZwave)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
