### PR TITLE
More detail on /local/ regarding media

### DIFF
--- a/source/_integrations/media_source.markdown
+++ b/source/_integrations/media_source.markdown
@@ -25,6 +25,8 @@ media_source:
 ## Local Media
 
 By default, the integration by default looks for media in a specified folder.
+If other `media_dirs` are not declared you need to use `/media/local` path for 
+example in companion app notification.
 
 For Home Assistant OS, Supervised and Container users, this folder is by default
 configured in the path `/media`.

--- a/source/_integrations/media_source.markdown
+++ b/source/_integrations/media_source.markdown
@@ -39,8 +39,7 @@ If you are a Home Assistant Core user, the default directory called is called
 `media` under the configuration path (where your `configuration.yaml` is located).
 
 Files served from `media` are protected by Home Assistant authentication
-unlike those served from `www`. If other `media_dirs` are not declared you need
-to use `/media/local` path for example in companion app notification.
+unlike those served from `www`.
 
 ## Using custom or additional media folders
 

--- a/source/_integrations/media_source.markdown
+++ b/source/_integrations/media_source.markdown
@@ -37,7 +37,8 @@ If you are a Home Assistant Core user, the default directory called is called
 `media` under the configuration path (where your `configuration.yaml` is located).
 
 Files served from `media` are protected by Home Assistant authentication
-unlike those served from `www`.
+unlike those served from `www`. If other `media_dirs` are not declared you need
+to use `/media/local` path for example in companion app notification.
 
 ## Using custom or additional media folders
 


### PR DESCRIPTION
Information about HA translating '/media' to '/media/local' is not visible enough for someone who sees what path should be provided for in example app notifications.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Provide more information about /media/local path translation.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
