### PR TITLE
Add note about hiding mobile app entities

### DIFF
--- a/source/_posts/2020-09-17-release-115.markdown
+++ b/source/_posts/2020-09-17-release-115.markdown
@@ -1211,6 +1211,18 @@ an issue when trying to use InfluxDB for example. This has been adjusted.
   </p>
 </details>
 
+<details>
+  <summary><b>Lovelace for generated (auto) mode</b></summary>
+  <p>
+
+Entities that are generated from mobile apps with the `mobile_app` integration is now hidden in the generated Lovelace view.
+If you want to continue to display those you need to take control over your view with the 3 dots in the top right corner of the Lovelace screen.
+
+([@ludeeus] - [#6873]) ([lovelace docs])
+
+  </p>
+</details>
+
 ## Farewell to the following
 
 - The **Prezzi Benzina** integration has been removed.
@@ -1833,6 +1845,7 @@ an issue when trying to use InfluxDB for example. This has been adjusted.
 
 </details>
 
+[#6873]: https://github.com/home-assistant/frontend/pull/6873
 [#31954]: https://github.com/home-assistant/core/pull/31954
 [#34659]: https://github.com/home-assistant/core/pull/34659
 [#34820]: https://github.com/home-assistant/core/pull/34820
@@ -2536,6 +2549,7 @@ an issue when trying to use InfluxDB for example. This has been adjusted.
 [@kit-klein]: https://github.com/kit-klein
 [@ktownsend-personal]: https://github.com/ktownsend-personal
 [@leofig-rj]: https://github.com/leofig-rj
+[@ludeeus]: https://github.com/ludeeus
 [@lukashass]: https://github.com/lukashass
 [@maddenp]: https://github.com/maddenp
 [@marciogranzotto]: https://github.com/marciogranzotto


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add note about hiding `mobile_app` entities in the generated lovelace view

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/6873
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
