### PR TITLE
Add documentation for hvv_departures elevators

### DIFF
--- a/source/_integrations/hvv_departures.markdown
+++ b/source/_integrations/hvv_departures.markdown
@@ -33,6 +33,26 @@ Menu: *Configuration* > *Integrations* > *Select your new integration* > *Press 
 - **offset**: set this if you want to list the departures some minutes in the future, for example, if you live ten minutes away from the station.
 - **use realtime data**: enable this to include delay and cancellation information.
 
+## Elevator sensors
+
+If the selected station has elevators, binary_sensors will be available.
+
+### States
+
+- OK (`off`): The elevator is working.
+- Problem (`on`): The elevator is out of order. See the cause attribute for more information.
+
+### Attributes
+
+| Attribute       | Description                                                                                                                                |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cabin_width`   | Width of the elevator cabin                                                                                                                |
+| `cabin_length`  | Length of the elevator cabin                                                                                                               |
+| `door_width`    | Width of the elevator doors                                                                                                                |
+| `elevator_type` | Type of the elevator                                                                                                                       |
+| `button_type`   | Type of the elevator buttons, can be one of the following: <br/><ul><li>`BRAILLE`</li><li>`ACUSTIC`</li><li>`COMBI`</li><li>`UNKNOWN`</li> |
+| `cause`         | If the state of the sensor is `on` ("Problem"), the `cause` attribute may contain further information about the cause                      |
+| `lines`         | List of lines that can be reached using this elevator                                                                                      |
 
 ## How to get the API credentials
 

--- a/source/_integrations/hvv_departures.markdown
+++ b/source/_integrations/hvv_departures.markdown
@@ -35,7 +35,7 @@ Menu: *Configuration* > *Integrations* > *Select your new integration* > *Press 
 
 ## Elevator sensors
 
-If the selected station has elevators, binary_sensors will be available.
+If the selected station has elevators, binary sensors will be available.
 
 ### States
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for hvv_departures elevator binary sensors.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36822
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
