### PR TITLE
Update URL fragment in Generic IP Camera Integration documentation

### DIFF
--- a/source/_integrations/generic_ip_camera.markdown
+++ b/source/_integrations/generic_ip_camera.markdown
@@ -106,7 +106,7 @@ camera:
 
 ### Sharing a camera feed from one Home Assistant instance to another
 
-If you are running more than one Home Assistant instance (let's call them the 'host' and 'receiver' instances) you may wish to display the camera feed from the host instance on the receiver instance. You can use the [REST API](/developers/rest_api/#get-apicamera_proxycameraentity_id) to access the camera feed on the host (IP address 127.0.0.5) and display it on the receiver instance by configuring the receiver with the following:
+If you are running more than one Home Assistant instance (let's call them the 'host' and 'receiver' instances) you may wish to display the camera feed from the host instance on the receiver instance. You can use the [REST API](https://developers.home-assistant.io/docs/api/rest/#get-apicamera_proxycameraentity_id) to access the camera feed on the host (IP address 127.0.0.5) and display it on the receiver instance by configuring the receiver with the following:
 
 ```yaml
 camera:

--- a/source/_integrations/generic_ip_camera.markdown
+++ b/source/_integrations/generic_ip_camera.markdown
@@ -106,7 +106,7 @@ camera:
 
 ### Sharing a camera feed from one Home Assistant instance to another
 
-If you are running more than one Home Assistant instance (let's call them the 'host' and 'receiver' instances) you may wish to display the camera feed from the host instance on the receiver instance. You can use the [REST API](/developers/rest_api/#get-apicamera_proxycameraltentity_id) to access the camera feed on the host (IP address 127.0.0.5) and display it on the receiver instance by configuring the receiver with the following:
+If you are running more than one Home Assistant instance (let's call them the 'host' and 'receiver' instances) you may wish to display the camera feed from the host instance on the receiver instance. You can use the [REST API](/developers/rest_api/#get-apicamera_proxycameraentity_id) to access the camera feed on the host (IP address 127.0.0.5) and display it on the receiver instance by configuring the receiver with the following:
 
 ```yaml
 camera:


### PR DESCRIPTION
## Proposed change
This change proposes to update the URL fragment in Generic IP Camera Integration documentation. The URL will be changed from [/developers/rest_api/#get-apicamera_proxycameraltentity_id](https://home-assistant.io/developers/rest_api/#get-apicamera_proxycameraltentity_id) to [/developers/rest_api/#get-apicamera_proxycameraentity_id](https://home-assistant.io/developers/rest_api/#get-apicamera_proxycameraentity_id). This pull request depends on #13469 as once that pull request is accepted, the URL will redirect to the correct location. Without that, the URL still points to a 404.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
