### PR TITLE
Allow automation to be turned off without stopping actions

### DIFF
--- a/source/_docs/automation.markdown
+++ b/source/_docs/automation.markdown
@@ -5,6 +5,8 @@ description: "Steps to help you get automation setup in Home Assistant."
 
 Home Assistant offers a wide range of automation configurations. In this section, we'll try to guide you through all the different possibilities and options. Besides this documentation, there are also a couple of people who have made their automations [publicly available](/cookbook/#example-configurationyaml).
 
+Please see [Automation Integration](/integrations/automation/) for configuration options and services.
+
 ### Automation basics
 
 Before you can go ahead and create your own automations, it's important to learn the basics. To explore these, let's have a look at the following example home automation rule:
@@ -40,55 +42,3 @@ Automation rules interact directly with the internal state of Home Assistant, so
 State changes can be used as the source of triggers and the current state can be used in conditions.
 
 Actions are all about calling services. To explore the available services open the <img src='/images/screenshots/developer-tool-services-icon.png' class='no-shadow' height='38' /> Services developer tool. Services allow to change anything. For example turn on a light, run a script or enable a scene. Each service has a domain and a name. For example the service `light.turn_on` is capable of turning on any light in your system. Services can be passed parameters to for example tell which device to turn on or what color to use.
-
-### Automation initial state
-
-When you create a new automation, it will be enabled unless you explicitly add `initial_state: false` to it or turn it off manually via UI/another automation/developer tools. In case automations need to be always enabled or disabled when Home Assistant starts, then you can set the `initial_state` in your automations. Otherwise, the previous state will be restored.
-
-Please note that if for some reason Home Assistant cannot restore the previous state, it will result in the automation being enabled.
-
-```yaml
-automation:
-- alias: Automation Name
-  initial_state: false
-  trigger:
-  ...
-```
-
-### Automation Modes
-
-The automation's `mode` configuration option controls what happens when the automation is triggered while the actions are still running from a previous trigger.
-
-Mode | Description
--|-
-`single` | (Default) Do not start a new run. Issue a warning.
-`restart` | Start a new run after first stopping previous run.
-`queued` | Start a new run after all previous runs complete. Runs are guaranteed to execute in the order they were queued.
-`parallel` | Start a new, independent run in parallel with previous runs.
-
-<p class='img'>
-  <img src='/images/integrations/script/script_modes.jpg'>
-</p>
-
-For both `queued` and `parallel` modes, configuration option `max` controls the maximum
-number of runs that can be executing and/or queued up at a time. The default is 10.
-
-#### Example Setting Automation Mode
-
-```yaml
-automation:
-  - trigger:
-      - ...
-    mode: queued
-    max: 25
-    action:
-      - ...
-```
-
-### Deleting Automations
-
-When automations remain visible in the Home Assistant Dashboard, even after having deleted in the YAML file, you have to delete them in the UI.
-
-To delete them completely, go to UI **Configuration** -> **Entities** and find the automation in the search field or by scrolling down.
-
-Check the square box aside of the automation you wish to delete and from the top-right of your screen, select 'REMOVE SELECTED'.

--- a/source/_integrations/automation.markdown
+++ b/source/_integrations/automation.markdown
@@ -80,7 +80,7 @@ Check the square box aside of the automation you wish to delete and from the top
 
 ## Services
 
-### automation.turn_on
+### `automation.turn_on`
 
 This service enables the automation's triggers.
 
@@ -88,7 +88,7 @@ Service data attribute | Optional | Description
 -|-|-
 `entity_id` | no | Entity ID of automation to turn on. Can be a list. `none` or `all` are also accepted.
 
-### automation.turn_off
+### `automation.turn_off`
 
 This service disables the automation's triggers, and optionally stops any currently active actions.
 
@@ -97,7 +97,7 @@ Service data attribute | Optional | Description
 `entity_id` | no | Entity ID of automation to turn on. Can be a list. `none` or `all` are also accepted.
 `stop_actions` | yes | Stop any currently active actions (defaults to true.)
 
-### automation.toggle
+### `automation.toggle`
 
 This service enables the automation's triggers if they were disabled, or disables the automation's triggers, and stops any currently active actions, if the triggers were enabled.
 
@@ -105,6 +105,6 @@ Service data attribute | Optional | Description
 -|-|-
 `entity_id` | no | Entity ID of automation to turn on. Can be a list. `none` or `all` are also accepted.
 
-### automation.reload
+### `automation.reload`
 
 This service reloads all automations, stopping any currently active actions in all of them.

--- a/source/_integrations/automation.markdown
+++ b/source/_integrations/automation.markdown
@@ -10,24 +10,12 @@ ha_codeowners:
 ha_domain: automation
 ---
 
-Please see the [automation section](/docs/automation/) for in-depth
+Please see [Automating Home Assistant](/docs/automation/) for in-depth
 documentation on how to use the automation integration.
 
 <p class='img'>
   <img src='{{site_root}}/images/screenshots/automation-switches.png' />
 </p>
-
-You can also use `initial_state: 'false'` so that the automation
-is not automatically turned on after a Home Assistant reboot.
-
-```yaml
-automation:
-  - alias: Door alarm
-    initial_state: true
-    trigger:
-      - platform: state
-  ...
-```
 
 ## Configuration
 
@@ -37,3 +25,86 @@ This integration is by default enabled, unless you've disabled or removed the [`
 # Example configuration.yaml entry
 automation:
 ```
+
+### Automation initial state
+
+When you create a new automation, it will be enabled unless you explicitly add `initial_state: false` to it or turn it off manually via UI/another automation/developer tools. In case automations need to be always enabled or disabled when Home Assistant starts, then you can set the `initial_state` in your automations. Otherwise, the previous state will be restored.
+
+Please note that if for some reason Home Assistant cannot restore the previous state, it will result in the automation being enabled.
+
+```yaml
+automation:
+- alias: Automation Name
+  initial_state: false
+  trigger:
+  ...
+```
+
+### Automation Modes
+
+The automation's `mode` configuration option controls what happens when the automation is triggered while the actions are still running from a previous trigger.
+
+Mode | Description
+-|-
+`single` | (Default) Do not start a new run. Issue a warning.
+`restart` | Start a new run after first stopping previous run.
+`queued` | Start a new run after all previous runs complete. Runs are guaranteed to execute in the order they were queued.
+`parallel` | Start a new, independent run in parallel with previous runs.
+
+<p class='img'>
+  <img src='/images/integrations/script/script_modes.jpg'>
+</p>
+
+For both `queued` and `parallel` modes, configuration option `max` controls the maximum
+number of runs that can be executing and/or queued up at a time. The default is 10.
+
+#### Example Setting Automation Mode
+
+```yaml
+automation:
+  - trigger:
+      - ...
+    mode: queued
+    max: 25
+    action:
+      - ...
+```
+
+### Deleting Automations
+
+When automations remain visible in the Home Assistant Dashboard, even after having deleted in the YAML file, you have to delete them in the UI.
+
+To delete them completely, go to UI **Configuration** -> **Entities** and find the automation in the search field or by scrolling down.
+
+Check the square box aside of the automation you wish to delete and from the top-right of your screen, select 'REMOVE SELECTED'.
+
+## Services
+
+### automation.turn_on
+
+This service enables the automation's triggers.
+
+Service data attribute | Optional | Description
+-|-|-
+`entity_id` | no | Entity ID of automation to turn on. Can be a list. `none` or `all` are also accepted.
+
+### automation.turn_off
+
+This service disables the automation's triggers, and optionally stops any currently active actions.
+
+Service data attribute | Optional | Description
+-|-|-
+`entity_id` | no | Entity ID of automation to turn on. Can be a list. `none` or `all` are also accepted.
+`stop_actions` | yes | Stop any currently active actions (defaults to true.)
+
+### automation.toggle
+
+This service enables the automation's triggers if they were disabled, or disables the automation's triggers, and stops any currently active actions, if the triggers were enabled.
+
+Service data attribute | Optional | Description
+-|-|-
+`entity_id` | no | Entity ID of automation to turn on. Can be a list. `none` or `all` are also accepted.
+
+### automation.reload
+
+This service reloads all automations, stopping any currently active actions in all of them.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add `stop_actions` option to `automation.turn_off` service so user can decide whether or not to stop any currently active actions when turning off automation.

Also move all automation configuration details to automation integration page and add service descriptions. This makes automation integration documentation more similar to scripts. Leave all information about how to build automations (triggers, conditions & action) where they were.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#38436
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
