### PR TITLE
ONVIF device triggers and line crossed event

### DIFF
--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -43,6 +43,10 @@ This integration uses the ONVIF pullpoint subscription API to process events int
 
 To help with development of this component, enable `info` level logging for `homeassistant.components.onvif` and create an issue on GitHub for any messages that show _"No registered handler for event"_.
 
+<div class='note'>
+  Some ONVIF events are not able to be represented as Home Assistant entities. In those cases, "onvif_event" will be fired on the Home Assistant event bus. To determine what events are being fired, you can listen for "onvif_event" in "Developer Tools -> Events". If you use the Automation UI, these events will show up as Device Triggers for you to select from.
+</div>
+
 | Topic(s) | Entity Type | Device Class | Description |
 |----------|-------------|--------------|-------------|
 | `tns1:VideoSource/MotionAlarm` | Binary Sensor | Motion | Generic motion alarm. |
@@ -55,6 +59,7 @@ To help with development of this component, enable `info` level logging for `hom
 | `tns1:VideoSource/GlobalSceneChange/AnalyticsService`<br>`tns1:VideoSource/GlobalSceneChange/ImagingService`<br>`tns1:VideoSource/GlobalSceneChange/RecordingService` | Binary Sensor | Problem | Device reports a large portion of the video content changing.  The cause can be tamper actions like camera movement or coverage. |
 | `tns1:RuleEngine/TamperDetector/Tamper` | Binary Sensor | Problem | Tamper Detection. |
 | `tns1:Device/HardwareFailure/StorageFailure` | Binary Sensor | Problem | Storage failure on device. |
+| `tns1:RuleEngine/LineDetector/Crossed` | Event | N/A | Line crossing/Tripwire was triggered. |
 | `tns1:Monitoring/ProcessorUsage` | Sensor | Percent | Device processor usage. |
 | `tns1:Monitoring/OperatingTime/LastReboot` | Sensor | Timestamp | When the device was last rebooted. |
 | `tns1:Monitoring/OperatingTime/LastReset` | Sensor | Timestamp | When the device was last reset. |

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -44,7 +44,7 @@ This integration uses the ONVIF pullpoint subscription API to process events int
 To help with development of this component, enable `info` level logging for `homeassistant.components.onvif` and create an issue on GitHub for any messages that show _"No registered handler for event"_.
 
 <div class='note'>
-  Some ONVIF events are not able to be represented as Home Assistant entities. In those cases, "onvif_event" will be fired on the Home Assistant event bus. To determine what events are being fired, you can listen for "onvif_event" in "Developer Tools -> Events". If you use the Automation UI, these events will show up as Device Triggers for you to select from.
+  Some ONVIF events are not able to be represented as Home Assistant entities. In those cases, "onvif_event" will be fired on the Home Assistant event bus. To determine what events are being fired, you can listen for `onvif_event` in **Developer Tools** -> **Events**. If you use the Automation UI, these events will show up as Device Triggers for you to select from.
 </div>
 
 | Topic(s) | Entity Type | Device Class | Description |

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -44,7 +44,9 @@ This integration uses the ONVIF pullpoint subscription API to process events int
 To help with development of this component, enable `info` level logging for `homeassistant.components.onvif` and create an issue on GitHub for any messages that show _"No registered handler for event"_.
 
 <div class='note'>
-  Some ONVIF events are not able to be represented as Home Assistant entities. In those cases, "onvif_event" will be fired on the Home Assistant event bus. To determine what events are being fired, you can listen for `onvif_event` in **Developer Tools** -> **Events**. If you use the Automation UI, these events will show up as Device Triggers for you to select from.
+  
+Some ONVIF events are not able to be represented as Home Assistant entities. In those cases, "onvif_event" will be fired on the Home Assistant event bus. To determine what events are being fired, you can listen for `onvif_event` in **Developer Tools** -> **Events**. If you use the Automation UI, these events will show up as Device Triggers for you to select from.
+
 </div>
 
 | Topic(s) | Entity Type | Device Class | Description |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds documentation for functionality implemented in https://github.com/home-assistant/core/pull/36428 regarding device triggers and line crossed event handling.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36428
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
