### PR TITLE
Process late review comment on ZHA change

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -149,10 +149,12 @@ Currently, OTA providers for firmware updates are only available for IKEA and LE
 To enable OTA firmware updates for the ZHA integration you need to add the following configuration to your `configuration.yaml` and restart Home Assistant:
 
 ```yaml
-ota:
-  ikea_provider: true                        # Auto update Trådfri devices
-  ledvance_provider: true                    # Auto update LEDVANCE devices
-  #otau_directory: /path/to/your/ota/folder  # Utilize .ota files to update everything else
+zha:
+  zigpy_config:
+    ota:
+      ikea_provider: true.                       # Auto update Trådfri devices
+      ledvance_provider: true                    # Auto update LEDVANCE devices
+      #otau_directory: /path/to/your/ota/folder  # Utilize .ota files to update everything else
 ```
 
 You can choose if the IKEA or LEDVANCE provider should be set to enabled (`true`) or disabled (`false`) individually. After the OTA firmware upgrades are finished, you can set these to `false` again if you do not want ZHA to automatically download and perform OTA firmware upgrades in the future.

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -152,7 +152,7 @@ To enable OTA firmware updates for the ZHA integration you need to add the follo
 zha:
   zigpy_config:
     ota:
-      ikea_provider: true.                       # Auto update Trådfri devices
+      ikea_provider: true                        # Auto update Trådfri devices
       ledvance_provider: true                    # Auto update LEDVANCE devices
       #otau_directory: /path/to/your/ota/folder  # Utilize .ota files to update everything else
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Processes a late review comment in: https://github.com/home-assistant/home-assistant.io/pull/13621#discussion_r443552646


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
