### PR TITLE
Remove Lovelace changelog link from aside

### DIFF
--- a/source/_includes/asides/lovelace_navigation.html
+++ b/source/_includes/asides/lovelace_navigation.html
@@ -6,7 +6,6 @@
     <h1 class="title delta">Lovelace UI</h1>
     <ul class="divided sidebar-menu">
       <li>{% active_link /lovelace/ Introduction %}</li>
-      <li>{% active_link /lovelace/changelog/ Changelog %}</li>
     </ul>
   </div>
 
@@ -21,10 +20,9 @@
       <li>{% active_link /lovelace/badges/ Badges %}</li>
       <li>{% active_link /lovelace/actions/ Actions %}</li>
       <li>
-        <a
-          href="https://developers.home-assistant.io/docs/frontend/custom-ui/lovelace-custom-card.html"
-          >Developing Custom Cards <i class="icon-external-link"></i
-        ></a>
+        <a href="https://developers.home-assistant.io/docs/frontend/custom-ui/lovelace-custom-card.html">Developing Custom Cards
+          <i class="icon-external-link"></i>
+        </a>
       </li>
     </ul>
   </div>
@@ -33,7 +31,7 @@
     <h1 class="title delta">Cards</h1>
     <ul class="divided sidebar-menu">
       {% for card in cards %}
-      <li>{% active_link {{card.url}} {{card.sidebar_label}} %}</li>
+        <li>{% active_link {{card.url}} {{card.sidebar_label}} %}</li>
       {% endfor %}
     </ul>
   </div>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Removes the link from the aside in the Lovelace UI documentation section.
The changelog is outdated and not part of our release process.

To prevent confusion, this PR removes it as a item from the aside for now.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
