### PR TITLE
Add documentation for unique_id on template platforms

### DIFF
--- a/source/_integrations/alarm_control_panel.template.markdown
+++ b/source/_integrations/alarm_control_panel.template.markdown
@@ -72,6 +72,10 @@ panels:
           required: false
           type: string
           default: Template Alarm Control Panel
+        unique_id:
+          description: An ID that uniquely identifies this alarm control panel. Set this to an unique value to allow customisation trough the UI.
+          required: false
+          type: string
         value_template:
           description: "Defines a template to set the state of the alarm panel. Only the states `armed_away`, `armed_home`, `armed_night`, `disarmed`, `pending`, `triggered` and `unavailable` are used."
           required: false

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -51,6 +51,10 @@ sensors:
           description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
           required: false
           type: [string, list]
+        unique_id:
+          description: An ID that uniquely identifies this binary sensor. Set this to an unique value to allow customisation trough the UI.
+          required: false
+          type: string
         device_class:
           description: Sets the [class of the device](/integrations/binary_sensor/), changing the device state and icon that is displayed on the frontend.
           required: false

--- a/source/_integrations/cover.template.markdown
+++ b/source/_integrations/cover.template.markdown
@@ -53,6 +53,10 @@ cover:
         description: A list of entity IDs so the cover only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
         required: false
         type: [string, list]
+      unique_id:
+        description: An ID that uniquely identifies this cover. Set this to an unique value to allow customisation trough the UI.
+        required: false
+        type: string
       value_template:
         description: Defines a template to get the state of the cover. Valid values are `open`/`true` or `closed`/`false`. [`value_template`](#value_template) and [`position_template`](#position_template) cannot be specified concurrently.
         required: exclusive

--- a/source/_integrations/fan.template.markdown
+++ b/source/_integrations/fan.template.markdown
@@ -63,6 +63,10 @@ fan:
         description: Name to use in the frontend.
         required: false
         type: string
+      unique_id:
+        description: An ID that uniquely identifies this fan. Set this to an unique value to allow customisation trough the UI.
+        required: false
+        type: string
       value_template:
         description: "Defines a template to get the state of the fan. Valid value: 'on'/'off'"
         required: true

--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -74,6 +74,10 @@ light:
         description: A list of entity IDs so the light only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
         required: false
         type: [string, list]
+      unique_id:
+        description: An ID that uniquely identifies this light. Set this to an unique value to allow customisation trough the UI.
+        required: false
+        type: string
       value_template:
         description: Defines a template to get the state of the light.
         required: false

--- a/source/_integrations/lock.template.markdown
+++ b/source/_integrations/lock.template.markdown
@@ -47,6 +47,10 @@ lock:
     required: false
     type: string
     default: Template Lock
+  unique_id:
+    description: An ID that uniquely identifies this lock. Set this to an unique value to allow customisation trough the UI.
+    required: false
+    type: string
   value_template:
     description: Defines a template to set the state of the lock.
     required: true

--- a/source/_integrations/sensor.template.markdown
+++ b/source/_integrations/sensor.template.markdown
@@ -110,7 +110,7 @@ The template engine will attempt to work out what entities should trigger an upd
 
 ### Unique ID
 
-The optional `unique_id` can be set so the entity will be registered in the [entity registry](https://developers.home-assistant.io/docs/entity_registry_index). This allows changing the `name`, `icon` and `entity_id` from the web interface instead of having to use the [customize](https://www.home-assistant.io/docs/configuration/customizing-devices/) key in your configuration.yaml file.
+The optional `unique_id` can be set so the entity will be registered in the [entity registry](https://developers.home-assistant.io/docs/entity_registry_index). This allows changing the `name`, `icon` and `entity_id` from the web interface instead of having to use the [customize](https://www.home-assistant.io/docs/configuration/customizing-devices/) key in your `configuration.yaml` file.
 
 ## Examples
 

--- a/source/_integrations/sensor.template.markdown
+++ b/source/_integrations/sensor.template.markdown
@@ -1,5 +1,5 @@
 ---
-title: Template
+title: "Template Sensor"
 description: Instructions on how to integrate Template Sensors into Home Assistant.
 ha_category:
   - Sensor
@@ -54,6 +54,10 @@ sensor:
         description: A list of entity IDs so the sensor only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
         required: false
         type: [string, list]
+      unique_id:
+        description: An ID that uniquely identifies this sensor. Set this to an unique value to allow customisation trough the UI.
+        required: false
+        type: string
       unit_of_measurement:
         description: "Defines the units of measurement of the sensor, if any. This will also influence the graphical presentation in the history visualization as a continuous value. Sensors with missing `unit_of_measurement` are showing as discrete values."
         required: false
@@ -103,6 +107,10 @@ If you are using the state of a platform that takes extra time to load, the Temp
 ### Entity IDs
 
 The template engine will attempt to work out what entities should trigger an update of the sensor. This can fail, for example, if your template loops over the contents of a group. In this case, you can use `entity_id` to provide a list of entity IDs that will cause the sensor to update or you can run the service `homeassistant.update_entity` to update the sensor at will.
+
+### Unique ID
+
+The optional `unique_id` can be set so the entity will be registered in the [entity registry](https://developers.home-assistant.io/docs/entity_registry_index). This allows changing the `name`, `icon` and `entity_id` from the web interface instead of having to use the [customize](https://www.home-assistant.io/docs/configuration/customizing-devices/) key in your configuration.yaml file.
 
 ## Examples
 

--- a/source/_integrations/switch.template.markdown
+++ b/source/_integrations/switch.template.markdown
@@ -54,6 +54,10 @@ switch:
         description: A list of entity IDs so the switch only reacts to state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities.
         required: false
         type: [string, list]
+      unique_id:
+        description: An ID that uniquely identifies this switch. Set this to an unique value to allow customisation trough the UI.
+        required: false
+        type: string
       value_template:
         description: Defines a template to set the state of the switch. If not defined, the switch will optimistically assume all commands are successful.
         required: false

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -110,7 +110,7 @@ The template engine will attempt to work out what entities should trigger an upd
 
 ### Unique ID
 
-The optional `unique_id` can be set so the entity will be registered in the [entity registry](https://developers.home-assistant.io/docs/entity_registry_index). This allows changing the `name`, `icon` and `entity_id` from the web interface instead of having to use the [customize](https://www.home-assistant.io/docs/configuration/customizing-devices/) key in your `configuration.yaml` file.
+The optional `unique_id` can be set so the entity will be registered in the [entity registry](https://developers.home-assistant.io/docs/entity_registry_index). This allows changing the `name`, `icon` and `entity_id` from the web interface instead of having to use the [customize](/docs/configuration/customizing-devices/) key in your `configuration.yaml` file.
 
 ## Examples
 
@@ -357,7 +357,7 @@ sensor:
 
 Useful entities to choose might be `sensor.date` which update once per day or `sensor.time`, which updates once per minute.  
 Please note that the resulting template will be evaluated by Home Assistant state engine on every state change of these sensors, which in case of `sensor.time` happens every minute and might have a negative impact on performance.
- 
+
 An alternative to this is to create an interval-based automation that calls the service `homeassistant.update_entity` for the entities requiring updates. This modified example updates every 5 minutes:
 
 {% raw %}

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Template Sensor"
+title: Template
 description: Instructions on how to integrate Template Sensors into Home Assistant.
 ha_category:
   - Sensor

--- a/source/_integrations/vacuum.template.markdown
+++ b/source/_integrations/vacuum.template.markdown
@@ -39,6 +39,10 @@ vacuum:
         description: Name to use in the frontend.
         required: false
         type: string
+      unique_id:
+        description: An ID that uniquely identifies this vacuum. Set this to an unique value to allow customisation trough the UI.
+        required: false
+        type: string
       value_template:
         description: "Defines a template to get the state of the vacuum. Valid value: `docked`/`cleaning`/`idle`/`paused`/`returning`/`error`"
         required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

* Add documentation for `unique_id` on template platforms.
* Also renamed `template.markdown` to `sensor.template.markdown`. Maybe it makes sense to create a new `template.markdown` page with general information about the templates that's now copied to all the platform pages?

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38011
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
