### PR TITLE
Add configuration & capability to follow symbolic links in the http local www folder

### DIFF
--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -91,6 +91,11 @@ ssl_profile:
   required: false
   type: string
   default: modern
+follow_symlinks:
+  description: Follow symbolic links.
+  required: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 <div class='note'>
@@ -115,6 +120,7 @@ http:
     - 10.0.0.200
   ip_ban_enabled: true
   login_attempts_threshold: 5
+  follow_symlinks: false
 ```
 
 The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-using-lets-encrypt/) blog post gives you details about the encryption of your traffic using free certificates from [Let's Encrypt](https://letsencrypt.org/).
@@ -167,6 +173,10 @@ If you want to use Home Assistant to host or serve static files then create a di
   Files served from the `www`/`local` folder, aren't protected by the Home Assistant authentication. Files stored in this folder, if the URL is known, can be accessed by anybody without authentication.
 
 </div>
+
+### Symbolic Links
+
+If you use symbolic links in your `www/` folder, then you will need to set `follow_symlinks: True` in the configuration file.
 
 ## Binary Sensor
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
In the local `www` folders under the `http` integration, Linux symbolic links are not followed.
There is code in the integration to follow symbolic links, but no configuration in the code path to allow this.
This pull adds the relevant configuration option.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/42295
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://community.home-assistant.io/t/how-to-follow-symlink-in-www-folder/19646

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
