### PR TITLE
Makes a clearer distinction between this card and mini-graph-card

### DIFF
--- a/source/_lovelace/sensor.markdown
+++ b/source/_lovelace/sensor.markdown
@@ -11,7 +11,7 @@ The Sensor card gives you a quick overview of your sensors state with an optiona
   Screenshot of the sensor card.
 </p>
 
-> Note: This card looks similar to the custom [mini-graph-card](https://github.com/kalkih/mini-graph-card) but these two cards do not share the same configuration parameters and must configured as per each cards documentation.
+> Note: This card looks similar to the custom [mini-graph-card](https://github.com/kalkih/mini-graph-card) but these two cards do not share the same configuration parameters and must be configured as per each cards documentation.
 
 {% configuration %}
 type:

--- a/source/_lovelace/sensor.markdown
+++ b/source/_lovelace/sensor.markdown
@@ -11,6 +11,8 @@ The Sensor card gives you a quick overview of your sensors state with an optiona
   Screenshot of the sensor card.
 </p>
 
+> Note: This card looks similar to the custom [mini-graph-card](https://github.com/kalkih/mini-graph-card) but these two cards do not share the same configuration parameters and must configured as per each cards documentation.
+
 {% configuration %}
 type:
   required: true


### PR DESCRIPTION


## Proposed change

When configuring from the Lovelace UI it was not immediately clear that the sensor card could not be configured in the same way as the custom mini-graph-card. It is my hope that this note in the doc will save someone else some time in future and possibly point them to a similar, more flexible card.


## Type of change

- [x ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
