### PR TITLE
Add Rehau integration documentation

### DIFF
--- a/source/_integrations/rehau_nea_smart_manager.markdown
+++ b/source/_integrations/rehau_nea_smart_manager.markdown
@@ -1,10 +1,10 @@
 ---
 title: "Rehau Nea Smart Manager"
-description: ""
+description: "Integrates Rehau Nea Smart Manager thermostat controller into Home Assistant"
 ha_release: "0.108.9"
 ha_category: Climate
 ha_iot_class: "Local Polling"
-ha_quality_scale: internal
+ha_quality_scale: silver
 ha_config_flow: true
 ha_codeowners:
   - '@Jeoffreybauvin'

--- a/source/_integrations/rehau_nea_smart_manager.markdown
+++ b/source/_integrations/rehau_nea_smart_manager.markdown
@@ -42,23 +42,3 @@ host:
 | `auto` | Auto mode : use Nea Smart Manager scheduling
 | `eco` | Eco mode
 | `comfort` | Comfort mode
-
-## Component services
-
-Enable comfort mode on your thermostat:
-
-`climate.set_preset_mode`
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String with device name.
-| `preset_mode` | no | String with the preset mode (see above).
-
-Set a new target temperature on your thermostat:
-
-`climate.set_temperature`
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String with device name.
-| `temperature` | no | Target temperature in Celsius (float).

--- a/source/_integrations/rehau_nea_smart_manager.markdown
+++ b/source/_integrations/rehau_nea_smart_manager.markdown
@@ -13,7 +13,7 @@ ha_domain: rehau
 
 Integrates [Rehau Nea Smart Manager](https://www.rehau.com/en-en/nea-smart/francais) Thermostat controller into Home Assistant.
 
-This integration generates a climate entity for each heatarea in your Nea Smart Manager.
+This integration generates a climate entity for each heating area in your Nea Smart Manager.
 
 To enable this platform, add the following lines to your `configuration.yaml` file:
 

--- a/source/_integrations/rehau_nea_smart_manager.markdown
+++ b/source/_integrations/rehau_nea_smart_manager.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Rehau Nea Smart Manager"
 description: ""
-ha_release: "0.0.1"
+ha_release: "0.108.9"
 ha_category: Climate
 ha_iot_class: "Local Polling"
 ha_quality_scale: internal

--- a/source/_integrations/rehau_nea_smart_manager.markdown
+++ b/source/_integrations/rehau_nea_smart_manager.markdown
@@ -61,4 +61,4 @@ Set a new target temperature on your thermostat:
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String with device name.
-| `temperature` | no | Target temperature in celcius (float).
+| `temperature` | no | Target temperature in Celsius (float).

--- a/source/_integrations/rehau_nea_smart_manager.markdown
+++ b/source/_integrations/rehau_nea_smart_manager.markdown
@@ -1,0 +1,64 @@
+---
+title: "Rehau Nea Smart Manager"
+description: ""
+ha_release: "0.0.1"
+ha_category: Climate
+ha_iot_class: "Local Polling"
+ha_quality_scale: internal
+ha_config_flow: true
+ha_codeowners:
+  - '@Jeoffreybauvin'
+ha_domain: rehau
+---
+
+Integrates [Rehau Nea Smart Manager](https://www.rehau.com/en-en/nea-smart/francais) Thermostat controller into Home Assistant.
+
+This integration generates a climate entity for each heatarea in your Nea Smart Manager.
+
+To enable this platform, add the following lines to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+climate:
+  - platform: rehau
+    host: '192.168.1.2'
+```
+
+<div class='note warning'>
+For security reasons, this integration is not compatible (yet) with the cloud version of Rehau Nea Smart Manager. Please use the local IP of your Nea Smart Manager.
+</div>
+
+{% configuration %}
+host:
+  description: Your Nea Smart Manager local IP (or DNS name).
+  required: true
+  type: string
+{% endconfiguration %}
+
+## Preset modes
+
+| Preset mode | Description |
+| ---------------------- | -------- |
+| `auto` | Auto mode : use Nea Smart Manager scheduling
+| `eco` | Eco mode
+| `comfort` | Comfort mode
+
+## Component services
+
+Enable comfort mode on your thermostat:
+
+`climate.set_preset_mode`
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String with device name.
+| `preset_mode` | no | String with the preset mode (see above).
+
+Set a new target temperature on your thermostat:
+
+`climate.set_temperature`
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String with device name.
+| `temperature` | no | Target temperature in celcius (float).

--- a/source/_integrations/rehau_nea_smart_manager.markdown
+++ b/source/_integrations/rehau_nea_smart_manager.markdown
@@ -19,13 +19,12 @@ To enable this platform, add the following lines to your `configuration.yaml` fi
 
 ```yaml
 # Example configuration.yaml entry
-climate:
-  - platform: rehau
-    host: IP_ADDRESS
+rehau:
+  host: IP_ADDRESS
 ```
 
 <div class='note warning'>
-For security reasons, this integration is not compatible (yet) with the cloud version of Rehau Nea Smart Manager. Please use the local IP of your Nea Smart Manager.
+For security reasons, this integration is not compatible with the cloud version of Rehau Nea Smart Manager. Please use the local IP of your Nea Smart Manager.
 </div>
 
 {% configuration %}

--- a/source/_integrations/rehau_nea_smart_manager.markdown
+++ b/source/_integrations/rehau_nea_smart_manager.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Rehau Nea Smart Manager"
 description: "Integrates Rehau Nea Smart Manager thermostat controller into Home Assistant"
-ha_release: "0.108.9"
+ha_release: "0.111.1"
 ha_category: Climate
 ha_iot_class: "Local Polling"
 ha_quality_scale: silver

--- a/source/_integrations/rehau_nea_smart_manager.markdown
+++ b/source/_integrations/rehau_nea_smart_manager.markdown
@@ -21,7 +21,7 @@ To enable this platform, add the following lines to your `configuration.yaml` fi
 # Example configuration.yaml entry
 climate:
   - platform: rehau
-    host: '192.168.1.2'
+    host: IP_ADDRESS
 ```
 
 <div class='note warning'>


### PR DESCRIPTION
## Proposed change

Documentation for the new Rehau integration (pull request  component in progress)

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch). 
- [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/34727
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1518
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
