### PR TITLE
Adding OpenRGB documentation

### DIFF
--- a/source/_integrations/openrgb.markdown
+++ b/source/_integrations/openrgb.markdown
@@ -1,0 +1,52 @@
+---
+title: "OpenRGB"
+description: "Open Source Desktop RGB Controller"
+ha_release: "0.114"
+ha_category: Light
+ha_iot_class: "Local Polling"
+ha_quality_scale: silver
+ha_config_flow: true
+ha_codeowners:
+  - '@bahorn'
+ha_domain: openrgb
+---
+
+The `OpenRGB` integration allows you to control various desktop RGB lighting products via the [OpenRGB SDK Server](https://gitlab.com/CalcProgrammer1/OpenRGB).
+
+## Configuration via frontend
+
+To connect to OpenRGB using the Home Assistant frontend:
+
+* Navigate to **Configuration -> Integrations**
+* Click the **+** in the bottom corner.
+* Find **OpenRGB** in the dropdown menu.
+* Fill in the connection details.
+
+Your RGB lighting should now be available to Home Assistant!
+
+## Configuration by YAML
+
+Add the following to your `configuration.yaml`, adjusting the host and port as required.
+
+```yaml
+openrgb:
+    host: locahost
+    port: 6742
+```
+
+{% configuration %}
+host:
+    description: The host the OpenRGB SDK Server is running on.
+    required: true
+    type: string
+port:
+    description: The port number the OpenRGB SDK Server is running on.
+    required: false
+    default: 6742
+    type: integer
+client_id:
+    description: The client name to provide to the server.
+    required: false
+    default: "Home Assistant"
+    type: string
+{% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This adds documentation for the [OpenRGB SDK Server](https://gitlab.com/CalcProgrammer1/OpenRGB) Integration that is being PR'd to core.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38309
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
