### PR TITLE
Updated for new "list" action

### DIFF
--- a/source/lovelace/actions.markdown
+++ b/source/lovelace/actions.markdown
@@ -33,7 +33,7 @@ tap_action:
   keys:
     action:
       required: true
-      description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `url`, `none`)"
+      description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `url`, `list`, `none`)"
       type: string
       default: "`toggle`"
     navigation_path:
@@ -55,6 +55,11 @@ tap_action:
       required: false
       description: "Service data to include (e.g., `entity_id: media_player.bedroom`) when `action` defined as `call-service`"
       type: string
+      default: none
+    actions:
+      required: false
+      description: "List of actions that will be displayed to the user in a popup to chose from when `action` defined as `list`"
+      type: list
       default: none
     confirmation:
       required: false
@@ -80,7 +85,7 @@ hold_action:
   keys:
     action:
       required: true
-      description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `url`, `none`)"
+      description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `url`, `list`, `none`)"
       type: string
       default: "`more-info`"
     navigation_path:
@@ -103,6 +108,11 @@ hold_action:
       description: "Service data to include (e.g., `entity_id: media_player.bedroom`) when `action` defined as `call-service`"
       type: string
       default: none
+    actions:
+      required: false
+      description: "List of actions that will be displayed to the user in a popup to chose from when `action` defined as `list`"
+      type: list
+      default: none  
     confirmation:
       required: false
       description: "Present a confirmation dialog to confirm the action. See `confirmation` object below"
@@ -127,7 +137,7 @@ double_tap_action:
   keys:
     action:
       required: true
-      description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `url`, `none`)"
+      description: "Action to perform (`more-info`, `toggle`, `call-service`, `navigate`, `url`, `list`, `none`)"
       type: string
       default: "`more-info`"
     navigation_path:
@@ -149,6 +159,11 @@ double_tap_action:
       required: false
       description: "Service data to include (e.g., `entity_id: media_player.bedroom`) when `action` defined as `call-service`"
       type: string
+      default: none
+    actions:
+      required: false
+      description: "List of actions that will be displayed to the user in a popup to chose from when `action` defined as `list`"
+      type: list
       default: none
     confirmation:
       required: false
@@ -189,7 +204,7 @@ exemptions:
 {% configuration exemptions %}
 user:
   required: true
-  description: User id that can see the view tab. For each user´s id listed, the confirmation dialog will NOT be shown.
+  description: User ID that can see the view tab. For each user's ID listed, the confirmation dialog will NOT be shown.
   type: string
 {% endconfiguration %}
 


### PR DESCRIPTION
Update for @iantrich's new feature: https://github.com/home-assistant/frontend/pull/7464

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/7464
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
