### PR TITLE
Add missing property to KNX binary sensor after recent refactoring

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -286,6 +286,11 @@ reset_after:
   description: Reset back to OFF state after specified milliseconds.
   required: false
   type: integer
+ignore_internal_state:
+  description: If set to true the update callbacks are always executed regardless of the current binary sensor state. If some of your automations are triggered multiple times make sure this setting is False.
+  required: false
+  type: boolean
+  default: True
 context_timeout:
   description: The time in seconds between multiple identical telegram payloads would count towards the internal counter that is used for automations. Ex. You have automations in place that trigger your lights on button press and another set of lights if you click that button twice. This setting defines the time that a second button press would count toward, so if you set this 3.0 you can take up to 3 seconds in order to trigger the second button press. Maximum value is 10.0.
   required: false

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -417,8 +417,8 @@ knx:
 
 `setpoint_shift_mode` allows the two following DPTs to be used:
 
-- DPT6.002 (for 1 byte signed integer)
-- DPT9.002 (for 2 byte float)
+- DPT6002 (for 1 byte signed integer)
+- DPT9002 (for 2 byte float)
 
 Example:
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

After the recent KNX breaking change there was a merge of the integration documentation into a single file. Apparently we forgot to add one missing property to the binary sensors during rebasing.

See https://github.com/home-assistant/core/issues/41564


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: -
- Link to parent pull request in the Brands repository: -
- This PR fixes or closes issue: -

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
