### PR TITLE
Fix telegram_bot callback samples

### DIFF
--- a/source/_integrations/telegram_bot.markdown
+++ b/source/_integrations/telegram_bot.markdown
@@ -351,7 +351,7 @@ Message editor:
         message: >
           Callback received from {{ trigger.event.data.from_first }}.
           Message id: {{ trigger.event.data.message.message_id }}.
-          Data: {{ trigger.event.data.data | replace("_", "\_") }}
+          Data: {{ trigger.event.data.data|replace("_", "\_") }}
 ```
 
 {% endraw %}

--- a/source/_integrations/telegram_bot.markdown
+++ b/source/_integrations/telegram_bot.markdown
@@ -318,7 +318,7 @@ Text repeater:
         disable_notification: true
         inline_keyboard:
           - "Edit message:/edit_msg, Don't:/do_nothing"
-          - "Remove this button:/remove button"
+          - "Remove this button:/remove_button"
 ```
 
 {% endraw %}
@@ -347,11 +347,11 @@ Message editor:
         title: '*Message edit*'
         inline_keyboard:
           - "Edit message:/edit_msg, Don't:/do_nothing"
-          - "Remove this button:/remove button"
+          - "Remove this button:/remove_button"
         message: >
           Callback received from {{ trigger.event.data.from_first }}.
           Message id: {{ trigger.event.data.message.message_id }}.
-          Data: {{ trigger.event.data.data }}
+          Data: {{ trigger.event.data.data | replace("_", "\_") }}
 ```
 
 {% endraw %}
@@ -366,7 +366,7 @@ Keyboard editor:
     platform: event
     event_type: telegram_callback
     event_data:
-      command: '/remove button'
+      command: '/remove_button'
   action:
     - service: telegram_bot.answer_callback_query
       data_template:


### PR DESCRIPTION
Fix some of the callback button samples:
"Remove this button" button - the space in the command caused the trigger to never fire
"Edit message" button - The value coming back in trigger.event.data.data is "/edit_msg" which, when then trying to send that value back to telegram in the message body, is being treated as markup. It causes the error "Error editing text message: Can't parse entities: can't find end of the entity starting at byte offset […]" and the edit never happens.

NB: I'm not sure if including the replace() is overly confusing. It might be better to just rename the /edit_msg command to /edit to avoid needing to understand what's happening in the template. It could also be explained in the text describing the sample, but it again just feels off-topic.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
