### PR TITLE
Update google_assistant.markdown - Fixed "Share an Action" steps

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -60,9 +60,13 @@ If you've added Home Assistant to your phone's home screen, you have to first re
 </div>
 
 1. If you want to allow other household users to control the devices:
-    1. Go to the settings for the project you created in the [Actions on Google console](https://console.actions.google.com/).
-    2. Click `Test -> Simulator`, then click `Share` icon in the right top corner. Follow the on-screen instruction:
-        1. Add team members: Got to `Settings -> Permission`, click `Add`, type the new user's e-mail address and choose `Project -> Viewer` role.
+    1. Open the project you created in the [Actions on Google console](https://console.actions.google.com/).
+    2. Click `Test` on the top of the page, then click `Simulator` located to the page left, then click the three little dots (more) icon in the upper right corner of the console.
+    3. Click Manage user access. This redirects you to the Google Cloud Platform IAM permissions page.
+    4. Click ADD at the top of the page.
+        1. Enter the email address of the user you want to add.
+        2. Click Select a role and choose Project < Viewer.
+        3. Click SAVE
         2. Copy and share the link with the new user.
         3. When the new user opens the link with their own Google account, it will enable your draft test app under their account.
     3. Have the new user go to their `Google Assistant` app to add `[test] your app name` to their account.


### PR DESCRIPTION
Updated inaccurate "Share an Action" steps, updated to match google's instructions https://developers.google.com/assistant/smarthome/develop/testing#share-action

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
