### PR TITLE
Fix sensor description in Powerwall Documentation

### DIFF
--- a/source/_integrations/powerwall.markdown
+++ b/source/_integrations/powerwall.markdown
@@ -51,7 +51,7 @@ The following binary sensors are added for each Powerwall:
 
 ### Sensor
 
-The following binary sensors are added for each Powerwall:
+The following sensors are added for each Powerwall:
 
 - Powerwall Charge
 - Powerwall Site Now


### PR DESCRIPTION
Removed the 'binary' descriptor for the sensors that are not binary.

## Proposed change
Tiny change to make the text clearer in the Powerwall documentation, suspect it was a copy/paste error originally. First pull request, apologies in advance!


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
