### PR TITLE
English code and fixes

### DIFF
--- a/source/_docs/automation/action.markdown
+++ b/source/_docs/automation/action.markdown
@@ -45,11 +45,11 @@ Conditions can also be part of an action. You can combine multiple service calls
 
 ```yaml
 automation:
-- alias: 'Enciende Despacho'
+- alias: 'Office at evening'
   trigger:
     platform: state
-    entity_id: sensor.mini_despacho
-    to: 'ON'
+    entity_id: sensor.office_occupancy
+    to: 'on'
   action:
     - service: notify.notify
       data:
@@ -59,7 +59,7 @@ automation:
         - condition: template
           value_template: '{% raw %}{{ state_attr('sun.sun', 'elevation') < 4 }}{% endraw %}'
         - condition: template
-          value_template: '{% raw %}{{ states('sensor.sensorluz_7_0') < 10 }}{% endraw %}'
+          value_template: '{% raw %}{{ states('sensor.office_illuminance') < 10 }}{% endraw %}'
     - service: scene.turn_on
-      entity_id: scene.DespiertaDespacho
+      entity_id: scene.office_at_evening
 ```


### PR DESCRIPTION
Documentation was in a language different than standard English. Users may not be able to understand the example.
Also, the example provided was not clear not only due to the language used but also in the choice of the same entities name. 

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
