### PR TITLE
updated garadget mqtt example to include value template

### DIFF
--- a/source/_integrations/garadget.markdown
+++ b/source/_integrations/garadget.markdown
@@ -134,4 +134,7 @@ cover:
     state_topic: "garadget/device_name/status"
     payload_open: "open"
     payload_close: "close"
+    value_template: "{{ value_json.status }}"
 ```
+
+Replace device_name with the name of the device provided when configuring garadget.


### PR DESCRIPTION
## Proposed change
Added minor additional information to the MQTT configuration that was required for MQTT and garadget integration to retrieve status properly.  


## Type of change

- [  ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [  ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [  ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [  ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [  ] Removed stale or deprecated documentation.

## Additional information

The status from garadget is returned in the payload formatted as JSON and in a field labeled "status". Adding the value template was required for Home Assistant to properly process the status returned from garadget. Updated the documentation to include that additional value in the configuration and a simple blurb indicating what the replacement value in the example was. 

## Checklist

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

