### PR TITLE
move configuration redirects

### DIFF
--- a/source/_docs/configuration/basic.markdown
+++ b/source/_docs/configuration/basic.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Setup basic information"
 description: "Setting up the basic info of Home Assistant."
-redirect_from: /getting-started/basic/
 ---
 
 As part of the default onboarding process, Home Assistant can detect your location from IP address geolocation. Home Assistant will automatically select a temperature unit and time zone based on this location. You may adjust this during onboarding, or afterwards at Configuration -> General.

--- a/source/_docs/configuration/customizing-devices.markdown
+++ b/source/_docs/configuration/customizing-devices.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Customizing entities"
 description: "Simple customization for entities in the frontend."
-redirect_from: /getting-started/customizing-devices/
 ---
 
 ## Changing the entity_id

--- a/source/_docs/configuration/devices.markdown
+++ b/source/_docs/configuration/devices.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Adding devices to Home Assistant"
 description: "Steps to help you get your devices in Home Assistant."
-redirect_from: /getting-started/devices/
 ---
 
 Home Assistant will be able to automatically discover many devices and services available on your network if you have [the discovery component](/integrations/discovery/) enabled (the default setting).

--- a/source/_docs/configuration/events.markdown
+++ b/source/_docs/configuration/events.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Events"
 description: "Describes all there is to know about events in Home Assistant."
-redirect_from: /topics/events/
 ---
 
 The core of Home Assistant is the event bus. The event bus allows any integration to fire or listen for events. It is the core of everything. For example, any state change will be announced on the event bus as a `state_changed` event containing the previous and the new state of an entity.

--- a/source/_docs/configuration/packages.markdown
+++ b/source/_docs/configuration/packages.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Packages"
 description: "Describes all there is to know about configuration packages in Home Assistant."
-redirect_from: /topics/packages/
 ---
 
 Packages in Home Assistant provide a way to bundle different component's configuration together. We already learned about the two configuration styles (specifying platforms entries together or individually) on the [adding devices](/docs/configuration/devices/) page. Both of these configuration methods require you to create the integration key in the main `configuration.yaml` file. With packages we have a way to include different components, or different configuration parts using any of the `!include` directives introduced in [splitting the configuration](/docs/configuration/splitting_configuration).

--- a/source/_docs/configuration/platform_options.markdown
+++ b/source/_docs/configuration/platform_options.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Entity integration platform options"
 description: "Shows how to customize polling interval for any integration via configuration.yaml."
-redirect_from: /topics/platform_options/
 ---
 
 <div class='note info'>

--- a/source/_docs/configuration/secrets.markdown
+++ b/source/_docs/configuration/secrets.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Storing secrets"
 description: "Storing secrets outside of your configuration.yaml."
-redirect_from: /topics/secrets/
 ---
 
 The `configuration.yaml` file is a plain-text file, thus it is readable by anyone who has access to the file. The file contains passwords and API tokens which need to be redacted if you want to share your configuration. By using `!secret` you can remove any private information from your configuration files. This separation can also help you to keep easier track of your passwords and API keys, as they are all stored at one place and no longer spread across the `configuration.yaml` file or even multiple YAML files if you [split up your configuration](/docs/configuration/splitting_configuration/).

--- a/source/_docs/configuration/securing.markdown
+++ b/source/_docs/configuration/securing.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Securing"
 description: "Instructions on how to secure your Home Assistant installation."
-redirect_from: /getting-started/securing/
 ---
 
 One major advantage of Home Assistant is that it's not dependent on cloud services. Even if you're only using Home Assistant on a local network, you should take steps to secure your instance.

--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Splitting up the configuration"
 description: "Splitting the configuration.yaml into several files."
-redirect_from: /topics/splitting_configuration/
 ---
 
 So you've been using Home Assistant for a while now and your `configuration.yaml` file brings people to tears or you simply want to start off with the distributed approach, here's how to split the `configuration.yaml` into more manageable (read: humanly readable) pieces.

--- a/source/_docs/configuration/state_object.markdown
+++ b/source/_docs/configuration/state_object.markdown
@@ -1,7 +1,6 @@
 ---
 title: "State Objects"
 description: "Describes all there is to know about state objects in Home Assistant."
-redirect_from: /topics/state_object/
 ---
 
 Your devices are represented in Home Assistant as entities. The entities will write their current state to the state machine for other entities/templates/frontend to access. States are a current representation of the entity.

--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Templating"
 description: "Instructions on how to use the templating feature of Home Assistant."
-redirect_from: /topics/templating/
 ---
 
 This is an advanced feature of Home Assistant. You'll need a basic understanding of:

--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -1,7 +1,6 @@
 ---
 title: "Troubleshooting your configuration"
 description: "Common problems with tweaking your configuration and their solutions."
-redirect_from: /getting-started/troubleshooting-configuration/
 ---
 
 It can happen that you run into trouble while configuring Home Assistant. Perhaps an integration is not showing up or is acting strangely. This page will discuss a few of the most common problems.

--- a/source/_docs/configuration/yaml.markdown
+++ b/source/_docs/configuration/yaml.markdown
@@ -1,7 +1,6 @@
 ---
 title: "YAML"
 description: "Details about YAML to configure Home Assistant."
-redirect_from: /getting-started/yaml/
 ---
 
 Home Assistant uses the [YAML](https://yaml.org/) syntax for configuration. YAML might take a while to get used to but is really powerful in allowing you to express complex configurations.

--- a/source/_redirects
+++ b/source/_redirects
@@ -2066,6 +2066,20 @@
 /integrations/switch.knx /integrations/knx#switch
 /integrations/weather.knx /integrations/knx#weather
 /integrations/zigbee /integrations/xbee
+/getting-started/basic docs/configuration/basic
+/getting-started/customizing-devices /docs/configuration/customizing-devices
+/getting-started/devices /docs/configuration/devices
+/topics/events /docs/configuration/events
+/topics/packages /docs/configuration/packages
+/topics/platform_options /docs/configuration/platform_options
+/topics/secrets /docs/configuration/secrets
+/getting-started/securing /docs/configuration/securing
+/topics/splitting_configuration /docs/configuration/splitting_configuration
+/topics/state_object /docs/configuration/state_object
+/topics/templating /docs/configuration/templating
+/getting-started/troubleshooting-configuration /docs/configuration/troubleshooting
+/getting-started/yaml /docs/configuration/yaml
+
 
 # Migrated Community Guides
 /cookbook/apache_configuration https://community.home-assistant.io/t/reverse-proxy-with-apache/196942

--- a/source/_redirects
+++ b/source/_redirects
@@ -2069,17 +2069,16 @@
 /getting-started/basic docs/configuration/basic
 /getting-started/customizing-devices /docs/configuration/customizing-devices
 /getting-started/devices /docs/configuration/devices
+/getting-started/securing /docs/configuration/securing
+/getting-started/troubleshooting-configuration /docs/configuration/troubleshooting
+/getting-started/yaml /docs/configuration/yaml
 /topics/events /docs/configuration/events
 /topics/packages /docs/configuration/packages
 /topics/platform_options /docs/configuration/platform_options
 /topics/secrets /docs/configuration/secrets
-/getting-started/securing /docs/configuration/securing
 /topics/splitting_configuration /docs/configuration/splitting_configuration
 /topics/state_object /docs/configuration/state_object
 /topics/templating /docs/configuration/templating
-/getting-started/troubleshooting-configuration /docs/configuration/troubleshooting
-/getting-started/yaml /docs/configuration/yaml
-
 
 # Migrated Community Guides
 /cookbook/apache_configuration https://community.home-assistant.io/t/reverse-proxy-with-apache/196942

--- a/source/_redirects
+++ b/source/_redirects
@@ -2066,7 +2066,7 @@
 /integrations/switch.knx /integrations/knx#switch
 /integrations/weather.knx /integrations/knx#weather
 /integrations/zigbee /integrations/xbee
-/getting-started/basic docs/configuration/basic
+/getting-started/basic /docs/configuration/basic
 /getting-started/customizing-devices /docs/configuration/customizing-devices
 /getting-started/devices /docs/configuration/devices
 /getting-started/securing /docs/configuration/securing


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Moves the redirects from source files located at `source\_docs\configuration` into the dedicated `source\_redirects` file

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR relates to : #14662 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
