### PR TITLE
Correcting configuration example

### DIFF
--- a/source/_integrations/media_source.markdown
+++ b/source/_integrations/media_source.markdown
@@ -48,10 +48,11 @@ This example makes two different folders available to the integration:
 
 ```yaml
 # Example configuration.yaml
-homeassistant:
-  media_dirs:
-    local: /media
-    recording: /mnt/recordings
+homeassistant
+  media_source:
+    media_dirs:
+      local: /media
+      recording: /mnt/recordings
 ```
 
 [basic-configuration]: /docs/configuration/basic/#media_dirs


### PR DESCRIPTION
## Proposed change
`media_source:` was omitted from the configuration example with folders. I could not get this feature to work until I figured this out.

## Type of change
This is a minor documentation change.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information


## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
