### PR TITLE
Fix links to pull requests in release 0.111.3

### DIFF
--- a/source/_posts/2020-06-10-release-111.markdown
+++ b/source/_posts/2020-06-10-release-111.markdown
@@ -415,14 +415,14 @@ The integrations below have been removed:
 [@teharris1]: https://github.com/teharris1
 [@balloob]: https://github.com/balloob
 [@kennedyshead]: https://github.com/kennedyshead
-[#36760]: https://github.com/home-assistant/pull/36760
-[#36769]: https://github.com/home-assistant/pull/36769
-[#36794]: https://github.com/home-assistant/pull/36794
-[#36797]: https://github.com/home-assistant/pull/36797
-[#36807]: https://github.com/home-assistant/pull/36807
-[#36812]: https://github.com/home-assistant/pull/36812
-[#36820]: https://github.com/home-assistant/pull/36820
-[#36836]: https://github.com/home-assistant/pull/36836
+[#36760]: https://github.com/home-assistant/core/pull/36760
+[#36769]: https://github.com/home-assistant/core/pull/36769
+[#36794]: https://github.com/home-assistant/core/pull/36794
+[#36797]: https://github.com/home-assistant/core/pull/36797
+[#36807]: https://github.com/home-assistant/core/pull/36807
+[#36812]: https://github.com/home-assistant/core/pull/36812
+[#36820]: https://github.com/home-assistant/core/pull/36820
+[#36836]: https://github.com/home-assistant/core/pull/36836
 
 ## All changes
 


### PR DESCRIPTION
## Proposed change

The links to pull requests in release 0.111.3 were broken. This change fixes those links.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
