### PR TITLE
Add support for multiple entity_ids in conditions

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -112,6 +112,18 @@ condition:
   value_template: {% raw %}'{{ float(state.state) + 2 }}'{% endraw %}
 ```
 
+It is also possible to test the condition against multiple entities at once.
+The condition will pass if all entities match the thresholds.
+
+```yaml
+condition:
+  condition: numeric_state
+  entity_id:
+    - sensor.kitchen_temperature
+    - sensor.living_room_temperature
+  below: 18
+```
+
 ### State condition
 
 Tests if an entity is a specified state.
@@ -126,6 +138,18 @@ condition:
     hours: 1
     minutes: 10
     seconds: 5
+```
+
+It is also possible to test the condition against multiple entities at once.
+The condition will pass if all entities match the state.
+
+```yaml
+condition:
+  condition: state
+  entity_id:
+    - light.kitchen
+    - light.living_room
+  state: 'on'
 ```
 
 ### Sun condition
@@ -269,6 +293,18 @@ Zone conditions test if an entity is in a certain zone. For zone automation to w
 condition:
   condition: zone
   entity_id: device_tracker.paulus
+  zone: zone.home
+```
+
+It is also possible to test the condition against multiple entities at once.
+The condition will pass if all entities are in the specified zone.
+
+```yaml
+condition:
+  condition: zone
+  entity_id:
+    - device_tracker.frenck
+    - device_tracker.daphne
   zone: zone.home
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add support for using multiple entities in a single state, numeric_state or zone condition.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36817
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
