### PR TITLE
Update the lost password documentation when using ha in a container

### DIFF
--- a/source/_docs/locked_out.md
+++ b/source/_docs/locked_out.md
@@ -20,7 +20,24 @@ Connect a keyboard and monitor to your device.
 
 `auth reset --username existing_user --password new_password`
 
-### Home Assistant Core and Home Assistant Container
+### Home Assistant Container
+
+If you are running Home Assistant in a container you can login into the container and use the `hass` command line tool to change your password. The following example shows how to do it using `docker-compose`, you can adapt the below commands if using `docker` only. The container running Home Assistant is called `ha` in the below example:
+
+```bash
+# Log into the container
+docker-compose exec ha bash
+
+# Change the password
+hass --script auth --config /config change_password your_username your_new_password
+
+# Exit the container with CTRL+C
+
+# Restart the container
+docker-compose restart ha
+```
+
+### Home Assistant Core
 
 While you should hopefully be storing your passwords in a password manager, if you lose the password associated with the owner account the only way to resolve this is to delete *all* the authentication data. You do this by shutting down Home Assistant and deleting the following files from the `.storage/` folder in your [configuration folder](/docs/configuration/):
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Improved the doc about changing a password when the current one is lost and ha is executed as a container.

From https://community.home-assistant.io/t/reset-password-from-ha-docker-container/215537

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
