### PR TITLE
Updated MQTT testing documentation

### DIFF
--- a/source/_docs/mqtt/testing.markdown
+++ b/source/_docs/mqtt/testing.markdown
@@ -10,7 +10,7 @@ The `mosquitto` broker package ships commandline tools (often as `*-clients` pac
 mosquitto_pub -h 127.0.0.1 -t home-assistant/switch/1/on -m "Switch is ON"
 ```
 
-Another way to send MQTT messages by hand is to use "MQTT" Integration in the Frontend. Choose the "Configuration" tab and click "Integrations" and click the "Configure" option under the MQTT integration. Enter something similar to the example below into the "Topic" field.
+Another way to send MQTT messages manually is to use the "MQTT" Integration in the frontend. Choose the "Configuration" tab, click "Integrations" and click the "Configure" option under the "MQTT" integration. Enter something similar to the example below into the "topic" field under "Publish a packet*.
 
 ```bash
    home-assistant/switch/1/power

--- a/source/_docs/mqtt/testing.markdown
+++ b/source/_docs/mqtt/testing.markdown
@@ -10,7 +10,7 @@ The `mosquitto` broker package ships commandline tools (often as `*-clients` pac
 mosquitto_pub -h 127.0.0.1 -t home-assistant/switch/1/on -m "Switch is ON"
 ```
 
-Another way to send MQTT messages by hand is to use the "Developer Tools" in the Frontend. Choose the "MQTT" tab. Enter something similar to the example below into the "Topic" field.
+Another way to send MQTT messages by hand is to use "MQTT" Integration in the Frontend. Choose the "Configuration" tab and click "Integrations" and click the "Configure" option under the MQTT integration. Enter something similar to the example below into the "Topic" field.
 
 ```bash
    home-assistant/switch/1/power


### PR DESCRIPTION
Updated UI testing procedure to reflect updated UI workflow (Integrations tab instead of Developer Tools).

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Just resetup MQTT and noticed that the UI had been updated and the testing worflow was no longer in the Dev Tools. Updated documentation to reflect new location. (MQTT Integration)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
