### PR TITLE
Add ozw.set_config_parameter command to documentation.

### DIFF
--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -76,6 +76,6 @@ LED colors on switches.
 | Service Data Attribute | Required | Description                                                                                                     |
 | ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
 | `instance_id`          | no       | The OZW Instance/Controller to use, defaults to 1.                                                              |
-| `node_id`              | yes      | Node id of the device to set config parameter to (integer).                                                     |
+| `node_id`              | yes      | Node id of the device to set configuration parameter to (integer).                                                     |
 | `parameter`            | yes      | Parameter number to set (integer).                                                                              |
 | `value`                | yes      | Value to set for parameter. (String or integer value for list, string for bool parameters, integer for others). |

--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -65,3 +65,17 @@ this operation.
 | Service Data Attribute | Required | Description                                        |
 | ---------------------- | -------- | -------------------------------------------------- |
 | `instance_id`          | no       | The OZW Instance/Controller to use, defaults to 1. |
+
+
+### Service `ozw.set_config_parameter`
+
+This service will set the specified configuration parameter to the value specified to 
+allow device-specific configurations. Example of this would be setting notification
+LED colors on switches.
+
+| Service Data Attribute | Required | Description                                                                                                     |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `instance_id`          | no       | The OZW Instance/Controller to use, defaults to 1.                                                              |
+| `node_id`              | yes      | Node id of the device to set config parameter to (integer).                                                     |
+| `parameter`            | yes      | Parameter number to set (integer).                                                                              |
+| `value`                | yes      | Value to set for parameter. (String or integer value for list, string for bool parameters, integer for others). |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add set_config_parameter command to documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37523
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
