### PR TITLE
Clean up octoprint.markdown

### DIFF
--- a/source/_integrations/octoprint.markdown
+++ b/source/_integrations/octoprint.markdown
@@ -86,20 +86,6 @@ sensors:
           description: Time elapsed on current print job, in seconds.
         "Time Remaining":
           description: Time remaining on current print job, in seconds.
-binary_sensors:
-  description: Configuration for the binary sensors.
-  required: false
-  type: map
-  keys:
-    monitored_conditions:
-      description: The sensors to activate.
-      type: list
-      default: all (`Printing`, `Printing Error`)
-      keys:
-        "Printing":
-          description: State of the printer.
-        "Printing Error":
-          description: Error while printing.
 {% endconfiguration %}
 
 <div class='note'>


### PR DESCRIPTION
Remove duplication of binary sensor from within octoprint key definition

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is duplicated as it is already defined farther down the page. Having it here is somewhat confusing as it is within the octoprint key definition


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
