### PR TITLE
changed state for hvac_action from heat to heating

### DIFF
--- a/source/_integrations/climate.markdown
+++ b/source/_integrations/climate.markdown
@@ -227,7 +227,7 @@ The climate entity has extra attributes to represent the state of the thermostat
 
 | Name | Description |
 | ---- | ----------- |
-| `hvac_action` | Current state: `heat` / `cool` / `idle`.
+| `hvac_action` | Current state: `heating` / `cooling` / `idle`.
 | `fan` | If the fan is currently on or off: `on` / `off`.
 
 It depends on the thermostat you are using which states are available.


### PR DESCRIPTION
## Proposed change
<!-- 
   Earlier this day I did a PR for a change in the documentation for Climate concerning the add of state attributes like hvac_action and fan. I accidentally added the wrong state values. It should be heating not heat and cooling not cool. After applying an automation with this state today I realised I wrote the wrong states
The states are also described on the blog post: https://www.home-assistant.io/blog/2019/07/17/release-96/#climate
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
