### PR TITLE
Update ozw.markdown with link to OpenZwave addon in the supervisor

### DIFF
--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -19,7 +19,7 @@ This integration allows you to utilize OpenZWave's ozwdaemon to control a Z-Wave
 
 - MQTT server and the [MQTT integration](/integrations/mqtt/) set up in Home Assistant.
 - The [ozwdaemon](https://github.com/OpenZWave/qt-openzwave) installed and running in your network.
-  For Home Assistant Supervisor there's a [custom add-on](https://github.com/marcelveldt/hassio-addons-repo/tree/master/ozwdaemon).
+  For Home Assistant Supervisor there's a custom add-on [OpenZwave](https://github.com/home-assistant/hassio-addons/tree/master/zwave).
 - Supported Z-Wave dongle compatible with OpenZWave 1.6. See this [list](/docs/z-wave/controllers/#supported-z-wave-usb-sticks--hardware-modules) of controllers. The Z-Wave controller dongle should be connected to the same host as where the ozwdaemon is running.
 
 ## Configuration


### PR DESCRIPTION
Updated the link to the supervisor OpenZwave addon.

## Proposed change
Point to the OpenZWave addon for home assistant supervisor instead of the old add-on from another repo




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
The old link could be used together with the HACS Z-Wave over MQTT (Pre-Release) addon, and not OpenZwave (beta) integration.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
