### PR TITLE
Add a Misssing 'A'

### DIFF
--- a/source/_integrations/alexa.smart_home.markdown
+++ b/source/_integrations/alexa.smart_home.markdown
@@ -63,7 +63,7 @@ Steps to Integrate an Amazon Alexa Smart Home Skill with Home Assistant:
 </p>
 
 - In next screen, make sure *v3* is selected in `Payload version`.
-- Now, you have created a skeleton of Smart Home skill. Next step we will do some "real" developer work. You can keep Alex Developer Console opened, we need change the skill configuration later.
+- Now, you have created a skeleton of Smart Home skill. Next step we will do some "real" developer work. You can keep Alexa Developer Console opened, we need change the skill configuration later.
 
 ## Create an AWS Lambda Function
 


### PR DESCRIPTION
alex to alexa

## Proposed change
This change fixes a bug not documented in the documentations issues on github

it is adding a missing A on the end of alexa as this helps the article flow easier when reading



## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

Idk what these are

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
