### PR TITLE
Add documentation for new Header Authentication provider.

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -128,6 +128,38 @@ In above example, if user try to access Home Assistant from 192.168.0.1, they wi
 
 Specially, you can use `group: GROUP_ID` to assign all users in certain `user group` to be available to choose. Group and users can be mix and match.
 
+### Header Authentication
+
+The Header auth provider authenticates users based on a HTTP Header. This Header is set by a reverse proxy, like [oauth2_proxy](https://github.com/oauth2-proxy/oauth2-proxy). Users are matched by their usernames, and new users are *not* automatically created.
+
+This authentication provider works together with the `trusted_proxies` setting from [HTTP](/integrations/http). Only requests coming from an IP in the trusted proxies setting are allowed.
+
+<div class='note info'>
+
+The [multi-factor authentication module](/docs/authentication/multi-factor-auth/) will not participate in the login process if you are using this auth provider.
+
+</div>
+
+Here is an example in `configuration.yaml` to set up Header Authentication:
+
+```yaml
+http:
+  trusted_proxies:
+    - 127.0.0.1/32
+
+homeassistant:
+  auth_providers:
+    - type: header
+```
+
+{% configuration %}
+username_header:
+  description: The header sent by the reverse proxy which contains the Username
+  required: false
+  default: X-Forwarded-Preferred-Username
+  type: string
+{% endconfiguration %}
+
 #### Skip Login Page Examples
 
 This is a feature to allow you bring back some of the experience before the user system was implemented. You can directly jump to main page if you are accessing from trusted networks, the `allow_bypass_login` is on, and you have ONLY ONE available user to choose in the login form.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for new Header Authentication provider.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/38175
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
