### PR TITLE
Update logbook and history for entity glob matching

### DIFF
--- a/source/_integrations/history.markdown
+++ b/source/_integrations/history.markdown
@@ -155,8 +155,8 @@ Filters are applied as follows:
 
 The following characters can be used in entity globs:
 
-* - The asterisk represents zero, one, or multiple characters
-. - The period represents a single character
+`*` - The asterisk represents zero, one, or multiple characters
+`.` - The period represents a single character
 
 #### Implementation details
 

--- a/source/_integrations/history.markdown
+++ b/source/_integrations/history.markdown
@@ -44,6 +44,10 @@ exclude:
       description: The list of entity ids to be excluded from the history.
       required: false
       type: list
+    entity_globs:
+      description: Include all entities matching a listed pattern when creating logbook entries (e.g., `sensor.weather_*`).
+      required: false
+      type: list
     domains:
       description: The list of domains to be excluded from the history.
       required: false
@@ -55,6 +59,10 @@ include:
   keys:
     entities:
       description: The list of entity ids to be included in the history.
+      required: false
+      type: list
+    entity_globs:
+      description: Include all entities matching a listed pattern when creating logbook entries (e.g., `sensor.weather_*`).
       required: false
       type: list
     domains:
@@ -83,6 +91,8 @@ history:
     entities:
       - sensor.last_boot
       - sensor.date
+    entity_globs:
+      - binary_sensor.*_occupancy
 ```
 
 Define domains and entities to display by using the `include` configuration
@@ -135,6 +145,18 @@ history:
       - sun.sun
       - light.front_porch
 ```
+
+Filters are applied as follows:
+
+1. No includes or excludes - pass all entities
+2. Includes, no excludes - only include specified entities
+3. Excludes, no includes - only exclude specified entities
+4. Both includes and excludes - include specified entities and exclude specified entities from the remaining.
+
+The following characters can be used in entity globs:
+
+* - The asterisk represents zero, one, or multiple characters
+. - The period represents a single character
 
 #### Implementation details
 

--- a/source/_integrations/logbook.markdown
+++ b/source/_integrations/logbook.markdown
@@ -92,8 +92,8 @@ Filters are applied as follows:
 
 The following characters can be used in entity globs:
 
-* "*" - The asterisk represents zero, one, or multiple characters
-* "." - The period represents a single character
+- `*` - The asterisk represents zero, one, or multiple characters
+- `.` - The period represents a single character
 
 ### Common filtering examples
 

--- a/source/_integrations/logbook.markdown
+++ b/source/_integrations/logbook.markdown
@@ -92,8 +92,8 @@ Filters are applied as follows:
 
 The following characters can be used in entity globs:
 
-* - The asterisk represents zero, one, or multiple characters
-. - The period represents a single character
+* "*" - The asterisk represents zero, one, or multiple characters
+* "." - The period represents a single character
 
 ### Common filtering examples
 

--- a/source/_integrations/logbook.markdown
+++ b/source/_integrations/logbook.markdown
@@ -88,18 +88,12 @@ Filters are applied as follows:
 1. No includes or excludes - pass all entities
 2. Includes, no excludes - only include specified entities
 3. Excludes, no includes - only exclude specified entities
-4. Both includes and excludes:
-   - Include domain and/or glob patterns specified
-      - If domain is included, and entity not excluded or match exclude glob pattern, pass
-      - If entity matches include glob pattern, and entity does not match any exclude criteria (domain, glob pattern or listed), pass
-      - If domain is not included, glob pattern does not match, and entity not included, fail
-   - Exclude domain and/or glob patterns specified and include does not list domains or glob patterns
-      - If domain is excluded and entity not included, fail
-      - If entity matches exclude glob pattern and entity not included, fail
-      - If entity does not match any exclude criteria (domain, glob pattern or listed), pass
-   - Neither include or exclude specifies domains or glob patterns
-      - If entity is included, pass (as #2 above)
-      - If entity include and exclude, the entity exclude is ignored
+4. Both includes and excludes - include specified entities and exclude specified entities from the remaining.
+
+The following characters can be used in entity globs:
+
+* - The asterisk represents zero, one, or multiple characters
+. - The period represents a single character
 
 ### Common filtering examples
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update logbook and history for entity glob matching.

The logbook and history docs document the include/exclude method as if it was an entity filter, however include/exclude matching is done in sql and uses a different algorithm.  Logbook was actually doing both so the behavior was a bit undefined.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40387
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
