### PR TITLE
Add warning about impending switch off date.

### DIFF
--- a/source/_integrations/loopenergy.markdown
+++ b/source/_integrations/loopenergy.markdown
@@ -12,10 +12,9 @@ ha_codeowners:
 
 <div class='note warning'>
 
-Loop Energy have said that on November 13, 2020 they will [switch off the servers which this integration uses](https://email.loop.homes/action-required-how-to-claim-your-free-loop-upgrade-1). This integration will stop working then.
+Loop Energy has said that on November 13, 2020, they will [switch off the servers which this integration uses](https://email.loop.homes/action-required-how-to-claim-your-free-loop-upgrade-1). This integration will stop working then.
 
 </div>
-
 
 Integrate your [Loop Energy](https://www.your-loop.com/) meter information into Home Assistant. To use this sensor you need the client serial number and secret keys for your devices.
 

--- a/source/_integrations/loopenergy.markdown
+++ b/source/_integrations/loopenergy.markdown
@@ -10,6 +10,13 @@ ha_codeowners:
   - '@pavoni'
 ---
 
+<div class='note warning'>
+
+Loop Energy have said that on November 13, 2020 they will [switch off the servers which this integration uses](https://email.loop.homes/action-required-how-to-claim-your-free-loop-upgrade-1). This integration will stop working then.
+
+</div>
+
+
 Integrate your [Loop Energy](https://www.your-loop.com/) meter information into Home Assistant. To use this sensor you need the client serial number and secret keys for your devices.
 
 The library used to get the data isn't officially supported and the only way to get the keys is to log into loop energy's website and type a command into your browser console.


### PR DESCRIPTION
## Proposed change
Quick note at the top of the loopenergy plugin warning of the impending switch off of their legacy servers (the only ones which work with home assistant).


## Type of change
Small warning.
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
