### PR TITLE
Deprecate `extra_module_url` in frontend

### DIFF
--- a/source/_integrations/frontend.markdown
+++ b/source/_integrations/frontend.markdown
@@ -38,11 +38,11 @@ frontend:
             required: true
             type: [list, string]
   extra_html_url:
-    description: "List of additional [resources](/developers/frontend_creating_custom_ui/) to load in `latest` javascript mode."
+    description: "DEPRECATED List of additional [resources](/developers/frontend_creating_custom_ui/) to load in `latest` javascript mode."
     required: false
     type: list
   extra_module_url:
-    description: "List of additional javascript modules to load."
+    description: "List of additional javascript modules to load in `latest` javascript mode."
     required: false
     type: list
   extra_js_url_es5:
@@ -120,23 +120,25 @@ When themes are enabled in the `configuration.yaml` file, a new option will show
   Set a theme
 </p>
 
-## Loading extra HTML
+## Loading extra JavaScript
 
-Starting with version 0.53 you can specify extra HTML files to load, and starting with version 0.95 extra JS modules.
+Starting with version 0.95 you load extra JS modules.
 
 Example:
 
 ```yaml
 # Example configuration.yaml entry
 frontend:
-  extra_html_url:
-    - https://example.com/file1.html
-    - /local/file2.html
   extra_module_url:
     - /local/my_module.js
+  extra_js_url_es5:
+    - /local/my_es5.js
 ```
 
-HTML will be loaded via `<link rel='import' href='{{ extra_url }}' async>` on any page (states and panels), and modules via `<script type='module' scr='{{ extra_module }}'></script>`.
+Modules will be loaded with `import({{ extra_module }})`, on devices that support it (`latest` mode).
+For other devices (`es5` mode) you can use `extra_js_url_es5`, this will be loaded with `<script defer scr='{{ extra_module }}'></script>`
+
+The ES5 and module version will never both be loaded, depending on if the device supports `import` the module of ES5 version will be loaded.
 
 ### Manual Language Selection
 

--- a/source/_integrations/frontend.markdown
+++ b/source/_integrations/frontend.markdown
@@ -122,7 +122,7 @@ When themes are enabled in the `configuration.yaml` file, a new option will show
 
 ## Loading extra JavaScript
 
-Starting with version 0.95 you load extra JS modules.
+Starting with version 0.95 you can load extra custom JavaScript.
 
 Example:
 
@@ -136,7 +136,7 @@ frontend:
 ```
 
 Modules will be loaded with `import({{ extra_module }})`, on devices that support it (`latest` mode).
-For other devices (`es5` mode) you can use `extra_js_url_es5`, this will be loaded with `<script defer scr='{{ extra_module }}'></script>`
+For other devices (`es5` mode) you can use `extra_js_url_es5`, this will be loaded with `<script defer src='{{ extra_module }}'></script>`
 
 The ES5 and module version will never both be loaded, depending on if the device supports `import` the module of ES5 version will be loaded.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Deprecate `extra_module_url` in the frontend

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37843
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
