### PR TITLE
Add MySQL socket examples to recorder documentation

### DIFF
--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -214,19 +214,21 @@ Note that purging will not immediately decrease disk space usage but it will sig
 
 ## Custom database engines
 
-| Database engine                | `db_url`                                                                                     |
-| :----------------------------- | :------------------------------------------------------------------------------------------- |
-| SQLite                         | `sqlite:////PATH/TO/DB_NAME`                                                                 |
-| MariaDB (omit pymysql)         | `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8`                                       |
-| MySQL                          | `mysql://SERVER_IP/DB_NAME?charset=utf8`                                                     |
-| MySQL                          | `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8`                                       |
-| MariaDB                        | `mysql+pymysql://SERVER_IP/DB_NAME?charset=utf8`                                             |
-| MariaDB                        | `mysql+pymysql://user:password@SERVER_IP/DB_NAME?charset=utf8`                               |
-| PostgreSQL                     | `postgresql://SERVER_IP/DB_NAME`                                                             |
-| PostgreSQL                     | `postgresql://user:password@SERVER_IP/DB_NAME`                                               |
-| PostgreSQL (Socket)            | `postgresql://@/DB_NAME`                                                                     |
-| PostgreSQL (Custom socket dir) | `postgresql://@/DB_NAME?host=/path/to/dir`                                                   |
-| MS SQL Server                  | `mssql+pyodbc://username:password@SERVER_IP/DB_NAME?charset=utf8;DRIVER={DRIVER};Port=1433;` |
+| Database engine                | `db_url`                                                                                               |
+| :----------------------------- | :----------------------------------------------------------------------------------------------------- |
+| SQLite                         | `sqlite:////PATH/TO/DB_NAME`                                                                           |
+| MariaDB (omit pymysql)         | `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8`                                                 |
+| MySQL                          | `mysql://SERVER_IP/DB_NAME?charset=utf8`                                                               |
+| MySQL                          | `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8`                                                 |
+| MySQL (Socket)                 | `mysql://user:password@localhost/DB_NAME?unix_socket=/var/run/mysqld/mysqld.sock&charset=utf8`         |
+| MariaDB                        | `mysql+pymysql://SERVER_IP/DB_NAME?charset=utf8`                                                       |
+| MariaDB                        | `mysql+pymysql://user:password@SERVER_IP/DB_NAME?charset=utf8`                                         |
+| MariaDB (Socket)               | `mysql+pymysql://user:password@localhost/DB_NAME?unix_socket=/var/run/mysqld/mysqld.sock&charset=utf8` |
+| PostgreSQL                     | `postgresql://SERVER_IP/DB_NAME`                                                                       |
+| PostgreSQL                     | `postgresql://user:password@SERVER_IP/DB_NAME`                                                         |
+| PostgreSQL (Socket)            | `postgresql://@/DB_NAME`                                                                               |
+| PostgreSQL (Custom socket dir) | `postgresql://@/DB_NAME?host=/path/to/dir`                                                             |
+| MS SQL Server                  | `mssql+pyodbc://username:password@SERVER_IP/DB_NAME?charset=utf8;DRIVER={DRIVER};Port=1433;`           |
 
 <div class='note'>
 

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -218,6 +218,7 @@ Note that purging will not immediately decrease disk space usage but it will sig
 | :----------------------------- | :----------------------------------------------------------------------------------------------------- |
 | SQLite                         | `sqlite:////PATH/TO/DB_NAME`                                                                           |
 | MariaDB (omit pymysql)         | `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8`                                                 |
+| MariaDB (omit pymysql, Socket) | `mysql://user:password@SERVER_IP/DB_NAME?unix_socket=/var/run/mysqld/mysqld.sock&charset=utf8`         |
 | MySQL                          | `mysql://SERVER_IP/DB_NAME?charset=utf8`                                                               |
 | MySQL                          | `mysql://user:password@SERVER_IP/DB_NAME?charset=utf8`                                                 |
 | MySQL (Socket)                 | `mysql://user:password@localhost/DB_NAME?unix_socket=/var/run/mysqld/mysqld.sock&charset=utf8`         |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
On the page it is explained that a socket is preferred over TCP, however there are no examples mentioned.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
