### PR TITLE
Time trigger can also accept an input_datetime Entity ID

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -282,9 +282,10 @@ automation:
 The `for` template(s) will be evaluated when the `value_template` becomes `true`.
 
 <div class='note warning'>
+  
 Rendering templates with time (`now()`) is dangerous as trigger templates are only updated based on entity state changes.
-</div>
 
+</div>
 
 As an alternative, providing you include the sensor [time](/integrations/time_date/) in your configuration, you can use the following template:
 
@@ -307,7 +308,7 @@ The time trigger is configured to fire once a day at a specific time, or at a sp
 
 #### Time String
 
-A string that represents a time to fire each day. Can be specified as HH:MM or HH:MM:SS. If the seconds is not specified :00 will be used.
+A string that represents a time to fire on each day. Can be specified as `HH:MM` or `HH:MM:SS`. If the seconds are not specified, `:00` will be used.
 
 ```yaml
 automation:
@@ -323,11 +324,12 @@ The Entity ID of an [Input Datetime](/integrations/input_datetime/).
 
 has_date | has_time | Description
 -|-|-
-true | true | Will fire at specifid date & time.
-true | false | Will fire at midnight on specified date.
-false | true | Will fire once a day at specified time.
+`true` | `true` | Will fire at specified date & time.
+`true` | `false` | Will fire at midnight on specified date.
+`false` | `true` | Will fire once a day at specified time.
 
 {% raw %}
+
 ```yaml
 automation:
   - trigger:
@@ -351,6 +353,7 @@ automation:
       service: climate.turn_off
       entity_id: climate.office
 ```
+
 {% endraw %}
 
 #### Multiple Times

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -303,7 +303,11 @@ which will evaluate to `True` if `YOUR.ENTITY` changed more than 300 seconds ago
 
 ### Time trigger
 
-The time trigger is configured to fire once at a specific point in time each day.
+The time trigger is configured to fire once a day at a specific time, or at a specific time on a specific date. There are two allowed formats:
+
+#### Time String
+
+A string that represents a time to fire each day. Can be specified as HH:MM or HH:MM:SS. If the seconds is not specified :00 will be used.
 
 ```yaml
 automation:
@@ -313,15 +317,53 @@ automation:
     at: "15:32:00"
 ```
 
-Or at multiple specific times:
+#### Input Datetime
+
+The Entity ID of an [Input Datetime](/integrations/input_datetime/).
+
+has_date | has_time | Description
+-|-|-
+true | true | Will fire at specifid date & time.
+true | false | Will fire at midnight on specified date.
+false | true | Will fire once a day at specified time.
+
+{% raw %}
+```yaml
+automation:
+  - trigger:
+      platform: state
+      entity_id: binary_sensor.motion
+      to: 'on'
+    action:
+      - service: climate.turn_on
+        entity_id: climate.office
+      - service: input_datetime.set_datetime
+        entity_id: input_datetime.turn_off_ac
+        data_template:
+          datetime: >
+            {{ (now().timestamp() + 2*60*60)
+               | timestamp_custom('%Y-%m-%d %H:%M:%S') }}
+
+  - trigger:
+      platform: time
+      at: input_datetime.turn_off_ac
+    action:
+      service: climate.turn_off
+      entity_id: climate.office
+```
+{% endraw %}
+
+#### Multiple Times
+
+Multiple times can be provided in a list. Both formats can be intermixed.
 
 ```yaml
 automation:
   trigger:
     platform: time
     at:
-      - "15:32:00"
-      - "20:30:00"
+      - input_datetime.leave_for_work
+      - "18:30:00"
 ```
 
 ### Time pattern trigger


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for new `time` trigger feature which allows an `input_datetime` entity to be used in place of a time string.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#38698
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
