### PR TITLE
Yaml configuration no longer supported for SPC

### DIFF
--- a/source/_integrations/spc.markdown
+++ b/source/_integrations/spc.markdown
@@ -19,25 +19,10 @@ There is currently support for the following device types within Home Assistant:
 - [Alarm](#alarm)
 - [Binary Sensor](#binary-sensor)
 
-Home Assistant needs to know where to find the SPC Web Gateway API endpoints, to configure this add the following section to your `configuration.yaml` file:
+Home Assistant needs to know where to find the SPC Web Gateway API endpoints, this is configured when you add the integration. The following information needs to be provided:
 
-```yaml
-# Example configuration.yaml entry
-spc:
-  api_url: API_URL
-  ws_url: WS_URL
-```
-
-{% configuration %}
-api_url:
-  description: URL of the SPC Web Gateway command REST API, e.g., `http://<ip>:8088`.
-  required: true
-  type: string
-ws_url:
-  description: URL of the SPC Web Gateway websocket, e.g., `ws://<ip>:8088/ws/spc`.
-  required: true
-  type: string
-{% endconfiguration %}
+- URL for the SPC Web Gateway REST API, e.g., `http://<IP>:8088`.
+- URL for the SPC Web Gateway websocket endpoint, e.g., `ws://<IP>:8088/ws/spc`.
 
 
 ## Alarm


### PR DESCRIPTION
## Proposed change
The SPC integration is being updated to use config flow for configuration and YAML config will no longer be supported.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/41906

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
