### PR TITLE
Remove rate_limit directive from documentation as it is not shipping in 0.116

### DIFF
--- a/source/_docs/configuration/templating.markdown
+++ b/source/_docs/configuration/templating.markdown
@@ -58,7 +58,6 @@ Extensions allow templates to access all of the Home Assistant specific states a
 - `is_state('device_tracker.paulus', 'home')` will test if the given entity is the specified state.
 - `state_attr('device_tracker.paulus', 'battery')` will return the value of the attribute or None if it doesn't exist.
 - `is_state_attr('device_tracker.paulus', 'battery', 40)` will test if the given entity attribute is the specified state (in this case, a numeric value). Note that the attribute can be `None` and you want to check if it is `None`, you need to use `state_attr('sensor.my_sensor', 'attr') == None`. 
-- `rate_limit` - limits re-renders of the template. Returns an empty string and accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
 <div class='note warning'>
 
   Avoid using `states.sensor.temperature.state`, instead use `states('sensor.temperature')`. It is strongly advised to use the `states()`, `is_state()`, `state_attr()` and `is_state_attr()` as much as possible, to avoid errors and error message when the entity isn't ready yet (e.g., during Home Assistant startup).

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -311,7 +311,7 @@ binary_sensor:
   - platform: template
     sensors:
       has_unavailable_states:
-        value_template: '{% states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}'
+        value_template: '{{ states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}'
 ```
 {% endraw %}
 

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -303,10 +303,6 @@ time any state changed event happens if any part of the state is accessed. When 
 is only re-rendered when a state is added or removed from the system. On busy systems with many entities or hundreds of
 thousands state changed events per day, templates may re-render more than desirable.
 
-A `rate_limit` directive can be used to limit how often the template re-renders.
-
-`rate_limit` returns an empty string and accepts the same arguments as the Python `datetime.timedelta` function -- days, seconds, microseconds, milliseconds, minutes, hours, weeks.
-
 In the below example, re-renders are limited to once per minute:
 
 {% raw %}
@@ -315,11 +311,11 @@ binary_sensor:
   - platform: template
     sensors:
       has_unavailable_states:
-        value_template: '{{ rate_limit(minutes=1) }}{% states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}'
+        value_template: '{% states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}'
 ```
 {% endraw %}
 
-If the template accesses every state on the system or all states under a specific domain, a default rate limit of one update per second is applied. If the template only accesses specific states, no rate limit is applied. The rate limit can be disabled by inserting {% raw %}`{{ rate_limit(seconds=0) }}`{% endraw %} into the template.
+If the template accesses every state on the system or all states under a specific domain, a rate limit of one update per minute is applied. If the template only accesses specific states, recieves update events for specifically referenced entities, or the `homeassistant.update_entity` service is used, no rate limit is applied.
 
 ### Working without entities
 

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -315,7 +315,7 @@ binary_sensor:
 ```
 {% endraw %}
 
-If the template accesses every state on the system or all states under a specific domain, a rate limit of one update per minute is applied. If the template only accesses specific states, recieves update events for specifically referenced entities, or the `homeassistant.update_entity` service is used, no rate limit is applied.
+If the template accesses every state on the system or all states under a specific domain, a rate limit of one update per minute is applied. If the template only accesses specific states, receives update events for specifically referenced entities, or the `homeassistant.update_entity` service is used, no rate limit is applied.
 
 ### Working without entities
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Remove `rate_limit` directive from documentation as it is not shipping in 0.116.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/41225
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
