### PR TITLE
Removes auto from the example attributes

### DIFF
--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -89,8 +89,8 @@ VeSync air purifiers will expose the following details.
 
 | Attribute               | Description                                                             | Example         |
 | ----------------------- | ----------------------------------------------------------------------- | --------------- |
-| `mode`                  | The current mode the device is in.                                      | auto            |
-| `speed`                 | The current speed setting of the device.                                | auto            |
+| `mode`                  | The current mode the device is in.                                      | manual          |
+| `speed`                 | The current speed setting of the device.                                | high            |
 | `speed_list`            | The available list of speeds supported by the device.                   | high            |
 | `active_time`           | The number of seconds since the device has been in a non-off mode.      | 1598            |
 | `filter_life`           | Remaining percentage of the filter.                                     | 142             |


### PR DESCRIPTION
## Proposed change
This is to remove the example that shows auto in the mode attribute and as a potential speed.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40559
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
