### PR TITLE
Add timestamp option for input_datetime.set_datetime

### DIFF
--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -88,21 +88,25 @@ If you set a valid value for `initial` this integration will start with state se
 
 Available service: `input_datetime.set_datetime` and `input_datetime.reload`.
 
+#### input_datetime.set_datetime
+
 Service data attribute | Format String | Description
 -|-|-
 `date` | `%Y-%m-%d` | This can be used to dynamically set the date.
 `time` | `%H:%M:%S` | This can be used to dynamically set the time.
 `datetime` | `%Y-%m-%d %H:%M:%S` | This can be used to dynamically set both the date & time.
+`timestamp` | N/A | This can be used to dynamically set both the date & time using a UNIX timestamp.
 
-To set both the date and time in the same call, use `date` and `time` together, or use `datetime` by itself. Using `datetime` has the advantage that both can be set using one template.
+To set both the date and time in the same call, use `date` and `time` together, or use `datetime` or `timestamp` by itself. Using `datetime` or `timestamp` has the advantage that both can be set using one template.
+
+#### input_datetime.reload
 
 `input_dateteime.reload` service allows one to reload `input_datetime`'s configuration without restarting Home Assistant itself.
 
-## Automation Examples
+## Examples
 
 The following example shows the usage of the `input_datetime` as a trigger in an
-automation (note that you will need a
-[time sensor](/integrations/time_date) elsewhere in your configuration):
+automation:
 
 {% raw %}
 ```yaml
@@ -110,56 +114,56 @@ automation (note that you will need a
 # Turns on bedroom light at the time specified.
 automation:
   trigger:
-    platform: template
-    value_template: "{{ states('sensor.time') == (state_attr('input_datetime.bedroom_alarm_clock_time', 'timestamp') | int | timestamp_custom('%H:%M', False)) }}"
-  action:
+    platform: time
+    at: input_datetime.bedroom_alarm_clock_time
+  action:
     service: light.turn_on
     entity_id: light.bedroom
 ```
 {% endraw %}
 
 To dynamically set the `input_datetime` you can call
-`input_datetime.set_datetime`. The values for `date` and `time` must be in a certain format for the call to be successful. (See service description above.)
-If you have a `datetime` object you can use its `strftime` method. Of if you have a timestamp you can use the `timestamp_custom` filter.
-The following example shows the different methods in an automation rule:
+`input_datetime.set_datetime`. The values for `date`, `time` and/or `datetime` must be in a certain format for the call to be successful. (See service description above.)
+If you have a `datetime` object you can use its `timestamp` method. Of if you have a timestamp you can just use it directly.
 
 {% raw %}
 ```yaml
-# Example configuration.yaml entry
-# Shows different ways to set input_datetime when an input_boolean is turned on
-automation:
-  trigger:
-    platform: state
-    entity_id: input_boolean.example
-    to: 'on'
-  action:
-  # Sets time to '05:30:00
-  - service: input_datetime.set_datetime
-    entity_id: input_datetime.bedroom_alarm_clock_time
-    data:
-      time: '05:30:00'
-   # Sets time to time from datetime object (current time in this example)
-  - service: input_datetime.set_datetime
-    entity_id: input_datetime.another_time
-    data:
-      time: "{{ now().strftime('%H:%M:%S') }}"
-  # Sets date to date from timestamp (current date in this example)
-  - service: input_datetime.set_datetime
-    entity_id: input_datetime.another_date
-    data:
-      date: "{{ as_timestamp(now())|timestamp_custom('%Y-%m-%d') }}"
-  # Sets date and time to date and time from datetime object (current date and time in this example)
-  - service: input_datetime.set_datetime
-    entity_id: input_datetime.date_and_time
-    data:
-      datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
-  # Sets date and time to date and time from timestamp (current date and time in this example)
-  - service: input_datetime.set_datetime
-    data:
-      entity_id: input_datetime.date_and_time
-      date: >
-        {{ now().timestamp() | timestamp_custom("%Y-%m-%d", true) }}
-      time: >
-        {{ now().timestamp() | timestamp_custom("%H:%M:%S", true) }}
+# Sets time to 05:30:00
+- service: input_datetime.set_datetime
+  entity_id: input_datetime.XXX
+  data:
+    time: '05:30:00'
+# Sets time to time from datetime object
+- service: input_datetime.set_datetime
+  entity_id: input_datetime.XXX
+  data:
+    time: "{{ now().strftime('%H:%M:%S') }}"
+# Sets date to 2020-08-24
+- service: input_datetime.set_datetime
+  entity_id: input_datetime.XXX
+  data:
+    date: '2020-08-24'
+# Sets date to date from datetime object
+- service: input_datetime.set_datetime
+  entity_id: input_datetime.XXX
+  data:
+    date: "{{ now().strftime('%Y-%m-%d') }}"
+# Sets date and time to 2020-08-25 05:30:00
+- service: input_datetime.set_datetime
+  entity_id: input_datetime.XXX
+  data:
+    datetime: '2020-08-25 05:30:00'
+# Sets date and time from datetime object
+- service: input_datetime.set_datetime
+  entity_id: input_datetime.XXX
+  data:
+    datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+# Sets date and/or time from UNIX timestamp
+# This can be used whether the input_datetime has just a date,
+# or just a time, or has both
+- service: input_datetime.set_datetime
+  data:
+    entity_id: input_datetime.XXX
+    timestamp: "{{ now().timestamp() }}"
 ```
 {% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add timestamp option for `input_datetime.set_datetime` service.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#39121
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
