### PR TITLE
Add documentation for scan_interval configuration for apcupsd

### DIFF
--- a/source/_integrations/apcupsd.markdown
+++ b/source/_integrations/apcupsd.markdown
@@ -44,7 +44,7 @@ port:
   required: false
   type: integer
   default: 3551
-poll_interval:
+scan_interval:
   description: The number of seconds between polling apcupsd.
   required: false
   type: integer

--- a/source/_integrations/apcupsd.markdown
+++ b/source/_integrations/apcupsd.markdown
@@ -44,6 +44,11 @@ port:
   required: false
   type: integer
   default: 3551
+poll_interval:
+  description: The number of seconds between polling apcupsd.
+  required: false
+  type: integer
+  default: 60
 {% endconfiguration %}
 
 <div class='note'>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

New documentation for feature addition in [PR #35688](https://github.com/home-assistant/core/pull/35688).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [PR #35688](https://github.com/home-assistant/core/pull/35688)
- This PR fixes or closes issue: [#15383](https://github.com/home-assistant/core/issues/15383)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards