### PR TITLE
Include new `attribute` parameter for Numeric State triggers in automation docs

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -72,7 +72,7 @@ automation:
     below: 25
     # If given, will trigger when the value of the given attribute for the given entity changes
     attribute: attribute_name
-    # If given, will trigger when the condition has been for X time; you can also use days and milliseconds.
+    # If given, will trigger when the condition has been true for X time; you can also use days and milliseconds.
     for:
       hours: 1
       minutes: 10

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -56,7 +56,7 @@ automation:
 
 ### Numeric state trigger
 
-Fires when numeric value of an entity's state crosses a given threshold. On state change of a specified entity, attempts to parse the state as a number and fires if value is changing from above to below or from below to above the given threshold.
+Fires when numeric value of an entity's state (or attribute if using the `attribute` property) crosses a given threshold. On state change of a specified entity, attempts to parse the state as a number and fires if value is changing from above to below or from below to above the given threshold.
 
 {% raw %}
 
@@ -70,7 +70,8 @@ automation:
     # At least one of the following required
     above: 17
     below: 25
-
+    # If given, will trigger when value of attribute for given entity changes
+    attribute: attribute_name
     # If given, will trigger when condition has been for X time, can also use days and milliseconds.
     for:
       hours: 1

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -56,7 +56,7 @@ automation:
 
 ### Numeric state trigger
 
-Fires when numeric value of an entity's state (or attribute if using the `attribute` property) crosses a given threshold. On state change of a specified entity, attempts to parse the state as a number and fires if value is changing from above to below or from below to above the given threshold.
+Fires when the numeric value of an entity's state (or attribute if using the `attribute` property) crosses a given threshold. On state change of a specified entity, attempts to parse the state as a number and fires if the value is changing from above to below or from below to above the given threshold.
 
 {% raw %}
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -70,9 +70,9 @@ automation:
     # At least one of the following required
     above: 17
     below: 25
-    # If given, will trigger when value of attribute for given entity changes
+    # If given, will trigger when the value of the given attribute for the given entity changes
     attribute: attribute_name
-    # If given, will trigger when condition has been for X time, can also use days and milliseconds.
+    # If given, will trigger when the condition has been for X time; you can also use days and milliseconds.
     for:
       hours: 1
       minutes: 10

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -56,7 +56,7 @@ automation:
 
 ### Numeric state trigger
 
-Fires when the numeric value of an entity's state (or attribute if using the `attribute` property) crosses a given threshold. On state change of a specified entity, attempts to parse the state as a number and fires if the value is changing from above to below or from below to above the given threshold.
+Fires when the numeric value of an entity's state (or attribute's value if using the `attribute` property) crosses a given threshold. On state change of a specified entity, attempts to parse the state as a number and fires if the value is changing from above to below or from below to above the given threshold.
 
 {% raw %}
 


### PR DESCRIPTION
## Proposed change
home-assistant/core#39238 added a new `attribute` parameter for `numeric_state` triggers. This PR updates the docs to reflect that change.

Note - I did not create the parent PR, just adding the documentation for it



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#39238

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
