### PR TITLE
Shopping List integration page updates

### DIFF
--- a/source/_integrations/shopping_list.markdown
+++ b/source/_integrations/shopping_list.markdown
@@ -10,18 +10,16 @@ ha_iot_class: Local Push
 ha_domain: shopping_list
 ---
 
-The `shopping_list` integration allows you to keep track of shopping list items. Includes the ability to add items via your voice using the sentence "Add eggs to my shopping list".
+The `shopping_list` integration allows you to keep track of shopping list items. 
+
+Your shopping list will be accessible from the sidebar, and you can optionally add the [Shopping List card](/lovelace/shopping-list/) to your Lovelace dashboard. With the [Conversation integration](/integrations/conversation/) you can add items to your shopping list using voice commands like "Add eggs to my shopping list." 
+
 
 ## Configuration - GUI
 
 From the Home Assistant front page go to **Configuration** and then select **Integrations** from the list.
 
 Use the plus button in the bottom right to add a new integration called **Shopping List**.
-
-In the popup:
-- Submit
-
-The success dialog will appear or an error will be displayed in the popup.
 
 ## Configuration - Manual
 
@@ -32,16 +30,16 @@ shopping_list:
 
 ## Services
 
-You can add or remove items on your shopping list by using the following services.
+You can add or remove items from your shopping list by using the following services.
 
 ### Service `shopping_list.add_item`
 
 | Service data attribute | Optional | Description                                            |
 |------------------------|----------|--------------------------------------------------------|
-| `name`                 |       no | Name of the item to add. Example: "Beer"               |
+| `name`                 |       no | Name of the item to add. Example: "Milk"               |
 
 ### Service `shopping_list.complete_item`
 
 | Service data attribute | Optional | Description                                            |
 |------------------------|----------|--------------------------------------------------------|
-| `name`                 |       no | Name of the item to mark as completed. Example: "Beer" |
+| `name`                 |       no | Name of the item to mark as completed. Example: "Milk" |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

1. Voice control used to work out of the box, but Conversation integration was removed from `default_config:` over a year ago (see: https://github.com/home-assistant/core/pull/24515), so these instructions were a bit outdated. Added clarification that this relies on conversation integration being installed too.
2. Cross-linked to the Shopping List Lovelace card page
3. Removed the "click submit" and 'you'll get a success or error' part of instructions as I feel that is very obvious and unnecessary. This makes instructions a bit more concise.
4. Changed "Beer" example to "Milk" to be a tiny bit more kid friendly :)


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
