### PR TITLE
Add auth key to doods documentation

### DIFF
--- a/source/_integrations/doods.markdown
+++ b/source/_integrations/doods.markdown
@@ -47,7 +47,7 @@ url:
     required: true
     type: string
 auth_key:
-    description: The authentication key as set in the doods config file or as a docker environment variable (DOODS_AUTH_KEY)
+    description: The authentication key as set in the doods configuration file or as a Docker environment variable (DOODS_AUTH_KEY)
     required: false
     type: string
 timeout:

--- a/source/_integrations/doods.markdown
+++ b/source/_integrations/doods.markdown
@@ -47,7 +47,7 @@ url:
     required: true
     type: string
 auth_key:
-    description: The authentication key as set in the doods configuration file or as a Docker environment variable (DOODS_AUTH_KEY)
+    description: The authentication key as set in the DOODS configuration file or as a Docker environment variable (DOODS_AUTH_KEY)
     required: false
     type: string
 timeout:

--- a/source/_integrations/doods.markdown
+++ b/source/_integrations/doods.markdown
@@ -46,6 +46,10 @@ url:
     description: The URL of the DOODS server.
     required: true
     type: string
+auth_key:
+    description: The authentication key as set in the doods config file or as a docker environment variable (DOODS_AUTH_KEY)
+    required: false
+    type: string
 timeout:
     description: Timeout for requests (in seconds).
     required: false
@@ -151,6 +155,7 @@ image_processing:
     url: "http://<my doods server>:8080"
     timeout: 60
     detector: default
+    auth_key: 2up3rL0ng4uthK3y
     source:
       - entity_id: camera.front_yard
     file_out:


### PR DESCRIPTION
## Proposed change
It is possible to set an auth_key in the configuration as a security measure (already possible in the code). This PR adds it to the documentation. I verified it working


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Configuration entry I'm referring to: https://github.com/home-assistant/core/blob/af9ae2e0a439322b78488a79806df662c530ac59/homeassistant/components/doods/image_processing.py#L31

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
