### PR TITLE
Fixed wrong PWM frequency variable name

### DIFF
--- a/source/_integrations/rpi_gpio_pwm.markdown
+++ b/source/_integrations/rpi_gpio_pwm.markdown
@@ -49,7 +49,7 @@ leds:
       description: The type of LED. Choose either `rgb`, `rgbw` or `simple`.
       required: true
       type: string
-    freq:
+    frequency:
       description: The PWM frequency.
       required: false
       default: 200


### PR DESCRIPTION
## Proposed change
Replaced `freq` with `frequency` in the configuration variables list.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Correct variable name in pigpio Daemon PWM LED source:
https://github.com/home-assistant/core/blob/aaf515ef674f363529ebb27237d69ba74bb175d8/homeassistant/components/rpi_gpio_pwm/light.py#L32

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
