### PR TITLE
Add Rachio zone moisture service.

### DIFF
--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -78,6 +78,22 @@ The `rachio` switch platform allows you to toggle zones and schedules connected 
 
 Once configured, a switch will be added for every zone that is enabled on every controller in the account provided and a switch to start or stop every schedule on a controller. There will also be a switch to toggle each controller's standby mode, as well as to activate a 24 hour rain delay on the device.
 
+
+## Service
+
+Rachio has one service that allows for setting the moisture percentage of a zone or group of zones. As Rachio only uses moisture levels for zones in a Flex Daily schedule, this service is only available when at least one zone is part of a Flex Daily schedule. 
+
+### Service `rachio.set_zone_moisture_percent`
+
+Set the zone moisture percentage for a zone or group of zones.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String, list or group of zones to set moisture percentage.
+| `percent` | no | Integer of the desired moisture percentage. Accepts 0-100.
+
+
+
 ## Examples
 
 In this section, you find some real-life examples of how to use this switch.

--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -78,7 +78,6 @@ The `rachio` switch platform allows you to toggle zones and schedules connected 
 
 Once configured, a switch will be added for every zone that is enabled on every controller in the account provided and a switch to start or stop every schedule on a controller. There will also be a switch to toggle each controller's standby mode, as well as to activate a 24 hour rain delay on the device.
 
-
 ## Service
 
 Rachio has one service that allows for setting the moisture percentage of a zone or group of zones. As Rachio only uses moisture levels for zones in a Flex Daily schedule, this service is only available when at least one zone is part of a Flex Daily schedule. 
@@ -91,8 +90,6 @@ Set the zone moisture percentage for a zone or group of zones.
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String, list or group of zones to set moisture percentage.
 | `percent` | no | Integer of the desired moisture percentage. Accepts 0-100.
-
-
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for newly added Rachio `set_zone_moisture_percent service`.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38817
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
