### PR TITLE
Add Roon media_player integration

### DIFF
--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -1,0 +1,38 @@
+---
+title: RoonLabs Media Player
+description: Instructions on how to integrate a RoonLabs multi room player into Home Assistant.
+ha_category:
+  - Media Player
+ha_release: 0.114
+ha_iot_class: Local Push
+ha_config_flow: true
+ha_codeowners:
+  - '@pavoni'
+ha_domain: roon
+---
+
+The Roon integration allows you to control [RoonLabs](https://roonlabs.com/) music players from Home Assistant.
+
+This integration uses Roon Core, a Roon application that runs on a machine on your network. Via Roon Core, Home Assistant can control all the Roon music players on your network.
+
+To integrate with Roon, you need to provide Home Assistant with the Hostname or IP address of the machine that runs your Roon Core, and then authorize Home Assistant in the Roon application.
+
+<div class='note'>
+
+If you use an IP address please assign a static IP address to the machine that runs Roon Core. This ensures that it won't change IP addresses, so you won't have to change the configuration in Home Assistant if it reboots and changes IP address. See your router's manual for details on how to set this up.
+
+</div>
+
+### Configuration
+
+<div class='note'>
+
+  You need the Hostname or IP adresss of the machine that runs your Roon Core. This might be a machine name (which can be followed buy .local, eg myserver.local) or can be an IP address.
+
+</div>
+
+1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'Roon' and click 'Configure'.
+2. Enter the Hostname or IP address for the Roon Core machine and click 'Submit'.
+3. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to 'Settings' and then 'Extensions', there you will see an entry for HomeAssistant with a button next to it. Click 'Enable'.
+4. Roon core will then provide Home Assistant with the details of your media players.
+5. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -17,19 +17,13 @@ This integration uses Roon Core, a Roon application that runs on a machine on yo
 
 To integrate with Roon, you need to provide Home Assistant with the Hostname or IP address of the machine that runs your Roon Core, and then authorize Home Assistant in the Roon application.
 
-<div class='note'>
-
 If you use an IP address please assign a static IP address to the machine that runs Roon Core. This ensures that it won't change IP addresses, so you won't have to change the configuration in Home Assistant if it reboots and changes IP address. See your router's manual for details on how to set this up.
 
 </div>
 
 ### Configuration
 
-<div class='note'>
-
-  You need the Hostname or IP adresss of the machine that runs your Roon Core. This might be a machine name (which can be followed buy .local, eg myserver.local) or can be an IP address.
-
-</div>
+You need the Hostname or IP adresss of the machine that runs your Roon Core. This might be a machine name (which can be followed buy .local, eg myserver.local) or can be an IP address.
 
 1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'Roon' and click 'Configure'.
 2. Enter the Hostname or IP address for the Roon Core machine and click 'Submit'.

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -3,7 +3,7 @@ title: RoonLabs Media Player
 description: Instructions on how to integrate a RoonLabs multi room player into Home Assistant.
 ha_category:
   - Media Player
-ha_release: 0.114
+ha_release: 0.115
 ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
@@ -25,8 +25,8 @@ If you use an IP address please assign a static IP address to the machine that r
 
 You need the Hostname or IP adresss of the machine that runs your Roon Core. This might be a machine name (which can be followed buy .local, eg myserver.local) or can be an IP address.
 
-1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'Roon' and click 'Configure'.
-2. Enter the Hostname or IP address for the Roon Core machine and click 'Submit'.
-3. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to 'Settings' and then 'Extensions', there you will see an entry for Home Assistant with a button next to it. Click 'Enable'.
+1. From the Home Assistant front-end, navigate to **Configuration** then **Integrations**. Under **Set up a new integration** locate 'Roon' and click **Configure**.
+2. Enter the `Hostname` or `IP address` for the Roon Core machine and click **Submit**.
+3. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to **Settings** and then **Extensions**, there you will see an entry for Home Assistant with a button next to it. Click **Enable**.
 4. Roon core will then provide Home Assistant with the details of your media players.
 5. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -33,6 +33,6 @@ If you use an IP address please assign a static IP address to the machine that r
 
 1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'Roon' and click 'Configure'.
 2. Enter the Hostname or IP address for the Roon Core machine and click 'Submit'.
-3. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to 'Settings' and then 'Extensions', there you will see an entry for HomeAssistant with a button next to it. Click 'Enable'.
+3. Home Assistant will then contact your Roon Core and ask to be authorized. You will need to enable this extension in the Room Application. Go to 'Settings' and then 'Extensions', there you will see an entry for Home Assistant with a button next to it. Click 'Enable'.
 4. Roon core will then provide Home Assistant with the details of your media players.
 5. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -17,11 +17,11 @@ This integration uses Roon Core, a Roon application that runs on a machine on yo
 
 To integrate with Roon, you need to provide Home Assistant with the Hostname or IP address of the machine that runs your Roon Core, and then authorize Home Assistant in the Roon application.
 
-If you use an IP address please assign a static IP address to the machine that runs Roon Core. This ensures that it won't change IP addresses, so you won't have to change the configuration in Home Assistant if it reboots and changes IP address. See your router's manual for details on how to set this up.
+If you use an IP address, please assign a static IP address to the machine that runs Roon Core. This ensures that it won't change IP addresses, so you won't have to change the configuration in Home Assistant if it reboots and changes IP address. See your router's manual for details on how to set this up.
 
 ### Configuration
 
-You need the Hostname or IP adresss of the machine that runs your Roon Core. This might be a machine name (which can be followed buy .local, eg myserver.local) or can be an IP address.
+You need the Hostname or IP address of the machine that runs your Roon Core. This might be a machine name (which can be followed by `.local`, e.g., `myserver.local`) or can be an IP address.
 
 1. From the Home Assistant front-end, navigate to **Configuration** then **Integrations**. Under **Set up a new integration** locate 'Roon' and click **Configure**.
 2. Enter the `Hostname` or `IP address` for the Roon Core machine and click **Submit**.

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -19,8 +19,6 @@ To integrate with Roon, you need to provide Home Assistant with the Hostname or 
 
 If you use an IP address please assign a static IP address to the machine that runs Roon Core. This ensures that it won't change IP addresses, so you won't have to change the configuration in Home Assistant if it reboots and changes IP address. See your router's manual for details on how to set this up.
 
-</div>
-
 ### Configuration
 
 You need the Hostname or IP adresss of the machine that runs your Roon Core. This might be a machine name (which can be followed buy .local, eg myserver.local) or can be an IP address.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the new Roon Labs media player integration,


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
https://github.com/home-assistant/core/pull/37553

- Link to parent pull request in the Brands repository: 
https://github.com/home-assistant/brands/pull/1769

- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
