### PR TITLE
Adding unprotected file warning to Cloud

### DIFF
--- a/source/_integrations/cloud.markdown
+++ b/source/_integrations/cloud.markdown
@@ -23,6 +23,8 @@ cloud:
 
 Documentation of further configuration possibilites are located at [NabuCasa](https://www.nabucasa.com/config/)
 
+**Warning:** Files in the `www` folder (`/local/` url), aren't protected by the Home Assistant authentication. Files stored in this folder, if the URL is known, can be accessed by anybody without authentication. For better security, you should place any sensitive files (like camera snapshots), in a subdirectory with a long, random name like `hjkhsnf342345523lkjshdfiu/my_camera_image.jpg`.
+
 Once activated, go to the configuration panel in Home Assistant and create an account and log in. If you are not seeing the **Configuration** panel, make sure you have the following option enabled in your `configuration.yaml` file.
 
 ```yaml


### PR DESCRIPTION
## Proposed change
The purpose of this came from the following WTH: https://community.home-assistant.io/t/wth-secure-access-to-www-local-behind-authentication/228030/6

The goal is to make all users aware that the /www directory is not protected by authentication and shows how to further protect sensitive files in more locations than just on the HTTP integrations page.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ x ] Spelling, grammar or other readability improvements (`current` branch).
- [ x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
