### PR TITLE
Document new Vizio service and parameter to fetch latest app lists for Smart TVs

### DIFF
--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -173,6 +173,11 @@ apps:
               required: false
               type: string
               default: null
+    scan_interval:
+      description: Defines the frequency (number of weeks) in which the integration will automatically pull the latest list of apps that Vizio supports. 0 disables the automatic sync."
+      required: false
+      type: int
+      default: 0
 {% endconfiguration %}
 
 ```yaml
@@ -196,6 +201,7 @@ vizio:
             APP_ID: 9
             NAME_SPACE: 9
             MESSAGE: MY_MESSAGE
+      scan_interval: 1
 ```
 
 ### Obtaining an app configuration
@@ -208,6 +214,10 @@ The list of apps that are provided by default is statically defined [here](https
 ```bash
 pyvizio --ip=0 get-apps-list
 ```
+
+## Service `vizio.fetch_latest_apps`
+
+This service allows you to fetch the latest list of apps for a given Vizio device. Vizio occasionally adds support for additional apps and this service allows you to sync Home Assistant with that list. This action can also be scheduled to perform automatically using the `scan_interval` configuration option in `configuration.yaml` or in the Config Entry Options menu.
 
 ## Notes and limitations
 

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -173,11 +173,6 @@ apps:
               required: false
               type: string
               default: null
-    scan_interval:
-      description: Defines the frequency (number of weeks) in which the integration will automatically pull the latest list of apps that Vizio supports. `0` disables the automatic sync.
-      required: false
-      type: integer
-      default: 0
 {% endconfiguration %}
 
 ```yaml
@@ -201,7 +196,6 @@ vizio:
             APP_ID: 9
             NAME_SPACE: 9
             MESSAGE: MY_MESSAGE
-      scan_interval: 1
 ```
 
 ### Obtaining an app configuration
@@ -217,7 +211,7 @@ pyvizio --ip=0 get-apps-list
 
 ## Service `vizio.fetch_latest_apps`
 
-This service allows you to fetch the latest list of apps for a given Vizio device. Vizio occasionally adds support for additional apps and this service allows you to sync Home Assistant with that list. This action can also be scheduled to perform automatically using the `scan_interval` configuration option in `configuration.yaml` or in the configuration entry Options menu.
+This service allows you to fetch the latest list of apps for a given Vizio device. Vizio occasionally adds support for additional apps and this service allows you to sync Home Assistant with that list. This action can also be scheduled to perform automatically by updating the configuration entry options (Go to **Configuration** > **Integrations** and click on **Options** on the **VIZIO SmartCast** card of the entry you want to update).
 
 ## Notes and limitations
 

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -211,7 +211,7 @@ pyvizio --ip=0 get-apps-list
 
 ## Service `vizio.fetch_latest_apps`
 
-This service allows you to fetch the latest list of apps for a given Vizio device. Vizio occasionally adds support for additional apps and this service allows you to sync Home Assistant with that list. This action can also be scheduled to perform automatically by updating the configuration entry options (Go to **Configuration** > **Integrations** and click on **Options** on the **VIZIO SmartCast** card of the entry you want to update).
+This service allows you to fetch the latest list of apps for a given Vizio device. Vizio occasionally adds support for additional apps and this service allows you to sync Home Assistant with that list. This action can also be scheduled to perform automatically by updating the configuration entry options: go to **Configuration** > **Integrations** and click on **Options** on the **Vizio SmartCast** card of the entry you want to update.
 
 ## Notes and limitations
 

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -174,7 +174,7 @@ apps:
               type: string
               default: null
     scan_interval:
-      description: Defines the frequency (number of weeks) in which the integration will automatically pull the latest list of apps that Vizio supports. 0 disables the automatic sync."
+      description: Defines the frequency (number of weeks) in which the integration will automatically pull the latest list of apps that Vizio supports. `0` disables the automatic sync.
       required: false
       type: integer
       default: 0

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -217,7 +217,7 @@ pyvizio --ip=0 get-apps-list
 
 ## Service `vizio.fetch_latest_apps`
 
-This service allows you to fetch the latest list of apps for a given Vizio device. Vizio occasionally adds support for additional apps and this service allows you to sync Home Assistant with that list. This action can also be scheduled to perform automatically using the `scan_interval` configuration option in `configuration.yaml` or in the Config Entry Options menu.
+This service allows you to fetch the latest list of apps for a given Vizio device. Vizio occasionally adds support for additional apps and this service allows you to sync Home Assistant with that list. This action can also be scheduled to perform automatically using the `scan_interval` configuration option in `configuration.yaml` or in the configuration entry Options menu.
 
 ## Notes and limitations
 

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -176,7 +176,7 @@ apps:
     scan_interval:
       description: Defines the frequency (number of weeks) in which the integration will automatically pull the latest list of apps that Vizio supports. 0 disables the automatic sync."
       required: false
-      type: int
+      type: integer
       default: 0
 {% endconfiguration %}
 


### PR DESCRIPTION
## Proposed change
Added a new configuration parameter that will allow the integration to automatically pull the latest app lists for Vizio Smart TV's on a schedule. I also added a new service to be able to fetch the list on demand.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#38641

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
