### PR TITLE
Add notifications to Keba EV chargers

### DIFF
--- a/source/_integrations/keba.markdown
+++ b/source/_integrations/keba.markdown
@@ -123,6 +123,7 @@ The service `keba.set_failsafe` sets the failsafe mode of the charging station. 
 ### Show Text on Display `keba.set_text``
 
 The service `keba.set_text` shows the submitted text on the display of chargers with built-in LED display. `min_time` is the minimum time in seconds the text will be shown if another message is requested. `max_time` is the maximum time to display the message when nothing else is requested. A maximum of 23 characters can be shown. Horizontal scroll is performed autiomatically when needed. Payload example:
+
 ```json
 {
   "text": "Hello!",

--- a/source/_integrations/keba.markdown
+++ b/source/_integrations/keba.markdown
@@ -5,6 +5,7 @@ ha_category:
   - Binary Sensor
   - Lock
   - Sensor
+  - Notifications
 ha_release: 0.98
 ha_codeowners:
   - '@dannerph'
@@ -120,15 +121,42 @@ The service `keba.set_failsafe` sets the failsafe mode of the charging station. 
 }
 ```
 
-### Show Text on Display `keba.set_text``
+## Notifications
 
-The service `keba.set_text` shows the submitted text on the display of chargers with built-in LED display. `min_time` is the minimum time in seconds the text will be shown if another message is requested. `max_time` is the maximum time to display the message when nothing else is requested. A maximum of 23 characters can be shown. Horizontal scroll is performed autiomatically when needed. Payload example:
+Some Keba chargers are equipped with a LED text display. The notification platform may be used to display text on this display. To enable this, add the following to your `configuration.yaml` file:
+
+### Configuration
+
+```yaml
+# Example configuration.yaml entry
+notify:
+  - name: NOTIFIER_NAME
+    platform: keba
+```
+
+{% configuration %}
+name:
+  description: Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
+  required: false
+  default: "`notify`"
+  type: string
+{% endconfiguration %}
+
+### Usage
+
+The use of the notify service is [described here](/integrations/notify/).
+
+The `message` part of the event payload is shown on the display. Scrolling is performed if needed. A maximum of 23 characters can be shown.
+
+The optional `data` part may contain specifications of the message duration. `min_time` is the minimum time in seconds the text will be shown if another message is requested. `max_time` is the maximum time to display the message when nothing else is requested. By default the message is shown minimum 2 seconds and maximum 10 seconds.
 
 ```json
 {
-  "text": "Hello!",
-  "min_time": 2,
-  "max_time": 10
+  "message": "Welcome home!",
+  "data": {
+    "min_time": 4,
+    "max_time": 20
+  }
 }
 ```
 

--- a/source/_integrations/keba.markdown
+++ b/source/_integrations/keba.markdown
@@ -19,7 +19,8 @@ This component provides the following platforms:
 - Binary Sensors: Online state, plug state, Charging state and failsafe mode state.
 - Lock: Authorization (like with the RFID card).
 - Sensors: current set by the user, target energy set by the user, charging power, charged energy of the current session and total energy charged.
-- Services: authorize, deauthorize, set energy target, set maximum allowed current, show text and manually update the states. More details can be found [here](/integrations/keba/#services).
+- Services: authorize, deauthorize, set energy target, set the maximum allowed current and manually update the states. More details can be found [here](/integrations/keba/#services).
+- Notify: Show a text on chargers with a built-in LED display.
 
 ## Configuration
 
@@ -148,16 +149,13 @@ The use of the notify service is [described here](/integrations/notify/).
 
 The `message` part of the event payload is shown on the display. Scrolling is performed if needed. A maximum of 23 characters can be shown.
 
-The optional `data` part may contain specifications of the message duration. `min_time` is the minimum time in seconds the text will be shown if another message is requested. `max_time` is the maximum time to display the message when nothing else is requested. By default the message is shown minimum 2 seconds and maximum 10 seconds.
+The optional `data` part may contain specifications of the message duration. `min_time` is the minimum time in seconds the text will be shown if another message is requested. `max_time` is the maximum time to display the message when nothing else is requested. By default, the message is shown a minimum of 2 seconds and a maximum of 10 seconds.
 
-```json
-{
-  "message": "Welcome home!",
-  "data": {
-    "min_time": 4,
-    "max_time": 20
-  }
-}
+```yaml
+message: "Welcome home"
+data:
+  min_time: 4
+  max_time: 10
 ```
 
 ## Disclaimer

--- a/source/_integrations/keba.markdown
+++ b/source/_integrations/keba.markdown
@@ -18,7 +18,7 @@ This component provides the following platforms:
 - Binary Sensors: Online state, plug state, Charging state and failsafe mode state.
 - Lock: Authorization (like with the RFID card).
 - Sensors: current set by the user, target energy set by the user, charging power, charged energy of the current session and total energy charged.
-- Services: authorize, deauthorize, set energy target, set maximum allowed current and manually update the states. More details can be found [here](/integrations/keba/#services).
+- Services: authorize, deauthorize, set energy target, set maximum allowed current, show text and manually update the states. More details can be found [here](/integrations/keba/#services).
 
 ## Configuration
 
@@ -117,6 +117,17 @@ The service `keba.set_failsafe` sets the failsafe mode of the charging station. 
   "failsafe_timeout": 30,
   "failsafe_fallback": 6,
   "failsafe_persist": 0
+}
+```
+
+### Show Text on Display `keba.set_text``
+
+The service `keba.set_text` shows the submitted text on the display of chargers with built-in LED display. `min_time` is the minimum time in seconds the text will be shown if another message is requested. `max_time` is the maximum time to display the message when nothing else is requested. A maximum of 23 characters can be shown. Horizontal scroll is performed autiomatically when needed. Payload example:
+```json
+{
+  "text": "Hello!",
+  "min_time": 2,
+  "max_time": 10
 }
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for new service that adds the possibility to display text messages on the display of Keba EV chargers. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [https://github.com/home-assistant/core/pull/36056](https://github.com/home-assistant/core/pull/36056)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
