### PR TITLE
Added support for tplink emulation of devices to sense

### DIFF
--- a/source/_integrations/sense.markdown
+++ b/source/_integrations/sense.markdown
@@ -33,20 +33,6 @@ Alternatively, to enable this sensor in your installation, add the following to 
 sense:
   email: CLIENT_ID
   password: CLIENT_SECRET
-
-  entities:
-    light.dining_room:
-      name: "Dining Room Lights"
-      power: 40.2
-    fan.ceiling_fan:
-      power: >-
-        {% if is_state_attr('fan.ceiling_fan','speed', 'low') %} 2
-        {% elif is_state_attr('fan.ceiling_fan','speed', 'medium') %} 12
-        {% elif is_state_attr('fan.ceiling_fan','speed', 'high') %} 48
-        {% endif %}
-    light.wled:
-      name: "Strip Lights"
-      power: "{{ states('sensor.wled_estimated_current') | float * 5 / 1000  }}"
 ```
 
 {% configuration %}
@@ -85,3 +71,27 @@ Sensors are added for both usage and production with the following names:
 Binary sensors are created for each of the devices detected by your Sense monitor to show their power state.
 
 Sensors are created for each of the devices detected by your Sense monitor to show their power usage in Watts.
+
+## Advanced Configuration
+
+The followring is a configuration example of setting up entities to be visible to the Sense monitor.
+The first uses a static power, the second sets the power based on the speed, and the third calculates it based off a sensor
+
+{% raw %}
+```yaml
+sense:
+  entities:
+    light.dining_room:
+      name: "Dining Room Lights"
+      power: 40.2
+    fan.ceiling_fan:
+      power: >-
+        {% if is_state_attr('fan.ceiling_fan','speed', 'low') %} 2
+        {% elif is_state_attr('fan.ceiling_fan','speed', 'medium') %} 12
+        {% elif is_state_attr('fan.ceiling_fan','speed', 'high') %} 48
+        {% endif %}
+    light.wled:
+      name: "Strip Lights"
+      power: "{{ states('sensor.wled_estimated_current') | float * 5 / 1000  }}"
+```
+{% endraw %}

--- a/source/_integrations/sense.markdown
+++ b/source/_integrations/sense.markdown
@@ -66,17 +66,15 @@ entities:
   description: Devices exposed to Sense as TP-Link Smart Plugs
   required: false
   type: list
-  
-The following are attributes that can be applied in the `entities` section:
-name:
-  description: The name that will show up in the Sense app
-  required: false
-  type: string
-power:
-  description: A float or template for the power in **watts** used by the device while on
-  required: true
-  type: string
-
+  keys:
+    name:
+      description: The name that will show up in the Sense app
+      required: false
+      type: string
+    power:
+      description: A float or template for the power in **watts** used by the device while on
+      required: true
+      type: string
 {% endconfiguration %}
 
 Sensors are added for both usage and production with the following names:

--- a/source/_integrations/sense.markdown
+++ b/source/_integrations/sense.markdown
@@ -40,10 +40,10 @@ sense:
       power: 40.2
     fan.ceiling_fan:
       power: >-
-		{% if is_state_attr('fan.ceiling_fan','speed', 'low') %} 2
-		{% elif is_state_attr('fan.ceiling_fan','speed', 'medium') %} 12
-		{% elif is_state_attr('fan.ceiling_fan','speed', 'high') %} 48
-		{% endif %}
+        {% if is_state_attr('fan.ceiling_fan','speed', 'low') %} 2
+        {% elif is_state_attr('fan.ceiling_fan','speed', 'medium') %} 12
+        {% elif is_state_attr('fan.ceiling_fan','speed', 'high') %} 48
+        {% endif %}
     light.wled:
       name: "Strip Lights"
       power: "{{ states('sensor.wled_estimated_current') | float * 5 / 1000  }}"

--- a/source/_integrations/sense.markdown
+++ b/source/_integrations/sense.markdown
@@ -20,6 +20,8 @@ There is currently support for the following device types within Home Assistant:
 - Binary Sensor
 - Sensor
 
+Additionally, Home Assistant can emulate TP-Link Kasa HS110 Smart Plugs to help identify up to 20 devices controlled in ways normally unsupported by Sense
+
 ## Configuration
 
 To add `Sense` to your installation, go to **Configuration** >> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select **Sense**.
@@ -31,21 +33,50 @@ Alternatively, to enable this sensor in your installation, add the following to 
 sense:
   email: CLIENT_ID
   password: CLIENT_SECRET
+
+  entities:
+    light.dining_room:
+      name: "Dining Room Lights"
+      power: 40.2
+    fan.ceiling_fan:
+      power: >-
+		{% if is_state_attr('fan.ceiling_fan','speed', 'low') %} 2
+		{% elif is_state_attr('fan.ceiling_fan','speed', 'medium') %} 12
+		{% elif is_state_attr('fan.ceiling_fan','speed', 'high') %} 48
+		{% endif %}
+    light.wled:
+      name: "Strip Lights"
+      power: "{{ states('sensor.wled_estimated_current') | float * 5 / 1000  }}"
 ```
 
 {% configuration %}
 email:
   description: The email associated with your Sense account/application.
-  required: true
+  required: false
   type: string
 password:
   description: The password for your Sense account/application.
-  required: true
+  required: false
   type: string
 timeout:
   description: Seconds for timeout of API requests.
   required: false
   type: integer
+entities:
+  description: Devices exposed to Sense as TP-Link Smart Plugs
+  required: false
+  type: list
+  
+The following are attributes that can be applied in the `entities` section:
+name:
+  description: The name that will show up in the Sense app
+  required: false
+  type: string
+power:
+  description: A float or template for the power in **watts** used by the device while on
+  required: true
+  type: string
+
 {% endconfiguration %}
 
 Sensors are added for both usage and production with the following names:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updated documentation for the added support for tplink emulation of devices to sense


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/39123
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
