### PR TITLE
Add docs for Guardian paired sensors

### DIFF
--- a/source/_integrations/guardian.markdown
+++ b/source/_integrations/guardian.markdown
@@ -38,6 +38,14 @@ Disable the device's onboard access point.
 
 Enable the device's onboard access point.
 
+### `guardian.pair_sensor`
+
+Add a new paired sensor to the valve controller.
+
+| Service Data Attribute | Optional | Description                                      |
+| ---------------------- | -------- | ------------------------------------------------ |
+| `uid`                    | yes      | The unique device ID on the bottom of the sensor.|
+
 ### `guardian.reboot`
 
 Reboot the device.
@@ -45,6 +53,14 @@ Reboot the device.
 ### `guardian.reset_valve_diagnostics`
 
 Fully (and irrecoverably) reset all valve diagnostics.
+
+### `guardian.unpair_sensor`
+
+Remove a paired sensor from the valve controller.
+
+| Service Data Attribute | Optional | Description                                      |
+| ---------------------- | -------- | ------------------------------------------------ |
+| `uid`                    | yes      | The unique device ID on the bottom of the sensor.|
 
 ### `guardian.upgrade_firmware`
 
@@ -55,3 +71,7 @@ Upgrade the device firmware.
 | `url`                    | yes      | The URL of the server hosting the firmware file. |
 | `port`                   | yes      | The port on which the firmware file is served.   |
 | `filename`               | yes      | The firmware filename.                           |
+
+*Note:* not all service calls are available on all Guardian valve controller firmwares.
+Please ensure you upgrade your valve controller to the latest firmware before opening
+bugs related to non-working service calls.

--- a/source/_integrations/guardian.markdown
+++ b/source/_integrations/guardian.markdown
@@ -75,3 +75,11 @@ Upgrade the device firmware.
 *Note:* not all service calls are available on all Guardian valve controller firmwares.
 Please ensure you upgrade your valve controller to the latest firmware before opening
 bugs related to non-working service calls.
+
+## Paired Sensor Notes
+
+When a paired sensor is first added to the valve controller, it may return inaccurate or
+nonsensical values for several of its attributes, such as `battery` and `temperature`. This
+is due to the sensor never having communicated its data to the valve controller and can
+be fixed by moving the sensor around (so that it beeps, indicating that data has been
+sent to the valve controller).


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds documentation updates for Guardian paired sensors.

Additionally, the PR adds a note encouraging users to upgrade their valve controller firmware if something isn't working.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37930
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
