### PR TITLE
Add plugwise port configuration

### DIFF
--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -47,6 +47,8 @@ Repeat the above procedure for each Smile gateway (i.e., if you have an Adam set
 
 After adding the Plugwise integration(s), the default Smile-data refresh-interval can be changed by pressing the "OPTIONS" button: change the number via the up- or down-button and press "SUBMIT".
 
+If you have a Smile that is connected, for example, using a (remote) port-forwarding devices can add the port number when configuring it manually. E.g. `192.168.1.2:81`.
+
 <div class='note warning'>
 When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press the "IGNORE" button on the Anna integration to remove this integration. In case you need to rediscover the Adam integration, make sure to click the "STOP IGNORING" button on the Plugwise integration first, available via "show ignored integrations".
 </div>
@@ -151,3 +153,4 @@ Smile P1 (DSMR):
  - v4.0
  - v3.3
  - v2.5
+ - v2.1

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -47,7 +47,7 @@ Repeat the above procedure for each Smile gateway (i.e., if you have an Adam set
 
 After adding the Plugwise integration(s), the default Smile-data refresh-interval can be changed by pressing the "OPTIONS" button: change the number via the up- or down-button and press "SUBMIT".
 
-If you have a Smile that is connected, for example, using a (remote) port-forwarding device and has a port other than `80` (HTTP) by default: you can add the port number when configuring it manually. E.g. `192.168.1.2:81`.
+If you have a Smile that is connected, for example, using a (remote) port-forwarding device and has a port other than `80` (HTTP) by default: you can add the port number when configuring it manually. E.g., `192.168.1.2:81`.
 
 <div class='note warning'>
 When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press the "IGNORE" button on the Anna integration to remove this integration. In case you need to rediscover the Adam integration, make sure to click the "STOP IGNORING" button on the Plugwise integration first, available via "show ignored integrations".

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -47,7 +47,7 @@ Repeat the above procedure for each Smile gateway (i.e., if you have an Adam set
 
 After adding the Plugwise integration(s), the default Smile-data refresh-interval can be changed by pressing the "OPTIONS" button: change the number via the up- or down-button and press "SUBMIT".
 
-If you have a Smile that is connected, for example, using a (remote) port-forwarding devices can add the port number when configuring it manually. E.g. `192.168.1.2:81`.
+If you have a Smile that is connected, for example, using a (remote) port-forwarding device and has a port other than `80` (HTTP) by default: you can add the port number when configuring it manually. E.g. `192.168.1.2:81`.
 
 <div class='note warning'>
 When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press the "IGNORE" button on the Anna integration to remove this integration. In case you need to rediscover the Adam integration, make sure to click the "STOP IGNORING" button on the Plugwise integration first, available via "show ignored integrations".


### PR DESCRIPTION
## Proposed change
Adding line indicating port number can be used for advanced users having different port numbers



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40017
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
