### PR TITLE
Revert zoneminder config flow

### DIFF
--- a/source/_integrations/zoneminder.markdown
+++ b/source/_integrations/zoneminder.markdown
@@ -11,7 +11,6 @@ ha_release: 0.31
 ha_iot_class: Local Polling
 ha_codeowners:
   - '@rohankapoorcom'
-  - '@vangorra'
 ha_domain: zoneminder
 ---
 
@@ -26,8 +25,11 @@ There is currently support for the following device types within Home Assistant:
 
 ## Configuration
 
-1. From the Home Assistant front-end, navigate to 'Configuration' then 'Integrations'. Under 'Set up a new integration' locate 'ZoneMinder' and click 'Configure'.
-2. Enter the information appropriate for the server and click 'Submit'.
+```yaml
+# Example configuration.yaml entry
+zoneminder:
+  - host: ZM_HOST
+```
 
 {% configuration %}
 host:
@@ -64,9 +66,23 @@ password:
   type: string
 {% endconfiguration %}
 
-## Service
+### Full configuration
 
-Once loaded, the `zoneminder` integration will expose a service (`set_run_state`) that can be used to change the current run state of ZoneMinder.
+```yaml
+# Example configuration.yaml entry
+zoneminder:
+  - host: ZM_HOST
+    path: ZM_PATH
+    path_zms: ZM_PATH_ZMS
+    ssl: true
+    verify_ssl: true
+    username: YOUR_USERNAME
+    password: YOUR_PASSWORD
+```
+
+### Service
+
+Once loaded, the `zoneminder` platform will expose a service (`set_run_state`) that can be used to change the current run state of ZoneMinder.
 
 | Service data attribute | Optional | Description                       |
 |:-----------------------|:---------|:----------------------------------|
@@ -92,6 +108,8 @@ Each binary_sensor created will be named after the hostname used when configurin
 ## Camera
 
 The `zoneminder` camera platform lets you monitor the current stream of your [ZoneMinder](https://www.zoneminder.com) cameras.
+
+### Configuration
 
 To set it up, add the following information to your `configuration.yaml` file:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Revert the docs change for https://github.com/home-assistant/core/pull/37060
- We'll revert that PR on core.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/41395
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
