### PR TITLE
Templates in data & service parameters (making data_template & service_template obsolete)

### DIFF
--- a/source/_cookbook/dim_and_brighten_lights.markdown
+++ b/source/_cookbook/dim_and_brighten_lights.markdown
@@ -129,7 +129,7 @@ script:
                    direction == 'down' and br > mn }}
           sequence:
             - service: light.turn_on
-              data_template:
+              data:
                 entity_id: "{{ light }}"
                 brightness: >
                   {% set br = state_attr(light, 'brightness')|int(0) %}

--- a/source/_cookbook/notify.mqtt.markdown
+++ b/source/_cookbook/notify.mqtt.markdown
@@ -63,7 +63,7 @@ script:
   notify_mqtt:
     sequence:
       - service: mqtt.publish
-        data_template:
+        data:
           payload: "{{ message }}"
           topic: home/"{{ target }}"
           retain: true

--- a/source/_cookbook/notify_if__new_ha_release.markdown
+++ b/source/_cookbook/notify_if__new_ha_release.markdown
@@ -44,7 +44,7 @@ automation:
         to: 'on'
     action:
       - service: notify.pushbullet
-        data_template: 
+        data: 
           title: 'New Home Assistant Release'
           target: 'YOUR_TARGET_HERE' #See Pushbullet integration for usage
           message: "Home Assistant {% raw %} {{ state_attr('binary_sensor.updater', 'newest_version') }} {% endraw %} is now available."

--- a/source/_cookbook/notify_if_over_threshold.markdown
+++ b/source/_cookbook/notify_if_over_threshold.markdown
@@ -21,7 +21,7 @@ automation:
       above: 2
     action:
       service: notify.mypushbullet
-      data_template:
+      data:
         title: "Furnace fan is running"
         message: "Fan running because current is {% raw %}{{ states('sensor.furnace') }}{% endraw %} amps"
 ```
@@ -36,7 +36,7 @@ If you also want a notification when it drops back down below that limit, you co
       below: 2
     action:
       service: notify.mypushbullet
-      data_template:
+      data:
         title: "Furnace fan is stopped"
         message: "Fan stopped because current is {% raw %}{{ states('sensor.furnace') }}{% endraw %} amps"
 ```

--- a/source/_cookbook/perform_actions_based_on_input_select.markdown
+++ b/source/_cookbook/perform_actions_based_on_input_select.markdown
@@ -105,7 +105,7 @@ automation:
         to: "None"
     action:
       service: media_player.turn_off
-      data_template:
+      data:
         entity_id: >{% raw %}
             {% if is_state("input_select.radio_player", "Mansarda") %}{% endraw %}
               media_player.bed_2{% raw %}
@@ -129,7 +129,7 @@ automation:
         entity_id: input_select.radio_station
     action:
       - service: media_player.play_media
-        data_template:
+        data:
           entity_id: >{% raw %}
             {% if is_state("input_select.radio_player", "Mansarda") %}{% endraw %}
               media_player.bed_2{% raw %}

--- a/source/_cookbook/sonos_say.markdown
+++ b/source/_cookbook/sonos_say.markdown
@@ -14,22 +14,22 @@ script:
     alias: "Sonos TTS script"
     sequence:
      - service: sonos.snapshot
-       data_template:
+       data:
          entity_id: {% raw %}"{{ sonos_entity }}"{% endraw %}
      - service: sonos.unjoin
-       data_template:
+       data:
          entity_id: {% raw %}"{{ sonos_entity }}"{% endraw %}
      - service: media_player.volume_set
-       data_template:
+       data:
          entity_id: {% raw %}"{{ sonos_entity }}"{% endraw %}
          volume_level: {% raw %}"{{ volume }}"{% endraw %}
      - service: tts.voicerss_say
-       data_template:
+       data:
          entity_id: {% raw %}"{{ sonos_entity }}"{% endraw %}
          message: {% raw %}"{{ message }}"{% endraw %}
      - delay: {% raw %}"{{ delay }}"{% endraw %}
      - service: sonos.restore
-       data_template:
+       data:
          entity_id: {% raw %}"{{ sonos_entity }}"{% endraw %}
 ```
 

--- a/source/_docs/automation/editor.markdown
+++ b/source/_docs/automation/editor.markdown
@@ -33,16 +33,6 @@ As "Service Data" we want a simple text that is shown as part of the notificatio
 }
 ```
 
-The Automation Editor does not currently support **data_template** as a "Service Data" entry. For these actions, it will be necessary to edit as YAML. This can be achieved by clicking the menu (3 vertical dots) and selecting "Edit as YAML"
-
-```yaml
-# Example of how to use data_template in the Automation Editor, using "Edit as YAML"
-data_template:
-  message: >
-    Paulus just changed from {{ trigger.from_state.state }}
-    to {{ trigger.to_state.state }}
-```
-
 Don't forget to save your new automation rule. For your saved automation rule to come into effect, you will need to go to the **Configuration** page and click on **Reload Automation**.
 
 ## Updating your configuration to use the editor

--- a/source/_docs/automation/examples.markdown
+++ b/source/_docs/automation/examples.markdown
@@ -70,8 +70,8 @@ automation:
       event_data:
         entity_id: binary_sensor.cube_158d000103a3de
     action:
-      service_template: notify.pushover
-      data_template: 
+      service: notify.pushover
+      data: 
         title: "Cube event detected"
         message: "Cube has triggered this event: {{ trigger.event }}"
 ```

--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -17,7 +17,7 @@ automation:
     entity_id: device_tracker.paulus
   action:
     service: notify.notify
-    data_template:
+    data:
       message: >
         Paulus just changed from {{ trigger.from_state.state }}
         to {{ trigger.to_state.state }}
@@ -29,7 +29,7 @@ automation 2:
   action:
     service_template: >
       notify.{{ trigger.topic.split('/')[-1] }}
-    data_template:
+    data:
       message: '{{ trigger.payload }}'
 
 automation 3:
@@ -45,7 +45,7 @@ automation 3:
       for: '00:10:00'
   action:
     - service: light.turn_off
-      data_template:
+      data:
         # Turn off whichever entity triggered the automation.
         entity_id: "{{ trigger.entity_id }}"
 ```
@@ -55,16 +55,12 @@ automation 3:
 
 There are a few very important rules to remember when writing automation templates:
 
-1. You **must** use `data_template` in place of `data` when using templates in the `data` section of a service call.
-1. You **must** use `service_template` in place of `service` when using templates in the `service` section of a service call.
 1. You **must** surround single-line templates with double quotes (`"`) or single quotes (`'`).
 1. It is advised that you prepare for undefined variables by using `if ... is not none` or the [`default` filter](http://jinja.pocoo.org/docs/dev/templates/#default), or both.
 1. It is advised that when comparing numbers, you convert the number(s) to a [`float`](http://jinja.pocoo.org/docs/dev/templates/#float) or an [`int`](http://jinja.pocoo.org/docs/dev/templates/#int) by using the respective [filter](http://jinja.pocoo.org/docs/dev/templates/#list-of-builtin-filters).
 1. While the [`float`](http://jinja.pocoo.org/docs/dev/templates/#float) and [`int`](http://jinja.pocoo.org/docs/dev/templates/#int) filters do allow a default fallback value if the conversion is unsuccessful, they do not provide the ability to catch undefined variables.
 
 Remembering these simple rules will help save you from many headaches and endless hours of frustration when using automation templates.
-
-It is possible to use `data` and `data_template` concurrently but be aware that `data_template` will overwrite attributes that are provided in both.
 
 ## Trigger State Object
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -123,7 +123,7 @@ automation:
       seconds: "{{ states('input_number.high_temp_sec')|int }}"
   action:
     service: persistent_notification.create
-    data_template:
+    data:
       message: >
         {{ trigger.to_state.name }} too high for {{ trigger.for }}!
 ```
@@ -341,7 +341,7 @@ automation:
         entity_id: climate.office
       - service: input_datetime.set_datetime
         entity_id: input_datetime.turn_off_ac
-        data_template:
+        data:
           datetime: >
             {{ (now().timestamp() + 2*60*60)
                | timestamp_custom('%Y-%m-%d %H:%M:%S') }}

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -35,7 +35,7 @@ script:
   msg_who_is_home:
     sequence:
       - service: notify.notify
-        data_template:
+        data:
           message: >
             {% if is_state('device_tracker.paulus', 'home') %}
               Ha, Paulus is home!

--- a/source/_docs/scripts.markdown
+++ b/source/_docs/scripts.markdown
@@ -124,7 +124,7 @@ It is also possible to use dummy variables, e.g., in scripts, when using `wait_t
 ```yaml
 # Service call, e.g., from an automation.
 - service: script.do_something
-  data_template:
+  data:
     dummy: input_boolean.switch
 
 # Inside the script
@@ -158,13 +158,13 @@ This action allows you to fire an event. Events can be used for many things. It 
     domain: light
 ```
 
-You can also use event_data_template to fire an event with custom data. This could be used to pass data to another script awaiting
+You can also use event_data to fire an event with custom data. This could be used to pass data to another script awaiting
 an event trigger.
 
 {% raw %}
 ```yaml
 - event: MY_EVENT
-  event_data_template:
+  event_data:
     name: myEvent
     customData: "{{ myCustomVariable }}"
 ```
@@ -198,7 +198,7 @@ The following automation shows how to capture the custom event `event_light_stat
       event_type: event_light_state_changed
   action:
     - service: notify.notify
-      data_template:
+      data:
         message: "kitchen light is turned {{ trigger.event.data.state }}"
 ```
 {% endraw %}
@@ -220,14 +220,14 @@ script:
     mode: restart
     sequence:
       - service: light.turn_on
-        data_template:
+        data:
           entity_id: "light.{{ light }}"
       - repeat:
           count: "{{ count|int * 2 - 1 }}"
           sequence:
             - delay: 2
             - service: light.toggle
-              data_template:
+              data:
                 entity_id: "light.{{ light }}"
   flash_hallway_light:
     sequence:

--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -67,23 +67,13 @@ Templates can also be used for the data that you pass to the service call.
 
 ```yaml
 service: thermostat.set_temperature
-data_template:
+data:
   entity_id: >
     {% raw %}{% if is_state('device_tracker.paulus', 'home') %}
       thermostat.upstairs
     {% else %}
       thermostat.downstairs
     {% endif %}{% endraw %}
-  temperature: {% raw %}{{ 22 - distance(states.device_tracker.paulus) }}{% endraw %}
-```
-
-It is even possible to use `data` and `data_template` concurrently but be aware that `data_template` will overwrite attributes that are provided in both.
-
-```yaml
-service: thermostat.set_temperature
-data:
-  entity_id: thermostat.upstairs
-data_template:
   temperature: {% raw %}{{ 22 - distance(states.device_tracker.paulus) }}{% endraw %}
 ```
 

--- a/source/_docs/tools/dev-tools.markdown
+++ b/source/_docs/tools/dev-tools.markdown
@@ -71,7 +71,7 @@ If there is an automation that handles that event, it will be automatically trig
     event_type: event_light_state_changed
   action:
     - service: notify.notify
-      data_template:
+      data:
         message: "Light is turned {{ trigger.event.data.state }}"
 ```
 

--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -1130,7 +1130,7 @@ automation:
           entity_id: zwave.scene_contrl
     action:
       - service: zwave.refresh_node_value
-        data_template:
+        data:
           node_id: 3
           value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
 switch:
@@ -1140,13 +1140,13 @@ switch:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(1) > 0 }}"
         turn_on:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 1 }}"
         turn_off:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 1 }}"
@@ -1154,13 +1154,13 @@ switch:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(2) > 0 }}"
         turn_on:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 2 }}"
         turn_off:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 2 }}"
@@ -1168,13 +1168,13 @@ switch:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(4) > 0 }}"
         turn_on:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 4 }}"
         turn_off:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 4 }}"
@@ -1182,13 +1182,13 @@ switch:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(8) > 0 }}"
         turn_on:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states(scene_contrl_indicator)|int + 8 }}"
         turn_off:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 8 }}"
@@ -1196,13 +1196,13 @@ switch:
         value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(16) > 0 }}"
         turn_on:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int + 16 }}"
         turn_off:
           service: zwave.set_node_value
-          data_template:
+          data:
             node_id: 3
             value_id: "{{ state_attr('sensor.scene_contrl_indicator','value_id') }}"
             value: "{{ states('sensor.scene_contrl_indicator')|int - 16 }}"

--- a/source/_integrations/alexa.intent.markdown
+++ b/source/_integrations/alexa.intent.markdown
@@ -218,7 +218,7 @@ intent_script:
   ActivateSceneIntent:
     action:
       service: scene.turn_on
-      data_template:
+      data:
         entity_id: scene.{% raw %}{{ Scene | replace(" ", "_") }}{% endraw %}
     speech:
       type: plain
@@ -266,7 +266,7 @@ intent_script:
   RunScriptIntent:
     action:
       service: script.turn_on
-      data_template:
+      data:
         entity_id: script.{% raw %}{{ Script | replace(" ", "_") }}{% endraw %}
     speech:
       type: plain

--- a/source/_integrations/amazon_polly.markdown
+++ b/source/_integrations/amazon_polly.markdown
@@ -82,7 +82,7 @@ Say to all `media_player` device entities:
 
 ```yaml
 - service: tts.amazon_polly_say
-  data_template:
+  data:
     message: '<speak>Hello from Amazon Polly</speak>'
 ```
 
@@ -90,7 +90,7 @@ or
 
 ```yaml
 - service: tts.amazon_polly_say
-  data_template:
+  data:
     message: >
       <speak>
           Hello from Amazon Polly
@@ -101,7 +101,7 @@ Say to the `media_player.living_room` device entity:
 
 ```yaml
 - service: tts.amazon_polly_say
-  data_template:
+  data:
     entity_id: media_player.living_room
     message: >
       <speak>
@@ -113,7 +113,7 @@ Say with break:
 
 ```yaml
 - service: tts.amazon_polly_say
-  data_template:
+  data:
     message: >
       <speak>
           Hello from

--- a/source/_integrations/binary_sensor.xiaomi_aqara.markdown
+++ b/source/_integrations/binary_sensor.xiaomi_aqara.markdown
@@ -147,7 +147,7 @@ The requirement is that you have setup the [`xiaomi aqara` integration](/integra
     to: 'on'
   action:
     - service: notify.html5
-      data_template:
+      data:
         title: Gas alarm!
         message: 'Gas with a density of {% raw %}{{ state_attr('binary_sensor.natgas_sensor_158dxxxxxxxxxx', 'density') }}{% endraw %} detected.'
 ```
@@ -274,7 +274,7 @@ The Aqara Wireless Switch is available as single-key and double-key version. Eac
   action:
     service: light.turn_on
     entity_id: light.gateway_light_34xxxxxxxx13
-    data_template:
+    data:
       brightness: {% raw %}>-
         {% if state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') %}
           {% if state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') - 60 >= 10 %}
@@ -296,7 +296,7 @@ The Aqara Wireless Switch is available as single-key and double-key version. Eac
   action:
     service: light.turn_on
     entity_id: light.gateway_light_34xxxxxxxx13
-    data_template:
+    data:
       brightness: {% raw %}>-
         {% if state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') %}
           {% if state_attr('light.gateway_light_34xxxxxxxx13', 'brightness') + 60 <= 255 %}

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -159,7 +159,7 @@ Again, this example assumes your camera's name (in the blink app) is `My Camera`
     to: 'on'
   action:
     service: blink.save_video
-    data_template:
+    data:
       name: "My Camera"
       filename: "/tmp/videos/blink_video_{{ now().strftime('%Y%m%d_%H%M%S') }}.mp4"
 

--- a/source/_integrations/camera.markdown
+++ b/source/_integrations/camera.markdown
@@ -85,7 +85,7 @@ For example, the following action in an automation would take a recording from "
 ```yaml
 action:
   service: camera.record
-  data_template:
+  data:
     entity_id: camera.yourcamera
     filename: '/tmp/{{ entity_id.name }}_{{ now().strftime("%Y%m%d-%H%M%S") }}.mp4'
 ```

--- a/source/_integrations/conversation.markdown
+++ b/source/_integrations/conversation.markdown
@@ -79,7 +79,7 @@ intent_script:
       text: Changed the lights to {{ color }}.
     action:
       service: light.turn_on
-      data_template:
+      data:
         rgb_color:
           - "{% if color == 'red' %}255{% else %}0{% endif %}"
           - "{% if color == 'green' %}255{% else %}0{% endif %}"

--- a/source/_integrations/cover.template.markdown
+++ b/source/_integrations/cover.template.markdown
@@ -210,7 +210,7 @@ cover:
             modus: 'stop'
         set_cover_position:
           service: script.cover_group_position
-          data_template:
+          data:
             position: "{{position}}"
         value_template: "{{is_state('sensor.cover_group', 'open')}}"
         icon_template: >-
@@ -239,7 +239,7 @@ sensor:
 script:
   cover_group:
     sequence:
-      - service_template: "cover.{{modus}}_cover"
+      - service: "cover.{{modus}}_cover"
         data:
           entity_id:
             - cover.bedroom
@@ -247,7 +247,7 @@ script:
   cover_group_position:
     sequence:
       - service: cover.set_cover_position
-        data_template:
+        data:
           entity_id:
             - cover.bedroom
             - cover.livingroom

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -196,7 +196,7 @@ automation:
         event: 2002
     action:
       - service: light.turn_on
-        data_template:
+        data:
           entity_id: light.lamp
           brightness: >
             {% set bri = state_attr('light.lamp', 'brightness') | int %}
@@ -212,7 +212,7 @@ automation:
         event: 3002
     action:
       - service: light.turn_on
-        data_template:
+        data:
           entity_id: light.lamp
           brightness: >
             {% set bri = state_attr('light.lamp', 'brightness') | int %}

--- a/source/_integrations/dialogflow.markdown
+++ b/source/_integrations/dialogflow.markdown
@@ -102,15 +102,15 @@ intent_script:
       text: Turning {{ Room }} lights {{ OnOff }}
     action:
       - service: notify.pushbullet
-        data_template:
+        data:
           message: Someone asked via apiai to turn {{ Room }} lights {{ OnOff }}
-      - service_template: >
+      - service: >
           {%- if OnOff == "on" -%}
             switch.turn_on
           {%- else -%}
             switch.turn_off
           {%- endif -%}
-        data_template:
+        data:
           entity_id: "switch.light_{{ Room | striptags | replace(' ', '_') }}"
 ```
 {% endraw %}

--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -63,7 +63,7 @@ Along with the event the following payload parameters are available:
     event_type: downloader_download_failed
   action:
     service: persistent_notification.create
-    data_template:
+    data:
       message: "{{trigger.event.data.filename}} download failed"
       title: "Download Failed"
  ```

--- a/source/_integrations/enocean.markdown
+++ b/source/_integrations/enocean.markdown
@@ -134,8 +134,8 @@ automation:
         id: [0xYY, 0xYY, 0xYY, 0xYY]
         pushed: 0
     action:
-      service_template: "{% raw %}{% if trigger.event.data.onoff %} light.turn_on {% else %} light.turn_off {%endif %}{% endraw %}"
-      data_template:
+      service: "{% raw %}{% if trigger.event.data.onoff %} light.turn_on {% else %} light.turn_off {%endif %}{% endraw %}"
+      data:
         entity_id: "{% raw %}{% if trigger.event.data.which == 1 %} light.hall_left {% else %} light.hall_right {%endif %}{% endraw %}"
 ```
 

--- a/source/_integrations/environment_canada.markdown
+++ b/source/_integrations/environment_canada.markdown
@@ -161,7 +161,7 @@ If you would like to have alerts announced via a text-to-speech service, you can
 weather_alert_tts:
   sequence:
    - service: tts.amazon_polly_say
-      data_template:
+      data:
         message: "{{ states('sensor.warnings') }} in effect."
 ```
 {% endraw %}

--- a/source/_integrations/facebox.markdown
+++ b/source/_integrations/facebox.markdown
@@ -92,7 +92,7 @@ source:
 
 ## Automations
 
-Use the `image_processing.detect_face` events to trigger automations, and breakout the `trigger.event.data` using a [data_template](/docs/automation/templating/). The following example automation sends a notification when Ringo Star is recognized:
+Use the `image_processing.detect_face` events to trigger automations, and breakout the `trigger.event.data` using a [template](/docs/automation/templating/). The following example automation sends a notification when Ringo Star is recognized:
 
 {% raw %}
 ```yaml
@@ -105,7 +105,7 @@ Use the `image_processing.detect_face` events to trigger automations, and breako
       name: 'Ringo_Starr'
   action:
     service: notify.platform
-    data_template:
+    data:
       message: Ringo_Starr recognised with probability {{ trigger.event.data.confidence }}
       title: Door-cam notification
 ```

--- a/source/_integrations/fan.template.markdown
+++ b/source/_integrations/fan.template.markdown
@@ -35,15 +35,15 @@ fan:
           service: script.fan_off
         set_speed:
           service: script.fan_speed
-          data_template:
+          data:
             speed: "{{ speed }}"
         set_oscillating:
           service: script.fan_oscillating
-          data_template:
+          data:
             oscillating: "{{ oscillating }}"
         set_direction:
           service: script.fan_direction
-          data_template:
+          data:
             direction: "{{ direction }}"
         speeds:
           - '1'

--- a/source/_integrations/feedreader.markdown
+++ b/source/_integrations/feedreader.markdown
@@ -72,7 +72,7 @@ automation:
       event_type: feedreader
     action:
       service: persistent_notification.create
-      data_template:
+      data:
         title: "New HA Podcast available"
         message: {% raw %}"New Podcast available - {{ as_timestamp(now()) | timestamp_custom('%I:%M:%S %p %d%b%Y', true) }}"{% endraw %}
         notification_id: {% raw %}"{{ trigger.event.data.title }}"{% endraw %}

--- a/source/_integrations/flic.markdown
+++ b/source/_integrations/flic.markdown
@@ -98,8 +98,8 @@ automation:
       platform: event
       event_type: flic_click
     action:
-      - service_template: notify.html5
-        data_template:
+      - service: notify.html5
+        data:
           title: "flic click"
           message: {% raw %}"flic {{ trigger.event.data.button_name }} was {{ trigger.event.data.click_type }} clicked"{% endraw %}
 ```

--- a/source/_integrations/folder_watcher.markdown
+++ b/source/_integrations/folder_watcher.markdown
@@ -57,7 +57,7 @@ folder_watcher:
 
 ## Automations
 
-Automations can be triggered on filesystem event data using a `data_template`. The following automation will send a notification with the name and folder of new files added to that folder:
+Automations can be triggered on filesystem event data using a template. The following automation will send a notification with the name and folder of new files added to that folder:
 
 {% raw %}
 ```yaml
@@ -71,7 +71,7 @@ automation:
       event_type: created
   action:
     service: notify.notify
-    data_template:
+    data:
       title: New image captured!
       message: "Created {{ trigger.event.data.file }} in {{ trigger.event.data.folder }}"
       data:

--- a/source/_integrations/fritzbox_callmonitor.markdown
+++ b/source/_integrations/fritzbox_callmonitor.markdown
@@ -94,7 +94,7 @@ automation:
         entity_id: sensor.phone
     action:
       - service: notify.notify
-        data_template:
+        data:
           title: "Phone"
           message: >-
             {% if is_state("sensor.phone", "idle") %}

--- a/source/_integrations/geniushub.markdown
+++ b/source/_integrations/geniushub.markdown
@@ -85,7 +85,7 @@ Each such entity has a state attribute that will contain a list of any such issu
     above: 0
   action:
   - service: notify.pushbullet_notifier
-    data_template:
+    data:
       title: "Genius Hub has errors"
       message: >-
         Genius Hub has the following {{ states('sensor.geniushub_errors') }} errors:
@@ -103,7 +103,7 @@ This alert may be useful to see if the CH is being turned on whilst you're on a 
     entity_id: binary_sensor.dual_channel_receiver_2_1
   action:
   - service: notify.pushbullet_notifier
-    data_template:
+    data:
       title: "Warning: CH State Change!"
       message: >-
         {{ trigger.to_state.attributes.friendly_name }} has changed

--- a/source/_integrations/geo_location.markdown
+++ b/source/_integrations/geo_location.markdown
@@ -58,7 +58,7 @@ automation:
       value_template: "{{ trigger.to_state.attributes.type == 'Bush Fire' }}"
     action:
       - service: persistent_notification.create
-        data_template:
+        data:
           message: "{{ trigger.to_state.name }} - {{ trigger.to_state.attributes.status }}"
           title: "Bush Fire Alert"
 ```

--- a/source/_integrations/hangouts.markdown
+++ b/source/_integrations/hangouts.markdown
@@ -187,7 +187,7 @@ intent_script:
       text: Changed the lights to {{ color }}.
     action:
       service: light.turn_on
-      data_template:
+      data:
         rgb_color:
           - "{% if color == 'red' %}255{% else %}0{% endif %}"
           - "{% if color == 'green' %}255{% else %}0{% endif %}"

--- a/source/_integrations/html5.markdown
+++ b/source/_integrations/html5.markdown
@@ -173,7 +173,7 @@ Example of adding a tag to your notification. This won't create new notification
         entity_id: sensor.sensor
     action:
       service: notify.notify
-      data_template:
+      data:
         message: "Last known sensor state is {{ states('sensor.sensor') }}."
       data:
         data:

--- a/source/_integrations/ifttt.markdown
+++ b/source/_integrations/ifttt.markdown
@@ -44,9 +44,9 @@ automation:
     platform: event
   condition: []
   action:
-  - data_template:
+  - data:
       entity_id: '{{ trigger.event.data.entity_id }}'
-    service_template: '{{ trigger.event.data.service }}'
+    service: '{{ trigger.event.data.service }}'
 ```
 {% endraw %}
 
@@ -139,7 +139,7 @@ automation:
 ```
 {% endraw %}
 
-IFTTT can also be used in scripts and with `data_template`.  Here is the above automation broken into an automation and script using variables and data_templates.
+IFTTT can also be used in scripts and with templates. Here is the above automation broken into an automation and script using variables and templates.
 
 {% raw %}
 ```yaml
@@ -151,7 +151,7 @@ automation:
     event: start
   action:
     service: script.ifttt_notify
-    data_template:
+    data:
       value1: 'HA Status:'
       value2: "{{ trigger.event.data.entity_id.split('_')[1] }} is "
       value3: "{{ trigger.event.data.to_state.state }}"
@@ -164,7 +164,7 @@ automation:
 ifttt_notify:
   sequence:
     - service: ifttt.trigger
-      data_template: {"event":"TestHA_Trigger", "value1":"{{ value1 }}", "value2":"{{ value2 }}", "value3":"{{ value3 }}"}
+      data: {"event":"TestHA_Trigger", "value1":"{{ value1 }}", "value2":"{{ value2 }}", "value3":"{{ value3 }}"}
 ```
 {% endraw %}
 

--- a/source/_integrations/incomfort.markdown
+++ b/source/_integrations/incomfort.markdown
@@ -42,7 +42,7 @@ To send an alert if the CV pressure is too low or too high, consider the followi
     below: 1.0
   action:
   - service: notify.pushbullet_notifier
-    data_template:
+    data:
       title: "Warning: Low CH Pressure"
       message: >-
         {{ trigger.to_state.attributes.friendly_name }}

--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -141,21 +141,21 @@ automation:
    # Sets time to time from datetime object (current time in this example)
   - service: input_datetime.set_datetime
     entity_id: input_datetime.another_time
-    data_template:
+    data:
       time: "{{ now().strftime('%H:%M:%S') }}"
   # Sets date to date from timestamp (current date in this example)
   - service: input_datetime.set_datetime
     entity_id: input_datetime.another_date
-    data_template:
+    data:
       date: "{{ as_timestamp(now())|timestamp_custom('%Y-%m-%d') }}"
   # Sets date and time to date and time from datetime object (current date and time in this example)
   - service: input_datetime.set_datetime
     entity_id: input_datetime.date_and_time
-    data_template:
+    data:
       datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
   # Sets date and time to date and time from timestamp (current date and time in this example)
   - service: input_datetime.set_datetime
-    data_template:
+    data:
       entity_id: input_datetime.date_and_time
       date: >
         {{ now().timestamp() | timestamp_custom("%Y-%m-%d", true) }}

--- a/source/_integrations/input_number.markdown
+++ b/source/_integrations/input_number.markdown
@@ -126,8 +126,7 @@ automation:
       entity_id: input_number.bedroom_brightness
     action:
       - service: light.turn_on
-        # Note the use of 'data_template:' below rather than the normal 'data:' if you weren't using an input variable
-        data_template:
+        data:
           entity_id: light.bedroom
           brightness: "{{ trigger.to_state.state | int }}"
 ```
@@ -164,8 +163,7 @@ automation:
       to: CUSTOM
     action:
       - service: light.turn_on
-        # Again, note the use of 'data_template:' rather than the normal 'data:' if you weren't using an input variable.
-        data_template:
+        data:
           entity_id: light.bedroom
           brightness: "{{ states('input_number.bedroom_brightness') | int }}"
 ```
@@ -194,7 +192,7 @@ automation:
       topic: 'setTemperature'
     action:
       service: input_number.set_value
-      data_template:
+      data:
         entity_id: input_number.target_temp
         value: "{{ trigger.payload }}"
 
@@ -206,7 +204,7 @@ automation:
       entity_id: input_number.target_temp
     action:
       service: mqtt.publish
-      data_template:
+      data:
         topic: 'setTemperature'
         retain: true
         payload: "{{ states('input_number.target_temp') | int }}"

--- a/source/_integrations/input_select.markdown
+++ b/source/_integrations/input_select.markdown
@@ -169,7 +169,7 @@ input_select:
    # entity_id: input_select.thermostat_mode
   action:
      service: input_select.select_option
-     data_template:
+     data:
       entity_id: input_select.thermostat_mode
       option: "{{ trigger.payload }}"
 
@@ -181,7 +181,7 @@ input_select:
     entity_id: input_select.thermostat_mode
   action:
     service: mqtt.publish
-    data_template:
+    data:
       topic: "thermostatMode"
       retain: true
       payload: "{{ states('input_select.thermostat_mode') }}"

--- a/source/_integrations/input_text.markdown
+++ b/source/_integrations/input_text.markdown
@@ -128,8 +128,7 @@ automation:
       entity_id: input_select.scene_bedroom
     action:
       - service: input_text.set_value
-        # Again, note the use of 'data_template:' rather than the normal 'data:' if you weren't using an input variable.
-        data_template:
+        data:
           entity_id: input_text.bedroom
           value: "{{ states('input_select.scene_bedroom') }}"
 ```

--- a/source/_integrations/intent_script.markdown
+++ b/source/_integrations/intent_script.markdown
@@ -18,7 +18,7 @@ intent_script:
       text: We have {% raw %}{{ states.sensor.temperature }}{% endraw %} degrees
     action:
       service: notify.notify
-      data_template:
+      data:
         message: Hello from an intent!
 ```
 

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -257,7 +257,7 @@ script:
           entity_id: media_player.kodi
       - alias: Play TV channel
         service: media_player.play_media
-        data_template:
+        data:
           entity_id: media_player.kodi
           media_content_type: "CHANNEL"
           media_content_id: >

--- a/source/_integrations/life360.markdown
+++ b/source/_integrations/life360.markdown
@@ -227,7 +227,7 @@ automation:
       event_type: life360_update_overdue
     action:
       service: notify.email_me
-      data_template:
+      data:
         title: Life360 update overdue
         message: >
           Update for {{
@@ -241,7 +241,7 @@ automation:
       event_type: life360_update_restored
     action:
       service: notify.email_me
-      data_template:
+      data:
         title: Life360 update restored
         message: >
           Update for {{

--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -35,25 +35,25 @@ light:
           service: script.theater_lights_off
         set_level:
           service: script.theater_lights_level
-          data_template:
+          data:
             brightness: "{{ brightness }}"
         set_temperature:
           service: input_number.set_value
-          data_template:
+          data:
             value: "{{ color_temp }}"
             entity_id: input_number.temperature_input
         set_white_value:
           service: input_number.set_value
-          data_template:
+          data:
             value: "{{ white_value }}"
             entity_id: input_number.white_value_input
         set_color:
           - service: input_number.set_value
-            data_template:
+            data:
               value: "{{ h }}"
               entity_id: input_number.h_input
           - service: input_number.set_value
-            data_template:
+            data:
               value: "{{ s }}"
               entity_id: input_number.s_input
 ```
@@ -192,7 +192,7 @@ light:
             is_volume_muted: true
         set_level:
           service: media_player.volume_set
-          data_template:
+          data:
             entity_id: media_player.receiver
             volume_level: "{{ (brightness / 255 * 100)|int / 100 }}"
         level_template: >-

--- a/source/_integrations/logbook.markdown
+++ b/source/_integrations/logbook.markdown
@@ -179,7 +179,7 @@ script:
     alias: Add Logbook
     sequence:
       - service: logbook.log
-        data_template:
+        data:
           name: Kitchen
           message: is being used
           # Optional

--- a/source/_integrations/manual.markdown
+++ b/source/_integrations/manual.markdown
@@ -216,7 +216,7 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
       to: 'disarmed'
   action:
     - service: notify.notify
-      data_template:
+      data:
         message: "ALARM! The alarm is Disarmed at {{ states('sensor.date_time') }}"
 ```
 {% endraw %}
@@ -230,7 +230,7 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
       to: 'pending'
   action:
     - service: notify.notify
-      data_template:
+      data:
         message: "ALARM! The alarm is in pending status at {{ states('sensor.date_time') }}"
 ```
 {% endraw %}
@@ -244,7 +244,7 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
       to: 'armed_away'
   action:
     - service: notify.notify
-      data_template:
+      data:
         message: "ALARM! The alarm is armed in Away mode {{ states('sensor.date_time') }}"
 ```
 {% endraw %}
@@ -258,7 +258,7 @@ Sending a Notification when the Alarm is Armed (Away/Home), Disarmed and in Pend
       to: 'armed_home'
   action:
     - service: notify.notify
-      data_template:
+      data:
         # Using multi-line notation allows for easier quoting
         message: >
           ALARM! The alarm is armed in Home mode {{ states('sensor.date_time') }}

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -131,7 +131,7 @@ automation:
         command: introduction
     action:
       service: notify.matrix_notify
-      data_template:
+      data:
         message: "Hello {{trigger.event.data.args['name']}}"
 ```
 {% endraw %}

--- a/source/_integrations/mediaroom.markdown
+++ b/source/_integrations/mediaroom.markdown
@@ -62,7 +62,7 @@ The `play_media` function can be used in scripts to change channels:
 change_channel:
   sequence:
     service: media_player.play_media
-    data_template:
+    data:
       entity_id: media_player.mediaroom_stb
       media_content_id: "{{ channel_number }}"
       media_content_type: "channel"
@@ -78,7 +78,7 @@ The `play_media` function can also be used to trigger actions on the set-up-box 
 press_button:
   sequence:
     service: media_player.play_media
-    data_template:
+    data:
       entity_id: media_player.mediaroom_stb
       media_content_id: "{{ action }}"
       media_content_type: "mediaroom"

--- a/source/_integrations/meteoalarm.markdown
+++ b/source/_integrations/meteoalarm.markdown
@@ -95,7 +95,7 @@ automation:
       from: ‘off’
     action:
       - service: notify.notify
-        data_template:
+        data:
           title: "{{state_attr('binary_sensor.meteoalarm', 'headline')}}"
           message: "{{state_attr('binary_sensor.meteoalarm', 'description')}} is effective on {{state_attr('binary_sensor.meteoalarm', 'effective')}}"
 ```

--- a/source/_integrations/miflora.markdown
+++ b/source/_integrations/miflora.markdown
@@ -145,7 +145,7 @@ An automation example to report a battery failure:
     platform: state
     to: unavailable
   action:
-  - data_template:
+  - data:
       message: "Flower 1 moisture is unavailable for more than 24 hours"
     service: notify.notifier_telegram_someone
 ```

--- a/source/_integrations/minio.markdown
+++ b/source/_integrations/minio.markdown
@@ -93,13 +93,13 @@ automation:
   action:
     - delay: '00:00:01'
     - service: minio.put
-      data_template:
+      data:
         file_path: "{{ trigger.event.data.path }}"
         bucket: "camera-image-object-detection"
         key: "input/{{ now().year }}/{{ (now().month | string).zfill(2) }}/{{ (now().day | string).zfill(2) }}/{{ trigger.event.data.file }}"
     - delay: '00:00:01'
     - service: shell_command.remove_file
-      data_template:
+      data:
         file: "{{ trigger.event.data.path }}"
 
 - alias: Download new Minio file
@@ -110,7 +110,7 @@ automation:
   condition: []
   action:
   - service: minio.get
-    data_template:
+    data:
       bucket: "{{trigger.event.data.bucket}}"
       key: "{{trigger.event.data.key}}"
       file_path: "/tmp/{{ trigger.event.data.file_name }}"

--- a/source/_integrations/modem_callerid.markdown
+++ b/source/_integrations/modem_callerid.markdown
@@ -94,7 +94,7 @@ automation:
       to: "callerid"
     action:
       service: tts.google_say
-      data_template:
+      data:
         message: 'Call from {{ state_attr('sensor.modem_callerid', 'cid_name') }}'
 ```
 {% endraw %}

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -168,7 +168,7 @@ Example:
       event_data:
         type: movement
   action:
-    - data_template:
+    - data:
         message: >
           {{ trigger.event.data["data"]["message"] }}  
           at {{ trigger.event.data["data"]["home_name"] }}
@@ -192,7 +192,7 @@ Example:
       event_data:
         type: human # other possible types: animal, vehicle
   action:
-    - data_template:
+    - data:
         message: >
           {{ trigger.event.data["data"]["message"] }}  
           at {{ trigger.event.data["data"]["home_name"] }}
@@ -224,7 +224,7 @@ Example:
       event_data:
         type: tag_small_move
   action:
-    - data_template:
+    - data:
         message: >
           {{ trigger.event.data["data"]["message"] }}
         title: Netatmo event

--- a/source/_integrations/netgear_lte.markdown
+++ b/source/_integrations/netgear_lte.markdown
@@ -192,10 +192,10 @@ automation:
         event_type: netgear_lte_sms
     action:
       - service: conversation.process
-        data_template:
+        data:
           text: '{{ trigger.event.data.message }}'
       - service: netgear_lte.delete_sms
-        data_template:
+        data:
           host: '{{ trigger.event.data.host }}'
           sms_id: '{{ trigger.event.data.sms_id }}'
 ```

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -25,7 +25,7 @@ Once loaded, the `notify` platform will expose a service that can be called to s
 | `target`               |      yes | Some platforms allow specifying a recipient that will receive the notification. See your platform page if it is supported.
 | `data`                 |      yes | On platforms who have extended functionality. See your platform page if it is supported.
 
-The notify integration supports specifying [templates](/topics/templating/) with `data_template`. This will allow you to use the current state of Home Assistant in your notifications.
+The notify integration supports specifying [templates](/topics/templating/). This will allow you to use the current state of Home Assistant in your notifications.
 
 In an [action](/getting-started/automation-action/) of your [automation setup](/getting-started/automation/) it could look like this with a customized subject.
 
@@ -52,7 +52,7 @@ The automation equivalent would be:
 ```yaml
 action:
   service: notify.notify
-  data_template:
+  data:
     message: "The sun is {% raw %}{% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}{% endraw %}!"
 ```
 

--- a/source/_integrations/notify.rest.markdown
+++ b/source/_integrations/notify.rest.markdown
@@ -73,7 +73,7 @@ data:
   description: Dictionary of extra parameters to send to the resource.
   required: false
   type: string
-data_template:
+data:
   description: Template dictionary of extra parameters to send to the resource.
   required: false
   type: template

--- a/source/_integrations/nzbget.markdown
+++ b/source/_integrations/nzbget.markdown
@@ -92,7 +92,7 @@ Example automation to send a Telegram message on a completed download:
     category: tv
   action:
     service: notify.telegram_notifier
-    data_template:
+    data:
       title: "Download completed!"
       message: "{{trigger.event.data.name}}"
 ```

--- a/source/_integrations/openhome.markdown
+++ b/source/_integrations/openhome.markdown
@@ -23,7 +23,7 @@ media_player:
 ```yaml
 action:
   - service: media_player.play_media
-    data_template:
+    data:
       entity_id:
         - media_player.linn_bedroom
       media_content_id: "http://172.24.32.13/Doorbell.mp3"
@@ -34,7 +34,7 @@ action:
 
 ```yaml
   - service: media_player.play_media
-    data_template:
+    data:
       entity_id:
         - media_player.linn_bedroom
       media_content_id: "http://media-ice.musicradio.com:80/ClassicFMMP3"

--- a/source/_integrations/opensky.markdown
+++ b/source/_integrations/opensky.markdown
@@ -50,7 +50,7 @@ automation:
       event_type: opensky_entry
     action:
       service: notify.mobile_app_<device_name>
-      data_template:
+      data:
         message : 'Flight entry of {{ trigger.event.data.callsign }} '
 ```
 {% endraw %}

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -36,14 +36,14 @@ action:
     title: "Custom subject"
 ```
 
-If you want to show some runtime information, you have to use [templates](/topics/templating/ inside `data_template`.
+If you want to show some runtime information, you have to use [templates](/topics/templating/).
 
 {% raw %}
 
 ```yaml
 action:
   service: persistent_notification.create
-  data_template:
+  data:
     title: >
       Thermostat is {{ state_attr('climate.thermostat', 'hvac_action') }}
     message: "Temperature {{ state_attr('climate.thermostat', 'current_temperature') }}"

--- a/source/_integrations/point.markdown
+++ b/source/_integrations/point.markdown
@@ -128,7 +128,7 @@ automation:
     value_template: "{{ trigger.event.data.event.type == 'short_button_press' }}"
   action:
   - service: persistent_notification.create
-    data_template:
+    data:
       title: Point button press (webhook)
       message: "Button press on Point {{ trigger.event.data.event.device_id }}"
 ```

--- a/source/_integrations/pushover.markdown
+++ b/source/_integrations/pushover.markdown
@@ -89,7 +89,7 @@ alexa:
     LocateIntent:
       action:
         service: notify.notify
-        data_template:
+        data:
           message: "The location of {{ User }} has been queried via Alexa."
         data:
           title: "Home Assistant"

--- a/source/_integrations/remember_the_milk.markdown
+++ b/source/_integrations/remember_the_milk.markdown
@@ -92,7 +92,7 @@ Here's an example for an automation that creates a new task whenever `sensor.mys
     to: on
   action:
     - service: remember_the_milk.myaccount_create_task
-      data_template:
+      data:
         name: "Please switch of {{trigger.entity_id}}"
         id: "{{trigger.entity_id}}"
 - id: mysensor_off
@@ -102,7 +102,7 @@ Here's an example for an automation that creates a new task whenever `sensor.mys
     to: off
   action:
     - service: remember_the_milk.myaccount_complete_task
-      data_template:
+      data:
         id: "{{trigger.entity_id}}"
 
 ```

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -62,7 +62,7 @@ Then you can use the following `action` in your automation (this will save the v
 ```yaml
 action:
   - service: downloader.download_file
-    data_template:
+    data:
       url: "{{ state_attr('camera.front_door', 'video_url') }}"
       subdir: "{{state_attr('camera.front_door', 'friendly_name')}}"
       filename: "{{state_attr('camera.front_door', 'friendly_name')}}"

--- a/source/_integrations/script.markdown
+++ b/source/_integrations/script.markdown
@@ -25,7 +25,7 @@ script:
     sequence:
       # This is Home Assistant Script Syntax
       - service: notify.notify
-        data_template:
+        data:
           message: "Current temperature is {{ states('sensor.temperature') }}"
 ```
 
@@ -176,7 +176,7 @@ automation:
       message: 'The light is on!'
 ```
 
-Using the variables in the script requires the use of `data_template`:
+Using the variables in the script requires the use of templates:
 
 ```yaml
 # Example configuration.yaml entry
@@ -195,7 +195,7 @@ script:
         entity_id: switch.pushover_notifications
         state: 'on'
       - service: notify.pushover
-        data_template:
+        data:
           title: "{% raw %}{{ title }}{% endraw %}"
           message: "{% raw %}{{ message }}{% endraw %}"
 ```

--- a/source/_integrations/smtp.markdown
+++ b/source/_integrations/smtp.markdown
@@ -128,7 +128,7 @@ The optional `html` field makes a custom text/HTML multi-part message, allowing 
       - delay:
             seconds: 1
       - service: notify.NOTIFIER_NAME
-        data_template:
+        data:
             message: 'Intruder alert at apartment!!'
             data:
               images:

--- a/source/_integrations/snips.markdown
+++ b/source/_integrations/snips.markdown
@@ -151,13 +151,13 @@ intent_script:
   ActivateLightColor:
     action:
       - service: light.turn_on
-        data_template:
+        data:
           entity_id: light.{{ objectLocation | replace(" ","_") }}
           color_name: {{ objectColor }}
 ```
 {% endraw %}
 
-In the `data_template` block, we have access to special variables, corresponding to the slot names for the intent. In the present case, the `ActivateLightColor` has two slots, `objectLocation` and `objectColor`.
+In the `data` block, we have access to special variables, corresponding to the slot names for the intent. In the present case, the `ActivateLightColor` has two slots, `objectLocation` and `objectColor`.
 
 ### Special slots
 
@@ -175,7 +175,7 @@ SetTimer:
     text: 'Set a timer'
   action:
     service: script.set_timer
-    data_template:
+    data:
       name: "{{ timer_name }}"
       duration: "{{ timer_duration }}"
       siteId: "{{ site_id }}"

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -161,7 +161,7 @@ condition:
         {{ trigger.from_state.attributes.queue_position < trigger.to_state.attributes.queue_position }}
 action:
   - service: sonos.remove_from_queue
-    data_template:
+    data:
       entity_id: >
         {{ trigger.entity_id }}
       queue_position: >

--- a/source/_integrations/spc.markdown
+++ b/source/_integrations/spc.markdown
@@ -54,7 +54,7 @@ automation:
         entity_id: alarm_control_panel.alarm_1
     action:
       - service: notify.notify
-        data_template:
+        data:
           message: >
             {% raw %}Alarm changed from {{ trigger.from_state.state }}
             to {{ trigger.to_state.state }}

--- a/source/_integrations/system_log.markdown
+++ b/source/_integrations/system_log.markdown
@@ -114,7 +114,7 @@ automation:
       value_template: '{{ "service" in trigger.event.data.message }}'
     action:
       service: persistent_notification.create
-      data_template:
+      data:
         title: Something bad happened
         message: '{{ trigger.event.data.message }}'
 ```
@@ -135,7 +135,7 @@ automation:
       to: 'on'
     action:
       service: system_log.write
-      data_template:
+      data:
         message: 'Door opened!'
         level: info
 ```

--- a/source/_integrations/telegram_bot.markdown
+++ b/source/_integrations/telegram_bot.markdown
@@ -285,7 +285,7 @@ An example to show the use of event_data in action:
       command: '/speak'
   action:
     - service: notify.kitchen_echo
-      data_template:
+      data:
         message: >
           Message from {{ trigger.event.data["from_first"] }}. {% for state in trigger.event.data["args"] %} {{ state }} {% endfor %}
 ```
@@ -311,7 +311,7 @@ Text repeater:
     event_type: telegram_text
   action:
     - service: telegram_bot.send_message
-      data_template:
+      data:
         title: '*Dumb automation*'
         target: '{{ trigger.event.data.user_id }}'
         message: 'You said: {{ trigger.event.data.text }}'
@@ -336,12 +336,12 @@ Message editor:
       command: '/edit_msg'
   action:
     - service: telegram_bot.answer_callback_query
-      data_template:
+      data:
         callback_query_id: '{{ trigger.event.data.id }}'
         message: 'Editing the message!'
         show_alert: true
     - service: telegram_bot.edit_message
-      data_template:
+      data:
         message_id: '{{ trigger.event.data.message.message_id }}'
         chat_id: '{{ trigger.event.data.chat_id }}'
         title: '*Message edit*'
@@ -369,11 +369,11 @@ Keyboard editor:
       command: '/remove_button'
   action:
     - service: telegram_bot.answer_callback_query
-      data_template:
+      data:
         callback_query_id: '{{ trigger.event.data.id }}'
         message: 'Callback received for editing the inline keyboard!'
     - service: telegram_bot.edit_replymarkup
-      data_template:
+      data:
         message_id: 'last'
         chat_id: '{{ trigger.event.data.chat_id }}'
         inline_keyboard:
@@ -395,7 +395,7 @@ Only acknowledges the 'NO' answer:
       command: '/do_nothing'
   action:
     - service: telegram_bot.answer_callback_query
-      data_template:
+      data:
         callback_query_id: '{{ trigger.event.data.id }}'
         message: 'OK, you said no!'
 ```
@@ -415,7 +415,7 @@ Telegram callbacks also support arguments and commands the same way as normal me
       command: '/repeat'
   action:
     - service: telegram_bot.answer_callback_query
-      data_template:
+      data:
         show_alert: true
         callback_query_id: '{{ trigger.event.data.id }}'
         message: 'I repeat: {{trigger.event.data["args"]}}'

--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -110,7 +110,7 @@ Example of configuration of an automation with completed torrents:
     event_type: transmission_downloaded_torrent
   action:
     service: notify.telegram_notifier
-    data_template:
+    data:
       title: "Torrent completed!"
       message: "{{trigger.event.data.name}}"
 ```

--- a/source/_integrations/tts.markdown
+++ b/source/_integrations/tts.markdown
@@ -131,7 +131,7 @@ With a template:
 
 ```yaml
 service: tts.google_translate_say
-data_template:
+data:
   message: "Temperature is {% raw %}{{states('sensor.temperature')}}{% endraw %}."
   cache: false
 ```

--- a/source/_integrations/universal.markdown
+++ b/source/_integrations/universal.markdown
@@ -114,12 +114,12 @@ media_player:
         entity_id: switch.living_room_mute
     select_source:
       service: media_player.select_source
-      data_template:
+      data:
         entity_id: media_player.receiver
         source: '{{ source }}'
     volume_set:
       service: media_player.volume_set
-      data_template:
+      data:
         entity_id: media_player.receiver
         volume_level: '{{ volume_level }}'
 
@@ -267,7 +267,7 @@ media_player:
           command: VolumeDown
       select_source:
         service: remote.turn_on
-        data_template:
+        data:
           entity_id: remote.alexander_down_guest
           activity: '{{ source }}'
 ```

--- a/source/_integrations/upb.markdown
+++ b/source/_integrations/upb.markdown
@@ -181,7 +181,7 @@ Start a scene blinking.
       address: '42_9'
   action:
     service: persistent_notification.create
-    data_template:
+    data:
       title: 'Scene Activated'
       message: >
         Activated scene 9 on network 42: {{trigger.event.data.command}}, {{trigger.event.data.address}}

--- a/source/_integrations/updater.markdown
+++ b/source/_integrations/updater.markdown
@@ -71,7 +71,7 @@ automation:
       to: 'on'
   action:
     - service: notify.notify
-      data_template:
+      data:
         message: "Home Assistant {{ state_attr('binary_sensor.updater', 'newest_version') }} is available."
 ```
 

--- a/source/_integrations/vacuum.template.markdown
+++ b/source/_integrations/vacuum.template.markdown
@@ -162,7 +162,7 @@ vacuum:
             service: script.vacuum_locate_vacuum
         set_fan_speed:
             service: script.vacuum_set_fan_speed
-            data_template:
+            data:
               speed: "{{ fan_speed }}"
         fan_speeds:
             - Low

--- a/source/_integrations/vallox.markdown
+++ b/source/_integrations/vallox.markdown
@@ -62,7 +62,7 @@ automation:
       entity_id: input_select.ventilation_profile
     action:
       service: vallox.set_profile
-      data_template:
+      data:
         profile: "{{ states('input_select.ventilation_profile') }}"
 ```
 {% endraw %}

--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -103,6 +103,8 @@ The requirement is that you have setup your Verisure hub first, with the instruc
 
 The `changed_by` attribute enables one to be able to take different actions depending on who armed/disarmed the alarm in [automation](/getting-started/automation/).
 
+{% raw %}
+
 ```yaml
 automation:
   - alias: Alarm status changed
@@ -111,12 +113,14 @@ automation:
         entity_id: alarm_control_panel.alarm_1
     action:
       - service: notify.notify
-        data_template:
+        data:
           message: >
-            {% raw %}Alarm changed from {{ trigger.from_state.state }}
+            Alarm changed from {{ trigger.from_state.state }}
             to {{ trigger.to_state.state }}
-            by {{ trigger.to_state.attributes.changed_by }}{% endraw %}
+            by {{ trigger.to_state.attributes.changed_by }}
 ```
+
+{% endraw %}
 
 ## Services
 

--- a/source/_integrations/watson_tts.markdown
+++ b/source/_integrations/watson_tts.markdown
@@ -63,7 +63,7 @@ Say to all `media_player` device entities:
 
 ```yaml
 - service: tts.watson_tts_say
-  data_template:
+  data:
     message: 'Hello from Watson'
 ```
 
@@ -71,7 +71,7 @@ or
 
 ```yaml
 - service: tts.watson_tts_say
-  data_template:
+  data:
     message: >
       <speak>
           Hello from Watson
@@ -82,7 +82,7 @@ Say to the `media_player.living_room` device entity:
 
 ```yaml
 - service: tts.watson_tts_say
-  data_template:
+  data:
     entity_id: media_player.living_room
     message: >
       <speak>
@@ -94,7 +94,7 @@ Say with break:
 
 ```yaml
 - service: tts.watson_tts_say
-  data_template:
+  data:
     message: >
       <speak>
           Hello from

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1224,7 +1224,7 @@ automation:
     condition: []
     action:
     - service: xiaomi_miio.vacuum_clean_zone
-      data_template:
+      data:
         entity_id: vacuum.xiaomi_vacuum
         repeats: '{{states('input_number.vacuum_passes')|int}}'
         zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]
@@ -1244,7 +1244,7 @@ automation:
     condition: []
     action:
     - service: xiaomi_miio.vacuum_clean_zone
-      data_template:
+      data:
         entity_id: vacuum.xiaomi_vacuum
         repeats: '{{states('input_number.vacuum_passes')|int}}'
         zone:

--- a/source/_posts/2016-03-12-z-wave-pep257-templated-service-calls.markdown
+++ b/source/_posts/2016-03-12-z-wave-pep257-templated-service-calls.markdown
@@ -25,6 +25,8 @@ Besides bug fixes, this release also brings:
  - Device Tracker: [OwnTracks] will allow filtering inaccurate GPS locations ([@HydrelioxGitHub])
  - Binary Sensor: Wemo Motion now supported ([@pavoni], [@ryanlaux])
 
+{% raw %}
+
 ```yaml
 # Example using templates for service and data in service call.
 # Works for automation, Alexa, universal media player, template switch.
@@ -33,15 +35,17 @@ automation:
       - platform: state
         entity_id: switch.bathroom
     action:
-      service_template: >
-        {% raw %}{% if is_state('switch.bathroom', 'on') %}
+      service: >
+        {% if is_state('switch.bathroom', 'on') %}
           switch.turn_on
         {% else %}
           switch.turn_off
-        {% endif %}{% endraw %}
-      data_template:
-        entity_id: switch.{% raw %}{{ states('input_select.is') }}{% endraw %}
+        {% endif %}
+      data:
+        entity_id: switch.{{ states('input_select.is') }}
 ```
+
+{% endraw %}
 
 ### Breaking Changes
 

--- a/source/_posts/2016-05-07-empowering-scripts-and-alexa.markdown
+++ b/source/_posts/2016-05-07-empowering-scripts-and-alexa.markdown
@@ -19,7 +19,7 @@ automation:
     topic: some/notify/topic
   action:
     service: notify.notify
-    data_template:
+    data:
       message: {{ trigger.payload }}
 
 automation 2:
@@ -28,7 +28,7 @@ automation 2:
     entity_id: light.hue
   action:
     service: notify.notify
-    data_template:
+    data:
       message: {{ trigger.to_state.name }} is now {{ trigger.to_state.state }}
 ```
 

--- a/source/_posts/2020-07-01-release-112.markdown
+++ b/source/_posts/2020-07-01-release-112.markdown
@@ -341,7 +341,7 @@ automation:
     condition: []
     action:
     - service: xiaomi_miio.vacuum_clean_zone
-      data_template:
+      data:
         repeats: '{{states('input_number.vacuum_passes')|int}}'
         zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]
 ```
@@ -361,7 +361,7 @@ automation:
     condition: []
     action:
     - service: xiaomi_miio.vacuum_clean_zone
-      data_template:
+      data:
         entity_id: vacuum.xiaomi_vacuum
         repeats: '{{states('input_number.vacuum_passes')|int}}'
         zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR removes the need for `service_template` & `data_template` in service and event actions. Instead, `service` & `data` now accept templates.

If the string passed into `data` and `service` isn't a template, it will be handled normally as before.

This change is backward compatible, as `data_template` & `service_template` are still processed as before (however, they are not needed anymore). For a documentation scope, those are not removed from existence.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39210
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
