### PR TITLE
Add AlarmDecoder alt_night_mode and Arming Key Sequences documentation

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -83,7 +83,7 @@ panel_display:
   default: false
   type: boolean
 autobypass:
-  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending '6#'). This will require your code to be entered even if `code_arm_required` is set to `false`."
+  description: "If this is set to `true`, then when arming (home or away), it will automatically bypass all open zones (sending `6#`). This will require your code to be entered even if `code_arm_required` is set to `false`."
   required: false
   default: false
   type: boolean
@@ -91,6 +91,11 @@ code_arm_required:
   description: "If this is set to `false`, you will not need to enter your code to arm the system."
   required: false
   default: true
+  type: boolean
+alt_night_mode:
+  description: "For Honeywell systems, setting this option to `true` enables *Night-Stay* mode instead of *Instant* mode for night arming. For DSC systems, setting this option to `true` enables *No-Entry* mode instead of *Stay* mode for night arming. For both systems, whenever this option is set to `true`, a code will be required for night arming **regardless of the `code_arm_required` setting.** See [Arming Key Sequences](#arming-key-sequences) section below for more information."
+  required: false
+  default: false
   type: boolean
 zones:
   description: "AlarmDecoder has no way to tell us which zones are actually in use, so each zone must be configured in Home Assistant. For each zone, at least a name must be given. For more information on the available zone types, take a look at the [Binary Sensor](/integrations/alarmdecoder) documentation. *Note: If no zones are specified, Home Assistant will not load any binary_sensor integrations.*"
@@ -138,6 +143,7 @@ There are several attributes available on the alarm panel to give you more infor
 - `ready`: Set to `true` if your system is ready to be armed. Any faults, including motions sensors, will make this value `false`.
 - `zone_bypassed`: Set to `true` if your system is currently bypassing a zone.
 - `code_arm_required`: Set to the value specified in your configuration.
+- `panel_brand`: Set to `honeywell` or `dsc` depending on the brand of your alarm panel.
 
 ## Services
 
@@ -185,3 +191,53 @@ Using a combination of the available services and attributes, you can create swi
           {% endif %}
 ```
 {% endraw %}
+
+## Arming Key Sequences
+
+The tables below show the key press sequences used for arming for the different panel brands and configuration setting combinations.
+
+### Honeywell
+
+#### code_arm_required = true (default)
+
+| Mode                                                    | Key Sequence                |
+| ------------------------------------------------------- | --------------------------- |
+| `alarm_arm_home`                                        | `code` + `3`                |
+| `alarm_arm_away`                                        | `code` + `2`                |
+| `alarm_arm_night` (`alt_night_mode` = `false`, default) | `code` + `7`                |
+| `alarm_arm_night` (`alt_night_mode` = `true`)           | `code` + `33`               |
+
+#### code_arm_required = false
+
+| Mode                                                    | Key Sequence                |
+| ------------------------------------------------------- | --------------------------- |
+| `alarm_arm_home`                                        | `#3`                        |
+| `alarm_arm_away`                                        | `#2`                        |
+| `alarm_arm_night` (`alt_night_mode` = `false`, default) | `#7`                        |
+| `alarm_arm_night` (`alt_night_mode` = `true`)           | `code` + `33`               |
+
+### DSC
+
+#### code_arm_required = true (default)
+
+| Mode                                                    | Key Sequence                |
+| ------------------------------------------------------- | --------------------------- |
+| `alarm_arm_home`                                        | `code`                      |
+| `alarm_arm_away`                                        | `code`                      |
+| `alarm_arm_night` (`alt_night_mode` = `false`, default) | `code`                      |
+| `alarm_arm_night` (`alt_night_mode` = `true`)           | `*9` + `code`               |
+
+#### code_arm_required = false
+
+<div class='note'>
+
+The `chr(4)` and `chr(5)` sequences below are equivalent to pressing the <em>Stay</em> and <em>Away</em> keypad keys respectively (as outlined in the <a href='http://www.alarmdecoder.com/wiki/index.php/Protocol#Special_Keys'>AlarmDecoder docs</a>).
+
+</div>
+
+| Mode                                                    | Key Sequence                    |
+| ------------------------------------------------------- | ------------------------------- |
+| `alarm_arm_home`                                        | `chr(4)` + `chr(4)` + `chr(4)`  |
+| `alarm_arm_away`                                        | `chr(5)` + `chr(5)` + `chr(5)`  |
+| `alarm_arm_night` (`alt_night_mode` = `false`, default) | `chr(4)` + `chr(4)` + `chr(4)`  |
+| `alarm_arm_night` (`alt_night_mode` = `true`)           | `*9` + `code`                   |

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -151,8 +151,8 @@ The Alarm Decoder integration gives you access to several services for you to co
 
 - `alarm_arm_away`: Arms the alarm in away mode; all faults will trigger the alarm.
 - `alarm_arm_home`: Arms the alarm in stay mode; faults to the doors or windows will trigger the alarm.
-- `alarm_arm_night`: Arms the alarm in instant mode; all faults will trigger the alarm. Additionally, the entry delay is turned off on the doors.
-- `alarm_disarm`: Disarms the alarm from any state. Also clears a `check_zone` flag after an alarm was triggered.
+- `alarm_arm_night`: Arms the alarm according to the `alt_night_mode` configuration setting.
+- `alarm_disarm`: Disarms the alarm from any state.
 - `alarmdecoder.alarm_keypress`: Sends a string of characters to the alarm, as if you had touched those keys on a keypad.
 - `alarmdecoder.alarm_toggle_chime`: Toggles the alarm's chime state.
 

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -231,7 +231,7 @@ The tables below show the key press sequences used for arming for the different 
 
 <div class='note'>
 
-The `chr(4)` and `chr(5)` sequences below are equivalent to pressing the <em>Stay</em> and <em>Away</em> keypad keys respectively (as outlined in the <a href='http://www.alarmdecoder.com/wiki/index.php/Protocol#Special_Keys'>AlarmDecoder docs</a>).
+The `chr(4)` and `chr(5)` sequences below are equivalent to pressing the <em>Stay</em> and <em>Away</em> keypad keys respectively (as outlined in the <a href='http://www.alarmdecoder.com/wiki/index.php/Protocol#Special_Keys'>AlarmDecoder documentation</a>).
 
 </div>
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR contains 2 changes related to https://github.com/home-assistant/core/pull/35761:

- First, it documents the new `alt_night_mode` configuration setting . `alt_night_mode` lets Honeywell users opt-in to using _Night-Stay_ mode instead of _Instant_ mode and lets DSC users opt-in to using _No-Entry_ mode instead of _Stay_ mode for night arming.

- Second, it documents the arm keypresses that are used with the various alarm panel brands and configuration settings. Between the alarm panel brand and `code_arm_required` and `alt_night_mode` settings, I thought a table displaying the keypresses would help users determine their ideal configuration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/35761
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
