### PR TITLE
Fix initial_state type

### DIFF
--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -62,6 +62,7 @@ initial_state:
   description: Sets the initial state for automations, `on` or `off`.
   required: false
   type: boolean
+  default: true
 {% endconfiguration %}
 
 #### Device Class

--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -61,7 +61,7 @@ unit_of_measurement:
 initial_state:
   description: Sets the initial state for automations, `on` or `off`.
   required: false
-  type: string
+  type: boolean
 {% endconfiguration %}
 
 #### Device Class

--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -62,7 +62,7 @@ initial_state:
   description: Sets the initial state for automations, `on` or `off`.
   required: false
   type: boolean
-  default: true
+  default: None
 {% endconfiguration %}
 
 #### Device Class


### PR DESCRIPTION
## Proposed change
As per the code at https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/__init__.py#L102, this should be a boolean.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: NA
- Link to parent pull request in the Brands repository: NA
- This PR fixes or closes issue: NA

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
