### PR TITLE
Automation to update the input select widget

### DIFF
--- a/source/_integrations/vallox.markdown
+++ b/source/_integrations/vallox.markdown
@@ -67,6 +67,24 @@ automation:
 ```
 {% endraw %}
 
+In order to also update the input select in case some external event changes the Vallox profile (web interface, mechanical switch, reboot, etc...) you can use the following automation:
+
+{% raw %}
+```yaml
+automation:
+- alias: Update Vallox input_select
+  description: Update input_select when external event changes the profile
+  trigger:
+  - entity_id: sensor.vallox_current_profile
+    platform: state
+  action:
+  - data_template:
+      entity_id: input_select.ventilation_profile
+      option: "{{ states('sensor.vallox_current_profile') }}"
+    service: input_select.select_option
+```
+{% endraw %}
+
 ## Fan Services
 
 ### Service `vallox.set_profile`

--- a/source/_integrations/vallox.markdown
+++ b/source/_integrations/vallox.markdown
@@ -72,16 +72,16 @@ In order to also update the input select in case some external event changes the
 {% raw %}
 ```yaml
 automation:
-- alias: Update Vallox input_select
-  description: Update input_select when external event changes the profile
-  trigger:
-  - entity_id: sensor.vallox_current_profile
-    platform: state
-  action:
-  - data_template:
-      entity_id: input_select.ventilation_profile
-      option: "{{ states('sensor.vallox_current_profile') }}"
-    service: input_select.select_option
+  - alias: Update Vallox input_select
+    description: Update input_select when external event changes the profile
+    trigger:
+      - entity_id: sensor.vallox_current_profile
+        platform: state
+    action:
+      - data_template:
+        entity_id: input_select.ventilation_profile
+        option: "{{ states('sensor.vallox_current_profile') }}"
+        service: input_select.select_option
 ```
 {% endraw %}
 


### PR DESCRIPTION
## Proposed change
In order to also update the input_select proposed in these docs in case some external event changes
the Vallox profile (web interface, mechanical switch, reboot, etc...) you
can use the following automation.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
Added an automation that achieves that to the sample docs.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
