### PR TITLE
Add dependencies required for building Pillow

### DIFF
--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -40,7 +40,7 @@ sudo apt-get upgrade -y
 Install the dependencies.
 
 ```bash
-sudo apt-get install python3 python3-dev python3-venv python3-pip libffi-dev libssl-dev libtiff-dev autoconf build-essential libopenjp2-7
+sudo apt-get install python3 python3-dev python3-venv python3-pip libffi-dev libssl-dev libtiff-dev autoconf build-essential libopenjp2-7 libjpeg-dev zlib1g-dev
 ```
 
 Add an account for Home Assistant Core called `homeassistant`.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
If Pillow needs to be build from source (because there aren't any wheels available) zlib1g-dev and libjpeg-dev are required. This is now required since the Image integration is now an indirect dependency of the frontend.

I also like to mention that `libtiff-dev`, `autoconf` and `libopenjp2-7` were not required at all for a successful installation of Home Assistant in a clean enviroment without using any wheels, but since two of those are added recently in #14581 and #14627, I don't feel comfortable removing them.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
