### PR TITLE
Add alt text to "Deploys by Netlify" badge in footer

### DIFF
--- a/source/_includes/site/footer.html
+++ b/source/_includes/site/footer.html
@@ -30,7 +30,7 @@
           <a href='https://github.com/coogie/oscailte'>Oscalite theme</a>.<br />
           <br />
           <a href="https://www.netlify.com">
-            <img src="/images/frontpage/netlify.svg"/>
+            <img src="/images/frontpage/netlify.svg" alt="Deploys by Netlify Badge"/>
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Proposed change
Adds the proper alt text to the "Deploys by Netlify" badge in the site footer. This is a web accessibility feature recommended by [Google's Lighthouse Auditing tool](https://web.dev/image-alt/?utm_source=lighthouse&utm_medium=devtools).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
