### PR TITLE
Documentation update for PR #36518

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     ffi (1.13.0-x64-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jekyll (4.1.0)
       addressable (~> 2.4)

--- a/_config.yml
+++ b/_config.yml
@@ -101,8 +101,8 @@ social:
 # Home Assistant release details
 current_major_version: 0
 current_minor_version: 110
-current_patch_version: 4
-date_released: 2020-05-28
+current_patch_version: 5
+date_released: 2020-06-05
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -188,7 +188,7 @@ To fix the problem, you need to follow these steps:
 - Remove the device from Broadlink App
 - Factory reset the device
 - Add the device to your local network using the app
-- Do not set up a cloud (not now, not ever)
+- Do not set up a cloud (not now, not ever). This means that you don't have to complete the setup in the app, configure only the Wi-Fi and don't add the Broadlink device to the app
 - Specify the correct device type in the configuration file
 
 Example 1: Set up the new RM Mini 3 using remote platform

--- a/source/_integrations/vacuum.markdown
+++ b/source/_integrations/vacuum.markdown
@@ -27,7 +27,7 @@ Before calling one of these services, make sure your vacuum platform supports it
 
 #### Service `vacuum.turn_on`
 
-Start a new cleaning task. For the Xiaomi Vacuum and Neato use `vacuum.start` instead.
+Start a new cleaning task. For the Xiaomi Vacuum, Roomba, and Neato use `vacuum.start` instead.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
@@ -35,7 +35,7 @@ Start a new cleaning task. For the Xiaomi Vacuum and Neato use `vacuum.start` in
 
 #### Service `vacuum.turn_off`
 
-Stop the current cleaning task and return to the dock. For the Xiaomi Vacuum and Neato use `vacuum.stop` instead.
+Stop the current cleaning task and return to the dock. For the Xiaomi Vacuum, Roomba, and Neato use `vacuum.stop` instead.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|

--- a/source/_integrations/vacuum.template.markdown
+++ b/source/_integrations/vacuum.template.markdown
@@ -51,6 +51,15 @@ vacuum:
         description: Defines a template to get the fan speed of the vacuum.
         required: false
         type: template
+      attribute_templates:
+        description: Defines templates for attributes of the sensor.
+        required: false
+        type: map
+        keys:
+          "attribute: template":
+            description: The attribute and corresponding template.
+            required: true
+            type: template          
       availability_template:
         description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
         required: false
@@ -155,6 +164,31 @@ vacuum:
             - Low
             - Medium
             - High
+```
+
+{% endraw %}
+### Add Custom Attributes
+
+This example shows how to add custom attributes.
+
+{% raw %}
+```yaml
+vacuum:
+  - platform: template
+    vacuums:
+      living_room_vacuum:
+        value_template: "{{ states('sensor.vacuum_state') }}"
+        battery_level_template: "{{ states('sensor.vacuum_battery_level')|int }}"
+        fan_speed_template: "{{ states('sensor.vacuum_fan_speed') }}"
+        attribute_templates:
+          status: >-
+            {% if (states('sensor.robot_vacuum_robot_cleaner_movement') == "after" and states('sensor.robot_vacuum_robot_cleaner_cleaning_mode') == "stop")  %}
+              Charging to Resume
+            {% elif states('sensor.robot_vacuum_robot_cleaner_cleaning_mode') == "auto" %}
+              Cleaning
+            {% else %}
+              Charging
+            {% endif %}
 ```
 
 {% endraw %}

--- a/source/_lovelace/picture.markdown
+++ b/source/_lovelace/picture.markdown
@@ -66,7 +66,9 @@ Toggle entity using a service:
 ```yaml
 type: picture
 image: /local/light.png
-service: light.toggle
-service_data:
-  entity_id: light.ceiling_lights
+tap_action:
+  action: call-service
+  service: light.toggle
+  service_data:
+    entity_id: light.ceiling_lights
 ```

--- a/source/_posts/2020-05-20-release-110.markdown
+++ b/source/_posts/2020-05-20-release-110.markdown
@@ -823,6 +823,16 @@ Experiencing issues introduced by this release? Please report them in our [issue
 [todoist docs]: /integrations/todoist/
 [zeroconf docs]: /integrations/zeroconf/
 
+## Release 0.110.5 - June 5
+
+- Add partial mobile app sensor validation ([#36433] - [@balloob])
+- Fix iOS app crashing on None values in Zeroconf service info ([#36490] - [@frenck])
+- Update myq for latest api changes ([#36469] - [@bdraco])
+
+[#36433]: https://github.com/home-assistant/core/pull/36433
+[#36490]: https://github.com/home-assistant/core/pull/36490
+[#36469]: https://github.com/home-assistant/core/pull/36469
+
 ## All changes
 
 <details>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add attribute_templates example and configuration scheme to documents.
Related to PR#36518


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36518
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
