### PR TITLE
cert_expiry docs for new CA option

### DIFF
--- a/source/_integrations/cert_expiry.markdown
+++ b/source/_integrations/cert_expiry.markdown
@@ -18,7 +18,7 @@ The `cert_expiry` integration fetches the certificate from a configured host and
 
 There are 2 options in configuring the `cert_expiry` sensor:
 
-- Via the Home Assistant user interface where it will let you enter a host and port for the certificate to check.
+- Via the Home Assistant user interface where it will let you enter a host, port and a custom CA for the certificate to check.
 - Via the Home Assistant `configuration.yaml` file.
 
 
@@ -27,7 +27,6 @@ There are 2 options in configuring the `cert_expiry` sensor:
 sensor:
   - platform: cert_expiry
     host: home-assistant.io
-    ca_certfile: /ssl/myca.crt
 ```
 
 {% configuration %}
@@ -40,11 +39,11 @@ port:
   required: false
   default: 443
   type: integer
-ca_certfile:
-  description: The file path to a custom CA certificate to check against. If not set its the system root CA certificates are used.
-  required: false
-  type: string
 {% endconfiguration %}
+
+## Options
+
+On every `cert_expiry` sensor the custom CA certificate can be changed or removed via the integration options.
 
 ## Attributes
 

--- a/source/_integrations/cert_expiry.markdown
+++ b/source/_integrations/cert_expiry.markdown
@@ -27,6 +27,7 @@ There are 2 options in configuring the `cert_expiry` sensor:
 sensor:
   - platform: cert_expiry
     host: home-assistant.io
+    ca_certfile: /ssl/myca.crt
 ```
 
 {% configuration %}
@@ -39,6 +40,10 @@ port:
   required: false
   default: 443
   type: integer
+ca_certfile:
+  description: The file path to a custom CA certificate to check against. If not set its the system root CA certificates are used.
+  required: false
+  type: string
 {% endconfiguration %}
 
 ## Attributes
@@ -49,3 +54,4 @@ The Certificate Expiry entities provide extra attributes to represent the state 
 | ---- | ----------- |
 | `is_valid` | If the certificate is able to be validated: `True` / `False`.
 | `error` | A human-readable error description if the certificate is considered invalid, "None" otherwise.
+| `ca_certfile` | The path to the custom CA certificate. It's hidden if none is set.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds the missing docs for a new option in the cert_expiry integration to set a custom CA certificate.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36482

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
