### PR TITLE
Add additional info to LaMetric notification docs

### DIFF
--- a/source/_integrations/lametric.markdown
+++ b/source/_integrations/lametric.markdown
@@ -69,27 +69,26 @@ lifetime:
   type: integer
   default: 10
 icon:
-  description: An icon or animation.
+  description: An icon or animation. List of all icons available at [https://developer.lametric.com/icons](https://developer.lametric.com/icons). Note that icons always begin with "i" while animations begin with "a". This is part of the name, you can't just use the number!
   required: false
   type: string
 cycles:
-  description: Defines how often the notification is displayed.
+  description: Defines how long the notification will be displayed. Set to 0 to require manual dismissal
   required: false
   type: integer
   default: 1
 priority:
-  description: Defines the priority of the notification.
+  description: Defines the priority of the notification. Allowed values are info, warning, and critical
   required: false
   type: string
   default: warning
 icon_type:
-  description: Defines the nature of notification.
+  description: Defines the nature of notification. Allowed values are none, info, and alert
   required: false
   type: string
   default: info
 {% endconfiguration %}
 
-Check out the list of all icons at [https://developer.lametric.com/icons](https://developer.lametric.com/icons). Note that icons always begin with "i" while animations begin with "a". This is part of the name, you can't just use the number!
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change
    LaMetric notification docs are missing the list of available options for data fields. I've added the available options based on the LaMetric api docs (https://lametric-documentation.readthedocs.io/en/latest/reference-docs/device-notifications.html) and made some minor wording changes for clarity


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
