### PR TITLE
generic_thermostat: add support for multiple presets

### DIFF
--- a/source/_integrations/generic_thermostat.markdown
+++ b/source/_integrations/generic_thermostat.markdown
@@ -74,6 +74,9 @@ initial_hvac_mode:
   description: Set the initial HVAC mode. Valid values are `off`, `heat` or `cool`. Value has to be double quoted. If this parameter is not set, it is preferable to set a *keep_alive* value. This is helpful to align any discrepancies between *generic_thermostat* and *heater* state.
   required: false
   type: string
+away_temp:
+  description: "Set the temperature used by `preset_mode: away`. Deprecated, use: `presets` configuration. Only for backward compatibility. Note: if you use both `away_temp` and `presets` configuration `away_temp` is simply ignored."
+  type: float
 presets:
   description: "The list of all enabled `preset_mode`. If this is not specified, the preset mode feature will not be available."
   required: false

--- a/source/_integrations/generic_thermostat.markdown
+++ b/source/_integrations/generic_thermostat.markdown
@@ -74,10 +74,35 @@ initial_hvac_mode:
   description: Set the initial HVAC mode. Valid values are `off`, `heat` or `cool`. Value has to be double quoted. If this parameter is not set, it is preferable to set a *keep_alive* value. This is helpful to align any discrepancies between *generic_thermostat* and *heater* state.
   required: false
   type: string
-away_temp:
-  description: "Set the temperature used by `preset_mode: away`. If this is not specified, the preset mode feature will not be available."
+presets:
+  description: "The list of all enabled `preset_mode`. If this is not specified, the preset mode feature will not be available."
   required: false
-  type: float
+  type: [list, map]
+  keys:
+    away:
+      description: "Set the temperature used by `preset_mode: away`. If this is not specified, this preset will not be available."
+      required: inclusive
+      type: float
+    comfort:
+      description: "Set the temperature used by `preset_mode: comfort`. If this is not specified, this preset will not be available."
+      required: inclusive
+      type: float
+    eco:
+      description: "Set the temperature used by `preset_mode: eco`. If this is not specified, this preset will not be available."
+      required: inclusive
+      type: float
+    home:
+      description: "Set the temperature used by `preset_mode: home`. If this is not specified, this preset will not be available."
+      required: inclusive
+      type: float
+    sleep:
+      description: "Set the temperature used by `preset_mode: sleep`. If this is not specified, this preset will not be available."
+      required: inclusive
+      type: float
+default_preset:
+  description: Set initial `preset_mode`. As of version 0.59, it will retain the `preset_mode` set before restart if available.
+  required: false
+  type: string
 precision:
   description: "The desired precision for this device. Can be used to match your actual thermostat's precision. Supported values are `0.1`, `0.5` and `1.0`."
   required: false
@@ -89,7 +114,7 @@ Time for `min_cycle_duration` and `keep_alive` must be set as "hh:mm:ss" or it m
 
 Currently the `generic_thermostat` climate platform supports 'heat', 'cool' and 'off' HVAC modes. You can force your `generic_thermostat` to avoid starting by setting HVAC mode to 'off'.
 
-Please note that when changing the preset mode to away, you will force a target temperature change as well that will get restored once the preset mode is set to none again.
+Please note that when changing the preset mode to one of defined presets, you will force a target temperature change as well that will get restored once the preset mode is set to none again.
 
 ## Full configuration example
 
@@ -110,6 +135,12 @@ climate:
     keep_alive:
       minutes: 3
     initial_hvac_mode: "off"
-    away_temp: 16
+    presets:
+      away: 16
+      comfort: 21
+      eco: 19
+      home: 20
+      sleep: 18
+    default_preset: eco
     precision: 0.1
 ```

--- a/source/_integrations/generic_thermostat.markdown
+++ b/source/_integrations/generic_thermostat.markdown
@@ -75,7 +75,7 @@ initial_hvac_mode:
   required: false
   type: string
 away_temp:
-  description: "Set the temperature used by `preset_mode: away`. Deprecated, use: `presets` configuration. Only for backward compatibility. Note: if you use both `away_temp` and `presets` configuration `away_temp` is simply ignored."
+  description: "**Deprecated. Configuration moved to presets, see below.** Set the temperature used by `preset_mode: away`. **Note: if you use both `away_temp` and `presets` configuration `away_temp` is ignored.**"
   type: float
 presets:
   description: "The list of all enabled `preset_mode`. If this is not specified, the preset mode feature will not be available."


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The generic_thermostat is a great integration, but today support only one preset "away"
I think that supporting multiple presets can be useful in automation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/41676
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
