### PR TITLE
Add custom mapping documentation to Risco

### DIFF
--- a/source/_integrations/risco.markdown
+++ b/source/_integrations/risco.markdown
@@ -33,7 +33,7 @@ You can configure additional behavior by clicking on **Options** in the relevant
 
 {% configuration_basic %}
 How often to poll Risco (in seconds):
-  description: "The lower this is, the faster your entities will reflect changes, but the more resource intensive it'll be."
+  description: "The lower this is, the faster your entities will reflect changes, but the more resource-intensive it'll be."
 Require pin code to arm:
   description: When checked, you'll need to enter your pin code when arming through Home Assistant.
 Require pin code to disarm:
@@ -43,10 +43,12 @@ Require pin code to disarm:
 Apart from these options, you can also define a custom mapping between your Home Assistant Alarm states and the Risco arming modes.
 This is an advanced configuration, and unless you're using group arming, the default mapping should probably be best.
 This is a two-way mapping, meaning you can map:
-* What Home Assistant state your partition entity will report when Risco is armed in a specific mode.
-* Which arming mode to use when arming from Home Assistant using one of its modes. Note that in this step, you can only choose combinations that map to each other in the previous step.
+
+- What Home Assistant state your partition entity will report when Risco is armed in a specific mode.
+- Which arming mode to use when arming from Home Assistant using one of its modes. Note that in this step, you can only choose combinations that map to each other in the previous step.
 
 The default mapping:
+
 |Risco Arming Mode | Home Assistant State |
 |---|---|
 | Arm (AWAY) | Armed Away |
@@ -57,11 +59,13 @@ The default mapping:
 | Group D | Armed Home |
 
 And in the reverse direction:
+
 | Home Assistant Mode | Risco Arming Mode |
 |---|---|
 | Arm Away | Arm |
 | Arm Home | Partial Arm |
 
 Currently supported plaforms:
+
 - [Alarm Control Panel](/integrations/alarm_control_panel/)
 - [Binary Sensor](/integrations/binary_sensor/)

--- a/source/_integrations/risco.markdown
+++ b/source/_integrations/risco.markdown
@@ -40,6 +40,28 @@ Require pin code to disarm:
   description: When checked, you'll need to enter your pin code when disarming through Home Assistant.
 {% endconfiguration_basic %}
 
+Apart from these options, you can also define a custom mapping between your Home Assistant Alarm states and the Risco arming modes.
+This is an advanced configuration, and unless you're using group arming, the default mapping should probably be best.
+This is a two-way mapping, meaning you can map:
+* What Home Assistant state your partition entity will report when Risco is armed in a specific mode.
+* Which arming mode to use when arming from Home Assistant using one of its modes. Note that in this step, you can only choose combinations that map to each other in the previous step.
+
+The default mapping:
+|Risco Arming Mode | Home Assistant State |
+|---|---|
+| Arm | Armed Away |
+| Partial Arm | Armed Home |
+| Group A | Armed Home |
+| Group B | Armed Home |
+| Group C | Armed Home |
+| Group D | Armed Home |
+
+And in the reverse direction:
+| Home Assistant Mode | Risco Arming Mode |
+|---|---|
+| Arm Away | Arm |
+| Arm Home | Partial Arm |
+
 Currently supported plaforms:
 - [Alarm Control Panel](/integrations/alarm_control_panel/)
 - [Binary Sensor](/integrations/binary_sensor/)

--- a/source/_integrations/risco.markdown
+++ b/source/_integrations/risco.markdown
@@ -49,8 +49,8 @@ This is a two-way mapping, meaning you can map:
 The default mapping:
 |Risco Arming Mode | Home Assistant State |
 |---|---|
-| Arm | Armed Away |
-| Partial Arm | Armed Home |
+| Arm (AWAY) | Armed Away |
+| Partial Arm (STAY) | Armed Home |
 | Group A | Armed Home |
 | Group B | Armed Home |
 | Group C | Armed Home |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add custom mapping documentation to Risco.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39218
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
