### PR TITLE
Fix Fitbit Integration With External URL Support

### DIFF
--- a/source/_integrations/fitbit.markdown
+++ b/source/_integrations/fitbit.markdown
@@ -10,6 +10,8 @@ ha_domain: fitbit
 
 The Fitbit sensor allows you to expose data from [Fitbit](https://fitbit.com/) to Home Assistant.
 
+First, make sure your Home Assistant instance has an External URL configured which can be reached by Fitbit. This can be achieved through the UI (`Configuration > General`) or [via YAML](https://www.home-assistant.io/docs/configuration/basic/). If you have a Nabu Casa account, the URL to use can be found through the UI, under `Configuration > Home Assistant Cloud > Remote Control`.
+
 Enable the sensor by adding the following to your `configuration.yaml` file:
 
 ```yaml

--- a/source/_integrations/fitbit.markdown
+++ b/source/_integrations/fitbit.markdown
@@ -21,7 +21,7 @@ sensor:
       - "body/weight"
 ```
 
-Restart Home Assistant once this is complete. Go to the frontend. You will see a new entry for configuring Fitbit. Follow the instructions there to complete the setup process.
+Restart Home Assistant once this is complete. Go to the frontend. You will see a new notification containing instructions for configuring Fitbit. Follow the instructions there to complete the setup process.
 
 Please be aware that Fitbit has very low rate limits, 150 per user per hour. The clock resets at the _top_ of the hour (meaning it is not a rolling 60 minutes). There is no way around the limits. Due to the rate limits, the sensor only updates every 30 minutes. You can manually trigger an update by restarting Home Assistant. Keep in mind that 1 request is used for every entry in `monitored_resources`.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
There are some issues with setting up the current Fitbit integration. At first, it's not obvious that the instructions for configuring the integration are provided via the Notifications section of the UI. Secondly, the integration defaults to using the Internal URL configured for Home Assistant, which may not be reachable by Fitbit. Updating this to preference using the External URL parameter will ensure that the callback required for setup works correctly. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38970
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
