### PR TITLE
Remove link to OSS Metrics

### DIFF
--- a/source/_posts/2017-01-18-numbers.markdown
+++ b/source/_posts/2017-01-18-numbers.markdown
@@ -10,7 +10,7 @@ categories: Community
 
 It's week 3 of 2017 and great things did already happen. This is just a little recap.
 
-- In the [OSS Metrics leaderboard](https://ossmetrics.com/leaderboard) we are on place 30. Within three months we moved from our starting place which was 66 in September 2016 up to the current one.
+- In the OSS Metrics leaderboard we are on place 30. Within three months we moved from our starting place which was 66 in September 2016 up to the current one.
 - We were listed on [Github Trending](https://github.com/trending/python). Also, was [@balloob](https://github.com/balloob) mentioned as trending developer.
 - [@balloob](https://github.com/balloob)'s talk at the OpenIoT Summit 2016 was rated as one of the [Top 5 videos](https://www.linuxfoundation.org/blog/2017/01/top-5-videos-from-embedded-linux-conference-and-openiot-summit-2016/) of the conference.
 - We now ship over [500](/integrations/#all) components and platforms.


### PR DESCRIPTION
Removed the link to https://ossmetrics.com/leaderboard as https://ossmetrics.com/ itself doesn't look to be active any more

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
As part of #14663 I have removed the hyperlink to the aforementioned website as it looks to no longer be active. I have left the text there however.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
