### PR TITLE
[iOS] Add new team ID to apple-app-site-association

### DIFF
--- a/source/.well-known/apple-app-site-association
+++ b/source/.well-known/apple-app-site-association
@@ -5,19 +5,22 @@
       {
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant.dev",
         "paths": [
-          "/ios/*"
+          "/ios/*",
+          "/nfc/*"
         ]
       },
       {
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant.beta",
         "paths": [
-          "/ios/*"
+          "/ios/*",
+          "/nfc/*"
         ]
       },
       {
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant",
         "paths": [
-          "/ios/*"
+          "/ios/*",
+          "/nfc/*"
         ]
       },
       {

--- a/source/.well-known/apple-app-site-association
+++ b/source/.well-known/apple-app-site-association
@@ -19,6 +19,27 @@
         "paths": [
           "/ios/*"
         ]
+      },
+      {
+        "appID": "QMQYCKL255.io.robbie.HomeAssistant.dev",
+        "paths": [
+          "/ios/*",
+          "/nfc/*"
+        ]
+      },
+      {
+        "appID": "QMQYCKL255.io.robbie.HomeAssistant.beta",
+        "paths": [
+          "/ios/*",
+          "/nfc/*"
+        ]
+      },
+      {
+        "appID": "QMQYCKL255.io.robbie.HomeAssistant",
+        "paths": [
+          "/ios/*",
+          "/nfc/*"
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Proposed change

This adds the new iOS app team ID (`QMQYCKL255`) and potentially `/nfc/*` for home-assistant/android#689 related unified path handling. This doesn't require an app update; it will just start working.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
