### PR TITLE
Gree

### DIFF
--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -15,7 +15,7 @@ The `gree` platform allows you to control a [Gree Smart HVAC](http://global.gree
 
 ### Setup
 
-Go to the integrations page in your configuration and click on new integration -> Gree.
+Go to the integrations page in your configuration and click on **new integration** -> **Gree**.
 
 Gree Smart compatible devices are detected and added automatically.
 

--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -1,0 +1,54 @@
+---
+title: Gree
+description: Instructions on how to integrate Gree Smart devices within Home Assistant.
+ha_category:
+  - Climate
+ha_release: 103.0
+ha_iot_class: Local Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@cmroche'
+ha_domain: gree
+---
+
+The `gree` platform allows you to control a [Gree Smart HVAC](http://global.gree.com/).
+
+### Setup
+
+Go to the integrations page in your configuration and click on new integration -> Gree.
+
+Gree Smart compatible devices are detected and added automatically.
+
+### YAML Configuration
+
+YAML configuration is around for people that prefer YAML.
+To use this integration, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+gree:
+  hosts:
+    - host: IP_ADDRESS
+  discovery: true
+```
+
+{% configuration %}
+hosts:
+  description: List with your Gree devices.
+  required: false
+  type: list
+  keys:
+    host:
+      description: The IP address or hostname of the HVAC.
+      required: true
+      type: string
+discovery:
+  description: If discovered devices should be automatically added.
+  required: false
+  default: true
+  type: boolean
+{% endconfiguration %}
+
+### Supported models
+
+Any Gree Smart device working with the Gree+ app should be supported, including non-Gree branded devices including some sold by Trane.

--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -27,9 +27,6 @@ To use this integration, add the following to your `configuration.yaml` file:
 ```yaml
 # Example configuration.yaml entry
 gree:
-  hosts:
-    - host: IP_ADDRESS
-  discovery: true
 ```
 
 {% configuration %}

--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -19,33 +19,6 @@ Go to the integrations page in your configuration and click on **new integration
 
 Gree Smart compatible devices are detected and added automatically.
 
-### YAML Configuration
-
-YAML configuration is around for people that prefer YAML.
-To use this integration, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-gree:
-```
-
-{% configuration %}
-hosts:
-  description: List with your Gree devices.
-  required: false
-  type: list
-  keys:
-    host:
-      description: The IP address or hostname of the HVAC.
-      required: true
-      type: string
-discovery:
-  description: If discovered devices should be automatically added.
-  required: false
-  default: true
-  type: boolean
-{% endconfiguration %}
-
 ### Supported models
 
 Any Gree Smart device working with the Gree+ app should be supported, including non-Gree branded devices including some sold by Trane.

--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -3,7 +3,7 @@ title: Gree
 description: Instructions on how to integrate Gree Smart devices within Home Assistant.
 ha_category:
   - Climate
-ha_release: 103.0
+ha_release: 0.113
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:

--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -3,7 +3,7 @@ title: Gree
 description: Instructions on how to integrate Gree Smart devices within Home Assistant.
 ha_category:
   - Climate
-ha_release: 0.113
+ha_release: 0.117
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
@@ -21,4 +21,4 @@ Gree Smart compatible devices are detected and added automatically.
 
 ### Supported models
 
-Any Gree Smart device working with the Gree+ app should be supported, including non-Gree branded devices including some sold by Trane.
+Any Gree Smart device working with the Gree+ app should be supported, including non-Gree branded devices, including some sold by Trane.

--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -12,13 +12,13 @@ ha_domain: gree
 ---
 
 The `gree` platform allows you to control a [Gree Smart HVAC](http://global.gree.com/).
-
-### Setup
+ 
+## Configuration
 
 Go to the integrations page in your configuration and click on **new integration** -> **Gree**.
 
 Gree Smart compatible devices are detected and added automatically.
 
-### Supported models
+## Supported models
 
 Any Gree Smart device working with the Gree+ app should be supported, including non-Gree branded devices, including some sold by Trane.

--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -11,7 +11,7 @@ ha_codeowners:
 ha_domain: gree
 ---
 
-The `gree` platform allows you to control a [Gree Smart HVAC](http://global.gree.com/).
+The Gree integration allows you to control a [Gree Smart HVAC](http://global.gree.com/).
  
 ## Configuration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adding documentation for a new platform integration (Gree)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37498
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1733
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
