### PR TITLE
Fix broken link in rfxtrx.markdown

### DIFF
--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -239,7 +239,7 @@ Make sure you trigger a dimming command to get switches detected as lights other
 
 #### Convert switch event to dimming event
 
-To convert a standard switch to a light, use the [Light Switch](integrations/light.switch/) component.
+To convert a standard switch to a light, use the [Light Switch](/integrations/light.switch/) component.
 
 To convert a switch to a dimmable light, make sure the event contain a dimming command. You can usually convert a command by changing one byte.
 


### PR DESCRIPTION
## Proposed change
Fix a broken link in the document rfxtrx.markdown. 
The link to light.switch component was a relative path instead of an absolute path and was therefore not working. This PR fixes just that.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
No additional information to give at this point.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards