### PR TITLE
Update Daikin doc with a note on UDP flows as per issue #37844

### DIFF
--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -37,12 +37,13 @@ The Daikin integration can be configured via the Home Assistant user interface w
 
 <div class='note'>
   
-If your Daikin unit does not reside in the same network as your HA, i.e. your network is segmented, note that a couple of UDP connections are made during discovery:
-- From HA to the Daikin controller: UDP:30000 => 30050
-- From the Daikin controller to HA: UDP:\<random port> => 30000
+If your Daikin unit does not reside in the same network as your Home Assistant instance, i.e. your network is segmented, note that a couple of UDP connections are made during discovery:
 
-You will need to adjust your firewall(s) accordingly. 
-  
+- From Home Assistant to the Daikin controller: `UDP:30000` => `30050`
+- From the Daikin controller to Home Assistant: `UDP:<random port>` => `30000`
+
+If this situation applies to you, you may need to adjust your firewall(s) accordingly.
+
 </div>
 
 ## Climate

--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -35,6 +35,15 @@ There is currently support for the following device types within Home Assistant:
 
 The Daikin integration can be configured via the Home Assistant user interface where it will let you enter the IP-address of your Daikin AC (SKYFi based devices need to provide a password and BRP072Cxx devices need to provide a key).
 
+<div class='note'>
+  
+If your Daikin unit does not reside in the same network as your HA, i.e. your network is segmented, note that a couple of UDP connections are made during discovery:
+- From HA to the Daikin controller: UDP:30000 => 30050
+- From the Daikin controller to HA: UDP:\<random port> => 30000
+
+You will need to adjust your firewall(s) accordingly. 
+  
+</div>
 
 ## Climate
 


### PR DESCRIPTION
In a segmented network, UDP flows that are used during discovery may be blocked. See https://github.com/home-assistant/core/issues/37844

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
