### PR TITLE
Remove /developers/api redirect as it no longer exists

### DIFF
--- a/source/_includes/asides/docs_navigation.html
+++ b/source/_includes/asides/docs_navigation.html
@@ -110,7 +110,7 @@
         <ul>
           <li>{% active_link /docs/backend/database/ Database %}</li>
           <li>{% active_link /docs/backend/updater/ Updater %}</li>
-          <li>{% active_link /developers/api/ API %}</li>
+          <li>{% active_link /developers/rest_api API %}</li>
         </ul>
       </li>
       <li>

--- a/source/_redirects
+++ b/source/_redirects
@@ -7,7 +7,6 @@
 # Older development pages
 /developers https://developers.home-assistant.io
 /developers/add_new_platform https://developers.home-assistant.io/docs/en/creating_platform_index.html
-/developers/api https://developers.home-assistant.io/docs/en/external_api_rest.html
 /developers/architecture_components https://developers.home-assistant.io/docs/en/architecture_components.html
 /developers/architecture https://developers.home-assistant.io/docs/en/architecture_index.html
 /developers/asyncio_101 https://developers.home-assistant.io/docs/en/asyncio_101.html


### PR DESCRIPTION
## Proposed change
This change proposes to remove the `/developers/api` redirect. The link would forward to https://developers.home-assistant.io/docs/en/external_api_rest.html, which no longer exists. This redirect was only found to be used in the [docs_navigation file](https://github.com/home-assistant/home-assistant.io/blob/72ddc2b7c005a736d8d6dbd8e74f8923cb5a9597/source/_includes/asides/docs_navigation.html#L113), so I replaced it with the `/developers/rest_api` redirect instead.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
