### PR TITLE
fix yaml for input_number use in delay

### DIFF
--- a/source/_integrations/input_number.markdown
+++ b/source/_integrations/input_number.markdown
@@ -242,7 +242,7 @@ automation:
      entity_id: switch.something
      to: 'on'
    action:
-     - delay: '00:{{ states('input_number.minutes') | int }}:{{ states('input_number.seconds') | int }}'
+     - delay: "00:{{ states('input_number.minutes') | int }}:{{ states('input_number.seconds') | int }}"
      - service: switch.turn_off
        entity_id: switch.something
 ```


### PR DESCRIPTION
## Proposed change
The yaml example for delay is not a valid yaml



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
## Checklist

- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
