### PR TITLE
Cleanup ecobee documentation

### DIFF
--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -103,37 +103,17 @@ To use notifications, please see the [getting started with automation page](/get
 
 The ecobee thermostat supports the following key concepts.
 
-The _target temperature_ is the temperature that the device attempts
-to achieve. The target temperature is either determined by the
-currently active climate or it may be overridden by a hold. When the
-thermostat is not in auto mode, there is a single target
-temperature. When the thermostat is in auto HVAC mode, there is a
-pair of target temperatures: the lower target temperature determines
-the lowest desired temperature, while the higher target temperature
-determines the highest desired temperature (the thermostat will switch
-between heating and cooling to keep the temperature within these
-limits).
+The _target temperature_ is the temperature that the device attempts to achieve. The target temperature is either determined by the currently active climate or it may be overridden by a hold. When the
+thermostat is not in auto mode, there is a single target temperature. When the thermostat is in auto HVAC mode, there is a pair of target temperatures: the lower target temperature determines the lowest desired temperature, while the higher target temperature determines the highest desired temperature (the thermostat will switch between heating and cooling to keep the temperature within these limits).
 
-A _climate_ is a predefined or user-defined set of presets that the
-thermostat aims to achieve. The ecobee thermostat provides three predefined
-climates: Home, Away, and Sleep. Ecobee refers to these as _comfort settings_. The user can define additional climates.
+A _climate_ is a predefined or user-defined set of presets that the thermostat aims to achieve. The ecobee thermostat provides three predefined climates: Home, Away, and Sleep. Ecobee refers to these as _comfort settings_. The user can define additional climates.
 
-A _preset_ is an override of the target temperature defined in the
-currently active climate. The temperature targeted in the preset mode may be
-explicitly set (temperature preset), it may be derived from a reference
-climate (home, away, sleep, etc.), or it may be derived from a vacation
-defined by the thermostat. All holds are temporary. Temperature and
-climate holds expire when the thermostat transitions to the next climate
-defined in its program. A vacation hold starts at the beginning of the
+A _preset_ is an override of the target temperature defined in the currently active climate. The temperature targeted in the preset mode may be explicitly set (temperature preset), it may be derived from a reference climate (home, away, sleep, etc.), or it may be derived from a vacation defined by the thermostat. All holds are temporary. Temperature and climate holds expire when the thermostat transitions to the next climate defined in its program. A vacation hold starts at the beginning of the
 defined vacation period and expires when the vacation period ends.
 
-When in _away preset_, the target temperature is permanently overridden by
-the target temperature defined for the away climate. The away preset is a
-simple way to emulate a vacation mode.
+When in _away preset_, the target temperature is permanently overridden by the target temperature defined for the away climate. The away preset is a simple way to emulate a vacation mode.
 
-The _HVAC mode_ of the device is the currently active operational
-modes that the ecobee thermostat provides: heat, auxHeatOnly, cool,
-auto, and off.
+The _HVAC mode_ of the device is the currently active operational modes that the ecobee thermostat provides: heat, auxHeatOnly, cool, auto, and off.
 
 ## Attributes
 

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -72,15 +72,7 @@ api_key:
   <img src='{{site_root}}/images/screenshots/ecobee-thermostat-card.png' />
 </p>
 
-[Restart Home Assistant](/docs/configuration/#reloading-changes) for the changes to take effect. In the **Configuration** > **Integrations** menu, hit **Configure** next to the discovered `ecobee` entry, and continue to authorize the App per the Integration menu instructions above.
-
-The first time you (re)run Home Assistant with this integration it will give you a PIN code that you need to authorize in the [ecobee consumer portal](https://www.ecobee.com/consumerportal/index.html). You can do this by clicking **Add Application** in the **My Apps** section in the sidebar.
-
-The PIN can be found in the Home Assistant portal on the ecobee card or from the `configurator.ecobee` entity in the States developer tool.
-
-- If you do not have an ecobee card, you may be using groups with `default_view` that don't show the card. To get around this, you can temporarily comment out the `default_view` section or add the `configurator.ecobee` integration to your `default_view` and restart Home Assistant.
-
-Once you enter the PIN on the ecobee site, wait approximately 5 minutes, and then click on the **I have authorized the app** link at the bottom of the ecobee pop-up window. If everything worked correctly, you should now be able to restart Home Assistant again to see the full ecobee card with all of the sensors populated or see the list of sensors in the developer tools. Now you can re-enable your `default_view` (if you had to disable it) and add the ecobee sensors to a group and/or view.
+[Restart Home Assistant](/docs/configuration/#reloading-changes) for the changes to take effect. In the **Configuration** > **Integrations** menu, hit **Configure** next to the discovered `ecobee` entry, and continue to authorize the App per the Integration menu instructions above, starting at step 2.
 
 ## Notifications
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR removes obsolete instructions from the ecobee documentation - the paragraphs were applicable to the old configuration.yaml configuration method and became obsolete after ecobee was migrated to config entries (see https://github.com/home-assistant/core/pull/26634). 

This PR also cleans up unnecessary line breaks from one section of the documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
