### PR TITLE
Documentation update - systemmonitor- Mandatory argument required for swap_free on 0.116.0b0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,9 +100,9 @@ social:
 
 # Home Assistant release details
 current_major_version: 0
-current_minor_version: 115
-current_patch_version: 6
-date_released: 2020-09-30
+current_minor_version: 116
+current_patch_version: 0
+date_released: 2020-10-07
 
 # Either # or the anchor link to latest release notes in the blog post.
 # Must be prefixed with a # and have double quotes around it.

--- a/source/_integrations/systemmonitor.markdown
+++ b/source/_integrations/systemmonitor.markdown
@@ -52,7 +52,7 @@ file.
 | memory_free            |                           |                           |
 | swap_use_percent       |                           |                           |
 | swap_use               |                           |                           |
-| swap_free              |                           |                           |
+| swap_free              | Path, e.g., `/`           | yes                       |
 | load_1m                |                           |                           |
 | load_5m                |                           |                           |
 | load_15m               |                           |                           |

--- a/source/_posts/2020-10-07-release-116.markdown
+++ b/source/_posts/2020-10-07-release-116.markdown
@@ -1,0 +1,1262 @@
+---
+layout: post
+title: "0.116: Beta release notes"
+description: "Beta release notes"
+date: 2020-09-29 00:00:00
+date_formatted: "October 7, 2020"
+author: Franck Nijhof
+author_twitter: frenck
+comments: true
+categories: Release-Notes
+og_image: /images/blog/2020-10-0.116/social.png
+---
+
+These are the beta release notes for Home Assistant 0.116.0.
+
+If you encounter any issues, please report them on GitHub:
+
+- Issues with integrations, automations and such (Core related):<br>
+  <https://github.com/home-assistant/core/issues>
+- Issues with the frontend/Lovelace:<br>
+  <https://github.com/home-assistant/frontend/issues>
+- Issues with the Supervisor:<br>
+  <https://github.com/home-assistant/supervisor/issues>
+- Issues with the documentation:<br>
+  <https://github.com/home-assistant/home-assistant.io/issues>
+
+Please be sure to include the beta version you are running in the issue
+description (not title), so we can classify your issue correctly.
+
+Issues introduced in the beta are processed with priority.
+
+TODO:
+
+- Social media image
+- Introduction
+- Core/backend topics
+- screenshots
+- noteworthy changes
+
+Possible PRs to use in the blog post or noteworthy changes:
+
+- Allow setting of hvac_mode when setting temperature in ozw ([@firstof9] - [#39853]) ([ozw docs])
+- Add template filter timedelta_seconds to create a timedelta from seconds ([@jschlyter] - [#39608])
+- Shelly: Power and Energy sensors in roller mode ([@chemelli74] - [#39709]) ([shelly docs])
+- Add UniFi Uptime sensor ([@timkoers] - [#40058]) ([unifi docs])
+- Fix support for Aqara WXKG06LM ([@fabricepipart] - [#40694]) ([deconz docs]) ([xiaomi_aqara docs])
+- Add MQTT tag scanner ([@emontnemery] - [#40709]) ([mqtt docs])
+- Refactor permit services to allow joining using install codes ([@Adminiuga] - [#40652]) ([zha docs]) (breaking-change)
+- Add deconz option to disable automatic addition of new devices ([@Kane610] - [#40545]) ([deconz docs])
+- Add template cover opening and closing states ([@TheNr1Guest] - [#40677]) ([template docs])
+- Add temperature and uptime to Synology DSM ([@thomasgermain] - [#39419]) ([synology_dsm docs])
+- Add bimonthly period feature for utility_meter component ([@hareeshmu] - [#39931]) ([utility_meter docs])
+- Add Influxdb precision option ([@twdkeule] - [#38454]) ([influxdb docs])
+- Add support for selecting multiple entity ids from logbook ([@bdraco] - [#40075]) ([logbook docs])
+- Add all supported languages to OpenWeatherMap ([@Misiu] - [#40448]) ([openweathermap docs])
+- Fix/Refactor Hyperion Integration ([@dermotduffy] - [#39738]) ([hyperion docs]) (breaking-change)
+- Reduce the number of template re-renders when we are only counting states ([@bdraco] - [#40272])
+- Ensure all jinja2 errors are trapped and displayed in the developer tools ([@bdraco] - [#40624]) ([websocket_api docs])
+- Add entity glob matching support to history ([@bdraco] - [#40387]) ([history docs])
+
+## Table of contents
+
+- [Table of contents](#table-of-contents)
+- [Lorem ipsum](#lorem-ipsum)
+- [Entities card editor](#entities-card-editor)
+- [User management combined with person management](#user-management-combined-with-person-management)
+- [H.256 stream support for Android](#h256-stream-support-for-android)
+- [Chromecast Media player](#chromecast-media-player)
+- [Restore snapshots](#restore-snapshots)
+- [Other noteworthy changes](#other-noteworthy-changes)
+- [New Integrations](#new-integrations)
+- [New Platforms](#new-platforms)
+- [Integrations now available to set up from the UI](#integrations-now-available-to-set-up-from-the-ui)
+- [If you need help...](#if-you-need-help)
+- [Breaking Changes](#breaking-changes)
+- [All changes](#all-changes)
+
+## Entities card editor
+
+You can now also edit the entity rows of your entity card. That means you can not only set an entity id, but can also set the name, icon and secondary info.
+Also using special rows will not longer force you use the YAML editor, but you now can still use the UI editor and edit the special rows. UI editors for the special rows will come in the future.
+
+## User management combined with person management
+
+We combined the user and person UI, this means that the user config panel will only be visible for users that have advanced mode enabled.
+
+The person detail dialog has now a toggle that allows you to give the person access to Home Assistant.
+If you toggle it on you can set a username and a password for the person. If you toggle it off, the user will be removed.
+
+This makes it easier to manage the people in Home Assistant, everything in one place.
+
+## H.256 stream support for Android
+
+@uvjustin added support for H.256 streaming in the Android app, it will use a native video player that is shown on top of the Home Assistant UI. This player will only work in the more info dialog, and can not be used In Lovelace cards.
+
+## Chromecast Media player
+
+We now have our own media player for the Chromecast. It is build in the same app we use for showing Lovelace dashboards, this means that if you play media via Home Assistant and you were showing a Lovelace view, the Lovelace view will be restored after the media is finished playing!
+
+
+## Restore snapshots
+
+You can now upload snapshots from the UI and restores them.
+You can do this in the supervisor UI in the snapshots panel. But you can also do this during onboarding!
+
+This means you no longer have to setup Home Assistant, add and setup the Samba add-on to then restore your snapshot. You can just select your snapshot in the first step and it will be restored.
+
+This makes moving to an other system a breeze!
+
+## Other noteworthy changes
+
+- @Misiu Added weekday support to time condition automation editor
+- @ludeeus Added performance metrics to the supervisor UI
+- The Material Design Icons are updated to v5.6.55, the `scooter` icon is replaced by a new icon, the old icon is available as `human-scooter`
+
+
+## New Integrations
+
+We welcome the following new integration this release:
+
+- [Raspberry Pi Power Supply Checker][rpi_power docs], added by [@shenxn]
+- [Zodiac][zodiac docs], added by [@JulienTant]
+- [Hayward OmniLogic][omnilogic docs], added by [@Oliver84]
+- [GoalZero][goalzero docs], added by [@tkdrob]
+
+## New Platforms
+
+The following integration got support for a new platform:
+
+- [Synology DSM][synology_dsm docs] now supports cameras, added by [@shenxn]
+- [HVV Departures][hvv_departures docs] added binary sensors to show elevator
+  statuses. Added by [@DaAwesomeP]
+- Support for covers was added to [Modbus][modbus docs], by [@vzahradnik]
+- [Firmata][firmata docs] to support analog input and PWM/analog output
+  Added by [@DaAwesomeP]
+- [NZBGet][nzbget docs] now has a switch to control downloads,
+  added by [@ctalkington]
+
+## Integrations now available to set up from the UI
+
+The following integrations are now available via the Home Assistant UI:
+
+- [AlarmDecoder][alarmdecoder docs], done by [@ajschmidt8]
+- [Canary][canary docs], done by [@ctalkington]
+- [ZoneMinder][zoneminder docs], done by [@vangorra]
+
+## If you need help...
+
+...don't hesitate to use our very active [forums](https://community.home-assistant.io/) or join us for a little [chat](https://discord.gg/c5DvZ4e).
+
+Experiencing issues introduced by this release? Please report them in our [issue tracker](https://github.com/home-assistant/core/issues). Make sure to fill in all fields of the issue template.
+
+<!--more-->
+
+## Breaking Changes
+
+Below is a listing of the breaking change for this release, per subject or
+integration. Click on one of those to read more about the breaking change
+for that specific item.
+
+<details>
+  <summary><b>System Monitor</b></summary>
+  <p>
+
+Not really a breaking change, since the overall logic did not change. Arguments
+that were previously mandatory for sensors of this integration are still
+mandatory and optional arguments remain optional.
+
+However, we now enforce those mandatory arguments to be present,
+since otherwise this integration creates entities that cannot do anything,
+e.g., the sensor for IPv4 addresses cannot do anything if no network interface
+is specified from which to take the IP.
+
+If the integration fails to load, check the log to see which arguments are
+missing in your configuration. The documentation also has been updated to
+clearly show which arguments are mandatory.
+
+([@spacegaier] - [#39687]) ([systemmonitor docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>AlarmDecoder</b></summary>
+  <p>
+
+YAML support for AlarmDecoder has been removed in favor of UI configuration.
+Additionally, the `panel_display` option has been removed and the alarm display
+sensor will always be created with AlarmDecoder now. Please see the updated
+[AlarmDecoder documentation][alarmdecoder docs] for instructions on how to
+set up AlarmDecoder via the UI.
+
+([@ajschmidt8] - [#37998]) ([alarmdecoder docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>Synology</b></summary>
+  <p>
+
+The Synology integration is now deprecated. You should now use the Synology DSM
+instead. Support for cameras has been added to the Synology DSM integration
+making it a full replacement.
+
+([@shenxn] - [#39958]) ([synology docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>ZoneMinder</b></summary>
+  <p>
+
+Configuration of ZoneMinder must now be done via the UI. If you have a
+YAML configuration for ZoneMinder, it will be imported on upgrade. After the
+upgrade, it can be safely removed from the YAML configuration.
+
+([@vangorra] - [#37060]) ([zoneminder docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>Pilight</b></summary>
+  <p>
+
+Lights using the Pilight integration will now turn on to the last used
+brightness instead of its maximum brightness.
+
+If you want to retain you lights turning on to its maximum brightness you can
+set the default intensity in the `light_profiles.csv` file.
+
+The steps to set this up:
+
+1. In the your main `config` folder (where you'll find `configuration.yaml`)
+   create a new file called `light_profiles.csv`.
+2. For each of lights add an line with its entity id and the brightness
+   you want, as a value from `0` to `255`.
+
+Example:
+
+```txt
+light.<deviceentityid>.default,0,0,255
+```
+
+([@daniel-jong] - [#39549]) ([pilight docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>Canary</b></summary>
+  <p>
+
+Canary is now available for configuration via the UI. This also means its no
+longer configured in YAML. Existing configurations should be automatically
+transitioned to configuration via UI. You can safely remove you Canary YAML
+configuration after ugprading. YAML support will be fully removed in
+Home Assistant 0.118.0.
+
+([@ctalkington] - [#40055]) ([canary docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>KNX</b></summary>
+  <p>
+
+We changed the way how we handle binary sensors in the underlying library. It
+is no longer possible to support automations based on the `binary_sensor`
+schema. Instead, you can use the new `counter` state attribute for any given
+KNX binary sensor.
+
+Before this change:
+
+```yaml
+-  name: cover_abstell
+   state_address: "2/0/33"
+   automation:
+     - counter: 1
+       hook: 'on'
+       action:
+         - entity_id: cover.sonne_abstellkammer
+           service: cover.open_cover
+     - counter: 1
+       hook: 'off'
+       action:
+         - entity_id: cover.sonne_abstellkammer
+           service: cover.close_cover
+```
+
+After this change:
+
+
+```yaml
+# binary_sensor.yaml
+- name: cover_abstell
+  state_address: "2/0/33"
+```
+
+```yaml
+# automation.yaml
+automation:
+  - alias: 'Binary sensor test counter=1 on'
+    trigger:
+      platform: numeric_state
+      entity_id: binary_sensor.cover_abstell
+      attribute: counter
+      above: 0
+      below: 2
+    condition:
+      - condition: state
+        entity_id: binary_sensor.cover_abstell
+        state: 'on'
+    action:
+      - service: cover.open_cover
+        entity_id: cover.sonne_abstellkammer
+
+  - alias: 'Binary sensor test counter=1 off'
+    trigger:
+      platform: numeric_state
+      entity_id: binary_sensor.cover_abstell
+      attribute: counter
+      above: 0
+      below: 2
+    condition:
+      - condition: state
+        entity_id: binary_sensor.cover_abstell
+        state: 'off'
+    action:
+      - service: cover.close_cover
+        entity_id: cover.sonne_abstellkammer
+```
+
+If you intend to use the counter feature (counter > 1) make sure you also
+enable `ignore_internal_state` (default: `true`) for your `binary_sensor` and
+set the new `context_timeout` attribute to the time in between you want it to
+react to your sensor clicks (defaults to `1` - which should be fine).
+Otherwise, the counter will not work correctly.
+
+([@marvin-w] - [#40304]) ([knx docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>HomeKit Controller, Plant, SmartThings, Xiaomi</b></summary>
+  <p>
+
+Some integrations (`homekit_controller`, `plant`, `smartthings`
+and `xiaomi_miio`) previously used `lux` as their unit of measurement for
+entities that covered illuminance. Now, these entities use `lx` as their unit
+of measurement to be consistent with other integrations.
+
+This could be a breaking change for using such entities in,
+for example, `influxdb`.
+
+([@springstan] - [#40171])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>Hyperion</b></summary>
+  <p>
+
+Fixes the Hyperion Integration to work with the current Hyperion-NG release.
+Refactors to rely on the
+[hyperion-py](https://github.com/dermotduffy/hyperion-py) client.
+
+The `default_color`, `hdmi_priority` and `effect_list` parameters no longer have
+any effect. Instead, users should use [light profiles](/integrations/light/)
+as default color.
+
+The `effect_list` is now automatically populated.
+
+The `hdmi_priority` parameter no longer make sense with Hyperion-NG and will
+be removed in a future release.
+
+([@dermotduffy] - [#39738]) ([hyperion docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>VeSync</b></summary>
+  <p>
+
+The auto fan mode for the fan platform has been removed. The auto mode isn't
+supported by the entity model in Home Assistant and was initially added
+overlooking our entity model.
+
+If you have automations or scripts targeting the VeSync fan entity should
+review these and update as needed.
+
+([@TheGardenMonkey] - [#40559]) ([vesync docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>Universal Devices ISY994 / LCN</b></summary>
+  <p>
+
+The Kelvin unit no longer includes the degree sign in accordance with
+scientific standards. If you use the `isy994` and `lcn` integrations you may
+need to update automations or data collectors that depend on the unit of
+measurement.
+
+([@RichieFrame] - [#40574]) ([isy994 docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>ZHA</b></summary>
+  <p>
+
+Not a breaking change, but `ieee_address` parameter was renamed to
+`ieee` for `zha.permit` and `zha.remove` services.
+
+This makes all services to use consistently named parameters.
+
+([@Adminiuga] - [#40652]) ([zha docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>TekSavvy</b></summary>
+  <p>
+
+The TekSavvy integration has been removed. The API that was used by this
+integration is no longer available.
+
+([@mikeodr] - [#40762]) ([teksavvy docs])
+
+  </p>
+</details>
+
+<details>
+  <summary><b>TekSavvy</b></summary>
+
+  <p>
+
+  </p>
+</details>
+
+## All changes
+
+<details>
+  <summary>Click to see all changes!</summary>
+
+- Add missing EDL21 OBIS codes ([@DAMEK86] - [#39714]) ([edl21 docs])
+- Bump version to 0.116.0dev0 ([@frenck] - [#39768])
+- Bump Synology DSM to 0.9.0 ([@Quentame] - [#39819]) ([synology_dsm docs])
+- Add systemmonitor check for mandatory "arg" of sensors ([@spacegaier] - [#39687]) ([systemmonitor docs]) (breaking-change)
+- Allow setting of hvac_mode when setting temperature in ozw ([@firstof9] - [#39853]) ([ozw docs])
+- Prompt user to reauthenticate AirVisual when API key expires ([@bachya] - [#38341]) ([airvisual docs])
+- Upgrade sentry-sdk to 0.17.4 ([@frenck] - [#39868]) ([sentry docs])
+- Bump pyTibber to 0.15.2 ([@soldag] - [#39870]) ([tibber docs])
+- Upgrade isort to 5.5.2 ([@frenck] - [#39879])
+- Use entity_class 'safety' in synology_dsm storage sensors ([@Mariusthvdb] - [#39757]) ([synology_dsm docs])
+- Optimize requirements check with stdlib ([@balloob] - [#39871])
+- Remove stale debug from WLED tests ([@frenck] - [#39882]) ([wled docs])
+- Add Carbon Monoxide binary sensor to Homekit Controller ([@RogerSelwyn] - [#39889]) ([homekit_controller docs])
+- Increase template test coverage. ([@bdraco] - [#39908])
+- Add zeroconf discovery to homekit ([@bdraco] - [#39907]) ([homekit docs])
+- Upgrade numpy to 1.19.2 ([@frenck] - [#39912]) ([iqvia docs]) ([opencv docs]) ([tensorflow docs]) ([trend docs])
+- Add camera support to synology_dsm ([@shenxn] - [#39838]) ([synology_dsm docs]) (new-platform)
+- Add async_track_state_removed_domain to allow tracking when a state is removed from a domain ([@bdraco] - [#39859])
+- Device automation triggers for stateless HomeKit accessories ([@Jc2k] - [#39090]) ([homekit_controller docs])
+- Activate hassfest requirements CI check ([@MartinHjelmare] - [#39940])
+- Use STATE_UNKNOWN constant in dlink and ecobee ([@springstan] - [#39948]) ([dlink docs]) ([ecobee docs])
+- Add template filter timedelta_seconds to create a timedelta from seconds ([@jschlyter] - [#39608])
+- Remove unchecked return value in synology_dsm ([@shenxn] - [#39929]) ([synology_dsm docs])
+- Use sound, vibration and safety device class constants in various integrations ([@springstan] - [#39952]) ([concord232 docs]) ([ffmpeg_noise docs]) ([meteoalarm docs]) ([mysensors docs]) ([nest docs]) ([smartthings docs]) ([wink docs])
+- Improve tests for Broadlink devices ([@felipediel] - [#39898]) ([broadlink docs])
+- Use DEVICE_CLASS_WINDOW constant in various integrations ([@springstan] - [#39949]) ([brunt docs]) ([deconz docs]) ([fibaro docs]) ([fritzbox docs]) ([maxcube docs]) ([notion docs]) ([somfy_mylink docs])
+- Upgrade codecov to 2.1.9 ([@frenck] - [#39960])
+- Upgrade pytest-cov to 2.10.1 ([@frenck] - [#39964])
+- Upgrade pytest-sugar to 0.9.4 ([@frenck] - [#39966])
+- Upgrade mypy to 0.782 ([@frenck] - [#39967])
+- Use DEVICE_CLASS_DOOR and DEVICE_CLASS_SMOKE in various integrations ([@springstan] - [#39950]) ([concord232 docs]) ([fibaro docs]) ([notion docs]) ([satel_integra docs]) ([spc docs]) ([tahoma docs]) ([wink docs])
+- Upgrade youtube_dl to version 2020.09.06 ([@BKPepe] - [#39969]) ([media_extractor docs])
+- Use opening and occupancy device class in various integrations ([@springstan] - [#39965])
+- Upgrade pytest-timeout to 1.4.2 ([@frenck] - [#39983])
+- Upgrade responses to 0.12.0 ([@frenck] - [#39986])
+- Use connectivity device class constant in various integrations ([@springstan] - [#39972])
+- Use problem, presence and plug device class constants in various integrations ([@springstan] - [#39973]) ([bmw_connected_drive docs]) ([opentherm_gw docs]) ([smappee docs]) ([smartthings docs]) ([smarty docs])
+- Shelly: Power and Energy sensors in roller mode ([@chemelli74] - [#39709]) ([shelly docs])
+- Use DEVICE_CLASS_MOTION in various integrations ([@springstan] - [#39962])
+- Add timeout config option to Synology DSM ([@Quentame] - [#40000]) ([synology_dsm docs])
+- Fix xiaomi_aqara duplicated battery sensors ([@shenxn] - [#39961]) ([xiaomi_aqara docs])
+- Cleanup and reduce duplicate code from recent template changes ([@bdraco] - [#40012])
+- Use moisture and moving device class in various integrations ([@springstan] - [#39963])
+- Revert 'Use STATE_UNKNOWN constant in dlink and ecobee' ([@springstan] - [#40022]) ([dlink docs]) ([ecobee docs])
+- Improve canary tests ([@ctalkington] - [#39956]) ([canary docs])
+- Add Config Flow to AlarmDecoder ([@ajschmidt8] - [#37998]) ([alarmdecoder docs]) (breaking-change)
+- Update phrasing and pin validation for homekit_controller ([@bdraco] - [#40006]) ([homekit_controller docs])
+- Add canary alarm_control_panel tests ([@ctalkington] - [#40029]) ([canary docs])
+- Refactor zeroconf setup to be async ([@bdraco] - [#39955]) ([zeroconf docs])
+- Mark Azure DevOps device as a service ([@timmo001] - [#40044]) ([azure_devops docs])
+- Add unique_id to canary alarm_control_panel ([@ctalkington] - [#40041]) ([canary docs])
+- Add device class to canary sensors ([@ctalkington] - [#40050]) ([canary docs])
+- Fix intermittently failing dyson test ([@bdraco] - [#40051]) ([dyson docs])
+- Upgrade coverage to 5.3.0 ([@frenck] - [#40056])
+- Fix vizio async mock fixtures on Python 3.8.0 and .1 ([@scop] - [#39926]) ([vizio docs])
+- Don't try to create /test dir in camera tests ([@scop] - [#39914]) ([camera docs])
+- Make recorder block_till_done reliable ([@bdraco] - [#40043]) ([recorder docs])
+- Make system_log test reliable ([@bdraco] - [#40049]) ([system_log docs])
+- Add more SSDP discovery data and constants ([@scop] - [#39984]) ([ssdp docs])
+- Add temperature and uptime to Synology DSM ([@thomasgermain] - [#39419]) ([synology_dsm docs])
+- Improve reproduce_state for media players ([@rajlaud] - [#38266]) ([media_player docs])
+- Deprecate the synology integration ([@shenxn] - [#39958]) ([synology docs]) (breaking-change)
+- Add rpi_power integration ([@shenxn] - [#35527]) ([rpi_power docs]) (new-integration)
+- Extract the icon and state for logbook state changed events ([@bdraco] - [#40039]) ([logbook docs])
+- Add unique_id to canary camera ([@ctalkington] - [#40054]) ([canary docs])
+- Reduce listener cancelation code in template tracker ([@bdraco] - [#40040])
+- Fix homekit error when the bridge has been ignored. ([@bdraco] - [#40082]) ([homekit docs])
+- Add support for multiple vera controller hubs ([@vangorra] - [#33613]) ([vera docs])
+- Upgrade pytest to 6.0.2 ([@frenck] - [#39959])
+- Upgrade sentry-sdk to 0.17.5 ([@frenck] - [#40092]) ([sentry docs])
+- Fix hvv_departures config flow patches ([@MartinHjelmare] - [#40095]) ([hvv_departures docs])
+- Upgrade pytest-xdist to 2.1.0 ([@frenck] - [#40057])
+- Add bimonthly period feature for utility_meter component ([@hareeshmu] - [#39931]) ([utility_meter docs])
+- Upgrade youtube_dl to version 2020.09.14 ([@BKPepe] - [#40104]) ([media_extractor docs])
+- Use http status constants more, add HTTP_ACCEPTED and HTTP_BAD_GATEWAY ([@springstan] - [#39993])
+- Add and use volume cubic constants ([@springstan] - [#40106]) ([airvisual docs]) ([comfoconnect docs]) ([isy994 docs]) ([mysensors docs]) ([zha docs])
+- Expose angle and xy attributes in deCONZ event if present ([@klada] - [#39822]) ([deconz docs])
+- Extract Netatmo test data ([@cgtobi] - [#40094]) ([netatmo docs])
+- Clean dyson climate tests ([@MartinHjelmare] - [#40110]) ([dyson docs])
+- Use AREA_SQUARE_METERS constant in all integrations ([@springstan] - [#40107]) ([ambient_station docs]) ([bloomsky docs]) ([isy994 docs]) ([smartthings docs]) ([zamg docs])
+- Add and use currency constants ([@springstan] - [#40113]) ([dsmr_reader docs]) ([growatt_server docs]) ([isy994 docs]) ([pvpc_hourly_pricing docs]) ([tankerkoenig docs])
+- AlarmDecoder config flow fixes ([@ajschmidt8] - [#40037]) ([alarmdecoder docs])
+- Upgrade sentry-sdk to 0.17.6 ([@frenck] - [#40133]) ([sentry docs])
+- Remove unsupported states from security systems in HomeKit ([@nzapponi] - [#40060]) ([homekit docs])
+- Prompt to reauth when the august password is changed or token expires ([@bdraco] - [#40103]) ([august docs])
+- Clean up vera typings ([@vangorra] - [#40143]) ([vera docs])
+- Fix static/class async mocks on Python 3.8.0 and .1 ([@scop] - [#40147]) ([forked_daapd docs]) ([shelly docs]) ([simplisafe docs])
+- Add config support to zoneminder integration ([@vangorra] - [#37060]) ([zoneminder docs]) (breaking-change)
+- Fix typo in strings for wolflink ([@SNoof85] - [#40164]) ([wolflink docs])
+- Do not default Pilight lights to max brightness ([@daniel-jong] - [#39549]) ([pilight docs]) (breaking-change)
+- Use async_on_remove for vizio listeners ([@raman325] - [#40185]) ([vizio docs])
+- Add cgtobi to sonos code owners ([@cgtobi] - [#40204]) ([sonos docs])
+- Add cgtobi to kodi code owners ([@cgtobi] - [#40202]) ([kodi docs])
+- Fix shelly sensor names ([@Misiu] - [#39854]) ([shelly docs])
+- Catch TypeError in strptime() template helper ([@spacegaier] - [#40226])
+- Use default values in advanced options in devolo home control ([@2Fake] - [#40216]) ([devolo_home_control docs])
+- Add UniFi Uptime sensor ([@timkoers] - [#40058]) ([unifi docs])
+- Update velbus to 2.0.45 ([@Cereal2nd] - [#40256]) ([velbus docs])
+- Add Influxdb precision option ([@twdkeule] - [#38454]) ([influxdb docs])
+- Make tplink SmartStrip communication more robust ([@gjbadros] - [#40281]) ([tplink docs])
+- Add config flow to canary ([@ctalkington] - [#40055]) ([canary docs]) (breaking-change)
+- Use pressure constants in code base ([@springstan] - [#40262])
+- Add missing integration quality scale to image integration ([@frenck] - [#40289]) ([image docs])
+- Add missing integration quality scale to tags integration ([@frenck] - [#40291]) ([tag docs])
+- Add port to plugwise ([@CoMPaTech] - [#40017]) ([plugwise docs])
+- Add device info to canary camera and sensors ([@ctalkington] - [#40053]) ([canary docs])
+- Add kodi browse media for channels ([@imduffy15] - [#40277]) ([kodi docs])
+- Use percentage constant in more integrations ([@springstan] - [#40165]) ([growatt_server docs]) ([numato docs]) ([nut docs])
+- Add and use currency cent constant ([@springstan] - [#40261]) ([griddy docs]) ([isy994 docs]) ([nsw_fuel_station docs])
+- Add binary_sensor for cloud connectivity to HomematicIP Cloud ([@SukramJ] - [#39675]) ([homematicip_cloud docs])
+- Update roku media browser classes ([@ctalkington] - [#40285]) ([roku docs])
+- Complete helpers.service type hints ([@scop] - [#40193])
+- Rebuilt Splunk using custom library ([@Bre77] - [#40123]) ([splunk docs])
+- Use content type text plain constant ([@springstan] - [#40313]) ([prometheus docs]) ([rest docs]) ([rest_command docs])
+- Update xknx to 0.14.2 ([@marvin-w] - [#40304]) ([knx docs]) (breaking-change)
+- Apply code review for canary config flow ([@ctalkington] - [#40355]) ([canary docs])
+- Add reauth source constant for config entries ([@ctalkington] - [#40352])
+- Add supervisor install add-on helper ([@MartinHjelmare] - [#40138]) ([hassio docs])
+- Upgrade youtube_dl to version 2020.09.20 ([@BKPepe] - [#40395]) ([media_extractor docs])
+- Remove myself as Luci code owner ([@fbradyirl] - [#40398]) ([luci docs])
+- Fix supervisor get addon info ([@MartinHjelmare] - [#40412]) ([hassio docs])
+- Add zodiac integration ([@JulienTant] - [#38935]) ([zodiac docs]) (new-integration)
+- Update voluptuous to 0.12.0 ([@spacegaier] - [#40401])
+- Update Solax Library to 0.2.4 ([@squishykid] - [#40330]) ([solax docs])
+- Use centralized KnxEntity for all KNX platforms ([@marvin-w] - [#40381]) ([knx docs])
+- bump pynws to 1.3.0 ([@MatthewFlamm] - [#40386]) ([nws docs])
+- Add supervisor add-on uninstall helper ([@MartinHjelmare] - [#40413]) ([hassio docs])
+- Use more state attribute name constants ([@scop] - [#40428])
+- Improve timeout error handling for Splunk ([@Bre77] - [#40384]) ([splunk docs])
+- Add debug logging to Bond fireplace entity ([@prystupa] - [#40318]) ([bond docs])
+- Add PLAY and PAUSE to webos button service description ([@basnijholt] - [#40353]) ([webostv docs])
+- Firmata analog input, PWM/analog output, deprecate arduino ([@DaAwesomeP] - [#40369]) ([arduino docs]) ([firmata docs]) (new-platform)
+- Bump pywemo to 0.5.0 ([@sqldiablo] - [#40439]) ([wemo docs])
+- Update xknx to 0.14.3 ([@marvin-w] - [#40430]) ([knx docs])
+- Serialize websocket event message once ([@bdraco] - [#40453]) ([websocket_api docs])
+- Add support for selecting multiple entity ids from logbook ([@bdraco] - [#40075]) ([logbook docs])
+- Defer template tracking setup until template entity start ([@bdraco] - [#40388]) ([template docs])
+- Add binary_sensor for elevator states to hvv_departures ([@vigonotion] - [#36822]) ([hvv_departures docs]) (new-platform)
+- deCONZ - move event handling ([@Kane610] - [#40424]) ([deconz docs])
+- Add and use length millimeters constant ([@springstan] - [#40116])
+- Update xknx to version 0.14.4 ([@marvin-w] - [#40472]) ([knx docs])
+- Improve DOODS folder handling and add process time attribute ([@lamiskin] - [#40344]) ([doods docs])
+- Support learning different command types with remote ([@felipediel] - [#39670]) ([remote docs])
+- Refactor Plex tests using fixtures ([@jjlawren] - [#40260]) ([plex docs])
+- Use content type multipart constant ([@springstan] - [#40314]) ([camera docs]) ([ffmpeg docs])
+- Revert "Support learning different command types with remote" ([@frenck] - [#40486]) ([remote docs])
+- Upgrade sentry-sdk to 0.17.7 ([@frenck] - [#40492]) ([sentry docs])
+- Upgrade isort to 5.5.3 ([@frenck] - [#40493])
+- Add supervisor helper to start add-on ([@MartinHjelmare] - [#40495]) ([hassio docs])
+- Add supervisor add-on stop helper ([@MartinHjelmare] - [#40501]) ([hassio docs])
+- Support all available languages in voicerss integration ([@nagyrobi] - [#40502]) ([voicerss docs])
+- Add all supported languages to OpenWeatherMap ([@Misiu] - [#40448]) ([openweathermap docs])
+- Adjust safe_theme for better readability ([@spacegaier] - [#40223]) ([frontend docs])
+- Use content type json constant ([@springstan] - [#40312])
+- Add and use light lux constant in entire code base ([@springstan] - [#40171]) (breaking-change)
+- Correct label in mqtt config flow ([@springstan] - [#40507]) ([mqtt docs])
+- Bump plexapi to 4.1.1 ([@jjlawren] - [#40512]) ([plex docs])
+- Update sonarr to 0.3.0 ([@ctalkington] - [#40515]) ([sonarr docs])
+- Fix Bond error logging format ([@prystupa] - [#40519]) ([bond docs])
+- Upgrade sentry-sdk to 0.17.8 ([@frenck] - [#40531]) ([sentry docs])
+- Add more Huawei LTE sensor metadata ([@scop] - [#39988]) ([huawei_lte docs])
+- Update constant name for onewire ([@epenet] - [#40530]) ([onewire docs])
+- Ensure consitstency of file docstring for 1-wire ([@epenet] - [#40528]) ([onewire docs])
+- Ensure the title is consistent ([@epenet] - [#40528]) ([onewire docs])
+- Improve devolo Home Control code quality ([@Shutgun] - [#40480]) ([devolo_home_control docs])
+- Add Huawei LTE SMS storage full and unread sensors ([@scop] - [#40021]) ([huawei_lte docs])
+- Fix/Refactor Hyperion Integration ([@dermotduffy] - [#39738]) ([hyperion docs]) (breaking-change)
+- Bump pyairvisual to 5.0.2 ([@bachya] - [#40554]) ([airvisual docs])
+- Bump simplisafe-python to 9.3.3 ([@bachya] - [#40560]) ([simplisafe docs])
+- Improve handling of sources without a name in Denon ([@asimonen] - [#40514]) ([denon docs])
+- Add @darkfox as Rejseplanen code owner ([@DarkFox] - [#40329])
+- Add modifications for snapshot uploads ([@ludeeus] - [#40503]) ([hassio docs])
+- Upgrade Tibber library to 0.15.3 ([@Danielhiversen] - [#40570]) ([tibber docs])
+- Use HA constants for Rfxtrx units ([@elupus] - [#40562]) ([rfxtrx docs])
+- Upgrade tqdm to 4.49.0 ([@frenck] - [#40573])
+- Remove auto from the fan speed modes for VeSync ([@TheGardenMonkey] - [#40559]) ([vesync docs]) (breaking-change)
+- Add Omnilogic integration ([@Oliver84] - [#40474]) ([omnilogic docs]) (new-integration)
+- Rewrite light component tests to async pytest tests ([@frenck] - [#40589]) ([light docs])
+- Improve tracking of existing entities in deconz ([@Kane610] - [#40265]) ([deconz docs])
+- Update schema for zha.set_zigbee_cluster_attribute service ([@Adminiuga] - [#40600]) ([zha docs])
+- Add device info to gogogate2 ([@bdraco] - [#40538]) ([gogogate2 docs])
+- Upgrade spotipy to 2.16.0 ([@frenck] - [#40606]) ([spotify docs])
+- Throttle ebusd sensors instead of the whole component ([@danielkucera] - [#40610]) ([ebusd docs])
+- Bump pychromecast to 7.4.1 ([@emontnemery] - [#40587]) ([cast docs])
+- Add installation type to discovery endpoint ([@ludeeus] - [#40585]) ([api docs])
+- Allow non-authenticated calls to snapshots during onboarding ([@ludeeus] - [#40582]) ([hassio docs])
+- Log the remote ip address for incoming websocket connections when debug is on ([@bdraco] - [#40581]) ([websocket_api docs])
+- Add bare hostname as valid known hostname in get_url helper ([@frenck] - [#40510])
+- Use direct service calls in light platform tests ([@frenck] - [#40604]) ([light docs])
+- Use common strings for somfy config flow ([@RobBie1221] - [#40594]) ([somfy docs])
+- Use common strings for monoprice config flow ([@RobBie1221] - [#40592]) ([monoprice docs])
+- Use common strings for Freebox config flow ([@SNoof85] - [#40590]) ([freebox docs])
+- Bump python-broadlink to 0.15.0 ([@felipediel] - [#39228]) ([broadlink docs])
+- Add Modbus cover ([@vzahradnik] - [#33642]) ([modbus docs]) (new-platform)
+- Improve performance of counting and iterating states in templates ([@bdraco] - [#40250])
+- Use direct service calls in tests instead of automation common ([@frenck] - [#40623])
+- Reduce the number of template re-renders when we are only counting states ([@bdraco] - [#40272])
+- Ensure all jinja2 errors are trapped and displayed in the developer tools ([@bdraco] - [#40624]) ([websocket_api docs])
+- Add support for homekit windows ([@Julius2342] - [#40635]) ([homekit docs])
+- Handle Shelly channel names (if available) ([@chemelli74] - [#40119]) ([shelly docs])
+- deCONZ fix comments from #40265 ([@Kane610] - [#40640]) ([deconz docs])
+- Fix solaredge service data KeyError ([@Cereal2nd] - [#40653]) ([solaredge docs])
+- Resolve Frontend Services.yaml Minor Oversight ([@Brahmah] - [#40659]) ([frontend docs])
+- Rewrite core event tests to pytest tests ([@frenck] - [#40664])
+- Bump python-velbus to 2.0.46 ([@Cereal2nd] - [#40663]) ([velbus docs])
+- Add authentication support to Nightscout ([@marciogranzotto] - [#40602]) ([nightscout docs])
+- Use common strings for oauth config flows ([@MBlokhuijzen] - [#40608]) ([almond docs]) ([home_connect docs]) ([smappee docs]) ([somfy docs]) ([spotify docs]) ([withings docs])
+- Remove pre-0.102 Huawei LTE setup noop warnings ([@scop] - [#40654]) ([huawei_lte docs])
+- Add Integration for Goal Zero Yeti Power Stations ([@tkdrob] - [#39231]) ([goalzero docs]) (new-integration)
+- Bump dwdwfsapi to v1.0.3 ([@stephan192] - [#40644]) ([dwd_weather_warnings docs])
+- Update wolf_smartset to 0.1.6 ([@adamkrol93] - [#40668]) ([wolflink docs])
+- Increase the timeout during config entry setup in Shelly integration ([@bieniu] - [#40684]) ([shelly docs])
+- Upgrade zigpy-znp from 0.1.1 to 0.2.0 ([@puddly] - [#40674]) ([zha docs])
+- Fix issue with HobbyBoard moisture meter ([@epenet] - [#40680]) ([onewire docs])
+- Move onewire constants to separate file ([@epenet] - [#40550]) ([onewire docs])
+- Add onewire humidity sensors connected via DS2438 ([@epenet] - [#39780]) ([onewire docs])
+- Add tests for modbus binary sensor ([@janiversen] - [#40367]) ([modbus docs])
+- Bump up zha dependency ([@Adminiuga] - [#40689]) ([zha docs])
+- Re-enable hdmi_cec component ([@newAM] - [#40671]) ([hdmi_cec docs])
+- Allow non-authenticated calls to supervisor logs during onboarding ([@ludeeus] - [#40617]) ([hassio docs])
+- Improve config flow descriptions in Shelly integration ([@bieniu] - [#40396]) ([shelly docs])
+- Bump snapcast dependency to 2.1.1 ([@mafrosis] - [#40561]) ([snapcast docs])
+- Abort execution of template renders that overwhelm the system ([@bdraco] - [#40647]) ([websocket_api docs])
+- Add entity glob matching support to history ([@bdraco] - [#40387]) ([history docs])
+- Remove degree from Kelvin unit ([@RichieFrame] - [#40574]) ([isy994 docs]) ([lcn docs]) (breaking-change)
+- Fix Android TV 'async_get_media_image' ([@JeffLIrion] - [#40672]) ([androidtv docs])
+- Add rpi_power during onboarding on RPi ([@MartinHjelmare] - [#40076]) ([onboarding docs]) ([rpi_power docs])
+- Add support to reauthorize expired Plex tokens ([@jjlawren] - [#40469]) ([plex docs])
+- Improve performance of accessing template state ([@bdraco] - [#40323])
+- Improve devolo Home Control code quality ([@Shutgun] - [#40708]) ([devolo_home_control docs])
+- Bump pypck to v0.7.2 ([@alengwenus] - [#40716]) ([lcn docs])
+- Use NamedTuple for Huawei LTE sensor metadata ([@scop] - [#40655]) ([huawei_lte docs])
+- Fix support for Aqara WXKG06LM ([@fabricepipart] - [#40694]) ([deconz docs]) ([xiaomi_aqara docs])
+- Fix name of the Vallox integration in the manifest ([@frenck] - [#40727]) ([vallox docs])
+- Add MQTT tag scanner ([@emontnemery] - [#40709]) ([mqtt docs])
+- Update islamic_prayer_times with common strings ([@Brahmah] - [#40712]) ([islamic_prayer_times docs])
+- Bump up ZHA dependency ([@Adminiuga] - [#40734]) ([zha docs])
+- Refactor permit services to allow joining using install codes ([@Adminiuga] - [#40652]) ([zha docs]) (breaking-change)
+- Add switch to control downloads for nzbget ([@ctalkington] - [#40673]) ([nzbget docs]) (new-platform)
+- Add ability to reauth sonarr ([@ctalkington] - [#40306]) ([sonarr docs])
+- Add deconz option to disable automatic addition of new devices ([@Kane610] - [#40545]) ([deconz docs])
+- Update pyatag to 0.3.4.4 ([@MatsNl] - [#40720]) ([atag docs])
+- Add template cover opening and closing states ([@TheNr1Guest] - [#40677]) ([template docs])
+- Upgrade paho-mqtt to 1.5.1 ([@frenck] - [#40703]) ([mqtt docs]) ([shiftr docs])
+- Add Neighbors & Endpoint Names to zha/devices reply ([@Samantha-uk] - [#40748]) ([zha docs])
+- Bump ZHA quirks lib to 0.0.45 ([@dmulcahey] - [#40769]) ([zha docs])
+- Normalise headers in onewire integration ([@epenet] - [#40774]) ([onewire docs])
+- Update xknx to 0.15.0 ([@marvin-w] - [#40649]) ([knx docs])
+- Use direct service calls in flux tests instead of switch common ([@frenck] - [#40704]) ([flux docs])
+- Update devolo-home-control-api to 0.15.0 ([@Shutgun] - [#40764]) ([devolo_home_control docs])
+- Code cleanups for async_track_template_result ([@bdraco] - [#40737])
+- Add unique_id to the light switch ([@tetienne] - [#40603]) ([switch docs])
+- Fix logbook with empty filter and remove unused code ([@bdraco] - [#40565]) ([logbook docs]) ([recorder docs])
+- Setup recorder model relationships to avoid calling flush ([@bdraco] - [#40467]) ([recorder docs])
+- Remove TekSavvy Component, no longer available ([@mikeodr] - [#40762]) ([teksavvy docs]) (breaking-change)
+- Improve command_line switch tests ([@frenck] - [#40749]) ([command_line docs])
+- Use common strings for velbus config flow ([@Cereal2nd] - [#40660]) ([velbus docs])
+- Upgrade sentry-sdk to 0.18.0 ([@frenck] - [#40784]) ([sentry docs])
+- Refactor group to extend domains that can be grouped ([@bdraco] - [#40607]) ([group docs])
+- Disable hourly sensor by default in NWS ([@MatthewFlamm] - [#40566]) ([nws docs])
+- Fix and clean tox.ini ([@MartinHjelmare] - [#40789])
+- Fix DWD namings ([@creichel] - [#40791]) ([dwd_weather_warnings docs])
+- Tibber, combine two fetches into one fetch ([@Danielhiversen] - [#40787]) ([tibber docs])
+- Create MQTTMatcher once per subscription instead of each message ([@bdraco] - [#40345]) ([mqtt docs])
+- Use the Home Assistant Cast app to play media on Chromecast ([@bramkragten] - [#40782]) ([cast docs])
+- Improve deCONZ state updates ([@Kane610] - [#40601]) ([deconz docs])
+- Switch group to use None for the state unknown case ([@bdraco] - [#40792]) ([group docs])
+- Log timestamp overflow in stream ([@uvjustin] - [#39844]) ([stream docs])
+- Return target duration of 1 when no segments ([@uvjustin] - [#40518]) ([stream docs])
+- Add Surveillance Station home mode switch for Synology DSM ([@Quentame] - [#40490]) ([synology_dsm docs]) (new-platform)
+- Remove message and domain from logbook state_changed events ([@bdraco] - [#40070]) ([logbook docs]) (breaking-change)
+- Update frontend to 20200930.0 ([@bramkragten] - [#40794]) ([frontend docs])
+- Include config flow modules in coverage ([@Danielhiversen] - [#40798])
+- Add deCONZ service to clean up orphaned device and entity entries ([@Kane610] - [#40629]) ([deconz docs])
+- Discover additional ozw thermostats lacking mode support ([@firstof9] - [#40799]) ([ozw docs])
+
+</details>
+
+[#33613]: https://github.com/home-assistant/core/pull/33613
+[#33642]: https://github.com/home-assistant/core/pull/33642
+[#35527]: https://github.com/home-assistant/core/pull/35527
+[#36822]: https://github.com/home-assistant/core/pull/36822
+[#37060]: https://github.com/home-assistant/core/pull/37060
+[#37998]: https://github.com/home-assistant/core/pull/37998
+[#38266]: https://github.com/home-assistant/core/pull/38266
+[#38341]: https://github.com/home-assistant/core/pull/38341
+[#38454]: https://github.com/home-assistant/core/pull/38454
+[#38935]: https://github.com/home-assistant/core/pull/38935
+[#39090]: https://github.com/home-assistant/core/pull/39090
+[#39228]: https://github.com/home-assistant/core/pull/39228
+[#39231]: https://github.com/home-assistant/core/pull/39231
+[#39419]: https://github.com/home-assistant/core/pull/39419
+[#39549]: https://github.com/home-assistant/core/pull/39549
+[#39608]: https://github.com/home-assistant/core/pull/39608
+[#39670]: https://github.com/home-assistant/core/pull/39670
+[#39675]: https://github.com/home-assistant/core/pull/39675
+[#39687]: https://github.com/home-assistant/core/pull/39687
+[#39709]: https://github.com/home-assistant/core/pull/39709
+[#39714]: https://github.com/home-assistant/core/pull/39714
+[#39738]: https://github.com/home-assistant/core/pull/39738
+[#39757]: https://github.com/home-assistant/core/pull/39757
+[#39768]: https://github.com/home-assistant/core/pull/39768
+[#39780]: https://github.com/home-assistant/core/pull/39780
+[#39819]: https://github.com/home-assistant/core/pull/39819
+[#39822]: https://github.com/home-assistant/core/pull/39822
+[#39838]: https://github.com/home-assistant/core/pull/39838
+[#39844]: https://github.com/home-assistant/core/pull/39844
+[#39853]: https://github.com/home-assistant/core/pull/39853
+[#39854]: https://github.com/home-assistant/core/pull/39854
+[#39859]: https://github.com/home-assistant/core/pull/39859
+[#39868]: https://github.com/home-assistant/core/pull/39868
+[#39870]: https://github.com/home-assistant/core/pull/39870
+[#39871]: https://github.com/home-assistant/core/pull/39871
+[#39879]: https://github.com/home-assistant/core/pull/39879
+[#39882]: https://github.com/home-assistant/core/pull/39882
+[#39889]: https://github.com/home-assistant/core/pull/39889
+[#39898]: https://github.com/home-assistant/core/pull/39898
+[#39907]: https://github.com/home-assistant/core/pull/39907
+[#39908]: https://github.com/home-assistant/core/pull/39908
+[#39912]: https://github.com/home-assistant/core/pull/39912
+[#39914]: https://github.com/home-assistant/core/pull/39914
+[#39926]: https://github.com/home-assistant/core/pull/39926
+[#39929]: https://github.com/home-assistant/core/pull/39929
+[#39931]: https://github.com/home-assistant/core/pull/39931
+[#39940]: https://github.com/home-assistant/core/pull/39940
+[#39948]: https://github.com/home-assistant/core/pull/39948
+[#39949]: https://github.com/home-assistant/core/pull/39949
+[#39950]: https://github.com/home-assistant/core/pull/39950
+[#39952]: https://github.com/home-assistant/core/pull/39952
+[#39955]: https://github.com/home-assistant/core/pull/39955
+[#39956]: https://github.com/home-assistant/core/pull/39956
+[#39958]: https://github.com/home-assistant/core/pull/39958
+[#39959]: https://github.com/home-assistant/core/pull/39959
+[#39960]: https://github.com/home-assistant/core/pull/39960
+[#39961]: https://github.com/home-assistant/core/pull/39961
+[#39962]: https://github.com/home-assistant/core/pull/39962
+[#39963]: https://github.com/home-assistant/core/pull/39963
+[#39964]: https://github.com/home-assistant/core/pull/39964
+[#39965]: https://github.com/home-assistant/core/pull/39965
+[#39966]: https://github.com/home-assistant/core/pull/39966
+[#39967]: https://github.com/home-assistant/core/pull/39967
+[#39969]: https://github.com/home-assistant/core/pull/39969
+[#39972]: https://github.com/home-assistant/core/pull/39972
+[#39973]: https://github.com/home-assistant/core/pull/39973
+[#39983]: https://github.com/home-assistant/core/pull/39983
+[#39984]: https://github.com/home-assistant/core/pull/39984
+[#39986]: https://github.com/home-assistant/core/pull/39986
+[#39988]: https://github.com/home-assistant/core/pull/39988
+[#39993]: https://github.com/home-assistant/core/pull/39993
+[#40000]: https://github.com/home-assistant/core/pull/40000
+[#40006]: https://github.com/home-assistant/core/pull/40006
+[#40012]: https://github.com/home-assistant/core/pull/40012
+[#40017]: https://github.com/home-assistant/core/pull/40017
+[#40021]: https://github.com/home-assistant/core/pull/40021
+[#40022]: https://github.com/home-assistant/core/pull/40022
+[#40029]: https://github.com/home-assistant/core/pull/40029
+[#40037]: https://github.com/home-assistant/core/pull/40037
+[#40039]: https://github.com/home-assistant/core/pull/40039
+[#40040]: https://github.com/home-assistant/core/pull/40040
+[#40041]: https://github.com/home-assistant/core/pull/40041
+[#40043]: https://github.com/home-assistant/core/pull/40043
+[#40044]: https://github.com/home-assistant/core/pull/40044
+[#40049]: https://github.com/home-assistant/core/pull/40049
+[#40050]: https://github.com/home-assistant/core/pull/40050
+[#40051]: https://github.com/home-assistant/core/pull/40051
+[#40053]: https://github.com/home-assistant/core/pull/40053
+[#40054]: https://github.com/home-assistant/core/pull/40054
+[#40055]: https://github.com/home-assistant/core/pull/40055
+[#40056]: https://github.com/home-assistant/core/pull/40056
+[#40057]: https://github.com/home-assistant/core/pull/40057
+[#40058]: https://github.com/home-assistant/core/pull/40058
+[#40060]: https://github.com/home-assistant/core/pull/40060
+[#40070]: https://github.com/home-assistant/core/pull/40070
+[#40075]: https://github.com/home-assistant/core/pull/40075
+[#40076]: https://github.com/home-assistant/core/pull/40076
+[#40082]: https://github.com/home-assistant/core/pull/40082
+[#40092]: https://github.com/home-assistant/core/pull/40092
+[#40094]: https://github.com/home-assistant/core/pull/40094
+[#40095]: https://github.com/home-assistant/core/pull/40095
+[#40103]: https://github.com/home-assistant/core/pull/40103
+[#40104]: https://github.com/home-assistant/core/pull/40104
+[#40106]: https://github.com/home-assistant/core/pull/40106
+[#40107]: https://github.com/home-assistant/core/pull/40107
+[#40110]: https://github.com/home-assistant/core/pull/40110
+[#40113]: https://github.com/home-assistant/core/pull/40113
+[#40116]: https://github.com/home-assistant/core/pull/40116
+[#40119]: https://github.com/home-assistant/core/pull/40119
+[#40123]: https://github.com/home-assistant/core/pull/40123
+[#40133]: https://github.com/home-assistant/core/pull/40133
+[#40138]: https://github.com/home-assistant/core/pull/40138
+[#40143]: https://github.com/home-assistant/core/pull/40143
+[#40147]: https://github.com/home-assistant/core/pull/40147
+[#40164]: https://github.com/home-assistant/core/pull/40164
+[#40165]: https://github.com/home-assistant/core/pull/40165
+[#40171]: https://github.com/home-assistant/core/pull/40171
+[#40185]: https://github.com/home-assistant/core/pull/40185
+[#40193]: https://github.com/home-assistant/core/pull/40193
+[#40202]: https://github.com/home-assistant/core/pull/40202
+[#40204]: https://github.com/home-assistant/core/pull/40204
+[#40216]: https://github.com/home-assistant/core/pull/40216
+[#40223]: https://github.com/home-assistant/core/pull/40223
+[#40226]: https://github.com/home-assistant/core/pull/40226
+[#40250]: https://github.com/home-assistant/core/pull/40250
+[#40256]: https://github.com/home-assistant/core/pull/40256
+[#40260]: https://github.com/home-assistant/core/pull/40260
+[#40261]: https://github.com/home-assistant/core/pull/40261
+[#40262]: https://github.com/home-assistant/core/pull/40262
+[#40265]: https://github.com/home-assistant/core/pull/40265
+[#40272]: https://github.com/home-assistant/core/pull/40272
+[#40277]: https://github.com/home-assistant/core/pull/40277
+[#40281]: https://github.com/home-assistant/core/pull/40281
+[#40285]: https://github.com/home-assistant/core/pull/40285
+[#40289]: https://github.com/home-assistant/core/pull/40289
+[#40291]: https://github.com/home-assistant/core/pull/40291
+[#40304]: https://github.com/home-assistant/core/pull/40304
+[#40306]: https://github.com/home-assistant/core/pull/40306
+[#40312]: https://github.com/home-assistant/core/pull/40312
+[#40313]: https://github.com/home-assistant/core/pull/40313
+[#40314]: https://github.com/home-assistant/core/pull/40314
+[#40318]: https://github.com/home-assistant/core/pull/40318
+[#40323]: https://github.com/home-assistant/core/pull/40323
+[#40329]: https://github.com/home-assistant/core/pull/40329
+[#40330]: https://github.com/home-assistant/core/pull/40330
+[#40344]: https://github.com/home-assistant/core/pull/40344
+[#40345]: https://github.com/home-assistant/core/pull/40345
+[#40352]: https://github.com/home-assistant/core/pull/40352
+[#40353]: https://github.com/home-assistant/core/pull/40353
+[#40355]: https://github.com/home-assistant/core/pull/40355
+[#40367]: https://github.com/home-assistant/core/pull/40367
+[#40369]: https://github.com/home-assistant/core/pull/40369
+[#40381]: https://github.com/home-assistant/core/pull/40381
+[#40384]: https://github.com/home-assistant/core/pull/40384
+[#40386]: https://github.com/home-assistant/core/pull/40386
+[#40387]: https://github.com/home-assistant/core/pull/40387
+[#40388]: https://github.com/home-assistant/core/pull/40388
+[#40395]: https://github.com/home-assistant/core/pull/40395
+[#40396]: https://github.com/home-assistant/core/pull/40396
+[#40398]: https://github.com/home-assistant/core/pull/40398
+[#40401]: https://github.com/home-assistant/core/pull/40401
+[#40412]: https://github.com/home-assistant/core/pull/40412
+[#40413]: https://github.com/home-assistant/core/pull/40413
+[#40424]: https://github.com/home-assistant/core/pull/40424
+[#40428]: https://github.com/home-assistant/core/pull/40428
+[#40430]: https://github.com/home-assistant/core/pull/40430
+[#40439]: https://github.com/home-assistant/core/pull/40439
+[#40448]: https://github.com/home-assistant/core/pull/40448
+[#40453]: https://github.com/home-assistant/core/pull/40453
+[#40467]: https://github.com/home-assistant/core/pull/40467
+[#40469]: https://github.com/home-assistant/core/pull/40469
+[#40472]: https://github.com/home-assistant/core/pull/40472
+[#40474]: https://github.com/home-assistant/core/pull/40474
+[#40480]: https://github.com/home-assistant/core/pull/40480
+[#40486]: https://github.com/home-assistant/core/pull/40486
+[#40490]: https://github.com/home-assistant/core/pull/40490
+[#40492]: https://github.com/home-assistant/core/pull/40492
+[#40493]: https://github.com/home-assistant/core/pull/40493
+[#40495]: https://github.com/home-assistant/core/pull/40495
+[#40501]: https://github.com/home-assistant/core/pull/40501
+[#40502]: https://github.com/home-assistant/core/pull/40502
+[#40503]: https://github.com/home-assistant/core/pull/40503
+[#40507]: https://github.com/home-assistant/core/pull/40507
+[#40510]: https://github.com/home-assistant/core/pull/40510
+[#40512]: https://github.com/home-assistant/core/pull/40512
+[#40514]: https://github.com/home-assistant/core/pull/40514
+[#40515]: https://github.com/home-assistant/core/pull/40515
+[#40518]: https://github.com/home-assistant/core/pull/40518
+[#40519]: https://github.com/home-assistant/core/pull/40519
+[#40528]: https://github.com/home-assistant/core/pull/40528
+[#40530]: https://github.com/home-assistant/core/pull/40530
+[#40531]: https://github.com/home-assistant/core/pull/40531
+[#40538]: https://github.com/home-assistant/core/pull/40538
+[#40545]: https://github.com/home-assistant/core/pull/40545
+[#40550]: https://github.com/home-assistant/core/pull/40550
+[#40554]: https://github.com/home-assistant/core/pull/40554
+[#40559]: https://github.com/home-assistant/core/pull/40559
+[#40560]: https://github.com/home-assistant/core/pull/40560
+[#40561]: https://github.com/home-assistant/core/pull/40561
+[#40562]: https://github.com/home-assistant/core/pull/40562
+[#40565]: https://github.com/home-assistant/core/pull/40565
+[#40566]: https://github.com/home-assistant/core/pull/40566
+[#40570]: https://github.com/home-assistant/core/pull/40570
+[#40573]: https://github.com/home-assistant/core/pull/40573
+[#40574]: https://github.com/home-assistant/core/pull/40574
+[#40581]: https://github.com/home-assistant/core/pull/40581
+[#40582]: https://github.com/home-assistant/core/pull/40582
+[#40585]: https://github.com/home-assistant/core/pull/40585
+[#40587]: https://github.com/home-assistant/core/pull/40587
+[#40589]: https://github.com/home-assistant/core/pull/40589
+[#40590]: https://github.com/home-assistant/core/pull/40590
+[#40592]: https://github.com/home-assistant/core/pull/40592
+[#40594]: https://github.com/home-assistant/core/pull/40594
+[#40600]: https://github.com/home-assistant/core/pull/40600
+[#40601]: https://github.com/home-assistant/core/pull/40601
+[#40602]: https://github.com/home-assistant/core/pull/40602
+[#40603]: https://github.com/home-assistant/core/pull/40603
+[#40604]: https://github.com/home-assistant/core/pull/40604
+[#40606]: https://github.com/home-assistant/core/pull/40606
+[#40607]: https://github.com/home-assistant/core/pull/40607
+[#40608]: https://github.com/home-assistant/core/pull/40608
+[#40610]: https://github.com/home-assistant/core/pull/40610
+[#40617]: https://github.com/home-assistant/core/pull/40617
+[#40623]: https://github.com/home-assistant/core/pull/40623
+[#40624]: https://github.com/home-assistant/core/pull/40624
+[#40629]: https://github.com/home-assistant/core/pull/40629
+[#40635]: https://github.com/home-assistant/core/pull/40635
+[#40640]: https://github.com/home-assistant/core/pull/40640
+[#40644]: https://github.com/home-assistant/core/pull/40644
+[#40647]: https://github.com/home-assistant/core/pull/40647
+[#40649]: https://github.com/home-assistant/core/pull/40649
+[#40652]: https://github.com/home-assistant/core/pull/40652
+[#40653]: https://github.com/home-assistant/core/pull/40653
+[#40654]: https://github.com/home-assistant/core/pull/40654
+[#40655]: https://github.com/home-assistant/core/pull/40655
+[#40659]: https://github.com/home-assistant/core/pull/40659
+[#40660]: https://github.com/home-assistant/core/pull/40660
+[#40663]: https://github.com/home-assistant/core/pull/40663
+[#40664]: https://github.com/home-assistant/core/pull/40664
+[#40668]: https://github.com/home-assistant/core/pull/40668
+[#40671]: https://github.com/home-assistant/core/pull/40671
+[#40672]: https://github.com/home-assistant/core/pull/40672
+[#40673]: https://github.com/home-assistant/core/pull/40673
+[#40674]: https://github.com/home-assistant/core/pull/40674
+[#40677]: https://github.com/home-assistant/core/pull/40677
+[#40680]: https://github.com/home-assistant/core/pull/40680
+[#40684]: https://github.com/home-assistant/core/pull/40684
+[#40689]: https://github.com/home-assistant/core/pull/40689
+[#40694]: https://github.com/home-assistant/core/pull/40694
+[#40703]: https://github.com/home-assistant/core/pull/40703
+[#40704]: https://github.com/home-assistant/core/pull/40704
+[#40708]: https://github.com/home-assistant/core/pull/40708
+[#40709]: https://github.com/home-assistant/core/pull/40709
+[#40712]: https://github.com/home-assistant/core/pull/40712
+[#40716]: https://github.com/home-assistant/core/pull/40716
+[#40720]: https://github.com/home-assistant/core/pull/40720
+[#40727]: https://github.com/home-assistant/core/pull/40727
+[#40734]: https://github.com/home-assistant/core/pull/40734
+[#40737]: https://github.com/home-assistant/core/pull/40737
+[#40748]: https://github.com/home-assistant/core/pull/40748
+[#40749]: https://github.com/home-assistant/core/pull/40749
+[#40762]: https://github.com/home-assistant/core/pull/40762
+[#40764]: https://github.com/home-assistant/core/pull/40764
+[#40769]: https://github.com/home-assistant/core/pull/40769
+[#40774]: https://github.com/home-assistant/core/pull/40774
+[#40782]: https://github.com/home-assistant/core/pull/40782
+[#40784]: https://github.com/home-assistant/core/pull/40784
+[#40787]: https://github.com/home-assistant/core/pull/40787
+[#40789]: https://github.com/home-assistant/core/pull/40789
+[#40791]: https://github.com/home-assistant/core/pull/40791
+[#40792]: https://github.com/home-assistant/core/pull/40792
+[#40794]: https://github.com/home-assistant/core/pull/40794
+[#40798]: https://github.com/home-assistant/core/pull/40798
+[#40799]: https://github.com/home-assistant/core/pull/40799
+[@2Fake]: https://github.com/2Fake
+[@Adminiuga]: https://github.com/Adminiuga
+[@BKPepe]: https://github.com/BKPepe
+[@Brahmah]: https://github.com/Brahmah
+[@Bre77]: https://github.com/Bre77
+[@Cereal2nd]: https://github.com/Cereal2nd
+[@CoMPaTech]: https://github.com/CoMPaTech
+[@DAMEK86]: https://github.com/DAMEK86
+[@DaAwesomeP]: https://github.com/DaAwesomeP
+[@Danielhiversen]: https://github.com/Danielhiversen
+[@DarkFox]: https://github.com/DarkFox
+[@Jc2k]: https://github.com/Jc2k
+[@JeffLIrion]: https://github.com/JeffLIrion
+[@JulienTant]: https://github.com/JulienTant
+[@Julius2342]: https://github.com/Julius2342
+[@Kane610]: https://github.com/Kane610
+[@MBlokhuijzen]: https://github.com/MBlokhuijzen
+[@Mariusthvdb]: https://github.com/Mariusthvdb
+[@MartinHjelmare]: https://github.com/MartinHjelmare
+[@MatsNl]: https://github.com/MatsNl
+[@MatthewFlamm]: https://github.com/MatthewFlamm
+[@Misiu]: https://github.com/Misiu
+[@Oliver84]: https://github.com/Oliver84
+[@Quentame]: https://github.com/Quentame
+[@RichieFrame]: https://github.com/RichieFrame
+[@RobBie1221]: https://github.com/RobBie1221
+[@RogerSelwyn]: https://github.com/RogerSelwyn
+[@SNoof85]: https://github.com/SNoof85
+[@Samantha-uk]: https://github.com/Samantha-uk
+[@Shutgun]: https://github.com/Shutgun
+[@SukramJ]: https://github.com/SukramJ
+[@TheGardenMonkey]: https://github.com/TheGardenMonkey
+[@TheNr1Guest]: https://github.com/TheNr1Guest
+[@adamkrol93]: https://github.com/adamkrol93
+[@ajschmidt8]: https://github.com/ajschmidt8
+[@alengwenus]: https://github.com/alengwenus
+[@asimonen]: https://github.com/asimonen
+[@bachya]: https://github.com/bachya
+[@balloob]: https://github.com/balloob
+[@basnijholt]: https://github.com/basnijholt
+[@bdraco]: https://github.com/bdraco
+[@bieniu]: https://github.com/bieniu
+[@bramkragten]: https://github.com/bramkragten
+[@cgtobi]: https://github.com/cgtobi
+[@chemelli74]: https://github.com/chemelli74
+[@creichel]: https://github.com/creichel
+[@ctalkington]: https://github.com/ctalkington
+[@daniel-jong]: https://github.com/daniel-jong
+[@danielkucera]: https://github.com/danielkucera
+[@dermotduffy]: https://github.com/dermotduffy
+[@dmulcahey]: https://github.com/dmulcahey
+[@elupus]: https://github.com/elupus
+[@emontnemery]: https://github.com/emontnemery
+[@epenet]: https://github.com/epenet
+[@fabricepipart]: https://github.com/fabricepipart
+[@fbradyirl]: https://github.com/fbradyirl
+[@felipediel]: https://github.com/felipediel
+[@firstof9]: https://github.com/firstof9
+[@frenck]: https://github.com/frenck
+[@gjbadros]: https://github.com/gjbadros
+[@hareeshmu]: https://github.com/hareeshmu
+[@imduffy15]: https://github.com/imduffy15
+[@janiversen]: https://github.com/janiversen
+[@jjlawren]: https://github.com/jjlawren
+[@jschlyter]: https://github.com/jschlyter
+[@klada]: https://github.com/klada
+[@lamiskin]: https://github.com/lamiskin
+[@ludeeus]: https://github.com/ludeeus
+[@mafrosis]: https://github.com/mafrosis
+[@marciogranzotto]: https://github.com/marciogranzotto
+[@marvin-w]: https://github.com/marvin-w
+[@mikeodr]: https://github.com/mikeodr
+[@nagyrobi]: https://github.com/nagyrobi
+[@newAM]: https://github.com/newAM
+[@nzapponi]: https://github.com/nzapponi
+[@prystupa]: https://github.com/prystupa
+[@puddly]: https://github.com/puddly
+[@rajlaud]: https://github.com/rajlaud
+[@raman325]: https://github.com/raman325
+[@scop]: https://github.com/scop
+[@shenxn]: https://github.com/shenxn
+[@soldag]: https://github.com/soldag
+[@spacegaier]: https://github.com/spacegaier
+[@springstan]: https://github.com/springstan
+[@sqldiablo]: https://github.com/sqldiablo
+[@squishykid]: https://github.com/squishykid
+[@stephan192]: https://github.com/stephan192
+[@tetienne]: https://github.com/tetienne
+[@thomasgermain]: https://github.com/thomasgermain
+[@timkoers]: https://github.com/timkoers
+[@timmo001]: https://github.com/timmo001
+[@tkdrob]: https://github.com/tkdrob
+[@twdkeule]: https://github.com/twdkeule
+[@uvjustin]: https://github.com/uvjustin
+[@vangorra]: https://github.com/vangorra
+[@vigonotion]: https://github.com/vigonotion
+[@vzahradnik]: https://github.com/vzahradnik
+[airvisual docs]: /integrations/airvisual/
+[alarmdecoder docs]: /integrations/alarmdecoder/
+[almond docs]: /integrations/almond/
+[ambient_station docs]: /integrations/ambient_station/
+[androidtv docs]: /integrations/androidtv/
+[api docs]: /integrations/api/
+[arduino docs]: /integrations/arduino/
+[atag docs]: /integrations/atag/
+[august docs]: /integrations/august/
+[azure_devops docs]: /integrations/azure_devops/
+[bloomsky docs]: /integrations/bloomsky/
+[bmw_connected_drive docs]: /integrations/bmw_connected_drive/
+[bond docs]: /integrations/bond/
+[broadlink docs]: /integrations/broadlink/
+[brunt docs]: /integrations/brunt/
+[camera docs]: /integrations/camera/
+[canary docs]: /integrations/canary/
+[cast docs]: /integrations/cast/
+[comfoconnect docs]: /integrations/comfoconnect/
+[command_line docs]: /integrations/command_line/
+[concord232 docs]: /integrations/concord232/
+[deconz docs]: /integrations/deconz/
+[denon docs]: /integrations/denon/
+[devolo_home_control docs]: /integrations/devolo_home_control/
+[dlink docs]: /integrations/dlink/
+[doods docs]: /integrations/doods/
+[dsmr_reader docs]: /integrations/dsmr_reader/
+[dwd_weather_warnings docs]: /integrations/dwd_weather_warnings/
+[dyson docs]: /integrations/dyson/
+[ebusd docs]: /integrations/ebusd/
+[ecobee docs]: /integrations/ecobee/
+[edl21 docs]: /integrations/edl21/
+[ffmpeg docs]: /integrations/ffmpeg/
+[ffmpeg_noise docs]: /integrations/ffmpeg_noise/
+[fibaro docs]: /integrations/fibaro/
+[firmata docs]: /integrations/firmata/
+[flux docs]: /integrations/flux/
+[forked_daapd docs]: /integrations/forked_daapd/
+[freebox docs]: /integrations/freebox/
+[fritzbox docs]: /integrations/fritzbox/
+[frontend docs]: /integrations/frontend/
+[goalzero docs]: /integrations/goalzero/
+[gogogate2 docs]: /integrations/gogogate2/
+[griddy docs]: /integrations/griddy/
+[group docs]: /integrations/group/
+[growatt_server docs]: /integrations/growatt_server/
+[hassio docs]: /integrations/hassio/
+[hdmi_cec docs]: /integrations/hdmi_cec/
+[history docs]: /integrations/history/
+[home_connect docs]: /integrations/home_connect/
+[homekit docs]: /integrations/homekit/
+[homekit_controller docs]: /integrations/homekit_controller/
+[homematicip_cloud docs]: /integrations/homematicip_cloud/
+[huawei_lte docs]: /integrations/huawei_lte/
+[hvv_departures docs]: /integrations/hvv_departures/
+[hyperion docs]: /integrations/hyperion/
+[image docs]: /integrations/image/
+[influxdb docs]: /integrations/influxdb/
+[iqvia docs]: /integrations/iqvia/
+[islamic_prayer_times docs]: /integrations/islamic_prayer_times/
+[isy994 docs]: /integrations/isy994/
+[knx docs]: /integrations/knx/
+[kodi docs]: /integrations/kodi/
+[lcn docs]: /integrations/lcn/
+[light docs]: /integrations/light/
+[logbook docs]: /integrations/logbook/
+[luci docs]: /integrations/luci/
+[maxcube docs]: /integrations/maxcube/
+[media_extractor docs]: /integrations/media_extractor/
+[media_player docs]: /integrations/media_player/
+[meteoalarm docs]: /integrations/meteoalarm/
+[modbus docs]: /integrations/modbus/
+[monoprice docs]: /integrations/monoprice/
+[mqtt docs]: /integrations/mqtt/
+[mysensors docs]: /integrations/mysensors/
+[nest docs]: /integrations/nest/
+[netatmo docs]: /integrations/netatmo/
+[nightscout docs]: /integrations/nightscout/
+[notion docs]: /integrations/notion/
+[nsw_fuel_station docs]: /integrations/nsw_fuel_station/
+[numato docs]: /integrations/numato/
+[nut docs]: /integrations/nut/
+[nws docs]: /integrations/nws/
+[nzbget docs]: /integrations/nzbget/
+[omnilogic docs]: /integrations/omnilogic/
+[onboarding docs]: /integrations/onboarding/
+[onewire docs]: /integrations/onewire/
+[opencv docs]: /integrations/opencv/
+[opentherm_gw docs]: /integrations/opentherm_gw/
+[openweathermap docs]: /integrations/openweathermap/
+[ozw docs]: /integrations/ozw/
+[pilight docs]: /integrations/pilight/
+[plex docs]: /integrations/plex/
+[plugwise docs]: /integrations/plugwise/
+[prometheus docs]: /integrations/prometheus/
+[pvpc_hourly_pricing docs]: /integrations/pvpc_hourly_pricing/
+[recorder docs]: /integrations/recorder/
+[remote docs]: /integrations/remote/
+[rest docs]: /integrations/rest/
+[rest_command docs]: /integrations/rest_command/
+[rfxtrx docs]: /integrations/rfxtrx/
+[roku docs]: /integrations/roku/
+[rpi_power docs]: /integrations/rpi_power/
+[satel_integra docs]: /integrations/satel_integra/
+[sentry docs]: /integrations/sentry/
+[shelly docs]: /integrations/shelly/
+[shiftr docs]: /integrations/shiftr/
+[simplisafe docs]: /integrations/simplisafe/
+[smappee docs]: /integrations/smappee/
+[smartthings docs]: /integrations/smartthings/
+[smarty docs]: /integrations/smarty/
+[snapcast docs]: /integrations/snapcast/
+[solaredge docs]: /integrations/solaredge/
+[solax docs]: /integrations/solax/
+[somfy docs]: /integrations/somfy/
+[somfy_mylink docs]: /integrations/somfy_mylink/
+[sonarr docs]: /integrations/sonarr/
+[sonos docs]: /integrations/sonos/
+[spc docs]: /integrations/spc/
+[splunk docs]: /integrations/splunk/
+[spotify docs]: /integrations/spotify/
+[ssdp docs]: /integrations/ssdp/
+[stream docs]: /integrations/stream/
+[switch docs]: /integrations/switch/
+[synology docs]: /integrations/synology/
+[synology_dsm docs]: /integrations/synology_dsm/
+[system_log docs]: /integrations/system_log/
+[systemmonitor docs]: /integrations/systemmonitor/
+[tag docs]: /integrations/tag/
+[tahoma docs]: /integrations/tahoma/
+[tankerkoenig docs]: /integrations/tankerkoenig/
+[teksavvy docs]: /integrations/teksavvy/
+[template docs]: /integrations/template/
+[tensorflow docs]: /integrations/tensorflow/
+[tibber docs]: /integrations/tibber/
+[tplink docs]: /integrations/tplink/
+[trend docs]: /integrations/trend/
+[unifi docs]: /integrations/unifi/
+[utility_meter docs]: /integrations/utility_meter/
+[vallox docs]: /integrations/vallox/
+[velbus docs]: /integrations/velbus/
+[vera docs]: /integrations/vera/
+[vesync docs]: /integrations/vesync/
+[vizio docs]: /integrations/vizio/
+[voicerss docs]: /integrations/voicerss/
+[webostv docs]: /integrations/webostv/
+[websocket_api docs]: /integrations/websocket_api/
+[wemo docs]: /integrations/wemo/
+[wink docs]: /integrations/wink/
+[withings docs]: /integrations/withings/
+[wled docs]: /integrations/wled/
+[wolflink docs]: /integrations/wolflink/
+[xiaomi_aqara docs]: /integrations/xiaomi_aqara/
+[zamg docs]: /integrations/zamg/
+[zeroconf docs]: /integrations/zeroconf/
+[zha docs]: /integrations/zha/
+[zodiac docs]: /integrations/zodiac/
+[zoneminder docs]: /integrations/zoneminder/


### PR DESCRIPTION
swap_free generates an error on restart if no arg is supplied

## Proposed change
    Add example arg and display the rags are mandatory with this sensor



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
