### PR TITLE
Document the 'androidtv.learn_sendevent' service

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -265,13 +265,17 @@ You can also use the command `GET_PROPERTIES` to retrieve the properties used by
 
 A list of various intents can be found [here](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304).
 
-#### Faster ADB commands
+### `androidtv.learn_sendevent` (for faster ADB commands)
 
-When sending commands like UP, DOWN, HOME, etc. via ADB, the device can be slow to respond. The problem isn't ADB, but rather the Android command `input` that is used to perform those actions. A faster way to send these commands is using the Android `sendevent` command. The challenge is that these commands are device-specific. To assist users in learning commands for their device, the `androidtv.adb_command` service provides a custom target: `LEARN_SENDEVENT`. Its usage is as follows:
+When sending commands like UP, DOWN, HOME, etc. via ADB, the device can be slow to respond. The problem isn't ADB, but rather the Android command `input` that is used to perform those actions. A faster way to send these commands is using the Android `sendevent` command. The challenge is that these commands are device-specific. To assist users in learning commands for their device, the Android TV integration provides the `androidtv.learn_sendevent` service. Its usage is as follows:
 
-1. Call the `androidtv.adb_command` service with the parameter `command: LEARN_SENDEVENT`. 
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id`            |       no | Name(s) of Android TV / Fire TV entities.
+
+1. Call the `androidtv.learn_sendevent` service. 
 2. Within 8 seconds, hit a single button on your Android TV / Fire TV remote. 
-3. After 8 seconds, check the `adb_response` attribute of the media player in Home Assistant. This will be the equivalent command that can be sent via the `androidtv.adb_command` service. 
+3. After 8 seconds, check the `adb_response` attribute of the media player in Home Assistant. This will be the equivalent command that can be sent via the `androidtv.adb_command` service. It will also be logged at the INFO level.
 
 As an example, a service call in a [script](/docs/scripts) could be changed from this:
 

--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -265,6 +265,34 @@ You can also use the command `GET_PROPERTIES` to retrieve the properties used by
 
 A list of various intents can be found [here](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304).
 
+#### Faster ADB commands
+
+When sending commands like UP, DOWN, HOME, etc. via ADB, the device can be slow to respond. The problem isn't ADB, but rather the Android command `input` that is used to perform those actions. A faster way to send these commands is using the Android `sendevent` command. The challenge is that these commands are device-specific. To assist users in learning commands for their device, the `androidtv.adb_command` service provides a custom target: `LEARN_SENDEVENT`. Its usage is as follows:
+
+1. Call the `androidtv.adb_command` service with the parameter `command: LEARN_SENDEVENT`. 
+2. Within 8 seconds, hit a single button on your Android TV / Fire TV remote. 
+3. After 8 seconds, check the `adb_response` attribute of the media player in Home Assistant. This will be the equivalent command that can be sent via the `androidtv.adb_command` service. 
+
+As an example, a service call in a [script](/docs/scripts) could be changed from this:
+
+```yaml
+# Send the "UP" command (slow)
+- service: androidtv.adb_command
+  data:
+    entity_id: media_player.fire_tv_living_room
+    command: UP
+```
+
+to this:
+
+```yaml
+# Send the "UP" command using `sendevent` (faster)
+- service: androidtv.adb_command
+  data:
+    entity_id: media_player.fire_tv_living_room
+    command: "sendevent /dev/input/event4 4 4 786979 && sendevent /dev/input/event4 1 172 1 && sendevent /dev/input/event4 0 0 0 && sendevent /dev/input/event4 4 4 786979 && sendevent /dev/input/event4 1 172 0 && sendevent /dev/input/event4 0 0 0"
+```
+
 ### `androidtv.download` and `androidtv.upload`
 
 You can use the `androidtv.download` service to download a file from your Android TV / Fire TV device to your Home Assistant instance. 

--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -275,7 +275,7 @@ When sending commands like UP, DOWN, HOME, etc. via ADB, the device can be slow 
 
 1. Call the `androidtv.learn_sendevent` service. 
 2. Within 8 seconds, hit a single button on your Android TV / Fire TV remote. 
-3. After 8 seconds, check the `adb_response` attribute of the media player in Home Assistant. This will be the equivalent command that can be sent via the `androidtv.adb_command` service. It will also be logged at the INFO level.
+3. After 8 seconds, a persistent notification will appear that contains the equivalent command that can be sent via the `androidtv.adb_command` service. This command can also be found in the `adb_response` attribute of the media player in Home Assistant, and it will be logged at the INFO level.
 
 As an example, a service call in a [script](/docs/scripts) could be changed from this:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the `LEARN_SENDEVENT` target for the `androidtv.adb_command` service. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35707
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
