### PR TITLE
Update syncthru for config flow

### DIFF
--- a/source/_integrations/ssdp.markdown
+++ b/source/_integrations/ssdp.markdown
@@ -29,6 +29,7 @@ The following integrations are automatically discovered by the SSDP integration:
  - [Huawei LTE](../huawei_lte/)
  - [Philips Hue](../hue/)
  - [Roku](/integrations/roku/)
+ - [Samsung SyncThru Printer](../syncthru/)
  - [Samsung TV](../samsungtv/)
  - [UPnP](../upnp/)
  - [Sony Songpal](../songpal/)

--- a/source/_integrations/ssdp.markdown
+++ b/source/_integrations/ssdp.markdown
@@ -24,12 +24,12 @@ ssdp:
 
 The following integrations are automatically discovered by the SSDP integration:
 
- - [deCONZ](../deconz/)
+ - [deCONZ](/integrations/deconz/)
  - [DirecTV](/integrations/directv/)
- - [Huawei LTE](../huawei_lte/)
- - [Philips Hue](../hue/)
+ - [Huawei LTE](/integrations/huawei_lte/)
+ - [Philips Hue](/integrations/hue/)
  - [Roku](/integrations/roku/)
- - [Samsung SyncThru Printer](../syncthru/)
- - [Samsung TV](../samsungtv/)
- - [UPnP](../upnp/)
- - [Sony Songpal](../songpal/)
+ - [Samsung SyncThru Printer](/integrations/syncthru/)
+ - [Samsung TV](/integrations/samsungtv/)
+ - [UPnP](/integrations/upnp/)
+ - [Sony Songpal](/integrations/songpal/)

--- a/source/_integrations/syncthru.markdown
+++ b/source/_integrations/syncthru.markdown
@@ -19,7 +19,7 @@ It usually provides information about the device's state, the left amount of ink
 
 Go to **Configuration** >> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select **Samsung SyncThru Printer**.
 
-If your printer is on and you have enabled [SSDP](/../ssdp) discovery, it's likely that the printer is automatically discovered. In that case, you shouldn't need any information to complete configuration - simply confirm that the information displayed is correct.
+If your printer is on and you have enabled [SSDP](../ssdp/) discovery, it's likely that the printer is automatically discovered. In that case, you shouldn't need any information to complete configuration - simply confirm that the information displayed is correct.
 
 The following information is displayed in separate sensors, if it is available:
 

--- a/source/_integrations/syncthru.markdown
+++ b/source/_integrations/syncthru.markdown
@@ -5,6 +5,7 @@ ha_category:
   - System Monitor
 ha_iot_class: Local Polling
 ha_release: 0.66
+ha_config_flow: true
 ha_codeowners:
   - '@nielstron'
 ha_domain: syncthru
@@ -13,30 +14,12 @@ ha_domain: syncthru
 The Samsung SyncThru Printer platform allows you to read current data from your local Samsung printer.
 
 It usually provides information about the device's state, the left amount of ink or toner and the state of paper trays.
-The platform automatically monitors every supported part.
 
-If you wish not to include certain monitored values specify the values that you would like to see in the front-end via the `monitored_conditions` setting.
+### Setup
 
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: syncthru
-    resource: http://my-printer.address
-    name: My Awesome Printer
-```
+Go to **Configuration** >> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select **Samsung SyncThru Printer**.
 
-{% configuration %}
-  resource:
-    description: The address for connecting to the printer. Equal to the SyncThru Webservice address.
-    required: true
-    default: false
-    type: string
-  name:
-    description: A user specified name for the printer. Defaults to "Samsung Printer" and the friendly name will be the name of the printer model.
-    required: false
-    default: Samsung Printer
-    type: string
-{% endconfiguration %}
+If your printer is on and you have enabled [SSDP](/../ssdp) discovery, it's likely that the printer is automatically discovered. In that case, you shouldn't need any information to complete configuration - simply confirm that the information displayed is correct.
 
 The following information is displayed in separate sensors, if it is available:
 

--- a/source/_integrations/syncthru.markdown
+++ b/source/_integrations/syncthru.markdown
@@ -15,11 +15,11 @@ The Samsung SyncThru Printer platform allows you to read current data from your 
 
 It usually provides information about the device's state, the left amount of ink or toner and the state of paper trays.
 
-### Setup
+## Configuration
 
 Go to **Configuration** >> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select **Samsung SyncThru Printer**.
 
-If your printer is on and you have enabled [SSDP](../ssdp/) discovery, it's likely that the printer is automatically discovered. In that case, you shouldn't need any information to complete configuration - simply confirm that the information displayed is correct.
+If your printer is on and you have enabled [SSDP](/integrations/ssdp/) discovery, it's likely that the printer is automatically discovered. In that case, you shouldn't need any information to complete configuration - simply confirm that the information displayed is correct.
 
 The following information is displayed in separate sensors, if it is available:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Syncthru config entry docs, for https://github.com/home-assistant/core/pull/36690


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36690
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
