### PR TITLE
Tell Dynalite which channel to use when querying area preset

### DIFF
--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -80,6 +80,11 @@ default:
       description: Default fade
       required: false
       type: float
+    query_channel:
+      description: Default to channel to query the area for its preset level. Normally, channel 1 replies for the area.
+      required: false
+      type: integer
+      default: 1
 area:
   description: Definition for the various Dynalite areas.
   required: true
@@ -109,6 +114,10 @@ area:
           required: false
           type: float
           default: 2.0
+        query_channel:
+          description: Channel to query the area for its preset level, if different than system global.
+          required: false
+          type: integer
         preset:
           description: Specific presets for the area.
           required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
adds a configuration parameter to tell Dynalite which channel to use when asking an area about the current preset


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38730
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
