### PR TITLE
Explain group state calculation

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -56,3 +56,43 @@ icon:
 ## Group behavior
 
 By default when any member of a group is `on` then the group will also be `on`. Similarly with a device tracker, when any member of the group is `home` then the group is `home`. If you set the `all` option to `true` though, this behavior is inverted and all members of the group have to be `on` for the group to turn on as well.
+
+## Group state calculation
+
+The system can calculate group state with entities from the following domains:
+
+* alarm_control_panel
+* binary_sensor
+* climate
+* cover
+* device_tracker
+* fan
+* humidifier
+* light
+* lock
+* media_player
+* person
+* remote
+* switch
+* vacuum
+* water_heater
+
+When entities all have a single on and off state, the group state will
+be calculated as follows:
+
+| Domain            | on     | off      |
+|-------------------|--------|----------|
+| device_tracker    | home   | not_home |
+| cover             | open   | closed   |
+| lock              | locked | unlocked |
+| person            | home   | not_home |
+| media_player      | ok     | problem  |
+
+When a group contains entities from domains that have multiple `on` states or only use `on`
+and `off`, the group state will be `on` or `off`.
+
+It is possible to create a group that the system cannot calculate a group state.
+Groups with entities from unsupported domains will always have an unknown state.
+
+These groups can still be in templates with the `expand()` directive, called using the
+`homeassistant.turn_on` and `homeassistant.turn_off` services, etc.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Explain group state calculation


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40607
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
