### PR TITLE
Document config flow for smarthab integration

### DIFF
--- a/source/_integrations/smarthab.markdown
+++ b/source/_integrations/smarthab.markdown
@@ -18,10 +18,7 @@ devices and you have access to their app-based services, you will be able
 to control your lights and shutters with the SmartHab integration for Home 
 Assistant.
 
-<div class='note info'>
-The easiest way to set up this integration is to do it from the UI. If you
-prefer to do it from `configuration.yaml`, follow these instructions.
-</div>
+## Configuration
 
 <div class='note warning'>
   To prevent being automatically logged out of your SmartHab mobile app, you
@@ -29,6 +26,12 @@ prefer to do it from `configuration.yaml`, follow these instructions.
   access to your home. You can then configure the integration using this account's
   credentials. This is also more secure, as this user should be less priviledged.
 </div>
+
+To add the SmartHab integration to your installation, go to **Configuration** >> 
+**Integrations** in the UI, click the button with `+` sign and from the list of 
+integrations select **SmartHab**.
+
+Alternatively, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/smarthab.markdown
+++ b/source/_integrations/smarthab.markdown
@@ -7,6 +7,7 @@ ha_category:
   - Cover
   - Light
 ha_iot_class: Cloud Polling
+ha_config_flow: true
 ha_codeowners:
   - '@outadoc'
 ha_domain: smarthab
@@ -17,8 +18,10 @@ devices and you have access to their app-based services, you will be able
 to control your lights and shutters with the SmartHab integration for Home 
 Assistant.
 
-Once you have added a `smarthab` entry to your configuration, your supported 
-devices will automatically be discovered and made available on your dashboard.
+<div class='note info'>
+The easiest way to set up this integration is to do it from the UI. If you
+prefer to do it from `configuration.yaml`, follow these instructions.
+</div>
 
 <div class='note warning'>
   To prevent being automatically logged out of your SmartHab mobile app, you


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR updates the doc for the `smarthab` integration to mention config flow support.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/34387
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
