### PR TITLE
Add more clear description of unit

### DIFF
--- a/source/_integrations/derivative.markdown
+++ b/source/_integrations/derivative.markdown
@@ -49,12 +49,12 @@ unit_prefix:
   default: None
   type: string
 unit_time:
-  description: SI unit of time of the derivative. Available units are s, min, h, d.
+  description: SI unit of time of the derivative. Available units are s, min, h, d. If this parameter is set, the attribute **unit_of_measurement** will be set like x/y where x is the unit of the sensor given via the **source** parameter and y is the value given here.
   required: false
   default: h
   type: string
 unit:
-  description: Unit of Measurement to be used for the derivative.
+  description: Unit of Measurement to be used for the derivative. This will overwrite the automatically set **unit_of_measurement** as explained above.
   required: false
   type: string
 time_window:
@@ -78,6 +78,6 @@ sensor:
     source: sensor.temperature
     name: Temperature change per hour
     round: 1
-    unit_time: h
+    unit_time: h # the resulting "unit_of_measurement" will be °C/h if the sensor.temperate has set °C as it's unit
     time_window: "00:30:00"  # we look at the change over the last half hour
 ```


### PR DESCRIPTION
it was not clear from this documentation how the unit of the derivative sensor is set if the "unit" parameter is not set. This PR should fix that

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
