### PR TITLE
August integration: documentation on how to handle expired access tokens

### DIFF
--- a/source/_integrations/august.markdown
+++ b/source/_integrations/august.markdown
@@ -122,3 +122,26 @@ Using the lock operation sensors, you can detect when a user operates a lock and
 ```
 
 {% endraw %}
+
+## Token Expiration Handling
+
+The August lock access_token is stored in a file called august.conf. When it expires, the integration fails, and you see errors in the home-assistant.log file.   For example:
+
+{% raw %}
+
+```
+2020-10-02 07:47:12 ERROR (MainThread) [august.authenticator_async] Token has expired.
+2020-10-02 07:47:14 ERROR (MainThread) [homeassistant.components.august] Access token is no longer valid
+```
+
+{% endraw %}
+
+
+Here are the steps to get a new access token (tested on Home Assistant Core `0.114.4`):
+
+1. Delete the august.conf file.
+1. Restart Home Assistant.
+1. Check your email to find a message from August that contains a verification code.
+1. When the Home Assistant UI reconnects, check the Notifications panel for a message.  Open the message, choose Configure, and enter the verification code.
+
+No further steps are required.  A new august.conf file is created and the august lock becomes available again. 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add steps for getting a new access_token for the August integration.

As a user, I found it difficult to track down the solution to a recurring and common issue, so adding it to the documentation seems obvious.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
