### PR TITLE
Revert "Updates to support the circuitpython version (#15142)"

### DIFF
--- a/source/_integrations/dht.markdown
+++ b/source/_integrations/dht.markdown
@@ -11,24 +11,16 @@ ha_domain: dht
 
 The `dht` sensor platform allows you to get the current temperature and humidity from a DHT11, DHT22 or AM2302 device.
 
-## Setup
-
-To use your DHTxx sensor in your installation, you must first install the `libgpiod2` library.
-
-```shell
-sudo apt install libgpiod2
-```
-
 ## Configuration
 
-Add the following to your `configuration.yaml` file:
+To use your DHTxx sensor in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry
 sensor:
   platform: dht
   sensor: DHT22
-  pin: D23
+  pin: 23
   monitored_conditions:
     - temperature
     - humidity
@@ -36,7 +28,7 @@ sensor:
 
 {% configuration %}
 sensor:
-  description: The sensor type, supported devices are DHT11, DHT22 and AM2302.
+  description: The sensor type, supported devices are DHT11, DHT22, and AM2302.
   required: true
   type: string
 pin:
@@ -69,7 +61,7 @@ humidity_offset:
   type: [integer, float]
 {% endconfiguration %}
 
-The name of the pin to which the sensor is connected has different names on different platforms. 'P8_11' for Beaglebone, 'D23' for Raspberry Pi.
+The name of the pin to which the sensor is connected has different names on different platforms. 'P8_11' for Beaglebone, '23' for Raspberry Pi.
 
 ### Example
 
@@ -79,7 +71,7 @@ An example for a Raspberry Pi 3 with a DHT22 sensor connected to GPIO4 (pin 7):
 sensor:
   - platform: dht
     sensor: DHT22
-    pin: D4
+    pin: 4
     temperature_offset: 2.1
     humidity_offset: -3.2
     monitored_conditions:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This reverts commit b1ba5c04f890cefdc7334b27a3b78566a78ec959, specifically PR #41525.

The PR was still pending a parent PR, but was merged early.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/41525
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
