### PR TITLE
Update zwave installation network key information

### DIFF
--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -4,7 +4,7 @@ description: "Installation of the Z-Wave component."
 redirect_from: /getting-started/z-wave-installation/
 ---
 
-Z-Wave can be configured using the Z-Wave _Integration_ in the _Configuration_ menu, or manually using an entry in `configuration.yaml`
+Z-Wave can be configured using the Z-Wave *Integration* in the *Configuration* menu, or manually using an entry in `configuration.yaml`
 
 ## Configuration
 
@@ -17,75 +17,75 @@ zwave:
 
 {% configuration Z-Wave %}
 usb_path:
-description: The port where your device is connected to your Home Assistant host. Z-Wave sticks will generally be `/dev/ttyACM0` and GPIO hats will generally be `/dev/ttyAMA0`.
-required: false
-type: string
-default: /zwaveusbstick
+  description: The port where your device is connected to your Home Assistant host. Z-Wave sticks will generally be `/dev/ttyACM0` and GPIO hats will generally be `/dev/ttyAMA0`.
+  required: false
+  type: string
+  default: /zwaveusbstick
 network_key:
-description: The 16-byte network key in the form `"0x01, 0x02..."` used in order to connect securely to compatible devices. It is recommended that a network key is configured as security enabled devices may not function correctly if they are not added securely.
-required: false
-type: string
-default: None
+  description: The 16-byte network key in the form `"0x01, 0x02..."` used in order to connect securely to compatible devices. It is recommended that a network key is configured as security enabled devices may not function correctly if they are not added securely.
+  required: false
+  type: string
+  default: None
 config_path:
-description: The path to the Python OpenZWave configuration files.
-required: false
-type: string
-default: the 'config' that is installed by python-openzwave
+  description: The path to the Python OpenZWave configuration files.
+  required: false
+  type: string
+  default: the 'config' that is installed by python-openzwave
 polling_interval:
-description: The time period in milliseconds between polls of a nodes value. Be careful about using polling values below 30000 (30 seconds) as polling can flood the Z-Wave network and cause problems.
-required: false
-type: integer
-default: 60000
+  description: The time period in milliseconds between polls of a nodes value. Be careful about using polling values below 30000 (30 seconds) as polling can flood the Z-Wave network and cause problems.
+  required: false
+  type: integer
+  default: 60000
 debug:
-description: Print verbose Z-Wave info to log.
-required: false
-type: boolean
-default: false
+  description: Print verbose Z-Wave info to log.
+  required: false
+  type: boolean
+  default: false
 autoheal:
-description: Allows enabling auto Z-Wave heal at midnight. Warning, this is inefficient and [should not be used](https://github.com/home-assistant/architecture/issues/81#issuecomment-478444085).
-required: false
-type: boolean
-default: false
+  description: Allows enabling auto Z-Wave heal at midnight. Warning, this is inefficient and [should not be used](https://github.com/home-assistant/architecture/issues/81#issuecomment-478444085).
+  required: false
+  type: boolean
+  default: false
 device_config / device_config_domain / device_config_glob:
-description: "This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the following options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format."
-required: false
-type: [string, list]
-keys:
-ignored:
-description: Ignore this entity completely. It won't be shown in the Web Interface and no events are generated for it.
-required: false
-type: boolean
-default: false
-polling_intensity:
-description: Enables polling of a value and sets the frequency of polling (0=none, 1=every time through the list, 2=every other time, etc). If not specified then your device will not be polled.
-required: false
-type: integer
-default: 0
-refresh_value:
-description: Enable refreshing of the node value. Only the light integration uses this.
-required: false
-type: boolean
-default: false
-delay:
-description: Specify the delay for refreshing of node value. Only the light integration uses this.
-required: false
-type: integer
-default: 5
-invert_openclose_buttons:
-description: Inverts function of the open and close buttons for the cover domain. This will not invert the position and state reporting.
-required: false
-type: boolean
-default: false
-invert_percent:
-description: Inverts the percentage of the position for the cover domain. This will invert the position and state reporting.
-required: false
-type: boolean
-default: false  
+  description: "This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the following options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format."
+  required: false
+  type: [string, list]
+  keys:
+    ignored:
+      description: Ignore this entity completely. It won't be shown in the Web Interface and no events are generated for it.
+      required: false
+      type: boolean
+      default: false
+    polling_intensity:
+      description: Enables polling of a value and sets the frequency of polling (0=none, 1=every time through the list, 2=every other time, etc). If not specified then your device will not be polled.
+      required: false
+      type: integer
+      default: 0
+    refresh_value:
+      description: Enable refreshing of the node value. Only the light integration uses this.
+      required: false
+      type: boolean
+      default: false
+    delay:
+      description: Specify the delay for refreshing of node value. Only the light integration uses this.
+      required: false
+      type: integer
+      default: 5
+    invert_openclose_buttons:
+      description: Inverts function of the open and close buttons for the cover domain. This will not invert the position and state reporting.
+      required: false
+      type: boolean
+      default: false
+    invert_percent:
+      description: Inverts the percentage of the position for the cover domain. This will invert the position and state reporting.
+      required: false
+      type: boolean
+      default: false  
 {% endconfiguration %}
 
 ### Network Key
 
-Security Z-Wave devices require a network key before being added to the network using the Add Secure Node button in the Z-Wave Network Management card. You must set the _network_key_ configuration variable to use a network key before adding these devices.
+Security Z-Wave devices require a network key before being added to the network using the Add Secure Node button in the Z-Wave Network Management card. You must set the *network_key* configuration variable to use a network key before adding these devices.
 
 An easy script to generate a random key:
 
@@ -115,7 +115,7 @@ The first run after adding a device is when the `zwave` integration will take ti
 
 You do not need to install any software to use Z-Wave.
 
-If the path of `/dev/ttyACM0` doesn't work, look in the _System_ section of the _Supervisor_ menu. There you'll find a _Hardware_ button which will list all the hardware found.
+If the path of `/dev/ttyACM0` doesn't work, look in the *System* section of the *Supervisor* menu. There you'll find a *Hardware* button which will list all the hardware found.
 
 You can also check what hardware has been found using the [`ha` command](/hassio/commandline/#hardware):
 
@@ -123,7 +123,7 @@ You can also check what hardware has been found using the [`ha` command](/hassio
 ha hardware info
 ```
 
-If you did an alternative install of Home Assistant on Linux (e.g., installing Ubuntu, then Docker, then Home Assistant Supervised) then the `modemmanager` package will interfere with any Z-Wave (or Zigbee) stick and should be removed or disabled in the host OS. Failure to do so will result in random failures of those components, e.g., dead or unreachable Z-Wave nodes, most notably right after Home Assistant restarts. Connect to your host OS via SSH, then you can disable with `sudo systemctl disable ModemManager` and remove with `sudo apt-get purge modemmanager` (commands are for Debian/Ubuntu).
+If you did an alternative install of Home Assistant on Linux (e.g.,  installing Ubuntu, then Docker, then Home Assistant Supervised) then the `modemmanager` package will interfere with any Z-Wave (or Zigbee) stick and should be removed or disabled in the host OS. Failure to do so will result in random failures of those components, e.g.,  dead or unreachable Z-Wave nodes, most notably right after Home Assistant restarts. Connect to your host OS via SSH, then you can disable with `sudo systemctl disable ModemManager` and remove with `sudo apt-get purge modemmanager` (commands are for Debian/Ubuntu).
 
 ### Docker
 
@@ -227,9 +227,9 @@ If this applies to your situation:
 
 Then chances are high that the ModemManager in the host OS is causing the issue, claiming or interfering with the USB Z-Wave stick like the much used Aeotec ones. In this case you need to disable ModemManager.
 
-Connect to your host OS (e.g., Ubuntu) through SSH, then execute the following command on your host system to disable the ModemManager:
+Connect to your host OS (e.g.,  Ubuntu) through SSH, then execute the following command on your host system to disable the ModemManager:
 
-```bash
+ ```bash
 systemctl disable ModemManager.service
 ```
 

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -4,7 +4,7 @@ description: "Installation of the Z-Wave component."
 redirect_from: /getting-started/z-wave-installation/
 ---
 
-Z-Wave can be configured using the Z-Wave *Integration* in the *Configuration* menu, or manually using an entry in `configuration.yaml`
+Z-Wave can be configured using the Z-Wave _Integration_ in the _Configuration_ menu, or manually using an entry in `configuration.yaml`
 
 ## Configuration
 
@@ -17,75 +17,75 @@ zwave:
 
 {% configuration Z-Wave %}
 usb_path:
-  description: The port where your device is connected to your Home Assistant host. Z-Wave sticks will generally be `/dev/ttyACM0` and GPIO hats will generally be `/dev/ttyAMA0`.
-  required: false
-  type: string
-  default: /zwaveusbstick
+description: The port where your device is connected to your Home Assistant host. Z-Wave sticks will generally be `/dev/ttyACM0` and GPIO hats will generally be `/dev/ttyAMA0`.
+required: false
+type: string
+default: /zwaveusbstick
 network_key:
-  description: The 16-byte network key in the form `"0x01, 0x02..."` used in order to connect securely to compatible devices. It is recommended that a network key is configured as security enabled devices may not function correctly if they are not added securely.
-  required: false
-  type: string
-  default: None
+description: The 16-byte network key in the form `"0x01, 0x02..."` used in order to connect securely to compatible devices. It is recommended that a network key is configured as security enabled devices may not function correctly if they are not added securely.
+required: false
+type: string
+default: None
 config_path:
-  description: The path to the Python OpenZWave configuration files.
-  required: false
-  type: string
-  default: the 'config' that is installed by python-openzwave
+description: The path to the Python OpenZWave configuration files.
+required: false
+type: string
+default: the 'config' that is installed by python-openzwave
 polling_interval:
-  description: The time period in milliseconds between polls of a nodes value. Be careful about using polling values below 30000 (30 seconds) as polling can flood the Z-Wave network and cause problems.
-  required: false
-  type: integer
-  default: 60000
+description: The time period in milliseconds between polls of a nodes value. Be careful about using polling values below 30000 (30 seconds) as polling can flood the Z-Wave network and cause problems.
+required: false
+type: integer
+default: 60000
 debug:
-  description: Print verbose Z-Wave info to log.
-  required: false
-  type: boolean
-  default: false
+description: Print verbose Z-Wave info to log.
+required: false
+type: boolean
+default: false
 autoheal:
-  description: Allows enabling auto Z-Wave heal at midnight. Warning, this is inefficient and [should not be used](https://github.com/home-assistant/architecture/issues/81#issuecomment-478444085).
-  required: false
-  type: boolean
-  default: false
+description: Allows enabling auto Z-Wave heal at midnight. Warning, this is inefficient and [should not be used](https://github.com/home-assistant/architecture/issues/81#issuecomment-478444085).
+required: false
+type: boolean
+default: false
 device_config / device_config_domain / device_config_glob:
-  description: "This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the following options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format."
-  required: false
-  type: [string, list]
-  keys:
-    ignored:
-      description: Ignore this entity completely. It won't be shown in the Web Interface and no events are generated for it.
-      required: false
-      type: boolean
-      default: false
-    polling_intensity:
-      description: Enables polling of a value and sets the frequency of polling (0=none, 1=every time through the list, 2=every other time, etc). If not specified then your device will not be polled.
-      required: false
-      type: integer
-      default: 0
-    refresh_value:
-      description: Enable refreshing of the node value. Only the light integration uses this.
-      required: false
-      type: boolean
-      default: false
-    delay:
-      description: Specify the delay for refreshing of node value. Only the light integration uses this.
-      required: false
-      type: integer
-      default: 5
-    invert_openclose_buttons:
-      description: Inverts function of the open and close buttons for the cover domain. This will not invert the position and state reporting.
-      required: false
-      type: boolean
-      default: false
-    invert_percent:
-      description: Inverts the percentage of the position for the cover domain. This will invert the position and state reporting.
-      required: false
-      type: boolean
-      default: false  
+description: "This attribute contains node-specific override values. NOTE: This needs to be specified if you are going to use any of the following options. See [Customizing devices and services](/docs/configuration/customizing-devices/) for the format."
+required: false
+type: [string, list]
+keys:
+ignored:
+description: Ignore this entity completely. It won't be shown in the Web Interface and no events are generated for it.
+required: false
+type: boolean
+default: false
+polling_intensity:
+description: Enables polling of a value and sets the frequency of polling (0=none, 1=every time through the list, 2=every other time, etc). If not specified then your device will not be polled.
+required: false
+type: integer
+default: 0
+refresh_value:
+description: Enable refreshing of the node value. Only the light integration uses this.
+required: false
+type: boolean
+default: false
+delay:
+description: Specify the delay for refreshing of node value. Only the light integration uses this.
+required: false
+type: integer
+default: 5
+invert_openclose_buttons:
+description: Inverts function of the open and close buttons for the cover domain. This will not invert the position and state reporting.
+required: false
+type: boolean
+default: false
+invert_percent:
+description: Inverts the percentage of the position for the cover domain. This will invert the position and state reporting.
+required: false
+type: boolean
+default: false  
 {% endconfiguration %}
 
 ### Network Key
 
-Security Z-Wave devices require a network key before being added to the network using the Add Secure Node button in the Z-Wave Network Management card. You must set the *network_key* configuration variable to use a network key before adding these devices.
+Security Z-Wave devices require a network key before being added to the network using the Add Secure Node button in the Z-Wave Network Management card. You must set the _network_key_ configuration variable to use a network key before adding these devices.
 
 An easy script to generate a random key:
 
@@ -99,13 +99,6 @@ You can also use sites like [this one](https://www.random.org/cgi-bin/randbyte?n
 # Example configuration.yaml entry for network_key
 zwave:
   network_key: "0x2e, 0xcc, 0xab, 0x1c, 0xa3, 0x7f, 0x0e, 0xb5, 0x70, 0x71, 0x2d, 0x98, 0x25, 0x43, 0xee, 0x0c"
-```
-
-In addition to modifying the `configuration.yaml` file, the `options.xml` file network key must be set as well:
-
-```xml
-<!-- Example options.xml entry for network_key -->
-<Option name="NetworkKey" value="0x2e, 0xcc, 0xab, 0x1c, 0xa3, 0x7f, 0x0e, 0xb5, 0x70, 0x71, 0x2d, 0x98, 0x25, 0x43, 0xee, 0x0c" />
 ```
 
 Ensure you keep a backup of this key. If you have to rebuild your system and don't have a backup of this key, you won't be able to reconnect to any security devices. This may mean you have to do a factory reset on those devices, and your controller, before rebuilding your Z-Wave network.
@@ -122,7 +115,7 @@ The first run after adding a device is when the `zwave` integration will take ti
 
 You do not need to install any software to use Z-Wave.
 
-If the path of `/dev/ttyACM0` doesn't work, look in the *System* section of the *Supervisor* menu. There you'll find a *Hardware* button which will list all the hardware found.
+If the path of `/dev/ttyACM0` doesn't work, look in the _System_ section of the _Supervisor_ menu. There you'll find a _Hardware_ button which will list all the hardware found.
 
 You can also check what hardware has been found using the [`ha` command](/hassio/commandline/#hardware):
 
@@ -130,7 +123,7 @@ You can also check what hardware has been found using the [`ha` command](/hassio
 ha hardware info
 ```
 
-If you did an alternative install of Home Assistant on Linux (e.g.,  installing Ubuntu, then Docker, then Home Assistant Supervised) then the `modemmanager` package will interfere with any Z-Wave (or Zigbee) stick and should be removed or disabled in the host OS. Failure to do so will result in random failures of those components, e.g.,  dead or unreachable Z-Wave nodes, most notably right after Home Assistant restarts. Connect to your host OS via SSH, then you can disable with `sudo systemctl disable ModemManager` and remove with `sudo apt-get purge modemmanager` (commands are for Debian/Ubuntu).
+If you did an alternative install of Home Assistant on Linux (e.g., installing Ubuntu, then Docker, then Home Assistant Supervised) then the `modemmanager` package will interfere with any Z-Wave (or Zigbee) stick and should be removed or disabled in the host OS. Failure to do so will result in random failures of those components, e.g., dead or unreachable Z-Wave nodes, most notably right after Home Assistant restarts. Connect to your host OS via SSH, then you can disable with `sudo systemctl disable ModemManager` and remove with `sudo apt-get purge modemmanager` (commands are for Debian/Ubuntu).
 
 ### Docker
 
@@ -234,9 +227,9 @@ If this applies to your situation:
 
 Then chances are high that the ModemManager in the host OS is causing the issue, claiming or interfering with the USB Z-Wave stick like the much used Aeotec ones. In this case you need to disable ModemManager.
 
-Connect to your host OS (e.g.,  Ubuntu) through SSH, then execute the following command on your host system to disable the ModemManager:
+Connect to your host OS (e.g., Ubuntu) through SSH, then execute the following command on your host system to disable the ModemManager:
 
- ```bash
+```bash
 systemctl disable ModemManager.service
 ```
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Correct inaccurate information provided in the installation documents regarding the `zwave` network key being set in `options.xml` AND `configuration.yaml`


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
