### PR TITLE
http - base_url basic config docs

### DIFF
--- a/source/_posts/2020-05-20-release-110.markdown
+++ b/source/_posts/2020-05-20-release-110.markdown
@@ -463,7 +463,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 
 - **HTTP** - `base_url` is deprecated and replaced by an `internal_url` and
   `external_url` core configuration setting. -
-  ([@frenck] - [#35224]) ([config docs]) ([http docs])
+  ([@frenck] - [#35224]) ([basic config docs]) ([http docs])
 
 - **Kodi** - Kodi previously reported the media content type for all PVR
   channels as "channel", no matter if it was a TV or a radio channel.
@@ -1513,6 +1513,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [automatic docs]: /integrations/automatic/
 [automation docs]: /integrations/automation/
 [axis docs]: /integrations/axis/
+[basic config docs]: /docs/configuration/basic/
 [blebox docs]: /integrations/blebox/
 [blink docs]: /integrations/blink/
 [bluetooth_le_tracker docs]: /integrations/bluetooth_le_tracker/


### PR DESCRIPTION
updating config docs to point to basic config docs that includes external_url & internal_url

## Proposed change
<!-- 
breaking change of base_url information is in basic config docs. not config.
Previous links were to 2 places base_url or external_url & internal_url were not mentioned.

Assume someone will validate to ensure link is correct now
-->

## Type of change
<!--
Update location
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
