### PR TITLE
Update Telegram Broadcast docs

### DIFF
--- a/source/_integrations/telegram_broadcast.markdown
+++ b/source/_integrations/telegram_broadcast.markdown
@@ -7,7 +7,7 @@ ha_release: 0.48
 ha_domain: telegram_bot
 ---
 
-Telegram implementation to support **sending messages only**. Your Home Assistant instance does not have to be exposed to the Internet and there is no polling to receive messages sent to the bot.
+Telegram implementation to support **sending messages only**. Your Home Assistant instance does not have to be exposed to the internet and there is no polling to receive messages or commands sent to the bot.
 
 ## Configuration
 
@@ -19,13 +19,12 @@ telegram_bot:
   - platform: broadcast
     api_key: YOUR_API_KEY
     allowed_chat_ids:
-      - 12345
-      - 67890
+      - 123456789 # example id of a user or a group
 ```
 
 {% configuration %}
 allowed_chat_ids:
-  description: A list of users in the `user_id` Telegram format that are authorized to interact with the webhook.
+  description: The id representing the user or group to which messages can be send. The message will only be sent to the first id in the list.
   required: true
   type: list
 api_key:

--- a/source/_integrations/telegram_broadcast.markdown
+++ b/source/_integrations/telegram_broadcast.markdown
@@ -9,6 +9,8 @@ ha_domain: telegram_bot
 
 Telegram implementation to support **sending messages only**. Your Home Assistant instance does not have to be exposed to the internet and there is no polling to receive messages or commands sent to the bot.
 
+Information on how to send a message via the service `telegram_bot.send_message` can be found [here](/integrations/telegram_bot/#service-telegram_botsend_message).
+
 ## Configuration
 
 To integrate this into Home Assistant, add the following section to your `configuration.yaml` file:
@@ -19,12 +21,13 @@ telegram_bot:
   - platform: broadcast
     api_key: YOUR_API_KEY
     allowed_chat_ids:
-      - 123456789 # example id of a user or a group
+      - 123456789 # example id of a user
+      - -987654321  # example id of a group, starts with a -
 ```
 
 {% configuration %}
 allowed_chat_ids:
-  description: The id representing the user or group to which messages can be send. The message will only be sent to the first id in the list.
+  description: The id representing the user or group to which messages can be send. Default the message will be send to the first alllowed chat_id. By using the `target` service data attribute the message can be send to other chat_ids from the list.
   required: true
   type: list
 api_key:

--- a/source/_integrations/telegram_broadcast.markdown
+++ b/source/_integrations/telegram_broadcast.markdown
@@ -27,7 +27,7 @@ telegram_bot:
 
 {% configuration %}
 allowed_chat_ids:
-  description: The id representing the user or group to which messages can be send. Default the message will be send to the first alllowed chat_id. By using the `target` service data attribute the message can be send to other chat_ids from the list.
+  description: A list of ids representing the users and group chats to which messages can be send. Default the message will be send to the first alllowed chat_id. By using the `target` service data attribute the message can be send to other chat_ids from the list.
   required: true
   type: list
 api_key:


### PR DESCRIPTION
## Proposed change
Update Telegram Broadcast docs.
Added info regarding the service to use and the regarding the `allowed_chat_ids` as the message is default only send to the first id in the list.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
