### PR TITLE
Update influxdb.markdown with measurement_attr option

### DIFF
--- a/source/_integrations/influxdb.markdown
+++ b/source/_integrations/influxdb.markdown
@@ -104,7 +104,7 @@ precision:
   default: ns
 measurement_attr:
   type: string
-  description: State object attribute to use as measurement name. Possible values: `unit_of_measurement` (default), `domain`, `entity_id`
+  description: "State object attribute to use as measurement name. Possible values: `unit_of_measurement`, `domain` or `entity_id`."
   required: false
   default: unit_of_measurement
 default_measurement:

--- a/source/_integrations/influxdb.markdown
+++ b/source/_integrations/influxdb.markdown
@@ -104,7 +104,7 @@ precision:
   default: ns
 measurement_attr:
   type: string
-  description: "State object attribute to use as measurement name. Possible values: `unit_of_measurement`, `domain` or `entity_id`."
+  description: "State object attribute(s) to use as measurement name. Possible values: `unit_of_measurement`, `domain__device_class` or `entity_id`."
   required: false
   default: unit_of_measurement
 default_measurement:

--- a/source/_integrations/influxdb.markdown
+++ b/source/_integrations/influxdb.markdown
@@ -102,14 +102,19 @@ precision:
   description: Set this to specify the time precision sent to influxdb. Setting a coarser precision allows InfluxDb to compress your data better. If not set, defaults to ns.
   required: false
   default: ns
+measurement_attr:
+  type: string
+  description: State object attribute to use as measurement name. Possible values: `unit_of_measurement` (default), `domain`, `entity_id`
+  required: false
+  default: unit_of_measurement
 default_measurement:
   type: string
-  description: Measurement name to use when an entity doesn't have a unit. 
+  description: Measurement name to use when the measurement_attr state attribute does not exist, e.g. when an entity doesn't have a unit. 
   required: false
   default: uses the entity id of the entity
 override_measurement:
   type: string
-  description: Measurement name to use instead of a unit or default measurement. This will store all data points in a single measurement.
+  description: Measurement name to use instead of measurement_attr or default measurement. This will store all data points in a single measurement.
   required: false
 exclude:
   type: list


### PR DESCRIPTION
Documentation for the new measurement_attr option.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
PR home-assistant/core#36020 introduces a new config option to select InfluxDB measurement names based on State object attributes.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#36020
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
