### PR TITLE
Typo and fixed links to integrations

### DIFF
--- a/source/_posts/2020-06-24-release-112.markdown
+++ b/source/_posts/2020-06-24-release-112.markdown
@@ -219,21 +219,21 @@ release, this attribute has been completely removed from the system.
 
 ## New Integrations
 
-- Add notify_events notify integration ([@papajojo] - [#36049]) ([notify_events documentation]) (new-integration)
-- Add HVV integration (Hamburg public transportation) ([@vigonotion] - [#31564]) ([hvv_departures documentation]) (new-integration)
-- Add new Remote Python Debugger integration ([@frenck] - [#36960]) ([debugpy documentation]) (new-integration)
-- Add new humidifier entity integration ([@Shulyaka] - [#28693]) ([humidity documentation]) (new-integration)
+- Add notify_events notify integration ([@papajojo] - [#36049]) ([notify_events docs]) (new-integration)
+- Add HVV integration (Hamburg public transportation) ([@vigonotion] - [#31564]) ([hvv_departures docs]) (new-integration)
+- Add new Remote Python Debugger integration ([@frenck] - [#36960]) ([debugpy docs]) (new-integration)
+- Add new humidifier entity integration ([@Shulyaka] - [#28693]) ([humidity docs]) (new-integration)
 
 ## New Platforms
 
-- Add devolo binary_sensor devices ([@2Fake] - [#36370]) ([devolo_home_control documentation]) (new-platform)
-- Add sensor platform for ViCare integration (heatpump) ([@crazyfx1] - [#34385]) ([ViCare documentation]) (breaking-change) (new-platform)
-- Add Withings webhooks ([@vangorra] - [#34447]) ([withings documentation]) (new-platform)
-- Light control support to Axis devices ([@Kane610] - [#36611]) ([Axis documentation]) (new-platform)
-- Fix/Rewrite of Toon integration ([@frenck] - [#36952]) ([Toon documentation]) (breaking-change) (new-platform)
-- Part 2: Add signal sensor ([@ocalvo] - [#34406]) ([SMS documentation]) (new-platform)
-- Part 3: Add support for incoming SMS events ([@ocalvo] - [#37015]) ([SMS documentation]) (new-platform)
-- Add smappee binary_sensor platform ([@bsmappee] - [#37023]) ([smappee documentation]) (new-platform)
+- Add devolo binary_sensor devices ([@2Fake] - [#36370]) ([devolo_home_control docs]) (new-platform)
+- Add sensor platform for ViCare integration (heatpump) ([@crazyfx1] - [#34385]) ([ViCare docs]) (breaking-change) (new-platform)
+- Add Withings webhooks ([@vangorra] - [#34447]) ([withings docs]) (new-platform)
+- Light control support to Axis devices ([@Kane610] - [#36611]) ([Axis docs]) (new-platform)
+- Fix/Rewrite of Toon integration ([@frenck] - [#36952]) ([Toon docs]) (breaking-change) (new-platform)
+- Part 2: Add signal sensor ([@ocalvo] - [#34406]) ([SMS docs]) (new-platform)
+- Part 3: Add support for incoming SMS events ([@ocalvo] - [#37015]) ([SMS docs]) (new-platform)
+- Add smappee binary_sensor platform ([@bsmappee] - [#37023]) ([smappee docs]) (new-platform)
 
 ## Integrations now available to set up from the UI
 
@@ -368,7 +368,7 @@ Experiencing issues introduced by this release? Please report them in our [issue
 
   ([@SukramJ] - [#36595]) ([homematicip_cloud docs])
 
-- **Sppedtest.net**
+- **Speedtest.net**
 
   This integration is now configured through the UI. To successfully import from `configuration.yaml` please remove `monitored_conditions`. If `server_id` is mentioned it will check against the list of servers before importing.
 


### PR DESCRIPTION
Fixed a type sppedtest -> speedtest
Fixed the links to the intragrations documentation, but they aren't made yet.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Typo


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
