### PR TITLE
Document the python_script.reload service

### DIFF
--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -97,6 +97,6 @@ Available services: `reload`.
 
 #### Service `python_script.reload`
 
-Reload all available python_scripts from the `<config>/python_scripts` folder. Use this when creating a new python script and you're not restarting Home Assistant.
+Reload all available python_scripts from the `<config>/python_scripts` folder. Use this when creating a new Python script and you're not restarting Home Assistant.
 
 This service takes no service data attributes.

--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -90,3 +90,13 @@ turn_on_light:
 ```
 
 For more examples, visit the [Scripts section](https://community.home-assistant.io/c/projects/scripts) in our forum.
+
+## Services
+
+Available services: `reload`.
+
+#### Service `python_script.reload`
+
+Reload all available python_scripts from the `<config>/python_scripts` folder. Use this when creating a new python script and you're not restarting Home Assistant.
+
+This service takes no service data attributes.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document the python_script.reload service.
I noticed it was missing while reading the doco.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
