### PR TITLE
Change "status" to "state" for clarity of use.

### DIFF
--- a/source/_integrations/person.markdown
+++ b/source/_integrations/person.markdown
@@ -10,19 +10,19 @@ ha_domain: person
 
 The `person` integration allows connecting [device tracker](/integrations/device_tracker/) entities to one or more person entities. The state updates of a connected device tracker will set the state of the person. When multiple device trackers are used, the state of person will be determined in this order:
 
-1. If there are stationary trackers (non-GPS trackers, e.g., a router or Bluetooth device tracker) presenting the status `home`, the tracker most recently updated will be used.
+1. If there are stationary trackers (non-GPS trackers, e.g., a router or Bluetooth device tracker) presenting the state `home`, the tracker most recently updated will be used.
 2. If there are trackers of type `gps`, then the most recently updated tracker will be used.
-3. Otherwise, the latest tracker with status `not_home` will be used.
+3. Otherwise, the latest tracker with state `not_home` will be used.
 
 Let's say, for example, that you have three trackers: `tracker_gps`, `tracker_router` and `tracker_ble`.
 
-1. You're at home, all three devices show status `home` - status of your Person entity will be `home` with source `tracker_router` or `tracker_ble`, whichever was most recently updated.
-2. You just left home. `tracker_gps` shows status `not_home`, but the other two trackers show status `home` (they may not have yet updated due to their `consider_home` setting see [device_tracker](/integrations/device_tracker/#configuring-a-device_tracker-platform)). Since the stationary trackers have priority, you are considered `home`.
-3. After some time, both stationary trackers show status `not_home`. Now your Person entity has status 'not_home' with source `tracker_gps`.
-4. While you are away from home, your Home Assistant instance is restarted. Until the `tracker_gps` receives an update, your status will be determined by the stationary trackers, since they will have the most recent update after a restart. Obviously, the status will be `not_home`.
-5. Then you're going into a zone you have defined as `zone1`, `tracker_gps` sends an update, and now your status is `zone1` with source `tracker_gps`.
-6. You've returned home and your mobile device has connected to the router, but `tracker_gps` hasn't updated yet. Your status will be `home` with source `tracker_router`.
-7. After the `tracker_gps` update occurs, your status will still be `home` with source `tracker_router` or `tracker_ble`, whichever has the most recent update.
+1. You're at home, all three devices show state `home` - the state of your Person entity will be `home` with source `tracker_router` or `tracker_ble`, whichever was most recently updated.
+2. You just left home. `tracker_gps` shows state `not_home`, but the other two trackers show state `home` (they may not have yet updated due to their `consider_home` setting see [device_tracker](/integrations/device_tracker/#configuring-a-device_tracker-platform)). Since the stationary trackers have priority, you are considered `home`.
+3. After some time, both stationary trackers show state `not_home`. Now your Person entity has state 'not_home' with source `tracker_gps`.
+4. While you are away from home, your Home Assistant instance is restarted. Until the `tracker_gps` receives an update, your status will be determined by the stationary trackers, since they will have the most recent update after a restart. Obviously, the state will be `not_home`.
+5. Then you're going into a zone you have defined as `zone1`, `tracker_gps` sends an update, and now your state is `zone1` with source `tracker_gps`.
+6. You've returned home and your mobile device has connected to the router, but `tracker_gps` hasn't updated yet. Your state will be `home` with source `tracker_router`.
+7. After the `tracker_gps` update occurs, your state will still be `home` with source `tracker_router` or `tracker_ble`, whichever has the most recent update.
 
 In short, when you're at home, your position is determined first by stationary trackers (if any) and then by GPS. When you're outside your home, your position is determined firstly by GPS and then by stationary trackers.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Each instance of the word "status" is a little ambiguous and could confuse new users as to what exactly that means. Consistency of language is important to keep new users on the right track. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
