### PR TITLE
Document device-specific attributes of tint remote control

### DIFF
--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -105,7 +105,7 @@ Note: deCONZ automatically signals Home Assistant when new sensors are added, bu
 
 ## Remote control devices
 
-Remote controls (ZHASwitch category) will not be exposed as regular entities, but as events named `deconz_event` with a payload of `id` and `event` and in case of the Aqara Magic Cube also `gesture`. Id will be the device name from deCONZ and Event will be the momentary state of the switch. Gesture is used for some Aqara Magic Cube specific events like: flip 90 degrees, flip 180 degrees, clockwise and counter clockwise rotation. However, a sensor entity will be created that shows the battery level of the switch as reported by deCONZ, named sensor.device_name_battery_level.
+Remote controls (ZHASwitch category) will not be exposed as regular entities, but as events named `deconz_event` with a payload of `id` and `event`. Id will be the device name from deCONZ and Event will be the momentary state of the switch. Depending on the device some device-specific attributes may also be included in the payload. In case of the Aqara Magic Cube an additional `gesture` attribute will be exposed and for the tint remote the `angle` and `xy` attributes will be included in the payload. Gesture is used for some Aqara Magic Cube specific events like: flip 90 degrees, flip 180 degrees, clockwise and counter clockwise rotation. However, a sensor entity will be created that shows the battery level of the switch as reported by deCONZ, named sensor.device_name_battery_level.
 
 Typical values for switches, the event codes are 4 numbers where the first and last number are of interest here.
 
@@ -232,6 +232,32 @@ automation:
 ```
 
 {% endraw %}
+
+#### Changing color through the Müller Licht tint remote control
+
+{% raw %}
+
+```yaml
+automation:
+  - alias: React to color wheel changes
+    trigger:
+      - platform: event
+        event_type: deconz_event
+        event_data:
+          id: tint_remote_1
+          event: 6002
+    action:
+      - service: light.turn_on
+        data:
+          xy_color:
+            - '{{ trigger.event.data.xy.0 }}'
+            - '{{ trigger.event.data.xy.1 }}'
+          entity_id: light.example_color_light_1
+    mode: restart
+```
+
+{% endraw %}
+
 
 ## Binary Sensor
 

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -105,7 +105,9 @@ Note: deCONZ automatically signals Home Assistant when new sensors are added, bu
 
 ## Remote control devices
 
-Remote controls (ZHASwitch category) will not be exposed as regular entities, but as events named `deconz_event` with a payload of `id` and `event`. Id will be the device name from deCONZ and Event will be the momentary state of the switch. Depending on the device some device-specific attributes may also be included in the payload. In case of the Aqara Magic Cube an additional `gesture` attribute will be exposed and for the tint remote the `angle` and `xy` attributes will be included in the payload. Gesture is used for some Aqara Magic Cube specific events like: flip 90 degrees, flip 180 degrees, clockwise and counter clockwise rotation. However, a sensor entity will be created that shows the battery level of the switch as reported by deCONZ, named sensor.device_name_battery_level.
+Remote controls (ZHASwitch category) will not be exposed as regular entities, but as events named `deconz_event` with a payload of `id` and `event`. Id will be the device name from deCONZ and Event will be the momentary state of the switch.
+
+Depending on the device some device-specific attributes may also be included in the payload. In case of the Aqara Magic Cube, an additional `gesture` attribute will be exposed. For the tint remote, the `angle` and `xy` attributes will be included in the payload. Gesture is used for some Aqara Magic Cube specific events like: flip 90 degrees, flip 180 degrees, clockwise and counterclockwise rotation. However, a sensor entity will be created that shows the battery level of the switch, as reported by deCONZ, named sensor.device_name_battery_level.
 
 Typical values for switches, the event codes are 4 numbers where the first and last number are of interest here.
 

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -259,8 +259,6 @@ automation:
 ```
 
 {% endraw %}
-
-
 ## Binary Sensor
 
 The following sensor types are supported:


### PR DESCRIPTION
## Proposed change

After adding support for the device-specific attributes of the Müller Licht tint remote we should also document them and provide an example automation for chaning colors through the color wheel, as this is quite different from the usual automations.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/39822

## Checklist


- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
