### PR TITLE
Update roku.markdown for Roku async update

### DIFF
--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -93,7 +93,16 @@ data:
 
 ## Media Player
 
-When the Home Assistant Roku integration is enabled and a Roku device has been configured, in the Home Assistant UI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will attempt to launch the channel on your Roku device. This action can also be automated, but it requires you to acquire an extra piece of information; the ```appID``` for the channel specific to your Roku. Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
+When the Home Assistant Roku integration is enabled and a Roku device has been configured, in the Home Assistant UI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will attempt to launch the channel on your Roku device. This action can also be automated. Beginning with Home Assistant Core 0.110, channels can be launched by ```name``` or ```appID``` (in an automation, for example) using a configuration similar to the one below:
+```yaml
+action:
+- data:
+    entity_id: media_player.roku
+    source: "Amazon Prime"
+  service: media_player.select_source
+```
+
+Prior to Home Assistant Core 0.110, only the ```appID``` for the channel specific to your Roku can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
 
 The API calls are like this:
 
@@ -105,9 +114,9 @@ YouTube example:
 POST http://YOUR_ROKU_IP:8060/launch/837?contentID=YOUR_YOUTUBE_VIDEOS_CONTENT_ID&MediaType=live
 ```
 
-More details can be found on the [Roku dev pages](https://developer.roku.com/docs/developer-program/discovery/external-control-api.md)
+More details can be found on the [Roku dev pages](https://developer.roku.com/docs/developer-program/debugging/external-control-api.md)
 
-To use this in Home Assistant, for instance in an automation, the format is as follows. Note that `source:` is the appID you discovered in the API call:
+To use this in Home Assistant, the format is as follows. Note that `source:` is the appID you discovered in the API call:
 
 ```yaml
 action:

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -102,7 +102,7 @@ action:
   service: media_player.select_source
 ```
 
-Alternatively, the ```appID``` for the channel can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end-user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
+Alternatively, the ```appID``` for the channel can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end-user. This item might be added in a future release. For now, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
 
 The API calls are like this:
 

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -93,7 +93,7 @@ data:
 
 ## Media Player
 
-When the Home Assistant Roku integration is enabled and a Roku device has been configured, in the Home Assistant UI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will attempt to launch the channel on your Roku device. This action can also be automated. Channels can be launched by ```name``` using a configuration similar to the one below:
+When the Home Assistant Roku integration is enabled and a Roku device has been configured, in the Home Assistant UI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will attempt to launch the channel on your Roku device. This action can also be automated. Channels can be launched by `name` using a configuration similar to the one below:
 ```yaml
 action:
 - data:
@@ -102,7 +102,7 @@ action:
   service: media_player.select_source
 ```
 
-Alternatively, the ```appID``` for the channel can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end-user. This item might be added in a future release. For now, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
+Alternatively, the `appID` for the channel can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end-user. This item might be added in a future release. For now, you can easily get the information yourself. All you need to do is a GET API call on the same network as your device.
 
 The API calls are like this:
 
@@ -114,7 +114,7 @@ YouTube example:
 POST http://YOUR_ROKU_IP:8060/launch/837?contentID=YOUR_YOUTUBE_VIDEOS_CONTENT_ID&MediaType=live
 ```
 
-The simplest method of performing the GET request is to open `http://ROKU_IP:8060/query/apps` in your web browser of choice. The Roku will return an XML-formatted list of available channels, including their full name and appID. 
+One method of performing the GET request is to open `http://ROKU_IP:8060/query/apps` in your web browser of choice. The Roku will return an XML-formatted list of available channels, including their full name and appID. 
 
 More details can be found on the [Roku dev pages](https://developer.roku.com/docs/developer-program/debugging/external-control-api.md)
 

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -93,7 +93,7 @@ data:
 
 ## Media Player
 
-When the Home Assistant Roku integration is enabled and a Roku device has been configured, in the Home Assistant UI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will attempt to launch the channel on your Roku device. This action can also be automated. Beginning with Home Assistant Core 0.110, channels can be launched by ```name``` or ```appID``` (in an automation, for example) using a configuration similar to the one below:
+When the Home Assistant Roku integration is enabled and a Roku device has been configured, in the Home Assistant UI the Roku media player will show a listing of the installed channels, or apps, under “source”. Select one and it will attempt to launch the channel on your Roku device. This action can also be automated. Channels can be launched by ```name``` using a configuration similar to the one below:
 ```yaml
 action:
 - data:
@@ -102,7 +102,7 @@ action:
   service: media_player.select_source
 ```
 
-Prior to Home Assistant Core 0.110, only the ```appID``` for the channel specific to your Roku can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
+Alternatively, the ```appID``` for the channel (specifc to your Roku) can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
 
 The API calls are like this:
 

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -98,7 +98,7 @@ When the Home Assistant Roku integration is enabled and a Roku device has been c
 action:
 - data:
     entity_id: media_player.roku
-    source: "Amazon Prime"
+    source: "Prime Video"
   service: media_player.select_source
 ```
 

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -102,21 +102,23 @@ action:
   service: media_player.select_source
 ```
 
-Alternatively, the ```appID``` for the channel (specifc to your Roku) can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
+Alternatively, the ```appID``` for the channel can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
 
 The API calls are like this:
 
 ```txt
-GET http:// ROKU_IP:8060/query/apps
+GET http://ROKU_IP:8060/query/apps
 POST http://ROKU_IP:8060/launch/APP_ID
 
 YouTube example:
 POST http://YOUR_ROKU_IP:8060/launch/837?contentID=YOUR_YOUTUBE_VIDEOS_CONTENT_ID&MediaType=live
 ```
 
+The simplest method of performing the GET request is to open `http://ROKU_IP:8060/query/apps` in your web browser of choice. The Roku will return an XML-formatted list of available channels, including their full name and appID. 
+
 More details can be found on the [Roku dev pages](https://developer.roku.com/docs/developer-program/debugging/external-control-api.md)
 
-To use this in Home Assistant, the format is as follows. Note that `source:` is the appID you discovered in the API call:
+To use this information in Home Assistant, the format is as follows. Note that `source:` is the appID you discovered in the API call:
 
 ```yaml
 action:

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -102,7 +102,7 @@ action:
   service: media_player.select_source
 ```
 
-Alternatively, the ```appID``` for the channel can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
+Alternatively, the ```appID``` for the channel can be used for `source:` Although this information is gathered by the Roku integration, at the moment it is not exposed to the end-user. This item might be added in a future release. For now though, you can easily get the information yourself. All you need to do is a simple GET API call on the same network as your device.
 
 The API calls are like this:
 


### PR DESCRIPTION
## Proposed change
Starting with PR #35104 for the Roku component, the code now supports using the Roku channel name in addition to the appID. Additionally, the link to the Roku dev documentation has changed. This updates the documentation to address those items.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: #35104
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
