### PR TITLE
opengarage docs - made the previously template sensor based garage_car_present a template binary_sensor

### DIFF
--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -119,7 +119,7 @@ binary_sensor:
       availability_template: >-
         {% raw %} {{ state_attr('cover.honda', 'door_state') == 'closed' }} {% endraw %}
       icon_template: >-
-        {% if is_state('binary_sensor.prius_in_garage','on') %} mdi:car
+        {% if is_state('binary_sensor.honda_in_garage','on') %} mdi:car
         {% else %} mdi:car-arrow-right
         {% endif %}
       unique_id: binary_sensor.honda_in_garage

--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -115,9 +115,9 @@ binary_sensor:
     honda_in_garage:
       friendly_name: "Honda in Garage"
       value_template: >-
-        {{ state_attr('cover.honda', 'distance_sensor') < 100 }}
+        {% raw %} {{ state_attr('cover.honda', 'distance_sensor') < 100 }} {% endraw %}
       availability_template: >-
-        {{ state_attr('cover.honda', 'door_state') == 'closed' }}
+        {% raw %} {{ state_attr('cover.honda', 'door_state') == 'closed' }} {% endraw %}
       unique_id: binary_sensor.honda_in_garage
 
 group:
@@ -135,5 +135,3 @@ customize:
   sensor.garage_car_present:
     icon: mdi:car
 ```
-
-{% endraw %}

--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -113,11 +113,14 @@ binary_sensor:
   platform: template
   sensors:
     honda_in_garage:
-      friendly_name: "Honda in Garage"
-      value_template: >-
-        {% raw %} {{ state_attr('cover.honda', 'distance_sensor') < 100 }} {% endraw %}
+      friendly_name: "Honda In Garage"
+      value_template: "{{ state_attr('cover.honda', 'distance_sensor') < 100 }}"
       availability_template: >-
-        {{ state_attr('cover.honda', 'door_state') == 'closed' }}
+        {%- if is_state('cover.honda','closed') -%}
+          true
+        {%- else -%}
+          unavailable
+        {%- endif -%}
       icon_template: >-
         {%- if is_state('binary_sensor.honda_in_garage','on') -%}
           mdi:car
@@ -125,6 +128,8 @@ binary_sensor:
           mdi:car-arrow-right
         {%- endif -%}
       unique_id: binary_sensor.honda_in_garage
+      delay_on: 5
+      delay_off: 5
 
 group:
   garage:

--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -118,6 +118,10 @@ binary_sensor:
         {% raw %} {{ state_attr('cover.honda', 'distance_sensor') < 100 }} {% endraw %}
       availability_template: >-
         {% raw %} {{ state_attr('cover.honda', 'door_state') == 'closed' }} {% endraw %}
+      icon_template: >-
+        {% if is_state('binary_sensor.prius_in_garage','on') %} mdi:car
+        {% else %} mdi:car-arrow-right
+        {% endif %}
       unique_id: binary_sensor.honda_in_garage
 
 group:
@@ -132,6 +136,4 @@ customize:
   cover.honda:
     friendly_name: Honda
     entity_picture: /local/honda.gif
-  sensor.garage_car_present:
-    icon: mdi:car
 ```

--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -109,24 +109,25 @@ sensor:
           {% else %}
           n/a
           {% endif %}'{% endraw %}
+
 binary_sensor:
   platform: template
   sensors:
     honda_in_garage:
       friendly_name: "Honda In Garage"
-      value_template: "{{ state_attr('cover.honda', 'distance_sensor') < 100 }}"
+      value_template: {% raw %}"{{ state_attr('cover.honda', 'distance_sensor') < 100 }}"{% endraw %}
       availability_template: >-
-        {%- if is_state('cover.honda','closed') -%}
+        {% raw %}{% if is_state('cover.honda','closed') %}
           true
-        {%- else -%}
+        {% else %}
           unavailable
-        {%- endif -%}
+        {% endif %}{% endraw %}
       icon_template: >-
-        {%- if is_state('binary_sensor.honda_in_garage','on') -%}
+        {% raw %}{% if is_state('binary_sensor.honda_in_garage','on') %}
           mdi:car
-        {%- else -%}
+        {% else %}
           mdi:car-arrow-right
-        {%- endif -%}
+        {% endif %}{% endraw %}
       unique_id: binary_sensor.honda_in_garage
       delay_on: 5
       delay_off: 5

--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -79,6 +79,8 @@ covers:
   <img src='{{site_root}}/images/integrations/opengarage/cover_opengarage_details.jpg' />
 </p>
 
+{% raw %}
+
 ```yaml
 # Related configuration.yaml entry
 cover:
@@ -94,7 +96,7 @@ sensor:
   sensors:
     garage_status:
       friendly_name: 'Honda Door Status'
-      value_template: {% raw %}'{% if states.cover.honda %}
+      value_template: '{% if states.cover.honda %}
           {% if states.cover.honda.attributes["door_state"] == "open" %}
             Open
           {% elif states.cover.honda.attributes["door_state"] == "closed" %}
@@ -108,26 +110,26 @@ sensor:
           {% endif %}
           {% else %}
           n/a
-          {% endif %}'{% endraw %}
+          {% endif %}'
 
 binary_sensor:
   platform: template
   sensors:
     honda_in_garage:
       friendly_name: "Honda In Garage"
-      value_template: {% raw %}"{{ state_attr('cover.honda', 'distance_sensor') < 100 }}"{% endraw %}
+      value_template: "{{ state_attr('cover.honda', 'distance_sensor') < 100 }}"
       availability_template: >-
-        {% raw %}{% if is_state('cover.honda','closed') %}
+        {% if is_state('cover.honda','closed') %}
           true
         {% else %}
           unavailable
-        {% endif %}{% endraw %}
+        {% endif %}
       icon_template: >-
-        {% raw %}{% if is_state('binary_sensor.honda_in_garage','on') %}
+        {% if is_state('binary_sensor.honda_in_garage','on') %}
           mdi:car
         {% else %}
           mdi:car-arrow-right
-        {% endif %}{% endraw %}
+        {% endif %}
       unique_id: binary_sensor.honda_in_garage
       delay_on: 5
       delay_off: 5
@@ -145,3 +147,5 @@ customize:
     friendly_name: Honda
     entity_picture: /local/honda.gif
 ```
+
+{% endraw %}

--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -109,19 +109,16 @@ sensor:
           {% else %}
           n/a
           {% endif %}'{% endraw %}
-    garage_car_present:
-      friendly_name: 'Honda in Garage'
-      value_template: {% raw %}'{% if states.cover.honda %}
-          {% if is_state("cover.honda", "open") %}
-            n/a
-          {% elif ((states.cover.honda.attributes["distance_sensor"] > 40) and (states.cover.honda.attributes["distance_sensor"] < 100)) %}
-            Yes
-          {% else %}
-            No
-          {% endif %}
-          {% else %}
-          n/a
-          {% endif %}'
+binary_sensor:
+  platform: template
+  sensors:
+    honda_in_garage:
+      friendly_name: "Honda in Garage"
+      value_template: >-
+        {{ state_attr('cover.honda', 'distance_sensor') < 100 }}
+      availability_template: >-
+        {{ state_attr('cover.honda', 'door_state') == 'closed' }}
+      unique_id: binary_sensor.honda_in_garage
 
 group:
   garage:

--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -117,11 +117,13 @@ binary_sensor:
       value_template: >-
         {% raw %} {{ state_attr('cover.honda', 'distance_sensor') < 100 }} {% endraw %}
       availability_template: >-
-        {% raw %} {{ state_attr('cover.honda', 'door_state') == 'closed' }} {% endraw %}
+        {{ state_attr('cover.honda', 'door_state') == 'closed' }}
       icon_template: >-
-        {% if is_state('binary_sensor.honda_in_garage','on') %} mdi:car
-        {% else %} mdi:car-arrow-right
-        {% endif %}
+        {%- if is_state('binary_sensor.honda_in_garage','on') -%}
+          mdi:car
+        {%- else -%}
+          mdi:car-arrow-right
+        {%- endif -%}
       unique_id: binary_sensor.honda_in_garage
 
 group:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Changed the previously documented method of detecting a car's presence in garage from a 'sensor' to a 'binary_sensor' so that the status can be used for automations more easily.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

When a car is in the garage, binary_sensor is on, when a car is not in the garage, binary_sensor is off, when the garage door is opened, binary_sensor reports unavailable (similar to previously documented behaviour).
![image](https://user-images.githubusercontent.com/12470297/91260939-fe9b3180-e7b2-11ea-9b1f-cee5b15bc884.png)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
