### PR TITLE
Fix in ads component documentation

### DIFF
--- a/source/_integrations/ads.markdown
+++ b/source/_integrations/ads.markdown
@@ -140,7 +140,7 @@ sensor:
   - platform: ads
     adsvar: GVL.temperature
     unit_of_measurement: '°C'
-    adstype: integer
+    adstype: int
 ```
 
 {% configuration %}


### PR DESCRIPTION
## Proposed change
Just a small fix in the documentation of ads component. Replacing invalid adstype integer by int.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
