### PR TITLE
Add Adaptive Lighting documentation

### DIFF
--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -45,17 +45,12 @@ adapt_color_temp:
   default: true
   type: boolean
 adapt_rgb_color:
-  description: Whether Adaptive Lighting should adjust RGB color of lights (when color temperature doesn't work).
+  description: Whether Adaptive Lighting should adjust RGB color of lights.
   required: false
   default: true
   type: boolean
-detect_non_ha_changes:
-  description: Whether to detect changes and stop adjusting lights, even not from `light.turn_on`. Requires `take_over_control` to be enabled.
-  required: inclusive
-  default: true
-  type: boolean
 initial_transition:
-  description: How long the first transition is.
+  description: How long the first transition is when the lights go from `off` to `on`.
   required: false
   default: 1
   type: time
@@ -110,6 +105,11 @@ sunrise_time:
 take_over_control:
   description: If another source calls `light.turn_on` while the lights are on and being adjusted, disable Adaptive Lighting.
   required: false
+  default: true
+  type: boolean
+detect_non_ha_changes:
+  description: Whether to detect changes and stop adjusting lights, even not from `light.turn_on`. Needs `take_over_control` to be enabled.
+  required: inclusive
   default: true
   type: boolean
 transition:

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -29,6 +29,7 @@ lights:
   description: List of light entities for Adaptive Lighting to control.
   required: true
   type: list
+  default: []
 name:
   description: The name to use when displaying this switch.
   required: false
@@ -54,6 +55,11 @@ initial_transition:
   required: false
   default: 1
   type: time
+interval:
+  description: How often to adjust the lights.
+  required: false
+  default: 90
+  type: integer
 max_brightness:
   description: The maximum percent of brightness to set the lights to.
   required: false
@@ -102,6 +108,16 @@ sunrise_time:
   description: Override the sunset time with a fixed time.
   required: false
   type: time
+sleep_brightness:
+  description: Brightness of lights while the sleep mode is enabled.
+  required: false
+  default: 1
+  type: integer
+sleep_color_temp:
+  description: Color temperature of lights while the sleep mode is enabled.
+  required: false
+  default: 1000
+  type: integer
 take_over_control:
   description: If another source calls `light.turn_on` while the lights are on and being adjusted, disable Adaptive Lighting.
   required: false
@@ -110,7 +126,7 @@ take_over_control:
 detect_non_ha_changes:
   description: Whether to detect changes and stop adjusting lights, even not from `light.turn_on`. Needs `take_over_control` to be enabled.
   required: inclusive
-  default: true
+  default: false
   type: boolean
 transition:
   description: How long the transition is when the lights change, in seconds.

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -1,6 +1,6 @@
 ---
 title: Adaptive Lighting
-description: Instructions for setting up Adaptive Lighting with Home Assistant
+description: How to set up Adaptive Lighting with Home Assistant
 ha_category:
   - Automation
 ha_release: 0.116
@@ -9,19 +9,11 @@ ha_domain: adaptive_lighting
 ha_config_flow: true
 ---
 
-The `adaptive_lighting` platform syncs the color and brightness of your lights to your circadian rhythm. You can set it up using the UI.
-
-The integration will update your lights based on the time of day. It will only affect lights that are turned on and listed in the flux configuration.
-
-During the day (in between `start time` and `sunset time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`.  After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights periodically.
-
-The color temperature is specified kelvin, and accepted values are between 1000 and 40000 kelvin. Lower values will seem more red, while higher will look more white.
-
-If you want to update at variable intervals, you can leave the switch turned off and use automation rules that call the service `switch.<name>_update` whenever you want the lights updated, where `<name>` equals the `name:` property in the switch configuration.
+The `adaptive_lighting` platform syncs the color and brightness of your lights to natural lighting brightness and color temperature. This helps maintain your circadian rhythm, which can help you have better sleep and feel better.
 
 ## Configuration
 
-The integration is configurable through the frontend. (**Configuration** -> **Integrations** -> **Adaptive Lighting**, **Adaptive Lighting** -> **Options**)
+This integration is configurable through the frontend. (**Configuration** -> **Integrations** -> **Adaptive Lighting**, **Adaptive Lighting** -> **Options**)
 
 You can configure more advanced options with `configuration.yaml`.
 
@@ -60,11 +52,6 @@ initial_transition:
   required: false
   default: 1
   type: time
-transition:
-  description: How long the transition is when the lights change, in seconds.
-  required: false
-  default: 60
-  type: integer
 max_brightness:
   description: The maximum percent of brightness to set the lights to.
   required: false
@@ -98,28 +85,66 @@ sleep_color_temp:
   description: Color temperature to use in sleep mode.
   required: false
   type: integer
+sleep_entity:
+  description: An entity to toggle sleep mode.
+  required: inclusive
+  type: string
+sleep_state:
+  description: When the sleep entity is one of/this state(s), use the sleep brightness and temperature.
+  required: inclusive
+  type: [list, string]
+sunrise_offset:
+  description: Positive or negative offset from the sunrise time.
+  required: false
+  type: time
+sunrise_time:
+  description: Set a fixed time for sunrise.
+  required: false
+  type: time
+sunset_offset:
+  description: Positive or negative offset from the sunset time.
+  required: false
+  type: time
+sunrise_time:
+  description: Set a fixed time for sunset.
+  required: false
+  type: time
+transition:
+  description: How long the transition is when the lights change, in seconds.
+  required: false
+  default: 60
+  type: integer
 {% endconfiguration %}
 
 Full example:
 
 ```yaml
 # Example configuration.yaml entry
-switch:
-  - platform: flux
-    lights:
-      - light.desk
-      - light.lamp
-    name: Fluxer
-    start_time: '7:00'
-    stop_time: '23:00'
-    start_colortemp: 4000
-    sunset_colortemp: 3000
-    stop_colortemp: 1900
-    brightness: 200
-    disable_brightness_adjust: true
-    mode: xy
-    transition: 30
-    interval: 60
+adaptive_lighting:
+  - name: All settings
+    lights: light.living_room_lights
+    disable_brightness_adjust: false
+    disable_entity: input_select.sleep_mode
+    disable_state:
+      - 'off'
+      - 'half'
+    initial_transition:
+      seconds: 10
+    interval: "00:00:30"
+    max_brightness: 90
+    max_color_temp: 5500
+    min_brightness: 1
+    min_color_temp: 2500
+    only_once: false
+    sleep_brightness: 1
+    sleep_color_temp: 1000
+    sleep_entity: input_boolean.sleep_mode
+    sleep_state: "total"
+    sunrise_offset: 1800
+    sunrise_time: "08:00:00"
+    sunset_offset: 0
+    sunset_time: null
+    transition: 10
 ```
 
 ### Services

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -9,7 +9,7 @@ ha_domain: adaptive_lighting
 ha_config_flow: true
 ---
 
-The `adaptive_lighting` platform syncs the color and brightness of your lights to natural lighting brightness and color temperature. This helps maintain your circadian rhythm, which can help you have better sleep and feel better.
+The `adaptive_lighting` platform syncs the color and brightness of your lights to natural lighting brightness and color temperature. This helps maintain your circadian rhythm, which can help you have better sleep and feel better. You can see [the README](https://github.com/claytonjn/hass-circadian_lighting/blame/db7d0574dd7e4fdad5bd9b9c08db24f85bdddedb/README.md#L2-L20) of the project that this component was based off of for more details.
 
 ## Configuration
 

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -26,9 +26,11 @@ The first switch `switch.adaptive_lighting_default` (with name `"default"`) turn
 It has several attributes that show the current light settings.
 The second switch is `switch.adaptive_lighting_sleep_mode_default` (with name `"default"`) that when activated, turns on "sleep mode".
 
-Although having your lights automatically adapt is great most of the time, there might be times at which you want to set the lights to a different color.
-For this purpose, the integration (when `take_over_control` is enabled) automatically detect whether someone (person toggling the light switch) or something (automation) changes the lights.
-If this happens *and* the light is already on, the light that was changed gets marked as "manually controlled" and the Adaptive Lighting component will stop adapting your lights until the light turns off and on again (or if you use the service call `adaptive_lighting.set_manual_control`).
+## Taking back control
+
+Although having your lights automatically adapt is great most of the time, there might be times at which you want to set the lights to a different color/brightness and keep it that way.
+For this purpose, the integration (when `take_over_control` is enabled) automatically detects whether someone (e.g., person toggling the light switch) or something (automation) changes the lights.
+If this happens *and* the light is already on, the light that was changed gets marked as "manually controlled" and the Adaptive Lighting component will stop adapting that light until it turns off and on again (or if you use the service call `adaptive_lighting.set_manual_control`).
 This mechanism works by listening to all `light.turn_on` calls and by noting that the component did not make the call.
 Additionally, there is an option to detect all state changes (when `detect_non_ha_changes` is enabled), so also changes to the lights that were not made by a `light.turn_on` call (e.g., through an app or via something not controlled by Home Assistant.)
 It does this by comparing a light's state to Adaptive Lighting's previously used settings.

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -1,0 +1,114 @@
+---
+title: Adaptive Lighting
+description: Instructions for setting up Adaptive Lighting with Home Assistant
+ha_category:
+  - Automation
+ha_release: 0.116
+ha_quality_scale: internal
+ha_domain: adaptive_lighting
+ha_config_flow: true
+---
+
+The `adaptive_lighting` platform syncs the color and brightness of your lights to your circadian rhythm. You can set it up using the UI.
+
+The integration will update your lights based on the time of day. It will only affect lights that are turned on and listed in the flux configuration.
+
+During the day (in between `start time` and `sunset time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`.  After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights periodically.
+
+The color temperature is specified kelvin, and accepted values are between 1000 and 40000 kelvin. Lower values will seem more red, while higher will look more white.
+
+If you want to update at variable intervals, you can leave the switch turned off and use automation rules that call the service `switch.<name>_update` whenever you want the lights updated, where `<name>` equals the `name:` property in the switch configuration.
+
+## Configuration
+
+The integration is configurable through the frontend. (**Configuration** -> **Integrations** -> **Adaptive Lighting**, **Adaptive Lighting** -> **Options**)
+
+You can configure more advanced options with `configuration.yaml`.
+
+```yaml
+# Example configuration.yaml entry
+adaptive_lighting:
+  lights:
+    - light.living_room_lights
+```
+
+{% configuration %}
+lights:
+  description: List of light entities.
+  required: true
+  type: list
+name:
+  description: The name to use when displaying this switch.
+  required: false
+  default: default
+  type: string
+disable_brightness_adjust:
+  description: Whether to disable adjusting brightness of lights.
+  required: false
+  type: boolean
+disable_entity:
+  description: An entity to disable adaptive lighting.
+  required: false
+  type: time
+start_colortemp:
+  description: The color temperature at the start.
+  required: false
+  default: 4000
+  type: integer
+sunset_colortemp:
+  description: The sun set color temperature.
+  required: false
+  default: 3000
+  type: integer
+stop_colortemp:
+  description: The color temperature at the end.
+  required: false
+  default: 1900
+  type: integer
+brightness:
+  description: The brightness of the lights.
+  required: false
+  type: integer
+disable_brightness_adjust:
+  description: If true, brightness will not be adjusted besides color temperature.
+  required: false
+  type: boolean
+  default: false
+mode:
+  description: Select how color temperature is passed to lights. Valid values are `xy`, `mired` and `rgb`.
+  required: false
+  default: xy
+  type: string
+transition:
+  description: Transition time in seconds for the light changes (high values may not be supported by all light models).
+  required: false
+  default: 30
+  type: integer
+interval:
+  description: Frequency in seconds at which the lights should be updated.
+  required: false
+  default: 30
+  type: integer
+{% endconfiguration %}
+
+Full example:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: flux
+    lights:
+      - light.desk
+      - light.lamp
+    name: Fluxer
+    start_time: '7:00'
+    stop_time: '23:00'
+    start_colortemp: 4000
+    sunset_colortemp: 3000
+    stop_colortemp: 1900
+    brightness: 200
+    disable_brightness_adjust: true
+    mode: xy
+    transition: 30
+    interval: 60
+```

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -26,7 +26,7 @@ adaptive_lighting:
 
 {% configuration %}
 lights:
-  description: List of light entities.
+  description: List of light entities for Adaptive Lighting to control.
   required: true
   type: list
 name:
@@ -34,19 +34,26 @@ name:
   required: false
   default: default
   type: string
-disable_brightness_adjust:
-  description: Whether to disable adjusting brightness of lights.
+adapt_brightness:
+  description: Whether Adaptive Lighting should adjust brightness of lights.
   required: false
-  default: false
+  default: true
   type: boolean
-disable_entity:
-  description: An entity to toggle disabling adaptive lighting.
+adapt_color_temp:
+  description: Whether Adaptive Lighting should adjust color temperature of lights.
+  required: false
+  default: true
+  type: boolean
+adapt_rgb_color:
+  description: Whether Adaptive Lighting should adjust RGB color of lights (when color temperature doesn't work).
+  required: false
+  default: true
+  type: boolean
+detect_non_ha_changes:
+  description: Whether to detect changes and stop adjusting lights, even not from `light.turn_on`. Requires `take_over_control` to be enabled.
   required: inclusive
-  type: string
-disable_state:
-  description: When the sleep entity is this state (or one of the states in the list), disable Adaptive Lighting.
-  required: inclusive
-  type: [list, string]
+  default: true
+  type: boolean
 initial_transition:
   description: How long the first transition is.
   required: false
@@ -70,32 +77,22 @@ min_brightness:
 min_color_temp:
   description: The coldest color temperature to set the lights to, in Kelvin.
   required: false
-  default: 2500
+  default: 2000
   type: integer
 only_once:
   description: Whether to keep adjusting the lights, or to only adjust the lights as soon as they're turned on.
   required: false
   default: false
   type: boolean
-sleep_brightness:
-  description: Brightness to use in sleep mode.
+prefer_rgb_color:
+  description: Whether to use RGB color adjustment instead of native light color temperature.
   required: false
-  type: integer
-sleep_color_temp:
-  description: Color temperature to use in sleep mode.
-  required: false
-  type: integer
-sleep_entity:
-  description: An entity to toggle sleep mode.
-  required: inclusive
-  type: string
-sleep_state:
-  description: When the sleep entity is this state (or one of the states in the list), use the sleep brightness and temperature.
-  required: inclusive
-  type: [list, string]
+  default: false
+  type: boolean
 sunrise_offset:
   description: Change the sunrise time with a positive or negative offset.
   required: false
+  default: 0
   type: time
 sunrise_time:
   description: Override the sunrise time with a fixed time.
@@ -104,15 +101,21 @@ sunrise_time:
 sunset_offset:
   description: Change the sunset time with a positive or negative offset.
   required: false
+  default: 0
   type: time
 sunrise_time:
   description: Override the sunset time with a fixed time.
   required: false
   type: time
+take_over_control:
+  description: If another source calls `light.turn_on` while the lights are on and being adjusted, disable Adaptive Lighting.
+  required: false
+  default: true
+  type: boolean
 transition:
   description: How long the transition is when the lights change, in seconds.
   required: false
-  default: 60
+  default: 45
   type: integer
 {% endconfiguration %}
 

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -58,7 +58,7 @@ max_brightness:
   default: 100
   type: integer
 max_color_temp:
-  description: The warmest color temperature to set the lights to.
+  description: The warmest color temperature to set the lights to, in Kelvin.
   required: false
   default: 5500
   type: integer
@@ -68,7 +68,7 @@ min_brightness:
   default: 1
   type: integer
 min_color_temp:
-  description: The coldest color temperature to set the lights to.
+  description: The coldest color temperature to set the lights to, in Kelvin.
   required: false
   default: 2500
   type: integer

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -3,19 +3,41 @@ title: Adaptive Lighting
 description: How to set up Adaptive Lighting with Home Assistant
 ha_category:
   - Automation
-ha_release: 0.116
-ha_quality_scale: internal
+  - Light
+ha_release: 0.117
 ha_domain: adaptive_lighting
+ha_codeowners:
+  - '@basnijholt'
 ha_config_flow: true
 ---
 
-The `adaptive_lighting` platform syncs the color and brightness of your lights to natural lighting brightness and color temperature. This helps maintain your circadian rhythm, which can help you have better sleep and feel better. You can see [the README](https://github.com/claytonjn/hass-circadian_lighting/blame/db7d0574dd7e4fdad5bd9b9c08db24f85bdddedb/README.md#L2-L20) of the project that this component was based off of for more details.
+The `adaptive_lighting` platform changes the settings of your lights throughout the day.
+It uses the position of the sun to calculate the color temperature and brightness that is most fitting for that time of the day.
+Scientific research has shown that this helps to maintain your natural circadian rhythm (your biological clock) and might lead to improved sleep, mood, and general well-being.
+
+In practical terms, this means that after the sun sets, the brightness of your lights will decrease to a certain minimum brightness, while the color temperature will be at its coolest color temperature at noon, after which it will decrease and reach its warmest color at sunset.
+Around sunrise, the opposite will happen.
+
+Additionally, the integration provides a way to define and set your lights in "sleep mode".
+When "sleep mode" is enabled, the lights will be at a minimal brightness and have a very warm color.
+
+The integration creates two switches.
+The first switch `switch.adaptive_lighting_default` (with name `"default"`) turns the Adaptive Lighting on or off.
+It has several attributes that show the current light settings.
+The second switch is `switch.adaptive_lighting_sleep_mode_default` (with name `"default"`) that when activated, turns on "sleep mode".
+
+Although having your lights automatically adapt is great most of the time, there might be times at which you want to set the lights to a different color.
+For this purpose, the integration (when `take_over_control` is enabled) automatically detect whether someone (person toggling the light switch) or something (automation) changes the lights.
+If this happens *and* the light is already on, the light that was changed gets marked as "manually controlled" and the Adaptive Lighting component will stop adapting your lights until the light turns off and on again (or if you use the service call `adaptive_lighting.set_manual_control`).
+This mechanism works by listening to all `light.turn_on` calls and by noting that the component did not make the call.
+Additionally, there is an option to detect all state changes (when `detect_non_ha_changes` is enabled), so also changes to the lights that were not made by a `light.turn_on` call (e.g., through an app or via something not controlled by Home Assistant.)
+It does this by comparing a light's state to Adaptive Lighting's previously used settings.
+Whenever a light gets marked as "manually controlled", an `adaptive_lighting.manual_control` event is fired, such that one can use this information in automations.
 
 ## Configuration
 
-This integration is configurable through the frontend. (**Configuration** -> **Integrations** -> **Adaptive Lighting**, **Adaptive Lighting** -> **Options**)
-
-You can configure more advanced options with `configuration.yaml`.
+This integration is both fully configurable through YAML _and_ the frontend. (**Configuration** -> **Integrations** -> **Adaptive Lighting**, **Adaptive Lighting** -> **Options**)
+Here, the options in the frontend and in YAML have the same names.
 
 ```yaml
 # Example configuration.yaml entry
@@ -25,89 +47,71 @@ adaptive_lighting:
 ```
 
 {% configuration %}
-lights:
-  description: List of light entities for Adaptive Lighting to control.
-  required: true
-  type: list
-  default: []
 name:
   description: The name to use when displaying this switch.
   required: false
   default: default
   type: string
+lights:
+  description: List of light entities for Adaptive Lighting to control (may be empty).
+  required: false
+  type: list
+  default: []
 adapt_brightness:
-  description: Whether Adaptive Lighting should adjust brightness of lights.
+  description: Whether Adaptive Lighting should adjust brightness of lights (if supported by the light).
   required: false
   default: true
   type: boolean
 adapt_color_temp:
-  description: Whether Adaptive Lighting should adjust color temperature of lights.
+  description: Whether Adaptive Lighting should adjust color temperature of lights (if supported by the light).
   required: false
   default: true
   type: boolean
 adapt_rgb_color:
-  description: Whether Adaptive Lighting should adjust RGB color of lights.
+  description: Whether Adaptive Lighting should adjust RGB color of lights (if supported by the light).
   required: false
   default: true
-  type: boolean
-initial_transition:
-  description: How long the first transition is when the lights go from `off` to `on`.
-  required: false
-  default: 1
-  type: time
-interval:
-  description: How often to adjust the lights.
-  required: false
-  default: 90
-  type: integer
-max_brightness:
-  description: The maximum percent of brightness to set the lights to.
-  required: false
-  default: 100
-  type: integer
-max_color_temp:
-  description: The warmest color temperature to set the lights to, in Kelvin.
-  required: false
-  default: 5500
-  type: integer
-min_brightness:
-  description: The minimum percent of brightness to set the lights to.
-  required: false
-  default: 1
-  type: integer
-min_color_temp:
-  description: The coldest color temperature to set the lights to, in Kelvin.
-  required: false
-  default: 2000
-  type: integer
-only_once:
-  description: Whether to keep adjusting the lights, or to only adjust the lights as soon as they're turned on.
-  required: false
-  default: false
   type: boolean
 prefer_rgb_color:
   description: Whether to use RGB color adjustment instead of native light color temperature.
   required: false
   default: false
   type: boolean
-sunrise_offset:
-  description: Change the sunrise time with a positive or negative offset.
+initial_transition:
+  description: How long the first transition is when the lights go from `off` to `on` (or when "sleep mode" is (de)activated).
   required: false
-  default: 0
+  default: 1
   type: time
-sunrise_time:
-  description: Override the sunrise time with a fixed time.
+transition:
+  description: How long the transition is when the lights change, in seconds.
   required: false
-  type: time
-sunset_offset:
-  description: Change the sunset time with a positive or negative offset.
+  default: 45
+  type: integer
+interval:
+  description: Period between adapting the lights, in seconds.
   required: false
-  default: 0
-  type: time
-sunrise_time:
-  description: Override the sunset time with a fixed time.
+  default: 90
+  type: integer
+min_brightness:
+  description: The minimum percent of brightness to set the lights to.
   required: false
-  type: time
+  default: 1
+  type: integer
+max_brightness:
+  description: The maximum percent of brightness to set the lights to.
+  required: false
+  default: 100
+  type: integer
+min_color_temp:
+  description: The coldest color temperature to set the lights to, in Kelvin.
+  required: false
+  default: 2000
+  type: integer
+max_color_temp:
+  description: The warmest color temperature to set the lights to, in Kelvin.
+  required: false
+  default: 5500
+  type: integer
 sleep_brightness:
   description: Brightness of lights while the sleep mode is enabled.
   required: false
@@ -118,21 +122,39 @@ sleep_color_temp:
   required: false
   default: 1000
   type: integer
+sunrise_time:
+  description: Override the sunrise time with a fixed time.
+  required: false
+  type: time
+sunrise_offset:
+  description: Change the sunrise time with a positive or negative offset.
+  required: false
+  default: 0
+  type: time
+sunrise_time:
+  description: Override the sunset time with a fixed time.
+  required: false
+  type: time
+sunset_offset:
+  description: Change the sunset time with a positive or negative offset.
+  required: false
+  default: 0
+  type: time
+only_once:
+  description: Whether to keep adapting the lights (false) or to only adapt the lights as soon as they are turned on (true).
+  required: false
+  default: false
+  type: boolean
 take_over_control:
-  description: If another source calls `light.turn_on` while the lights are on and being adjusted, disable Adaptive Lighting.
+  description: If another source calls `light.turn_on` while the lights are on and being adaptive, disable Adaptive Lighting.
   required: false
   default: true
   type: boolean
 detect_non_ha_changes:
-  description: Whether to detect changes and stop adjusting lights, even not from `light.turn_on`. Needs `take_over_control` to be enabled.
+  description: Whether to detect state changes and stop adapting lights, even not from `light.turn_on`. Needs `take_over_control` to be enabled. Note that by enabling this option, it calls 'homeassistant.update_entity' every 'interval'!
   required: inclusive
   default: false
   type: boolean
-transition:
-  description: How long the transition is when the lights change, in seconds.
-  required: false
-  default: 45
-  type: integer
 {% endconfiguration %}
 
 Full example:
@@ -140,50 +162,49 @@ Full example:
 ```yaml
 # Example configuration.yaml entry
 adaptive_lighting:
-  - name: All settings
-    lights: light.living_room_lights
-    disable_brightness_adjust: false
-    disable_entity: input_select.sleep_mode
-    disable_state:
-      - 'off'
-      - 'half'
-    initial_transition:
-      seconds: 10
-    interval: "00:00:30"
-    max_brightness: 90
-    max_color_temp: 5500
-    min_brightness: 1
-    min_color_temp: 2500
-    only_once: false
-    sleep_brightness: 1
-    sleep_color_temp: 1000
-    sleep_entity: input_boolean.sleep_mode
-    sleep_state: "total"
-    sunrise_offset: 1800
-    sunrise_time: "08:00:00"
-    sunset_offset: 0
-    sunset_time: null
-    transition: 10
+- name: "default"
+  lights: []
+  adapt_brightness: true
+  adapt_color_temp: true
+  adapt_rgb_color: true
+  prefer_rgb_color: false
+  transition: 45
+  initial_transition: 1
+  interval: 90
+  min_brightness: 1
+  max_brightness: 100
+  min_color_temp: 2000
+  max_color_temp: 5500
+  sleep_brightness: 1
+  sleep_color_temp: 1000
+  sunrise_time: "08:00:00"  # override the sunrise time
+  sunrise_offset: "00:15:00"
+  sunset_time:
+  sunset_offset: -1800  # in seconds
+  take_over_control: true
+  detect_non_ha_changes: false
+  only_once: false
+
 ```
 
 ### Services
 
-`adaptive_lighting.apply` applies adaptive lighting settings to lights on demand.
+`adaptive_lighting.apply` applies Adaptive Lighting settings to lights on demand.
 
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |       no | The entity ID of the switch with the settings to apply.                 |
-| `lights`                  |       no | A list of lights to apply the settings to.                              |
+| Service data attribute    | Optional | Description                                                             |
+|---------------------------|----------|-------------------------------------------------------------------------|
+| `entity_id`               |       no | The `entity_id` of the switch with the settings to apply.               |
+| `lights`                  |       no | A light (or list of lights) to apply the settings to.                   |
 | `transition`              |      yes | The number of seconds for the transition.                               |
 | `adapt_brightness`        |      yes | Whether to change the brightness of the light or not.                   |
 | `adapt_color_temp`        |      yes | Whether to adapt the color temperature on supporting lights.            |
-| `adapt_rgb_color`         |      yes | Whether to adapt the color temperature with RGB.                        |
-| `turn_on_lights`          |      yes | Whether turn on lights that are currently off.                          |
+| `adapt_rgb_color`         |      yes | Whether to adapt the color temperature with `rgb_color`.                |
+| `turn_on_lights`          |      yes | Whether to turn on lights that are currently off.                       |
 
-`adaptive_lighting.set_manually_controlled` changes whether lights are automatically adjusted.
+`adaptive_lighting.set_manual_control` can mark (or unmark) whether a light is "manually controlled", meaning that when a light has `manual_control`, the light is not adapted.
 
-| Service data attribute    | Optional | Description                                           |
-|---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |       no | The entity ID of the switch with the settings to apply.                                            |
-| `lights`                  |       no | A list of lights to apply the settings to.                                                         |
-| `manually_controlled`     |       no | Whether to add (true) or remove (false) this/these lights in the list of lights to not adjust.     |
+| Service data attribute    | Optional | Description                                                                                        |
+|---------------------------|----------|----------------------------------------------------------------------------------------------------|
+| `entity_id`               |       no | The `entity_id` of the switch in which to (un)mark the light as being "manually controlled".       |
+| `lights`                  |       no | A light (or list of lights) to apply the settings to.                                              |
+| `manual_control`          |       no | Whether to mark (true) or unmark (false) the light as "manually controlled".                       |

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -50,7 +50,7 @@ disable_brightness_adjust:
 disable_entity:
   description: An entity to toggle disabling adaptive lighting.
   required: false
-  type: boolean
+  type: string
 disable_state:
   description: The state of the entity to disable adaptive lighting.
   required: false

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -116,8 +116,14 @@ switch:
 
 ### Services
 
-You can call `adaptive_lighting.apply` to manually adjust a light.
+`adaptive_lighting.apply` applies adaptive lighting settings to lights on demand.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |
+| `entity_id`               |       no | The entity ID of the switch with the settings to apply.                 |
+| `lights`                  |       no | A list of lights to apply the settings to.                              |
+| `transition`              |      yes | The number of seconds for the transition.                               |
+| `adapt_brightness`        |      yes | Whether to change the brightness of the light or not.                   |
+| `adapt_color_temp`        |      yes | Whether to adapt the color temperature on supporting lights.            |
+| `adapt_rgb_color`         |      yes | Whether to adapt the color temperature with RGB.                        |
+| `turn_on_lights`          |      yes | Whether turn on lights that are currently off.                          |

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -210,3 +210,27 @@ adaptive_lighting:
 | `entity_id`               |       no | The `entity_id` of the switch in which to (un)mark the light as being "manually controlled".       |
 | `lights`                  |       no | A light (or list of lights) to apply the settings to.                                              |
 | `manual_control`          |       no | Whether to mark (true) or unmark (false) the light as "manually controlled".                       |
+
+
+### Automation examples
+
+Reset the `manual_control` status of a light after an hour.
+```yaml
+- alias: "Adaptive lighting: reset manual_control after 1 hour"
+  mode: parallel
+  trigger:
+    platform: event
+    event_type: adaptive_lighting.manual_control
+  variables:
+    light: "{{ trigger.event.data.entity_id }}"
+    switch: "{{ trigger.entity_id }}"
+  action:
+    - delay: "01:00:00"
+    - condition: template
+      value_template: "{{ light in state_attr('switch', 'manual_control') }}"
+    - service: adaptive_lighting.set_manually_controlled
+      data:
+        entity_id: "{{ switch }}"
+        lights: "{{ light }}"
+        manual_control: false
+```

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -179,3 +179,10 @@ adaptive_lighting:
 | `adapt_color_temp`        |      yes | Whether to adapt the color temperature on supporting lights.            |
 | `adapt_rgb_color`         |      yes | Whether to adapt the color temperature with RGB.                        |
 | `turn_on_lights`          |      yes | Whether turn on lights that are currently off.                          |
+
+`adaptive_lighting.set_manually_controlled` changes whether lights are manually controlled.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |       no | The entity ID of the switch with the settings to apply.                 |
+| `lights`                  |       no | A list of lights to apply the settings to.                              |

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -44,7 +44,7 @@ disable_entity:
   required: inclusive
   type: string
 disable_state:
-  description: The state of the entity to disable adaptive lighting.
+  description: When the sleep entity is this state (or one of the states in the list), disable Adaptive Lighting.
   required: inclusive
   type: [list, string]
 initial_transition:
@@ -90,23 +90,23 @@ sleep_entity:
   required: inclusive
   type: string
 sleep_state:
-  description: When the sleep entity is one of/this state(s), use the sleep brightness and temperature.
+  description: When the sleep entity is this state (or one of the states in the list), use the sleep brightness and temperature.
   required: inclusive
   type: [list, string]
 sunrise_offset:
-  description: Positive or negative offset from the sunrise time.
+  description: Change the sunrise time with a positive or negative offset.
   required: false
   type: time
 sunrise_time:
-  description: Set a fixed time for sunrise.
+  description: Override the sunrise time with a fixed time.
   required: false
   type: time
 sunset_offset:
-  description: Positive or negative offset from the sunset time.
+  description: Change the sunset time with a positive or negative offset.
   required: false
   type: time
 sunrise_time:
-  description: Set a fixed time for sunset.
+  description: Override the sunset time with a fixed time.
   required: false
   type: time
 transition:

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -49,11 +49,11 @@ disable_brightness_adjust:
   type: boolean
 disable_entity:
   description: An entity to toggle disabling adaptive lighting.
-  required: false
+  required: inclusive
   type: string
 disable_state:
   description: The state of the entity to disable adaptive lighting.
-  required: false
+  required: inclusive
   type: [list, string]
 initial_transition:
   description: How long the first transition is.
@@ -90,6 +90,14 @@ only_once:
   required: false
   default: false
   type: boolean
+sleep_brightness:
+  description: Brightness to use in sleep mode.
+  required: false
+  type: integer
+sleep_color_temp:
+  description: Color temperature to use in sleep mode.
+  required: false
+  type: integer
 {% endconfiguration %}
 
 Full example:

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -180,9 +180,10 @@ adaptive_lighting:
 | `adapt_rgb_color`         |      yes | Whether to adapt the color temperature with RGB.                        |
 | `turn_on_lights`          |      yes | Whether turn on lights that are currently off.                          |
 
-`adaptive_lighting.set_manually_controlled` changes whether lights are manually controlled.
+`adaptive_lighting.set_manually_controlled` changes whether lights are automatically adjusted.
 
 | Service data attribute    | Optional | Description                                           |
 |---------------------------|----------|-------------------------------------------------------|
-| `entity_id`               |       no | The entity ID of the switch with the settings to apply.                 |
-| `lights`                  |       no | A list of lights to apply the settings to.                              |
+| `entity_id`               |       no | The entity ID of the switch with the settings to apply.                                            |
+| `lights`                  |       no | A list of lights to apply the settings to.                                                         |
+| `manually_controlled`     |       no | Whether to add (true) or remove (false) this/these lights in the list of lights to not adjust.     |

--- a/source/_integrations/adaptive_lighting.markdown
+++ b/source/_integrations/adaptive_lighting.markdown
@@ -45,50 +45,51 @@ name:
 disable_brightness_adjust:
   description: Whether to disable adjusting brightness of lights.
   required: false
+  default: false
   type: boolean
 disable_entity:
-  description: An entity to disable adaptive lighting.
-  required: false
-  type: time
-start_colortemp:
-  description: The color temperature at the start.
-  required: false
-  default: 4000
-  type: integer
-sunset_colortemp:
-  description: The sun set color temperature.
-  required: false
-  default: 3000
-  type: integer
-stop_colortemp:
-  description: The color temperature at the end.
-  required: false
-  default: 1900
-  type: integer
-brightness:
-  description: The brightness of the lights.
-  required: false
-  type: integer
-disable_brightness_adjust:
-  description: If true, brightness will not be adjusted besides color temperature.
+  description: An entity to toggle disabling adaptive lighting.
   required: false
   type: boolean
-  default: false
-mode:
-  description: Select how color temperature is passed to lights. Valid values are `xy`, `mired` and `rgb`.
+disable_state:
+  description: The state of the entity to disable adaptive lighting.
   required: false
-  default: xy
-  type: string
+  type: [list, string]
+initial_transition:
+  description: How long the first transition is.
+  required: false
+  default: 1
+  type: time
 transition:
-  description: Transition time in seconds for the light changes (high values may not be supported by all light models).
+  description: How long the transition is when the lights change, in seconds.
   required: false
-  default: 30
+  default: 60
   type: integer
-interval:
-  description: Frequency in seconds at which the lights should be updated.
+max_brightness:
+  description: The maximum percent of brightness to set the lights to.
   required: false
-  default: 30
+  default: 100
   type: integer
+max_color_temp:
+  description: The warmest color temperature to set the lights to.
+  required: false
+  default: 5500
+  type: integer
+min_brightness:
+  description: The minimum percent of brightness to set the lights to.
+  required: false
+  default: 1
+  type: integer
+min_color_temp:
+  description: The coldest color temperature to set the lights to.
+  required: false
+  default: 2500
+  type: integer
+only_once:
+  description: Whether to keep adjusting the lights, or to only adjust the lights as soon as they're turned on.
+  required: false
+  default: false
+  type: boolean
 {% endconfiguration %}
 
 Full example:
@@ -112,3 +113,11 @@ switch:
     transition: 30
     interval: 60
 ```
+
+### Services
+
+You can call `adaptive_lighting.apply` to manually adjust a light.
+
+| Service data attribute    | Optional | Description                                           |
+|---------------------------|----------|-------------------------------------------------------|
+| `entity_id`               |      yes | Only act on specific vacuum. Use `entity_id: all` to target all.        |


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds documentation for `adaptive_lighting`.

Builds on top of the great work done by @KTibow in https://github.com/home-assistant/home-assistant.io/pull/14877 (see commits here).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/40626
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
