### PR TITLE
Fix IOT Classification for Apprise

### DIFF
--- a/source/_integrations/apprise.markdown
+++ b/source/_integrations/apprise.markdown
@@ -3,7 +3,7 @@ title: Apprise
 description: Instructions on how to add Apprise notifications to Home Assistant.
 ha_category:
   - Notifications
-ha_iot_class: Cloud Polling
+ha_iot_class: Cloud Push
 ha_release: 0.101
 ha_codeowners:
   - '@caronc'


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Based on @caronc commit comment located here: https://github.com/home-assistant/home-assistant.io/commit/60c76922abe327ba859fce55b72b5fb8be6ff232 and after examining the Integration this integration is not a Cloud Polling integration but a Push one, since all it does is send Notifications to Apprise's server


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
