### PR TITLE
Update OZW docs for new config parameter type and provide example

### DIFF
--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -98,12 +98,10 @@ LED colors on switches.
 | `instance_id`          | no       | The OZW Instance/Controller to use, defaults to 1.                                                              |
 | `node_id`              | yes      | Node id of the device to set configuration parameter to (integer).                                              |
 | `parameter`            | yes      | Parameter number to set (integer).                                                                              |
-| `value`                | yes      | Value to set for parameter. (String or integer value for list, string or boolean for bool parameters, dictionary for bitset parameters (see example below), integer for others). |
+| `value`                | yes      | Value to set for parameter. (String or integer value for list, string or boolean for bool parameters, list of dicts for bitset parameters (see example below), integer for others). |
 
 
 #### Example BitSet service call
-
-The dictionary passed as the value should be of the form <BIT POSITION OR LABEL>: <1 for on or 0 for off>
 
 Here is an example of what to send to the service for a BitSet parameter:
 
@@ -111,9 +109,12 @@ Here is an example of what to send to the service for a BitSet parameter:
 node_id: 4
 parameter: 5
 value:
-  1: 1
-  "Humidity": 0
-  3: 0
+  - position: 1
+    value: true
+  - label: Humidity
+    value: false
+  - position: 3
+    value: false
 ```
 
 ## Events

--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -102,9 +102,11 @@ LED colors on switches.
 
 
 #### Example BitSet service call
+
 The dictionary passed as the value should be of the form <BIT POSITION OR LABEL>: <1 for on or 0 for off>
 
 Here is an example of what to send to the service for a BitSet parameter:
+
 ```yaml
 node_id: 4
 parameter: 5

--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -102,7 +102,7 @@ LED colors on switches.
 
 
 #### Example BitSet value
-The dictionary passed as the value should be of the form <BIT NUMBER OR LABEL>: <1 for on or 0 for off>
+The dictionary passed as the value should be of the form <BIT POSITION OR LABEL>: <1 for on or 0 for off>
 
 Here is an example of what to send:
 ```yaml

--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -101,10 +101,10 @@ LED colors on switches.
 | `value`                | yes      | Value to set for parameter. (String or integer value for list, string or boolean for bool parameters, dictionary for bitset parameters (see example below), integer for others). |
 
 
-#### Example BitSet value
+#### Example BitSet service call
 The dictionary passed as the value should be of the form <BIT POSITION OR LABEL>: <1 for on or 0 for off>
 
-Here is an example of what to send:
+Here is an example of what to send to the service for a BitSet parameter:
 ```yaml
 node_id: 4
 parameter: 5

--- a/source/_integrations/ozw.markdown
+++ b/source/_integrations/ozw.markdown
@@ -98,7 +98,21 @@ LED colors on switches.
 | `instance_id`          | no       | The OZW Instance/Controller to use, defaults to 1.                                                              |
 | `node_id`              | yes      | Node id of the device to set configuration parameter to (integer).                                              |
 | `parameter`            | yes      | Parameter number to set (integer).                                                                              |
-| `value`                | yes      | Value to set for parameter. (String or integer value for list, string for bool parameters, integer for others). |
+| `value`                | yes      | Value to set for parameter. (String or integer value for list, string or boolean for bool parameters, dictionary for bitset parameters (see example below), integer for others). |
+
+
+#### Example BitSet value
+The dictionary passed as the value should be of the form <BIT NUMBER OR LABEL>: <1 for on or 0 for off>
+
+Here is an example of what to send:
+```yaml
+node_id: 4
+parameter: 5
+value:
+  1: 1
+  "Humidity": 0
+  3: 0
+```
 
 ## Events
 


### PR DESCRIPTION
## Proposed change
My parent PR adds support for a new parameter type for the `set_config_parameter` service, so this PR updates the docs to instruct users on how to use the service for that type.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40527
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
