### PR TITLE
Remove obsolete "how it works" page from Lovelace sidebar

### DIFF
--- a/source/_includes/asides/lovelace_navigation.html
+++ b/source/_includes/asides/lovelace_navigation.html
@@ -12,7 +12,6 @@
   <div class="section">
     <h1 class="title delta">Advanced</h1>
     <ul class="divided sidebar-menu">
-      <li>{% active_link /lovelace/how-it-works/ How it works %}</li>
       <li>{% active_link /lovelace/header-footer/ Headers & Footers %}</li>
       <li>
         {% active_link /lovelace/dashboards-and-views/ Dashboards & Views %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This removes the "[How It Works](https://www.home-assistant.io/lovelace/how-it-works/)" link from the Lovelace sidebar navigation. The actual page will still exist, this simply demotes it from the sidebar nav for now.

Reasoning is, the "How it Works" page is obsolete and will only cause confusion and frustration. New users click on "How it works" expecting to see a user guide for Lovelace, but instead they get some nerdy tech document comparing it to the older "States" UI which no longer even exists. 

I would like to eventually rewrite the page to be more user-focused and then re-add it to sidebar.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
