### PR TITLE
Add support for attributes in (numeric) state conditions

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -96,9 +96,17 @@ condition:
 
 ### Numeric state condition
 
-This type of condition attempts to parse the state of the specified entity as a number, and triggers if the value matches the thresholds.
+This type of condition attempts to parse the state of the specified entity or the attribute of an entity as a number, and triggers if the value matches the thresholds.
 
 If both `below` and `above` are specified, both tests have to pass.
+
+```yaml
+condition:
+  condition: numeric_state
+  entity_id: sensor.temperature
+  above: 17
+  below: 25
+```
 
 You can optionally use a `value_template` to process the value of the state before testing it.
 
@@ -122,6 +130,18 @@ condition:
     - sensor.kitchen_temperature
     - sensor.living_room_temperature
   below: 18
+```
+
+Alternatively, the condition can test against a state attribute.
+The condition will pass if the attribute value of the entity matches the thresholds.
+
+```yaml
+condition:
+  condition: numeric_state
+  entity_id: climate.living_room_thermostat
+  attribute: temperature
+  above: 17
+  below: 25
 ```
 
 ### State condition
@@ -176,6 +196,17 @@ condition:
   state:
     - playing
     - paused
+```
+
+Alternatively, the condition can test against a state attribute.
+The condition will pass if the attribute matches the given state.
+
+```yaml
+condition:
+  condition: state
+  entity_id: climate.living_room_thermostat
+  attribute: hvac_modes
+  state: heat
 ```
 
 ### Sun condition


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Related to "What the heck?!" topic <https://community.home-assistant.io/t/why-doesnt-a-trigger-platform-for-state-attributes-exist/219651>

This PR documents the (numeric) state conditions on attributes.

```yaml
- condition: state
  entity_id: light.hue
  attribute: hue_group
  state: "on"
```

```yaml
- condition: numeric_state
  entity_id: sensor.temperature
  attribute: outside
  above: 20
```

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39050
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
