### PR TITLE
Documentation update: Added reflector setting in avahi for docker setups

### DIFF
--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -110,7 +110,13 @@ If mDNS is still not working:
 #### mDNS forwarding
 If it's not possible to have Home Assistant and the devices on the same network, mDNS forwarding may allow mDNS discovery between networks.
 
-mDNS forwarding is a configurable option in some routers. It can also be called mDNS reflector or mDNS repeater, depending on the manufacturer.
+mDNS forwarding is a configurable option in some routers. It can also be called mDNS reflector or mDNS repeater, depending on the manufacturer. For Docker setups that use bridge network (instead of `net=host` - not recommended) the following Avahi setting can help:
+
+```
+[reflector]
+enable-reflector=yes
+reflect-ipv=no
+```
 
 ### Windows
 

--- a/source/_integrations/discovery.markdown
+++ b/source/_integrations/discovery.markdown
@@ -112,7 +112,7 @@ If it's not possible to have Home Assistant and the devices on the same network,
 
 mDNS forwarding is a configurable option in some routers. It can also be called mDNS reflector or mDNS repeater, depending on the manufacturer. For Docker setups that use bridge network (instead of `net=host` - not recommended) the following Avahi setting can help:
 
-```
+```properties
 [reflector]
 enable-reflector=yes
 reflect-ipv=no


### PR DESCRIPTION
## Proposed change
This avahi setting allows HomeAssistant mDns work also in a docker setup that uses bridge networking instead of the recommended host networking.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
