### PR TITLE
Fix typo in state trigger warning

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -180,7 +180,7 @@ The `for` template(s) will be evaluated when an entity changes as specified.
 
 <div class='note warning'>
 
-Use quotes around your values for `for` and `to` to avoid the YAML parser from interpreting values as booleans.
+Use quotes around your values for `from` and `to` to avoid the YAML parser from interpreting values as booleans.
 
 </div>
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -180,7 +180,7 @@ The `for` template(s) will be evaluated when an entity changes as specified.
 
 <div class='note warning'>
 
-Use quotes around your values for `from` and `to` to avoid the YAML parser interpreting values as booleans.
+Use quotes around your values for `for` and `to` to avoid the YAML parser from interpreting values as booleans.
 
 </div>
 


### PR DESCRIPTION
## Proposed change
Fix a typo



## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
