### PR TITLE
Updating deconz documentation

### DIFF
--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -47,7 +47,13 @@ Home Assistant will automatically discover deCONZ presence on your network, if `
 
 If you don't have the API key, you can generate an API key for deCONZ by using the one-click functionality similar to Philips Hue. Go to **Settings** → **Gateway** → **Advanced** → **Authenticate app** in the Phoscon App and then use the deCONZ configurator in Home Assistant frontend to create an API key. When you're done setting up deCONZ it will be stored as a configuration entry.
 
-You can manually add deCONZ by going to the integrations page.
+You can manually add deCONZ by going to the integrations page, or by adding those lines to configuration.yml:
+
+```yaml
+deconz:
+  host: IP_ADRESS
+  port: API_PORT
+```
 
 ## Debugging integration
 


### PR DESCRIPTION
## Proposed change
adding the manual configuration for deConz through configuration.yml



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

When using docker, HA will automatically use the internal containers IP, which changes every time the containers or the server are restarted. Using this will allow to use the server IP instead, thus remove the need to reconfigure the deConz integration everytime the containers are restarted

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
