### PR TITLE
Remove unused Dev Tools icon from Fan integration

### DIFF
--- a/source/_integrations/fan.markdown
+++ b/source/_integrations/fan.markdown
@@ -19,13 +19,13 @@ Available services:
 
 <div class='note'>
 
-Not all fan services may be available for your platform. Be sure to check the available services Home Assistant has enabled by checking <img src='/images/screenshots/developer-tool-services-icon.png' alt='service developer tool icon' class="no-shadow" height="38" /> **Services**.
+Not all fan services may be available for your platform. You can check which services are available for your fan(s) under **Developer Tools** -> **Services**.
 
 </div>
 
 ### Service `fan.set_speed`
 
-Sets the speed for fan device
+Sets the speed for fan device.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -48,7 +48,7 @@ automation:
 
 ### Service `fan.set_direction`
 
-Sets the rotation for fan device
+Sets the rotation for fan device.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -71,7 +71,7 @@ automation:
 
 ### Service `fan.oscillate`
 
-Sets the oscillation for fan device
+Sets the oscillation for fan device.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The Services icon this is referencing was removed over a year ago in Home Assistant 0.96 when the sidebar was redesigned. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
