### PR TITLE
Remove unnecessary _template after service call

### DIFF
--- a/source/_docs/scripts/service-calls.markdown
+++ b/source/_docs/scripts/service-calls.markdown
@@ -42,7 +42,7 @@ A full list of the parameters for a service can be found on the documentation pa
 You can use [templating] support to dynamically choose which service to call. For example, you can call a certain service based on if a light is on.
 
 ```yaml
-service_template: >
+service: >
   {% raw %}{% if states('sensor.temperature') | float > 15 %}
     switch.turn_on
   {% else %}


### PR DESCRIPTION
Since 0.115 the simpler ```service``` can be used instead of ```service_template```.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Remove the unnecessary _template after service call in a document



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
