### PR TITLE
[iOS] Exclude /ios/beta from universal links

### DIFF
--- a/source/.well-known/apple-app-site-association
+++ b/source/.well-known/apple-app-site-association
@@ -6,6 +6,7 @@
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant.dev",
         "paths": [
           "/ios/*",
+          "NOT /ios/beta",
           "/tag/*"
         ]
       },
@@ -13,6 +14,7 @@
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant.beta",
         "paths": [
           "/ios/*",
+          "NOT /ios/beta",
           "/tag/*"
         ]
       },
@@ -20,6 +22,7 @@
         "appID": "UTQFCBPQRF.io.robbie.HomeAssistant",
         "paths": [
           "/ios/*",
+          "NOT /ios/beta",
           "/tag/*"
         ]
       },
@@ -27,6 +30,7 @@
         "appID": "QMQYCKL255.io.robbie.HomeAssistant.dev",
         "paths": [
           "/ios/*",
+          "NOT /ios/beta",
           "/tag/*"
         ]
       },
@@ -34,6 +38,7 @@
         "appID": "QMQYCKL255.io.robbie.HomeAssistant.beta",
         "paths": [
           "/ios/*",
+          "NOT /ios/beta",
           "/tag/*"
         ]
       },
@@ -41,6 +46,7 @@
         "appID": "QMQYCKL255.io.robbie.HomeAssistant",
         "paths": [
           "/ios/*",
+          "NOT /ios/beta",
           "/tag/*"
         ]
       }

--- a/source/.well-known/apple-app-site-association
+++ b/source/.well-known/apple-app-site-association
@@ -7,6 +7,7 @@
         "paths": [
           "/ios/*",
           "NOT /ios/beta",
+          "NOT /ios/beta/*",
           "/tag/*"
         ]
       },
@@ -15,6 +16,7 @@
         "paths": [
           "/ios/*",
           "NOT /ios/beta",
+          "NOT /ios/beta/*",
           "/tag/*"
         ]
       },
@@ -23,6 +25,7 @@
         "paths": [
           "/ios/*",
           "NOT /ios/beta",
+          "NOT /ios/beta/*",
           "/tag/*"
         ]
       },
@@ -31,6 +34,7 @@
         "paths": [
           "/ios/*",
           "NOT /ios/beta",
+          "NOT /ios/beta/*",
           "/tag/*"
         ]
       },
@@ -39,6 +43,7 @@
         "paths": [
           "/ios/*",
           "NOT /ios/beta",
+          "NOT /ios/beta/*",
           "/tag/*"
         ]
       },
@@ -47,6 +52,7 @@
         "paths": [
           "/ios/*",
           "NOT /ios/beta",
+          "NOT /ios/beta/*",
           "/tag/*"
         ]
       }


### PR DESCRIPTION
## Proposed change
Prevents the `/ios/beta` TestFlight short link from opening the iOS app.

## Type of change
Not a documentation change.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards