### PR TITLE
Add Ruckus Unleashed integration documentation

### DIFF
--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -1,0 +1,46 @@
+---
+title: Ruckus Unleashed
+description: Instructions on how to integrate your Ruckus Unleashed device into Home Assistant.
+ha_category:
+  - Presence Detection
+ha_release: 0.116
+ha_iot_class: Local Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@gabe565'
+ha_domain: ruckus
+---
+
+This platform allows you to connect to a [Ruckus Unleashed](https://support.ruckuswireless.com/product_families/19-ruckus-unleashed) router.
+
+There is currently support for the following device types within Home Assistant:
+
+- **Presence Detection** - The platform will look at devices connected to the router and will create a `device_tracker` for each discovered device.
+
+## Configuration
+
+To add a Ruckus Unleashed device to your installation, go to **Configuration** -> **Integrations**, click the `+` button, then select **Ruckus** from the list of integrations.
+
+You will have to create a user on the device which is a **Monitoring Admin**. Login to the Ruckus Unleashed admin UI and follow these steps:
+
+ - [Create a new role](https://docs.ruckuswireless.com/unleashed/200.1.9.12/t-ConfigUserRoles.html).
+   - Check **Allow Unleashed Administration**.
+   - Select the **Monitoring Admin (Monitoring and viewing operation status only)** radio button. 
+ - [Create a new user](https://docs.ruckuswireless.com/unleashed/200.1.9.12/t-AddingNewUsersInternal.html) with the new role.
+
+## Troubleshooting
+
+For this platform to work, the Ruckus Unleashed device will need to be accessible over SSH. If you are having trouble with Home Assistant not connecting, make sure the user you created above can login to SSH and can run privileged commands.
+
+Terminal:
+
+```bash
+ssh <ruckus_ip>
+
+Please login: <username>
+Password: <password>
+Welcome to Ruckus Unleashed Network Command Line Interface
+ruckus> enable
+ruckus# exit
+Exit ruckus CLI.
+```

--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -3,7 +3,7 @@ title: Ruckus Unleashed
 description: Instructions on how to integrate your Ruckus Unleashed device into Home Assistant.
 ha_category:
   - Presence Detection
-ha_release: 0.116
+ha_release: 0.117
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
@@ -30,7 +30,7 @@ You will have to create a user on the device which is a **Monitoring Admin**. Lo
 
 ## Troubleshooting
 
-For this platform to work, the Ruckus Unleashed device will need to be accessible over SSH. If you are having trouble with Home Assistant not connecting, make sure the user you created above can login to SSH and can run privileged commands.
+For this platform to work, the Ruckus Unleashed device will need to be accessible over SSH. If you are having trouble with Home Assistant not connecting, make sure the user you created above can log in to SSH and can run privileged commands.
 
 Terminal:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for new Ruckus Unleashed router integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#40002
- Link to parent pull request in the Brands repository: home-assistant/brands#1852
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
