### PR TITLE
Update lovelace-custom-cards URL

### DIFF
--- a/source/_includes/asides/lovelace_navigation.html
+++ b/source/_includes/asides/lovelace_navigation.html
@@ -18,7 +18,7 @@
       <li>{% active_link /lovelace/yaml-mode/ YAML mode %}</li>
       <li>{% active_link /lovelace/dashboards-and-views/ Dashboards & Views %}</li>
       <li>{% active_link /lovelace/actions/ Actions %}</li>
-      <li><a href='https://developers.home-assistant.io/docs/en/lovelace_custom_card.html'>Developing Custom Cards <i icon='icon-external-link'></i></a></li>
+      <li><a href='https://developers.home-assistant.io/docs/frontend/custom-ui/lovelace-custom-card.html'>Developing Custom Cards <i icon='icon-external-link'></i></a></li>
     </ul>
   </div>
 

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -385,7 +385,7 @@ style:
 {% endconfiguration %}
 
 The process for creating and referencing custom elements is the same as for custom cards.
-Please see the [developer documentation](https://developers.home-assistant.io/docs/en/lovelace_custom_card.html)
+Please see the [developer documentation](https://developers.home-assistant.io/docs/frontend/custom-ui/lovelace-custom-card.html)
 for more information.
 
 ## How to use the style object


### PR DESCRIPTION
## Proposed change
Update the lovelace-custom-cards URL found on multiple pages from https://developers.home-assistant.io/docs/en/lovelace_custom_card.html to https://developers.home-assistant.io/docs/frontend/custom-ui/lovelace-custom-card.html

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
