### PR TITLE
Added IGMP no response information

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -586,7 +586,7 @@ If you have any iOS 12.x devices signed into your iCloud account, media player e
 
 #### Accessories are all listed as not responding
 
-There are some reports where the IGMP settings of a router were causing issues. With the wrong IGMP settings all accessories will stop responding a few minutes after Home Assistant (re)started. To solve this, turn off your router IGMP settings: **IGMP Proxy**, **IGMP Snooping** and **IGMP Fast Leave**.
+There are reports where the IGMP settings in a router were causing issues with HomeKit. This resulted in a situation where all of the Home Assistant HomeKit accessories stopped responding a few minutes after Home Assistant (re)started. Double check your router's IGPM settings if you experiencing this issue. The default IGMP settings typically work best.
 
 See [specific entity doesn't work](#specific-entity-doesnt-work)
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -596,6 +596,8 @@ See [resetting accessories](#resetting-accessories)
 
 Unfortunately, that sometimes happens at the moment. It might help to close the `Home` App and delete it from the cache. Usually, the accessory should get back to responding after a few minutes at most.
 
+There are reports where the IGMP settings of a router were causing issues. See [HomeKit - No Response](https://community.home-assistant.io/t/homekit-no-response-solved/170981) and [HomeKit “No Response”](https://community.home-assistant.io/t/homekit-no-response/170974) for more information.
+
 #### The linked battery sensor isn't recognized
 
 Try removing the entity from HomeKit and then adding it again. If you are adding this configuration option to an existing entity in HomeKit, any changes you make to this entity's configuration options won't appear until the accessory is removed from HomeKit and then re-added. See [resetting accessories](#resetting-accessories).

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -586,6 +586,8 @@ If you have any iOS 12.x devices signed into your iCloud account, media player e
 
 #### Accessories are all listed as not responding
 
+There are some reports where the IGMP settings of a router were causing issues. With the wrong IGMP settings all accessories will stop responding a few minutes after Home Assistant (re)started. To solve this, turn off your router IGMP settings: **IGMP Proxy**, **IGMP Snooping** and **IGMP Fast Leave**.
+
 See [specific entity doesn't work](#specific-entity-doesnt-work)
 
 #### Accessory not responding - after restart or update
@@ -595,8 +597,6 @@ See [resetting accessories](#resetting-accessories)
 #### Accessory not responding - randomly
 
 Unfortunately, that sometimes happens at the moment. It might help to close the `Home` App and delete it from the cache. Usually, the accessory should get back to responding after a few minutes at most.
-
-There are reports where the IGMP settings of a router were causing issues. See [HomeKit - No Response](https://community.home-assistant.io/t/homekit-no-response-solved/170981) and [HomeKit “No Response”](https://community.home-assistant.io/t/homekit-no-response/170974) for more information.
 
 #### The linked battery sensor isn't recognized
 


### PR DESCRIPTION
I had an issue in the past where my router was blocking IGMP which resulted in an unstable HomeKit connection with Home Assistant (HomeKit: No Response). It took me days to found the solution. After I shared the solution on the forum I noticed others were helped too. So I think it is useful to put it in the documentation.

Ps. I could not find anything about if it is allowed to link to the forum in the documentation standards.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
