### PR TITLE
Update Bond documentation to specify minimum supported firmware

### DIFF
--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -35,5 +35,5 @@ After completing the configuration flow, the Bond integration will be available.
 ## Requirements
 
 This integration supports Bond bridges with firmware v2.10.x and up.
-Bond bridges with firmware v2.9.x and lower will **not** work correctly - please,
+Bond bridges with firmware v2.9.x and lower will **not** work correctly. Please
 upgrade your firmware from Bond app before adding this integration.

--- a/source/_integrations/bond.markdown
+++ b/source/_integrations/bond.markdown
@@ -17,7 +17,7 @@ ha_config_flow: true
 
 The Bond integration allows you to control appliances through your [Bond Bridge](https://bondhome.io/). Duplicates your RF remote control.
 
-Supported devices:
+Supported devices (see Requirements section below):
 
 - Ceiling fans
 - Shades
@@ -31,3 +31,9 @@ Menu: **Configuration** -> **Integrations**.
 
 Click on the `+` sign to add an integration and click on **Bond** (use typeahead if necessary).
 After completing the configuration flow, the Bond integration will be available.
+
+## Requirements
+
+This integration supports Bond bridges with firmware v2.10.x and up.
+Bond bridges with firmware v2.9.x and lower will **not** work correctly - please,
+upgrade your firmware from Bond app before adding this integration.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Explain the minimum required firmware version for Bond bridge in order to work correctly with this integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
