### PR TITLE
Adding notes about how to edit the config

### DIFF
--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -32,9 +32,9 @@ If you run into trouble while configuring Home Assistant, have a look at the [co
 
 There are many ways you can edit `configuration.yaml`. Here are three options to get you started:
 
-The simplest is to use the File Editor add-on. This will allow you to edit your configuration from within Home Assitant itself.
+The simplest is to use the "File Editor" add-on. This will allow you to edit your configuration from within Home Assistant itself.
 
-You can also use Samba (you may need to install the Samba add-on) and your favourite file editor.
+You can also use Samba (you may need to install the "Samba" add-on) and your favorite file editor.
 
 The most basic is to use SSH to connect to the system (you may need to install the SSH add-on) and then use `nano` (or `vim`) to edit the file.
 

--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -28,6 +28,16 @@ If you run into trouble while configuring Home Assistant, have a look at the [co
 
 </div>
 
+## Editing `configuration.yaml`
+
+There are many ways you can edit `configuration.yaml`. Here are three options to get you started:
+
+The most basic is to use SSH to connect to the system (you may need to install the SSH add-on) and then use `nano` (or `vim`) to edit the file.
+
+You can also use Samba (again, you may need to install the Samba add-on) and your favourite file editor.
+
+There's a [Visual Studio Code](https://github.com/hassio-addons/addon-vscode#home-assistant-community-add-on-visual-studio-code) that allows you to edit your configuration within Home Assistant itself.
+
 ## Reloading changes
 
 You will have to restart Home Assistant for most changes to `configuration.yaml` to take effect.

--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -32,11 +32,11 @@ If you run into trouble while configuring Home Assistant, have a look at the [co
 
 There are many ways you can edit `configuration.yaml`. Here are three options to get you started:
 
+The simplest is to use the File Editor add-on. This will allow you to edit your configuration from within Home Assitant itself.
+
+You can also use Samba (you may need to install the Samba add-on) and your favourite file editor.
+
 The most basic is to use SSH to connect to the system (you may need to install the SSH add-on) and then use `nano` (or `vim`) to edit the file.
-
-You can also use Samba (again, you may need to install the Samba add-on) and your favourite file editor.
-
-There's a [Visual Studio Code](https://github.com/hassio-addons/addon-vscode#home-assistant-community-add-on-visual-studio-code) that allows you to edit your configuration within Home Assistant itself.
 
 ## Reloading changes
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

It was quite reasonably pointed out that while the `configuration.yaml` file is mentioned, there's no mention of how you can reach it and edit it.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
