### PR TITLE
Added the word "on"

### DIFF
--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -43,7 +43,7 @@ For UniFi OS a local-only user needs to be created. A user who uses the Ubiquiti
 
 ### Conflicts with MQTT
 
-The UniFi controller can either be a dedicated hardware device (UniFi's cloud key), or as software any Linux system. If you run the UniFi controller on the same operating system as Home Assistant there may be conflicts in ports if you have the MQTT integration as well.
+The UniFi controller can either be a dedicated hardware device (UniFi's cloud key), or as software on any Linux system. If you run the UniFi controller on the same operating system as Home Assistant there may be conflicts in ports if you have the MQTT integration as well.
 
 It is recommended that you run the UniFi controller in a dedicated virtual machine to avoid that situation.
 


### PR DESCRIPTION
## Proposed change

I added the word "on" to "or as software any Linux system" to make "or as software on any Linux system" as I think this makes more sense and makes it easier to read.

(First pull request, so I apologise if I`ve done anything wrong)

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
