### PR TITLE
Update zha.markdown to clarify Z-Stack 3.x.x vs Z-Stack Home 1.2.x

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -101,12 +101,12 @@ a new pop-up asking for a radio type. In the pop-up:
 
 | Radio Type | Zigbee Radio Hardware |
 | ------------- | ------------- |
-| `ezsp`  | Silicon Labs EmberZNet protocol (e.g. Elelabs, HUSBZB-1, Telegesis) |
-| `deconz` | dresden elektronik deCONZ protocol (e.g. ConBee I/II, RaspBee I/II) |
-| `znp` | Texas Instruments new (active): Z-Stack 3.x.x ZNP protocol (e.g. CC26x2, CC13x2) |
-| `ti_cc` | Texas Instruments legacy & HA12: Z-Stack Home 1.2.x ZNP protocol (e.g. CC253x) |
-| `zigate` | ZiGate Serial protocol (e.g. ZiGate USB-TTL, PiZiGate, ZiGate WiFi) |
-| `xbee` | Digi XBee ZB Coordinator Firmware protocol (e.g. Digi XBee Series 2, 2C, 3) |
+| `ezsp`  | Silicon Labs EmberZNet protocol (e.g., Elelabs, HUSBZB-1, Telegesis) |
+| `deconz` | dresden elektronik deCONZ protocol (e.g., ConBee I/II, RaspBee I/II) |
+| `znp` | Texas Instruments new (active): Z-Stack 3.x.x ZNP protocol (e.g., CC26x2, CC13x2) |
+| `ti_cc` | Texas Instruments legacy & HA12: Z-Stack Home 1.2.x ZNP protocol (e.g., CC253x) |
+| `zigate` | ZiGate Serial protocol (e.g., ZiGate USB-TTL, PiZiGate, ZiGate WiFi) |
+| `xbee` | Digi XBee ZB Coordinator Firmware protocol (e.g., Digi XBee Series 2, 2C, 3) |
 
 - Submit
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -101,12 +101,12 @@ a new pop-up asking for a radio type. In the pop-up:
 
 | Radio Type | Zigbee Radio Hardware |
 | ------------- | ------------- |
-| `ezsp`  | Silicon Labs EmberZNet protocol (ex; Elelabs, HUSBZB-1, Telegesis) |
-| `deconz` | dresden elektronik deCONZ protocol: ConBee I/II, RaspBee I/II |
-| `znp` | Actively maintained: Texas Instruments Z-Stack ZNP protocol (ex: CC253x, CC26x2, CC13x2) |
-| `ti_cc` | Legacy & HA12 ZStack Texas Instruments Z-Stack ZNP protocol (ex: CC253x, CC26x2, CC13x2) |
-| `zigate` | ZiGate Serial protocol: PiZiGate, ZiGate USB-TTL, ZiGate WiFi |
-| `xbee` | Digi XBee ZB Coordinator Firmware protocol (Digi XBee Series 2, 2C, 3) |
+| `ezsp`  | Silicon Labs EmberZNet protocol (e.g. Elelabs, HUSBZB-1, Telegesis) |
+| `deconz` | dresden elektronik deCONZ protocol (e.g. ConBee I/II, RaspBee I/II) |
+| `znp` | Texas Instruments new (active): Z-Stack 3.x.x ZNP protocol (e.g. CC26x2, CC13x2) |
+| `ti_cc` | Texas Instruments legacy & HA12: Z-Stack Home 1.2.x ZNP protocol (e.g. CC253x) |
+| `zigate` | ZiGate Serial protocol (e.g. ZiGate USB-TTL, PiZiGate, ZiGate WiFi) |
+| `xbee` | Digi XBee ZB Coordinator Firmware protocol (e.g. Digi XBee Series 2, 2C, 3) |
 
 - Submit
 


### PR DESCRIPTION
## Proposed change

Update zha.markdown to clarify radio type Z-Stack 3.x.x verses Z-Stack Home 1.2.x Zigbee stack + a few e.g. nitpick for `next` branch.

This is as such just a very small correction to https://github.com/home-assistant/home-assistant.io/pull/14410 by @Adminiuga  These type of clarifications will be needed now that there is an alternative zigpy radio library for Texas Instruments radios with zigpy-znp with https://github.com/home-assistant/core/pull/39700 from @puddly

Hopefully, this will make it a little easier to understand that `znp` radio type can only be used with Texas Instruments "Z-Stack 3.x.x" (and that the `znp` radio type does not support "Z-Stack Home 1.2.x"), while the `ti_cc` radio type can today technically be used with either "Z-Stack 3.x.x" or "Z-Stack Home 1.2.x" but only the latter should be used in new configurations.

## Type of change
- [x] Spelling, grammar or other readability improvements (`next` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`next` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39700
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
