### PR TITLE
Add quotes to the payload_template example.

### DIFF
--- a/source/_docs/mqtt/service.markdown
+++ b/source/_docs/mqtt/service.markdown
@@ -28,7 +28,7 @@ payload: on
 {% raw %}
 ```yaml
 topic: home-assistant/light/1/state
-payload_template: {{ states('device_tracker.paulus') }}
+payload_template: "{{ states('device_tracker.paulus') }}"
 ```
 {% endraw %}
 


### PR DESCRIPTION
The payload_template example was missing enclosing quotes. Confirmed that this is required. 

`payload_template: {{ states('sun.sun') }}` causes the service call to fail, ("value should be string for dictionary value").

`payload_template: "{{ states('sun.sun') }}"` publishes correctly

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
