### PR TITLE
Fix Vallox state update automation to work

### DIFF
--- a/source/_integrations/vallox.markdown
+++ b/source/_integrations/vallox.markdown
@@ -78,10 +78,10 @@ automation:
       - entity_id: sensor.vallox_current_profile
         platform: state
     action:
-      - data_template:
-        entity_id: input_select.ventilation_profile
-        option: "{{ states('sensor.vallox_current_profile') }}"
-        service: input_select.select_option
+      - service: input_select.select_option
+        data_template:
+          entity_id: input_select.ventilation_profile
+          option: "{{ states('sensor.vallox_current_profile') }}"
 ```
 {% endraw %}
 

--- a/source/_integrations/vallox.markdown
+++ b/source/_integrations/vallox.markdown
@@ -79,7 +79,7 @@ automation:
         platform: state
     action:
       - service: input_select.select_option
-        data_template:
+        data:
           entity_id: input_select.ventilation_profile
           option: "{{ states('sensor.vallox_current_profile') }}"
 ```


### PR DESCRIPTION
## Proposed change

I tried using the current example, but Home Assistant didn't accept it:

```
Invalid config for [automation]: expected dict for dictionary value @ data['action'][0]['data_template']. Got None
extra keys not allowed @ data['action'][0]['option']. Got None. (See /home/homeassistant/.homeassistant/configuration.yaml, line 25). 
```

With the change in this PR, it seems to work.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
