### PR TITLE
Add attribute templates to template vacuum

### DIFF
--- a/source/_integrations/vacuum.template.markdown
+++ b/source/_integrations/vacuum.template.markdown
@@ -51,6 +51,15 @@ vacuum:
         description: Defines a template to get the fan speed of the vacuum.
         required: false
         type: template
+      attribute_templates:
+        description: Defines templates for attributes of the sensor.
+        required: false
+        type: map
+        keys:
+          "attribute: template":
+            description: The attribute and corresponding template.
+            required: true
+            type: template          
       availability_template:
         description: Defines a template to get the `available` state of the component. If the template returns `true`, the device is `available`. If the template returns any other value, the device will be `unavailable`. If `availability_template` is not configured, the component will always be `available`.
         required: false
@@ -155,6 +164,31 @@ vacuum:
             - Low
             - Medium
             - High
+```
+
+{% endraw %}
+### Add Custom Attributes
+
+This example shows how to add custom attributes.
+
+{% raw %}
+```yaml
+vacuum:
+  - platform: template
+    vacuums:
+      living_room_vacuum:
+        value_template: "{{ states('sensor.vacuum_state') }}"
+        battery_level_template: "{{ states('sensor.vacuum_battery_level')|int }}"
+        fan_speed_template: "{{ states('sensor.vacuum_fan_speed') }}"
+        attribute_templates:
+          status: >-
+            {% if (states('sensor.robot_vacuum_robot_cleaner_movement') == "after" and states('sensor.robot_vacuum_robot_cleaner_cleaning_mode') == "stop")  %}
+              Charging to Resume
+            {% elif states('sensor.robot_vacuum_robot_cleaner_cleaning_mode') == "auto" %}
+              Cleaning
+            {% else %}
+              Charging
+            {% endif %}
 ```
 
 {% endraw %}

--- a/source/_integrations/vacuum.template.markdown
+++ b/source/_integrations/vacuum.template.markdown
@@ -191,5 +191,4 @@ vacuum:
               Charging
             {% endif %}
 ```
-
 {% endraw %}

--- a/source/_integrations/vacuum.template.markdown
+++ b/source/_integrations/vacuum.template.markdown
@@ -167,6 +167,7 @@ vacuum:
 ```
 
 {% endraw %}
+
 ### Add Custom Attributes
 
 This example shows how to add custom attributes.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add attribute_templates example and configuration scheme to documents.
Related to PR#36518


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36518
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
