### PR TITLE
Added states

### DIFF
--- a/source/_integrations/climate.markdown
+++ b/source/_integrations/climate.markdown
@@ -220,3 +220,15 @@ Turn climate device off. This is only supported if the climate device has the HV
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
+
+
+## Attributes
+
+The climate entity has extra attributes to represent the state of the thermostat.
+
+| Name | Description |
+| ---- | ----------- |
+| `hvac_action` | Current state: `heat` / `cool` / `idle`.
+| `fan` | If the fan is currently on or off: `on` / `off`.
+
+It depends on the thermostat you are using which states are available. 

--- a/source/_integrations/climate.markdown
+++ b/source/_integrations/climate.markdown
@@ -221,7 +221,6 @@ Turn climate device off. This is only supported if the climate device has the HV
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that define the entity ID(s) of climate device(s) to control. To target all climate devices, use `all`.
 
-
 ## Attributes
 
 The climate entity has extra attributes to represent the state of the thermostat.
@@ -231,4 +230,4 @@ The climate entity has extra attributes to represent the state of the thermostat
 | `hvac_action` | Current state: `heat` / `cool` / `idle`.
 | `fan` | If the fan is currently on or off: `on` / `off`.
 
-It depends on the thermostat you are using which states are available. 
+It depends on the thermostat you are using which states are available.


### PR DESCRIPTION
Trough the forum I found out there is a `hvac_action`  attribute, which shows the current state. This wasn't yet available in the documentation. Therefore chose to add this. 

I wasn't sure which page this should be placed, either the climate description or the generic_thermostat. I chose Climate as it is a climate attribute. 

This attribute is described here: https://www.home-assistant.io/blog/2019/07/17/release-96/#climate
This was the forum post which lead me to it:
https://community.home-assistant.io/t/generic-thermostat-state/140174

Here is a forum post which also describes the `fan` attribute. 
https://community.home-assistant.io/t/how-to-trigger-automation-from-hvac-action/202597




## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
