### PR TITLE
Rewrote Sonarr integration page

### DIFF
--- a/source/_integrations/sonarr.markdown
+++ b/source/_integrations/sonarr.markdown
@@ -16,4 +16,20 @@ The `Sonarr` integration pulls data from a given [Sonarr](https://sonarr.tv/) in
 
 ## Configuration
 
-Go to the integrations page in your configuration and click on new integration -> Sonarr.
+To add Sonarr to Home Assistant, go to **Configuration** -> **Integrations** and click the + button in the bottom right corner. Search for Sonarr and follow the on-screen instructions to complete setup.
+
+To retrieve your API key, open your Sonarr web interface and navigate to Settings then General tab. Your Sonarr API Key will be listed on this page under the Security section.
+
+## Sensors
+
+The Sonarr integration will add the following sensors:
+
+`sensor.sonarr_upcoming`: The number of upcoming episodes.
+
+The remaining five sensors are disabled by default and can be enabled on the device page.
+
+* `sensor.sonarr_commands`: The number of commands being run.
+* `sensor.sonarr_disk_space`: Available disk space.
+* `sensor.sonarr_queue`: The number of episodes in the queue.
+* `sensor.sonarr_shows`: The number of series in Sonarr.
+* `sensor.sonarr_wanted`: The number of episodes still wanted.

--- a/source/_integrations/sonarr.markdown
+++ b/source/_integrations/sonarr.markdown
@@ -16,7 +16,7 @@ The `Sonarr` integration pulls data from a given [Sonarr](https://sonarr.tv/) in
 
 ## Configuration
 
-To add Sonarr to Home Assistant, go to **Configuration** -> **Integrations** and click the + button in the bottom right corner. Search for Sonarr and follow the on-screen instructions to complete setup.
+To add Sonarr to Home Assistant, go to **Configuration** -> **Integrations** and click the + button in the bottom right corner. Search for Sonarr and follow the on-screen instructions to complete the setup.
 
 To retrieve your API key, open your Sonarr web interface and navigate to Settings then General tab. Your Sonarr API Key will be listed on this page under the Security section.
 
@@ -28,8 +28,8 @@ The Sonarr integration will add the following sensors:
 
 The remaining five sensors are disabled by default and can be enabled on the device page.
 
-* `sensor.sonarr_commands`: The number of commands being run.
-* `sensor.sonarr_disk_space`: Available disk space.
-* `sensor.sonarr_queue`: The number of episodes in the queue.
-* `sensor.sonarr_shows`: The number of series in Sonarr.
-* `sensor.sonarr_wanted`: The number of episodes still wanted.
+- `sensor.sonarr_commands`: The number of commands being run.
+- `sensor.sonarr_disk_space`: Available disk space.
+- `sensor.sonarr_queue`: The number of episodes in the queue.
+- `sensor.sonarr_shows`: The number of series in Sonarr.
+- `sensor.sonarr_wanted`: The number of episodes still wanted.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added information on how to get your Sonarr API key (required to complete the config flow). Also added a section describing the sensors and how to enable them (since most are disabled by default).


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
