### PR TITLE
Create input_schedule.markdown

### DIFF
--- a/source/_integrations/input_schedule.markdown
+++ b/source/_integrations/input_schedule.markdown
@@ -1,0 +1,77 @@
+---
+title: Input Schedule
+description: Instructions on how to integrate the Input Schedule integration into Home Assistant.
+ha_category:
+  - Automation
+ha_release: 0.116
+ha_iot_class: ~
+ha_quality_scale: internal
+ha_codeowners:
+  - '@home-assistant/core'
+ha_domain: input_schedule
+---
+
+The `input_schedule` integration allows the user to define time periods throughout the day when the `input_schedule` entity is set to on or off. An automation rule can be used to tie this schedule to other entities. Changes to the time periods will then impact the other entities, without the need to change the automation rule (see more in the example below).
+
+Input schedules can be configured via `configuration.yaml`:
+
+```yaml
+# Example configuration.yaml entry
+input_schedule:
+  lights:
+    name: Lights
+  windows:
+    name: Windows
+```
+
+{% configuration %}
+  input_schedule:
+    description: Alias for the input. Multiple entries are allowed.
+    required: true
+    type: map
+    keys:
+      name:
+        description: Friendly name of the input.
+        required: false
+        type: string
+      icon:
+        description: Icon to display in front of the input element in the frontend.
+        required: false
+        type: icon
+{% endconfiguration %}
+
+### Services
+
+This integration provides the following services to modify the state of the `input_schedule` and a service to reload the
+configuration without restarting Home Assistant itself.
+
+| Service | Data | Description |
+| ------- | ---- | ----------- |
+| `set_on` | `start`<br>`end`<br>`entity_id(s)`<br>`area_id(s)` | Add an on time period to the specific `input_schedule` entities 
+| `set_off` | `start`<br>`end`<br>`entity_id(s)`<br>`area_id(s)` | Add an off time period to the specific `input_schedule` entities
+| `reset` | `entity_id(s)`<br>`area_id(s)` | Set the specific `input_schedule` entities to be always off
+| `reload` | Reload `input_schedule` configuration |
+
+### Initial State
+When initially created, the schedule is configured to be always off. Periods added to it will be preserved, even when Home Assistant is restarted.
+
+## Automation Examples
+
+Here's an example of `input_schedule` being used in an automation.
+
+{% raw %}
+```yaml
+# Example configuration.yaml entry using 'input_schedule'
+input_schedule:
+  lights:
+automation:
+  - alias: Lights
+    trigger:
+      platform: state
+      entity_id: input_schedule.lights
+    action:
+      - service: "switch.{{ 'turn_on' if is_state('input_schedule.lights', 'on') else 'turn_off' }}"
+        data:
+          entity_id: all
+```
+{% endraw %}

--- a/source/_integrations/input_schedule.markdown
+++ b/source/_integrations/input_schedule.markdown
@@ -11,7 +11,7 @@ ha_codeowners:
 ha_domain: input_schedule
 ---
 
-The `input_schedule` integration allows the user to define time periods throughout the day when the `input_schedule` entity is set to on or off. An automation rule can be used to tie this schedule to other entities. Changes to the time periods will then impact the other entities, without the need to change the automation rule (see more in the example below).
+The `input_schedule` integration allows the user to define time periods throughout the day when the `input_schedule` entity is set to on or off. An automation rule can be used to tie this schedule to other entities. Changes to the time periods will then impact the other entities, without the need to change the automation rule iteslf.
 
 Input schedules can be configured via `configuration.yaml`:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is a new integration which should help using fixed automation rules, while controlling their behavior through this new entity type.
The "input_scheudle" entity has an on/off state based on the time periods provided as input from the user. It preserves the time periods during reboots.
A typical usage will be to create a static automation rule, which will behave according to changes in the time periods of the schedule, without the need to change the rule itself.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
