### PR TITLE
Example of multiple !include files for integration

### DIFF
--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -84,7 +84,44 @@ switch: !include switch.yaml
 device_tracker: !include device_tracker.yaml
 ```
 
-Note that there can only be one `!include:` for each integration so chaining them isn't going to work. If that sounds like Greek, don't worry about it.
+Nesting `!include`s (having an `!include` within a file that is itself `!include`d) isn't going to work. You can, however, have multiple top-level `!include`s for a given integration, if you give a different label to each one:
+
+```yaml
+light:
+- platform: group
+  name: Bedside Lights
+  entities:
+    - light.left_bedside_light
+    - light.right_bedside_light
+
+# define more light groups in a separate file
+light groups: !include light-groups.yaml
+
+# define some light switch mappings in a different file
+light switches: !include light-switches.yaml
+```
+
+where `light-groups.yaml` might look like:
+
+```yaml
+- platform: group
+  name: Outside Lights
+  entities:
+    - light.porch_lights
+    - light.patio_lights
+ ```
+
+with `light-switches.yaml` containing:
+
+```yaml
+- platform: switch
+  name: Patio Lights
+  entity_id: switch.patio_lights
+  
+- platform: switch
+  name: Floor Lamp
+  entity_id: switch.floor_lamp_plug
+```
 
 Alright, so we've got the single integrations and the include statements in the base file, what goes in those extra files?
 


### PR DESCRIPTION
For integrations that might have a large number of configured elements (`light`, `sensor`, `automation`) it can be nice to split them across multiple files. This PR adds an example of doing so, and corrects some wording that might lead people to believe it's not possible!

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
