### PR TITLE
Extend triggers intro section

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -6,8 +6,7 @@ redirect_from: /getting-started/automation-trigger/
 
 ### What are triggers
 
-Triggers are what starts the execution of an automation rule.
-When a trigger becomes true (trigger _fires_), Home Assistant will validate the [conditions](/docs/automation/condition/), if any, and call defined [actions](/docs/automation/action/).
+Triggers are what starts the processing of an automation rule. When _any_ of the automation's triggers becomes true (trigger _fires_), Home Assistant will validate the [conditions](/docs/automation/condition/), if any, and call the [action](/docs/automation/action/).
 
 An automation can be triggered by an event, with a certain entity state, at a given time, and more. These can be specified directly or more flexible via templates. It is also possible to specify multiple triggers for one automation.
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -5,7 +5,15 @@ redirect_from: /getting-started/automation-trigger/
 ---
 
 ### What are triggers
-Triggers are what starts the processing of an automation rule. When _any_ of the automation's triggers becomes true (trigger _fires_), Home Assistant will validate the [conditions](/docs/automation/condition/), if any, and call the [action](/docs/automation/action/).
+
+Triggers are what starts the execution of an automation rule.
+When a trigger becomes true (trigger _fires_), Home Assistant will validate the [conditions](/docs/automation/condition/), if any, and call defined [actions](/docs/automation/action/).
+
+An automation can be triggered by an event, with a certain entity state, at a given time, and more.
+These can be specifed directly or more flexible via templates.
+It is also possible to specify multiple triggers for one automation.
+
+The following sections introduce all trigger types and further details to get started.
 
 ### Event trigger
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -9,9 +9,7 @@ redirect_from: /getting-started/automation-trigger/
 Triggers are what starts the execution of an automation rule.
 When a trigger becomes true (trigger _fires_), Home Assistant will validate the [conditions](/docs/automation/condition/), if any, and call defined [actions](/docs/automation/action/).
 
-An automation can be triggered by an event, with a certain entity state, at a given time, and more.
-These can be specifed directly or more flexible via templates.
-It is also possible to specify multiple triggers for one automation.
+An automation can be triggered by an event, with a certain entity state, at a given time, and more. These can be specified directly or more flexible via templates. It is also possible to specify multiple triggers for one automation.
 
 The following sections introduce all trigger types and further details to get started.
 


### PR DESCRIPTION
## Proposed change

Simple addition to the intro text for triggers. The second paragraph summarizes the options and creates context for the reader. This contribution originates in #12476. 

Feel free to make corrections and changes if needed.

## Type of change

Does not quite fit the options below.

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
