### PR TITLE
Add documentation for NIU integration

### DIFF
--- a/source/_integrations/niu.markdown
+++ b/source/_integrations/niu.markdown
@@ -1,0 +1,43 @@
+---
+title: NIU
+description: Instructions on how to integrate NIU vehicles into Home Assistant.
+ha_category:
+  - Car
+  - Binary Sensor
+  - Sensor
+ha_release: 0.114
+ha_iot_class: Cloud Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@Bonnee'
+ha_domain: niu
+---
+
+The `NIU` integration offers integration with the [NIU](https://www.niu.com) cloud service and provides sensors such as battery level, odometer and range.
+
+This integration provides the following platforms:
+
+- Binary sensors - such as power status, charging status, connection and lock.
+- Sensors - such as battery level and temperature, odometer, estimated range and charging time.
+
+## Configuration
+
+Home Assistant offers the NIU integration through `configuration.yaml`. Add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+niu:
+  username: YOUR_EMAIL_ADDRESS
+  password: YOUR_PASSWORD
+```
+
+{% configuration %}
+username:
+  description: The email address associated with your NIU account.
+  required: true
+  type: string
+password:
+  description: The password associated with your NIU account.
+  required: true
+  type: string
+{% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR adds the documentation for the NIU integration that provides access to [NIU](https://www.niu.com) cloud services.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/37717
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
