### PR TITLE
Clarified on connection

### DIFF
--- a/source/_integrations/xiaomi_aqara.markdown
+++ b/source/_integrations/xiaomi_aqara.markdown
@@ -285,6 +285,8 @@ That means that Home Assistant is not getting any response from your Xiaomi gate
   - Turn on the gateway (220V).
   - Open a serial terminal application (e.g.,  PuTTY) and connect to the serial port assigned to the USB-UART module (baudrate: 115200).
   - Wait until the gateway is booted up, connect the RX, TX and GND wires to the UART module (don't connect the Vcc (power) wire!).
+   - RX on UART to TX on gateway
+   - TX on UART to RX on gateway
   - You will see all the messages from the gateway.
   - Send the command `psm-set network open_pf 3` (the command has to end with a `CR` newline character).
   - Check your settings executing the command `psm-get network open_pf` to be sure it's OK.


### PR DESCRIPTION
   - RX on UART to TX on gateway
   - TX on UART to RX on gateway

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added some clarity on connection, hope to save the next person an hour of time


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
