### PR TITLE
Update Kodi documentation for Config Flow

### DIFF
--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -13,7 +13,7 @@ ha_domain: kodi
 
 The `kodi` platform allows you to control a [Kodi](https://kodi.tv/) multimedia system from Home Assistant.
 
-The preferred way to set up the Kodi platform is by enabling the [discovery component](/integrations/discovery/) which requires enabled [web interface](https://kodi.wiki/view/Web_interface) on your Kodi installation.
+The preferred way to set up the Kodi platform is by through discovery, which requires an enabled [web interface](https://kodi.wiki/view/Web_interface) on your Kodi installation.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -22,66 +22,18 @@ There is currently support for the following device types within Home Assistant:
 
 ## Configuration
 
-In case the discovery does not work, or you need specific configuration variables, you can add the following to your `configuration.yaml` file:
+The Kodi media player is configured through the integrations screen. If your Kodi is discovered, you'll see it there and can click to set it up.
+If you do not see your device, you can click on the `+` button and choose Kodi.
+The flow will guide you through the setup. Most of the settings are advanced, and the defaults should work.
 
-```yaml
-# Example configuration.yaml entry
-media_player:
-  - platform: kodi
-    host: IP_ADDRESS
-```
+If you previously had Kodi configured through `configuration.yaml`, it's advisable to remove it, and configure from the UI.
+If you do not remove it, your configuration will be imported with the following limitations:
+* Your turn on/off actions will not be imported. This functionality is now available through device triggers.
+* You may have duplicate entities.
 
-{% configuration %}
-host:
-  description: The host name or address of the device that is running XBMC/Kodi.
-  required: true
-  type: string
-port:
-  description: The HTTP port number.
-  required: false
-  type: integer
-  default: 8080
-tcp_port:
-  description: The TCP port number. Used for WebSocket connections to Kodi.
-  required: false
-  type: integer
-  default: 9090
-name:
-  description: The name of the device used in the frontend.
-  required: false
-  type: string
-proxy_ssl:
-  description: Connect to Kodi with HTTPS and WSS. Useful if Kodi is behind an SSL proxy.
-  required: false
-  type: boolean
-  default: false
-username:
-  description: The XBMC/Kodi HTTP username.
-  required: false
-  type: string
-password:
-  description: The XBMC/Kodi HTTP password.
-  required: false
-  type: string
-turn_on_action:
-  description: Home Assistant script sequence to call when turning on.
-  required: false
-  type: list
-turn_off_action:
-  description: Home Assistant script sequence to call when turning off.
-  required: false
-  type: list
-enable_websocket:
-  description: Enable websocket connections to Kodi via the TCP port. The WebSocket connection allows Kodi to push updates to Home Assistant and removes the need for Home Assistant to poll. If websockets don't work on your installation this can be set to `false`.
-  required: false
-  type: boolean
-  default: true
-timeout:
-  description: Set timeout for connections to Kodi. Defaults to 5 seconds.
-  required: false
-  type: integer
-  default: 5
-{% endconfiguration %}
+### Turning On/Off
+
+You can customize your turn on and off actions through automations. Simply use the relevant Kodi device triggers and your automation will be called to perform the `turn_on` or `turn_off` sequence.
 
 ### Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update the Kodi integrations documentation with config flow instructions.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38551
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
