### PR TITLE
Update dynalite.markdown

### DIFF
--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -129,6 +129,11 @@ area:
                   required: false
                   type: float
                   default: 2.0
+                level:
+                  description: Level of the channels when the preset is selected, between 0 and 1.
+                  required: false
+                  type: float
+                  default: None
         nodefault:
           description: Do not use the default presets defined globally, but only the specific ones defined for this area.
           required: false
@@ -179,6 +184,11 @@ preset:
           required: false
           type: float
           default: 2.0
+        level:
+          description: Level of the channels when the preset is selected, between 0 and 1.
+          required: false
+          type: float
+          default: None
 template:
   description: Set the default parameters for the templates.
   required: false

--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -98,7 +98,6 @@ area:
           description: "Type of template to use for the area. Supported values are: `room` and `time_cover`. They are described in detail below in the **template** section. If the template parameters are different than defaults, they can be overridden in this section as well."
           require: false
           type: string
-          default: No template
         TEMPLATE_PARAMS:
           description: "This can be any of the settings of the template. For example, for template `room`: `room_on` and `room_off` are possible options."
           required: false
@@ -133,7 +132,6 @@ area:
                   description: Level of the channels when the preset is selected, between 0 and 1.
                   required: false
                   type: float
-                  default: None
         nodefault:
           description: Do not use the default presets defined globally, but only the specific ones defined for this area.
           required: false
@@ -188,7 +186,6 @@ preset:
           description: Level of the channels when the preset is selected, between 0 and 1.
           required: false
           type: float
-          default: None
 template:
   description: Set the default parameters for the templates.
   required: false
@@ -233,7 +230,6 @@ template:
           description: Channel that monitors the cover.
           required: false
           type: integer
-          default: No channel
         duration:
           description: Time in seconds it takes to open or close the cover.
           required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Added the parameter level to a preset to tell the level to set the channels
when it is selected


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37533
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
