### PR TITLE
[iOS] app-site-association: change /nfc/ to /tag/

### DIFF
--- a/source/.well-known/apple-app-site-association
+++ b/source/.well-known/apple-app-site-association
@@ -6,42 +6,42 @@
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant.dev",
         "paths": [
           "/ios/*",
-          "/nfc/*"
+          "/tag/*"
         ]
       },
       {
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant.beta",
         "paths": [
           "/ios/*",
-          "/nfc/*"
+          "/tag/*"
         ]
       },
       {
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant",
         "paths": [
           "/ios/*",
-          "/nfc/*"
+          "/tag/*"
         ]
       },
       {
         "appID": "QMQYCKL255.io.robbie.HomeAssistant.dev",
         "paths": [
           "/ios/*",
-          "/nfc/*"
+          "/tag/*"
         ]
       },
       {
         "appID": "QMQYCKL255.io.robbie.HomeAssistant.beta",
         "paths": [
           "/ios/*",
-          "/nfc/*"
+          "/tag/*"
         ]
       },
       {
         "appID": "QMQYCKL255.io.robbie.HomeAssistant",
         "paths": [
           "/ios/*",
-          "/nfc/*"
+          "/tag/*"
         ]
       }
     ]


### PR DESCRIPTION
## Proposed change
Change the `/nfc/*` tag path handling to `/tag/*` so it isn't specific to NFC.

## Type of change
Not a documentation change, really.

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: home-assistant/iOS/pull/868
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

This PR is not dependent on this PR merging, the iOS app is not going out for a bit.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
