### PR TITLE
Fix broken links Documentation, standards, create new page

### DIFF
--- a/source/_includes/asides/help_navigation.html
+++ b/source/_includes/asides/help_navigation.html
@@ -11,10 +11,10 @@
         <a href='https://developers.home-assistant.io'>Developer documentation <i class='icon-external-link'></i></a>
       </li>
       <li>
-        {% active_link /developers/documentation/ Website/Documentation %}
+        {% active_link /developers/documenting Website/Documentation %}
         <ul>
-          <li>{% active_link /developers/documentation/standards/ Standards %}</li>
-          <li>{% active_link /developers/documentation/create_page/ Create a new page %}</li>
+          <li>{% active_link /developers/documenting/standards/ Standards %}</li>
+          <li>{% active_link /developers/documenting/create-page Create a new page %}</li>
         </ul>
       </li>
       <li>


### PR DESCRIPTION
## Proposed change
I am updating links that were broken for the new developer site.  

Documentation, standards and create new page.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
