### PR TITLE
Add support for multiple states/zones in conditions

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -152,6 +152,32 @@ condition:
   state: 'on'
 ```
 
+Testing if an entity is matching a set of possible conditions;
+The condition will pass if the entity matches one of the states given.
+
+```yaml
+condition:
+  condition: state
+  entity_id: alarm_control_panel.home
+  state:
+    - armed_away
+    - armed_home
+```
+
+Or, combine multiple entities with multiple states. In the following example,
+both media players need to be either paused or playing for the condition to pass.
+
+```yaml
+condition:
+  condition: state
+  entity_id:
+    - media_player.living_room
+    - media_player.kitchen
+  state:
+    - playing
+    - paused
+```
+
 ### Sun condition
 
 #### Sun state condition
@@ -306,6 +332,33 @@ condition:
     - device_tracker.frenck
     - device_tracker.daphne
   zone: zone.home
+```
+
+Testing if an entity is matching a set of possible zones;
+The condition will pass if the entity is in one of the zones.
+
+```yaml
+condition:
+  condition: zone
+  entity_id: device_tracker.paulus
+  state:
+    - zone.home
+    - zone.work
+```
+
+Or, combine multiple entities with multiple zones. In the following example,
+both entities need to be either in the home or the work zone for the condition
+to pass.
+
+```yaml
+condition:
+  condition: zone
+  entity_id:
+    - device_tracker.frenck
+    - device_tracker.daphne
+  state:
+    - zone.home
+    - zone.work
 ```
 
 ### Examples


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for the multiple states/zones support added to conditions.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36835
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
