### PR TITLE
Adding IoT Class for Cisco Mobility Express Integration

### DIFF
--- a/source/_integrations/cisco_mobility_express.markdown
+++ b/source/_integrations/cisco_mobility_express.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate Cisco Mobility Express wireless co
 ha_category:
   - Presence Detection
 ha_release: '0.90'
+ha_iot_class: Local Polling
 ha_codeowners:
   - '@fbradyirl'
 ha_domain: cisco_mobility_express


### PR DESCRIPTION
## Proposed change

As requested in #14661 this is to add the IoT class to the Cisco Mobility Express integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
