### PR TITLE
Amendment for plugwise platform update

### DIFF
--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -20,10 +20,13 @@ The platform supports [Anna](https://www.plugwise.com/en_US/products/anna), [Ada
 
 Platforms available - depending on your Smile and setup are include:
 
- - `binary_sensor`
- - `climate`
- - `light`
- - `sensor`
+ - `climate` (for the Anna and Lisa products)
+ - `sensor` (for all relevant products including the Smile P1)
+
+Coming soon (not available yet):
+
+ - `binary_sensor` (for domestic hot water and secondary heater)
+ - `switch` (for plugs)
 
 The password can be found on the bottom of your Smile, it should consist of 6 characters. To find your IP address use the Plugwise App: 
 
@@ -134,7 +137,8 @@ Adam (zone_control):
  - v3.0
  - v2.3
 
- - Devices supported are Floor, Koen, Lisa, Plug and Tom - note a Koen always comes with a plug (the active part)
+ - Devices supported are Floor, Lisa, nd Tom 
+ - Koen and Plug support coming soon - note a Koen always comes with a plug (the active part) 
 
 Anna (thermostat):
 


### PR DESCRIPTION
## Proposed change
As two of our PRs are still to be filed (i.e. `binary_sensor` and `switch`) the documentation should reflect this. I wrote it down as todo in one of the child PRs, but we pinged ok for merge and it slipped my mind while fetching tea :(

For those rightfully wondering: the statements in the documentation are still correct, Anna support continues (though breaking as per config_flow instead of yaml) and Adam and P1 users able to use this. The upcoming PRs handle 'plugs' (i.e. `switch`es within a climate environment) and domestic how water and secondary heater `binary_sensor`s. 

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: #12738
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
