### PR TITLE
Update REST API URL to use the redirect on MQTT Notifications Cookbook page

### DIFF
--- a/source/_cookbook/notify.mqtt.markdown
+++ b/source/_cookbook/notify.mqtt.markdown
@@ -31,7 +31,7 @@ The same will work for automations.
 
 ### REST API
 
-Using the [REST API](/developers/rest_api) to send a message to a given topic.
+Using the [REST API](https://developers.home-assistant.io/docs/api/rest/ to send a message to a given topic.
 
 ```bash
 $ curl -X POST \

--- a/source/_cookbook/notify.mqtt.markdown
+++ b/source/_cookbook/notify.mqtt.markdown
@@ -31,7 +31,7 @@ The same will work for automations.
 
 ### REST API
 
-Using the [REST API](https://developers.home-assistant.io/docs/en/external_api_rest.html) to send a message to a given topic.
+Using the [REST API](/developers/rest_api) to send a message to a given topic.
 
 ```bash
 $ curl -X POST \


### PR DESCRIPTION
## Proposed change
Updates the REST API URL on the [MQTT Notifications Cookbook page](https://www.home-assistant.io/cookbook/notify.mqtt/) to be the REST API redirect URL, `/developers/rest_api`. The only link points to a 404.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
