### PR TITLE
Add intructions for UI use of Input Helpers when `default_config:` is missing from configuration

### DIFF
--- a/source/_integrations/input_boolean.markdown
+++ b/source/_integrations/input_boolean.markdown
@@ -14,6 +14,9 @@ The `input_boolean` integration allows the user to define boolean values that ca
 
 The preferred way to configure input booleans is via the user interface at **Configuration** -> **Helpers**. Click the add button and then choose the "**Toggle**" option.
 
+To be able to add **Helpers** via the user interface you should have `default_config:` in your `configuration.yaml`, it should already be there by default unless you removed it.
+If you removed `default_config:` from you configuration, you must add `input_boolean:` to your `configuration.yaml` first, then you can use the UI.
+
 Input booleans can also be configured via `configuration.yaml`:
 
 ```yaml

--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -16,6 +16,9 @@ templates.
 
 The preferred way to configure input datetime is via the user interface at **Configuration** -> **Helpers**. Click the add button and then choose the **Date and/or time** option.
 
+To be able to add **Helpers** via the user interface you should have `default_config:` in your `configuration.yaml`, it should already be there by default unless you removed it.
+If you removed `default_config:` from you configuration, you must add `input_datetime:` to your `configuration.yaml` first, then you can use the UI.
+
 `input_datetime` can also be configured via YAML. To add three datetime inputs to your installation,
 one with both date and time, and one with date or time each,
 add the following lines to your `configuration.yaml`:

--- a/source/_integrations/input_number.markdown
+++ b/source/_integrations/input_number.markdown
@@ -14,6 +14,9 @@ The `input_number` integration allows the user to define values that can be cont
 
 The preferred way to configure an input number is via the user interface at **Configuration** -> **Helpers**. Click the add button and then choose the **Number** option.
 
+To be able to add **Helpers** via the user interface you should have `default_config:` in your `configuration.yaml`, it should already be there by default unless you removed it.
+If you removed `default_config:` from you configuration, you must add `input_number:` to your `configuration.yaml` first, then you can use the UI.
+
 Input numbers can also be configured via `configuration.yaml`:
 
 ```yaml

--- a/source/_integrations/input_select.markdown
+++ b/source/_integrations/input_select.markdown
@@ -14,6 +14,9 @@ The `input_select` integration allows the user to define a list of values that c
 
 The preferred way to configure an input select is via the user interface at **Configuration** -> **Helpers**. Click the add button and then choose the **Dropdown** option.
 
+To be able to add **Helpers** via the user interface you should have `default_config:` in your `configuration.yaml`, it should already be there by default unless you removed it.
+If you removed `default_config:` from you configuration, you must add `input_select:` to your `configuration.yaml` first, then you can use the UI.
+
 Input selects can also be configured via `configuration.yaml`:
 
 ```yaml

--- a/source/_integrations/input_text.markdown
+++ b/source/_integrations/input_text.markdown
@@ -14,6 +14,9 @@ The `input_text` integration allows the user to define values that can be contro
 
 The preferred way to configure an input text is via the user interface at **Configuration** -> **Helpers**. Click the add button and then choose the **Text** option.
 
+To be able to add **Helpers** via the user interface you should have `default_config:` in your `configuration.yaml`, it should already be there by default unless you removed it.
+If you removed `default_config:` from you configuration, you must add `input_text:` to your `configuration.yaml` first, then you can use the UI.
+
 It can also be configured via `configuration.yaml`:
 
 ```yaml


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Related to the Input Helpers use via the UI
The user can run into some greyed out options in the UI with no obvious reason if the `default_config:` is not beeing used in the `configuration.yaml`.
The proposed documentation addition instructs how to properly setup in that case.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue:  Related to the already closed issue #38660 https://github.com/home-assistant/core/issues/38660

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
