### PR TITLE
Add styling to active integrations filter 

### DIFF
--- a/sass/custom/_component_page.scss
+++ b/sass/custom/_component_page.scss
@@ -46,6 +46,10 @@
 @media only screen and (min-width: $desk-start) {
   #components-page {
     .filter-button-group {
+      .active {
+        font-weight: bold;
+      }
+
       .featured {
         margin: 12px 0;
       }

--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -207,7 +207,7 @@ allComponents.pop(); // remove placeholder element at the end
       jQuery('.filter-button-group a.active').removeClass('active');
       jQuery(`.filter-button-group a[href*="${hash}"]`).addClass('active');
       if (hash === "") {
-        jQuery('.filter-button-group a[href*="#all"]').addClass('active');
+        jQuery('.filter-button-group a[href*="#featured"]').addClass('active');
       }
 
       // remove previous elements and css classes, add the new stuff and then trigger the fade-in css animation

--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -203,6 +203,13 @@ allComponents.pop(); // remove placeholder element at the end
 
       rendered = Mustache.render(template, data);
 
+      // set active class on active menu item
+      jQuery('.filter-button-group a.active').removeClass('active');
+      jQuery(`.filter-button-group a[href*="${hash}"]`).addClass('active');
+      if (hash === "") {
+        jQuery('.filter-button-group a[href*="#all"]').addClass('active');
+      }
+
       // remove previous elements and css classes, add the new stuff and then trigger the fade-in css animation
       $('#componentContainer').html('').removeClass('show-items remove-items').html(rendered).addClass('show-items');
       logoLazyLoad.update();


### PR DESCRIPTION
## Proposed change
Add styling to the active menu item on the integrations page to make clear what filter is currently active. I think this is a nice improvement to make the integrations page a bit better usable.

![afbeelding](https://user-images.githubusercontent.com/7275740/95659036-d0816f00-0b1e-11eb-8677-8740731450c4.png)

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: -
- Link to parent pull request in the Brands repository: -
- This PR fixes or closes issue: -

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
