### PR TITLE
"Https:" to "https:" on Nextcloud Integration

### DIFF
--- a/source/_integrations/nextcloud.markdown
+++ b/source/_integrations/nextcloud.markdown
@@ -27,7 +27,7 @@ To enable the Nextcloud integration, add the following lines to your `configurat
 ```yaml
 # Example configuration.yaml entry
 nextcloud:
-  url: Https://YOUR_NEXTCLOUD_URL
+  url: https://YOUR_NEXTCLOUD_URL
   username: YOUR_USERNAME
   password: YOUR_APP_PASSWORD
 


### PR DESCRIPTION
Every other site uses "https:" instead of "Https:", I guess it's just a typo

## Proposed change
The nextcloud integration page has "Https:" instead of "https:" in the config box.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Just a small cosmetic change.