### PR TITLE
Update ZHA service descriptions

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -144,6 +144,32 @@ enable_quirks:
 
 To add new devices to the network, call the `permit` service on the `zha` domain. Do this by clicking the Service icon in Developer tools and typing `zha.permit` in the **Service** dropdown box. Next, follow the device instructions for adding, scanning or factory reset.
 
+
+## Services
+### Service `permit`
+This service opens network for joining new devices
+
+|  Data | Optional | Description |
+| ---- | ---- | ----------- |
+| `duration` |  yes | For how long to allow new devices to join, default 60s
+| `ieee` | yes | allow new devices to join via an existing device
+| `src_ieee` | | The IEEE address of the joining ZB3 device. Use with `install_code`
+| `install_code` | | Install Code of the joining device. Use with `src_ieee`
+| `qr_code` | | QR code containing IEEE and Install Code of the joining ZB3 device
+
+* currently `qr_cde` supports QR Install Codes from:
+- Aqara
+- Consciot
+- Embrighten 
+
+### Service `remove`
+This service remove an existing device from the network
+
+|  Data | Optional | Description |
+| ---- | ---- | ----------- |
+| `ieee` | no | What device to remove 
+
+
 ### OTA firmware updates
 
 ZHA component does have the ability to automatically download and perform OTA (Over-The-Air) firmware updates of Zigbee devices if the OTA firmware provider source URL for updates is available. OTA firmware updating is set to disabled (`false`) in the configuration by default.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

https://github.com/home-assistant/core/pull/40652 introduces support to join devices using install codes. Update service descriptions

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40652
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
