### PR TITLE
Fix HVV Departures elevators were added by someone else

### DIFF
--- a/source/_posts/2020-10-07-release-116.markdown
+++ b/source/_posts/2020-10-07-release-116.markdown
@@ -129,7 +129,7 @@ The following integration got support for a new platform:
 
 - [Synology DSM][synology_dsm docs] now supports cameras, added by [@shenxn]
 - [HVV Departures][hvv_departures docs] added binary sensors to show elevator
-  statuses. Added by [@DaAwesomeP]
+  statuses. Added by [@vigonotion]
 - Support for covers was added to [Modbus][modbus docs], by [@vzahradnik]
 - [Firmata][firmata docs] to support analog input and PWM/analog output
   Added by [@DaAwesomeP]


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I added elevator binary sensors for the HVV Departures integration via https://github.com/home-assistant/core/pull/36822.

The beta release notes say it's been added by *DaAwesomeP*.

I changed it now to my name.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
