### PR TITLE
Added time_format, trim_leading_zero

### DIFF
--- a/source/_integrations/worldclock.markdown
+++ b/source/_integrations/worldclock.markdown
@@ -34,6 +34,16 @@ name:
   required: false
   type: string
   default: Worldclock Sensor
+time_format:
+  description: The time format.
+  required: false
+  type: string
+  default: "%H:%M"
+trim_leading_zero:
+  description: Remove leading zeros, e.g. 9:30 PM instead of 09:30 PM
+  required: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 For valid time zones check the **TZ** column in the [Wikipedia overview](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). Or get the full list from the [pytz](https://pypi.python.org/pypi/pytz) module.

--- a/source/_integrations/worldclock.markdown
+++ b/source/_integrations/worldclock.markdown
@@ -39,11 +39,6 @@ time_format:
   required: false
   type: string
   default: "%H:%M"
-trim_leading_zero:
-  description: Remove leading zeros, e.g. 9:30 PM instead of 09:30 PM
-  required: false
-  type: boolean
-  default: false
 {% endconfiguration %}
 
 For valid time zones check the **TZ** column in the [Wikipedia overview](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). Or get the full list from the [pytz](https://pypi.python.org/pypi/pytz) module.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The [WorldClock ](https://www.home-assistant.io/integrations/worldclock/) sensor generates time in the fixed "%H:%M" format. This PR addes the capability to define a custom format.

- Allow defining custom format instead of the default  "%H:%M"
- Allow removing leading zeros e.g. 9:30 PM instead of 09:30 PM

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36157
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
