### PR TITLE
opensky: List new attributes

### DIFF
--- a/source/_integrations/opensky.markdown
+++ b/source/_integrations/opensky.markdown
@@ -33,11 +33,29 @@ Configuration options for the OpenSky Network sensor:
 - **opensky_entry**: Fired when a flight enters the region.
 - **opensky_exit**: Fired when a flight exits the region.
 
-Both events have three attributes:
+Events include attributes forwarded from the [OpenSky Network API](https://opensky-network.org/apidoc/rest.html#response):
+
+- **icao24**: Unique ICAO 24-bit address of the transponder in hex string representation.
+- **callsign**: Callsign of the vehicle (8 chars). Can be null if no callsign has been received.
+- **origin_country**: Country name inferred from the ICAO 24-bit address.
+- **time_position**: Unix timestamp (seconds) for the last position update. Can be null if no position report was received by OpenSky within the past 15s.
+- **last_contact**: Unix timestamp (seconds) for the last update in general. This field is updated for any new, valid message received from the transponder.
+- **longitude**: WGS-84 longitude in decimal degrees. Can be null.
+- **latitude**: WGS-84 latitude in decimal degrees. Can be null.
+- **altitude**: Barometric altitude in meters. Can be null.
+- **on_ground**: Boolean value which indicates if the position was retrieved from a surface position report.
+- **velocity**: Velocity over ground in m/s. Can be null.
+- **true_track**: True track in decimal degrees clockwise from north (north=0°). Can be null.
+- **vertical_rate**: Vertical rate in m/s. A positive value indicates that the airplane is climbing, a negative value indicates that it descends. Can be null.
+- **sensors**: IDs of the receivers which contributed to this state vector. Is null if no filtering for sensor was used in the request.
+- **geo_altitude**: Geometric altitude in meters. Can be null.
+- **squawk**: The transponder code aka Squawk. Can be null.
+- **spi**: Whether flight status indicates special purpose indicator.
+- **position_source**: Origin of this state’s position: 0 = ADS-B, 1 = ASTERIX, 2 = MLAT
+
+Additionally, the following attribute is available:
 
 - **sensor**: Name of `opensky` sensor that fired the event.
-- **callsign**: Callsign of the flight.
-- **altitude**: Altitude of the flight in meters.
 
 To receive notifications of the entering flights using the [Home Assistant Companion App](https://companion.home-assistant.io/), add the following lines to your `configuration.yaml` file:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document event attributes added by a PR in core.

Because these attributes are fields forwarded from the OpenSky Network API, the descriptions were copied from  https://opensky-network.org/apidoc/rest.html#response.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38533
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
