### PR TITLE
Fixed version number for Xiaomi Gateway Alarm (Closes #13528)

### DIFF
--- a/source/_integrations/alarm_control_panel.xiaomi_miio.markdown
+++ b/source/_integrations/alarm_control_panel.xiaomi_miio.markdown
@@ -5,7 +5,7 @@ logo: xiaomi.png
 ha_category:
   - Alarm
 ha_iot_class: Local Polling
-ha_release: 0.110
+ha_release: '0.110'
 ha_domain: xiaomi_miio
 ---
 


### PR DESCRIPTION
## Proposed change
The version number was showing up as 0.11 instead of 0.110. Fixed the release number for this specific component. 



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
