### PR TITLE
Add port field to wake_on_lan

### DIFF
--- a/source/_integrations/wake_on_lan.markdown
+++ b/source/_integrations/wake_on_lan.markdown
@@ -32,10 +32,11 @@ Available services: `send_magic_packet`.
 
 Send a _magic packet_ to wake up a device with 'Wake-On-LAN' capabilities.
 
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `mac`                     |       no | MAC address of the device to wake up.                 |
-| `broadcast_address`       |      yes | Optional broadcast IP where to send the magic packet. |
+| Service data attribute    | Optional | Description                                             |
+|---------------------------|----------|---------------------------------------------------------|
+| `mac`                     |       no | MAC address of the device to wake up.                   |
+| `broadcast_address`       |      yes | Optional broadcast IP where to send the magic packet.   |
+| `broadcast_port`          |      yes | Optional port where to send the magic packet.           |
 
 Sample service data:
 
@@ -87,6 +88,10 @@ broadcast_address:
   required: false
   default: 255.255.255.255
   type: string
+broadcast_port:
+  description: The port to send the magic packet to.
+  required: false
+  type: integer
 {% endconfiguration %}
 
 ### Examples


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Allow specifying a port for wake_on_lan where to send the magic packet

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36510
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
