### PR TITLE
Add wait_for_trigger script action

### DIFF
--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -164,7 +164,7 @@ After each time a wait completes, either because the condition was met, the even
 Variable | Description
 -|-
 `wait.completed` | Exists only after `wait_template`. `true` if the condition was met, `false` otherwise
-`wait.trigger` | Exists only after `wait_for_trigger`. See [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data)
+`wait.trigger` | Exists only after `wait_for_trigger`. Contains information about which trigger fired. (See [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data).) Will be `none` if no trigger happened before timeout expired
 `wait.remaining` | Timeout remaining, or `none` if a timeout was not specified
 
 This can be used to take different actions based on whether or not the condition was met, or to use more than one wait sequentially while implementing a single timeout overall.

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -57,45 +57,52 @@ While executing a script you can add a condition to stop further execution. When
 
 Delays are useful for temporarily suspending your script and start it at a later moment. We support different syntaxes for a delay as shown below.
 
+{% raw %}
 ```yaml
+# Seconds
+# Waits 5 seconds
+- delay: 5
+```
+
+```yaml
+# HH:MM
 # Waits 1 hour
 - delay: '01:00'
 ```
 
 ```yaml
-# Waits 1 minute, 30 seconds
+# HH:MM:SS
+# Waits 1.5 minutes
 - delay: '00:01:30'
 ```
 
 ```yaml
+# Supports milliseconds, seconds, minutes, hours, days
+# Can be used in combination, at least one required
 # Waits 1 minute
 - delay:
-    # Supports milliseconds, seconds, minutes, hours, days
     minutes: 1
 ```
-
-{% raw %}
-```yaml
-# Waits however many seconds input_number.second_delay is set to
-- delay:
-    # Supports milliseconds, seconds, minutes, hours, days
-    seconds: "{{ states('input_number.second_delay') | int }}"
-```
 {% endraw %}
+
+All forms accept templates.
 
 {% raw %}
 ```yaml
 # Waits however many minutes input_number.minute_delay is set to
-# Valid formats include HH:MM and HH:MM:SS
-- delay: "{{ states('input_number.minute_delay') | multiply(60) | timestamp_custom('%H:%M:%S',False) }}"
+- delay: "{{ states('input_number.minute_delay') | multiply(60) | int }}"
 ```
 {% endraw %}
 
 ### Wait
 
-Wait until some things are complete. We support at the moment `wait_template` for waiting until a condition is `true`, see also on [Template-Trigger](/docs/automation/trigger/#template-trigger).
+These actions allow a script to wait for entities in the system to be in a certain state as specified by a template, or some event to happen as expressed by one or more triggers.
+
+When used within an automation the `trigger` variable is available. See [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data).
 
 #### Wait Template
+
+This action evaluates the template, and if true, the script will continue. If not, then it will wait until it is true.
 
 {% raw %}
 ```yaml
@@ -104,34 +111,61 @@ Wait until some things are complete. We support at the moment `wait_template` fo
 ```
 {% endraw %}
 
-When using `wait_template` within an automation `trigger.entity_id` is supported for `state`, `numeric_state` and `template` triggers, see also [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data).
+#### Wait for Trigger
 
+This action can use the same triggers that are available in an automation's `trigger` section. See [Automation Trigger](/docs/automation/trigger). The script will continue whenever any of the triggers fires.
 {% raw %}
 ```yaml
-- wait_template: "{{ is_state(trigger.entity_id, 'on') }}"
+# Wait for a custom event or light to turn on and stay on for 10 sec
+- wait_for_trigger:
+    - platform: event
+      event_type: MY_EVENT
+    - platform: state
+      entity_id: light.LIGHT
+      to: 'on'
+      for: 10
 ```
 {% endraw %}
 
-It is also possible to use dummy variables, e.g., in scripts, when using `wait_template`.
+#### Wait Timeout
+
+With both types of waits it is possible to set a timeout after which the script will continue its execution if the condition/event is not satisfied. Timeout has the same syntax as `delay`, and like `delay`, also accepts templates.
 
 {% raw %}
 ```yaml
-# Service call, e.g., from an automation.
-- service: script.do_something
-  data:
-    dummy: input_boolean.switch
-
-# Inside the script
-- wait_template: "{{ is_state(dummy, 'off') }}"
+# Wait for sensor to change to 'on' up to 1 minute before continuing to execute.
+- wait_template: "{{ is_state('binary_sensor.entrance', 'on') }}"
+  timeout: '00:01:00'
 ```
 {% endraw %}
 
-After each time the wait completes, either because the condition was met, or the timeout expired, the variable `wait` will be created/updated to indicate the result.
+You can also get the script to abort after the timeout by using optional `continue_on_timeout`.
+
+{% raw %}
+```yaml
+# Wait for IFTTT event or abort after specified timeout.
+- wait_for_trigger:
+    - platform: event
+      event_type: ifttt_webhook_received
+      event_data:
+        action: connected_to_network
+  timeout:
+    minutes: "{{ timeout_minutes }}"
+  continue_on_timeout: false
+```
+{% endraw %}
+
+Without `continue_on_timeout` the script will always continue.
+
+#### Wait Variable
+
+After each time a wait completes, either because the condition was met, the event happened, or the timeout expired, the variable `wait` will be created/updated to indicate the result.
 
 Variable | Description
 -|-
-`wait.completed` | `true` if the condition was met, `false` otherwise
-`wait.remaining` | timeout remaining, or `none` if a timeout was not specified
+`wait.completed` | Exists only after `wait_template`. `true` if the condition was met, `false` otherwise
+`wait.trigger` | Exists only after `wait_for_trigger`. See [Available-Trigger-Data](/docs/automation/templating/#available-trigger-data)
+`wait.remaining` | Timeout remaining, or `none` if a timeout was not specified
 
 This can be used to take different actions based on whether or not the condition was met, or to use more than one wait sequentially while implementing a single timeout overall.
 
@@ -147,7 +181,10 @@ This can be used to take different actions based on whether or not the condition
       sequence:
         - service: script.door_did_not_open
   default:
-    - service: script.door_did_open
+    - service: script.turn_on
+      entity_id:
+        - script.door_did_open
+        - script.play_fanfare
 
 # Wait a total of 10 seconds.
 - wait_template: "{{ is_state('binary_sensor.door_1', 'on') }}"
@@ -155,39 +192,17 @@ This can be used to take different actions based on whether or not the condition
   continue_on_timeout: false
 - service: switch.turn_on
   entity_id: switch.some_light
-- wait_template: "{{ is_state('binary_sensor.door_2', 'on') }}"
+- wait_for_trigger:
+    - platform: state
+      entity_id: binary_sensor.door_2
+      to: 'on'
+      for: 2
   timeout: "{{ wait.remaining }}"
   continue_on_timeout: false
 - service: switch.turn_off
   entity_id: switch.some_light
 ```
 {% endraw %}
-
-#### Wait Timeout
-
-It is possible to set a timeout after which the script will continue its execution if the condition is not satisfied. Timeout has the same syntax as `delay`, and like `delay`, also accepts templates.
-
-{% raw %}
-```yaml
-# Wait for sensor to trigger or 1 minute before continuing to execute.
-- wait_template: "{{ is_state('binary_sensor.entrance', 'on') }}"
-  timeout: '00:01:00'
-```
-{% endraw %}
-
-You can also get the script to abort after the timeout by using optional `continue_on_timeout`
-
-{% raw %}
-```yaml
-# Wait until a valve is < 10 or abort after specified timeout.
-- wait_template: "{{ state_attr('climate.kitchen', 'valve')|int < 10 }}"
-  timeout:
-    minutes: "{{ timeout_minutes }}"
-  continue_on_timeout: false
-```
-{% endraw %}
-
-Without `continue_on_timeout` the script will always continue.
 
 ### Fire an Event
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for new `wait_for_trigger` script action. Also update `delay` descriptions.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#38075
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
