### PR TITLE
Remove YAML documentation for RainMachine

### DIFF
--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -22,47 +22,10 @@ There is currently support for the following device types within Home Assistant:
 - Sensor
 - [Switch](#switch)
 
-## Base Configuration
+## Configuration
 
-To connect to your RainMachine device, add the following to your `configuration.yaml` file:
-
-```yaml
-rainmachine:
-  controllers:
-    - ip_address: 192.168.1.100
-      password: YOUR_PASSWORD
-```
-
-{% configuration %}
-ip_address:
-  description: The IP address or hostname of your RainMachine unit.
-  required: false
-  type: string
-password:
-  description: Your RainMachine password.
-  required: true
-  type: string
-port:
-  description: The TCP port used by your unit for the REST API.
-  required: false
-  type: integer
-  default: 8080
-ssl:
-  description: Whether communication with the local device should occur over HTTPS.
-  required: false
-  type: boolean
-  default: true
-scan_interval:
-  description: The frequency (in seconds) between data updates.
-  required: false
-  type: integer
-  default: 60
-zone_run_time:
-  description: The default number of seconds that a zone should run when turned on.
-  required: false
-  type: integer
-  default: 600
-{% endconfiguration %}
+This integration can be configured via the Home Assistant UI by navigating to
+**Configuration** -> **Integrations**.
 
 ## Services
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR removes YAML configuration information for RainMachine, which is being deprecated in https://github.com/home-assistant/core/pull/41971


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/41971
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
