### PR TITLE
Make DSMR links mobile friendly

### DIFF
--- a/source/_integrations/dsmr.markdown
+++ b/source/_integrations/dsmr.markdown
@@ -15,7 +15,7 @@ A sensor platform for Dutch Smart Meters which comply to DSMR (Dutch Smart Meter
 
 - Currently support DSMR V2.2, V3, V4, V5 and V5 Belgian through the [dsmr_parser](https://github.com/ndokter/dsmr_parser) module by Nigel Dokter.
 - For official information about DSMR refer to: [DSMR Document](https://www.netbeheernederland.nl/dossiers/slimme-meter-15)
-- For official information about the P1 port refer to: <https://www.netbeheernederland.nl/_upload/Files/Slimme_meter_15_a727fce1f1.pdf>
+- For official information about the P1 port refer to: [P1 Companion Standard](https://www.netbeheernederland.nl/_upload/Files/Slimme_meter_15_a727fce1f1.pdf)
 - For unofficial hardware connection examples refer to: [Domoticx](http://domoticx.com/p1-poort-slimme-meter-hardware/)
 
 <p class='img'>
@@ -35,13 +35,13 @@ This integration is known to work for:
 USB serial converters:
 
 - Cheap (Banggood/ebay) Generic PL2303
-- <https://sites.google.com/site/nta8130p1smartmeter/webshop>
-- <https://www.sossolutions.nl/slimme-meter-kabel>
-- <https://nl.aliexpress.com/item/32945187155.html>
+- [Smartmeter Webshop](https://sites.google.com/site/nta8130p1smartmeter/webshop)
+- [SOS Solutions](https://www.sossolutions.nl/slimme-meter-kabel)
+- [AliExpress](https://nl.aliexpress.com/item/32945187155.html)
 
 Serial to network proxies:
 
-- ser2net - <http://ser2net.sourceforge.net/>
+- [ser2net](http://ser2net.sourceforge.net)
 
 DIY solutions (ESP8266 based):
 


### PR DESCRIPTION
## Proposed change
Make the links mobile friendly to avoid the current layout as shown in below screenshot.
Show all links in an uniform way.

![Screenshot_2](https://user-images.githubusercontent.com/11230573/95508356-21745480-09b3-11eb-8cde-d4c2207fe40f.png)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
