### PR TITLE
Add explanation of the new template `rate_limit` directive.

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -58,7 +58,7 @@ Extensions allow templates to access all of the Home Assistant specific states a
 - `is_state('device_tracker.paulus', 'home')` will test if the given entity is the specified state.
 - `state_attr('device_tracker.paulus', 'battery')` will return the value of the attribute or None if it doesn't exist.
 - `is_state_attr('device_tracker.paulus', 'battery', 40)` will test if the given entity attribute is the specified state (in this case, a numeric value). Note that the attribute can be `None` and you want to check if it is `None`, you need to use `state_attr('sensor.my_sensor', 'attr') == None`. 
-
+- `rate_limit` - limits re-renders of the template. Returns a timedelta object and accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
 <div class='note warning'>
 
   Avoid using `states.sensor.temperature.state`, instead use `states('sensor.temperature')`. It is strongly advised to use the `states()`, `is_state()`, `state_attr()` and `is_state_attr()` as much as possible, to avoid errors and error message when the entity isn't ready yet (e.g., during Home Assistant startup).

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -58,7 +58,7 @@ Extensions allow templates to access all of the Home Assistant specific states a
 - `is_state('device_tracker.paulus', 'home')` will test if the given entity is the specified state.
 - `state_attr('device_tracker.paulus', 'battery')` will return the value of the attribute or None if it doesn't exist.
 - `is_state_attr('device_tracker.paulus', 'battery', 40)` will test if the given entity attribute is the specified state (in this case, a numeric value). Note that the attribute can be `None` and you want to check if it is `None`, you need to use `state_attr('sensor.my_sensor', 'attr') == None`. 
-- `rate_limit` - limits re-renders of the template. Returns a timedelta object and accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
+- `rate_limit` - limits re-renders of the template. Returns an empty string and accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
 <div class='note warning'>
 
   Avoid using `states.sensor.temperature.state`, instead use `states('sensor.temperature')`. It is strongly advised to use the `states()`, `is_state()`, `state_attr()` and `is_state_attr()` as much as possible, to avoid errors and error message when the entity isn't ready yet (e.g., during Home Assistant startup).

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -315,7 +315,7 @@ binary_sensor:
   - platform: template
     sensors:
       has_unavailable_states:
-        value_template: '{% set delta = rate_limit(minutes=1) %}{{ states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}'
+        value_template: '{% rate_limit(minutes=1) and states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}'
 ```
 {% endraw %}
 

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -305,7 +305,19 @@ thousands state changed events per day, templates may re-render more than desira
 
 A `rate_limit` directive can be used to limit how often the template re-renders.
 
+`rate_limit` accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
 
+In the below example, re-renders are limited to once per minute:
+
+{% raw %}
+```yaml
+binary_sensor:
+  - platform: template
+    sensors:
+      has_unavailable_states:
+        value_template: '{% set delta = rate_limit(minutes=1) %}{{ states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}'
+```
+{% endraw %}
 
 ### Working without entities
 

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -305,7 +305,7 @@ thousands state changed events per day, templates may re-render more than desira
 
 A `rate_limit` directive can be used to limit how often the template re-renders.
 
-`rate_limit` returns a `timedelta` object and accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
+`rate_limit` returns an empty string and accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
 
 In the below example, re-renders are limited to once per minute:
 

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -315,7 +315,7 @@ binary_sensor:
   - platform: template
     sensors:
       has_unavailable_states:
-        value_template: '{% rate_limit(minutes=1) and states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}'
+        value_template: '{{ rate_limit(minutes=1) }}{% states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}'
 ```
 {% endraw %}
 

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -305,7 +305,7 @@ thousands state changed events per day, templates may re-render more than desira
 
 A `rate_limit` directive can be used to limit how often the template re-renders.
 
-`rate_limit` accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
+`rate_limit` returns a `timedelta` object and accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
 
 In the below example, re-renders are limited to once per minute:
 

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -294,6 +294,19 @@ binary_sensor:
 
 {% endraw %}
 
+### Rate limiting updates
+
+When there are entities present in the template, the template will be re-rendered when one of the entities changes states.
+
+When `states` is used in a template by itself to iterate all states on the system, the template is re-rendered each
+time any state changed event happens if any part of the state is accessed. When merely counting states, the template
+is only re-rendered when a state is added or removed from the system. On busy systems with many entities or hundreds of
+thousands state changed events per day, templates may re-render more than desirable.
+
+A `rate_limit` directive can be used to limit how often the template re-renders.
+
+
+
 ### Working without entities
 
 The `template` sensors are not limited to use attributes from other entities but can also work with [Home Assistant's template extensions](/docs/configuration/templating/#home-assistant-template-extensions). If the template includes some non-deterministic property such as time in its calculation, the result will not continually update, but will only update when some entity referenced by the template updates. 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add explanation of the new template `rate_limit` directive.

https://github.com/home-assistant/architecture/issues/206


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40667
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
