### PR TITLE
Fix incomplete quotations in Vacuum.MQTT docs

### DIFF
--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -158,7 +158,7 @@ retain:
   type: boolean
   default: false
 schema:
-  description: The schema to use. Must be `legacy` or omitted to select the legacy schema".
+  description: The schema to use. Must be `legacy` or omitted to select the legacy schema.
   required: false
   type: string
   default: legacy
@@ -171,7 +171,7 @@ set_fan_speed_topic:
   required: false
   type: string
 supported_features:
-  description: List of features that the vacuum supports (possible values are `turn_on`, `turn_off`, `pause`, `stop`, `return_home`, `battery`, `status`, `locate`, `clean_spot`, `fan_speed`, `send_command`)."
+  description: List of features that the vacuum supports (possible values are `turn_on`, `turn_off`, `pause`, `stop`, `return_home`, `battery`, `status`, `locate`, `clean_spot`, `fan_speed`, `send_command`).
   required: false
   type: [string, list]
   default: "`turn_on`, `turn_off`, `stop`, `return_home`, `status`, `battery`, `clean_spot`"
@@ -370,7 +370,7 @@ retain:
   type: boolean
   default: false
 schema:
-  description: The schema to use. Must be `state` to select the state schema".
+  description: The schema to use. Must be `state` to select the state schema.
   required: false
   type: string
   default: legacy


### PR DESCRIPTION
## Proposed change
Removed incomplete quotations in docs, where only one of two quotes were present.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
