### PR TITLE
Change XboxAPI.com to xapi.us

### DIFF
--- a/source/_integrations/xbox_live.markdown
+++ b/source/_integrations/xbox_live.markdown
@@ -13,11 +13,11 @@ ha_domain: xbox_live
 The Xbox Live integration is able to track [Xbox](https://xbox.com/) profiles.
 
 To use this sensor you need a free API key from
-[XboxAPI.com](https://xboxapi.com/).
+[xapi.us](https://xapi.us/).
 Please also make sure to connect your Xbox account on that site.
 
 The configuration requires you to specify XUIDs which are the unique identifiers
-for profiles. These can be determined on [XboxAPI.com](https://xboxapi.com/) by
+for profiles. These can be determined on [xapi.us](https://xapi.us/) by
 either looking at your own profile page or using their interactive documentation
 to search for gamertags. Sensor names default to the gamertag associated with an XUID.
 
@@ -36,7 +36,7 @@ sensor:
 
 {% configuration %}
 api_key:
-  description: Your API key from [XboxAPI.com](https://xboxapi.com/).
+  description: Your API key from [xapi.us](https://xapi.us/).
   required: true
   type: string
 xuid:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The third party service that the docs refer to moved to a different domain. The integration has now been updated to use this domain, so the docs should follow suit.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#38146
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
