### PR TITLE
Add to conditional card support for conditions operator

### DIFF
--- a/source/_lovelace/conditional.markdown
+++ b/source/_lovelace/conditional.markdown
@@ -22,6 +22,68 @@ conditions:
       required: true
       description: Home Assistant entity ID.
       type: string
+    operator:
+      required: true
+      description: Operator to use in the comparison. Can be `==`, `<=`, `<`, `>=`, `>`, `!=`, `in`, `not in`, or `regex`.
+      type: string
+    value:
+      required: true
+      description: Value which will be compared with the entity state.
+      type: string
+    attribute:
+      required: false
+      description: Attribute of the entity to use instead of the state.
+      type: string
+card:
+  required: true
+  description: Card to display if all conditions match.
+  type: map
+{% endconfiguration %}
+
+Note: Conditions with more than one entity are treated as an 'and' condition. This means that for the card to show, *all* entities must meet the state requirements set.
+Order is: result = entity.`state` `operator` `value`.
+
+## Examples
+
+```yaml
+type: conditional
+conditions:
+  - entity: sensor.elektromer_l1
+    operator: '<'
+    value: 100
+  - entity: light.bed_light
+    operator: '=='
+    value: "on"
+  - entity: switch.decorative_lights
+    operator: '!='
+    value: "off"
+card:
+  type: entities
+  entities:
+    - device_tracker.demo_paulus
+    - cover.kitchen_window
+    - group.kitchen
+    - lock.kitchen_door
+    - light.bed_light
+```
+
+
+### Deprecated configuration
+
+{% configuration %}
+type:
+  required: true
+  description: conditional
+  type: string
+conditions:
+  required: true
+  description: List of entity IDs and matching states.
+  type: list
+  keys:
+    entity:
+      required: true
+      description: HA entity ID.
+      type: string
     state:
       required: false
       description: Entity state is equal to this value.*
@@ -37,24 +99,3 @@ card:
 {% endconfiguration %}
 
 *one is required (`state` or `state_not`)
-
-Note: Conditions with more than one entity are treated as an 'and' condition. This means that for the card to show, *all* entities must meet the state requirements set.
-
-## Examples
-
-```yaml
-type: conditional
-conditions:
-  - entity: light.bed_light
-    state: "on"
-  - entity: switch.decorative_lights
-    state_not: "off"
-card:
-  type: entities
-  entities:
-    - device_tracker.demo_paulus
-    - cover.kitchen_window
-    - group.kitchen
-    - lock.kitchen_door
-    - light.bed_light
-```


### PR DESCRIPTION
Lovelace conditional card now supports conditions operators

operator '==' as equal
operator '!=' as not equal
operator '>' as greater
operator '<' as less
operator '>=' as greater or equal
operator '<=' as less or equal

UI editor is not supported now

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Lovelace conditional card supports only 'equal' or 'not equal', so this patch adds operator where user can specify operation.
UI editor is not supported.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/7381
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
