### PR TITLE
Add missing IoT class to vacuum integration

### DIFF
--- a/source/_integrations/vacuum.markdown
+++ b/source/_integrations/vacuum.markdown
@@ -3,7 +3,7 @@ title: Vacuum
 description: Instructions on how to setup and use vacuum's in Home Assistant.
 ha_release: 0.51
 ha_domain: vacuum
-ha_iot_class: Local Polling
+ha_iot_class: ~
 ---
 
 The `vacuum` integration enables the ability to control home cleaning robots within Home Assistant.

--- a/source/_integrations/vacuum.markdown
+++ b/source/_integrations/vacuum.markdown
@@ -3,6 +3,7 @@ title: Vacuum
 description: Instructions on how to setup and use vacuum's in Home Assistant.
 ha_release: 0.51
 ha_domain: vacuum
+ha_iot_class: Local Polling
 ---
 
 The `vacuum` integration enables the ability to control home cleaning robots within Home Assistant.


### PR DESCRIPTION
## Proposed change

The Vacuum integration depends on [xiaomi_miio](https://www.home-assistant.io/integrations/xiaomi_miio/) which is also
under the Local Polling IoT class.

For https://github.com/home-assistant/home-assistant.io/issues/14661

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
