### PR TITLE
Fix boolean vs string in scene YAML examples

### DIFF
--- a/source/_docs/scene.markdown
+++ b/source/_docs/scene.markdown
@@ -10,21 +10,21 @@ You can create scenes that capture the states you want certain entities to be. F
 scene:
   - name: Romantic
     entities:
-      light.tv_back_light: on
+      light.tv_back_light: "on"
       light.ceiling:
-        state: on
+        state: "on"
         xy_color: [0.33, 0.66]
         brightness: 200
   - name: Movies
     entities:
       light.tv_back_light:
-        state: on
+        state: "on"
         brightness: 125
       light.ceiling: off
       media_player.sony_bravia_tv:
-        state: on
+        state: "on"
         source: HDMI 1
-        state: on
+        state: "on"
 ```
 
 {% configuration %}
@@ -75,11 +75,11 @@ automation:
     data:
       entities:
         light.tv_back_light:
-          state: on
+          state: "on"
           brightness: 100
         light.ceiling: off
         media_player.sony_bravia_tv:
-          state: on
+          state: "on"
           source: HDMI 1
 ```
 

--- a/source/_integrations/scene.markdown
+++ b/source/_integrations/scene.markdown
@@ -18,19 +18,19 @@ scene:
   - name: Romantic
     icon: "mdi:flower-tulip"
     entities:
-      light.tv_back_light: on
+      light.tv_back_light: "on"
       light.ceiling:
-        state: on
+        state: "on"
         xy_color: [0.33, 0.66]
         brightness: 200
   - name: Movies
     entities:
       light.tv_back_light:
-        state: on
+        state: "on"
         brightness: 125
       light.ceiling: off
       media_player.sony_bravia_tv:
-        state: on
+        state: "on"
         source: HDMI 1
 ```
 
@@ -86,11 +86,11 @@ automation:
     data:
       entities:
         light.tv_back_light:
-          state: on
+          state: "on"
           brightness: 100
         light.ceiling: off
         media_player.sony_bravia_tv:
-          state: on
+          state: "on"
           source: HDMI 1
 ```
 
@@ -145,11 +145,11 @@ automation:
       scene_id: my_scene
       entities:
         light.tv_back_light:
-          state: on
+          state: "on"
           brightness: 100
         light.ceiling: off
         media_player.sony_bravia_tv:
-          state: on
+          state: "on"
           source: HDMI 1
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Fixes a common mistake in our examples, where the state is written as `on` instead of `"on"`, which makes it a boolean...


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
