### PR TITLE
Add documentation for publish state changes to Zabbix

### DIFF
--- a/source/_integrations/zabbix.markdown
+++ b/source/_integrations/zabbix.markdown
@@ -11,7 +11,9 @@ ha_domain: zabbix
 
 The `zabbix` integration is the main integration to connect to a [Zabbix](https://www.zabbix.com/) monitoring instance via the Zabbix API.
 
-There is currently support for the following device types within Home Assistant:
+It is possible to publish Home Assistant state changes to Zabbix. In Zabbix a host has to be created which will contain the Home Assistant states as individual items. These items are automatically created using Zabbix Low Level Discovery (LLD). In order to make setup in Zabbix easy you can use this [template](/assets/integrations/zabbix/zbx_template_home_assistant.xml) for the host.
+
+There is currently also support for the following device types within Home Assistant:
 
 - [Sensor](#sensor)
 
@@ -48,6 +50,44 @@ password:
   description: Your Zabbix password.
   required: false
   type: string
+publish_states_host:
+  description: The host that will receive the state changes from Home Assistant. It needs to be manually created in Zabbix first and have the template associated with it (see above).
+  required: false
+  type: string
+exclude:
+  type: list
+  description: Configure which integrations should be excluded from being published to Zabbix. ([Configure Filter](#configure-filter))
+  required: false
+  keys:
+    entities:
+      type: [string, list]
+      description: The list of entity ids to be excluded from being published to Zabbix.
+      required: false
+    entity_globs:
+      type: [string, list]
+      description: Exclude all entities matching a listed pattern.
+      required: false
+    domains:
+      type: [string, list]
+      description: The list of domains to be excluded from being published to Zabbix.
+      required: false
+include:
+  type: list
+  description: Configure which integrations should be included in being published to Zabbix. If set, all other entities will not be published to Zabbix. ([Configure Filter](#configure-filter))
+  required: false
+  keys:
+    entities:
+      type: [string, list]
+      description: The list of entity ids to be included in being published to Zabbix.
+      required: false
+    entity_globs:
+      type: [string, list]
+      description: Include all entities matching a listed pattern.
+      required: false
+    domains:
+      type: [string, list]
+      description: The list of domains to be included in being published to Zabbix.
+      required: false
 {% endconfiguration %}
 
 ### Full configuration
@@ -60,7 +100,54 @@ zabbix:
   ssl: false
   username: USERNAME
   password: PASSWORD
+  publish_states_host: homeassistant
+  exclude:
+    domains:
+      - device_tracker
+    entities:
+      - sun.sun
+      - sensor.time
 ```
+
+## Configure Filter
+
+By default, no entity will be excluded. To limit which entities are being published to Zabbix, you can use the `include` and `exclude` parameters.
+
+{% raw %}
+
+```yaml
+# Example filter to include specified domains and exclude specified entities
+zabbix:
+  include:
+    domains:
+      - alarm_control_panel
+      - light
+    entity_globs:
+      - binary_sensor.*_occupancy
+  exclude:
+    entities:
+      - light.kitchen_light
+```
+
+{% endraw %}
+
+Filters are applied as follows:
+
+1. No includes or excludes - pass all entities
+2. Includes, no excludes - only include specified entities
+3. Excludes, no includes - only exclude specified entities
+4. Both includes and excludes:
+   - Include domain and/or glob patterns specified
+      - If domain is included, and entity not excluded or match exclude glob pattern, pass
+      - If entity matches include glob pattern, and entity does not match any exclude criteria (domain, glob pattern or listed), pass
+      - If domain is not included, glob pattern does not match, and entity not included, fail
+   - Exclude domain and/or glob patterns specified and include does not list domains or glob patterns
+      - If domain is excluded and entity not included, fail
+      - If entity matches exclude glob pattern and entity not included, fail
+      - If entity does not match any exclude criteria (domain, glob pattern or listed), pass
+   - Neither include or exclude specifies domains or glob patterns
+      - If entity is included, pass (as #2 above)
+      - If entity include and exclude, the entity exclude is ignored
 
 ## Sensor
 

--- a/source/_integrations/zabbix.markdown
+++ b/source/_integrations/zabbix.markdown
@@ -11,7 +11,7 @@ ha_domain: zabbix
 
 The `zabbix` integration is the main integration to connect to a [Zabbix](https://www.zabbix.com/) monitoring instance via the Zabbix API.
 
-It is possible to publish Home Assistant state changes to Zabbix. In Zabbix a host has to be created which will contain the Home Assistant states as individual items. These items are automatically created using Zabbix Low Level Discovery (LLD). In order to make setup in Zabbix easy you can use this [template](/assets/integrations/zabbix/zbx_template_home_assistant.xml) for the host.
+It is possible to publish Home Assistant state changes to Zabbix. In Zabbix a host has to be created which will contain the Home Assistant states as individual items. These items are automatically created using Zabbix Low-Level Discovery (LLD). In order to make setup in Zabbix easy, you can use this [template](/assets/integrations/zabbix/zbx_template_home_assistant.xml) for the host.
 
 There is currently also support for the following device types within Home Assistant:
 

--- a/source/assets/integrations/zabbix/zbx_template_home_assistant.xml
+++ b/source/assets/integrations/zabbix/zbx_template_home_assistant.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>5.0</version>
+    <date>2020-06-10T16:13:32Z</date>
+    <groups>
+        <group>
+            <name>Templates</name>
+        </group>
+    </groups>
+    <templates>
+        <template>
+            <template>Template Home Assistant</template>
+            <name>Template Home Assistant</name>
+            <groups>
+                <group>
+                    <name>Templates</name>
+                </group>
+            </groups>
+            <discovery_rules>
+                <discovery_rule>
+                    <name>Floats Discovery</name>
+                    <type>TRAP</type>
+                    <key>homeassistant.floats_discovery</key>
+                    <delay>0</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>{#KEY}</name>
+                            <type>TRAP</type>
+                            <key>homeassistant.float[{#KEY}]</key>
+                            <delay>0</delay>
+                            <history>1095d</history>
+                            <trends>0</trends>
+                            <value_type>FLOAT</value_type>
+                            <preprocessing>
+                                <step>
+                                    <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                                    <params>14400</params>
+                                </step>
+                            </preprocessing>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+            </discovery_rules>
+        </template>
+    </templates>
+</zabbix_export>


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document new feature for Zabbix integration which allows to publish state changes of Home Assistant to Zabbix.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/36659
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
