### PR TITLE
Update ubus.markdown

### DIFF
--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -21,7 +21,7 @@ For OpenWrt version 18.06.x the package uhttpd-mod-ubus should also be installed
 opkg install uhttpd-mod-ubus
 ```
 
-And create a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/user.json`.
+And create on your OpenWRT device a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/user.json`.
 
 ```json
 {
@@ -38,7 +38,7 @@ And create a read-only user to be used by setting up the ACL file `/usr/share/rp
 }
 ```
 
-Restart the services.
+Restart the services. This ACL file needs to be recreated after updating/upgrading your OpenWRT firmware. 
 
 ```bash
 # /etc/init.d/rpcd restart && /etc/init.d/uhttpd restart

--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -21,7 +21,7 @@ For OpenWrt version 18.06.x the package uhttpd-mod-ubus should also be installed
 opkg install uhttpd-mod-ubus
 ```
 
-And create on your OpenWRT device a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/user.json`.
+And create on your OpenWrt device a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/user.json`.
 
 ```json
 {
@@ -38,7 +38,7 @@ And create on your OpenWRT device a read-only user to be used by setting up the 
 }
 ```
 
-Restart the services. This ACL file needs to be recreated after updating/upgrading your OpenWRT firmware. 
+Restart the services. This ACL file needs to be recreated after updating/upgrading your OpenWrt firmware. 
 
 ```bash
 # /etc/init.d/rpcd restart && /etc/init.d/uhttpd restart


### PR DESCRIPTION
Made more clear that the ACL file should be created on the OpenWRT device and not on the HA. For many experienced users this is evident but for a beginner it's more clear.
After updating Openwrt the ACL file will be deleted. If you do not know this it can take hours to find out why the integration is not working anymore, so I added this to the page.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
