### PR TITLE
Add sudo: option to nmap_tracker (for Mac OS, not needed on Linux)

### DIFF
--- a/source/_integrations/nmap_tracker.markdown
+++ b/source/_integrations/nmap_tracker.markdown
@@ -50,6 +50,11 @@ scan_options:
   required: false
   default: -F --host-timeout 5s
   type: string
+sudo:
+  description: Run Nmap with sudo. This is suitable for Mac OS, but under Linux, it would be better to use setcap as described below.
+  required: false
+  default: false
+  type: boolean
 {% endconfiguration %}
 
 ## Examples


### PR DESCRIPTION
## Proposed change
Documents new sudo option for the Nmap tracker


## Type of change


- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37649
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist


- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
