### PR TITLE
Add 'alarm_event_occurred' attribute definition to AlarmDecoder documentation

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -129,6 +129,7 @@ zones:
 There are several attributes available on the alarm panel to give you more information about your alarm.
 
 - `ac_power`: Set to `true` if your system has AC power supplying it.
+- `alarm_event_occurred`: Set to `true` if your system was recently triggered. When `alarm_event_occurred` is `true`, it must be cleared by entering your code + 1 (or calling the `alarm_control_panel.alarm_disarm` service) before attempting to arm your alarm.
 - `backlight_on`: Set to `true` if your keypad's backlight is on.
 - `battery_low`: Set to `true` if your system's back-up battery is low.
 - `check_zone`: Set to `true` if your system detects a problem with a zone.


### PR DESCRIPTION
Add the `alarm_event_occurred` attribute of the AlarmDecoder alarm panel entity to the AlarmDecoder alarm panel entity. The PR for the change itself is immediately following.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add the `alarm_event_occurred` attribute of the AlarmDecoder alarm panel entity to the AlarmDecoder alarm panel entity. It echoes the old `check_zone` attribute definition. That was removed by my earlier PR.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38055

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
