### PR TITLE
Config block styling & text selection fixes

### DIFF
--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -61,7 +61,7 @@ module Jekyll
 
       result << vars.map do |key, attr|
         markup = Array.new
-        markup << "<div class='config-vars-item'><div class='config-vars-label'><a name='#{slug(key)}' class='title-link' href='\##{slug(key)}'></a> <span class='config-vars-label-name'>#{key}</span>"
+        markup << "<div class='config-vars-item'><div class='config-vars-label'><a name='#{slug(key)}' class='title-link' href='\##{slug(key)}'></a> <span class='config-vars-label-name'> #{key} </span>"
 
         if attr.key? 'type'
 
@@ -115,7 +115,7 @@ module Jekyll
             shortDefaultValue = ", default: " + shortDefaultValue
           end
 
-          markup << "<span class='config-vars-required'>#{startSymbol}<span class='#{attr['required'].to_s}'>#{required_value(attr['required'])}</span>#{shortDefaultValue}#{endSymbol}</span>"
+          markup << "<span class='config-vars-required'>#{startSymbol}<span class='#{attr['required'].to_s}'>#{required_value(attr['required'])}</span><span class='default'>#{shortDefaultValue}</span>#{endSymbol}</span>"
         end
 
         markup << "</div><div class='config-vars-description-and-children'>"

--- a/plugins/configuration.rb
+++ b/plugins/configuration.rb
@@ -61,6 +61,7 @@ module Jekyll
 
       result << vars.map do |key, attr|
         markup = Array.new
+        # There are spaces around the "{key}", to improve double-click selection in Chrome.
         markup << "<div class='config-vars-item'><div class='config-vars-label'><a name='#{slug(key)}' class='title-link' href='\##{slug(key)}'></a> <span class='config-vars-label-name'> #{key} </span>"
 
         if attr.key? 'type'

--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -500,16 +500,12 @@ div.config-vars {
   }
 
   .nested .config-vars-item:last-child {
-    border: none
+    border: none;
   }
 
   .config-vars-label {
     padding-bottom: 4px;
     position: relative;
-
-    > span {
-      padding-right: 4px;
-    }
 
     &:hover a.title-link::before {
       position: absolute;
@@ -525,17 +521,17 @@ div.config-vars {
 
   .config-vars-label-name {
     font-weight: bold;
-    font-size: 16px; 
+    font-size: 16px;
     color: #222222bd;
   }
 
   .config-vars-type {
-    color :#8792a2;
+    color: #8792a2;
     font-size: 13px;
   }
 
   .config-vars-required {
-    color :#8792a2;
+    color: #8792a2;
     font-size: 13px;
     text-transform: lowercase;
 
@@ -543,6 +539,10 @@ div.config-vars {
       color: #e56f4a;
       text-transform: uppercase;
       font-size: 11px;
+    }
+
+    .default {
+      text-transform: None;
     }
   }
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR addresses 2 issues reported with our configuration blocks.

- Default values are text transformed to lower case. In some cases (like MQTT), this is not wished for, as the value should be `ON` not `on`. This text transformation has been removed from the default value. (#14040)

- Variable names in configuration blocks are hard to select/copy. A little old trick has been added to this PR to add spaces around the config variable name in the HTML. When double clicking, Chrome will now select just the config var. (#14414)


![image](https://user-images.githubusercontent.com/195327/92659834-6a27e780-f2f9-11ea-8e77-8532e4934969.png)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #14040 fixes #14414

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
