### PR TITLE
Add documentation for new Bond integration

### DIFF
--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -1,0 +1,21 @@
+---
+title: Bond
+description: Instructions on setting up Bond Bridge within Home Assistant.
+ha_category:
+  - Hub
+  - Cover
+ha_iot_class: Local Pull
+ha_release: 0.113
+ha_domain: bond
+ha_codeowners:
+  - '@prystupa'
+---
+
+Duplicates your RF remote control. Supported devices:
+- Ceiling fans
+- Shades
+- Fireplaces
+
+## Configuration
+
+To use Bond controlled devices in your installation, add your Bond hub host and access token from the integrations page.

--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -11,12 +11,15 @@ ha_codeowners:
   - '@prystupa'
 ---
 
-Duplicates your RF remote control. Supported devices:
+Duplicates your RF remote control.
+
+Supported devices:
+
 - Ceiling fans
 - Shades
 - Fireplaces
 
-## Configuration via UI
+## Configuration
 
 To use Bond controlled devices in your installation, add your Bond hub host and access token from the integrations page.
 

--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -16,6 +16,11 @@ Duplicates your RF remote control. Supported devices:
 - Shades
 - Fireplaces
 
-## Configuration
+## Configuration via UI
 
 To use Bond controlled devices in your installation, add your Bond hub host and access token from the integrations page.
+
+Menu: **Configuration** -> **Integrations**.
+
+Click on the `+` sign to add an integration and click on **Bond** (use typeahead if necessary).
+After completing the configuration flow, the Bond integration will be available.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documentation for new Bond integration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37477
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1732
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
