### PR TITLE
Change Material Design Icons URL

### DIFF
--- a/source/_posts/2020-07-01-release-113.markdown
+++ b/source/_posts/2020-07-01-release-113.markdown
@@ -344,7 +344,7 @@ Please note: It is possible that custom integrations (also known as
 custom components) use deprecated icons. These can throw warnings that need
 to be addressed in the custom integration.
 
-[mdi]: https://www.materialdesignicons.com
+[mdi]: https://materialdesignicons.com
 [mdi-upgrade]: https://dev.materialdesignicons.com/upgrade#4.9.95-to-5.0.45
 [simple-icons]: https://simpleicons.org/
 [hass-simpleicons]: https://github.com/vigonotion/hass-simpleicons


### PR DESCRIPTION
It looks as though Material Design Icons don't use the www prefix for their URL as the certificate for that prefix ran out on "02‎ ‎June‎ ‎2017 ‎00‎:‎59‎:‎59". I've removed the "www." from their URL in this blog post to avoid confusion.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
All the detail is above. I came across this in Xenu when looking for broken links for #14663 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
