### PR TITLE
Doc for new include & exclude traccar filters

### DIFF
--- a/source/_integrations/traccar.markdown
+++ b/source/_integrations/traccar.markdown
@@ -71,6 +71,14 @@ skip_accuracy_filter_on:
   description: Skip filter position by "max_accuracy filter" if any of specified attributes are pressent on the traccar message.
   required: false
   type: list
+devices_include:
+  description: Configure which devices should be tracked. If set, all other entities will not be tracked.
+  required: false
+  type: list
+devices_exclude:
+  description: Configure which devices should be excluded from tracking. An exclusion filter takes precedence over an inclusion filter. 
+  required: false
+  type: list
 monitored_conditions:
   description: Additional traccar computed attributes or device-related attributes to include in the scan.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
New features are added to existing Traccar integration: the `include` &  `exclude` filters to allow a mayor control about entities imported from traccar. (https://github.com/home-assistant/core/pull/37814)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
