### PR TITLE
Add instructions on how to find UUID

### DIFF
--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -109,7 +109,7 @@ media_player:
   type: list
   keys:
     uuid:
-      description: UUID of a Cast device to add to Home Assistant. Use only if you don't want to add all available devices. The device won't be added until discovered through mDNS. In order to find the UUID for your device install pyChromecast on a computer or enter the Home Assistant Docker container and type the following changing the friendly names as required for your situation. python3 -c "import pychromecast; print(pychromecast.get_listed_chromecasts(friendly_names=["Living Room TV", "Bedroom TV", "Office Chromecast"]))"
+      description: UUID of a Cast device to add to Home Assistant. Use only if you don't want to add all available devices. The device won't be added until discovered through mDNS. In order to find the UUID for your device use a mDNS browser or advanced users can use the following python command - python3 -c "import pychromecast; print(pychromecast.get_listed_chromecasts(friendly_names=["Living Room TV", "Bedroom TV", "Office Chromecast"]))"
       required: false
       type: string
     ignore_cec:

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -109,7 +109,7 @@ media_player:
   type: list
   keys:
     uuid:
-      description: UUID of a Cast device to add to Home Assistant. Use only if you don't want to add all available devices. The device won't be added until discovered through mDNS. In order to find the UUID for your device install pyChromecast on a computer or enter the Home Assistant docker container and type the following changing the friendly names as required for your situation. python3 -c "import pychromecast; print(pychromecast.get_listed_chromecasts(friendly_names=["Living Room TV", "Bedroom TV", "Office Chromecast"]))"
+      description: UUID of a Cast device to add to Home Assistant. Use only if you don't want to add all available devices. The device won't be added until discovered through mDNS. In order to find the UUID for your device install pyChromecast on a computer or enter the Home Assistant Docker container and type the following changing the friendly names as required for your situation. python3 -c "import pychromecast; print(pychromecast.get_listed_chromecasts(friendly_names=["Living Room TV", "Bedroom TV", "Office Chromecast"]))"
       required: false
       type: string
     ignore_cec:

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -109,7 +109,7 @@ media_player:
   type: list
   keys:
     uuid:
-      description: UUID of a Cast device to add to Home Assistant. Use only if you don't want to add all available devices. The device won't be added until discovered through mDNS. In order to find the UUID for your device use a mDNS browser or advanced users can use the following python command - python3 -c "import pychromecast; print(pychromecast.get_listed_chromecasts(friendly_names=["Living Room TV", "Bedroom TV", "Office Chromecast"]))"
+      description: UUID of a Cast device to add to Home Assistant. Use only if you don't want to add all available devices. The device won't be added until discovered through mDNS. In order to find the UUID for your device use a mDNS browser or advanced users can use the following Python command (adjust friendly names as required) - python3 -c "import pychromecast; print(pychromecast.get_listed_chromecasts(friendly_names=["Living Room TV", "Bedroom TV", "Office Chromecast"]))"
       required: false
       type: string
     ignore_cec:

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -109,7 +109,7 @@ media_player:
   type: list
   keys:
     uuid:
-      description: UUID of a Cast device to add to Home Assistant. Use only if you don't want to add all available devices. The device won't be added until discovered through mDNS.
+      description: UUID of a Cast device to add to Home Assistant. Use only if you don't want to add all available devices. The device won't be added until discovered through mDNS. In order to find the UUID for your device install pyChromecast on a computer or enter the Home Assistant docker container and type the following changing the friendly names as required for your situation. python3 -c "import pychromecast; print(pychromecast.get_listed_chromecasts(friendly_names=["Living Room TV", "Bedroom TV", "Office Chromecast"]))"
       required: false
       type: string
     ignore_cec:


### PR DESCRIPTION
## Proposed change
<!-- 
    Solves the problem being asked about here https://github.com/home-assistant/home-assistant.io/issues/14090
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    This is a fairly simple addition to explain how to get the UUID for Chromecast devices.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://github.com/home-assistant/home-assistant.io/issues/14090

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
