### PR TITLE
Salex sun patch 1

### DIFF
--- a/source/_docs/frontend/browsers.markdown
+++ b/source/_docs/frontend/browsers.markdown
@@ -68,7 +68,7 @@ There are reports that devices running with iOS prior to iOS 10, especially old 
 
 | Browser               | Release        | State      | Comments                 |
 | :-------------------- |:---------------|:-----------|:-------------------------|
-| [LG webOS TV Built-in]| 2019-2020      | fails      | loads empty page         |
+| [LG webOS TV Built-in]| webOSv04.80.03 | words      | including magic remote   |
 
 [Chrome]: https://www.google.com/chrome/
 [Chromium]: https://www.chromium.org/

--- a/source/_docs/frontend/browsers.markdown
+++ b/source/_docs/frontend/browsers.markdown
@@ -68,7 +68,7 @@ There are reports that devices running with iOS prior to iOS 10, especially old 
 
 | Browser               | Release        | State      | Comments                 |
 | :-------------------- |:---------------|:-----------|:-------------------------|
-| [LG webOS TV Built-in]| webOSv04.80.03 | words      | including magic remote   |
+| [LG webOS TV Built-in]| webOS 04.80.03 | works      | including magic remote   |
 
 [Chrome]: https://www.google.com/chrome/
 [Chromium]: https://www.chromium.org/
@@ -89,4 +89,4 @@ There are reports that devices running with iOS prior to iOS 10, especially old 
 [Uzbl]: https://www.uzbl.org/
 [w3m]: http://w3m.sourceforge.net/
 [Waterfox]: https://www.waterfoxproject.org
-[LG webOS TV Built-In]: https://www.lg.com/uk/support/solutions/tv/smart-tv/internet-browsing
+[LG webOS TV Built-In]: https://www.lg.com/uk/support/help-library/details-on-enjoying-internet-browsing-on-your-lg-webos-tv-CT00008334-1435838149474


### PR DESCRIPTION
Update state for support of LG webOS built-in browser

## Proposed change
Update the state for the browser support on LG webOS built-in browser. The state is changed from FAILS to WORKS. Works very well on my personal LG OLED C9, software version 04.80.03 (latest). As far as I can tell there is no separate software version for the build in browser.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
This is my first PR on github. Let me know if anything can be improved

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant.io/blob/current/source/_docs/frontend/browsers.markdown  
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: -

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
