### PR TITLE
hint to add local url

### DIFF
--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -36,7 +36,7 @@ To create the required Spotify application:
 - Click **Save** after adding the URI.
 
 <div class='note'>
-  Your Home Assistant instance does not need to be exposed to the internet. It works just fine with local IP addresses.
+  Your Home Assistant instance does not need to be exposed to the internet. It works just fine with local IP addresses. Please make sure that your local URL is also set at **Configuration** > **General** > **Internal URL**.
 </div>  
 
 ## Configuration


### PR DESCRIPTION
without that setting the integration did not work for me
(failed with "aborted" and no further explanation)

## Proposed change
Without the local url setting the spotify integration does not work.
This PR adds a hint to the setting.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

I'm not 100% sure if it's the right location for it.
Also I don't know it this is the correct way to reference settings.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
