### PR TITLE
Change blink.trigger_camera service payload

### DIFF
--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -90,7 +90,7 @@ Trigger a camera to take a new still image.
 
 | Service Data Attribute | Optional | Description                            |
 | ---------------------- | -------- | -------------------------------------- |
-| `entity_id`            | no       | Camera entity to take picture with.    |
+| `entity_id`            | yes      | Camera entity to take picture with.    |
 
 ### `blink.save_video`
 
@@ -136,7 +136,7 @@ alias: Blink Snap Picture
 sequence:
     - service: blink.trigger_camera
       data:
-          entity_id: camera.blink_my_camera
+        entity_id: camera.blink_my_camera
     - delay: 00:00:05  
     - service: blink.blink_update
     - service: camera.snapshot

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -90,7 +90,7 @@ Trigger a camera to take a new still image.
 
 | Service Data Attribute | Optional | Description                            |
 | ---------------------- | -------- | -------------------------------------- |
-| `name`                 | no       | Name of camera to take new image with. |
+| `entity_id`            | no       | Camera entity to take picture with.    |
 
 ### `blink.save_video`
 
@@ -136,7 +136,7 @@ alias: Blink Snap Picture
 sequence:
     - service: blink.trigger_camera
       data:
-          name: "My Camera"
+          entity_id: camera.blink_my_camera
     - delay: 00:00:05  
     - service: blink.blink_update
     - service: camera.snapshot


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The `blink.trigger_camera` service was moved to the camera platform and now takes the actualy `entity_id` of the camera rather than the name as the payload.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35635
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
