### PR TITLE
Fix Pi-hole brand capitalisation

### DIFF
--- a/source/_integrations/pi_hole.markdown
+++ b/source/_integrations/pi_hole.markdown
@@ -35,7 +35,7 @@ name:
   description: >
     The name for this Pi-hole. This name will be a part of the sensors created, e.g.,  `name: My Awesome Pi-hole` would result in sensor names beginning with `sensor.my_awesome_pi_hole_`.
 
-    **Note:** If you configure multiple Pi-Holes, each one *must* have a unique name.
+    **Note:** If you configure multiple Pi-holes, each one *must* have a unique name.
   required: false
   type: string
   default: Pi-hole
@@ -45,13 +45,13 @@ location:
   type: string
   default: admin
 ssl:
-  description: "If `true`, use SSL/TLS to connect to the Pi-Hole system."
+  description: "If `true`, use SSL/TLS to connect to the Pi-hole system."
   required: false
   type: boolean
   default: false
 verify_ssl:
   description: >
-    Verify the SSL/TLS certificate of the system. If your Pi-Hole instance uses a self-signed certificate, you should specify `false`.
+    Verify the SSL/TLS certificate of the system. If your Pi-hole instance uses a self-signed certificate, you should specify `false`.
   required: false
   type: boolean
   default: true
@@ -77,7 +77,7 @@ Multiple Pi-holes:
 pi_hole:
   - host: '192.168.0.2'
   - host: '192.168.0.3'
-    name: 'Secondary Pi-Hole'
+    name: 'Secondary Pi-hole'
 ```
 
 Pi-hole with a self-signed certificate:


### PR DESCRIPTION
## Proposed change
N/A

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
