### PR TITLE
Fix rmvtransport documentation

### DIFF
--- a/source/_integrations/rmvtransport.markdown
+++ b/source/_integrations/rmvtransport.markdown
@@ -49,7 +49,7 @@ next_departure:
       required: true
       type: string
     destinations:
-      description: "One or multiple final stop names, e.g., 'Frankfurt (Main) Hauptbahnhof' or ['Frankfurt (Main) Hauptbahnhof','Frankfurt (Main) Stadion']. This can be used to only consider a particular direction of travel."
+      description: "One or multiple final stop IDs, e.g., `'3000010'` or `['3000010','3002899']`. This can be used to only consider a particular direction of travel."
       required: false
       type: [string]
     direction:
@@ -63,7 +63,7 @@ next_departure:
     products:
       description: "One or more modes of transport `['U-Bahn', 'Tram', 'Bus', 'S', 'RB', 'RE', 'EC', 'IC', 'ICE']`."
       required: false
-      default: ['U-Bahn', 'Tram', 'Bus', 'S', 'RB', 'RE', 'EC', 'IC', 'ICE']
+      default: `['U-Bahn', 'Tram', 'Bus', 'S', 'RB', 'RE', 'EC', 'IC', 'ICE']`
       type: [string]
     time_offset:
       description: Do not display departures leaving sooner than this number of minutes. Useful if you are a couple of minutes away from the stop.
@@ -93,8 +93,8 @@ sensor:
       - station: 3000010
         time_offset: 5
         destinations:
-          - 'Frankfurt (Main) Flughafen Regionalbahnhof'
-          - 'Frankfurt (Main) Stadion'
+          - '3002930
+          - '3002899'
         products:
           - 'RB'
           - 'RE'
@@ -102,7 +102,7 @@ sensor:
           - 'S'
       - station: 3006907
         products: 'Bus'
-        destinations: ['Wiesbaden Dernsches Gelände', 'Mainz Hauptbahnhof']
+        destinations: ['3025622', '3006904']
         name: Destination
       - station: 3006904
         lines: 'S8'

--- a/source/_integrations/rmvtransport.markdown
+++ b/source/_integrations/rmvtransport.markdown
@@ -63,7 +63,7 @@ next_departure:
     products:
       description: "One or more modes of transport `['U-Bahn', 'Tram', 'Bus', 'S', 'RB', 'RE', 'EC', 'IC', 'ICE']`."
       required: false
-      default: `['U-Bahn', 'Tram', 'Bus', 'S', 'RB', 'RE', 'EC', 'IC', 'ICE']`
+      default: ['U-Bahn', 'Tram', 'Bus', 'S', 'RB', 'RE', 'EC', 'IC', 'ICE']
       type: [string]
     time_offset:
       description: Do not display departures leaving sooner than this number of minutes. Useful if you are a couple of minutes away from the stop.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The documentation falsely instructed to use the station name instead of the station id to specify the direction.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/38356

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
