### PR TITLE
0.115.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,8 +101,8 @@ social:
 # Home Assistant release details
 current_major_version: 0
 current_minor_version: 115
-current_patch_version: 2
-date_released: 2020-09-19
+current_patch_version: 3
+date_released: 2020-09-25
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/source/_posts/2020-09-17-release-115.markdown
+++ b/source/_posts/2020-09-17-release-115.markdown
@@ -106,6 +106,7 @@ navigating you around this release.
 - [Farewell to the following](#farewell-to-the-following)
 - [Release 0.115.1 - September 18](#release-01151---september-18)
 - [Release 0.115.2 - September 19](#release-01152---september-19)
+- [Release 0.115.3 - September 25](#release-01153---september-25)
 - [All changes](#all-changes)
 
 ## Media Browser
@@ -1729,6 +1730,97 @@ discovery. Users currently using that should set up all devices through UI.
 [rfxtrx docs]: /integrations/rfxtrx/
 [vera docs]: /integrations/vera/
 [zha docs]: /integrations/zha/
+
+## Release 0.115.3 - September 25
+
+- Use Cloud State as alternative state if condition unknown ([@thehaxxa] - [#37121]) ([bom docs])
+- Guard SolarEdge for inverters without batteries ([@mhaack] - [#40295]) ([solaredge docs])
+- Ignore packets with missing dts in peek_first_pts ([@uvjustin] - [#40299]) ([stream docs])
+- Axis - Fix list applications breaks if empty response ([@Kane610] - [#40360]) ([axis docs])
+- Fix Met.no missing conditions in API forecasts ([@thimic] - [#40373]) ([met docs])
+- Bump pyinsteon to 1.0.8 ([@teharris1] - [#40383]) ([insteon docs])
+- Fix OSError ([@bieniu] - [#40393]) ([shelly docs])
+- Fix handling of empty ws port ([@OnFreund] - [#40399]) ([kodi docs])
+- Validate Met.no forecast entries before passing them on to HA ([@thimic] - [#40400]) ([met docs])
+- Fix luci device_tracker incorrectly reporting devices status ([@cagnulein] - [#40409]) ([luci docs])
+- Make modbus switch read_coil failure resistent ([@janiversen] - [#40417]) ([modbus docs])
+- Fix webostv supported features for "external_speaker" sound output ([@PedroLamas] - [#40435]) ([webostv docs])
+- Fix regression in Nextcloud component ([@meichthys] - [#40438]) ([nextcloud docs])
+- Fix proxy camera conversion with PNG Alpha(RGBA) ([@square99] - [#40446]) ([proxy docs])
+- Bump accuweather library to version 0.0.11 ([@bieniu] - [#40458])
+- Increase gogogate2 request timeout ([@vangorra] - [#40461]) ([gogogate2 docs])
+- Fix handling of quoted time_pattern values ([@amelchio] - [#40470]) ([homeassistant docs])
+- Ensure group state is recalculated when re-adding on reload ([@bdraco] - [#40497]) ([group docs])
+- Disable audio in stream when audio stream profile is None ([@uvjustin] - [#40521]) ([stream docs])
+- Fix luci device_tracker when release is none ([@cagnulein] - [#40524]) ([luci docs])
+- Increase upnp timeout from 5 seconds to 10 seconds ([@StevenLooman] - [#40540]) ([upnp docs])
+- Fix connection validation during import for dsmr integration ([@RobBie1221] - [#40548]) ([dsmr docs])
+- Updated frontend to 20200918.2 ([@bramkragten] - [#40549]) ([frontend docs])
+- Fix bug in state trigger when using for: without to: ([@KevinCathcart] - [#40556]) ([homeassistant docs])
+
+[#37121]: https://github.com/home-assistant/core/pull/37121
+[#40295]: https://github.com/home-assistant/core/pull/40295
+[#40299]: https://github.com/home-assistant/core/pull/40299
+[#40360]: https://github.com/home-assistant/core/pull/40360
+[#40373]: https://github.com/home-assistant/core/pull/40373
+[#40383]: https://github.com/home-assistant/core/pull/40383
+[#40393]: https://github.com/home-assistant/core/pull/40393
+[#40399]: https://github.com/home-assistant/core/pull/40399
+[#40400]: https://github.com/home-assistant/core/pull/40400
+[#40409]: https://github.com/home-assistant/core/pull/40409
+[#40417]: https://github.com/home-assistant/core/pull/40417
+[#40435]: https://github.com/home-assistant/core/pull/40435
+[#40438]: https://github.com/home-assistant/core/pull/40438
+[#40446]: https://github.com/home-assistant/core/pull/40446
+[#40458]: https://github.com/home-assistant/core/pull/40458
+[#40461]: https://github.com/home-assistant/core/pull/40461
+[#40470]: https://github.com/home-assistant/core/pull/40470
+[#40497]: https://github.com/home-assistant/core/pull/40497
+[#40521]: https://github.com/home-assistant/core/pull/40521
+[#40524]: https://github.com/home-assistant/core/pull/40524
+[#40540]: https://github.com/home-assistant/core/pull/40540
+[#40548]: https://github.com/home-assistant/core/pull/40548
+[#40549]: https://github.com/home-assistant/core/pull/40549
+[#40556]: https://github.com/home-assistant/core/pull/40556
+[@Kane610]: https://github.com/Kane610
+[@KevinCathcart]: https://github.com/KevinCathcart
+[@OnFreund]: https://github.com/OnFreund
+[@PedroLamas]: https://github.com/PedroLamas
+[@RobBie1221]: https://github.com/RobBie1221
+[@StevenLooman]: https://github.com/StevenLooman
+[@amelchio]: https://github.com/amelchio
+[@bdraco]: https://github.com/bdraco
+[@bieniu]: https://github.com/bieniu
+[@bramkragten]: https://github.com/bramkragten
+[@cagnulein]: https://github.com/cagnulein
+[@janiversen]: https://github.com/janiversen
+[@meichthys]: https://github.com/meichthys
+[@mhaack]: https://github.com/mhaack
+[@square99]: https://github.com/square99
+[@teharris1]: https://github.com/teharris1
+[@thehaxxa]: https://github.com/thehaxxa
+[@thimic]: https://github.com/thimic
+[@uvjustin]: https://github.com/uvjustin
+[@vangorra]: https://github.com/vangorra
+[axis docs]: /integrations/axis/
+[bom docs]: /integrations/bom/
+[dsmr docs]: /integrations/dsmr/
+[frontend docs]: /integrations/frontend/
+[gogogate2 docs]: /integrations/gogogate2/
+[group docs]: /integrations/group/
+[homeassistant docs]: /integrations/homeassistant/
+[insteon docs]: /integrations/insteon/
+[kodi docs]: /integrations/kodi/
+[luci docs]: /integrations/luci/
+[met docs]: /integrations/met/
+[modbus docs]: /integrations/modbus/
+[nextcloud docs]: /integrations/nextcloud/
+[proxy docs]: /integrations/proxy/
+[shelly docs]: /integrations/shelly/
+[solaredge docs]: /integrations/solaredge/
+[stream docs]: /integrations/stream/
+[upnp docs]: /integrations/upnp/
+[webostv docs]: /integrations/webostv/
 
 ## All changes
 


### PR DESCRIPTION
- Use Cloud State as alternative state if condition unknown ([@thehaxxa] - [#37121]) ([bom docs])
- Guard SolarEdge for inverters without batteries ([@mhaack] - [#40295]) ([solaredge docs])
- Ignore packets with missing dts in peek_first_pts ([@uvjustin] - [#40299]) ([stream docs])
- Axis - Fix list applications breaks if empty response ([@Kane610] - [#40360]) ([axis docs])
- Fix Met.no missing conditions in API forecasts ([@thimic] - [#40373]) ([met docs])
- Bump pyinsteon to 1.0.8 ([@teharris1] - [#40383]) ([insteon docs])
- Fix OSError ([@bieniu] - [#40393]) ([shelly docs])
- Fix handling of empty ws port ([@OnFreund] - [#40399]) ([kodi docs])
- Validate Met.no forecast entries before passing them on to HA ([@thimic] - [#40400]) ([met docs])
- Fix luci device_tracker incorrectly reporting devices status ([@cagnulein] - [#40409]) ([luci docs])
- Make modbus switch read_coil failure resistent ([@janiversen] - [#40417]) ([modbus docs])
- Fix webostv supported features for "external_speaker" sound output ([@PedroLamas] - [#40435]) ([webostv docs])
- Fix regression in Nextcloud component ([@meichthys] - [#40438]) ([nextcloud docs])
- Fix proxy camera conversion with PNG Alpha(RGBA) ([@square99] - [#40446]) ([proxy docs])
- Bump accuweather library to version 0.0.11 ([@bieniu] - [#40458])
- Increase gogogate2 request timeout ([@vangorra] - [#40461]) ([gogogate2 docs])
- Fix handling of quoted time_pattern values ([@amelchio] - [#40470]) ([homeassistant docs])
- Ensure group state is recalculated when re-adding on reload ([@bdraco] - [#40497]) ([group docs])
- Disable audio in stream when audio stream profile is None ([@uvjustin] - [#40521]) ([stream docs])
- Fix luci device_tracker when release is none ([@cagnulein] - [#40524]) ([luci docs])
- Increase upnp timeout from 5 seconds to 10 seconds ([@StevenLooman] - [#40540]) ([upnp docs])
- Fix connection validation during import for dsmr integration ([@RobBie1221] - [#40548]) ([dsmr docs])
- Updated frontend to 20200918.2 ([@bramkragten] - [#40549]) ([frontend docs])
- Fix bug in state trigger when using for: without to: ([@KevinCathcart] - [#40556]) ([homeassistant docs])

[#37121]: https://github.com/home-assistant/core/pull/37121
[#40295]: https://github.com/home-assistant/core/pull/40295
[#40299]: https://github.com/home-assistant/core/pull/40299
[#40360]: https://github.com/home-assistant/core/pull/40360
[#40373]: https://github.com/home-assistant/core/pull/40373
[#40383]: https://github.com/home-assistant/core/pull/40383
[#40393]: https://github.com/home-assistant/core/pull/40393
[#40399]: https://github.com/home-assistant/core/pull/40399
[#40400]: https://github.com/home-assistant/core/pull/40400
[#40409]: https://github.com/home-assistant/core/pull/40409
[#40417]: https://github.com/home-assistant/core/pull/40417
[#40435]: https://github.com/home-assistant/core/pull/40435
[#40438]: https://github.com/home-assistant/core/pull/40438
[#40446]: https://github.com/home-assistant/core/pull/40446
[#40458]: https://github.com/home-assistant/core/pull/40458
[#40461]: https://github.com/home-assistant/core/pull/40461
[#40470]: https://github.com/home-assistant/core/pull/40470
[#40497]: https://github.com/home-assistant/core/pull/40497
[#40521]: https://github.com/home-assistant/core/pull/40521
[#40524]: https://github.com/home-assistant/core/pull/40524
[#40540]: https://github.com/home-assistant/core/pull/40540
[#40548]: https://github.com/home-assistant/core/pull/40548
[#40549]: https://github.com/home-assistant/core/pull/40549
[#40556]: https://github.com/home-assistant/core/pull/40556
[@Kane610]: https://github.com/Kane610
[@KevinCathcart]: https://github.com/KevinCathcart
[@OnFreund]: https://github.com/OnFreund
[@PedroLamas]: https://github.com/PedroLamas
[@RobBie1221]: https://github.com/RobBie1221
[@StevenLooman]: https://github.com/StevenLooman
[@amelchio]: https://github.com/amelchio
[@bdraco]: https://github.com/bdraco
[@bieniu]: https://github.com/bieniu
[@bramkragten]: https://github.com/bramkragten
[@cagnulein]: https://github.com/cagnulein
[@janiversen]: https://github.com/janiversen
[@meichthys]: https://github.com/meichthys
[@mhaack]: https://github.com/mhaack
[@square99]: https://github.com/square99
[@teharris1]: https://github.com/teharris1
[@thehaxxa]: https://github.com/thehaxxa
[@thimic]: https://github.com/thimic
[@uvjustin]: https://github.com/uvjustin
[@vangorra]: https://github.com/vangorra
[axis docs]: https://www.home-assistant.io/integrations/axis/
[bom docs]: https://www.home-assistant.io/integrations/bom/
[dsmr docs]: https://www.home-assistant.io/integrations/dsmr/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[gogogate2 docs]: https://www.home-assistant.io/integrations/gogogate2/
[group docs]: https://www.home-assistant.io/integrations/group/
[homeassistant docs]: https://www.home-assistant.io/integrations/homeassistant/
[insteon docs]: https://www.home-assistant.io/integrations/insteon/
[kodi docs]: https://www.home-assistant.io/integrations/kodi/
[luci docs]: https://www.home-assistant.io/integrations/luci/
[met docs]: https://www.home-assistant.io/integrations/met/
[modbus docs]: https://www.home-assistant.io/integrations/modbus/
[nextcloud docs]: https://www.home-assistant.io/integrations/nextcloud/
[proxy docs]: https://www.home-assistant.io/integrations/proxy/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[solaredge docs]: https://www.home-assistant.io/integrations/solaredge/
[stream docs]: https://www.home-assistant.io/integrations/stream/
[upnp docs]: https://www.home-assistant.io/integrations/upnp/
[webostv docs]: https://www.home-assistant.io/integrations/webostv/