### PR TITLE
Update sun elevation example to Home Assistant Documentation standards

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -210,15 +210,15 @@ condition:
   condition: and  # 'twilight' condition: dusk and dawn, in typical locations
   conditions:
     - condition: template
-      value_template: {% raw %}'{{ state_attr("sun.sun", "elevation") < 0 }}'{% endraw %}
+      value_template: {% raw %}"{{ state_attr('sun.sun', 'elevation') < 0 }}"{% endraw %}
     - condition: template
-      value_template: {% raw %}'{{ state_attr("sun.sun", "elevation") > -6 }}'{% endraw %}
+      value_template: {% raw %}"{{ state_attr('sun.sun', 'elevation') > -6 }}"{% endraw %}
 ```
 
 ```yaml
 condition:
   condition: template  # 'night' condition: from dusk to dawn, in typical locations
-  value_template: {% raw %}'{{ state_attr("sun.sun", "elevation") < -6 }}'{% endraw %}
+  value_template: {% raw %}"{{ state_attr('sun.sun', 'elevation') < -6 }}"{% endraw %}
 ```
 
 #### Sunset/sunrise condition

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -102,6 +102,7 @@ If both `below` and `above` are specified, both tests have to pass.
 
 You can optionally use a `value_template` to process the value of the state before testing it.
 
+{% raw %}
 ```yaml
 condition:
   condition: numeric_state
@@ -109,8 +110,9 @@ condition:
   above: 17
   below: 25
   # If your sensor value needs to be adjusted
-  value_template: {% raw %}'{{ float(state.state) + 2 }}'{% endraw %}
+  value_template: '{{ float(state.state) + 2 }}'
 ```
+{% endraw %}
 
 It is also possible to test the condition against multiple entities at once.
 The condition will pass if all entities match the thresholds.
@@ -205,21 +207,25 @@ For an in-depth explanation of sun elevation, see [sun elevation trigger][sun_el
 
 [sun_elevation_trigger]: /docs/automation/trigger/#sun-elevation-trigger
 
+{% raw %}
 ```yaml
 condition:
   condition: and  # 'twilight' condition: dusk and dawn, in typical locations
   conditions:
     - condition: template
-      value_template: {% raw %}"{{ state_attr('sun.sun', 'elevation') < 0 }}"{% endraw %}
+      value_template: "{{ state_attr('sun.sun', 'elevation') < 0 }}"
     - condition: template
-      value_template: {% raw %}"{{ state_attr('sun.sun', 'elevation') > -6 }}"{% endraw %}
+      value_template: "{{ state_attr('sun.sun', 'elevation') > -6 }}"
 ```
+{% endraw %}
 
+{% raw %}
 ```yaml
 condition:
   condition: template  # 'night' condition: from dusk to dawn, in typical locations
-  value_template: {% raw %}"{{ state_attr('sun.sun', 'elevation') < -6 }}"{% endraw %}
+  value_template: "{{ state_attr('sun.sun', 'elevation') < -6 }}"
 ```
+{% endraw %}
 
 #### Sunset/sunrise condition
 
@@ -273,11 +279,13 @@ A visual timeline is provided below showing an example of when these conditions 
 
 The template condition tests if the [given template][template] renders a value equal to true. This is achieved by having the template result in a true boolean expression or by having the template render 'true'.
 
+{% raw %}
 ```yaml
 condition:
   condition: template
-  value_template: "{% raw %}{{ (state_attr('device_tracker.iphone', 'battery_level')|int) > 50 }}{% endraw %}"
+  value_template: "{{ (state_attr('device_tracker.iphone', 'battery_level')|int) > 50 }}"
 ```
+{% endraw %}
 
 Within an automation, template conditions also have access to the `trigger` variable as [described here][automation-templating].
 
@@ -363,6 +371,7 @@ condition:
 
 ### Examples
 
+{% raw %}
 ```yaml
 condition:
   - condition: numeric_state
@@ -379,3 +388,4 @@ condition:
     entity_id: script.light_turned_off_5min
     state: 'off'
 ```
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update sun elevation example to documentation standard (single quotes inside double quotes).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
