### PR TITLE
Add documentation for rpi_power

### DIFF
--- a/source/_integrations/rpi_power.markdown
+++ b/source/_integrations/rpi_power.markdown
@@ -1,0 +1,18 @@
+---
+title: Raspberry Pi Power Supply Checker
+description: Instructions on how to integrate Raspberry Pi Power Supply Checker within Home Assistant.
+ha_category:
+  - System Monitor
+ha_iot_class: Local Polling
+ha_release: 0.116
+ha_domain: rpi_power
+ha_codeowners:
+  - '@shenxn'
+ha_config_flow: true
+---
+
+The `rpi_power` integration allows you to detect [bad power supply](https://www.raspberrypi.org/documentation/hardware/raspberrypi/power/README.md) on Raspberry Pi. 
+
+## Configuration
+
+This integration can only be set up through UI. Go to *Configuration* -> *Integration*. Click the *+* button and search for Raspberry Pi Power Supply Checker.

--- a/source/_integrations/rpi_power.markdown
+++ b/source/_integrations/rpi_power.markdown
@@ -8,6 +8,7 @@ ha_release: 0.116
 ha_domain: rpi_power
 ha_codeowners:
   - '@shenxn'
+  - '@swetoast'
 ha_config_flow: true
 ---
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation for the new integration `rpi_power`.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#35527
- Link to parent pull request in the Brands repository: home-assistant/brands#1854
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
