### PR TITLE
Fix I2C documentation

### DIFF
--- a/source/hassio/enable_i2c.markdown
+++ b/source/hassio/enable_i2c.markdown
@@ -17,7 +17,7 @@ You will need:
 ### Step 1 - Access the Home Assistant OS boot partition
 
 Shutdown/turn-off your Home Assistant installation and unplug the SD card.
-Plug the SD card into a SD card reader and find a drive/file system named
+Plug the SD card into an SD card reader and find a drive/file system named
 `hassos-boot`. The file system might be shown/mounted automatically. If not,
 use your operating systems disk management utility to find the SD card reader
 and make sure the first partition is available.

--- a/source/hassio/enable_i2c.markdown
+++ b/source/hassio/enable_i2c.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Enable I2C on the Home Assistant Operating System"
-description: "Instructions on how to enable I2C on a Raspberry PI"
+description: "Instructions on how to enable I2C on a Raspberry Pi"
 ---
 
 Home Assistant using the Home Assistant Operating System is a managed environment, which means you can't use existing methods to enable the I2C bus on a Raspberry Pi.
@@ -11,35 +11,38 @@ If you're attempting to add an external sensor you will have to [enable the I2C 
 
 You will need:
 
-- USB drive
-- A way to add files to the USB drive
-- A way to connect the drive to your Raspberry Pi
+- SD card reader
+- SD card with Home Assistant Operating System flashed on it
 
-### Step 1 - Prepare the USB drive
+### Step 1 - Access the Home Assistant OS boot partition
 
-Connect the USB drive to a device capable of adding and editing files to the USB drive.
-
-Format a USB stick with FAT32/EXT4/NTFS and name the drive `CONFIG` (uppercase).
+Shutdown/turn-off your Home Assistant installation and unplug the SD card.
+Plug the SD card into a SD card reader and find a drive/file system named
+`hassos-boot`. The file system might be shown/mounted automatically. If not,
+use your operating systems disk management utility to find the SD card reader
+and make sure the first partition is available.
 
 ### Step 2 - Add files to enable I2C
 
-- In the root of the USB drive add a folder called `/modules`.
-- Inside that folder add a text file called `rpi-i2c.conf` with the following contents:
+- In the root of the `hassos-boot` partition, add a new folder called `CONFIG`.
+- In the `CONFIG` folder, add another new folder called `modules`.
+- Inside the `modules` folder add a text file called `rpi-i2c.conf` with the following content:
   ```txt
-  i2c-bcm2708
   i2c-dev
   ```
-- In the root of the USB drive add a file called `config.txt` with the following contents:
+- In the root of the USB drive edit the file called `config.txt` add two lines
+  to it:
   ```txt
-  dtparam=i2c1=on 
+  dtparam=i2c_vc=on
   dtparam=i2c_arm=on
   ```
 
-### Step 3 - Load the new USB configuration
+### Step 3 - Start with the new configuration
 
-- Insert the USB drive into your Raspberry Pi.
-- Now go to your Home Assistant web interface, in the sidebar click **Supervisor** > **System**.
-- Now click `Import from USB`.
-- This will restart your Home Assistant instance, and load the new USB configuration.
+- Insert the SD card back into your Raspberry Pi.
+- On startup, the `hassos-config.service` will automatically pickup the new
+  `rpi-i2c.conf` configuration.
+- Another reboot might be necessary to make sure the just imported `rpi-i2c.conf` is
+  present at boot time.
 
-When the service has restarted, you will have a working I2C interface.
+The I2C devices should now be present under /dev.


### PR DESCRIPTION
## Proposed change

There is no support of updating `config.txt` via `CONFIG` USB flash drive.
Document how to find the `hassos-boot` partition to configure `config.txt`
directly on it and use the `hassos-boot` config method.

Also, instead of using i2c1 use the preferred (according to RPi
documenation) name `i2c_vc`.

Adresses https://github.com/home-assistant/operating-system/issues/825

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/operating-system/issues/825

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
