### PR TITLE
Update documentation to match proposed update to component

### DIFF
--- a/source/_integrations/manual_mqtt.markdown
+++ b/source/_integrations/manual_mqtt.markdown
@@ -135,12 +135,12 @@ state_topic:
 command_topic:
   description: The MQTT topic Home Assistant will subscribe to, to receive commands from a remote device to change the alarm state.
   required: false
-  type: JSON map
+  type: string
   default: home/alarm/set
 config_topic:
   description: The MQTT topic Home Assistant will use to publish the alarm configuration for the Alarm Panel to use.
   required: false
-  type: JSON map
+  type: string
   default: home/alarm/config
 status_topic:
   description: The MQTT topic Home Assistant will use to publish immediate status when a state transition command fails.
@@ -230,7 +230,7 @@ To receive state updates from HA, subscribe to the `state_topic`. Home Assistant
  - `arming_night`
  - `triggered`
 
-Finally, when the integration starts it will send a JSON map to the `config_topic` which provides the necessary information for the alarm application to discover how HA was configured in order to provide a better user experience.  The config topics have the following definitions:
+Finally, when the integration starts it will send a JSON map to the `config_topic` which provides the necessary information for the alarm application to discover how HA was configured in order to provide a better user experience.  The `config_topic` keys have the following definitions:
 
 
 {% configuration %}

--- a/source/_integrations/manual_mqtt.markdown
+++ b/source/_integrations/manual_mqtt.markdown
@@ -236,7 +236,7 @@ Finally, when the integration starts it will send a JSON map to the `config_topi
 {% configuration %}
 version:
   description: The version of the integration / MQTT Protocol
-  type: int
+  type: integer
   default: 1
 code_arm_required:
   description: Whether a code is required to transition to an armed state.

--- a/source/_integrations/manual_mqtt.markdown
+++ b/source/_integrations/manual_mqtt.markdown
@@ -241,9 +241,11 @@ version:
 code_arm_required:
   description: Whether a code is required to transition to an armed state.
   type: boolean
+  default: true
 code_disarm_required:
   description: Whether a code is required to disarm the alarm
   type: boolean
+  default: false
 state_topic:
   description: The MQTT topic Home Assistant will publish state updates to.
   type: string

--- a/source/_integrations/manual_mqtt.markdown
+++ b/source/_integrations/manual_mqtt.markdown
@@ -31,7 +31,10 @@ When the state of the manual alarm changes, Home Assistant will publish one of t
 - `arming_home`
 - `arming_away`
 - `arming_night`
+- `pending`
 - `triggered`
+
+Note that the `pending` state is during the delay from an armed state going into a triggered state.  For example, if you have a delay from `armed_away` (to let you enter the code), when the alarm gets triggered it will sit in `pending` state for the delay, before going into the `triggered` state.
 
 When the integration starts, it will publish the configuration parameters to the `config_topic`.  The configuration is a JSON map that contains the following keys (see below for descriptions of these):
 
@@ -228,6 +231,7 @@ To receive state updates from HA, subscribe to the `state_topic`. Home Assistant
  - `arming_home`
  - `arming_away`
  - `arming_night`
+ - `pending`
  - `triggered`
 
 Finally, when the integration starts it will send a JSON map to the `config_topic` which provides the necessary information for the alarm application to discover how HA was configured in order to provide a better user experience.  The `config_topic` keys have the following definitions:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This change is coinciding with a PR on the manual_mqtt component.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#40973
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
