### PR TITLE
Add Risco binary sensor to documentation

### DIFF
--- a/source/_integrations/risco.markdown
+++ b/source/_integrations/risco.markdown
@@ -3,6 +3,7 @@ title: Risco Alarm
 description: Instructions on how to integrate Risco alarms into HA using Risco Cloud.
 ha_category:
   - Alarm
+  - Binary Sensor
 ha_release: "0.115"
 ha_iot_class: Cloud Polling
 ha_config_flow: true
@@ -22,9 +23,10 @@ Menu: **Configuration** -> **Integrations**.
 
 Click on the `+` sign to add an integration and click on **Risco**.
 You will be prompted for your username, password, and pin code (you can create a specific user for this purpose).
-An Alarm Control Panel entity will be created for each partition in your site.
+An Alarm Control Panel entity will be created for each partition in your site, and binary sensors for each of your zones.
 
 If you have multiple sites, only the first site will be used.
 
 Currently supported plaforms:
 - [Alarm Control Panel](/integrations/alarm_control_panel/)
+- [Binary Sensor](/integrations/binary_sensor/)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add the binary sensor platform to the Risco integration documentation.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39137
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
