### PR TITLE
Plugwise: include info w.r.t. Zeroconf discovery

### DIFF
--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -2,12 +2,12 @@
 title: Plugwise
 description: Plugwise Smile platform integration.
 ha_category:
+  - Binary Sensor
   - Climate
   - Sensor
   - Switch
-  - Water Heater
 ha_iot_class: Local Polling
-ha_release: 0.98
+ha_release: 0.111
 ha_codeowners:
   - '@CoMPaTech'
   - '@bouwew'
@@ -41,11 +41,14 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 
 ## Configuration
 
-To set up this integration, click Configuration in the sidebar and then click Integrations. Add a new integration using the "+" button in the lower right corner and look for 'Plugwise'. Click configure and you will be presented with a dialog requesting the Smile ID or password of your Smile and it's IP address. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
+To set up this integration, click Configuration in the sidebar and then click Integrations. Add a new integration using the "+" button in the lower right corner and look for 'Plugwise'. Click **CONFIGURE** and you will be presented with a dialog requesting the Smile ID or password of your Smile and it's IP address. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
 Depending on your `climate` setup an auxiliary entitiy will be added when there is information available about such Plugwise devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
+
+OPTIONS: newly added, click **OPTIONS** to change the Smile-data refresh-interval: the time between subsequent data refreshes.
+Defaults: "Smile-Anna and Adam": 60 seconds, "Smile P1": 10 seconds.
 
 ### Services
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -7,7 +7,7 @@ ha_category:
   - Sensor
   - Switch
 ha_iot_class: Local Polling
-ha_release: 0.111
+ha_release: 0.98
 ha_codeowners:
   - '@CoMPaTech'
   - '@bouwew'

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -33,11 +33,11 @@ The password can be found on the bottom of your Smile, it should consist of 6 ch
 
 ## Entities
 
-This integration will show all Plugwise devices present in your Plugwise configuration. In addition you will see a 'Smile' device representing your central Plugwise gateway (i.e. the Smile, Smile P1 or Adam).
+This integration will show all Plugwise entities present in your Plugwise configuration. In addition you will see a 'Smile' entity representing your central Plugwise gateway (i.e. the Smile, Smile P1 or Adam).
 
-For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom' these will show up as individual devices. For setups where an auxiliary heater (or heater/cooler) is present there will be an additional device representing it called 'Auxiliary'.
+For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom' these will show up as individual entities. When there are more (than one) Plugwise thermostats present, an "Auxiliary Device" will be added representing the active heating/cooling device present in your climate system. If you have Plugs (as in, pluggable switches connecting to an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
 
-Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna or Smile will be assigned to your gateway device. Auxiliary Heater(/Cooler) measurements such as 'boiler_temperature' will be assigned to the Auxiliary entity.
+Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna or Smile will be assigned to your gateway entity. Auxiliary Heater(/Cooler) measurements such as 'boiler_temperature' will be assigned to the Auxiliary entity.
 
 ## Configuration
 
@@ -48,8 +48,6 @@ PLEASE NOTE 1: the Unique ID(s) of the Plugwise integration(s) has(have) changed
 PLEASE NOTE 2: when you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
 
 PLEASE NOTE 3: BE AWARE that ignoring one Plugwise integration also blocks any other Plugwise integration from future discovery. If you ever need to rediscover an existing Plugwise integration, make sure to first STOP IGNORING the Plugwise integration before you try rediscovery.
-
-When there are more (than one) Plugwise thermostats present, an "auxiliary device" will be added representing the active heating/cooling device present in your climate system. If you have Plugs (as in, pluggable switches connecting to an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -49,9 +49,7 @@ PLEASE NOTE 2: when you have an Anna and an Adam, make sure to only configure th
 
 PLEASE NOTE 3: BE AWARE that ignoring one Plugwise integration also blocks any other Plugwise integration from future discovery. If you ever need to rediscover an existing Plugwise integration, make sure to first STOP IGNORING the Plugwise integration before you try rediscovery.
 
-Depending on your `climate` setup an auxiliary entitiy will be added when there is information available about such Plugwise devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor` or `binary_sensor`.
-
-Depending on your `climate` setup an auxiliary entitiy will be added when there is information available about such Plugwise devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
+Depending on your `climate` setup an auxiliary entity will be added when there is information available about such a Plugwise device. If you have Plugs (as in, pluggable switches that can be connected to an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -41,7 +41,7 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 
 ## Configuration
 
-The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click CONFIGURATION on the discovered Entity and you will be presented with a dialog requesting the Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
+The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click the "CONFIGURATION" button on the discovered integration and you will be presented with a dialog requesting your Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
 PLEASE NOTE 1: the Unique ID(s) of the Plugwise integration(s) has(have) changed due to the introduction of automatic discovery. If you have already configured the Plugwise integration(s) via the "Integrations --> Plus-button"-method, you can ignore the newly discovered Plugwise integration(s).
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -43,14 +43,14 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 
 The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click the "CONFIGURATION" button on the discovered integration and you will be presented with a dialog requesting your Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
+Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
+
 <div class='note warning'>
   
   When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
   In case you need to rediscover the Adam integration, make sure to STOP IGNORING the Plugwise integration first, available via "show ignored integrations".
   
 </div>
-
-Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 
 ### Services
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -2,10 +2,10 @@
 title: Plugwise
 description: Plugwise Smile platform integration.
 ha_category:
-  - Binary Sensor
   - Climate
   - Sensor
   - Switch
+  - Water Heater
 ha_iot_class: Local Polling
 ha_release: 0.98
 ha_codeowners:
@@ -41,14 +41,17 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 
 ## Configuration
 
-To set up this integration, click Configuration in the sidebar and then click Integrations. Add a new integration using the "+" button in the lower right corner and look for 'Plugwise'. Click **CONFIGURE** and you will be presented with a dialog requesting the Smile ID or password of your Smile and it's IP address. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
+The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click CONFIGURATION on the discovered Entity and you will be presented with a dialog requesting the Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
-Depending on your `climate` setup an auxiliary entitiy will be added when there is information available about such Plugwise devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
+PLEASE NOTE 1: the Unique ID(s) of the Plugwise integration(s) has(have) changed due to the introduction of automatic discovery. If you have already configured the Plugwise integration(s) via the "Integrations --> Plus-button"-method, you can ignore the newly discovered Plugwise integration(s).
+
+PLEASE NOTE 2: when you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
+
+PLEASE NOTE 3: BE AWARE that ignoring one Plugwise integration also blocks any other Plugwise integration from future discovery. If you ever need to rediscover an existing Plugwise integration, make sure to first STOP IGNORING the Plugwise integration before you try rediscovery.
+
+Depending on your `climate` setup an auxiliary entitiy will be added when there is information available about such Plugwise devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor` or `binary_sensor`.
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
-
-OPTIONS: newly added, click **OPTIONS** to change the Smile-data refresh-interval: the time between subsequent data refreshes.
-Defaults: "Smile-Anna and Adam": 60 seconds, "Smile P1": 10 seconds.
 
 ### Services
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -43,11 +43,9 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 
 The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click the "CONFIGURATION" button on the discovered integration and you will be presented with a dialog requesting your Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
-PLEASE NOTE 1: the Unique ID(s) of the Plugwise integration(s) has(have) changed due to the introduction of automatic discovery. If you have already configured the Plugwise integration(s) via the "Integrations --> Plus-button"-method, you can ignore the newly discovered Plugwise integration(s).
+PLEASE NOTE 1: when you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
 
-PLEASE NOTE 2: when you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
-
-PLEASE NOTE 3: BE AWARE that ignoring one Plugwise integration also blocks any other Plugwise integration from future discovery. If you ever need to rediscover an existing Plugwise integration, make sure to first STOP IGNORING the Plugwise integration before you try rediscovery.
+PLEASE NOTE 2: BE AWARE that ignoring one Plugwise integration also blocks any other Plugwise integration from future discovery. If you ever need to rediscover an existing Plugwise integration, make sure to first STOP IGNORING the Plugwise integration before you try rediscovery.
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -44,10 +44,8 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click the "CONFIGURATION" button on the discovered integration and you will be presented with a dialog requesting your Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
 <div class='note warning'>
-  
   When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
   In case you need to rediscover the Adam integration, make sure to STOP IGNORING the Plugwise integration first, available via "show ignored integrations".
-
 </div>
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -44,8 +44,10 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click the "CONFIGURATION" button on the discovered integration and you will be presented with a dialog requesting your Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
 <div class='note warning'>
+  
   When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
   In case you need to rediscover the Adam integration, make sure to STOP IGNORING the Plugwise integration first, available via "show ignored integrations".
+  
 </div>
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -43,9 +43,12 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 
 The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click the "CONFIGURATION" button on the discovered integration and you will be presented with a dialog requesting your Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
-PLEASE NOTE 1: when you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
+<div class='note warning'>
+  
+  When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
+  In case you need to rediscover the Adam integration, make sure to STOP IGNORING the Plugwise integration first, available via "show ignored integrations".
 
-PLEASE NOTE 2: BE AWARE that ignoring one Plugwise integration also blocks any other Plugwise integration from future discovery. If you ever need to rediscover an existing Plugwise integration, make sure to first STOP IGNORING the Plugwise integration before you try rediscovery.
+</div>
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -49,7 +49,7 @@ PLEASE NOTE 2: when you have an Anna and an Adam, make sure to only configure th
 
 PLEASE NOTE 3: BE AWARE that ignoring one Plugwise integration also blocks any other Plugwise integration from future discovery. If you ever need to rediscover an existing Plugwise integration, make sure to first STOP IGNORING the Plugwise integration before you try rediscovery.
 
-Depending on your `climate` setup an auxiliary entity will be added when there is information available about such a Plugwise device. If you have Plugs (as in, pluggable switches that can be connected to an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
+When there are more (than one) Plugwise thermostats present, an "auxiliary device" will be added representing the active heating/cooling device present in your climate system. If you have Plugs (as in, pluggable switches connecting to an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
 
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -18,7 +18,7 @@ ha_domain: plugwise
 This enables [Plugwise](https://www.plugwise.com) components with a central Smile gateway to be integrated. This integration talks locally to your **Smile** interface, and you will need its password and IP address.
 The platform supports [Anna](https://www.plugwise.com/en_US/products/anna), [Adam (zonecontrol)](https://www.plugwise.com/en_US/zonecontrol) and [P1](https://www.plugwise.com/en_US/products/smile-p1) Smile products. See below list for more details.
 
-Platforms available - depending on your Smile and setup are include:
+Platforms available - depending on your Smile and setup include:
 
  - `climate` (for the Anna and Lisa products, or a single Tom)
  - `sensor` (for all relevant products including the Smile P1)
@@ -33,9 +33,9 @@ The password can be found on the bottom of your Smile, it should consist of 6 ch
 
 ## Entities
 
-This integration will show all Plugwise entities present in your Plugwise configuration. In addition you will see a 'Smile' entity representing your central Plugwise gateway (i.e. the Smile, Smile P1 or Adam).
+This integration will show all Plugwise entities present in your Plugwise configuration. In addition, you will see a 'Smile' entity representing your central Plugwise gateway (i.e., the Smile, Smile P1 or Adam).
 
-For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom' these will show up as individual entities. When there are more (than one) Plugwise thermostats present, an "Auxiliary Device" will be added representing the active heating/cooling device present in your climate system. If you have Plugs (as in, pluggable switches connecting to an Adam) those will be discovered as switches. Various other measures of your setup will be available as sensors or binary sensors.
+For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom', these will show up as individual entities. When there are more (than one) Plugwise thermostats present, an "Auxiliary Device" will be added, representing the active heating/cooling device present in your climate system. If you have Plugs (as in, pluggable switches connecting to an Adam) those will be discovered as switches. Various other measures of your setup will be available as sensors or binary sensors.
 
 Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna or Smile will be assigned to your gateway entity. Auxiliary Heater(/Cooler) measurements such as 'boiler_temperature' will be assigned to the Auxiliary entity.
 
@@ -43,13 +43,10 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 
 The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click the "CONFIGURATION" button on the discovered integration and you will be presented with a dialog requesting your Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located.
 
-Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
+Repeat the above procedure for each Smile gateway (i.e., if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 
 <div class='note warning'>
-  
-  When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press IGNORE on the Anna integration to remove this integration. 
-  In case you need to rediscover the Adam integration, make sure to STOP IGNORING the Plugwise integration first, available via "show ignored integrations".
-  
+When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press the "IGNORE" button on the Anna integration to remove this integration. In case you need to rediscover the Adam integration, make sure to click the "STOP IGNORING" button on the Plugwise integration first, available via "show ignored integrations".
 </div>
 
 ### Services

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -51,6 +51,8 @@ PLEASE NOTE 3: BE AWARE that ignoring one Plugwise integration also blocks any o
 
 Depending on your `climate` setup an auxiliary entitiy will be added when there is information available about such Plugwise devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor` or `binary_sensor`.
 
+Depending on your `climate` setup an auxiliary entitiy will be added when there is information available about such Plugwise devices. If you have "plug"s (as in, pluggable switches that come with an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
+
 Repeat the above procedure for each Smile gateway (i.e. if you have an Adam setup and a P1 DSMR you'll have to add two integrations).
 
 ### Services

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -35,7 +35,7 @@ The password can be found on the bottom of your Smile, it should consist of 6 ch
 
 This integration will show all Plugwise entities present in your Plugwise configuration. In addition you will see a 'Smile' entity representing your central Plugwise gateway (i.e. the Smile, Smile P1 or Adam).
 
-For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom' these will show up as individual entities. When there are more (than one) Plugwise thermostats present, an "Auxiliary Device" will be added representing the active heating/cooling device present in your climate system. If you have Plugs (as in, pluggable switches connecting to an Adam) those will be discovered as `switch`es. Various other measures of your setup will be available as `sensor`s or `binary_sensor`s.
+For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom' these will show up as individual entities. When there are more (than one) Plugwise thermostats present, an "Auxiliary Device" will be added representing the active heating/cooling device present in your climate system. If you have Plugs (as in, pluggable switches connecting to an Adam) those will be discovered as switches. Various other measures of your setup will be available as sensors or binary sensors.
 
 Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna or Smile will be assigned to your gateway entity. Auxiliary Heater(/Cooler) measurements such as 'boiler_temperature' will be assigned to the Auxiliary entity.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add info describing the newly added automatic discovery via zeroconf.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37289
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
