### PR TITLE
Add Cover category to OpenGarage integration

### DIFF
--- a/source/_integrations/opengarage.markdown
+++ b/source/_integrations/opengarage.markdown
@@ -2,6 +2,7 @@
 title: OpenGarage
 description: Instructions on how to integrate OpenGarage.io covers within Home Assistant.
 ha_category:
+  - Cover
   - DIY
 ha_iot_class: Local Polling
 ha_release: 0.44


### PR DESCRIPTION
## Proposed change

This adds the "Cover" category to the OpenGarage integration. It creates a `cover` entity but currently is not included in this category of integrations.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
