### PR TITLE
Adding GoControl HUSBZB-1 stick to Z-Wave docs

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -15,6 +15,7 @@ There have [been reports](https://www.raspberrypi.org/forums/viewtopic.php?f=28&
 
 - Aeotec Z-Stick Series 5
 - Everspring USB stick - Gen 5
+- GoControl HUSBZB-1 stick
 - Sigma Designs UZB stick
 - Vision USB stick - Gen5
 - Zooz Z-Wave Plus S2 stick ZST10


### PR DESCRIPTION
## Proposed change

Adding GoControl HUSBZB-1 stick to Z-Wave docs

Closes #13376 

## Type of change
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
