### PR TITLE
Update samsungtv.markdown with additional TV model

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -107,6 +107,7 @@ For example: for model `UN55NU7100`, the `UN55` would mean it's an LED, North Am
 - KS8000
 - KS8005
 - KS8500
+- KU6000W
 - KU6020
 - KU6100
 - KU6290


### PR DESCRIPTION
Added KU6000W TV model to the Samsung TV Integration file.

## Proposed change
Added model KU6000W to the samsungtv.markdown file.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Very simple, one line change.

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A 
- This PR fixes or closes issue: N/A

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
