### PR TITLE
Add IoT class to cover integration

### DIFF
--- a/source/_integrations/cover.markdown
+++ b/source/_integrations/cover.markdown
@@ -8,6 +8,7 @@ ha_quality_scale: internal
 ha_codeowners:
   - '@home-assistant/core'
 ha_domain: cover
+ha_iot_class: Local Push
 ---
 
 Home Assistant can give you an interface to control covers such as rollershutters, blinds, and garage doors.


### PR DESCRIPTION
As requested in #[14661](https://github.com/home-assistant/home-assistant.io/issues/14661) this is to add the IoT class to the cover integration.

Proposed change
Type of change

- [ ] Spelling, grammar or other readability improvements (current branch).

- [x]  Adjusted missing or incorrect information in the current documentation (current branch).

- [ ] Added documentation for a new integration I'm adding to Home Assistant (next branch).

- [ ] I've opened up a PR to add logo's and icons in Brands repository.

- [ ] Added documentation for a new feature I'm adding to Home Assistant (next branch).

- [ ] Removed stale or deprecated documentation.

Additional information
Link to parent pull request in the codebase:
Link to parent pull request in the Brands repository:
This PR fixes or closes issue:
Checklist
This PR uses the correct branch, based on one of the following:
I made a change to the existing documentation and used the current branch.
I made a change that is related to an upcoming version of Home Assistant and used the next branch.
The documentation follows the Home Assistant documentation standards.

Type of change
 Spelling, grammar or other readability improvements (current branch).
 Adjusted missing or incorrect information in the current documentation (current branch).
 Added documentation for a new integration I'm adding to Home Assistant (next branch).
 I've opened up a PR to add logo's and icons in Brands repository.
 Added documentation for a new feature I'm adding to Home Assistant (next branch).
 Removed stale or deprecated documentation.
Additional information
Link to parent pull request in the codebase:
Link to parent pull request in the Brands repository:
This PR fixes or closes issue:
Checklist
 This PR uses the correct branch, based on one of the following:
I made a change to the existing documentation and used the current branch.
I made a change that is related to an upcoming version of Home Assistant and used the next branch.
 The documentation follows the Home Assistant documentation standards.