### PR TITLE
Update rmvtransport.markdown

### DIFF
--- a/source/_integrations/rmvtransport.markdown
+++ b/source/_integrations/rmvtransport.markdown
@@ -87,8 +87,6 @@ The example below shows a full configuration with three sensors that showcase th
 # Example configuration.yaml entry
 sensor:
   - platform: rmvtransport
-    scan_interval: 120
-    timeout: 10
     next_departure:
       - station: 3000010
         time_offset: 5


### PR DESCRIPTION
Remove "scan_intervall" and "timeout" from sample cause it is an invalid optione for "rmvtransport".

## Proposed change
<!-- 
Remove "scan_intervall" and "timeout" from sample cause it is an invalid option for "rmvtransport" (found out by testing the config via HA).
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
Tested with HA core 0.113.3
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
