### PR TITLE
Fix dead zigbee links in 0.111 release blog

### DIFF
--- a/source/_posts/2020-06-10-release-111.markdown
+++ b/source/_posts/2020-06-10-release-111.markdown
@@ -165,7 +165,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 
   The `zigbee` integration has been renamed to `xbee`, as it is an integration for XBee devices. This is done to avoid confusion with ZHA, which is the general integration to go to when having Zigbee needs.
 
-  ([@frenck] - [#35613]) ([xbee docs]) ([zigbee docs])
+  ([@frenck] - [#35613]) ([xbee docs])
 
 - **Insteon**
 
@@ -407,7 +407,7 @@ The integrations below have been removed:
 - Run pre-commit gen_requirements_all on pre-commit config changes ([@scop] - [#35588])
 - Axis - Code improvements ([@Kane610] - [#35592]) ([axis docs])
 - Remove Automatic integration ([@bachya] - [#35029]) (breaking-change)
-- Rename zigbee to xbee ([@frenck] - [#35613]) ([xbee docs]) ([xbee docs]) (breaking-change)
+- Rename zigbee to xbee ([@frenck] - [#35613]) ([xbee docs]) (breaking-change)
 - Xiaomi Miio zeroconf discovery ([@starkillerOG] - [#35352]) ([xiaomi_miio docs])
 - Provide yeelight unique_id using ssdp discovery ([@zewelor] - [#35448]) ([yeelight docs])
 - Add tado zone variable open window detected ([@isk0001y] - [#34969]) ([tado docs])


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fixes the links to the renamed/removed `zigbee` component in the 0.111 release blog post.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
