### PR TITLE
Document MQTT availability list

### DIFF
--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -53,7 +53,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:

--- a/source/_integrations/alarm_control_panel.mqtt.markdown
+++ b/source/_integrations/alarm_control_panel.mqtt.markdown
@@ -37,8 +37,27 @@ alarm_control_panel:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 code:

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -18,8 +18,7 @@ Stateless devices such as buttons, remote controls etc are better represented by
 
 ## Configuration
 
-The `mqtt` binary sensor platform optionally supports an `availability_topic` to receive online and offline messages (birth and LWT messages) from the MQTT device. During normal operation, if the MQTT sensor device goes offline (i.e., publishes `payload_not_available` to `availability_topic`), Home Assistant will display the binary sensor as `unavailable`. If these messages are published with the `retain` flag set, the binary sensor will receive an instant update after subscription and Home Assistant will display the correct availability state of the binary sensor when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the binary sensor as `unavailable` when Home Assistant starts up. If no `availability_topic`
-is defined, Home Assistant will consider the MQTT device to be `available` and will display its state.
+The `mqtt` binary sensor platform optionally supports a list of  `availability` topics to receive online and offline messages (birth and LWT messages) from the MQTT device. During normal operation, if the MQTT sensor device goes offline (i.e., publishes `payload_not_available` to an `availability` topic), Home Assistant will display the binary sensor as `unavailable`. If these messages are published with the `retain` flag set, the binary sensor will receive an instant update after subscription and Home Assistant will display the correct availability state of the binary sensor when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the binary sensor as `unavailable` when Home Assistant starts up. If no `availability` topic is defined, Home Assistant will consider the MQTT device to be `available` and will display its state.
 
 To use an MQTT binary sensor in your installation,
 add the following to your `configuration.yaml` file:
@@ -32,8 +31,27 @@ binary_sensor:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: "The MQTT topic subscribed to receive birth and LWT messages from the MQTT device. If `availability_topic` is not defined, the binary sensor will always be considered `available` and its state will be `on`, `off` or `unknown`. If `availability_topic` is defined, the binary sensor will be considered as `unavailable` by default and the sensor's state will be `unavailable`."
+  description: "The MQTT topic subscribed to receive birth and LWT messages from the MQTT device. If `availability` is not defined, the binary sensor will always be considered `available` and its state will be `on`, `off` or `unknown`. If `availability` is defined, the binary sensor will be considered as `unavailable` by default and the sensor's initial state will be `unavailable`."  Must not be used together with `availability`.
   required: false
   type: string
 device:
@@ -74,7 +92,7 @@ device_class:
   required: false
   type: string
 expire_after:
-  description: "Defines the number of seconds after the sensor's state expires if it's not updated. After expiry, the sensor's state becomes `unavailable` if `availability_topic` is defined and `unknown` otherwise."
+  description: "Defines the number of seconds after the sensor's state expires if it's not updated. After expiry, the sensor's state becomes `unavailable` if any `availability` topic is defined and `unknown` otherwise."
   required: false
   type: integer
 force_update:
@@ -164,9 +182,10 @@ binary_sensor:
     state_topic: "home-assistant/window/contact"
     payload_on: "ON"
     payload_off: "OFF"
-    availability_topic: "home-assistant/window/availability"
-    payload_available: "online"
-    payload_not_available: "offline"
+    availability:
+      - topic: "home-assistant/window/availability"
+        payload_available: "online"
+        payload_not_available: "offline"
     qos: 0
     device_class: opening
     value_template: '{{ value.x }}'

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -47,7 +47,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:

--- a/source/_integrations/binary_sensor.mqtt.markdown
+++ b/source/_integrations/binary_sensor.mqtt.markdown
@@ -51,7 +51,7 @@ availability:
       required: true
       type: string
 availability_topic:
-  description: "The MQTT topic subscribed to receive birth and LWT messages from the MQTT device. If `availability` is not defined, the binary sensor will always be considered `available` and its state will be `on`, `off` or `unknown`. If `availability` is defined, the binary sensor will be considered as `unavailable` by default and the sensor's initial state will be `unavailable`."  Must not be used together with `availability`.
+  description: "The MQTT topic subscribed to receive birth and LWT messages from the MQTT device. If `availability` is not defined, the binary sensor will always be considered `available` and its state will be `on`, `off` or `unknown`. If `availability` is defined, the binary sensor will be considered as `unavailable` by default and the sensor's initial state will be `unavailable`. Must not be used together with `availability`."
   required: false
   type: string
 device:

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -24,8 +24,27 @@ camera:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 device:

--- a/source/_integrations/camera.mqtt.markdown
+++ b/source/_integrations/camera.mqtt.markdown
@@ -40,7 +40,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -59,7 +59,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:

--- a/source/_integrations/climate.mqtt.markdown
+++ b/source/_integrations/climate.mqtt.markdown
@@ -43,8 +43,27 @@ aux_state_topic:
   description: The MQTT topic to subscribe for changes of the auxiliary heat mode. If this is not set, the auxiliary heat mode works in optimistic mode (see below).
   required: false
   type: string
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 away_mode_command_topic:

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -38,9 +38,9 @@ cover:
 
 {% configuration %}
 availability:
-  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  description: "A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`."
   required: false
-  type: list
+  type: map
   keys:
     payload_available:
       description: The payload that represents the available state.
@@ -53,11 +53,11 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:
-  description: "The MQTT topic subscribed to to receive birth and LWT messages from the MQTT cover device. If an `availability` topic is not defined, the cover availability state will always be `available`. If an `availability` topic is defined, the cover availability state will be `unavailable` by default." Must not be used together with `availability`.
+  description: "The MQTT topic subscribed to to receive birth and LWT messages from the MQTT cover device. If an `availability` topic is not defined, the cover availability state will always be `available`. If an `availability` topic is defined, the cover availability state will be `unavailable` by default. Must not be used together with `availability`."
   required: false
   type: string
 command_topic:
@@ -235,7 +235,7 @@ tilt_optimistic:
   type: boolean
   default: "`true` if `tilt_status_topic` is not defined, else `false`"
 tilt_status_template:
-  description: "Defines a [template](/topics/templating/) that can be used to extract the payload for the `tilt_status_topic` topic. "
+  description: "Defines a [template](/topics/templating/) that can be used to extract the payload for the `tilt_status_topic` topic."
   required: false
   type: string
 tilt_status_topic:

--- a/source/_integrations/cover.mqtt.markdown
+++ b/source/_integrations/cover.mqtt.markdown
@@ -25,7 +25,7 @@ If a state topic and position topic are not defined, the cover will work in opti
 
 Optimistic mode can be forced, even if a `state_topic` / `position_topic` is defined. Try to enable it if experiencing incorrect cover operation (Google Assistant gauge may need optimistic mode as it often send request to your Home Assistant immediately after send set_cover_position in which case MQTT could be too slow).
 
-The `mqtt` cover platform optionally supports an `availability_topic` to receive online and offline messages (birth and LWT messages) from the MQTT cover device. During normal operation, if the MQTT cover device goes offline (i.e., publishes `payload_not_available` to `availability_topic`), Home Assistant will display the cover as "unavailable". If these messages are published with the `retain` flag set, the cover will receive an instant update after subscription and Home Assistant will display correct availability state of the cover when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the cover as "unavailable" when Home Assistant starts up.
+The `mqtt` cover platform optionally supports a list of `availability` topics to receive online and offline messages (birth and LWT messages) from the MQTT cover device. During normal operation, if the MQTT cover device goes offline (i.e., publishes a matching `payload_not_available` to any `availability` topic), Home Assistant will display the cover as "unavailable". If these messages are published with the `retain` flag set, the cover will receive an instant update after subscription and Home Assistant will display correct availability state of the cover when Home Assistant starts up. If the `retain` flag is not set, Home Assistant will display the cover as "unavailable" when Home Assistant starts up.
 
 To use your MQTT cover in your installation, add the following to your `configuration.yaml` file:
 
@@ -37,8 +37,27 @@ cover:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: "The MQTT topic subscribed to to receive birth and LWT messages from the MQTT cover device. If `availability_topic` is not defined, the cover availability state will always be `available`. If `availability_topic` is defined, the cover availability state will be `unavailable` by default."
+  description: "The MQTT topic subscribed to to receive birth and LWT messages from the MQTT cover device. If an `availability` topic is not defined, the cover availability state will always be `available`. If an `availability` topic is defined, the cover availability state will be `unavailable` by default." Must not be used together with `availability`.
   required: false
   type: string
 command_topic:
@@ -250,7 +269,8 @@ cover:
     name: "MQTT Cover"
     command_topic: "home-assistant/cover/set"
     state_topic: "home-assistant/cover/state"
-    availability_topic: "home-assistant/cover/availability"
+    availability:
+      - topic: "home-assistant/cover/availability"
     qos: 0
     retain: true
     payload_open: "OPEN"
@@ -281,7 +301,8 @@ cover:
     name: "MQTT Cover"
     command_topic: "home-assistant/cover/set"
     position_topic: "home-assistant/cover/position"
-    availability_topic: "home-assistant/cover/availability"
+    availability:
+      - "home-assistant/cover/availability"
     set_position_topic: "home-assistant/cover/set_position"
     qos: 0
     retain: true
@@ -311,7 +332,8 @@ cover:
     name: "MQTT Cover"
     command_topic: "home-assistant/cover/set"
     state_topic: "home-assistant/cover/state"
-    availability_topic: "home-assistant/cover/availability"
+    availability:
+      - topic: "home-assistant/cover/availability"
     qos: 0
     retain: true
     payload_open: "OPEN"

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -28,8 +28,27 @@ fan:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 command_topic:

--- a/source/_integrations/fan.mqtt.markdown
+++ b/source/_integrations/fan.mqtt.markdown
@@ -44,7 +44,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -61,7 +61,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:
@@ -434,7 +434,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:
@@ -762,7 +762,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:

--- a/source/_integrations/light.mqtt.markdown
+++ b/source/_integrations/light.mqtt.markdown
@@ -45,8 +45,27 @@ light:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 brightness_command_topic:
@@ -399,8 +418,27 @@ light:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 brightness:
@@ -708,8 +746,27 @@ light:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 blue_template:

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -44,7 +44,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -28,8 +28,27 @@ lock:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 command_topic:

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -143,7 +143,8 @@ sensor:
     state_topic: "home/sensor1/infojson"
     unit_of_measurement: 'dBm'
     value_template: "{{ value_json.RSSI }}"
-    availability_topic: "home/sensor1/status"
+    availability:
+      - topic: "home/sensor1/status"
     payload_available: "online"
     payload_not_available: "offline"
     json_attributes_topic: "home/sensor1/attributes"

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -28,8 +28,27 @@ switch:
 ```
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 command_topic:
@@ -163,7 +182,8 @@ switch:
     name: "Bedroom Switch"
     state_topic: "home/bedroom/switch1"
     command_topic: "home/bedroom/switch1/set"
-    availability_topic: "home/bedroom/switch1/available"
+    availability:
+      - topic: "home/bedroom/switch1/available"
     payload_on: "ON"
     payload_off: "OFF"
     state_on: "ON"

--- a/source/_integrations/switch.mqtt.markdown
+++ b/source/_integrations/switch.mqtt.markdown
@@ -44,7 +44,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -45,7 +45,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:
@@ -296,7 +296,7 @@ availability:
       type: string
       default: offline
     topic:
-  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
       required: true
       type: string
 availability_topic:

--- a/source/_integrations/vacuum.mqtt.markdown
+++ b/source/_integrations/vacuum.mqtt.markdown
@@ -29,8 +29,27 @@ vacuum:
 Legacy MQTT vacuum configuration section.
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 battery_level_template:
@@ -261,8 +280,27 @@ MQTT payload:
 State MQTT vacuum configuration section.
 
 {% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+  description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
 availability_topic:
-  description: The MQTT topic subscribed to receive availability (online/offline) updates.
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
   required: false
   type: string
 command_topic:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document MQTT availability list


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37418

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
