### PR TITLE
Add documentation for deprecation of scan_interval

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -169,3 +169,24 @@ sensor:
         unit_of_measurement: 'kWh'
 ```
 {% endraw %}
+
+## Increase Polling Frequency
+
+Homeassistant deprecated the 'scan_interval' setting.  TP Link devices seem to be particularly affected by this change as many users report TP Link devices take upwards of 15-30 seconds to respond to automations.  If you find that the automatically determined polling frequency is too low  you can set an automation to poll specific devices at a user defined frequency with the following automation.
+
+{% raw %}
+```yaml
+# automations.yaml
+- id: update_tp_link
+  initial_state: 'on'
+  trigger:
+    - platform: time_pattern
+      seconds: '/5' # every 5 seconds
+  action:
+    - service: homeassistant.update_entity
+      data:
+        entity_id: 
+          - light.tp_link_light
+          - switch.tp_link_switch
+```
+{% endraw %}


### PR DESCRIPTION
## Proposed change
Since the deprecation of the 'scan_interval' setting TP  Link devices take approx 30s to respond to any automation.  User ljmerza identified a fix to allow users to define their own scan interval for specific devices @ <a href="https://github.com/home-assistant/core/issues/21768#issuecomment-470959458">#21768 (comment)</a>.



## Type of change
Adds documentation to address a common mismatch between expected and actual behavior that does not require a code change, only an additional automation to resolve.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
This was reported in <a href="https://github.com/home-assistant/core/issues/21768">Issue 21768</a> which is marked as closed, however the fix action is not clear in the documentation.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
