### PR TITLE
Remove obsolete warning for `api_password`

### DIFF
--- a/source/_integrations/websocket_api.markdown
+++ b/source/_integrations/websocket_api.markdown
@@ -12,12 +12,6 @@ ha_domain: websocket_api
 
 The `websocket_api` integration set up a WebSocket API and allows one to interact with a Home Assistant instance that is running headless. This integration depends on the [`http` component](/integrations/http/).
 
-<div class='note warning'>
-
-It is HIGHLY recommended that you set the `api_password`, especially if you are planning to expose your installation to the internet.
-
-</div>
-
 ## Configuration
 
 ```yaml


### PR DESCRIPTION
The `api_password` config key has been completely removed from Home Assistant Core, therefore this warning is no longer relevant.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove the warning for setting `api_password` as it is no longer supported.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
See here: https://www.home-assistant.io/blog/2019/10/30/release-101/#api-password-and-trusted-networks

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
