### PR TITLE
Updating and correction example to avoid warnings in HA log

### DIFF
--- a/source/_integrations/climate.mysensors.markdown
+++ b/source/_integrations/climate.mysensors.markdown
@@ -41,15 +41,77 @@ For more information, visit the [serial API](https://www.mysensors.org/download)
 ## Example sketch for MySensors 2.x
 
 ```cpp
-/*
-* Documentation: https://www.mysensors.org
-* Support Forum: https://forum.mysensors.org
-*/
+/**
+ * The MySensors Arduino library handles the wireless radio link and protocol
+ * between your home built sensors/actuators and HA controller of choice.
+ * The sensors forms a self healing radio network with optional repeaters. Each
+ * repeater and gateway builds a routing tables in EEPROM which keeps track of the
+ * network topology allowing messages to be routed to nodes.
+ *
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2015 Sensnology AB
+ * Full contributor list: https://github.com/mysensors/Arduino/graphs/contributors
+ *
+ * Documentation: http://www.mysensors.org
+ * Support Forum: http://forum.mysensors.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ *******************************
+ *
+ * REVISION HISTORY
+ * Version 1.0 - Toni A - https://github.com/ToniA/arduino-heatpumpir
+ * Version 2.1 - Author unknown - example script from the Home Assistant website : https://www.home-assistant.io/integrations/climate.mysensors
+ * Version 2.2 - Eric Van Bocxlaer - based on the example script from the Home Assistant website : https://www.home-assistant.io/integrations/climate.mysensors
+ *                                 - https://community.home-assistant.io/t/mysensors-hvac-not-showing-up/22540
+ * Version 2.3 - Eric Van Bocxlaer - correction states send back to home assistant, is expecting text values and not numeric values                               
+ * 
+ * DESCRIPTION
+ * Heatpump controller
+ */
 
-#define MY_RADIO_NRF24
-#define CHILD_ID_HVAC 0
+// Enable debug prints to serial monitor
+//#define MY_DEBUG
+// Enable specific RFM69 debug prints to serial monitor
+//#define MY_DEBUG_VERBOSE_RFM69
 
-#include <MySensors.h>
+#define MY_NODE_ID 3  // set the node ID manually because a MQTT gateway will not assign automatically a node Id - this must be set before the mysensors.h call
+
+// Enable and select radio type attached. Replace the defines if you use other radio type hardware.
+#define MY_RADIO_RFM69
+#define MY_RFM69_FREQUENCY RFM69_868MHZ // Set your frequency here
+#define MY_IS_RFM69HW // Omit if your RFM is not "H"
+#define MY_RFM69_NEW_DRIVER  // soft spi for rfm69 radio works only with new driver
+
+//enable radio communication encryption
+// more information can be found on https://forum.mysensors.org/topic/10382/security-signing-messages-and-encryption-of-messages-a-guide-or-more-a-summary-of-my-tests?_=1588348189475
+//#define MY_ENCRYPTION_SIMPLE_PASSWD "your16bitpassword"
+//enable simple signing
+//#define MY_SIGNING_SIMPLE_PASSWD "your32bitpassword"
+//#define MY_SIGNING_SIMPLE_PASSWD "your16bitpassword"
+//enable simple signing and encryption
+//#define MY_SECURITY_SIMPLE_PASSWORD "your16bitpassword"
+//enable simple signing and encryption
+#define MY_SECURITY_SIMPLE_PASSWORD "your32bitpassword"
+//enable soft signing
+//#define MY_SIGNING_SOFT
+//#define MY_SIGNING_REQUEST_SIGNATURES
+//#define MY_SIGNING_SOFT_RANDOMSEED_PIN A0 
+// following hex codes are dummy hex codes, replace by your hexcodes (see the link above how to generate)
+//#define MY_SIGNING_NODE_WHITELISTING {{.nodeId = 0,.serial = {0x99,0x88,0x77,0x66,0x55,0x44,0x33,0x22,0x11}},{.nodeId = 1,.serial = {0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99}}}
+
+#include <MySensors.h> // sketch tested with version 2.3.2, see http://librarymanager/all#MySensors
+
+#define SENSOR_NAME "Heatpump Sensor"
+#define SENSOR_VERSION "2.3"
+
+#define CHILD_ID_HVAC 0 // Each radio node can report data for up to 254 different child sensors. You are free to choose the child id yourself. 
+                        // You should avoid using child-id 255 because it is used for things like sending in battery level and other (protocol internal) node specific information.
+                        
+#define IR_PIN  3  // Arduino pin tied to the IR led using Arduino PWM
+
 
 // Uncomment your heatpump model
 //#include <FujitsuHeatpumpIR.h>
@@ -58,11 +120,11 @@ For more information, visit the [serial API](https://www.mysensors.org/download)
 //#include <CarrierHeatpumpIR.h>
 //#include <MideaHeatpumpIR.h>
 //#include <MitsubishiHeatpumpIR.h>
-//#include <SamsungHeatpumpIR.h>
+//#include <SamsungHeatpumpIR.h> // sketch tested with version 1.0.15, see http://librarymanager#HeatpumpIR by Toni Arte
 //#include <SharpHeatpumpIR.h>
 //#include <DaikinHeatpumpIR.h>
 
-//Some global variables to hold the states
+//Some global variables to hold the numeric states sent to the airco unit
 int POWER_STATE;
 int TEMP_STATE;
 int FAN_STATE;
@@ -70,11 +132,15 @@ int MODE_STATE;
 int VDIR_STATE;
 int HDIR_STATE;
 
-IRSenderPWM irSender(3);       // IR led on Arduino digital pin 3, using Arduino PWM
+//Some global variables to hold the text states sent to the home assistant controller
+String FAN_STATE_TXT;  // possible values ("Min", "Normal", "Max", "Auto")
+String MODE_STATE_TXT; // possible values ("Off", "HeatOn", "CoolOn", or "AutoChangeOver")
 
-//Change to your Heatpump
-HeatpumpIR *heatpumpIR = new PanasonicNKEHeatpumpIR();
 
+IRSenderPWM irSender(IR_PIN);
+
+//Change to your own Heatpump
+//HeatpumpIR *heatpumpIR = new SamsungAQV12MSANHeatpumpIR();
 /*
 new PanasonicDKEHeatpumpIR()
 new PanasonicJKEHeatpumpIR()
@@ -84,7 +150,9 @@ new MideaHeatpumpIR()
 new FujitsuHeatpumpIR()
 new MitsubishiFDHeatpumpIR()
 new MitsubishiFEHeatpumpIR()
-new SamsungHeatpumpIR()
+new SamsungAQVHeatpumpIR()
+new SamsungFJMHeatpumpIR()
+// new SamsungHeatpumpIR() is a protected generic method, cannot be created directly
 new SharpHeatpumpIR()
 new DaikinHeatpumpIR()
 */
@@ -96,7 +164,10 @@ MyMessage msgHVACFlowState(CHILD_ID_HVAC, V_HVAC_FLOW_STATE);
 bool initialValueSent = false;
 
 void presentation() {
-  sendSketchInfo("Heatpump", "2.1");
+  // Send the sketch version information to the gateway and Controller
+  sendSketchInfo(SENSOR_NAME, SENSOR_VERSION);
+
+  // Register all sensors to gw (they will be created as child devices) by their ID and S_TYPE
   present(CHILD_ID_HVAC, S_HVAC, "Thermostat");
 }
 
@@ -106,9 +177,13 @@ void setup() {
 void loop() {
   // put your main code here, to run repeatedly:
   if (!initialValueSent) {
-    send(msgHVACSetPointC.set(20));
-    send(msgHVACSpeed.set("Auto"));
-    send(msgHVACFlowState.set("Off"));
+    FAN_STATE_TXT = "Auto"; // default fan start state
+    TEMP_STATE = 20; // default start temperature
+    MODE_STATE_TXT = "Off"; // default mode state
+    
+    send(msgHVACSetPointC.set(TEMP_STATE));
+    send(msgHVACSpeed.set(FAN_STATE_TXT.c_str()));
+    send(msgHVACFlowState.set(MODE_STATE_TXT.c_str()));
 
     initialValueSent = true;
   }
@@ -136,6 +211,7 @@ void receive(const MyMessage &message) {
       else if(recvData.equalsIgnoreCase("min")) FAN_STATE = 1;
       else if(recvData.equalsIgnoreCase("normal")) FAN_STATE = 2;
       else if(recvData.equalsIgnoreCase("max")) FAN_STATE = 3;
+      FAN_STATE_TXT = recvData;        
     break;
 
     case V_HVAC_SETPOINT_COOL:
@@ -161,6 +237,7 @@ void receive(const MyMessage &message) {
       else if (recvData.equalsIgnoreCase("off")){
         POWER_STATE = 0;
       }
+      MODE_STATE_TXT = recvData;
       break;
   }
   sendHeatpumpCommand();
@@ -168,12 +245,19 @@ void receive(const MyMessage &message) {
 }
 
 void sendNewStateToGateway() {
+  Serial.println("Status update send to HA:");
+  Serial.println("*************************");
+  Serial.println("Mode = " + MODE_STATE_TXT + "(" + (String)MODE_STATE + ")");
+  Serial.println("Fan = " + FAN_STATE_TXT + "(" + (String)FAN_STATE + ")");
+  Serial.println("Temp = " + (String)TEMP_STATE);
+  send(msgHVACFlowState.set(MODE_STATE_TXT.c_str()));
+  send(msgHVACSpeed.set(FAN_STATE_TXT.c_str()));
   send(msgHVACSetPointC.set(TEMP_STATE));
-  send(msgHVACSpeed.set(FAN_STATE));
-  send(msgHVACFlowState.set(MODE_STATE));
 }
 
 void sendHeatpumpCommand() {
+  Serial.println("Heatpump commands send to airco:");
+  Serial.println("********************************");
   Serial.println("Power = " + (String)POWER_STATE);
   Serial.println("Mode = " + (String)MODE_STATE);
   Serial.println("Fan = " + (String)FAN_STATE);

--- a/source/_integrations/climate.mysensors.markdown
+++ b/source/_integrations/climate.mysensors.markdown
@@ -39,7 +39,7 @@ You can use V_TEMP to send the current temperature from the node to Home Assista
 For more information, visit the [serial API](https://www.mysensors.org/download) of MySensors.
 
 ## Example sketch for MySensors 2.x
-
+{% raw %}
 ```cpp
 /**
  * The MySensors Arduino library handles the wireless radio link and protocol
@@ -266,6 +266,7 @@ void sendHeatpumpCommand() {
   heatpumpIR->send(irSender, POWER_STATE, MODE_STATE, FAN_STATE, TEMP_STATE, VDIR_AUTO, HDIR_AUTO);
 }
 ```
+{% endraw %}
 
 ## Example sketch for MySensors 1.x
 


### PR DESCRIPTION
Updating and correction of example to avoid warnings in HA log about incorrect payload in data object.

## Proposed change
An updated and corrected example for the MySensors lib 2.x

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ x] Removed stale or deprecated documentation.

## Additional information

## Checklist
- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
