### PR TITLE
Revert "Fix ZHA docs link in release 0.111 blog post"

### DIFF
--- a/source/_posts/2020-06-10-release-111.markdown
+++ b/source/_posts/2020-06-10-release-111.markdown
@@ -165,7 +165,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 
   The `zigbee` integration has been renamed to `xbee`, as it is an integration for XBee devices. This is done to avoid confusion with ZHA, which is the general integration to go to when having Zigbee needs.
 
-  ([@frenck] - [#35613]) ([xbee docs]) ([zha docs])
+  ([@frenck] - [#35613]) ([xbee docs]) ([zigbee docs])
 
 - **Insteon**
 


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#13737

This change is incorrect and reverting it.

The ZHA documentation is not related to the `xbee` (previously known as `zigbee`) integration.