### PR TITLE
Remove reference to old Hue FAQ link

### DIFF
--- a/source/_posts/2015-12-12-philips-hue-blocks-3rd-party-bulbs.markdown
+++ b/source/_posts/2015-12-12-philips-hue-blocks-3rd-party-bulbs.markdown
@@ -19,7 +19,7 @@ Philips Hue FAQ entries regarding reversing the decision.
 <!--more-->
 Philips Hue was one of the first to get smart lights accepted by the mainstream. Their Zigbee-based hub is rock solid, never crashes, great API and worked with other Zigbee light bulbs too. They are a bit expensive but the platform was worth every penny, till now.
 
-Yesterday a thread on [/r/homeautomation][reddit-hue] published that Philips Hue now blocks all but their own bulbs and those of "friends of Hue". I have been able to confirm this in the ~~Philips Hue FAQ~~ (Update Dec 14: they have removed the entries - [mirror here][philips-hue-faq-mirror]):
+Yesterday a thread on [/r/homeautomation][reddit-hue] published that Philips Hue now blocks all but their own bulbs and those of "friends of Hue". I have been able to confirm this in the Philips Hue FAQ (Update Dec 14: they have removed the entries - [mirror here][philips-hue-faq-mirror]):
 
 <p class='img'>
 <img src='/images/blog/2015-12-philips-hue-3rd-party/philips-hue-faq.png'>

--- a/source/_posts/2015-12-12-philips-hue-blocks-3rd-party-bulbs.markdown
+++ b/source/_posts/2015-12-12-philips-hue-blocks-3rd-party-bulbs.markdown
@@ -19,7 +19,7 @@ Philips Hue FAQ entries regarding reversing the decision.
 <!--more-->
 Philips Hue was one of the first to get smart lights accepted by the mainstream. Their Zigbee-based hub is rock solid, never crashes, great API and worked with other Zigbee light bulbs too. They are a bit expensive but the platform was worth every penny, till now.
 
-Yesterday a thread on [/r/homeautomation][reddit-hue] published that Philips Hue now blocks all but their own bulbs and those of "friends of Hue". I have been able to confirm this in the [Philips Hue FAQ][philips-hue-faq] (Update Dec 14: they have removed the entries - [mirror here][philips-hue-faq-mirror]):
+Yesterday a thread on [/r/homeautomation][reddit-hue] published that Philips Hue now blocks all but their own bulbs and those of "friends of Hue". I have been able to confirm this in the ~~Philips Hue FAQ~~ (Update Dec 14: they have removed the entries - [mirror here][philips-hue-faq-mirror]):
 
 <p class='img'>
 <img src='/images/blog/2015-12-philips-hue-3rd-party/philips-hue-faq.png'>
@@ -41,5 +41,4 @@ I will no longer suggest people to buy into the Philips Hue ecosystem.
 
 [philips-reverse]: http://www.developers.meethue.com/documentation/friends-hue-update
 [reddit-hue]: https://www.reddit.com/r/homeautomation/comments/3wet8h/fyi_the_hue_hub_is_now_blocking_third_party/
-[philips-hue-faq]: http://www2.meethue.com/en-us/support/search/?q=Another+brand
 [philips-hue-faq-mirror]: /images/blog/2015-12-philips-hue-3rd-party/mirror.png


### PR DESCRIPTION
The FAQ page no longer exists so I have removed the link from the blog post and added a strikethrough to the original text also.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
All the the info has been provided above. Part of #14663


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
