### PR TITLE
Add IoT class to Gitter sensor

### DIFF
--- a/source/_integrations/gitter.markdown
+++ b/source/_integrations/gitter.markdown
@@ -3,6 +3,7 @@ title: Gitter
 description: Instructions on how to integrate a Gitter room sensor with Home Assistant
 ha_category:
   - Sensor
+ha_iot_class: Cloud Polling
 ha_release: 0.47
 ha_codeowners:
   - '@fabaff'


### PR DESCRIPTION
## Proposed change

Add `Cloud Polling` as the IoT class of the Gitter sensor since it polls a service on an external network when used. 

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant.io/issues/14661

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
