### PR TITLE
Fixed description of 'check_zone'

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -131,7 +131,7 @@ There are several attributes available on the alarm panel to give you more infor
 - `ac_power`: Set to `true` if your system has AC power supplying it.
 - `backlight_on`: Set to `true` if your keypad's backlight is on.
 - `battery_low`: Set to `true` if your system's back-up battery is low.
-- `check_zone`: Set to `true` if your system was recently triggered. When `check_zone` is `true`, it must be cleared by entering your code + 1 before attempting to rearm your alarm.
+- `check_zone`: Set to `true` if your system detects a problem with a zone.
 - `chime`: Set to `true` if your system's chime is activated. When activated, your system will beep anytime a door or window is faulted while the alarm is disarmed.
 - `entry_delay_off`: Set to `true` if your system is in "Instant" mode, meaning the alarm will sound on any faults.
 - `programming_mode`: Set to `true` if your system is in programming mode.


### PR DESCRIPTION
The 'check_zone' attribute was mistaken for AlarmDecoder's 'alarm_event_occurred' property, which is the property that indicates that your system was recently triggered, not 'check_zone'. See http://www.alarmdecoder.com/wiki/index.php/Protocol#Keypad.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Change the description of 'check_zone' to be one that matches the information found on the AlarmDecoder website http://www.alarmdecoder.com/wiki/index.php/Protocol#Keypad and (supplemented by my own knowledge of the "CHECK ZONE" message).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
