### PR TITLE
Added info re command line sensors being a breaking change

### DIFF
--- a/source/_posts/2020-06-10-release-111.markdown
+++ b/source/_posts/2020-06-10-release-111.markdown
@@ -322,6 +322,13 @@ Experiencing issues introduced by this release? Please report them in our [issue
   Previously it was set after the action that was part of the trigger was done.
 
   ([@basnijholt] - [#35671]) ([automation docs])
+  
+  **Command Line Sensors**
+  
+  The fix for command line sensors removing quotes with template breaks any sensors where the quote has been escaped using a backslash.
+  E.g. to work around the previous bug a quote could be added using \" and this must now be replaced with simply "
+  
+  (@shenxn - #35559) (command_line docs)
 
 ## Farewell to the following
 


### PR DESCRIPTION
The fix for command line sensor was promoted as just a bugfix, whereas it is a breaking change. The workaround for the bug was to escape the quote with a backslash, and now the backslash is treated as a character and passed through.

## Proposed change
<!--
Update breaking change section to include relevant information
-->

Update breaking change section to include relevant information

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->



## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.

- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
