### PR TITLE
Adding scan_interval and name to configuration documentation

### DIFF
--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -33,11 +33,6 @@ host:
   description: The IP address or hostname of the system you want to track.
   required: true
   type: string
-name:
-  description: You can specify a name of the component.
-  required: false
-  type: string
-  default: ping_HOST
 count:
   description: Number of packages to be sent up to a maximum of 100.
   required: false
@@ -47,7 +42,7 @@ name:
   description: Let you overwrite the name of the device.
   required: false
   type: string
-  default: Ping Binary sensor
+  default: Ping Binary sensor [hostname]
 scan_interval:
   description: Minimum time interval between updates in secconds.
   required: false

--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -51,7 +51,7 @@ name:
 scan_interval:
   description: Minimum time interval between updates in secconds.
   required: false
-  type: int
+  type: integer
   default: 300 seconds 
 {% endconfiguration %}
 

--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -33,6 +33,11 @@ host:
   description: The IP address or hostname of the system you want to track.
   required: true
   type: string
+name:
+  description: You can specify a name of the component.
+  required: false
+  type: string
+  default: ping_HOST
 count:
   description: Number of packages to be sent up to a maximum of 100.
   required: false
@@ -57,13 +62,14 @@ The sensor exposes the different round trip times values measured by `ping` as a
 - `round trip time min`
 - `round trip time max`
 
-The default polling interval is 5 minutes. As many integrations [based on the entity class](/docs/configuration/platform_options), it is possible to overwrite this scan interval by specifying a `scan_interval` configuration key (value in seconds). In the example below we setup the `ping` binary sensor to poll the devices every 30 seconds.
+The default polling interval is 5 minutes. As many integrations [based on the entity class](/docs/configuration/platform_options), it is possible to overwrite this scan interval by specifying a `scan_interval` configuration key (value in seconds). In the example below we setup the `ping` binary sensor to poll the device every 30 seconds.
 
 ```yaml
 # Example configuration.yaml entry to ping host 192.168.0.1 with 2 packets every 30 seconds.
 binary_sensor:
   - platform: ping
     host: 192.168.0.1
+    name: "device name"
     count: 2
     scan_interval: 30
 ```

--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -90,7 +90,7 @@ To use this presence detection in your installation, add the following to your `
 device_tracker:
   - platform: ping
     hosts:
-      hostone: 192.168.2.10
+      hostname: 192.168.2.10
 ```
 
 {% configuration %}

--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -34,7 +34,7 @@ host:
   required: true
   type: string
 count:
-  description: Number of packets to send.
+  description: Number of packages to be sent up to a maximum of 100.
   required: false
   type: integer
   default: 5
@@ -43,6 +43,11 @@ name:
   required: false
   type: string
   default: Ping Binary sensor
+scan_interval:
+  description: Minimum time interval between updates in secconds.
+  required: false
+  type: int
+  default: 300 seconds 
 {% endconfiguration %}
 
 The sensor exposes the different round trip times values measured by `ping` as attributes:

--- a/source/_integrations/ping.markdown
+++ b/source/_integrations/ping.markdown
@@ -42,12 +42,7 @@ name:
   description: Let you overwrite the name of the device.
   required: false
   type: string
-  default: Ping Binary sensor [hostname]
-scan_interval:
-  description: Minimum time interval between updates in secconds.
-  required: false
-  type: integer
-  default: 300 seconds 
+  default: Binary sensor Ping [hostname]
 {% endconfiguration %}
 
 The sensor exposes the different round trip times values measured by `ping` as attributes:


### PR DESCRIPTION
## Proposed change
Adding scan_interval to configuration documentation
Adding name to configuration documentation
hostone -> hostname

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
