### PR TITLE
Add compensation integration

### DIFF
--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -5,7 +5,7 @@ ha_category:
   - Utility
   - Sensor
 ha_iot_class: Calculated
-ha_release: "2021.4.0"
+ha_release: "2021.5"
 ha_quality_scale: internal
 ha_codeowners:
   - '@petro31'

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -22,14 +22,14 @@ To enable the compensation sensor, add the following lines to your `configuratio
 # Example configuration.yaml entry
 compensation:
   media_player_db_volume:
-    entity_id: media_player.yamaha_receiver
+    source: media_player.yamaha_receiver
     data_points:
       - [0.2, -80.0]
       - [1.0, 0.0]
 ```
 
 {% configuration %}
-entity_id:
+source:
   description: The entity to monitor.
   required: true
   type: string
@@ -37,10 +37,9 @@ data_points:
   description: "The collection of data point conversions with the format `[uncompensated_value, compensated_value]`.  e.g., `[1.0, 2.1]`. The number of required data points is equal to the polynomial `degree` + 1. For example, a linear compensation (with `degree: 1`) requires at least 2 data points."
   required: true
   type: list
-name:
-  description: Name of the sensor to use in the frontend.
+unique_id:
+  description: An ID that uniquely identifies this sensor. Set this to a unique value to allow customization through the UI.
   required: false
-  default: Compensation
   type: string
 attribute:
   description: Attribute to monitor.

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -5,7 +5,7 @@ ha_category:
   - Utility
   - Sensor
 ha_iot_class: Calculated
-ha_release: '0.117'
+ha_release: "2021.4.0"
 ha_quality_scale: internal
 ha_codeowners:
   - '@petro31'

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -12,7 +12,7 @@ ha_codeowners:
 ha_domain: compensation
 ---
 
-The Compensation integration consumes the state from other sensors. It exports the compensated value as state and the following values as attributes: `entity_id` and `coefficients`.
+The Compensation integration consumes the state from other sensors. It exports the compensated value as state and the following values as attributes: `entity_id` and `coefficients`.  A single polynomial, linear by default, is fit to all data points provided.
 
 ## Configuration
 

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -37,7 +37,7 @@ entity_id:
   required: true
   type: string
 data_points:
-  description: The collection of data point conversions with the format `uncompensated_value -> compensated_value`.  e.g. `1.0 -> 2.1`. The number of required data points is equal to the polynomial `degree` + 1. For example, a linear compensation (with `degree: 1`) requires at least 2 data points.
+  description: "The collection of data point conversions with the format `uncompensated_value -> compensated_value`.  e.g. `1.0 -> 2.1`. The number of required data points is equal to the polynomial `degree` + 1. For example, a linear compensation (with `degree: 1`) requires at least 2 data points."
   required: true
   type: list
 name:

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -12,7 +12,7 @@ ha_codeowners:
 ha_domain: compensation
 ---
 
-The `compensation` sensor platform consumes the state from other sensors. It exports the `compensated` value as state and the following values as attributes: `entity_id` and `coefficients`.
+The Compensation integration consumes the state from other sensors. It exports the compensated value as state and the following values as attributes: `entity_id` and `coefficients`.
 
 ## Configuration
 

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -1,0 +1,66 @@
+---
+title: Compensation
+description: Instructions on how to integrate compensation sensors into Home Assistant.
+ha_category:
+  - Utility
+  - Sensor
+ha_iot_class: Local Push
+ha_release: '0.117'
+ha_quality_scale: internal
+ha_codeowners:
+  - '@petro31'
+ha_domain: compensation
+---
+
+The `compensation` sensor platform consumes the state from other sensors. It exports the `compensated` value as state and the following values as attributes: `entity_id` and `coefficients`.
+
+## Configuration
+
+To enable the compensation sensor, add the following lines to your `configuration.yaml`:
+
+```yaml
+# Example configuration.yaml entry
+sensor:
+  - platform: compensation
+    name: Yamaha Zone 1 Volume
+    entity_id: media_player.yamaha_receiver
+    attribute: volume_level
+    unit_of_measurement: dB
+    data_points:
+      - 0.2 -> -80.0
+      - 1.0 -> 0.0
+```
+
+{% configuration %}
+entity_id:
+  description: The entity to monitor.
+  required: true
+  type: string
+data_points:
+  description: The collection of data point conversions with the format `uncompensated_value -> compensated_value`.  e.g. `1.0 -> 2.1`. The number of required data points is equal to the polynomial `degree` + 1. For example, a linear compensation (with `degree: 1`) requires at least 2 data points.
+  required: true
+  type: list
+name:
+  description: Name of the sensor to use in the frontend.
+  required: false
+  default: Compensation
+  type: string
+attribute:
+  description: Attribute to monitor.
+  required: false
+  type: string
+degree:
+  description: The degree of a polynomial. e.g. Linear compensation (y = x + 3) has 1 degree, Quadratic compensation (y = x<sup>2</sup> + x + 3) has 2 degrees, etc.
+  required: false
+  default: 1
+  type: integer
+precision:
+  description: Defines the precision of the calculated values, through the argument of round().
+  required: false
+  default: 2
+  type: integer
+unit_of_measurement:
+  description: Defines the units of measurement of the sensor, if any.
+  required: false
+  type: string
+{% endconfiguration %}

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate compensation sensors into Home Ass
 ha_category:
   - Utility
   - Sensor
-ha_iot_class: Local Push
+ha_iot_class: Calculated
 ha_release: '0.117'
 ha_quality_scale: internal
 ha_codeowners:

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -37,7 +37,7 @@ entity_id:
   required: true
   type: string
 data_points:
-  description: "The collection of data point conversions with the format `uncompensated_value -> compensated_value`.  e.g. `1.0 -> 2.1`. The number of required data points is equal to the polynomial `degree` + 1. For example, a linear compensation (with `degree: 1`) requires at least 2 data points."
+  description: "The collection of data point conversions with the format `uncompensated_value -> compensated_value`.  e.g., `1.0 -> 2.1`. The number of required data points is equal to the polynomial `degree` + 1. For example, a linear compensation (with `degree: 1`) requires at least 2 data points."
   required: true
   type: list
 name:

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -20,12 +20,9 @@ To enable the compensation sensor, add the following lines to your `configuratio
 
 ```yaml
 # Example configuration.yaml entry
-sensor:
-  - platform: compensation
-    name: Yamaha Zone 1 Volume
+compensation:
+  media_player_db_volume:
     entity_id: media_player.yamaha_receiver
-    attribute: volume_level
-    unit_of_measurement: dB
     data_points:
       - 0.2 -> -80.0
       - 1.0 -> 0.0
@@ -50,7 +47,7 @@ attribute:
   required: false
   type: string
 degree:
-  description: The degree of a polynomial. e.g. Linear compensation (y = x + 3) has 1 degree, Quadratic compensation (y = x<sup>2</sup> + x + 3) has 2 degrees, etc.
+  description: "The degree of a polynomial. e.g., Linear compensation (y = x + 3) has 1 degree, Quadratic compensation (y = x<sup>2</sup> + x + 3) has 2 degrees, etc."
   required: false
   default: 1
   type: integer

--- a/source/_integrations/compensation.markdown
+++ b/source/_integrations/compensation.markdown
@@ -24,8 +24,8 @@ compensation:
   media_player_db_volume:
     entity_id: media_player.yamaha_receiver
     data_points:
-      - 0.2 -> -80.0
-      - 1.0 -> 0.0
+      - [0.2, -80.0]
+      - [1.0, 0.0]
 ```
 
 {% configuration %}
@@ -34,7 +34,7 @@ entity_id:
   required: true
   type: string
 data_points:
-  description: "The collection of data point conversions with the format `uncompensated_value -> compensated_value`.  e.g., `1.0 -> 2.1`. The number of required data points is equal to the polynomial `degree` + 1. For example, a linear compensation (with `degree: 1`) requires at least 2 data points."
+  description: "The collection of data point conversions with the format `[uncompensated_value, compensated_value]`.  e.g., `[1.0, 2.1]`. The number of required data points is equal to the polynomial `degree` + 1. For example, a linear compensation (with `degree: 1`) requires at least 2 data points."
   required: true
   type: list
 name:


### PR DESCRIPTION
Adds the compensation integration

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds the compensation integration documentation


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/41675
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
