### PR TITLE
Update alert docs

### DIFF
--- a/source/_integrations/alert.markdown
+++ b/source/_integrations/alert.markdown
@@ -15,8 +15,15 @@ remind you of this by sending you repeating notifications at customizable
 intervals. This is also used for low battery sensors,
 water leak sensors, or any condition that may need your attention.
 
-Alerts will add an entity to the front end only when they are firing.
-This entity allows you to silence an alert until it is resolved.
+Alerts will add an entity to the front end.
+This entity allows you to silence an alert until it is resolved and has three
+possible states:
+
+State | Description
+-|-
+`idle` | The condition for the alert is false.
+`on` | The condition for the alert is true.
+`off` | The condition for the alert is true but it was acknowledged.
 
 ### Basic Example
 
@@ -80,13 +87,13 @@ skip_first:
   default: false
 message:
   description: >
-    A message to be sent after an alert transitions from `off` to `on`
+    A message to be sent after an alert transitions from `idle` to `on`
     with [template](/docs/configuration/templating/) support.
   required: false
   type: template
 done_message:
   description: >
-    A message sent after an alert transitions from `on` to `off` with
+    A message sent after an alert transitions from `on` to `idle` with
     [template](/docs/configuration/templating/) support. Is only sent if an alert notification
     was sent for transitioning from `off` to `on`.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Fixes documentation issues clarifying the use of alerts: added state overview for the entity, 'idle' was not mentioned and corrected message options descriptions.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
