### PR TITLE
Support 'for' without setting the 'to'-state in automation state trigger

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -158,6 +158,9 @@ automation:
 
 You can use `for` to have the state trigger only fire if the state holds for some time.
 
+This example fires, when the entity state changed to `"on"` and holds that
+state for 30 seconds:
+
 ```yaml
 automation:
   trigger:
@@ -168,14 +171,46 @@ automation:
     for: "00:00:30"
 ```
 
+You can also fire the trigger when the state values changed from a specific
+state, but hasn't returned to that state value for the specified time.
+
+This can be useful, e.g., checking if a media player hasn't turned "off" for
+the time specified, but doesn't care about "playing" or "paused".
+
 ```yaml
 automation:
   trigger:
     platform: state
     entity_id: media_player.kitchen
-    # Not "playing" for 30 seconds
-    from: "playing"
-    for: "00:00:30"
+    # Not "off" for 30 minutes
+    from: "off"
+    for: "00:30:00"
+```
+
+In this example, the trigger fires if the state value of the entity remains the
+same for `for` the time specified, regardless of the current state value.
+
+```yaml
+automation:
+  trigger:
+    platform: state
+    entity_id: media_player.kitchen
+    # The media player remained in its current state for 1 hour
+    for: "01:00:00"
+```
+
+When the `attribute` option is specified, all of the above works, but only
+applies to the specific state value of that attribute.
+
+For example, this trigger only fires if the boiler was heating for 10 minutes:
+
+```yaml
+automation:
+  trigger:
+    platform: state
+    entity_id: climate.living_room
+    attribute: hvac_action
+    state: "heating"
 ```
 
 You can also use templates in the `for` option.

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -171,7 +171,7 @@ automation:
     for: "00:00:30"
 ```
 
-You can also fire the trigger when the state values changed from a specific
+You can also fire the trigger when the state value changed from a specific
 state, but hasn't returned to that state value for the specified time.
 
 This can be useful, e.g., checking if a media player hasn't turned "off" for
@@ -186,6 +186,9 @@ automation:
     from: "off"
     for: "00:30:00"
 ```
+
+Please note, that when using `from`, `to` and `for`, only the value of the
+`to` option is considered for the time specified.
 
 In this example, the trigger fires if the state value of the entity remains the
 same for `for` the time specified, regardless of the current state value.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Support for using `for` automation state triggers without specifying a `to`-state.

Similar to #39480, which implements a `for` when specifying a `from`-state.

WTH Topic: <https://community.home-assistant.io/t/wth-why-can-t-i-use-for-without-defining-a-to-state-in-automations/222137>

I've updated the current documentation with more examples and more extensive descriptions to make the different cases clear.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/39730
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
