### PR TITLE
Add profiler integration

### DIFF
--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -22,7 +22,9 @@ Start the profiler for the specified number of seconds.
 | ---------------------- | -------- | ----------- |
 | `seconds` | yes | The number of seconds to run the profile. Defaults to 60.0
 
-When the profile is complete, Profiler will generate a Python `cprof` which can be viewed with:
+When the profile is complete, Profiler will generate a Python `cprof` and a `callgrind.out` file in your configuration directory. The exact path to these files will appear in a persistent notification so they can be easily located and copied to your desktop. 
+
+The `cprof` file can be viewed with:
 
 [SnakeViz](https://jiffyclub.github.io/snakeviz/)
 [Gprof2dot](https://github.com/jrfonseca/gprof2dot)

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -27,7 +27,7 @@ When the profile is complete, Profiler will generate a Python `cprof` which can 
 [SnakeViz](https://jiffyclub.github.io/snakeviz/)
 [Gprof2dot](https://github.com/jrfonseca/gprof2dot)
 
-Additionally, the profile will generate a `callgrind.out` file that can be viewed with:
+Additionally, the profiler will generate a `callgrind.out` file that can be viewed with:
 
 [kcachegrind](https://kcachegrind.github.io/) or qcachegrind
 

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -22,7 +22,7 @@ Start the profiler for the specified number of seconds.
 | ---------------------- | -------- | ----------- |
 | `seconds` | yes | The number of seconds to run the profile. Defaults to 60.0
 
-When the profile is complete, Profiler will generate a python `cprof` which can be viewed with:
+When the profile is complete, Profiler will generate a Python `cprof` which can be viewed with:
 
 [SnakeViz](https://jiffyclub.github.io/snakeviz/)
 [Gprof2dot](https://github.com/jrfonseca/gprof2dot)

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -1,0 +1,33 @@
+---
+title: Profiler
+description: Profile Home Assistant.
+ha_category:
+  - Utility
+ha_release: 0.117
+ha_quality_scale: internal
+ha_domain: profiler
+---
+
+The Profiler integration provides a profile which is a set of statistics that identifies how much time each part of Home Assistant is taking. It can help track down a performance issue or provide insight about a misbehaving integration.
+
+## Configuration
+
+To add `Profiler` to your installation, go to **Configuration** >> **Integrations** in the UI, click the button with `+` sign and from the list of integrations select **Profiler**.
+
+### Service `profiler.start`
+
+Start the profiler for the specified number of seconds.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `seconds` | yes | The number of seconds to run the profile. Defaults to 60.0
+
+When the profile is complete, Profiler will generate a python `cprof` which can be viewed with:
+
+[SnakeViz](https://jiffyclub.github.io/snakeviz/)
+[Gprof2dot](https://github.com/jrfonseca/gprof2dot)
+
+Additionally, the profile will generate a `callgrind.out` file that can be viewed with:
+
+[kcachegrind](https://kcachegrind.github.io/) or qcachegrind
+


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Provides a way to generate profiles to help track down performance issues.

A config flow is used which allows the integration can be setup without a restart when the problem is occurring.

Example usage: https://github.com/bdraco/profiler





## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/41175
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1904
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
