### PR TITLE
Changes 1-wire integration documentation to advise users to use owserver, . . . 

### DIFF
--- a/source/_integrations/onewire.markdown
+++ b/source/_integrations/onewire.markdown
@@ -88,13 +88,20 @@ The device IDs begin with `28-`.
 
 ## Interface adapter setup
 
-### owfs
-
-When an interface adapter is used, sensors can be accessed on Linux hosts via [owfs 1-Wire file system](https://owfs.org/). When using an interface adapter and the owfs, the `mount_dir` option must be configured to correspond to a directory, where owfs device tree has been mounted. On systems where Home Assistant runs in a Docker container. `owfs` cannot escape that environment and hence cannot populate the `mount_dir`. Use the owserver method on these systems instead.
-
 ### owserver
 
-When an interface adapter is used, you can also access sensors on a remote or local Linux host that is running owserver.  owserver by default runs on port 4304. Use the `host` option to specify the host or IP of the remote server, and the optional `port` option to change the port from the default.
+`owsever` on Linux hosts is part of the [owfs 1-Wire file system](https://owfs.org/). When a 1-wire interface adapter is used, you can access sensors on a remote or local Linux host that is running `owserver`. `owserver` by default runs on port 4304. Use the `host` option to specify the host or IP of the remote server, and the optional `port` option to change the port from the default.
+
+### owfs
+
+It is also possible to use `owfs`, the filesystem portion of the package, to access 1-wire sensors but not advised.
+The [owfs project pagen on Github](https://github.com/owfs/owfs) says:
+
+> Despite the project name, the owfs package itself is **NOT** recommended for any real use, it has well known issues with races etc.
+
+If you still choose to use `owfs`, the `mount_dir` option must be configured to correspond to a directory, where owfs device tree has been mounted. On systems where Home Assistant runs in a Docker container `owfs` cannot escape that environment and hence cannot populate the `mount_dir`. Use the `owserver` method on these systems instead.
+
+
 
 ## Configuration
 

--- a/source/_integrations/onewire.markdown
+++ b/source/_integrations/onewire.markdown
@@ -95,7 +95,7 @@ The device IDs begin with `28-`.
 ### owfs
 
 It is also possible to use `owfs`, the filesystem portion of the package, to access 1-wire sensors but not advised.
-The [owfs project pagen on Github](https://github.com/owfs/owfs) says:
+The [owfs project pagen on GitHub](https://github.com/owfs/owfs) says:
 
 > Despite the project name, the owfs package itself is **NOT** recommended for any real use, it has well known issues with races etc.
 

--- a/source/_integrations/onewire.markdown
+++ b/source/_integrations/onewire.markdown
@@ -92,9 +92,10 @@ The device IDs begin with `28-`.
 
 `owsever` on Linux hosts is part of the [owfs 1-Wire file system](https://owfs.org/). When a 1-wire interface adapter is used, you can access sensors on a remote or local Linux host that is running `owserver`. `owserver` by default runs on port 4304. Use the `host` option to specify the host or IP of the remote server, and the optional `port` option to change the port from the default.
 
-### owfs
+### owfs - (Soon to be depreciated)
 
-It is also possible to use `owfs`, the filesystem portion of the package, to access 1-wire sensors but not advised.
+It is also possible to use `owfs`, the filesystem portion of the package, to access 1-wire sensors but not advised as it will be depreciated in an upcoming release. See this [pull request](https://github.com/home-assistant/core/pull/42041) for more information.
+
 The [owfs project pagen on GitHub](https://github.com/owfs/owfs) says:
 
 > Despite the project name, the owfs package itself is **NOT** recommended for any real use, it has well known issues with races etc.

--- a/source/_integrations/onewire.markdown
+++ b/source/_integrations/onewire.markdown
@@ -96,7 +96,7 @@ The device IDs begin with `28-`.
 
 It is also possible to use `owfs`, the filesystem portion of the package, to access 1-wire sensors but not advised as it will be depreciated in an upcoming release. See this [pull request](https://github.com/home-assistant/core/pull/42041) for more information.
 
-The [owfs project pagen on GitHub](https://github.com/owfs/owfs) says:
+The [owfs project page on GitHub](https://github.com/owfs/owfs) says:
 
 > Despite the project name, the owfs package itself is **NOT** recommended for any real use, it has well known issues with races etc.
 

--- a/source/_integrations/onewire.markdown
+++ b/source/_integrations/onewire.markdown
@@ -92,9 +92,9 @@ The device IDs begin with `28-`.
 
 `owsever` on Linux hosts is part of the [owfs 1-Wire file system](https://owfs.org/). When a 1-wire interface adapter is used, you can access sensors on a remote or local Linux host that is running `owserver`. `owserver` by default runs on port 4304. Use the `host` option to specify the host or IP of the remote server, and the optional `port` option to change the port from the default.
 
-### owfs - (Soon to be depreciated)
+### owfs - (Soon to be deprecated)
 
-It is also possible to use `owfs`, the filesystem portion of the package, to access 1-wire sensors but not advised as it will be depreciated in an upcoming release. See this [pull request](https://github.com/home-assistant/core/pull/42041) for more information.
+It is also possible to use `owfs`, the filesystem portion of the package, to access 1-wire sensors but not advised as it will be deprecated in an upcoming release. See this [pull request](https://github.com/home-assistant/core/pull/42041) for more information.
 
 The [owfs project page on GitHub](https://github.com/owfs/owfs) says:
 


### PR DESCRIPTION
. . . not owfs as it has known issues and the owfs project advises against its use.

## Proposed change
Change 1-wire documentation to advise to user to use `owserver` not `owfs` to access 1-wire devices, as the [`owfs` project](https://github.com/owfs/owfs) advises to do this:

> Despite the project name, the owfs package itself is **NOT** recommended for any real use, it has well known issues with races etc.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
