### PR TITLE
Update zoneminder documentation to support config flow.

### DIFF
--- a/source/_integrations/zoneminder.markdown
+++ b/source/_integrations/zoneminder.markdown
@@ -6,11 +6,11 @@ ha_category:
   - Binary Sensor
   - Camera
   - Sensor
-  - Switch
 ha_release: 0.31
 ha_iot_class: Local Polling
 ha_codeowners:
   - '@rohankapoorcom'
+  - '@vangorra'
 ha_domain: zoneminder
 ---
 
@@ -21,68 +21,15 @@ There is currently support for the following device types within Home Assistant:
 - [Binary Sensor](#binary-sensor)
 - [Camera](#camera)
 - [Sensor](#sensor)
-- [Switch](#switch)
 
 ## Configuration
 
-```yaml
-# Example configuration.yaml entry
-zoneminder:
-  - host: ZM_HOST
-```
+1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'ZoneMinder' and click 'Configure'.
+2. Enter the information appropriate for the server and click 'Submit'.
 
-{% configuration %}
-host:
-  description: Your ZoneMinder server's host (and optional port), not including the scheme.
-  required: true
-  type: string
-path:
-  description: Path to your ZoneMinder install.
-  required: false
-  type: string
-  default: "`/zm/`"
-path_zms:
-  description: Path to the CGI script for streaming. This should match `PATH_ZMS` in ZM's "Paths" settings.
-  required: false
-  type: string
-  default: "`/zm/cgi-bin/nph-zms`"
-ssl:
-  description: Set to `true` if your ZoneMinder installation is using SSL.
-  required: false
-  type: boolean
-  default: false
-verify_ssl:
-  description: Verify the certification of the endpoint.
-  required: false
-  type: boolean
-  default: true
-username:
-  description: Your ZoneMinder username.
-  required: false
-  type: string
-password:
-  description: Your ZoneMinder password. Required if `OPT_USE_AUTH` is enabled in ZM.
-  required: false
-  type: string
-{% endconfiguration %}
+## Service
 
-### Full configuration
-
-```yaml
-# Example configuration.yaml entry
-zoneminder:
-  - host: ZM_HOST
-    path: ZM_PATH
-    path_zms: ZM_PATH_ZMS
-    ssl: true
-    verify_ssl: true
-    username: YOUR_USERNAME
-    password: YOUR_PASSWORD
-```
-
-### Service
-
-Once loaded, the `zoneminder` platform will expose a service (`set_run_state`) that can be used to change the current run state of ZoneMinder.
+Once loaded, the `zoneminder` integration will expose a service (`set_run_state`) that can be used to change the current run state of ZoneMinder.
 
 | Service data attribute | Optional | Description                       |
 |:-----------------------|:---------|:----------------------------------|
@@ -95,97 +42,6 @@ For example, if your ZoneMinder instance was configured with a run state called 
 action:
   service: zoneminder.set_run_state
   data:
-    id: ZM_HOST
+    id: 10.10.3.2
     name: Home
 ```
-
-## Binary Sensor
-
-The `zoneminder` binary sensor platform lets you monitor the availability of your [ZoneMinder](https://www.zoneminder.com) install.
-
-Each binary_sensor created will be named after the hostname used when configuring the [ZoneMinder component](/integrations/zoneminder/).
-
-## Camera
-
-The `zoneminder` camera platform lets you monitor the current stream of your [ZoneMinder](https://www.zoneminder.com) cameras.
-
-### Configuration
-
-To set it up, add the following information to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-camera:
-  - platform: zoneminder
-```
-
-## Sensor
-
-The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of events, the current state of the cameras and ZoneMinder's current run state.
-
-To set it up, add the following information to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: zoneminder
-    include_archived: false
-```
-
-{% configuration %}
-include_archived:
-  description: Whether to include archived ZoneMinder events in event counts.
-  required: false
-  default: false
-  type: boolean
-monitored_conditions:
-  description: Event count sensors to display in the frontend.
-  required: false
-  type: list
-  keys:
-    all:
-      description: All events.
-    month:
-      description: Events in the last month.
-    week:
-      description: Events in the last week.
-    day:
-      description: Events in the last day.
-    hour:
-      description: Events in the last hour.
-{% endconfiguration %}
-
-## Switch
-
-The `zoneminder` switch platform allows you to toggle the current function of all cameras attached to your [ZoneMinder](https://www.zoneminder.com) instance.
-
-<div class='note'>
-
-You must have the [ZoneMinder component](/integrations/zoneminder/) configured to use this and if ZoneMinder authentication is enabled the account specified in the integration configuration must have "Edit" permission for "System".
-
-</div>
-
-To enable this switch, add the following lines to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-switch:
-  - platform: zoneminder
-    command_on: Modect
-    command_off: Monitor
-```
-
-{% configuration %}
-command_on:
-  description: The function you want the camera to run when turned on.
-  required: true
-  type: string
-command_off:
-  description: The function you want the camera to run when turned off.
-  required: true
-  type: string
-{% endconfiguration %}
-
-<div class='note'>
-The default functions installed by ZoneMinder are: None, Monitor, Modect, Record, Mocord, Nodect.
-</div>

--- a/source/_integrations/zoneminder.markdown
+++ b/source/_integrations/zoneminder.markdown
@@ -79,7 +79,7 @@ For example, if your ZoneMinder instance was configured with a run state called 
 action:
   service: zoneminder.set_run_state
   data:
-    id: 10.10.3.2
+    id: ZM_HOST
     name: Home
 ```
 

--- a/source/_integrations/zoneminder.markdown
+++ b/source/_integrations/zoneminder.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Binary Sensor
   - Camera
   - Sensor
+  - Switch
 ha_release: 0.31
 ha_iot_class: Local Polling
 ha_codeowners:
@@ -21,6 +22,7 @@ There is currently support for the following device types within Home Assistant:
 - [Binary Sensor](#binary-sensor)
 - [Camera](#camera)
 - [Sensor](#sensor)
+- [Switch](#switch)
 
 ## Configuration
 
@@ -45,3 +47,94 @@ action:
     id: 10.10.3.2
     name: Home
 ```
+
+## Binary Sensor
+
+The `zoneminder` binary sensor platform lets you monitor the availability of your [ZoneMinder](https://www.zoneminder.com) install.
+
+Each binary_sensor created will be named after the hostname used when configuring the [ZoneMinder component](/integrations/zoneminder/).
+
+## Camera
+
+The `zoneminder` camera platform lets you monitor the current stream of your [ZoneMinder](https://www.zoneminder.com) cameras.
+
+### Configuration
+
+To set it up, add the following information to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+camera:
+  - platform: zoneminder
+```
+
+## Sensor
+
+The `zoneminder` sensor platform lets you monitor the current state of your [ZoneMinder](https://www.zoneminder.com) install including the number of events, the current state of the cameras and ZoneMinder's current run state.
+
+To set it up, add the following information to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: zoneminder
+    include_archived: false
+```
+
+{% configuration %}
+include_archived:
+  description: Whether to include archived ZoneMinder events in event counts.
+  required: false
+  default: false
+  type: boolean
+monitored_conditions:
+  description: Event count sensors to display in the frontend.
+  required: false
+  type: list
+  keys:
+    all:
+      description: All events.
+    month:
+      description: Events in the last month.
+    week:
+      description: Events in the last week.
+    day:
+      description: Events in the last day.
+    hour:
+      description: Events in the last hour.
+{% endconfiguration %}
+
+## Switch
+
+The `zoneminder` switch platform allows you to toggle the current function of all cameras attached to your [ZoneMinder](https://www.zoneminder.com) instance.
+
+<div class='note'>
+
+You must have the [ZoneMinder component](/integrations/zoneminder/) configured to use this and if ZoneMinder authentication is enabled the account specified in the integration configuration must have "Edit" permission for "System".
+
+</div>
+
+To enable this switch, add the following lines to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: zoneminder
+    command_on: Modect
+    command_off: Monitor
+```
+
+{% configuration %}
+command_on:
+  description: The function you want the camera to run when turned on.
+  required: true
+  type: string
+command_off:
+  description: The function you want the camera to run when turned off.
+  required: true
+  type: string
+{% endconfiguration %}
+
+<div class='note'>
+The default functions installed by ZoneMinder are: None, Monitor, Modect, Record, Mocord, Nodect.
+</div>

--- a/source/_integrations/zoneminder.markdown
+++ b/source/_integrations/zoneminder.markdown
@@ -29,6 +29,41 @@ There is currently support for the following device types within Home Assistant:
 1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'ZoneMinder' and click 'Configure'.
 2. Enter the information appropriate for the server and click 'Submit'.
 
+{% configuration %}
+host:
+  description: Your ZoneMinder server's host (and optional port), not including the scheme.
+  required: true
+  type: string
+path:
+  description: Path to your ZoneMinder install.
+  required: false
+  type: string
+  default: "`/zm/`"
+path_zms:
+  description: Path to the CGI script for streaming. This should match `PATH_ZMS` in ZM's "Paths" settings.
+  required: false
+  type: string
+  default: "`/zm/cgi-bin/nph-zms`"
+ssl:
+  description: Set to `true` if your ZoneMinder installation is using SSL.
+  required: false
+  type: boolean
+  default: false
+verify_ssl:
+  description: Verify the certification of the endpoint.
+  required: false
+  type: boolean
+  default: true
+username:
+  description: Your ZoneMinder username.
+  required: false
+  type: string
+password:
+  description: Your ZoneMinder password. Required if `OPT_USE_AUTH` is enabled in ZM.
+  required: false
+  type: string
+{% endconfiguration %}
+
 ## Service
 
 Once loaded, the `zoneminder` integration will expose a service (`set_run_state`) that can be used to change the current run state of ZoneMinder.
@@ -57,8 +92,6 @@ Each binary_sensor created will be named after the hostname used when configurin
 ## Camera
 
 The `zoneminder` camera platform lets you monitor the current stream of your [ZoneMinder](https://www.zoneminder.com) cameras.
-
-### Configuration
 
 To set it up, add the following information to your `configuration.yaml` file:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update zoneminder documentation to support config flow.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37060
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
