### PR TITLE
Update emulated_hue.markdown

### DIFF
--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -111,7 +111,6 @@ lights_all_dimmable:
   required: false
   type: boolean
   default: false
-
 {% endconfiguration %}
 
 A full configuration sample looks like the one below.

--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -106,6 +106,12 @@ entities:
   description: Customization for entities.
   required: false
   type: list
+lights_all_dimmable:
+  description: "By default, all lights that do not support brightness adjustment will be reported as On/Off lights; however some users have reported that this may cause discovery issues with Alexa. By setting this option to true, all non-dimmable lights or switches will be reported as dimmable lights with a fixed dimming setting."
+  required: false
+  type: boolean
+  default: false
+
 {% endconfiguration %}
 
 A full configuration sample looks like the one below.


### PR DESCRIPTION
Documentation change to go with https://github.com/home-assistant/core/pull/37978
Document the new lights_all_dimmable option.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
As described above, add new setting that make the new fix in #37978 conditional.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/37978
- Link to parent pull request in the Brands repository:  NA
- This PR fixes or closes issue: #26860

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
