### PR TITLE
Update Smappee doc

### DIFF
--- a/source/_integrations/smappee.markdown
+++ b/source/_integrations/smappee.markdown
@@ -32,10 +32,10 @@ Once Home Assistant restarted, go to Configuration > Integrations and select the
 {% configuration %}
 client_id:
   description: Your Smappee API client ID.
-  required: True
+  required: true
   type: string
 client_secret:
   description: Your Smappee API client secret.
-  required: True
+  required: true
   type: string
 {% endconfiguration %}

--- a/source/_integrations/smappee.markdown
+++ b/source/_integrations/smappee.markdown
@@ -1,81 +1,41 @@
 ---
 title: Smappee
 description: Instructions on how to setup Smappee within Home Assistant.
-ha_release: 0.64
 ha_category:
   - Hub
   - Energy
   - Sensor
   - Switch
-ha_iot_class: Local Push
+ha_iot_class: Cloud polling
+ha_release: 0.64
+ha_config_flow: true
+ha_codeowners:
+  - '@bsmappee'
 ha_domain: smappee
 ---
 
-The `smappee` integration adds support for the [Smappee](https://www.smappee.com/) controller for energy monitoring and Comport plug switches.
-
-There is currently support for the following device types within Home Assistant:
-
-- Sensor
-- Switch
-
-Will be automatically added when you connect to the Smappee controller.
-
-The smappee integration gets information from [Smappee API](https://smappee.atlassian.net/wiki/spaces/DEVAPI/overview). Note: their cloud API now requires a subscription fee of €2.50 per month for Smappee Energy/Solar or €3 per month for Smappee Plus.
+The Smappee integration will allow users to integrate their Smappee monitors, plugs and switches into Home Assistant using the [official API](https://smappee.atlassian.net/wiki/spaces/DEVAPI/overview).
 
 ## Configuration
 
-Info on how to get API access is described in the [smappy wiki](https://github.com/EnergieID/smappy/wiki).
-
-To use the `smappee` integration in your installation, add the following to your `configuration.yaml` file:
+To use the Smappee integration you need a personal `client_id` and `client_secret` and add these to your `configuration.yaml` file.  The `client_id` and `client_secret` can be obtained by contacting [support@smappee.com](mailto:support@smappee.com).
 
 ```yaml
 # Example configuration.yaml entry
 smappee:
-  host: 10.0.0.5
   client_id: YOUR_CLIENT_ID
   client_secret: YOUR_CLIENT_SECRET
-  username: YOUR_MYSMAPPEE_USERNAME
-  password: YOUR_MYSMAPPEE_PASSWORD
 ```
 
-```yaml
-# Minimal example configuration.yaml entry
-smappee:
-  host: 10.0.0.5
-```
-
-```yaml
-# Cloud only example configuration.yaml entry
-smappee:
-  client_id: YOUR_CLIENT_ID
-  client_secret: YOUR_CLIENT_SECRET
-  username: YOUR_MYSMAPPEE_USERNAME
-  password: YOUR_MYSMAPPEE_PASSWORD
-```
+Once Home Assistant restarted, go to Configuration > Integrations and select the Smappee integration. You will be redirected to a login page and be able to select the locations you would like to use within Home Assistant.
 
 {% configuration %}
-host:
-  description: Your Local Smappee unit IP.
-  required: false
-  type: string
-host_password:
-  description: Your Local Smappee password.
-  required: false
-  type: string
 client_id:
   description: Your Smappee API client ID.
-  required: false
+  required: True
   type: string
 client_secret:
   description: Your Smappee API client secret.
-  required: false
-  type: string
-username:
-  description: Your My Smappee username.
-  required: false
-  type: string
-password:
-  description: Your My Smappee password.
-  required: false
+  required: True
   type: string
 {% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Review documentation for Smappee integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36445
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1707
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
