### PR TITLE
Add average_speed and doors_tailgate_open to voc resource list

### DIFF
--- a/source/_integrations/volvooncall.markdown
+++ b/source/_integrations/volvooncall.markdown
@@ -88,6 +88,7 @@ The list of currently available resources:
 - `odometer`
 - `trip_meter1`
 - `trip_meter2`
+- `average_speed`
 - `fuel_amount`
 - `fuel_amount_level`
 - `average_fuel_consumption`
@@ -104,6 +105,7 @@ The list of currently available resources:
 - `last_trip`
 - `is_engine_running`
 - `doors.hood_open`
+- `doors_tailgate_open`
 - `doors.front_left_door_open`
 - `doors.front_right_door_open`
 - `doors.rear_left_door_open`


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Two new resources were added with a PR to the core repo.
This PR adds them both to the docs.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38142
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue:  N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
