### PR TITLE
Updating workday documentation

### DIFF
--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -62,6 +62,10 @@ add_holidays:
   description: "Add custom holidays (such as company, personal holidays or vacations). Needs to formatted as `YYYY-MM-DD`."
   required: false
   type: list
+working_holidays:
+  description: "If holidays is in the excludes list, add holiday names according to [holidays](https://pypi.org/project/holidays/) that should be treated as a work day.
+  required: false
+  type: list
 {% endconfiguration %}
 
 Days are specified as follows: `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun`.
@@ -104,6 +108,18 @@ binary_sensor:
     excludes: [sat, sun, holiday]
     add_holidays:
       - '2020-02-24'
+```
+
+This example excludes Saturdays, Sundays, and holidays.  Martin Luther King Jr. Day is treated as a work day.
+
+```yaml
+# Example 3 configuration.yaml entry
+binary_sensor:
+  - platform: workday
+    country: US
+    workdays: [mon, wed, fri]
+    excludes: [sat, sun, holiday]
+    working_holidays: ['Martin Luther King Jr. Day']
 ```
 
 ## Automation example

--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -63,7 +63,7 @@ add_holidays:
   required: false
   type: list
 working_holidays:
-  description: "If holidays is in the excludes list, add holiday names according to [holidays](https://pypi.org/project/holidays/) that should be treated as a work day.
+  description: "If holidays is in the excludes list, add holiday names according to [holidays](https://pypi.org/project/holidays/) that should be treated as a work day."
   required: false
   type: list
 {% endconfiguration %}


### PR DESCRIPTION
Added working_holidays so one can exclude holidays from workdays, but work on specific holidays that everyone does not have off.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/37993
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
