### PR TITLE
Clarify state triggers holding using for, ignore attribute changes

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -171,8 +171,8 @@ automation:
     for: "00:00:30"
 ```
 
-Please note, that when holding a state, changes to attributes ignored and do
-not cancel the hold time.
+Please note, that when holding a state, changes to attributes are ignored and
+do not cancel the hold time.
 
 You can also fire the trigger when the state value changed from a specific
 state, but hasn't returned to that state value for the specified time.

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -171,6 +171,9 @@ automation:
     for: "00:00:30"
 ```
 
+Please note, that when holding a state, changes to attributes ignored and do
+not cancel the hold time.
+
 You can also fire the trigger when the state value changed from a specific
 state, but hasn't returned to that state value for the specified time.
 
@@ -203,7 +206,8 @@ automation:
 ```
 
 When the `attribute` option is specified, all of the above works, but only
-applies to the specific state value of that attribute.
+applies to the specific state value of that attribute. In this case the
+normal state value of the entity is ignored.
 
 For example, this trigger only fires if the boiler was heating for 10 minutes:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds a small additional note about triggers using a `for` to hold the state for X time before triggering.

Using the `for` causes all other attribute state changes to be ignored. This has always been the case, but now it is possible to omit the use of `to` and `from` with `for`, this may become unclear.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
