### PR TITLE
Add missing alexa breaking change

### DIFF
--- a/source/_posts/2020-06-24-release-112.markdown
+++ b/source/_posts/2020-06-24-release-112.markdown
@@ -538,6 +538,25 @@ Previously the `autobypass` configuration option only worked for `home` and `awa
 
   ([@rajlaud] - [#35669]) ([squeezebox docs])
 
+- **Alexa**
+
+  Alexa Flash Briefings users must now set a configuration option called `password`, like this:
+
+  ```yaml
+  alexa:
+    flash_briefings:
+      password: YOUR_PASSWORD
+      whoishome:
+        - title: Who's at home?
+          # ...
+  ```
+
+  If you had configured a flash briefing with the name `password` before, you have to rename it. It is not required anymore to use the legacy `api_password` authentication to use Alexa Flash Briefings.
+
+  You also have to change the endpoint in the Alexa Developer Console to include this password in your URL, like this: `https://YOUR_HOST/api/alexa/flash_briefings/BRIEFING_ID?password=YOUR_PASSWORD`.
+
+  ([@Tho85] - [#36789]) ([alexa docs])
+
 ## Farewell to the following
 
 The integrations below have been removed:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add a missing breaking change of the `alexa` component. This was missed as the original PR did not have the breaking-change label.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#36789
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
