### PR TITLE
Add 'IoT class' filter

### DIFF
--- a/sass/custom/_component_page.scss
+++ b/sass/custom/_component_page.scss
@@ -50,11 +50,15 @@
         margin: 12px 0;
       }
 
-      .version_select {
+      .version_select, iot_select {
         margin: 12px 0 12px 0;
       }
 
       .version_select > select {
+        width: 100%;
+      }
+
+      .iot_select > select {
         width: 100%;
       }
 

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -16,7 +16,7 @@
 
   {%- if page.ha_iot_class -%}
     <div class='section'>
-      IoT class<sup><a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'><i class="icon-info-sign"></i></a></sup>: {{ page.ha_iot_class }}
+      IoT class<sup><a href='/blog/2016/02/12/classifying-the-internet-of-things/#classifiers'><i class="icon-info-sign"></i></a></sup>: {{ page.ha_iot_class | join: ', ' }}
     </div>
   {%- endif -%}
 

--- a/source/_integrations/agent_dvr.markdown
+++ b/source/_integrations/agent_dvr.markdown
@@ -5,7 +5,8 @@ ha_category:
   - Camera
 ha_config_flow: true
 ha_release: '0.110'
-ha_iot_class: Local Pull
+ha_iot_class:
+  - Local Polling
 ha_codeowners:
   - '@ispysoftware'
 ha_domain: agent_dvr

--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -7,7 +7,8 @@ ha_category:
   - Fan
   - Light
   - Switch
-ha_iot_class: Local Pull
+ha_iot_class:
+  - Local Polling
 ha_release: 0.113
 ha_domain: bond
 ha_codeowners:

--- a/source/_integrations/ecobee.markdown
+++ b/source/_integrations/ecobee.markdown
@@ -9,7 +9,8 @@ ha_category:
   - Weather
 featured: true
 ha_release: 0.9
-ha_iot_class: Cloud Poll
+ha_iot_class:
+  - Cloud Polling
 ha_config_flow: true
 ha_codeowners:
   - '@marthoc'

--- a/source/_integrations/foursquare.markdown
+++ b/source/_integrations/foursquare.markdown
@@ -4,7 +4,9 @@ description: Instructions on how to the Foursquare API into Home Assistant.
 ha_category:
   - Social
 ha_release: 0.26
-ha_iot_class: Cloud Polling and Cloud Push
+ha_iot_class:
+  - Cloud Polling
+  - Cloud Push
 ha_domain: foursquare
 ---
 

--- a/source/_integrations/hisense_aehw4a1.markdown
+++ b/source/_integrations/hisense_aehw4a1.markdown
@@ -4,7 +4,8 @@ description: Instructions to setup the Hisense AEH W4A1 WiFi module for ACs.
 ha_release: 0.103
 ha_category:
   - Climate
-ha_iot_class: Local Poll
+ha_iot_class:
+  - Local Polling
 ha_config_flow: true
 ha_codeowners:
   - '@bannhead'

--- a/source/_integrations/smappee.markdown
+++ b/source/_integrations/smappee.markdown
@@ -6,7 +6,7 @@ ha_category:
   - Energy
   - Sensor
   - Switch
-ha_iot_class: Cloud polling
+ha_iot_class: Cloud Polling
 ha_release: 0.64
 ha_config_flow: true
 ha_codeowners:

--- a/source/_integrations/wirelesstag.markdown
+++ b/source/_integrations/wirelesstag.markdown
@@ -6,7 +6,9 @@ ha_category:
   - Binary Sensor
   - Sensor
   - Switch
-ha_iot_class: Cloud Polling and Local Push
+ha_iot_class:
+  - Cloud Polling
+  - Local Push
 ha_release: 0.68
 ha_domain: wirelesstag
 ---

--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -23,6 +23,7 @@ regenerate: false
 {%- assign components = site.integrations | sort: 'title' -%}
 {%- assign components_by_version = site.integrations | group_components_by_release -%}
 {%- assign categories = components | map: 'ha_category' | join: ',' | join: ',' | split: ',' | uniq | sort -%}
+{%- assign iot_classes = components | map: 'ha_iot_class' | join: ',' | split: ',' | uniq | sort -%}
 
 <p class='note'>
   Support for these integrations is provided by the Home Assistant community.
@@ -42,6 +43,14 @@ regenerate: false
             </option>
             {%- endfor -%}
           </optgroup>
+          {%- endfor -%}
+        </select></div>
+      <div class="iot_select">IoT Class: <select name="iot_class">
+          <option value="#"></option>
+          {%- for iot_class in iot_classes -%}
+            {%- if iot_class != "" -%}
+              <option value="#iot_class/{{ iot_class }}">{{ iot_class }}</option>
+            {%- endif -%}
           {%- endfor -%}
         </select></div>
       {%- for category in categories -%}
@@ -95,7 +104,7 @@ var allComponents = [
         {% capture category %}"{{ ha_category | slugify | downcase }}"{% endcapture %}
         {% assign categories = categories | push: category %}
       {%- endfor -%}
-      {url:"{{ component.url }}", title:"{{component.title}}", cat: [{{categories|join: ","}}], featured: {% if component.featured %}true{% else %}false{% endif %}, v: "{{major_version}}.{{minor_version}}", logo: "{{component.logo}}", domain: "{{component.ha_domain}}"},
+  {url:"{{ component.url }}", title:"{{component.title}}", cat: [{{categories|join: ","}}], featured: {% if component.featured %}true{% else %}false{% endif %}, v: "{{major_version}}.{{minor_version}}", logo: "{{component.logo}}", domain: "{{component.ha_domain}}", iot_class: "{{ component.ha_iot_class }}"},
     {% endif -%}
   {%- endfor -%}
   false
@@ -185,6 +194,13 @@ allComponents.pop(); // remove placeholder element at the end
             return comp.v === search;
           };
 
+        } else if (hash.indexOf('#iot_class/') === 0) {
+          search = decodeURIComponent(hash).substring(11);
+          filter = function (comp) {
+            // compare against the ha_iot_class of the component
+            console.log(search);
+            return comp.iot_class === search;
+          };
         } else {
           // regular filter categories
           search = hash.substring(1);


### PR DESCRIPTION
## Proposed change
This PR adds a filter against IoT class - specifically because I found myself wanting to know "Which lock are supported by Home Assistant that do not rely on the cloud?"

To answer that question, I needed to click through every integration in the locks category; and that was a little bit tedious - thankfully the locks category is only 30-something devices. If I had been curious about sensors ... well, that would take all day.

So - this PR adds a simple filter on IoT class, and also fixes the 7 integrations that were not using an IoT class as defined in the blog: https://www.home-assistant.io/blog/2016/02/12/classifying-the-internet-of-things/#classifiers

It should be noted that there are 272 integrations that do not have an IoT class listed:

<details>
<summary>Click here to see them</summary>

source/_integrations/actiontec.markdown
source/_integrations/air_quality.markdown
source/_integrations/alarm_control_panel.ifttt.markdown
source/_integrations/alarm_control_panel.markdown
source/_integrations/alert.markdown
source/_integrations/alexa.flash_briefings.markdown
source/_integrations/alexa.intent.markdown
source/_integrations/alexa.markdown
source/_integrations/alexa.smart_home.markdown
source/_integrations/amazon_polly.markdown
source/_integrations/apache_kafka.markdown
source/_integrations/api.markdown
source/_integrations/apns.markdown
source/_integrations/apprise.markdown
source/_integrations/arris_tg2492lg.markdown
source/_integrations/aruba.markdown
source/_integrations/asterisk_cdr.markdown
source/_integrations/aten_pe.markdown
source/_integrations/aurora.markdown
source/_integrations/auth.markdown
source/_integrations/automation.markdown
source/_integrations/aws.markdown
source/_integrations/azure_event_hub.markdown
source/_integrations/azure_service_bus.markdown
source/_integrations/baidu.markdown
source/_integrations/binary_sensor.markdown
source/_integrations/browser.markdown
source/_integrations/bt_home_hub_5.markdown
source/_integrations/calendar.markdown
source/_integrations/camera.markdown
source/_integrations/circuit.markdown
source/_integrations/cisco_ios.markdown
source/_integrations/cisco_mobility_express.markdown
source/_integrations/cisco_webex_teams.markdown
source/_integrations/citybikes.markdown
source/_integrations/clickatell.markdown
source/_integrations/clicksend.markdown
source/_integrations/clicksend_tts.markdown
source/_integrations/climate.markdown
source/_integrations/cloudflare.markdown
source/_integrations/concord232.markdown
source/_integrations/config.markdown
source/_integrations/configurator.markdown
source/_integrations/conversation.markdown
source/_integrations/counter.markdown
source/_integrations/cover.markdown
source/_integrations/cover.rflink.markdown
source/_integrations/datadog.markdown
source/_integrations/ddwrt.markdown
source/_integrations/debugpy.markdown
source/_integrations/default_config.markdown
source/_integrations/demo.markdown
source/_integrations/device_automation.markdown
source/_integrations/device_sun_light_trigger.markdown
source/_integrations/device_tracker.markdown
source/_integrations/device_tracker.xiaomi.markdown
source/_integrations/dialogflow.markdown
source/_integrations/discord.markdown
source/_integrations/discovery.markdown
source/_integrations/dlib_face_detect.markdown
source/_integrations/dlib_face_identify.markdown
source/_integrations/downloader.markdown
source/_integrations/duckdns.markdown
source/_integrations/edimax.markdown
source/_integrations/edl21.markdown
source/_integrations/emoncms_history.markdown
source/_integrations/facebook.markdown
source/_integrations/facebox.markdown
source/_integrations/fan.markdown
source/_integrations/feedreader.markdown
source/_integrations/ffmpeg.markdown
source/_integrations/ffmpeg_motion.markdown
source/_integrations/ffmpeg_noise.markdown
source/_integrations/flock.markdown
source/_integrations/flux.markdown
source/_integrations/freedns.markdown
source/_integrations/free_mobile.markdown
source/_integrations/fritz.markdown
source/_integrations/frontend.markdown
source/_integrations/futurenow.markdown
source/_integrations/geo_location.markdown
source/_integrations/gitter.markdown
source/_integrations/gntp.markdown
source/_integrations/goalfeed.markdown
source/_integrations/google_assistant.markdown
source/_integrations/google_cloud.markdown
source/_integrations/google_domains.markdown
source/_integrations/google_pubsub.markdown
source/_integrations/google_translate.markdown
source/_integrations/graphite.markdown
source/_integrations/group.markdown
source/_integrations/guardian.markdown
source/_integrations/hangouts.markdown
source/_integrations/hikvisioncam.markdown
source/_integrations/history.markdown
source/_integrations/hitron_coda.markdown
source/_integrations/homeassistant.markdown
source/_integrations/html5.markdown
source/_integrations/huawei_router.markdown
source/_integrations/humidifier.markdown
source/_integrations/ialarm.markdown
source/_integrations/image_processing.markdown
source/_integrations/input_boolean.markdown
source/_integrations/input_datetime.markdown
source/_integrations/input_number.markdown
source/_integrations/input_select.markdown
source/_integrations/input_text.markdown
source/_integrations/intent_script.markdown
source/_integrations/iss.markdown
source/_integrations/joaoapps_join.markdown
source/_integrations/keba.markdown
source/_integrations/keenetic_ndms2.markdown
source/_integrations/keyboard.markdown
source/_integrations/kira.markdown
source/_integrations/konnected.markdown
source/_integrations/lametric.markdown
source/_integrations/lannouncer.markdown
source/_integrations/lifx_cloud.markdown
source/_integrations/light.markdown
source/_integrations/linksys_smart.markdown
source/_integrations/llamalab_automate.markdown
source/_integrations/lock.markdown
source/_integrations/logbook.markdown
source/_integrations/logentries.markdown
source/_integrations/logger.markdown
source/_integrations/luci.markdown
source/_integrations/mailbox.markdown
source/_integrations/mailgun.markdown
source/_integrations/manual.markdown
source/_integrations/manual_mqtt.markdown
source/_integrations/map.markdown
source/_integrations/marytts.markdown
source/_integrations/mastodon.markdown
source/_integrations/matrix.markdown
source/_integrations/media_extractor.markdown
source/_integrations/media_player.markdown
source/_integrations/meraki.markdown
source/_integrations/message_bird.markdown
source/_integrations/microsoft_face_detect.markdown
source/_integrations/microsoft_face_identify.markdown
source/_integrations/microsoft_face.markdown
source/_integrations/microsoft.markdown
source/_integrations/mikrotik.markdown
source/_integrations/mobile_app.markdown
source/_integrations/mochad.markdown
source/_integrations/msteams.markdown
source/_integrations/mycroft.markdown
source/_integrations/namecheapdns.markdown
source/_integrations/nfandroidtv.markdown
source/_integrations/nmap_tracker.markdown
source/_integrations/noaa_tides.markdown
source/_integrations/no_ip.markdown
source/_integrations/notify.command_line.markdown
source/_integrations/notify_events.markdown
source/_integrations/notify.group.markdown
source/_integrations/notify.markdown
source/_integrations/notify.rest.markdown
source/_integrations/onboarding.markdown
source/_integrations/onvif.markdown
source/_integrations/openalpr_cloud.markdown
source/_integrations/openalpr_local.markdown
source/_integrations/opencv.markdown
source/_integrations/opengarage.markdown
source/_integrations/opnsense.markdown
source/_integrations/orvibo.markdown
source/_integrations/osramlightify.markdown
source/_integrations/owntracks.markdown
source/_integrations/panel_custom.markdown
source/_integrations/panel_iframe.markdown
source/_integrations/persistent_notification.markdown
source/_integrations/person.markdown
source/_integrations/picotts.markdown
source/_integrations/ping.markdown
source/_integrations/plant.markdown
source/_integrations/prometheus.markdown
source/_integrations/prowl.markdown
source/_integrations/proximity.markdown
source/_integrations/proxy.markdown
source/_integrations/ptvsd.markdown
source/_integrations/pushover.markdown
source/_integrations/pushsafer.markdown
source/_integrations/python_script.markdown
source/_integrations/qrcode.markdown
source/_integrations/quantum_gateway.markdown
source/_integrations/qvr_pro.markdown
source/_integrations/qwikswitch.markdown
source/_integrations/radarr.markdown
source/_integrations/recorder.markdown
source/_integrations/remember_the_milk.markdown
source/_integrations/remote.markdown
source/_integrations/rflink.markdown
source/_integrations/rfxtrx.markdown
source/_integrations/rocketchat.markdown
source/_integrations/route53.markdown
source/_integrations/rss_feed_template.markdown
source/_integrations/safe_mode.markdown
source/_integrations/scene.knx.markdown
source/_integrations/scene.markdown
source/_integrations/script.markdown
source/_integrations/search.markdown
source/_integrations/sendgrid.markdown
source/_integrations/sensor.markdown
source/_integrations/shell_command.markdown
source/_integrations/shiftr.markdown
source/_integrations/shopping_list.markdown
source/_integrations/signal_messenger.markdown
source/_integrations/simplepush.markdown
source/_integrations/simplisafe.markdown
source/_integrations/sinch.markdown
source/_integrations/sky_hub.markdown
source/_integrations/slack.markdown
source/_integrations/smarty.markdown
source/_integrations/smtp.markdown
source/_integrations/snips.markdown
source/_integrations/spaceapi.markdown
source/_integrations/splunk.markdown
source/_integrations/sql.markdown
source/_integrations/ssdp.markdown
source/_integrations/statsd.markdown
source/_integrations/stt.markdown
source/_integrations/sun.markdown
source/_integrations/swisscom.markdown
source/_integrations/switch.markdown
source/_integrations/switch.rflink.markdown
source/_integrations/synology_chat.markdown
source/_integrations/synology_srm.markdown
source/_integrations/syslog.markdown
source/_integrations/system_health.markdown
source/_integrations/system_log.markdown
source/_integrations/tank_utility.markdown
source/_integrations/telegram_broadcast.markdown
source/_integrations/telegram.markdown
source/_integrations/telegram_polling.markdown
source/_integrations/telegram_webhooks.markdown
source/_integrations/thingspeak.markdown
source/_integrations/thomson.markdown
source/_integrations/timer.markdown
source/_integrations/tomato.markdown
source/_integrations/totalconnect.markdown
source/_integrations/tts.markdown
source/_integrations/twilio_call.markdown
source/_integrations/twilio.markdown
source/_integrations/twilio_sms.markdown
source/_integrations/twitter.markdown
source/_integrations/ubee.markdown
source/_integrations/ubus.markdown
source/_integrations/universal.markdown
source/_integrations/upc_connect.markdown
source/_integrations/updater.markdown
source/_integrations/vacuum.markdown
source/_integrations/vacuum.mqtt.markdown
source/_integrations/vera.markdown
source/_integrations/vesync.markdown
source/_integrations/voicerss.markdown
source/_integrations/volumio.markdown
source/_integrations/water_heater.markdown
source/_integrations/watson_iot.markdown
source/_integrations/watson_tts.markdown
source/_integrations/weather.markdown
source/_integrations/webhook.markdown
source/_integrations/websocket_api.markdown
source/_integrations/wemo.markdown
source/_integrations/worldtidesinfo.markdown
source/_integrations/xmpp.markdown
source/_integrations/yale_smart_alarm.markdown
source/_integrations/yamaha.markdown
source/_integrations/yamaha_musiccast.markdown
source/_integrations/yandex_transport.markdown
source/_integrations/yandextts.markdown
source/_integrations/yessssms.markdown
source/_integrations/zeroconf.markdown
source/_integrations/zone.markdown
</details>

This was something of a quick hack; so if we do not like the way it looks or feel that it should be presented another way, I'm open to other ways of presenting/filtering on this characteristic. That said - I do think this is a really useful way to filter! "Does Home Assistant support this" prominently figures into my decision when I'm picking up new toys, and I suspect it does for others as well! :smile: 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
