### PR TITLE
Update addon_development link found in Navigation Bar

### DIFF
--- a/source/_redirects
+++ b/source/_redirects
@@ -49,7 +49,7 @@
 /developers/frontend https://developers.home-assistant.io/docs/en/frontend_index.html
 /developers/hassio/addon_communication https://developers.home-assistant.io/docs/en/hassio_addon_communication.html
 /developers/hassio/addon_config https://developers.home-assistant.io/docs/en/hassio_addon_config.html
-/developers/hassio/addon_development https://developers.home-assistant.io/docs/en/hassio_addon_index.html
+/developers/hassio/addon_development https://developers.home-assistant.io/docs/add-ons.html
 /developers/hassio/addon_presentation https://developers.home-assistant.io/docs/en/hassio_addon_presentation.html
 /developers/hassio/addon_publishing https://developers.home-assistant.io/docs/en/hassio_addon_publishing.html
 /developers/hassio/addon_repository https://developers.home-assistant.io/docs/en/hassio_addon_repository.html


### PR DESCRIPTION
## Proposed change
Update the addon_development URL redirect that is found in the [navigation bar file](https://github.com/home-assistant/home-assistant.io/blob/current/source/_includes/asides/hassio_navigation.html#L25).

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Fixes link found in the sidebar of the following pages:
- https://www.home-assistant.io/hassio/installation/
- https://www.home-assistant.io/hassio/
- https://www.home-assistant.io/addons/
- https://www.home-assistant.io/hassio/installation/
- https://www.home-assistant.io/hassio/installing_third_party_addons/
- https://www.home-assistant.io/hassio/commandline/
- https://www.home-assistant.io/hassio/zwave/
- https://www.home-assistant.io/hassio/enable_i2c/
## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
