### PR TITLE
Make Modbus hub name mandatory

### DIFF
--- a/source/_integrations/binary_sensor.modbus.markdown
+++ b/source/_integrations/binary_sensor.modbus.markdown
@@ -4,7 +4,7 @@ description: "Instructions on how to set up Modbus binary sensors within Home As
 ha_category:
   - Binary Sensor
 ha_release: 0.28
-ha_iot_class: Local Push
+ha_iot_class: Local Polling
 ha_domain: modbus
 ---
 
@@ -42,8 +42,7 @@ inputs:
       type: string
     hub:
       description: The name of the hub.
-      required: false
-      default: default
+      required: true
       type: string
     slave:
       description: The number of the slave (Optional for TCP and UDP Modbus).

--- a/source/_integrations/climate.modbus.markdown
+++ b/source/_integrations/climate.modbus.markdown
@@ -41,8 +41,7 @@ name:
   type: string
 hub:
   description: The name of the hub.
-  required: false
-  default: default
+  required: true
   type: string
 slave:
   description: The number of the slave (Optional for tcp and upd Modbus, use 1).

--- a/source/_integrations/flexit.markdown
+++ b/source/_integrations/flexit.markdown
@@ -19,6 +19,7 @@ To enable this platform, add the following lines to your `configuration.yaml` fi
 climate:
   - platform: flexit
     slave: 21
+    hub: hub1
 ```
 
 {% configuration %}
@@ -32,8 +33,7 @@ name:
   type: string
 hub:
   description: The name of the hub where this slave is located.
-  required: false
-  default: default
+  required: true
   type: string
 {% endconfiguration %}
 
@@ -63,4 +63,5 @@ climate:
   - platform: flexit
     name: Main A/C
     slave: 21
+    hub: hub1
 ```

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate Modbus within Home Assistant.
 ha_category:
   - Hub
 ha_release: pre 0.7
-ha_iot_class: Local Push
+ha_iot_class: Local Polling
 ha_codeowners:
   - '@adamchengtkc'
   - '@janiversen'
@@ -46,8 +46,7 @@ port:
   type: integer
 name:
   description: Name for this hub. Must be unique, so it is required when setting up multiple instances.
-  required: false
-  default: default
+  required: true
   type: string
 timeout:
   description: Timeout for slave response in seconds.
@@ -109,8 +108,7 @@ parity:
   type: string
 name:
   description: Name for this hub. Must be unique, so it is required when setting up multiple instances.
-  required: false
-  default: default
+  required: true
   type: string
 timeout:
   description: Timeout for slave response in seconds.
@@ -148,7 +146,7 @@ modbus:
 
 | Attribute | Description |
 | --------- | ----------- |
-| hub       | Hub name (defaults to 'default' when omitted) |
+| hub       | Hub name |
 | unit      | Slave address (1-255, mostly 255 if you talk to Modbus via TCP) |
 | address   | Address of the Register (e.g., 138) |
 | value     | A single value or an array of 16-bit values. Single value will call modbus function code 6. Array will call modbus function code 16. Array might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]` |

--- a/source/_integrations/sensor.modbus.markdown
+++ b/source/_integrations/sensor.modbus.markdown
@@ -4,7 +4,7 @@ description: "Instructions on how to integrate Modbus sensors into Home Assistan
 ha_category:
   - Sensor
 ha_release: pre 0.7
-ha_iot_class: Local Push
+ha_iot_class: Local Polling
 ha_domain: modbus
 ---
 
@@ -54,8 +54,7 @@ registers:
       type: string
     hub:
       description: The name of the hub.
-      required: false
-      default: default
+      required: true
       type: string
     slave:
       description: The number of the slave (Optional for tcp and upd Modbus).

--- a/source/_integrations/stiebel_eltron.markdown
+++ b/source/_integrations/stiebel_eltron.markdown
@@ -50,6 +50,7 @@ To enable this component, add the following lines to your `configuration.yaml` f
 # Example configuration.yaml entry
 stiebel_eltron:
   name: LWZ504e
+  hub: hub1
 ```
 
 {% configuration %}
@@ -60,8 +61,7 @@ name:
   type: string
 hub:
   description: The name of the hub where this slave is located.
-  required: false
-  default: default
+  required: true
   type: string
 {% endconfiguration %}
 
@@ -79,7 +79,9 @@ modbus:
   type: tcp
   host: YOUR_ISGWEB_IP
   port: 502
+  name: hub1
 
 stiebel_eltron:
   name: LWZ504e
+  hub: hub1
 ```

--- a/source/_integrations/switch.modbus.markdown
+++ b/source/_integrations/switch.modbus.markdown
@@ -4,7 +4,7 @@ description: "Instructions on how to integrate Modbus switches into Home Assista
 ha_category:
   - Switch
 ha_release: pre 0.7
-ha_iot_class: Local Push
+ha_iot_class: Local Polling
 ha_domain: modbus
 ---
 
@@ -43,8 +43,7 @@ coils:
   keys:
     hub:
       description: The name of the hub.
-      required: false
-      default: default
+      required: true
       type: string
     slave:
       description: The number of the slave (can be omitted for tcp and udp Modbus).
@@ -65,8 +64,7 @@ registers:
   keys:
     hub:
       description: The hub to use.
-      required: false
-      default: default
+      required: true
       type: string
     slave:
       description: The number of the slave (can be omitted for tcp and udp Modbus).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This pull request enforces hub name as a mandatory parameter. At the moment it's entirely optional, which introduces ambiguity.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#37546
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
