### PR TITLE
Add the options dark_mode_filter and dark_mode_image to the picture elements card

### DIFF
--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -48,6 +48,7 @@ theme:
   description: "Set to any theme within `themes.yaml`"
   type: string
 dark_mode:
+  default: false
   required: false
   description: "Inverts the picture when the dark mode is activated. Will be overwritten by `state_filter`."
   type: boolean

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -47,6 +47,10 @@ theme:
   required: false
   description: "Set to any theme within `themes.yaml`"
   type: string
+dark_mode:
+  required: false
+  description: "Inverts the picture when the dark mode is activated. Will be overwritten by `state_filter`."
+  type: boolean
 {% endconfiguration %}
 
 ## Elements

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -50,7 +50,7 @@ theme:
 dark_mode:
   default: false
   required: false
-  description: "Inverts the picture when the dark mode is activated. Will be overwritten by `state_filter`."
+  description: "Inverts the picture when the dark mode is activated."
   type: boolean
 {% endconfiguration %}
 

--- a/source/_lovelace/picture-elements.markdown
+++ b/source/_lovelace/picture-elements.markdown
@@ -47,11 +47,14 @@ theme:
   required: false
   description: "Set to any theme within `themes.yaml`"
   type: string
-dark_mode:
-  default: false
+dark_mode_image:
   required: false
-  description: "Inverts the picture when the dark mode is activated."
-  type: boolean
+  description: "This image is used when the dark mode is activated and no state image is set."
+  type: string
+dark_mode_filter:
+  required: false
+  description: "This CSS filter is used when the dark mode is activated."
+  type: string
 {% endconfiguration %}
 
 ## Elements


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add `dark_mode` config option to picture elements card


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/7304
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
