### PR TITLE
Updated omnilogic documentation for switch platform.

### DIFF
--- a/source/_integrations/omnilogic.markdown
+++ b/source/_integrations/omnilogic.markdown
@@ -3,21 +3,23 @@ title: Hayward OmniLogic
 description: Instructions on how to configure Hayward OmniLogic integration.
 ha_category:
   - Sensor
+  - Switch
 ha_release: 0.116
 ha_iot_class: Cloud Polling
 ha_config_flow: true
 ha_codeowners:
   - '@oliver84'
+  - '@djtimca'
+  - '@gentoosu'
 ha_domain: omnilogic
 ---
 
-OmniLogic by [Hayward](https://www.hayward-pool.com/shop/en/pools/omnilogic-i-auomni--1) 
-
-Elite automation for fully featured new pool and spas. OmniLogic® brings backyard control to the forefront of pool technology. Enjoy the luxuries of full automation from the most intuitive app with effortless upgrades to always keep your backyard on the cutting edge.
+[Hayward OmniLogic](https://www.hayward-pool.com/shop/en/pools/omnilogic-i-auomni--1) smart pool and spa technology control.
 
 There is currently support for the following device types within Home Assistant:
 
-- Sensor
+- ***Sensor*** - Air Temperature, Water Temperature, Variable Pump Speed, Chlorinator Setting, Salt Level, pH, and ORP
+- ***Switch*** - All relays, pumps (single, dual, variable speed), and relay-based lights.
 
 ## Configuration
 
@@ -25,7 +27,7 @@ Home Assistant offers Hayward OmniLogic integration through **Configuration** ->
 
 ## Known limitations
 
-- The platform only supports sensors at the initial release. Future releases will include light/switch/water heater for control of lights, pumps, relays and heaters.
+- The platform only supports sensors and switches at the current release. Future releases will include light/water heater for control of Colorlogic lights and pool heaters.
 
 ## Debugging integration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Added documentation for switch platform for the OmniLogic integration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/42116
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
