### PR TITLE
Fix link to GPSLogger

### DIFF
--- a/source/_integrations/gpslogger.markdown
+++ b/source/_integrations/gpslogger.markdown
@@ -17,7 +17,7 @@ To configure GPSLogger, you must set it up via the integrations panel in the con
 
 ## Setup on your smartphone
 
-Install [GPSLogger for Android](https://play.google.com/store/apps/details?id=com.mendhak.gpslogger) on your device.
+Install GPSLogger for Android from [GitHub](https://github.com/mendhak/gpslogger/releases) or [F-Droid](https://apt.izzysoft.de/fdroid/index/apk/com.mendhak.gpslogger) on your device.
 
 After the launch, go to **General Options**. Enable **Start on bootup** and **Start on app launch**.
 


### PR DESCRIPTION
As it is no longer on the Google Play Store as discussed here: https://github.com/mendhak/gpslogger/issues/849

## Proposed change
Replace Play Store link with GitHub and F-Droid links.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
This PR is a part of issue: [#14663](https://github.com/home-assistant/home-assistant.io/issues/14663)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
