### PR TITLE
Update documentation for Entites card - special row button and confirmation

### DIFF
--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -124,6 +124,10 @@ name:
   required: true
   description: Main Label.
   type: string
+icon:
+  required: false
+  description: An icon to display to the left of the label.
+  type: string
 action_name:
   required: false
   description: Button label.

--- a/source/_lovelace/entities.markdown
+++ b/source/_lovelace/entities.markdown
@@ -365,6 +365,14 @@ entities:
     name: Home Assistant
     url: https://www.home-assistant.io/
     icon: mdi:home-assistant
+  - type: button
+    name: Power cycle LibreELEC
+    icon: mdi:power-cycle
+    tap_action:
+      action: call-service
+      confirmation:
+        text: Are you sure you want to restart?
+      service: script.libreelec_power_cycle
 ```
 
 <div class='note'>

--- a/source/lovelace/actions.markdown
+++ b/source/lovelace/actions.markdown
@@ -167,6 +167,10 @@ double_tap_action:
   confirmation:
     text: Are you sure you want to restart?
   service: script.restart
+hold_action:
+  action: call-service
+  confirmation: true
+  service: script.do_other_thing
 ```
 
 {% configuration confirmation%}
@@ -185,9 +189,20 @@ exemptions:
 {% configuration exemptions %}
 user:
   required: true
-  description: User id that can see the view tab.
+  description: User id that can see the view tab. For each user´s id listed, the confirmation dialog will NOT be shown.
   type: string
 {% endconfiguration %}
+
+```yaml
+double_tap_action:
+  action: call-service
+  confirmation:
+    text: Are you sure you want to restart?
+    exemptions:
+      - x9405b8c64ee49bb88c42000e0a9dfa8
+      - 88bcfbdc39155d16c3b2d09cbf8b0367
+  service: script.restart
+```
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change
Update documentation for Entites card - special row button with missing property (`icon`) and added examples.
Also added additional action `confirmation` examples and text that clarifies the use.
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
