### PR TITLE
Added service to Dynalite

### DIFF
--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -298,6 +298,24 @@ For example, you would go to your kitchen light and turn it on. Now you log into
 
 The initial process can be a bit time consuming and tedious, but it only has to be done once. Once you are done configuring, it is better to set `autodiscover` to `false`, since there are many "fake" channels and areas that the system uses for internal communication and you do not want to have visible.
 
+## Services
+
+### Service `dynalite.request_area_preset`
+
+Send a command on the Dynalite network asking an area to report its currently selected preset. Normally, channel 1 (default) is used, but in some implementation, specific areas will need other channels.
+
+<div class='note'>
+
+This does not return the area preset. It sends a network command asking the area to report its preset. Once it reports, that will be caught and handled by the system.
+
+</div>
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `host` | yes | Which gatway to send the command to. If not specificed, sends to all configured gateways.
+| `area` | no | Which area to request the preset for.
+| `query_channel` | yes | Which channel to use. If not specified, uses the area configuration or system default.
+
 ## Events
 
 ### Event `dynalite_preset`

--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -80,11 +80,6 @@ default:
       description: Default fade
       required: false
       type: float
-    query_channel:
-      description: Default to channel to query the area for its preset level. Normally, channel 1 replies for the area.
-      required: false
-      type: integer
-      default: 1
 area:
   description: Definition for the various Dynalite areas.
   required: true
@@ -114,10 +109,6 @@ area:
           required: false
           type: float
           default: 2.0
-        query_channel:
-          description: Channel to query the area for its preset level, if different than system global.
-          required: false
-          type: integer
         preset:
           description: Specific presets for the area.
           required: false

--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -312,7 +312,7 @@ This does not return the area preset. It sends a network command asking the area
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `host` | yes | Which gatway to send the command to. If not specificed, sends to all configured gateways.
+| `host` | yes | Which gateway to send the command to. If not specified, sends to all configured gateways.
 | `area` | no | Which area to request the preset for.
 | `channel` | yes | Which channel to use. If not specified, uses the area configuration or system default.
 

--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -323,7 +323,7 @@ This does not return the area preset. It sends a network command asking the area
 | ---------------------- | -------- | ----------- |
 | `host` | yes | Which gatway to send the command to. If not specificed, sends to all configured gateways.
 | `area` | no | Which area to request the preset for.
-| `query_channel` | yes | Which channel to use. If not specified, uses the area configuration or system default.
+| `channel` | yes | Which channel to use. If not specified, uses the area configuration or system default.
 
 ## Events
 

--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -83,7 +83,7 @@ default:
     query_channel:
       description: Default to channel to query the area for its preset level. Normally, channel 1 replies for the area.
       required: false
-      type: float
+      type: integer
       default: 1
 area:
   description: Definition for the various Dynalite areas.
@@ -117,7 +117,7 @@ area:
         query_channel:
           description: Channel to query the area for its preset level, if different than system global.
           required: false
-          type: int
+          type: integer
         preset:
           description: Specific presets for the area.
           required: false

--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -80,6 +80,11 @@ default:
       description: Default fade
       required: false
       type: float
+    query_channel:
+      description: Default to channel to query the area for its preset level. Normally, channel 1 replies for the area.
+      required: false
+      type: float
+      default: 1
 area:
   description: Definition for the various Dynalite areas.
   required: true
@@ -109,6 +114,10 @@ area:
           required: false
           type: float
           default: 2.0
+        query_channel:
+          description: Channel to query the area for its preset level, if different than system global.
+          required: false
+          type: int
         preset:
           description: Specific presets for the area.
           required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This is the documentation that follows the code PR to add a service call to Dynalite to request and area preset and also to allow configuration of which channel to use for the query

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38689
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
