### PR TITLE
dynalite - add service to request the channel level

### DIFF
--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -313,6 +313,22 @@ This does not return the area preset. It sends a network command asking the area
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `host` | yes | Which gateway to send the command to. If not specified, sends to all configured gateways.
+| `area` | no | Area for the requested channel.
+| `channel` | no | Which channel to request.
+
+### Service `dynalite.request_channel_level`
+
+Send a command on the Dynalite network asking a specific channel in an area to report its current level.
+
+<div class='note'>
+
+This does not return the channel level. It sends a network command asking the channel to report its level. Once it reports, that will be caught and handled by the system.
+
+</div>
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `host` | yes | Which gateway to send the command to. If not specified, sends to all configured gateways.
 | `area` | no | Which area to request the preset for.
 | `channel` | yes | Which channel to use. If not specified, uses the area configuration or system default.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
adds a service call to request a channel to report its level


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38735
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
