### PR TITLE
Always expose Toon gas sensors

### DIFF
--- a/source/_integrations/toon.markdown
+++ b/source/_integrations/toon.markdown
@@ -29,7 +29,7 @@ Sensors for energy, power and gas consumption, sensors for solar production and
 several binary sensors for things like boiler burner on/off, hot tap water and
 boiler health status.
 
-For the Toon integration to work, you'll need an active Toon subscription 
+For the Toon integration to work, you'll need an active Toon subscription
 and a Toon API developer account.
 
 There is currently support for the following device types within Home Assistant:
@@ -106,12 +106,12 @@ when values of the thermostat are changed.
 The Toon integration provides the following sensors:
 
 - Average Daily Energy Usage*
-- Average Daily Gas Usage* (only with a "smart" gas meter)
-- Average Gas Usage (only with a "smart" gas meter)
+- Average Daily Gas Usage*
+- Average Gas Usage
 - Average Power Usage*
 - Average Solar Power Production to Grid* (only with solar module)
 - Boiler Modulation Level* (only with OpenTherm)
-- Current Gas Usage (only with a "smart" gas meter)
+- Current Gas Usage
 - Current Power Usage
 - Current Power Usage Covered By Solar (only with solar module)
 - Current Solar Power Production (only with solar module)
@@ -123,9 +123,9 @@ The Toon integration provides the following sensors:
 - Energy Produced To Grid Today* (only with solar module)
 - Energy Usage From Grid Today* (only with solar module)
 - Energy Usage Today
-- Gas Cost Today (only with a "smart" gas meter)
-- Gas Meter (only with a "smart" gas meter)
-- Gas Usage Today (only with a "smart" gas meter)
+- Gas Cost Today
+- Gas Meter
+- Gas Usage Today
 - Max Solar Power Production Today (only with solar module)
 - Solar Energy Produced Today (only with solar module)
 - Solar Power Production to Grid (only with solar module)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Toon gas sensors are now always exposed, regardless of their "smart" status or not.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37829
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
