### PR TITLE
Document the recorder db_integrity_check option

### DIFF
--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -47,6 +47,11 @@ recorder:
       required: false
       default: 3
       type: integer
+    db_integrity_check:
+      description: When using sqlite, if Home Assistant is not restarted cleanly or the recorder fails to shutdown, a `quick_check` is performed on the database to ensure it is usable. If you disable `db_integrity_check`, only basic sanity checks will be performed, and the `quick_check` will be skipped. It is recommended that you keep this check enabled, as Home Assistant will not be able to automatically recover and startup the recorder in the event the the database is malformed.
+      required: false
+      default: True
+      type: boolean      
     auto_purge:
       description: Automatically purge the database every night at 04:12 local time. Purging keeps the database from growing indefinitely, which takes up disk space and can make Home Assistant slow. If you disable `auto_purge` it is recommended that you create an automation to call the [`recorder.purge`](#service-purge) periodically.
       required: false

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -48,7 +48,7 @@ recorder:
       default: 3
       type: integer
     db_integrity_check:
-      description: When using SQLite, if Home Assistant does not restart cleanly or the recorder fails to shut down, a `quick_check` is performed on the database to ensure it is usable. If `db_integrity_check` is disabled, the system will only perform necessary sanity checks and skip the `quick_check`. Home Assistant will not be able to automatically recover and start the recorder in the event the database is malformed if `db_integrity_check` is disabled.
+      description: When using SQLite, if Home Assistant does not restart cleanly or the recorder fails to shut down, a `quick_check` is performed on the database to ensure it is usable. If `db_integrity_check` is disabled, the system will only perform necessary sanity checks and skip the `quick_check`. Home Assistant may not be able to automatically recover and start the recorder in the event the database is malformed if `db_integrity_check` is disabled.
       required: false
       default: true
       type: boolean      

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -48,7 +48,7 @@ recorder:
       default: 3
       type: integer
     db_integrity_check:
-      description: When using sqlite, if Home Assistant is not restarted cleanly or the recorder fails to shutdown, a `quick_check` is performed on the database to ensure it is usable. If you disable `db_integrity_check`, only basic sanity checks will be performed, and the `quick_check` will be skipped. It is recommended that you keep this check enabled, as Home Assistant will not be able to automatically recover and startup the recorder in the event the the database is malformed.
+      description: When using SQLite, if Home Assistant does not restart cleanly or the recorder fails to shut down, a `quick_check` is performed on the database to ensure it is usable. If `db_integrity_check` is disabled, the system will only perform necessary sanity checks and skip the `quick_check`. Home Assistant will not be able to automatically recover and start the recorder in the event the database is malformed if `db_integrity_check` is disabled.
       required: false
       default: True
       type: boolean      

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -50,7 +50,7 @@ recorder:
     db_integrity_check:
       description: When using SQLite, if Home Assistant does not restart cleanly or the recorder fails to shut down, a `quick_check` is performed on the database to ensure it is usable. If `db_integrity_check` is disabled, the system will only perform necessary sanity checks and skip the `quick_check`. Home Assistant will not be able to automatically recover and start the recorder in the event the database is malformed if `db_integrity_check` is disabled.
       required: false
-      default: True
+      default: true
       type: boolean      
     auto_purge:
       description: Automatically purge the database every night at 04:12 local time. Purging keeps the database from growing indefinitely, which takes up disk space and can make Home Assistant slow. If you disable `auto_purge` it is recommended that you create an automation to call the [`recorder.purge`](#service-purge) periodically.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the recorder db_integrity_check option

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39479
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/38973

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
