### PR TITLE
document rx_mode for homematic

### DIFF
--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -382,7 +382,7 @@ action:
       WEEK_PROGRAM_POINTER: 1
 ```
 
-Set the week program of a wall thermostat with explicit rx_mode (BidCos-RF only):
+Set the week program of a wall thermostat with explicit `rx_mode` (BidCos-RF only):
 
 ```yaml
 ...
@@ -399,9 +399,9 @@ action:
 
 BidCos-RF devices have an optional parameter for put_paramset which defines the way the configuration data is sent to the device.
 
-rx_mode BURST, which is the default value, will wake up every device when submitting the configuration data and hence makes all devices use some battery. It is instant, i.e. the data is sent almost immediately.
+`rx_mode` `BURST`, which is the default value, will wake up every device when submitting the configuration data and hence makes all devices use some battery. It is instant, i.e. the data is sent almost immediately.
 
-rx_mode WAKEUP will send the configuration data only after a device submitted updated values to CCU, which usually happens every 3 minutes. It will not wake up every device and thus saves devices battery.
+`rx_mode` `WAKEUP` will send the configuration data only after a device submitted updated values to CCU, which usually happens every 3 minutes. It will not wake up every device and thus saves devices battery.
 
 Manually set lock on KeyMatic devices:
 

--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -382,6 +382,27 @@ action:
       WEEK_PROGRAM_POINTER: 1
 ```
 
+Set the week program of a wall thermostat with explicit rx_mode (BidCos-RF only):
+
+```yaml
+...
+action:
+  service: homematic.put_paramset
+  data:
+    interface: wireless
+    address: LEQ1234567
+    paramset_key: MASTER
+    rx_mode: WAKEUP
+    paramset:
+      WEEK_PROGRAM_POINTER: 1
+```
+
+BidCos-RF devices have an optional parameter for put_paramset which defines the way the configuration data is sent to the device.
+
+rx_mode BURST, which is the default value, will wake up every device when submitting the configuration data and hence makes all devices use some battery. It is instant, i.e. the data is sent almost immediately.
+
+rx_mode WAKEUP will send the configuration data only after a device submitted updated values to CCU, which usually happens every 3 minutes. It will not wake up every device and thus saves devices battery.
+
 Manually set lock on KeyMatic devices:
 
 ```yaml


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Explain rx_mode for put_paramset in homematic integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40065
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
