### PR TITLE
Update ecovacs.markdown

### DIFF
--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -51,7 +51,7 @@ continent:
 
 Note: For some countries, you will need to set `continent` to `ww` (meaning worldwide.) There is unfortunately no way to know the correct settings other than guessing and checking. See the [sucks library protocol documentation](https://github.com/wpietri/sucks/blob/master/protocol.md) for more information about what has been figured out about the Ecovacs servers.
 
-Additional note: There are some issues during the password encoding. Using some special characters (e.g "-") in your password does not work.
+Additional note: There are some issues during the password encoding. Using some special characters (e.g., `-`) in your password does not work.
 
 ### Stability and Reporting Bugs
 

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -51,6 +51,8 @@ continent:
 
 Note: For some countries, you will need to set `continent` to `ww` (meaning worldwide.) There is unfortunately no way to know the correct settings other than guessing and checking. See the [sucks library protocol documentation](https://github.com/wpietri/sucks/blob/master/protocol.md) for more information about what has been figured out about the Ecovacs servers.
 
+Additional note: There are some issues during the password encoding. Using some special characters (e.g "-") in your password does not work.
+
 ### Stability and Reporting Bugs
 
 The library that talks to the Ecovacs servers is in a very early state and still under development. As such, it is likely that not all regions and devices will work at the current time.


### PR DESCRIPTION
I faced some login issues with my ecovacs credentials using this module. First I thought, i has some regular issues with the country/contintent, but in the end it was a simple special character ("-") in my password. After changing my password everything worked correctly.

This issue may be related to `def encrypt(text):`, (sucks/__init__.py, line 206).
