### PR TITLE
Reset integrations search to all if search input is emptied

### DIFF
--- a/source/integrations/index.html
+++ b/source/integrations/index.html
@@ -263,10 +263,13 @@ allComponents.pop(); // remove placeholder element at the end
       var text = $(this).val();
       // sanitize input
       text = text.replace(/[(\?|\&\{\}\(\))]/gi, '').trim();
-      if (typeof text === "string" && text.length !== 0) {
+      if (typeof text === "string" && text.length >= 1) {
         updateHash('#search/' + text);
-        applyFilter();
       }
+      else {
+        updateHash('#all');
+      }
+      applyFilter();
     }, 500));
 
     window.addEventListener('hashchange', applyFilter);


### PR DESCRIPTION
## Proposed change
Reset the integrations search to all intergrations if search input is emptied. Currently if a users empties the search input the last search stays active.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: -
- Link to parent pull request in the Brands repository: -
- This PR fixes or closes issue: -

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
