### PR TITLE
Added service data attributes

### DIFF
--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -115,6 +115,11 @@ This service can be used to ask an update of a certain iDevice or all devices li
 
 This service will play the Lost iPhone sound on your iDevice. It will still ring if you are on "Mute" or "Do not disturb" mode.
 
+| Service data attribute    | Optional | Description                                             |
+|---------------------------|----------|---------------------------------------------------------|
+| `account`                 |       no | E-mail address of the iCloud account                    |
+| `device_name`             |       no | Human Friendly device name like Bob's iPhone            |
+
 ### Service `icloud.display_message`
 
 This service will display a message on your iDevice. It can also ring your device.


### PR DESCRIPTION
## Proposed change
Added service data attributes for the icloud.play_sound service.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
