### PR TITLE
Update REST API URL

### DIFF
--- a/source/_redirects
+++ b/source/_redirects
@@ -72,7 +72,7 @@
 /developers/platform_example_sensor https://github.com/home-assistant/example-custom-config/tree/master/custom_components/example_sensor
 /developers/python_api https://developers.home-assistant.io/docs/en/external_api_rest_python.html
 /developers/releasing https://developers.home-assistant.io/docs/en/releasing.html
-/developers/rest_api https://developers.home-assistant.io/docs/en/external_api_rest.html
+/developers/rest_api https://developers.home-assistant.io/docs/api/rest.html
 /developers/server_sent_events https://developers.home-assistant.io/docs/en/external_api_server_sent_events.html
 /developers/websocket_api https://developers.home-assistant.io/docs/en/external_api_websocket.html
 


### PR DESCRIPTION
## Proposed change
Changes the `/developers/rest_api` redirect to redirect to `https://developers.home-assistant.io/docs/api/rest.html` instead of `https://developers.home-assistant.io/docs/en/external_api_rest.html`, which currently redirects to a 404.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
This update affects links found on the following pages:
- [source/_integrations/api.markdown](https://github.com/home-assistant/home-assistant.io/tree/current/source/_integrations/api.markdown)
- [source/_integrations/generic_ip_camera.markdown](https://github.com/home-assistant/home-assistant.io/tree/current/source/_integrations/generic_ip_camera.markdown)
- [source/_integrations/history.markdown](https://github.com/home-assistant/home-assistant.io/tree/current/source/_integrations/history.markdown)
- [source/_integrations/http.markdown](https://github.com/home-assistant/home-assistant.io/tree/current/source/_integrations/http.markdown)
- [source/_integrations/rest.markdown](https://github.com/home-assistant/home-assistant.io/tree/current/source/_integrations/rest.markdown)
- [source/_posts/2016-04-07-static-website.markdown](https://github.com/home-assistant/home-assistant.io/tree/current/source/_posts/2016-04-07-static-website.markdown)
- [source/_posts/2016-06-08-super-fast-web-enocean-lirc.markdown](https://github.com/home-assistant/home-assistant.io/tree/current/source/_posts/2016-06-08-super-fast-web-enocean-lirc.markdown)
- [source/_posts/2016-07-28-esp8266-and-micropython-part1.markdown](https://github.com/home-assistant/home-assistant.io/tree/current/source/_posts/2016-07-28-esp8266-and-micropython-part1.markdown)

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards](https://developers.home-assistant.io/docs/documenting/standards).