### PR TITLE
Update tts.markdown

### DIFF
--- a/source/_integrations/tts.markdown
+++ b/source/_integrations/tts.markdown
@@ -104,8 +104,7 @@ Say to all `media_player` device entities:
 # Replace google_translate_say with <platform>_say when you use a different platform.
 service: tts.google_translate_say
 entity_id: "all"
-data:
-  message: 'May the Force be with you.'
+message: 'May the Force be with you.'
 ```
 
 Say to the `media_player.floor` device entity:
@@ -113,8 +112,7 @@ Say to the `media_player.floor` device entity:
 ```yaml
 service: tts.google_translate_say
 entity_id: media_player.floor
-data:
-  message: 'May the Force be with you.'
+message: 'May the Force be with you.'
 ```
 
 Say to the `media_player.floor` device entity in French:
@@ -122,18 +120,17 @@ Say to the `media_player.floor` device entity in French:
 ```yaml
 service: tts.google_translate_say
 entity_id: media_player.floor
-data:
-  message: 'Que la force soit avec toi.'
-  language: 'fr'
+message: 'Que la force soit avec toi.'
+language: 'fr'
 ```
 
 With a template:
 
 ```yaml
 service: tts.google_translate_say
-data_template:
-  message: "Temperature is {% raw %}{{states('sensor.temperature')}}{% endraw %}."
-  cache: false
+
+message: "Temperature is {% raw %}{{states('sensor.temperature')}}{% endraw %}."
+cache: false
 ```
 
 ## Cache


### PR DESCRIPTION

## Proposed change
According to https://github.com/home-assistant/core/blob/dev/homeassistant/components/tts/services.yaml

This no longer allows the use of 

```
data:
  message: "message"
```



## Type of change
Adjust the templates

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
