### PR TITLE
Sentry integration enhancements

### DIFF
--- a/source/_integrations/sentry.markdown
+++ b/source/_integrations/sentry.markdown
@@ -8,6 +8,7 @@ ha_release: 0.104
 ha_config_flow: true
 ha_codeowners:
   - '@dcramer'
+  - '@frenck'
 ha_domain: sentry
 ---
 
@@ -19,30 +20,9 @@ ha_domain: sentry
 
 The `sentry` integration integrates with [Sentry](https://sentry.io/) to capture both logged errors as well as unhandled exceptions in Home Assistant.
 
-## Configuration
+## Preparation
 
-To use the `sentry` integration in your installation, add the following to your `configuration.yaml` file:
-
-```yaml
-# Example configuration.yaml entry
-sentry:
-  dsn: SENTRY_DSN
-```
-
-Then navigate to Configuration -> Integrations and add the DSN provided to you by Sentry where prompted.
-
-{% configuration %}
-dsn:
-  description: The DSN provided to you by Sentry.
-  required: true
-  type: string
-environment:
-  description: An environment name to associate with events.
-  required: false
-  type: string
-{% endconfiguration %}
-
-### Getting the DSN
+Before configuring the Sentry integration, you'll need to get Sentry account and a DSN.
 
 Follow these steps to get the DSN:
 
@@ -51,3 +31,25 @@ Follow these steps to get the DSN:
 - Fill out **Give your project a name** and **choose Assign a Team** fields and click Create project button.
 - Click **Get your DSN** link in top of the page.
 - Your DSN is now visible and looks like <https://sdasdasdasdsadsadas@sentry.io/sdsdfsdf>
+
+## Configuration
+
+Add the Sentry integration by going into: **Configuration** -> **Integrations**.
+
+Click on the `+` sign to add an integration and click on **Sentry** and follow the steps shown on screen. The DSN you've
+retrieved in the preparation step above, will be prompted.
+
+## Options
+
+The Sentry integration provides settings to:
+
+- Set an environment name for your instance.
+- Limit the event log level to trigger on, and the log level of the breadcrumbs.
+- Ability to send out error events that are handled.
+- Ability to send out events caused by custom integrations (custom components).
+- Ability to send out events originating from third-party Python packages.
+- Enable performance tracing and tune the tracing sample rate used.
+
+To change the settings go in **Configuration** -> **Integrations**, find the already installed **Sentry** box and click on **Options**.
+
+After changing Sentry settings, you'll need to restart Home Assistant in order to make them effective.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updates documentation for the Sentry integration enhancements made in a parent PR.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/38833
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
