### PR TITLE
Jewish calendar docs

### DIFF
--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -49,7 +49,7 @@ candle_lighting_minutes_before_sunset:
   type: integer
 havdalah_minutes_after_sunset:
   required: false
-  description: Number of minutes after sunset to report as havdalah time. If this is set to 0, uses the time that the sun is 8.5 degrees below the horizon (same as the 'three_stars' sensor). If non-zero, this value is added as an offset to the time of sunset to report havdalah.
+  description: Number of minutes after sunset to report as havdalah time. If this is set to 0, uses the time that the sun is 8.5 degrees below the horizon (same as the `t_set_hakochavim` sensor). If non-zero, this value is added as an offset to the time of sunset to report havdalah.
   default: 0
   type: integer
 {% endconfiguration %}
@@ -83,7 +83,7 @@ For easier use in automations, all time sensors have a `timestamp` attribute, wh
 - `shkia`: Sunset (Shkiya - שקיעה)
 - `t_set_hakochavim`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים)
 - `upcoming_shabbat_candle_lighting`: The time of candle lighting for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat.
-- `upcoming_shabbat_havdalah`: The time of havdalah for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat. If it is currently a three-day holiday, this value *could* be None (i.e., if holiday is Sat./Sun./Mon. and it's Saturday, there will be no shabbat_havdalah value. See comments in hdate library for details.)
+- `upcoming_shabbat_havdalah`: The time of havdalah for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat. If it is currently a three-day holiday, this value *could* be None (i.e., if holiday is Sat./Sun./Mon. and it's Saturday, there will be no `shabbat_havdalah` value. See comments in hdate library for details.)
 - `upcoming_candle_lighting`: The time of candle lighting for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the candle lighting for Rosh Hashana on Monday night. This avoids a situation of triggering pre-candle-lighting automations while it is currently Yom Tov. To always get the Shabbat times, use the `upcoming_shabbat_candle_lighting` sensor.
 - `upcoming_havdalah`: The time of havdalah for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the havdalah for Rosh Hashana on Wednesday night. To always get the Shabbat times, use the `upcoming_shabbat_havdalah` sensor.
 

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -98,50 +98,50 @@ The *type_id* is useful for cases to condition automations based on a range of t
 
 The following is the list of holidays the sensor knows about with their selected type:
 
-| ID                   | English                    | Hebrew                | Type                          |
-|----------------------|----------------------------|-----------------------|--------------------------------|
-| erev_rosh_hashana    | Erev Rosh Hashana          | ערב ראש השנה          | EREV_YOM_TOV (2)              |
-| rosh_hashana_i       | Rosh Hashana I             | א' ראש השנה           | YOM_TOV (1)                   |
-| rosh_hashana_ii      | Rosh Hashana II            | ב' ראש השנה           | YOM_TOV (1)                   |
-| tzom_gedaliah        | Tzom Gedaliah              | צום גדליה             | FAST_DAY (5)                  |
-| erev_yom_kippur      | Erev Yom Kippur            | עיוה"כ                | EREV_YOM_TOV (2)              |
-| yom_kippur           | Yom Kippur                 | יום הכפורים           | YOM_TOV (1)                   |
-| erev_sukkot          | Erev Sukkot                | ערב סוכות             | EREV_YOM_TOV (2)              |
-| sukkot               | Sukkot                     | סוכות                 | YOM_TOV (1)                   |
-| hol_hamoed_sukkot    | Hol hamoed Sukkot          | חול המועד סוכות       | HOL_HAMOED (3)                |
-| hoshana_raba         | Hoshana Raba               | הושענא רבה            | EREV_YOM_TOV (2)              |
-| simchat_torah        | Simchat Torah              | שמחת תורה             | YOM_TOV (1)                   |
-| chanukah             | Chanukah                   | חנוכה                 | MELACHA_PERMITTED_HOLIDAY (4) |
-| asara_btevet         | Asara B'Tevet              | צום עשרה בטבת         | FAST_DAY (5)                  |
-| tu_bshvat            | Tu B'Shvat                 | ט"ו בשבט              | MINOR_HOLIDAY (7)             |
-| taanit_esther        | Ta'anit Esther             | תענית אסתר            | FAST_DAY (5)                  |
-| purim                | Purim                      | פורים                 | MELACHA_PERMITTED_HOLIDAY (4) |
-| shushan_purim        | Shushan Purim              | שושן פורים            | MELACHA_PERMITTED_HOLIDAY (4) |
-| erev_pesach          | Erev Pesach                | ערב פסח               | EREV_YOM_TOV (2)              |
-| pesach               | Pesach                     | פסח                   | YOM_TOV (1)                   |
-| hol_hamoed_pesach    | Hol hamoed Pesach          | חול המועד פסח         | HOL_HAMOED (3)                |
-| pesach_vii           | Pesach VII                 | שביעי פסח             | YOM_TOV (1)                   |
-| yom_haatzmaut        | Yom HaAtzma'ut             | יום העצמאות           | MODERN_HOLIDAY (6)            |
-| lag_bomer            | Lag B'Omer                 | ל"ג בעומר             | MINOR_HOLIDAY (7)             |
-| erev_shavuot         | Erev Shavuot               | ערב שבועות            | EREV_YOM_TOV (2)              |
-| shavuot              | Shavuot                    | שבועות                | YOM_TOV (1)                   |
-| tzom_tammuz          | Tzom Tammuz                | צום שבעה עשר בתמוז    | FAST_DAY (5)                  |
-| tisha_bav            | Tish'a B'Av                | תשעה באב              | FAST_DAY (5)                  |
-| tu_bav               | Tu B'Av                    | ט"ו באב               | MINOR_HOLIDAY (7)             |
-| yom_hashoah          | Yom HaShoah                | יום השואה             | MEMORIAL_DAY (8)              |
-| yom_hazikaron        | Yom HaZikaron              | יום הזכרון            | MEMORIAL_DAY (8)              |
-| yom_yerushalayim     | Yom Yerushalayim           | יום ירושלים           | MODERN_HOLIDAY (6)            |
-| shmini_atzeret       | Shmini Atzeret             | שמיני עצרת            | YOM_TOV (1)                   |
-| pesach_viii          | Pesach VIII                | אחרון של פסח          | YOM_TOV (1)                   |
-| shavuot_ii           | Shavuot II                 | שני של שבועות         | YOM_TOV (1)                   |
-| sukkot_ii            | Sukkot II                  | שני של סוכות          | YOM_TOV (1)                   |
-| pesach_ii            | Pesach II                  | שני של פסח            | YOM_TOV (1)                   |
-| family_day           | Family Day                 | יום המשפחה            | ISRAEL_NATIONAL_HOLIDAY (9)   |
-| memorial_day_unknown | Memorial day for fallen whose place of burial is unknown | יום זכרון... | MEMORIAL_DAY (8) |
-| rabin_memorial_day   | Yitzhak Rabin memorial day | יום הזכרון ליצחק רבין | MEMORIAL_DAY (8)              |
-| zeev_zhabotinsky_day | Zeev Zhabotinsky day       | יום ז'בוטינסקי        | MEMORIAL_DAY (8)              |
+| ID                   | English                    | Hebrew                | Type                      | Type ID |
+|----------------------|----------------------------|-----------------------|---------------------------|---------|
+| erev_rosh_hashana    | Erev Rosh Hashana          | ערב ראש השנה          | EREV_YOM_TOV              | 2       |
+| rosh_hashana_i       | Rosh Hashana I             | א' ראש השנה           | YOM_TOV                   | 1       |
+| rosh_hashana_ii      | Rosh Hashana II            | ב' ראש השנה           | YOM_TOV                   | 1       |
+| tzom_gedaliah        | Tzom Gedaliah              | צום גדליה             | FAST_DAY                  | 5       |
+| erev_yom_kippur      | Erev Yom Kippur            | עיוה"כ                | EREV_YOM_TOV              | 2       |
+| yom_kippur           | Yom Kippur                 | יום הכפורים           | YOM_TOV                   | 1       |
+| erev_sukkot          | Erev Sukkot                | ערב סוכות             | EREV_YOM_TOV              | 2       |
+| sukkot               | Sukkot                     | סוכות                 | YOM_TOV                   | 1       |
+| hol_hamoed_sukkot    | Hol hamoed Sukkot          | חול המועד סוכות       | HOL_HAMOED                | 3       |
+| hoshana_raba         | Hoshana Raba               | הושענא רבה            | EREV_YOM_TOV              | 2       |
+| simchat_torah        | Simchat Torah              | שמחת תורה             | YOM_TOV                   | 1       |
+| chanukah             | Chanukah                   | חנוכה                 | MELACHA_PERMITTED_HOLIDAY | 4       |
+| asara_btevet         | Asara B'Tevet              | צום עשרה בטבת         | FAST_DAY                  | 5       |
+| tu_bshvat            | Tu B'Shvat                 | ט"ו בשבט              | MINOR_HOLIDAY             | 7       |
+| taanit_esther        | Ta'anit Esther             | תענית אסתר            | FAST_DAY                  | 5       |
+| purim                | Purim                      | פורים                 | MELACHA_PERMITTED_HOLIDAY | 4       |
+| shushan_purim        | Shushan Purim              | שושן פורים            | MELACHA_PERMITTED_HOLIDAY | 4       |
+| erev_pesach          | Erev Pesach                | ערב פסח               | EREV_YOM_TOV              | 2       |
+| pesach               | Pesach                     | פסח                   | YOM_TOV                   | 1       |
+| hol_hamoed_pesach    | Hol hamoed Pesach          | חול המועד פסח         | HOL_HAMOED                | 3       |
+| pesach_vii           | Pesach VII                 | שביעי פסח             | YOM_TOV                   | 1       |
+| yom_haatzmaut        | Yom HaAtzma'ut             | יום העצמאות           | MODERN_HOLIDAY            | 6       |
+| lag_bomer            | Lag B'Omer                 | ל"ג בעומר             | MINOR_HOLIDAY             | 7       |
+| erev_shavuot         | Erev Shavuot               | ערב שבועות            | EREV_YOM_TOV              | 2       |
+| shavuot              | Shavuot                    | שבועות                | YOM_TOV                   | 1       |
+| tzom_tammuz          | Tzom Tammuz                | צום שבעה עשר בתמוז    | FAST_DAY                  | 5       |
+| tisha_bav            | Tish'a B'Av                | תשעה באב              | FAST_DAY                  | 5       |
+| tu_bav               | Tu B'Av                    | ט"ו באב               | MINOR_HOLIDAY             | 7       |
+| yom_hashoah          | Yom HaShoah                | יום השואה             | MEMORIAL_DAY              | 8       |
+| yom_hazikaron        | Yom HaZikaron              | יום הזכרון            | MEMORIAL_DAY              | 8       |
+| yom_yerushalayim     | Yom Yerushalayim           | יום ירושלים           | MODERN_HOLIDAY            | 6       |
+| shmini_atzeret       | Shmini Atzeret             | שמיני עצרת            | YOM_TOV                   | 1       |
+| pesach_viii          | Pesach VIII                | אחרון של פסח          | YOM_TOV                   | 1       |
+| shavuot_ii           | Shavuot II                 | שני של שבועות         | YOM_TOV                   | 1       |
+| sukkot_ii            | Sukkot II                  | שני של סוכות          | YOM_TOV                   | 1       |
+| pesach_ii            | Pesach II                  | שני של פסח            | YOM_TOV                   | 1       |
+| family_day           | Family Day                 | יום המשפחה            | ISRAEL_NATIONAL_HOLIDAY   | 9       |
+| memorial_day_unknown | Memorial day for fallen whose place of burial is unknown | יום הזיכרון לחללי מערכות ישראל שמקום קבורתם לא נודע | MEMORIAL_DAY | 8      |
+| rabin_memorial_day   | Yitzhak Rabin memorial day | יום הזכרון ליצחק רבין | MEMORIAL_DAY              | 8       |
+| zeev_zhabotinsky_day | Zeev Zhabotinsky day       | יום זאב ז'בוטינסקי    | MEMORIAL_DAY              | 8       |
 
-## Full configuration sample
+## Full configuration example
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -10,11 +10,11 @@ ha_codeowners:
 ha_domain: jewish_calendar
 ---
 
-The Jewish Calendar (`jewish_calendar`) sensor platform displays a variety of information related to the Jewish Calendar as a variety of sensors.
+The Jewish Calendar (`jewish_calendar`) integration displays a variety of information related to the Jewish Calendar as a variety of sensors.
 
 ## Configuration
 
-To enable this sensor in your installation, add the following to your `configuration.yaml` file:
+To enable this integration in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -49,7 +49,7 @@ candle_lighting_minutes_before_sunset:
   type: integer
 havdalah_minutes_after_sunset:
   required: false
-  description: Number of minutes after sunset to report as havdalah time. If this is set to 0, uses the time that the sun is 8.5 degrees below the horizon (same as the `t_set_hakochavim` sensor). If non-zero, this value is added as an offset to the time of sunset to report havdalah.
+  description: Number of minutes after sunset to report as havdalah time. If this is set to 0, uses the time that the sun is 8.5 degrees below the horizon (same as the `three_stars` sensor). If non-zero, this value is added as an offset to the time of sunset to report havdalah.
   default: 0
   type: integer
 {% endconfiguration %}
@@ -59,9 +59,9 @@ havdalah_minutes_after_sunset:
 ### Data sensors
 
 - `date`: Shows the hebrew date for today.
-- `parshat_hashavua`: Shows the weekly portion (parshat hashavu'a - פרשת השבוע)
+- `weekly_portion`: Shows the weekly portion (parshat hashavu'a - פרשת השבוע)
 - `holiday`: If it is a holiday, shows the name of the holiday _(see below for more info)_.
-- `day_of_the_omer`: An integer sensor indicating the day of the Omer (1-49) or 0 if it is not currently the Omer.
+- `omer_count`: An integer sensor indicating the day of the Omer (1-49) or 0 if it is not currently the Omer.
 - `daf_yomi`: Shows the date's daf yomi page.
 
 ### Time sensors
@@ -71,17 +71,17 @@ havdalah_minutes_after_sunset:
 Time sensor states are represented as ISO8601 formatted *UTC time*.
 For easier use in automations, all time sensors have a `timestamp` attribute, which returns the UNIX timestamp.
 
-- `alot_hashachar`: First light of dawn (Alot Hashachar - עלות השחר)
-- `talit_and_tefillin`: Earliest time for tallit and tefillin (Misheyakir - משיכיר)
-- `latest_time_for_shma_gr_a`: Last time for reading of the Shma according to the Gr"a.
-- `latest_time_for_shma_mg_a`: Last time for reading of the Shma according to the MG"A.
-- `latest_time_for_tefilla_gr_a`: Last time for full shacharit according to the Gr"a.
-- `latest_time_for_tefilla_mg_a`: Last time for full shacharit according to the MG"A.
-- `mincha_gedola`: Earliest time for Mincha (Mincha Gedola - מנחה גדולה)
-- `mincha_ketana`: Preferable earliest time for Mincha (Mincha Ketana - מנחה קטנה)
-- `plag_hamincha`: Time of the Plag Hamincha (פלג המנחה)
-- `shkia`: Sunset (Shkiya - שקיעה)
-- `t_set_hakochavim`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים)
+- `first_light`: First light of dawn (Alot Hashachar - עלות השחר)
+- `talit`: Earliest time for tallit and tefillin (Misheyakir - משיכיר)
+- `gra_end_shma`: Last time for reading of the Shma according to the Gr"a.
+- `mga_end_shma`: Last time for reading of the Shma according to the MG"A.
+- `gra_end_tefilla`: Last time for full shacharit according to the Gr"a.
+- `mga_end_tefilla`: Last time for full shacharit according to the MG"A.
+- `big_mincha`: Earliest time for Mincha (Mincha Gedola - מנחה גדולה)
+- `little_mincha`: Preferable earliest time for Mincha (Mincha Ketana - מנחה קטנה)
+- `plag_mincha`: Time of the Plag Hamincha (פלג המנחה)
+- `sunset`: Sunset (Shkiya - שקיעה)
+- `three_stars`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים)
 - `upcoming_shabbat_candle_lighting`: The time of candle lighting for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat.
 - `upcoming_shabbat_havdalah`: The time of havdalah for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat. If it is currently a three-day holiday, this value *could* be None (i.e., if holiday is Sat./Sun./Mon. and it's Saturday, there will be no `shabbat_havdalah` value. See comments in hdate library for details.)
 - `upcoming_candle_lighting`: The time of candle lighting for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the candle lighting for Rosh Hashana on Monday night. This avoids a situation of triggering pre-candle-lighting automations while it is currently Yom Tov. To always get the Shabbat times, use the `upcoming_shabbat_candle_lighting` sensor.

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -59,7 +59,7 @@ havdalah_minutes_after_sunset:
 ### Data sensors
 
 - `date`: Shows the hebrew date for today.
-- `weekly_portion`: Shows the weekly portion (parshat hashavu'a).
+- `weekly_portion`: Shows the weekly portion (parshat hashavu'a - פרשת השבוע)
 - `holiday`: If it is a holiday, shows the name of the holiday _(see below for more info)_.
 - `omer_count`: An integer sensor indicating the day of the Omer (1-49) or 0 if it is not currently the Omer.
 - `daf_yomi`: Shows the date's daf yomi page.

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -57,6 +57,7 @@ havdalah_minutes_after_sunset:
 ## Sensor list
 
 ### Data sensors
+
 - date: Shows the hebrew date for today.
 - weekly_portion: Shows the weekly portion (parshat hashavu'a).
 - holiday: If it is a holiday, shows the name of the holiday _(see below for more info)_.
@@ -87,8 +88,8 @@ For easier use in automations, all time sensors have a `timestamp` attribute, wh
 - upcoming_havdalah: The time of havdalah for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the havdalah for Rosh Hashana on Wednesday night. To always get the Shabbat times, use the upcoming_shabbat_havdalah sensor.
 
 ### Binary sensors
-- issur_melacha_in_effect: A boolean sensor indicating if melacha is currently not permitted. The value is true when it is currently Shabbat or Yom Tov and false otherwise.
 
+- issur_melacha_in_effect: A boolean sensor indicating if melacha is currently not permitted. The value is true when it is currently Shabbat or Yom Tov and false otherwise.
 
 ### Holiday sensor
 
@@ -96,7 +97,6 @@ The holiday sensor includes 3 attributes: *type*, *type_id* and *id*.
 The *type_id* is useful for cases to condition automations based on a range of types.
 
 The following is the list of holidays the sensor knows about with their selected type:
-
 
 | ID                   | English                    | Hebrew                | Type                          |
 |----------------------|----------------------------|-----------------------|--------------------------------|
@@ -140,7 +140,6 @@ The following is the list of holidays the sensor knows about with their selected
 | memorial_day_unknown | Memorial day for fallen whose place of burial is unknown | יום זכרון... | MEMORIAL_DAY (8) |
 | rabin_memorial_day   | Yitzhak Rabin memorial day | יום הזכרון ליצחק רבין | MEMORIAL_DAY (8)              |
 | zeev_zhabotinsky_day | Zeev Zhabotinsky day       | יום ז'בוטינסקי        | MEMORIAL_DAY (8)              |
-
 
 ## Full configuration sample
 

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -49,7 +49,7 @@ candle_lighting_minutes_before_sunset:
   type: integer
 havdalah_minutes_after_sunset:
   required: false
-  description: Number of minutes after sunset to report as havdalah time. If this is set to 0, uses the time that the sun is 8.5 degrees below the horizon (same as the `three_stars` sensor). If non-zero, this value is added as an offset to the time of sunset to report havdalah.
+  description: Number of minutes after sunset to report as havdalah time. If this is set to 0, uses the time that the sun is 8.5 degrees below the horizon (same as the `first_stars` sensor). If non-zero, this value is added as an offset to the time of sunset to report havdalah.
   default: 0
   type: integer
 {% endconfiguration %}
@@ -81,7 +81,7 @@ For easier use in automations, all time sensors have a `timestamp` attribute, wh
 - `little_mincha`: Preferable earliest time for Mincha (Mincha Ketana - מנחה קטנה)
 - `plag_mincha`: Time of the Plag Hamincha (פלג המנחה)
 - `sunset`: Sunset (Shkiya - שקיעה)
-- `three_stars`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים)
+- `first_stars`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים)
 - `upcoming_shabbat_candle_lighting`: The time of candle lighting for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat.
 - `upcoming_shabbat_havdalah`: The time of havdalah for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat. If it is currently a three-day holiday, this value *could* be None (i.e., if holiday is Sat./Sun./Mon. and it's Saturday, there will be no `shabbat_havdalah` value. See comments in hdate library for details.)
 - `upcoming_candle_lighting`: The time of candle lighting for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the candle lighting for Rosh Hashana on Monday night. This avoids a situation of triggering pre-candle-lighting automations while it is currently Yom Tov. To always get the Shabbat times, use the `upcoming_shabbat_candle_lighting` sensor.

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -58,11 +58,11 @@ havdalah_minutes_after_sunset:
 
 ### Data sensors
 
-- date: Shows the hebrew date for today.
-- weekly_portion: Shows the weekly portion (parshat hashavu'a).
-- holiday: If it is a holiday, shows the name of the holiday _(see below for more info)_.
-- omer_count: An integer sensor indicating the day of the Omer (1-49) or 0 if it is not currently the Omer.
-- daf_yomi: Shows the date's daf yomi page.
+- `date`: Shows the hebrew date for today.
+- `weekly_portion`: Shows the weekly portion (parshat hashavu'a).
+- `holiday`: If it is a holiday, shows the name of the holiday _(see below for more info)_.
+- `omer_count`: An integer sensor indicating the day of the Omer (1-49) or 0 if it is not currently the Omer.
+- `daf_yomi`: Shows the date's daf yomi page.
 
 ### Time sensors
 
@@ -71,25 +71,25 @@ havdalah_minutes_after_sunset:
 Time sensor states are represented as ISO8601 formatted *UTC time*.
 For easier use in automations, all time sensors have a `timestamp` attribute, which returns the UNIX timestamp.
 
-- first_light: First light of dawn (Alot Hashachar - עלות השחר).
-- talit: Earliest time for tallit and tefillin
-- gra_end_shma: Last time for reading of the Shma according to the Gr"a.
-- mga_end_shma: Last time for reading of the Shma according to the MG"A.
-- gra_end_tefilla: Last time for full shacharit according to the Gr"a.
-- mga_end_tefilla: Last time for full shacharit according to the MG"A.
-- big_mincha: Earliest time for Mincha (Mincha Gedola)
-- little_mincha: Preferable earliest time for Mincha (Mincha Ketana)
-- plag_mincha: Time of the Plag Hamincha.
-- sunset: Sunset (Shkiya)
-- first_stars: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים).
-- upcoming_shabbat_candle_lighting: The time of candle lighting for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat.
-- upcoming_shabbat_havdalah: The time of havdalah for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat. If it is currently a three-day holiday, this value *could* be None (i.e., if holiday is Sat./Sun./Mon. and it's Saturday, there will be no shabbat_havdalah value. See comments in hdate library for details.)
-- upcoming_candle_lighting: The time of candle lighting for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the candle lighting for Rosh Hashana on Monday night. This avoids a situation of triggering pre-candle-lighting automations while it is currently Yom Tov. To always get the Shabbat times, use the upcoming_shabbat_candle_lighting sensor.
-- upcoming_havdalah: The time of havdalah for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the havdalah for Rosh Hashana on Wednesday night. To always get the Shabbat times, use the upcoming_shabbat_havdalah sensor.
+- `first_light`: First light of dawn (Alot Hashachar - עלות השחר).
+- `talit`: Earliest time for tallit and tefillin
+- `gra_end_shma`: Last time for reading of the Shma according to the Gr"a.
+- `mga_end_shma`: Last time for reading of the Shma according to the MG"A.
+- `gra_end_tefilla`: Last time for full shacharit according to the Gr"a.
+- `mga_end_tefilla`: Last time for full shacharit according to the MG"A.
+- `big_mincha`: Earliest time for Mincha (Mincha Gedola)
+- `little_mincha`: Preferable earliest time for Mincha (Mincha Ketana)
+- `plag_mincha`: Time of the Plag Hamincha.
+- `sunset`: Sunset (Shkiya)
+- `first_stars`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים).
+- `upcoming_shabbat_candle_lighting`: The time of candle lighting for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat.
+- `upcoming_shabbat_havdalah`: The time of havdalah for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat. If it is currently a three-day holiday, this value *could* be None (i.e., if holiday is Sat./Sun./Mon. and it's Saturday, there will be no shabbat_havdalah value. See comments in hdate library for details.)
+- `upcoming_candle_lighting`: The time of candle lighting for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the candle lighting for Rosh Hashana on Monday night. This avoids a situation of triggering pre-candle-lighting automations while it is currently Yom Tov. To always get the Shabbat times, use the `upcoming_shabbat_candle_lighting` sensor.
+- `upcoming_havdalah`: The time of havdalah for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the havdalah for Rosh Hashana on Wednesday night. To always get the Shabbat times, use the `upcoming_shabbat_havdalah` sensor.
 
 ### Binary sensors
 
-- issur_melacha_in_effect: A boolean sensor indicating if melacha is currently not permitted. The value is true when it is currently Shabbat or Yom Tov and false otherwise.
+- `issur_melacha_in_effect`: A boolean sensor indicating if melacha is currently not permitted. The value is true when it is currently Shabbat or Yom Tov and false otherwise.
 
 ### Holiday sensor
 
@@ -98,7 +98,7 @@ The *type_id* is useful for cases to condition automations based on a range of t
 
 The following is the list of holidays the sensor knows about with their selected type:
 
-| ID                   | English                    | Hebrew                | Type                      | Type ID |
+| ID                   | English                    | Hebrew                | Type                      | Type_ID |
 |----------------------|----------------------------|-----------------------|---------------------------|---------|
 | erev_rosh_hashana    | Erev Rosh Hashana          | ערב ראש השנה          | EREV_YOM_TOV              | 2       |
 | rosh_hashana_i       | Rosh Hashana I             | א' ראש השנה           | YOM_TOV                   | 1       |

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -59,9 +59,9 @@ havdalah_minutes_after_sunset:
 ### Data sensors
 
 - `date`: Shows the hebrew date for today.
-- `weekly_portion`: Shows the weekly portion (parshat hashavu'a - פרשת השבוע)
+- `parshat_hashavua`: Shows the weekly portion (parshat hashavu'a - פרשת השבוע)
 - `holiday`: If it is a holiday, shows the name of the holiday _(see below for more info)_.
-- `omer_count`: An integer sensor indicating the day of the Omer (1-49) or 0 if it is not currently the Omer.
+- `day_of_the_omer`: An integer sensor indicating the day of the Omer (1-49) or 0 if it is not currently the Omer.
 - `daf_yomi`: Shows the date's daf yomi page.
 
 ### Time sensors
@@ -71,17 +71,17 @@ havdalah_minutes_after_sunset:
 Time sensor states are represented as ISO8601 formatted *UTC time*.
 For easier use in automations, all time sensors have a `timestamp` attribute, which returns the UNIX timestamp.
 
-- `first_light`: First light of dawn (Alot Hashachar - עלות השחר)
-- `talit`: Earliest time for tallit and tefillin (Misheyakir - משיכיר)
-- `gra_end_shma`: Last time for reading of the Shma according to the Gr"a.
-- `mga_end_shma`: Last time for reading of the Shma according to the MG"A.
-- `gra_end_tefilla`: Last time for full shacharit according to the Gr"a.
-- `mga_end_tefilla`: Last time for full shacharit according to the MG"A.
-- `big_mincha`: Earliest time for Mincha (Mincha Gedola - מנחה גדולה)
-- `little_mincha`: Preferable earliest time for Mincha (Mincha Ketana - מנחה קטנה)
-- `plag_mincha`: Time of the Plag Hamincha (פלג המנחה)
-- `sunset`: Sunset (Shkiya - שקיעה)
-- `first_stars`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים)
+- `alot_hashachar`: First light of dawn (Alot Hashachar - עלות השחר)
+- `talit_and_tefillin`: Earliest time for tallit and tefillin (Misheyakir - משיכיר)
+- `latest_time_for_shma_gr_a`: Last time for reading of the Shma according to the Gr"a.
+- `latest_time_for_shma_mg_a`: Last time for reading of the Shma according to the MG"A.
+- `latest_time_for_tefilla_gr_a`: Last time for full shacharit according to the Gr"a.
+- `latest_time_for_tefilla_mg_a`: Last time for full shacharit according to the MG"A.
+- `mincha_gedola`: Earliest time for Mincha (Mincha Gedola - מנחה גדולה)
+- `mincha_ketana`: Preferable earliest time for Mincha (Mincha Ketana - מנחה קטנה)
+- `plag_hamincha`: Time of the Plag Hamincha (פלג המנחה)
+- `shkia`: Sunset (Shkiya - שקיעה)
+- `t_set_hakochavim`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים)
 - `upcoming_shabbat_candle_lighting`: The time of candle lighting for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat.
 - `upcoming_shabbat_havdalah`: The time of havdalah for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat. If it is currently a three-day holiday, this value *could* be None (i.e., if holiday is Sat./Sun./Mon. and it's Saturday, there will be no shabbat_havdalah value. See comments in hdate library for details.)
 - `upcoming_candle_lighting`: The time of candle lighting for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the candle lighting for Rosh Hashana on Monday night. This avoids a situation of triggering pre-candle-lighting automations while it is currently Yom Tov. To always get the Shabbat times, use the `upcoming_shabbat_candle_lighting` sensor.

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -99,7 +99,7 @@ The *type_id* is useful for cases to condition automations based on a range of t
 The following is the list of holidays the sensor knows about with their selected type:
 
 | ID                   | English                    | Hebrew                | Type                      | Type_ID |
-|----------------------|----------------------------|-----------------------|---------------------------|---------|
+|----------------------|----------------------------|-----------------------|---------------------------|:-------:|
 | erev_rosh_hashana    | Erev Rosh Hashana          | ערב ראש השנה          | EREV_YOM_TOV              | 2       |
 | rosh_hashana_i       | Rosh Hashana I             | א' ראש השנה           | YOM_TOV                   | 1       |
 | rosh_hashana_ii      | Rosh Hashana II            | ב' ראש השנה           | YOM_TOV                   | 1       |

--- a/source/_integrations/jewish_calendar.markdown
+++ b/source/_integrations/jewish_calendar.markdown
@@ -71,17 +71,17 @@ havdalah_minutes_after_sunset:
 Time sensor states are represented as ISO8601 formatted *UTC time*.
 For easier use in automations, all time sensors have a `timestamp` attribute, which returns the UNIX timestamp.
 
-- `first_light`: First light of dawn (Alot Hashachar - עלות השחר).
-- `talit`: Earliest time for tallit and tefillin
+- `first_light`: First light of dawn (Alot Hashachar - עלות השחר)
+- `talit`: Earliest time for tallit and tefillin (Misheyakir - משיכיר)
 - `gra_end_shma`: Last time for reading of the Shma according to the Gr"a.
 - `mga_end_shma`: Last time for reading of the Shma according to the MG"A.
 - `gra_end_tefilla`: Last time for full shacharit according to the Gr"a.
 - `mga_end_tefilla`: Last time for full shacharit according to the MG"A.
-- `big_mincha`: Earliest time for Mincha (Mincha Gedola)
-- `little_mincha`: Preferable earliest time for Mincha (Mincha Ketana)
-- `plag_mincha`: Time of the Plag Hamincha.
-- `sunset`: Sunset (Shkiya)
-- `first_stars`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים).
+- `big_mincha`: Earliest time for Mincha (Mincha Gedola - מנחה גדולה)
+- `little_mincha`: Preferable earliest time for Mincha (Mincha Ketana - מנחה קטנה)
+- `plag_mincha`: Time of the Plag Hamincha (פלג המנחה)
+- `sunset`: Sunset (Shkiya - שקיעה)
+- `first_stars`: Time at which the first stars are visible (Tseit Hakochavim - צאת הכוכבים)
 - `upcoming_shabbat_candle_lighting`: The time of candle lighting for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat.
 - `upcoming_shabbat_havdalah`: The time of havdalah for either the current Shabbat (if it is currently Shabbat) or the immediately upcoming Shabbat. If it is currently a three-day holiday, this value *could* be None (i.e., if holiday is Sat./Sun./Mon. and it's Saturday, there will be no shabbat_havdalah value. See comments in hdate library for details.)
 - `upcoming_candle_lighting`: The time of candle lighting for either the current Shabbat OR Yom Tov, or the immediately upcoming Shabbat OR Yom Tov. If, for example, today is Sunday, and Rosh Hashana is Monday night through Wednesday night, this reports the candle lighting for Rosh Hashana on Monday night. This avoids a situation of triggering pre-candle-lighting automations while it is currently Yom Tov. To always get the Shabbat times, use the `upcoming_shabbat_candle_lighting` sensor.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Changed the sensor names to comply with the actual names of the sensors in home-assistant.
- Better readability of the holiday table.
---
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
