### PR TITLE
Update asterisk_mbox.markdown

### DIFF
--- a/source/_docs/asterisk_mbox.markdown
+++ b/source/_docs/asterisk_mbox.markdown
@@ -92,7 +92,7 @@ Before beginning make sure that you have the following:
    Type=simple
    User=asterisk
    Group=asterisk
-   ExecStart=/usr/local/bin/asterisk_mbox_server --cfg /etc/asterisk/asterisk_mbox.ini
+   ExecStart=/usr/local/bin/asterisk-mbox-server --cfg /etc/asterisk/asterisk_mbox.ini
    Restart=on-failure
 
    [Install]


### PR DESCRIPTION
The executable installed with the python package is `/usr/local/bin/asterisk-mbox-server`, hyphens instead of underscores.

## Proposed change

Fix the example service configuration in the README

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
