### PR TITLE
Added alternative method for finding home_id

### DIFF
--- a/source/_integrations/tado.markdown
+++ b/source/_integrations/tado.markdown
@@ -127,3 +127,16 @@ Find your `home_id` by browsing to `https://my.tado.com/api/v2/me?username=YOUR_
 ```
 
 In this example `12345` is the `home_id` you'll need to configure.
+
+### Finding your 'home_id' alternative
+
+If the above method returns an unauthorized error. The home_id can also be found using Chrome developer tools whilst logged into https://my.tado.com/webapp take the following steps: 
+
+- select the 'Network' tab
+- filter for 'home'
+- under Name, select 'users'
+- click on 'Response' tab
+
+The home_id appears in the Response for users as "id":12345
+
+In this example `12345` is the `home_id` you'll need to configure.

--- a/source/_integrations/tado.markdown
+++ b/source/_integrations/tado.markdown
@@ -128,15 +128,15 @@ Find your `home_id` by browsing to `https://my.tado.com/api/v2/me?username=YOUR_
 
 In this example `12345` is the `home_id` you'll need to configure.
 
-### Finding your 'home_id' alternative
+### Finding your `home_id` alternative
 
-If the above method returns an unauthorized error. The home_id can also be found using Chrome developer tools whilst logged into https://my.tado.com/webapp take the following steps: 
+If the above method returns an unauthorized error. The `home_id` can also be found using Chrome developer tools. Whilst logged into https://my.tado.com/webapp, take the following steps: 
 
-- select the 'Network' tab
-- filter for 'home'
-- under Name, select 'users'
-- click on 'Response' tab
+- Select the "Networ"' tab
+- Filter for "home"
+- Under "Name", select "users"
+- Click on the "Response" tab
 
-The home_id appears in the Response for users as "id":12345
+The `home_id` appears in the response for users as `"id":12345`
 
 In this example `12345` is the `home_id` you'll need to configure.


### PR DESCRIPTION
It's much easier to find the home_id using developer tools. Particularly if tado is returning an auth error when using the suggested method.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
