### PR TITLE
Clarified path to .storage when mounting SD card

### DIFF
--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -57,8 +57,8 @@ You will then be at the Home Assistant CLI, where you can run the custom command
 
 ### Remove the SD and access the files from another computer
 
-The files are on an EXT4 partition (`hassos-data`) and the path is `/mnt/data/supervisor`.
-These are easily accessed using another Linux machine with EXT support.
+On linux, the files are easily accessed. Modern distributions will automagically mount the partitions from the SD card.  As an
+example, in ubuntu, the files can be found in `/media/<username>//hassos-data/supervisor/homeassistant/.storage/'
 
 For Windows or macOS you will need third party software. Below are some options.
 

--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -58,7 +58,7 @@ You will then be at the Home Assistant CLI, where you can run the custom command
 ### Remove the SD and access the files from another computer
 
 On linux, the files are easily accessed. Modern distributions will automagically mount the partitions from the SD card.  As an
-example, in ubuntu, the files can be found in `/media/<username>//hassos-data/supervisor/homeassistant/.storage/'
+example, in ubuntu, the files can be found in `/media/<username>/hassos-data/supervisor/homeassistant/.storage/'
 
 For Windows or macOS you will need third party software. Below are some options.
 


### PR DESCRIPTION
## Proposed change

Clarified path to the .storage directly when mounting the SD card on another linux box.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
