### PR TITLE
Homepage hero styles

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -50,7 +50,6 @@ $primary-color: #049cdb;
 }
 
 .hero {
-  background-color: #038FC7;
   padding-bottom: 0;
 
   .lead {
@@ -58,7 +57,6 @@ $primary-color: #049cdb;
   }
 
   .hero-buttons a {
-    color: white;
     text-transform: uppercase;
     white-space: nowrap;
     display: inline-block;

--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -54,6 +54,7 @@ $primary-color: #049cdb;
 
   .lead {
     margin-bottom: 16px;
+    color: $gray;
   }
 
   .hero-buttons a {

--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -5,7 +5,6 @@
      -moz-background-size: cover;
        -o-background-size: cover;
           background-size: cover;
-  border-bottom: 1px solid $white;
   color: $white;
   margin-top: -2em;
   margin-bottom: 1.5em;
@@ -71,5 +70,9 @@
       color: $grayLighter;
       font-size: .65em;
     }
+  }
+
+  img {
+    display: block;
   }
 }

--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -67,5 +67,7 @@
 
   img {
     display: block;
+    max-width: 80%;
+    margin: 0 auto;
   }
 }

--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -56,7 +56,6 @@
   h1 {
     font-size: 3.5em;
     line-height: 1em;
-    text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.75);
   }
 
   hr {
@@ -65,7 +64,6 @@
   }
 
   p {
-    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.75);
     small {
       color: $grayLighter;
       font-size: .65em;

--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -1,15 +1,10 @@
 .hero {
-  background-color: rgb(11, 107, 148);
-  background-position: 0 50%;
-  -webkit-background-size: cover;
-     -moz-background-size: cover;
-       -o-background-size: cover;
-          background-size: cover;
-  color: $white;
+  background-color: $white;
   margin-top: -2em;
   margin-bottom: 1.5em;
   padding: 50px 0;
   position: relative;
+  box-shadow: 0 3px 3px rgba(0,0,0,0.05);
 
   // &::before {
   //   background: url("../images/matrix.png") 0 0 rgba(0, 0, 0, 0.35);

--- a/sass/oscailte/homepage/_hero_unit.scss
+++ b/sass/oscailte/homepage/_hero_unit.scss
@@ -70,4 +70,20 @@
     max-width: 80%;
     margin: 0 auto;
   }
+
+  .hero-button-primary {
+    border-radius: 3px;
+    background: $button-color;
+    color: $button-text;
+    padding: .75rem 2rem;
+    text-decoration: none;
+    opacity: .9;
+    margin: 0 0 1rem;
+    &:hover {
+      opacity: 1;
+    }
+    &:active {
+      background: $button-color;
+    }
+  }
 }

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -1,6 +1,6 @@
- <h1>Awaken your home</h1>
- <p class="lead">
-Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts. Perfect to run on a Raspberry Pi or a local server.
+<h1>Awaken your home</h1>
+<p class="lead">
+  Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts. Perfect to run on a Raspberry Pi or a local server.
 </p>
 
 <p class='hero-buttons'>

--- a/source/_includes/custom/welcome.html
+++ b/source/_includes/custom/welcome.html
@@ -4,7 +4,8 @@
 </p>
 
 <p class='hero-buttons'>
-  <a href='/getting-started/'>Get started</a>
+  <a class='hero-button-primary' href='/getting-started/'>Get started</a>
+  <br/>
   <a href='https://demo.home-assistant.io' target='_blank'>View demo</a>
   <a rel="me" href='https://github.com/home-assistant/home-assistant'>Browse code on GitHub</a>
 </p>

--- a/source/_includes/site/hero_unit.html
+++ b/source/_includes/site/hero_unit.html
@@ -1,12 +1,12 @@
 <div class="hero">
   <div class="grid-wrapper">
     <div class="grid flex">
-      <div class="grid__item flex__item two-fifths palm-one-whole">
+      <div class="grid__item flex__item one-half palm-one-whole">
         <a href='https://demo.home-assistant.io/' target='_blank'>
           <img src="/images/hero_screenshot.png" alt="Home Assistant screenshot">
         </a>
       </div>
-      <div class="grid__item flex__item three-fifths palm-one-whole">
+      <div class="grid__item flex__item one-half palm-one-whole">
       {% include custom/welcome.html %}
       </div>
     </div>


### PR DESCRIPTION
## Proposed change
When I was checking out the HA website for the first time, my first impression was that HA is simple and powerful--but a bit dated, and not particularly user friendly.

After watching the State of the Union and seeing all the hard work that goes into the usability of HA, I realized that's not true--and I wanted the website look to reflect all that effort!

## Type of change

I tweaked the visual style of the hero on the homepage, fixed [the issue with the space under the image](https://github.com/home-assistant/home-assistant.io/pull/9745#issuecomment-507205178), and emphasized the primary call-to-action.

### Before...

![before](https://user-images.githubusercontent.com/231851/92314054-b644f600-efa0-11ea-92db-68dcae0e7fe9.png)


### After...

![after](https://user-images.githubusercontent.com/231851/92314055-b93fe680-efa0-11ea-967b-8624a5336f9b.png)



- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

n/a

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
