### PR TITLE
Updating gogogate2 documentation to include ismartgate.

### DIFF
--- a/source/_integrations/gogogate2.markdown
+++ b/source/_integrations/gogogate2.markdown
@@ -6,6 +6,10 @@ ha_category:
   - Cover
 ha_release: 0.67
 ha_iot_class: Local Polling
+ha_domain: gogogate2
+ha_codeowners:
+  - '@vangorra'
+ha_config_flow: true
 ---
 
 The `gogogate2` cover platform lets you control Gogogate2 and iSmartGate enabled garage doors and gates through Home Assistant. Device names in Home Assistant are generated based on the names defined in the GogoGate2 or iSmartGate mobile app.

--- a/source/_integrations/gogogate2.markdown
+++ b/source/_integrations/gogogate2.markdown
@@ -1,24 +1,16 @@
 ---
-title: Gogogate2
-description: Instructions on how to integrate Gogogate2-Enabled garage door covers into Home Assistant.
+title: "Gogogate2 and iSmartGate Cover"
+description: "Instructions on how to integrate Gogogate2 and iSmartGate enabled garage door covers into Home Assistant."
 logo: gogogate2.png
 ha_category:
   - Cover
 ha_release: 0.67
 ha_iot_class: Local Polling
-ha_domain: gogogate2
-ha_codeowners:
-  - '@vangorra'
-ha_config_flow: true
 ---
 
-The GogoGate2 integration lets you control Gogogate2-Enabled garage doors through Home Assistant. Device names in Home Assistant are generated based on the names defined in your Gogogate2 mobile app.
+The `gogogate2` cover platform lets you control Gogogate2 and iSmartGate enabled garage doors and gates through Home Assistant. Device names in Home Assistant are generated based on the names defined in the GogoGate2 or iSmartGate mobile app.
 
 ## Configuration
 
-<div class='note'>
-It is recommended to assign a static IP address to your GogoGate device. This ensures that it won't change IP addresses, so you won't have to change the configuration if it reboots and comes up with a different IP address. See your router's manual for details on how to set this up. If you need the MAC address of your GogoGate2, check the label on the bottom.
-</div>
-
-1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'GogoGate2' and click 'Configure'.
-2. Enter the IP address, username, password and name for the device and click 'Submit'.
+1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'GogoGate2 or iSmartGate' and click 'Configure'.
+2. Enter the information appropriate for the server and click 'Submit'.


### PR DESCRIPTION
Removing configuration.yaml section as UI config is the preferred method.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updating gogogate2 documentation to include ismartgate.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39437
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
