### PR TITLE
Describe new Plex play_media syntax for movies

### DIFF
--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -127,20 +127,49 @@ media_content_type: EPISODE
 media_content_id: '{ "library_name": "Kid TV", "show_name": "Sesame Street", "shuffle": "1" }'
 ```
 
-#### Video
+#### Movie
 
 | Service data attribute | Description                                                                                             |
 | ---------------------- | ------------------------------------------------------------------------------------------------------- |
 | `entity_id`            | `entity_id` of the client                                                                               |
-| `media_content_id`     | Quoted JSON containing:<br/><ul><li>`library_name` (Required)</li><li>`video_name` (Required)</li></ul> |
-| `media_content_type`   | `VIDEO`                                                                                                 |
+| `media_content_id`     | Quoted JSON containing:<br/><ul><li>`library_name` (Required)</li><li>`title` (Required)</li><li>`<SEARCH_KEY>` (optional)</li></ul> |
+| `media_content_type`   | `movie`                                                                                                 |
 
-##### Example:
+For movies it's usually sufficient to provide the title. However, if the title you provide has multiple matches (such as with remakes), more search keys may be necessary. These optional keys can be included in the `media_content_id` JSON payload to restrict the search:
+
+* `unwatched`: Restrict search to unwatched items only (`True`, `False`)
+* `actor`: Restrict search for movies that include a specific actor
+* `collection`: Restrict search within a named Plex collection ("Back to the Future", "Indiana Jones")
+* `contentRating`: Restrict search to a specific content rating ("PG", "R")
+* `country`: Restrict search to a specific country of origin
+* `decade`: Restrict search to a specific decade ("1960", "2010")
+* `director`: Restrict search to a specific director
+* `genre`: Restrict search to a specific genre ("Animation", "Drama", "Sci-Fi")
+* `resolution`: Restrict search to a specific video resolution (480, 720, 1080, "4k")
+* `year`: Restrict search to a specific year
+
+##### Examples:
 ```yaml
 entity_id: media_player.plex_player
-media_content_type: VIDEO
-media_content_id: '{ "library_name": "Adult Movies", "video_name": "Blade" }'
+media_content_type: movie
+media_content_id: '{ "library_name": "Adult Movies", "title": "Blade" }'
 ```
+
+```yaml
+entity_id: media_player.plex_player
+media_content_type: movie
+media_content_id: '{ "library_name": "Adult Movies", "title": "The Manchurian Candidate", year=1962 }'
+# Would find the original instead of the 2004 remake
+```
+
+"Lazy" searches are also possible:
+```yaml
+entity_id: media_player.plex_player
+media_content_type: movie
+media_content_id: '{ "library_name": "Adult Movies", "title": "die hard", year=1995 }'
+# Would find the sequel, "Die Hard: With a Vengeance"
+```
+
 
 ### Compatibility
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updates the docs to reflect the new service syntax for Plex `media_player.play_media` calls as they relate to movies.

The legacy "VIDEO" lookup method will still work for compatibility purposes, but the documentation should reflect the current recommended method instead.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39584
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
