### PR TITLE
Add config reloaded events for automation and scene

### DIFF
--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -6,9 +6,10 @@ redirect_from: /topics/events/
 
 The core of Home Assistant is the event bus. The event bus allows any integration to fire or listen for events. It is the core of everything. For example, any state change will be announced on the event bus as a `state_changed` event containing the previous and the new state of an entity.
 
-Home Assistant contains a few built-in events that are used to coordinate between various components.
+Home Assistant contains a few built-in events that are used to coordinate between various integrations.
 
-### Event `state_changed`
+## Event `state_changed`
+
 Event `state_changed` is fired when a state changes. Both `old_state` and `new_state` are state objects. [Documentation about state objects.](/topics/state_object/)
 
 | Field       | Description                                                                                         |
@@ -17,16 +18,16 @@ Event `state_changed` is fired when a state changes. Both `old_state` and `new_s
 | `old_state` | The previous state of the entity before it changed. This field is omitted if the entity is new.     |
 | `new_state` | The new state of the entity. This field is omitted if the entity is removed from the state machine. |
 
+## Event `time_changed`
 
-### Event `time_changed`
 Event `time_changed` is fired every second by the timer and contains the current time.
 
 | Field | Description                                                                                                                  |
 | ----- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `now` | A [datetime object](https://docs.python.org/3.4/library/datetime.html#datetime.datetime) containing the current time in UTC. |
 
+## Event `service_registered`
 
-### Event `service_registered`
 Event `service_registered` is fired when a new service has been registered within Home Assistant.
 
 | Field     | Description                              |
@@ -34,8 +35,8 @@ Event `service_registered` is fired when a new service has been registered withi
 | `domain`  | Domain of the service. Example: `light`. |
 | `service` | The service to call. Example: `turn_on`  |
 
+## Event `call_service`
 
-### Event `call_service`
 Event `call_service` is fired to call a service.
 
 | Field             | Description                                                                    |
@@ -45,14 +46,27 @@ Event `call_service` is fired to call a service.
 | `service_data`    | Dictionary with the service call parameters. Example: `{ 'brightness': 120 }`. |
 | `service_call_id` | String with a unique call id. Example: `23123-4`.                              |
 
-### Event `service_executed`
+## Event `service_executed`
+
 Event `service_executed` is fired by the service handler to indicate the service is done.
 
 | Field             | Description                                                                               |
 | ----------------- | ----------------------------------------------------------------------------------------- |
 | `service_call_id` | String with the unique call id of the service call that was executed. Example: `23123-4`. |
 
-### Event `platform_discovered`
+## Event `automation_reloaded`
+
+Event `automation_reloaded` is fired when automations have been reloaded and thus might have changed.
+
+This event has no addition data.
+
+## Event `scene_reloaded`
+
+Event `scene_reloaded` is fired when scenes have been reloaded and thus might have changed.
+
+This event has no addition data.
+
+## Event `platform_discovered`
 
 Event `platform_discovered` is fired when a new platform has been discovered by the [`discovery`](/integrations/discovery/) component.
 
@@ -61,8 +75,8 @@ Event `platform_discovered` is fired when a new platform has been discovered by 
 | `service`    | The platform that is discovered. Example: `zwave`.                                               |
 | `discovered` | Dictionary containing discovery information. Example: `{ "host": "192.168.1.10", "port": 8889}`. |
 
+## Event `component_loaded`
 
-### Event `component_loaded`
 Event `component_loaded` is fired when a new integration has been loaded and initialized.
 
 | Field       | Description                                                                 |

--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -58,13 +58,13 @@ Event `service_executed` is fired by the service handler to indicate the service
 
 Event `automation_reloaded` is fired when automations have been reloaded and thus might have changed.
 
-This event has no addition data.
+This event has no additional data.
 
 ## Event `scene_reloaded`
 
 Event `scene_reloaded` is fired when scenes have been reloaded and thus might have changed.
 
-This event has no addition data.
+This event has no additional data.
 
 ## Event `platform_discovered`
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for 2 new built-in events + some Markdown lint warning fixes.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34664
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
