### PR TITLE
Clarify Update on Docker HA Core install

### DIFF
--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -24,7 +24,7 @@ Do not try to combine Docker `restart` policies with host-level process managers
 
 </div>
 
-Add `--restart=always` to your `docker run` command before homeassistant/home-assistant:stable. See [the Docker autostart docs](https://docs.docker.com/config/containers/start-containers-automatically/) for details and more options.
+Add `--restart=always` to your `docker run` command before homeassistant/home-assistant:stable. See [the Docker autostart documentation](https://docs.docker.com/config/containers/start-containers-automatically/) for details and more options.
 
 ### Linux
 

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -33,6 +33,7 @@ docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v 
 ```
 
 Updating:
+
 ```bash
 docker pull homeassistant/home-assistant:stable  # if this returns "Image is up to date" then you can stop here
 docker stop home-assistant  # stop the running container

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -38,7 +38,7 @@ Updating:
 docker pull homeassistant/home-assistant:stable  # if this returns "Image is up to date" then you can stop here
 docker stop home-assistant  # stop the running container
 docker rm home-assistant  # remove it from Docker's list of containers
-docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant:stable  # finally, start a new one
+docker run -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant:stable  # finally, start a new one
 ```
 
 ### Raspberry Pi 3 (Raspberry Pi OS)

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -19,7 +19,21 @@ Installation with Docker is straightforward. Adjust the following command so tha
 ### Linux
 
 ```bash
-docker run --init -d --name="home-assistant" -e "TZ=America/New_York" -v /PATH_TO_YOUR_CONFIG:/config --net=host homeassistant/home-assistant:stable
+docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant:stable
+```
+
+Updating:
+```bash
+docker pull homeassistant/home-assistant:stable  # if this returns "Image is up to date" then you can stop here
+docker stop home-assistant  # stop the running container
+docker rm home-assistant  # remove it from Docker's list of containers
+docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant:stable  # finally, start a new one
+```
+If you are running your Home Assistant Core Docker as an autostarted service, then you should use the relevant commands to stop it, for example for systemd:
+```bash
+docker pull homeassistant/home-assistant:stable
+systemctl stop home-assistant@USERNAME
+systemctl start home-assistant@USERNAME
 ```
 
 ### Raspberry Pi 3 (Raspberry Pi OS)

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -16,6 +16,16 @@ Note that Docker command line option `--net=host` or the compose file equivalent
 
 Installation with Docker is straightforward. Adjust the following command so that `/PATH_TO_YOUR_CONFIG` points at the folder where you want to store your configuration and run it:
 
+## Autostart using Docker
+
+<div class='note warning'>
+
+Do not try to combine Docker `restart` policies with host-level process managers (such as `systemd`), because this creates conflicts.
+
+</div>
+
+Add `--restart=always` to your `docker run` command before homeassistant/home-assistant:stable. See [the Docker autostart docs](https://docs.docker.com/config/containers/start-containers-automatically/) for details and more options.
+
 ### Linux
 
 ```bash
@@ -28,12 +38,6 @@ docker pull homeassistant/home-assistant:stable  # if this returns "Image is up 
 docker stop home-assistant  # stop the running container
 docker rm home-assistant  # remove it from Docker's list of containers
 docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant:stable  # finally, start a new one
-```
-If you are running your Home Assistant Core Docker as an autostarted service, then you should use the relevant commands to stop it, for example for systemd:
-```bash
-docker pull homeassistant/home-assistant:stable
-systemctl stop home-assistant@USERNAME
-systemctl start home-assistant@USERNAME
 ```
 
 ### Raspberry Pi 3 (Raspberry Pi OS)

--- a/source/_docs/installation/docker.markdown
+++ b/source/_docs/installation/docker.markdown
@@ -29,7 +29,7 @@ Add `--restart=always` to your `docker run` command before homeassistant/home-as
 ### Linux
 
 ```bash
-docker run --init -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant:stable
+docker run -d --name="home-assistant" -v /PATH_TO_YOUR_CONFIG:/config -v /etc/localtime:/etc/localtime:ro --net=host homeassistant/home-assistant:stable
 ```
 
 Updating:


### PR DESCRIPTION
## Proposed change
I could not find any clear instructions in the docs on how to update a Docker install of Home Assistant Core. It seems to be recommended over a virtualenv install, but there are no instructions on how to update your install, and even a conflicting run command between the systemd service file and the install docs.
I want to save others the hassle of figuring this out.
If I put anything in a wrong place, or if what I figured out is incorrect, please tell me. I do believe this information should be in the documentation.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
1. I consolidated the docker run command between Docker install and Docker systemd pages. Both now use `homeassistant/home-assistant:stable`
2. I added timezone binding (`/etc/localtime`). I am not sure if this is recommended, but it works for my install. Please confirm?
3. I added instructions on how to update a Docker install in the Docker installation page. Just like the update information is included in the virtualenv install page. I put it under Linux since I am not sure who this would work on other platforms. Maybe this should be structured differently?
4. I added the update procedure for HA Core running in a Docker as a systemd service  on the same page as well, to demonstrate that whether you are running HA as a service impacts the way you should stop and start it and that the update script is not universal. Do you agree with my placement of the info in the update info instead of in the systemd page?

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
