### PR TITLE
Add missing pull request link in 0.116.1 release post section

### DIFF
--- a/source/_posts/2020-10-07-release-116.markdown
+++ b/source/_posts/2020-10-07-release-116.markdown
@@ -202,6 +202,7 @@ The following integrations are now available via the Home Assistant UI:
 [#41487]: https://github.com/home-assistant/core/pull/41487
 [#41488]: https://github.com/home-assistant/core/pull/41488
 [#41491]: https://github.com/home-assistant/core/pull/41491
+[#41496]: https://github.com/home-assistant/core/pull/41496
 [@KJonline]: https://github.com/KJonline
 [@Shutgun]: https://github.com/Shutgun
 [@balloob]: https://github.com/balloob


### PR DESCRIPTION
## Proposed change

The 0.116.1 release section included a missing link identifier.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
