### PR TITLE
Remove deprecated internal MQTT broker

### DIFF
--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -121,49 +121,8 @@ If you experience an error message like `Failed to connect due to exception: [SS
 
 </div>
 
-### Embedded broker (Deprecated)
-
-Home Assistant contains an embedded MQTT broker called [HBMQTT](https://pypi.python.org/pypi/hbmqtt). If you don't have an MQTT broker, you can configure this one to be used. If configured, Home Assistant will automatically connect to it.
-
-| Setting        | Value                              |
-| -------------- | ---------------------------------- |
-| Host           | localhost                          |
-| Port           | 1883                               |
-| Protocol       | 3.1.1                              |
-| User           | `homeassistant`                    |
-| Password       | _password set under MQTT settings_ |
-| Websocket port | 8080                               |
-
-```yaml
-# Example configuration.yaml entry
-mqtt:
-  password: hello
-```
-
-<div class='note warning'>
-As of release 0.92, the embedded broker has been marked as deprecated. This means bugs may not be fixed, and the functionality may be removed in a future release.
-</div>
-
-<div class='note warning'>
-
-There is [an issue](https://github.com/beerfactory/hbmqtt/issues/62) with the HBMQTT broker and the WebSocket connection that is causing a memory leak. If you experience this issue, consider using another broker like Mosquitto.
-
-</div>
-
 #### Owntracks
 
 To use Owntracks with the internal broker a small configuration change must be made in order for the app to use MQTT protocol 3.1.1 (Protocol Level 4).
 
-In the Owntracks preferences (Android: v1.2.3+, iOS: v9.5.1+) open **Configuration Management**; Find the value named `mqttProtocolLevel` and set the value to `4`. The application will now use MQTT 3.1.1 to connect, which is compatible with the embedded broker.
-
-#### Settings
-
-If you want to customize the settings of the embedded broker, use `embedded:` and the values shown in the [HBMQTT Broker configuration](http://hbmqtt.readthedocs.org/en/latest/references/broker.html#broker-configuration). This will replace the default configuration.
-
-```yaml
-# Example configuration.yaml entry
-mqtt:
-  embedded:
-    # Your HBMQTT config here. Example at:
-    # http://hbmqtt.readthedocs.org/en/latest/references/broker.html#broker-configuration
-```
+In the Owntracks preferences (Android: v1.2.3+, iOS: v9.5.1+) open **Configuration Management**; Find the value named `mqttProtocolLevel` and set the value to `4`. The application will now use MQTT 3.

--- a/source/_docs/mqtt/broker.markdown
+++ b/source/_docs/mqtt/broker.markdown
@@ -120,9 +120,3 @@ Home Assistant will automatically load the correct certificate if you connect to
 If you experience an error message like `Failed to connect due to exception: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed`, then add `certificate: auto` to your broker configuration and restart Home Assistant.
 
 </div>
-
-#### Owntracks
-
-To use Owntracks with the internal broker a small configuration change must be made in order for the app to use MQTT protocol 3.1.1 (Protocol Level 4).
-
-In the Owntracks preferences (Android: v1.2.3+, iOS: v9.5.1+) open **Configuration Management**; Find the value named `mqttProtocolLevel` and set the value to `4`. The application will now use MQTT 3.

--- a/source/_docs/mqtt/discovery.markdown
+++ b/source/_docs/mqtt/discovery.markdown
@@ -43,12 +43,6 @@ discovery_prefix:
   type: string
 {% endconfiguration %}
 
-<div class='note'>
-
-The [embedded MQTT broker](/docs/mqtt/broker#embedded-broker) does not save any messages between restarts. If you use the embedded MQTT broker you have to send the MQTT discovery messages after every Home Assistant restart for the devices to show up.
-
-</div>
-
 The discovery topic need to follow a specific format:
 
 ```text

--- a/source/_docs/mqtt/testing.markdown
+++ b/source/_docs/mqtt/testing.markdown
@@ -10,12 +10,6 @@ The `mosquitto` broker package ships commandline tools (often as `*-clients` pac
 mosquitto_pub -h 127.0.0.1 -t home-assistant/switch/1/on -m "Switch is ON"
 ```
 
-If you are using the embedded MQTT broker, the command looks a little different because you need to add the MQTT protocol version and your [broker credentials](/docs/mqtt/broker#embedded-broker).
-
-```bash
-mosquitto_pub -V mqttv311 -u homeassistant -P <broker password> -t "hello" -m world
-```
-
 Another way to send MQTT messages by hand is to use the "Developer Tools" in the Frontend. Choose the "MQTT" tab. Enter something similar to the example below into the "Topic" field.
 
 ```bash
@@ -45,10 +39,4 @@ For reading all messages sent on the topic `home-assistant` to a broker running 
 
 ```bash
 mosquitto_sub -h 127.0.0.1 -v -t "home-assistant/#"
-```
-
-For the embedded MQTT broker the command looks like:
-
-```bash
-mosquitto_sub -v -V mqttv311 -u homeassistant -P <broker password> -t "#"
 ```

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -29,20 +29,6 @@ mqtt:
   broker: IP_ADDRESS_BROKER
 ```
 
-You can also use the [embedded MQTT broker](/docs/mqtt/broker#embedded-broker-deprecated). A separate broker is advised for more stability.
-
-<div class='note warning'>
-As of release 0.92, the embedded broker has been marked as deprecated. This means bugs may not be fixed, and the broker functionality will be removed in a future release.
-</div>
-
-```yaml
-# Example configuration.yaml entry
-mqtt:
-  password: hello
-```
-
-This allows you to connect to the MQTT broker with user `homeassistant` and password `hello`.
-
 ## Additional features
 
 - [Certificate](/docs/mqtt/certificate/)

--- a/source/_posts/2015-09-11-different-ways-to-use-mqtt-with-home-assistant.markdown
+++ b/source/_posts/2015-09-11-different-ways-to-use-mqtt-with-home-assistant.markdown
@@ -20,7 +20,7 @@ This post will give you a small overview of some other possibilities on how to u
 
 ## Manual usage
 
-The simplest but not the coolest way as a human to interact with a Home Assistant sensor is launching a command manually. Let's create a "Mood" sensor. For simplicity Home Assistant and the MQTT broker are both running on the same host. The needed configuration snipplets to add to the `configuration.yaml` file consists of two parts: one for the broker and one for the sensor.
+The simplest but not the coolest way as a human to interact with a Home Assistant sensor is launching a command manually. Let's create a "Mood" sensor. For simplicity Home Assistant and the MQTT broker are both running on the same host. The needed configuration snippets to add to the `configuration.yaml` file consists of two parts: one for the broker and one for the sensor.
 
 ```yaml
 mqtt:

--- a/source/_posts/2016-03-26-embedded-mqtt-broker-uber-yamaha-growl.markdown
+++ b/source/_posts/2016-03-26-embedded-mqtt-broker-uber-yamaha-growl.markdown
@@ -8,7 +8,7 @@ author_twitter: balloob
 categories: Release-Notes
 ---
 
-Party people, 0.16 is here! The big thing with this release is that we have completely removed the barrier to get started by MQTT by being able to launch an embedded MQTT server: [hbMQTT]. Just add `mqtt:` to your config and a broker is launched and connected with Home Assistant. See the [documentation][embedded server] for more info.
+Party people, 0.16 is here! The big thing with this release is that we have completely removed the barrier to get started by MQTT by being able to launch an embedded MQTT server: [hbMQTT]. Just add `mqtt:` to your config and a broker is launched and connected with Home Assistant.
 
 Further in this release a bunch of cool new stuff, bug fixes and rewrites for the Vera and Tellstick component (see breaking changes section at bottom for this!).
 
@@ -49,7 +49,6 @@ Rock on.
 [@robbiet480]: https://github.com/robbiet480
 [@srcLurker]: https://github.com/srcLurker
 [@stefan-jonasson]: https://github.com/stefan-jonasson
-[embedded server]: /integrations/mqtt/#use-the-embedded-broker
 [Arduino]: /integrations/arduino#switch
 [Discovery]: /integrations/discovery/
 [Growl (GNTP)]: /integrations/gntp

--- a/source/_posts/2017-10-28-demo.markdown
+++ b/source/_posts/2017-10-28-demo.markdown
@@ -89,14 +89,15 @@ binary_sensor:
 
 ## MQTT Discovery
 
-This is a section for advanced users as it will require to run a separate script. Instead of adding `demo` platforms to the configuration this setup make use of [MQTT discovery](/docs/mqtt/discovery/) and the [embedded MQTT broker](/docs/mqtt/broker/#embedded-broker). Simply add MQTT to your `configuration.yaml` file with `discovery:`
+This is a section for advanced users as it will require to run a separate script. Instead of adding `demo` platforms to the configuration this setup make use of [MQTT discovery](/docs/mqtt/discovery/). Simply add MQTT to your `configuration.yaml` file with `discovery:`
 
 ```yaml
 mqtt:
+  host: YOUR_MQTT_HOST
   discovery: true
 ```
 
-Download the [sample script](https://github.com/home-assistant/home-assistant-dev-helper/blob/master/ha-mqtt-demo.py). It depends on [paho-mqtt](https://pypi.python.org/pypi/paho-mqtt). If you run the script inside your [Home Assistant's virtual environment](/docs/installation/virtualenv/) then you are good to go as the dependency should be present if you have used MQTT before. Otherwise, install it with `$ pip3 install paho-mqtt`. The same applies to the embedded broker.
+Download the [sample script](https://github.com/home-assistant/home-assistant-dev-helper/blob/master/ha-mqtt-demo.py). It depends on [paho-mqtt](https://pypi.python.org/pypi/paho-mqtt). If you run the script inside your [Home Assistant's virtual environment](/docs/installation/virtualenv/) then you are good to go as the dependency should be present if you have used MQTT before. Otherwise, install it with `$ pip3 install paho-mqtt`.
 
 ```bash
 (ha)[ha-demo]$ python3 ha-mqtt-demo.py


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Cleanup of documentation since the embedded MQTT broker has been removed.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37032
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
