### PR TITLE
Typo: customisation -> customization

### DIFF
--- a/source/_integrations/alarm_control_panel.template.markdown
+++ b/source/_integrations/alarm_control_panel.template.markdown
@@ -73,7 +73,7 @@ panels:
           type: string
           default: Template Alarm Control Panel
         unique_id:
-          description: An ID that uniquely identifies this alarm control panel. Set this to an unique value to allow customisation trough the UI.
+          description: An ID that uniquely identifies this alarm control panel. Set this to an unique value to allow customization trough the UI.
           required: false
           type: string
         value_template:

--- a/source/_integrations/binary_sensor.template.markdown
+++ b/source/_integrations/binary_sensor.template.markdown
@@ -52,7 +52,7 @@ sensors:
           required: false
           type: [string, list]
         unique_id:
-          description: An ID that uniquely identifies this binary sensor. Set this to an unique value to allow customisation through the UI.
+          description: An ID that uniquely identifies this binary sensor. Set this to an unique value to allow customization through the UI.
           required: false
           type: string
         device_class:

--- a/source/_integrations/cover.template.markdown
+++ b/source/_integrations/cover.template.markdown
@@ -50,7 +50,7 @@ cover:
         required: false
         type: string
       unique_id:
-        description: An ID that uniquely identifies this cover. Set this to an unique value to allow customisation trough the UI.
+        description: An ID that uniquely identifies this cover. Set this to an unique value to allow customization trough the UI.
         required: false
         type: string
       value_template:

--- a/source/_integrations/fan.template.markdown
+++ b/source/_integrations/fan.template.markdown
@@ -64,7 +64,7 @@ fan:
         required: false
         type: string
       unique_id:
-        description: An ID that uniquely identifies this fan. Set this to an unique value to allow customisation trough the UI.
+        description: An ID that uniquely identifies this fan. Set this to an unique value to allow customization trough the UI.
         required: false
         type: string
       value_template:

--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -71,7 +71,7 @@ light:
         required: false
         type: string
       unique_id:
-        description: An ID that uniquely identifies this light. Set this to an unique value to allow customisation trough the UI.
+        description: An ID that uniquely identifies this light. Set this to an unique value to allow customization trough the UI.
         required: false
         type: string
       value_template:

--- a/source/_integrations/lock.template.markdown
+++ b/source/_integrations/lock.template.markdown
@@ -48,7 +48,7 @@ lock:
     type: string
     default: Template Lock
   unique_id:
-    description: An ID that uniquely identifies this lock. Set this to an unique value to allow customisation trough the UI.
+    description: An ID that uniquely identifies this lock. Set this to an unique value to allow customization trough the UI.
     required: false
     type: string
   value_template:

--- a/source/_integrations/switch.template.markdown
+++ b/source/_integrations/switch.template.markdown
@@ -51,7 +51,7 @@ switch:
         required: false
         type: string
       unique_id:
-        description: An ID that uniquely identifies this switch. Set this to an unique value to allow customisation trough the UI.
+        description: An ID that uniquely identifies this switch. Set this to an unique value to allow customization trough the UI.
         required: false
         type: string
       value_template:

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -51,7 +51,7 @@ sensor:
         required: false
         type: template
       unique_id:
-        description: An ID that uniquely identifies this sensor. Set this to an unique value to allow customisation through the UI.
+        description: An ID that uniquely identifies this sensor. Set this to an unique value to allow customization through the UI.
         required: false
         type: string
       unit_of_measurement:

--- a/source/_integrations/vacuum.template.markdown
+++ b/source/_integrations/vacuum.template.markdown
@@ -40,7 +40,7 @@ vacuum:
         required: false
         type: string
       unique_id:
-        description: An ID that uniquely identifies this vacuum. Set this to an unique value to allow customisation trough the UI.
+        description: An ID that uniquely identifies this vacuum. Set this to an unique value to allow customization trough the UI.
         required: false
         type: string
       value_template:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

customisation -> customization


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
