### PR TITLE
OZW usercode documentation

### DIFF
--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -77,17 +77,6 @@ Valid usercodes are at least 4 digits.
 | `code_slot`            | yes      | The code slot to set the usercode into. |
 | `usercode`             | yes      | The code to set in the slot.            |
 
-### Service `ozw.get_usercode`
-
-This service will get the usercode from code_slot X.
-The code will display as an `INFO` message in the log.
-Valid code_slots are 1-254.
-
-| Service Data Attribute | Required | Description                             |
-| ---------------------- | -------- | --------------------------------------- |
-| `entity_id`            | yes      | Lock entity to get the usercode.        |
-| `code_slot`            | yes      | The code slot to get the usercode from. |
-
 ### Service `ozw.clear_usercode`
 
 This service will clear the usercode in code_slot X.

--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -3,13 +3,13 @@ title: OpenZWave (beta)
 description: Instructions on how to integrate OpenZWave with Home Assistant.
 ha_category:
   - Switch
-ha_release: '0.110'
+ha_release: "0.110"
 ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
-  - '@cgarwood'
-  - '@marcelveldt'
-  - '@MartinHjelmare'
+  - "@cgarwood"
+  - "@marcelveldt"
+  - "@MartinHjelmare"
 ha_domain: ozw
 ---
 
@@ -65,3 +65,35 @@ this operation.
 | Service Data Attribute | Required | Description                                        |
 | ---------------------- | -------- | -------------------------------------------------- |
 | `instance_id`          | no       | The OZW Instance/Controller to use, defaults to 1. |
+
+### Service `ozw.set_usercode`
+
+This service will set the usercode to X at code_slot Y.
+Valid usercodes are at least 4 digits.
+
+| Service Data Attribute | Required | Description                             |
+| ---------------------- | -------- | --------------------------------------- |
+| `entity_id`            | yes      | Lock entity to set the usercode.        |
+| `code_slot`            | yes      | The code slot to set the usercode into. |
+| `usercode`             | yes      | The code to set in the slot.            |
+
+### Service `ozw.get_usercode`
+
+This service will get the usercode from code_slot X.
+The code will display as an `INFO` message in the log.
+Valid code_slots are 1-254.
+
+| Service Data Attribute | Required | Description                             |
+| ---------------------- | -------- | --------------------------------------- |
+| `entity_id`            | yes      | Lock entity to get the usercode.        |
+| `code_slot`            | yes      | The code slot to get the usercode from. |
+
+### Service `ozw.clear_usercode`
+
+This service will clear the usercode in code_slot X.
+Valid code_slots are 1-254.
+
+| Service Data Attribute | Required | Description                               |
+| ---------------------- | -------- | ----------------------------------------- |
+| `entity_id`            | yes      | Lock entity to clear the usercode.        |
+| `code_slot`            | yes      | The code slot to clear the usercode from. |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for ozw.set_usercode, ozw.get_usercode, and ozw.clear_usercode


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37390
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
