### PR TITLE
✏️ Fix config format for Supla integration

### DIFF
--- a/source/_integrations/supla.markdown
+++ b/source/_integrations/supla.markdown
@@ -26,7 +26,7 @@ To use Supla devices in your installation, add the following to your `configurat
 supla:
   servers:
     - server: svr1.supla.org
-      access_token: your_really_long_access_token
+      access_token: YOUR_ACCESS_TOKEN
 ```
 
 {% configuration %}
@@ -34,14 +34,14 @@ servers:
   description: List of server configurations.
   requires: true
   type: list
-server:
-  description: Address of your Supla Cloud server (either IP or DNS name)
-  required: true
-  type: string
-access_token:
-  description:
-    An access token for REST API configuration. Can be acquired from
-    `http[s]://your.server.org/integrations/tokens` (please add at least Channel's Read and Action Execution permissions).
-  required: true
-  type: string
+  keys:
+    server:
+      description: Address of your Supla Cloud server (either IP or DNS name)
+      required: true
+      type: string
+    access_token:
+      description: An access token for REST API configuration. Can be acquired from 
+      `http[s]://your.server.org/integrations/tokens` (please add at least Channel's Read and Action Execution permissions).
+      required: true
+      type: string
 {% endconfiguration %}

--- a/source/_integrations/supla.markdown
+++ b/source/_integrations/supla.markdown
@@ -40,8 +40,7 @@ servers:
       required: true
       type: string
     access_token:
-      description: An access token for REST API configuration. Can be acquired from 
-      `http[s]://your.server.org/integrations/tokens` (please add at least Channel's Read and Action Execution permissions).
+      description: An access token for REST API configuration. Can be acquired from `http[s]://your.server.org/integrations/tokens` (please add at least Channel's Read and Action Execution permissions).
       required: true
       type: string
 {% endconfiguration %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This pull request fixes the config variable format, since `servers` is a list, the rest should hang as keys below it.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
