### PR TITLE
Include use case for triggering an automation

### DIFF
--- a/source/_integrations/tag.markdown
+++ b/source/_integrations/tag.markdown
@@ -54,7 +54,6 @@ To use a tag scan as the trigger for an automation use the `tag` platform:
 automation:
   - id: '12000'
     alias: Lamp NFC
-    initial_state: 'on'
     trigger:
       platform: tag
       tag_id: lamp_nfc_tag

--- a/source/_integrations/tag.markdown
+++ b/source/_integrations/tag.markdown
@@ -42,6 +42,31 @@ Home Assistant has a dedicated panel that allows you to manage your tags. You ca
 
 ![Tag user interface in Home Assistant](/images/blog/2020-09-15-home-assistant-tags/tag-ui.gif)
 
+
+## Using Scanned Tags as a Trigger
+
+To use a tag scan as the trigger for an automation use the ```tag``` platform:
+
+{% raw %}
+
+```yaml
+
+automation:
+- id: '12000'
+  alias: Lamp NFC
+  initial_state: 'on'
+  trigger:
+    platform: tag
+    tag_id: lamp_nfc_tag
+  condition: []
+  action:
+  - service: light.toggle
+    entity_id:
+    - light.some_lamp
+```
+{% endraw %}
+
+
 ## Building an RFID jukebox
 
 One of the most fun applications of tags is to pick music in your living room. To make this super easy, you can use the below automation:

--- a/source/_integrations/tag.markdown
+++ b/source/_integrations/tag.markdown
@@ -57,7 +57,6 @@ automation:
     trigger:
       platform: tag
       tag_id: lamp_nfc_tag
-    condition: []
     action:
       - service: light.toggle
         entity_id: light.some_lamp

--- a/source/_integrations/tag.markdown
+++ b/source/_integrations/tag.markdown
@@ -52,17 +52,16 @@ To use a tag scan as the trigger for an automation use the ```tag``` platform:
 ```yaml
 
 automation:
-- id: '12000'
-  alias: Lamp NFC
-  initial_state: 'on'
-  trigger:
-    platform: tag
-    tag_id: lamp_nfc_tag
-  condition: []
-  action:
-  - service: light.toggle
-    entity_id:
-    - light.some_lamp
+  - id: '12000'
+    alias: Lamp NFC
+    initial_state: 'on'
+    trigger:
+      platform: tag
+      tag_id: lamp_nfc_tag
+    condition: []
+    action:
+      - service: light.toggle
+        entity_id: light.some_lamp
 ```
 {% endraw %}
 

--- a/source/_integrations/tag.markdown
+++ b/source/_integrations/tag.markdown
@@ -45,7 +45,7 @@ Home Assistant has a dedicated panel that allows you to manage your tags. You ca
 
 ## Using Scanned Tags as a Trigger
 
-To use a tag scan as the trigger for an automation use the ```tag``` platform:
+To use a tag scan as the trigger for an automation use the `tag` platform:
 
 {% raw %}
 


### PR DESCRIPTION
The RFID Jukebox is an awesome example, but it wasn't directly translatable for simpler use cases.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
