### PR TITLE
xiaomi_miio: Add docs for Air Purifier 2H

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -323,6 +323,7 @@ Supported devices:
 | Air Purifier MA1       | zhimi.airpurifier.ma1  | |
 | Air Purifier 2S        | zhimi.airpurifier.ma2  | |
 | Air Purifier 2S        | zhimi.airpurifier.mc1  | |
+| Air Purifier 2H        | zhimi.airpurifier.mc2  | |
 | Air Purifier Super     | zhimi.airpurifier.sa1  | |
 | Air Purifier Super 2   | zhimi.airpurifier.sa2  | |
 | Air Purifier 3 (2019)  | zhimi.airpurifier.ma4  | |
@@ -464,6 +465,33 @@ Supported devices:
   - `filter_rfid_tag`
   - `filter_type`
   - `illuminance`
+  - `buzzer`
+  
+### Air Purifier 2H (zhimi.airpurifier.mc2)
+
+- Power (on, off)
+- Operation modes (auto, silent, favorite)
+- Buzzer (on, off)
+- Child lock (on, off)
+- LED (on, off)
+- Favorite Level (0...16)
+- Attributes
+  - `model`
+  - `temperature`
+  - `humidity`
+  - `aqi`
+  - `mode`
+  - `filter_hours_used`
+  - `filter_life_remaining`
+  - `favorite_level`
+  - `child_lock`
+  - `led`
+  - `motor_speed`
+  - `average_aqi`
+  - `learn_mode`
+  - `extra_features`
+  - `turbo_mode_supported`
+  - `button_pressed`
   - `buzzer`
 
 ### Air Purifier 3/3H (2019) (zhimi.airpurifier.ma4/zhimi.airpurifier.mb3)


### PR DESCRIPTION
Related to PR https://github.com/home-assistant/core/pull/41242

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds docs for newly supported model in xiaomi_miio integration.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/41242
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
