### PR TITLE
Update python_api redirect URL

### DIFF
--- a/source/_redirects
+++ b/source/_redirects
@@ -70,7 +70,7 @@
 /developers/multiple_instances https://developers.home-assistant.io
 /developers/platform_example_light https://github.com/home-assistant/example-custom-config/tree/master/custom_components/example_light
 /developers/platform_example_sensor https://github.com/home-assistant/example-custom-config/tree/master/custom_components/example_sensor
-/developers/python_api https://developers.home-assistant.io/docs/en/external_api_rest_python.html
+/developers/python_api https://developers.home-assistant.io/docs/api_lib_index.html
 /developers/releasing https://developers.home-assistant.io/docs/en/releasing.html
 /developers/rest_api https://developers.home-assistant.io/docs/api/rest.html
 /developers/server_sent_events https://developers.home-assistant.io/docs/en/external_api_server_sent_events.html


### PR DESCRIPTION
## Proposed change
Update `/developers/python_api` to redirect to https://developers.home-assistant.io/docs/api_lib_index.html instead of https://developers.home-assistant.io/docs/en/external_api_rest_python.html. I am unsure if this new URL is the equivalent URL as the old one, or if an equivalent link is available. This link may need to be removed altogether if an equivalent link doesn't exist.


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
