### PR TITLE
Advantage Air Documentation

### DIFF
--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -28,32 +28,3 @@ After completing the configuration flow, the Advantage Air integration will dyna
 
 The `advantage_air` climate platform will create a climate entity for each air conditioning system found, and for each zone that is temperature controlled.
 
-
-### Cover
-
-The `advantage_air` cover platform will create a cover entity for each zone that is not temperature controlled, allowing you to adjust the opening level manually from 0% to 100% in 5% increments.
-
-### Sensor
-
-The `advantage_air` sensor platform will create sensor entities for a variety of aspects:
-
-- The air filter sensor shows if it needs to be replaced.
-- Two sensor entity will be created for the 'time to on' and 'time to off' features. Use the `advantage_air.set_time_to` service to change these.
-- Each zone that is temperature controlled will have a sensor to show how open the damper is.
-- Each zone with a wireless temperature or motion sensor will have a sensor that reports its wireless RSSI.
-
-### Binary Sensor
-
-The `advantage_air` binary sensor platform will create a binary sensor for each zone that has a motion sensor.
-
-## Component services
-
-### set_time_to
-
-Set the On/Off Timer using the relevant sensor entity.
-
-| Service data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | `sensor.[name]_time_to_on` or `sensor.[name]_time_to_off`
-| `entity_id` | no | Number of minutes between `0` and `720`.
-

--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -2,7 +2,7 @@
 title: Advantage Air
 description: Instructions on how to integrate Advantage Air A/C controller into Home Assistant.
 ha_category: Climate
-ha_release: 0.115
+ha_release: 0.116
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
@@ -10,7 +10,7 @@ ha_codeowners:
 ha_domain: advantage_air
 ---
 
-The `Advantage Air` integration allows you to control you [Advantage Air](https://www.advantageair.com.au/) Air Conditioning controllers into Home Assistant.
+The `Advantage Air` integration allows you to control [Advantage Air](https://www.advantageair.com.au/) Air Conditioning controllers into Home Assistant.
 
 ## Configuration
 
@@ -26,7 +26,7 @@ After completing the configuration flow, the Advantage Air integration will dyna
 
 ### Climate
 
-The `advantage_air` climate platform will create a climate entity for each Air Conditioning system found, and for each zone only if they are temperature controlled.
+The `advantage_air` climate platform will create a climate entity for each air conditioning system found, and for each zone that is temperature controlled.
 
 
 ### Cover
@@ -35,12 +35,12 @@ The `advantage_air` cover platform will create a cover entity for each zone that
 
 ### Sensor
 
-The `advantage_air` sensor platform will create sensor entities for a variety of aspects.
+The `advantage_air` sensor platform will create sensor entities for a variety of aspects:
 
-- The Air Filter sensor shows if it needs to be replaced.
-- Two sensor entity will be created for the 'time to on' and 'time to off' features. Use the `myair.set_time_to` service to change these.
+- The air filter sensor shows if it needs to be replaced.
+- Two sensor entity will be created for the 'time to on' and 'time to off' features. Use the `advantage_air.set_time_to` service to change these.
 - Each zone that is temperature controlled will have a sensor to show how open the damper is.
-- A sensor entity will be created for each zone that has a wireless temperature/motion sensors that reports its wireless RSSI.
+- Each zone with a wireless temperature or motion sensor will have a sensor that reports its wireless RSSI.
 
 ### Binary Sensor
 
@@ -48,12 +48,12 @@ The `advantage_air` binary sensor platform will create a binary sensor for each 
 
 ## Component services
 
-Set the On/Off Timer:
+### Service set_time_to
 
-`advantage_air.set_time_to`
+Set the On/Off Timer using the relevant sensor entity.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | sensor.[name]_time_to_on or sensor.[name]_time_to_off
-| `entity_id` | no | Number of minutes between 0 and 720.
+| `entity_id` | no | `sensor.[name]_time_to_on` or `sensor.[name]_time_to_off`
+| `entity_id` | no | Number of minutes between `0` and `720`.
 

--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -1,0 +1,59 @@
+---
+title: Advantage Air
+description: Instructions on how to integrate Advantage Air A/C controller into Home Assistant.
+ha_category: Climate
+ha_release: 0.115
+ha_iot_class: Local Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@Bre77'
+ha_domain: advantage_air
+---
+
+The `Advantage Air` integration allows you to control you [Advantage Air](https://www.advantageair.com.au/) Air Conditioning controllers into Home Assistant.
+
+## Configuration
+
+The wall mounted Android table running the [MyPlace](https://play.google.com/store/apps/details?id=com.air.advantage.myair5), [e-zone](https://play.google.com/store/apps/details?id=com.air.advantage.ezone), or [zone10e](https://play.google.com/store/apps/details?id=com.air.advantage.zone10) must have a static IP, which you will enter on the integrations page in Home Assistant.
+
+Menu: **Configuration** -> **Integrations**.
+
+Click on the `+` sign to add an integration and click on **Advantage Air** (use typeahead if necessary).
+Enter the IP address, and leave the port as the default value.
+After completing the configuration flow, the Advantage Air integration will dynamically add relevant entities for each Air Conditioning system and controlled zones.
+
+## Entities
+
+### Climate
+
+The `advantage_air` climate platform will create a climate entity for each Air Conditioning system found, and for each zone only if they are temperature controlled.
+
+
+### Cover
+
+The `advantage_air` cover platform will create a cover entity for each zone that is not temperature controlled, allowing you to adjust the opening level manually from 0% to 100% in 5% increments.
+
+### Sensor
+
+The `advantage_air` sensor platform will create sensor entities for a variety of aspects.
+
+- The Air Filter sensor shows if it needs to be replaced.
+- Two sensor entity will be created for the 'time to on' and 'time to off' features. Use the `myair.set_time_to` service to change these.
+- Each zone that is temperature controlled will have a sensor to show how open the damper is.
+- A sensor entity will be created for each zone that has a wireless temperature/motion sensors that reports its wireless RSSI.
+
+### Binary Sensor
+
+The `advantage_air` binary sensor platform will create a binary sensor for each zone that has a motion sensor.
+
+## Component services
+
+Set the On/Off Timer:
+
+`advantage_air.set_time_to`
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | sensor.[name]_time_to_on or sensor.[name]_time_to_off
+| `entity_id` | no | Number of minutes between 0 and 720.
+

--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -48,7 +48,7 @@ The `advantage_air` binary sensor platform will create a binary sensor for each 
 
 ## Component services
 
-### Service set_time_to
+### set_time_to
 
 Set the On/Off Timer using the relevant sensor entity.
 

--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -2,7 +2,7 @@
 title: Advantage Air
 description: Instructions on how to integrate Advantage Air A/C controller into Home Assistant.
 ha_category: Climate
-ha_release: 0.116
+ha_release: 0.117
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:

--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -45,6 +45,10 @@ The `advantage_air` sensor platform will create sensor entities for a variety of
 
 The `advantage_air` binary sensor platform will create a binary sensor for each zone that has a motion sensor.
 
+### Switch
+
+The `advantage_air` switch platform will create a switch entity to toggle fresh air mode, if it is supported.
+
 ## Component services
 
 ### set_time_to

--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -10,11 +10,11 @@ ha_codeowners:
 ha_domain: advantage_air
 ---
 
-The `Advantage Air` integration allows you to control [Advantage Air](https://www.advantageair.com.au/) Air Conditioning controllers into Home Assistant.
+The Advantage Air integration allows you to control [Advantage Air](https://www.advantageair.com.au/) Air Conditioning controllers into Home Assistant.
 
 ## Configuration
 
-The wall mounted Android table running the [MyPlace](https://play.google.com/store/apps/details?id=com.air.advantage.myair5), [e-zone](https://play.google.com/store/apps/details?id=com.air.advantage.ezone), or [zone10e](https://play.google.com/store/apps/details?id=com.air.advantage.zone10) must have a static IP, which you will enter on the integrations page in Home Assistant.
+The wall-mounted Android table running the [MyPlace](https://play.google.com/store/apps/details?id=com.air.advantage.myair5), [e-zone](https://play.google.com/store/apps/details?id=com.air.advantage.ezone), or [zone10e](https://play.google.com/store/apps/details?id=com.air.advantage.zone10) must have a static IP, which you will enter on the integrations page in Home Assistant.
 
 Menu: **Configuration** -> **Integrations**.
 
@@ -26,19 +26,19 @@ After completing the configuration flow, the Advantage Air integration will dyna
 
 ### Climate
 
-The `advantage_air` climate platform will create a climate entity for each air conditioning system found, and for each zone that is temperature controlled.
+The integration will create a climate entity for each air conditioning system found and for each zone that is temperature-controlled.
 
 ### Cover
 
-The `advantage_air` cover platform will create a cover entity for each zone that is not temperature controlled, allowing you to adjust the opening level manually from 0% to 100% in 5% increments.
+The integration will create a cover entity for each zone that is not temperature controlled, allowing you to adjust the opening level manually from 0% to 100% in 5% increments.
 
 ### Sensor
 
-The `advantage_air` sensor platform will create sensor entities for a variety of aspects:
+The integration will create sensor entities for a variety of aspects:
 
 - The air filter sensor shows if it needs to be replaced.
-- Two sensor entity will be created for the 'time to on' and 'time to off' features. Use the `advantage_air.set_time_to` service to change these.
-- Each zone that is temperature controlled will have a sensor to show how open the damper is.
+- Two sensor entities will be created for the 'time to on' and 'time to off' features. Use the `advantage_air.set_time_to` service to change these.
+- Each zone that is temperature-controlled will have a sensor to show how open the damper is.
 - Each zone with a wireless temperature or motion sensor will have a sensor that reports its wireless RSSI.
 
 ### Binary Sensor
@@ -49,13 +49,13 @@ The `advantage_air` binary sensor platform will create a binary sensor for each 
 
 The `advantage_air` switch platform will create a switch entity to toggle fresh air mode, if it is supported.
 
-## Component services
+## Services
 
-### set_time_to
+### Service `advantage_air.set_time_to`
 
 Set the On/Off Timer using the relevant sensor entity.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `entity_id` | no | `sensor.[name]_time_to_on` or `sensor.[name]_time_to_off`
-| `entity_id` | no | Number of minutes between `0` and `720`.
+| `entity_id` | yes | `sensor.[name]_time_to_on` or `sensor.[name]_time_to_off`
+| `minutes` | no | Number of minutes between `0` and `720`.

--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -28,3 +28,10 @@ After completing the configuration flow, the Advantage Air integration will dyna
 
 The `advantage_air` climate platform will create a climate entity for each air conditioning system found, and for each zone that is temperature controlled.
 
+### Cover
+
+The `advantage_air` cover platform will create a cover entity for each zone that is not temperature controlled, allowing you to adjust the opening level manually from 0% to 100% in 5% increments.
+
+### Binary Sensor
+
+The `advantage_air` binary sensor platform will create a binary sensor for each zone that has a motion sensor.

--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -32,6 +32,26 @@ The `advantage_air` climate platform will create a climate entity for each air c
 
 The `advantage_air` cover platform will create a cover entity for each zone that is not temperature controlled, allowing you to adjust the opening level manually from 0% to 100% in 5% increments.
 
+### Sensor
+
+The `advantage_air` sensor platform will create sensor entities for a variety of aspects:
+
+- The air filter sensor shows if it needs to be replaced.
+- Two sensor entity will be created for the 'time to on' and 'time to off' features. Use the `advantage_air.set_time_to` service to change these.
+- Each zone that is temperature controlled will have a sensor to show how open the damper is.
+- Each zone with a wireless temperature or motion sensor will have a sensor that reports its wireless RSSI.
+
 ### Binary Sensor
 
 The `advantage_air` binary sensor platform will create a binary sensor for each zone that has a motion sensor.
+
+## Component services
+
+### set_time_to
+
+Set the On/Off Timer using the relevant sensor entity.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | `sensor.[name]_time_to_on` or `sensor.[name]_time_to_off`
+| `entity_id` | no | Number of minutes between `0` and `720`.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is an integration for the Advantage Air range of ducted air-conditioning systems controlled by a wall mounted Android tablet. The products have various names such as MyAir, e-zone, and zone10e. The integration creates Climate entities, Cover entities, Sensors, and Binary Sensors dynamically based on what hardware is exposed by the product.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [X] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40159
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1864
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
