### PR TITLE
Remove deprecated Slack attachments documentation

### DIFF
--- a/source/_integrations/slack.markdown
+++ b/source/_integrations/slack.markdown
@@ -76,11 +76,10 @@ The following attributes can be placed inside the `data` key of the service call
 | Attribute              | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `file`                   |      yes | A file to include with the message; see below.
-| `attachments`            |      yes | Array of [Slack attachments](https://api.slack.com/messaging/composing/layouts#attachments) (legacy). *NOTE*: if using `attachments`, they are shown **in addition** to `message`.
 | `blocks`                 |      yes | Array of [Slack blocks](https://api.slack.com/messaging/composing/layouts). *NOTE*: if using `blocks`, they are shown **in place of** the `message` (note that the `message` is required nonetheless).
 | `blocks_template`        |      yes | The same as `blocks`, but able to support [templates](https://www.home-assistant.io/docs/configuration/templating).
 
-Note that using `file` will ignore all usage of `attachments`, `blocks`, and `blocks_template` (as Slack does not support those frameworks in messages that accompany uploaded files).
+Note that using `file` will ignore all usage of `blocks` and `blocks_template` (as Slack does not support those frameworks in messages that accompany uploaded files).
 
 To include a local file with the Slack message, use these attributes underneath the `file` key:
 
@@ -159,15 +158,4 @@ data:
         text: |-
           *Average Rating*
           1.0
-```
-
-To use the legacy attachments framework:
-
-```yaml
-message: Message that will be added as a comment to the file.
-title: Title of the file.
-data:
-  attachments:
-    - title: WHAT A HORRIBLE NIGHT TO HAVE A CURSE.
-      image_url: https://i.imgur.com/JEExnsI.gif
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR removes documentation for the deprecated Slack attachments framework, which is set for removal in 0.114.0.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38139
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
