### PR TITLE
Add deprecated warning to synology integration

### DIFF
--- a/source/_integrations/synology.markdown
+++ b/source/_integrations/synology.markdown
@@ -10,7 +10,7 @@ ha_domain: synology
 
 <div class='note warning'>
 
-This integration is deprecated. Please use the [Synology DSM](/integrations/synology_dsm/) integration instead.
+This integration is deprecated. Please use the [Synology DSM](/integrations/synology_dsm/) integration instead. This integration will be removed in version 0.118.0.
 
 </div>
 

--- a/source/_integrations/synology.markdown
+++ b/source/_integrations/synology.markdown
@@ -8,6 +8,12 @@ ha_iot_class: Local Polling
 ha_domain: synology
 ---
 
+<div class='note warning'>
+
+This integration is deprecated. Please use the [Synology DSM](/integrations/synology_dsm/) integration instead.
+
+</div>
+
 The `synology` camera platform allows you to watch the live streams of your [Synology](https://www.synology.com/) Surveillance Station based IP cameras in Home Assistant.
 
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The `synology` integration is deprecated. Adds warning note to the documentation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#39958
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
