### PR TITLE
Fix URL documentation

### DIFF
--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -11,7 +11,7 @@ ha_codeowners:
 ---
 
 The `hyperion` platform allows you to integrate your
-[Hyperion](https://hyperion-project.org/wiki) into Home Assistant. Hyperion is
+[Hyperion](https://docs.hyperion-project.org/) into Home Assistant. Hyperion is
 an open source Ambilight implementation which runs on many platforms.
 
 NOTE: [Hyperion-NG](https://github.com/hyperion-project/hyperion.ng) is


### PR DESCRIPTION
## Proposed change
URL https://hyperion-project.org/wiki doesn't exist, now it's http://docs.hyperion-project.org/

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards