### PR TITLE
Update broadlink.markdown

### DIFF
--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -363,11 +363,6 @@ timeout:
   description: Timeout in seconds for the connection to the device.
   required: false
   type: integer
-retry:
-  description: Retry times for fetch data if failed.
-  required: false
-  type: integer
-  default: 2
 friendly_name:
   description: The name used to display the switch in the frontend.
   required: false

--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -430,7 +430,6 @@ switch:
     host: 192.168.1.2
     mac: 'B4:43:0D:CC:0F:58'
     timeout: 15
-    retry: 5
     switches:
       # Will work on most Phillips TVs:
       tv_phillips:
@@ -478,7 +477,6 @@ switch:
     host: IP_ADDRESS
     mac: 'MAC_ADDRESS'
     type:  sp2
-    retry: 5
     friendly_name: 'Humidifier'
 ```
 


### PR DESCRIPTION
```
retry
  (integer)(Optional)
  Retry times for fetch data if failed.
  Default value:
  2
```
Is no longer a valid config, docs are not updated to reflect this change in 0.110.0

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
