### PR TITLE
Add docs for posting remote files to Slack

### DIFF
--- a/source/_integrations/slack.markdown
+++ b/source/_integrations/slack.markdown
@@ -69,29 +69,68 @@ icon:
   type: string
 {% endconfiguration %}
 
-### Slack service data
+### Slack Service Data
 
-The following attributes can be placed inside `data` for extended functionality.
+The following attributes can be placed inside the `data` key of the service call for extended functionality:
 
-| Service data attribute | Optional | Description |
+| Attribute              | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `file`                   |      yes | Local path of file, photo, etc. to post to Slack.
+| `file`                   |      yes | A file to include with the message; see below.
 | `attachments`            |      yes | Array of [Slack attachments](https://api.slack.com/messaging/composing/layouts#attachments) (legacy). *NOTE*: if using `attachments`, they are shown **in addition** to `message`.
 | `blocks`                 |      yes | Array of [Slack blocks](https://api.slack.com/messaging/composing/layouts). *NOTE*: if using `blocks`, they are shown **in place of** the `message` (note that the `message` is required nonetheless).
 | `blocks_template`        |      yes | The same as `blocks`, but able to support [templates](https://www.home-assistant.io/docs/configuration/templating).
 
-Example for posting a file from local path:
+Note that using `file` will ignore all usage of `attachments`, `blocks`, and `blocks_template` (as Slack does not support those frameworks in messages that accompany uploaded files).
+
+To include a local file with the Slack message, use these attributes underneath the `file` key:
+
+| Attribute              | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `path`                   |      no  | A local filepath that has been [whitelisted](/docs/configuration/basic/#whitelist_external_dirs).
+
+To include a remote file with the Slack message, use these attributes underneath the `file` key:
+
+| Attribute              | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `url`                    |      no  | A URL that has been [whitelisted](/docs/configuration/basic/#allowlist_external_urls).
+| `username`               |      yes | An optional username if the URL is protected by HTTP Basic Auth.
+| `password`               |      yes | An optional password if the URL is protected by HTTP Basic Auth.
+
+### Examples
+
+To send a file from local path:
 
 ```yaml
 message: Message that will be added as a comment to the file.
 title: Title of the file.
 data:
-  file: "/path/to/file.ext"
+  file:
+    path: /path/to/file.ext
 ```
 
-Please note that `file` is validated against the `whitelist_external_dirs` in the `configuration.yaml`.
+To send a file from remote path:
 
-Example for using the block framework:
+```yaml
+message: Message that will be added as a comment to the file.
+title: Title of the file.
+data:
+  file:
+    url: "http://site.com/image.jpg"
+```
+
+To send a file from remote path that is protected by HTTP Basic Auth:
+
+```yaml
+message: Message that will be added as a comment to the file.
+title: Title of the file.
+data:
+  file:
+    url: "http://site.com/image.jpg"
+    username: user
+    password: pass
+```
+
+To use the block framework:
 
 ```yaml
 message: Fallback message in case the blocks don't display anything.
@@ -122,7 +161,7 @@ data:
           1.0
 ```
 
-Example for using the legacy attachments framework:
+To use the legacy attachments framework:
 
 ```yaml
 message: Message that will be added as a comment to the file.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds docs for forthcoming Slack functionality re: sending remote files.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37161
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
