### PR TITLE
Symlink

### DIFF
--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -91,6 +91,11 @@ ssl_profile:
   required: false
   type: string
   default: modern
+follow_symlinks:
+  description: Follow symbolic links.
+  required: false
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 <div class='note'>
@@ -115,6 +120,7 @@ http:
     - 10.0.0.200
   ip_ban_enabled: true
   login_attempts_threshold: 5
+  follow_symlinks: false
 ```
 
 The [Set up encryption using Let's Encrypt](/blog/2015/12/13/setup-encryption-using-lets-encrypt/) blog post gives you details about the encryption of your traffic using free certificates from [Let's Encrypt](https://letsencrypt.org/).
@@ -167,6 +173,10 @@ If you want to use Home Assistant to host or serve static files then create a di
   Files served from the `www`/`local` folder, aren't protected by the Home Assistant authentication. Files stored in this folder, if the URL is known, can be accessed by anybody without authentication.
 
 </div>
+
+### Symbolic Links
+
+If you use symbolic links in your `www/` folder, then you will need to set `follow_symlinks: True` in the configuration file.
 
 ## Binary Sensor
 

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -47,7 +47,7 @@ The first use of a light or switch will try to register with your Lightwave WiFi
 # TRVs
 Lightwave Thermostatic Radiator Values (TRV) are supported but require an additional proxy to capture the current TRV temperature.
 See [LWProxy](https://github.com/ColinRobbins/Homeassistant-Lightwave-TRV)
-```
+```yaml
 # Example TRV configuration.yaml for TRVs
 lightwave:
   host: 192.168.1.2

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -10,7 +10,7 @@ ha_release: 0.84
 ha_iot_class: Assumed State
 ---
 
-The `lightwave` integration links Home Assistant with your Lightwave WiFi link for controlling Lightwave lights and switches.
+The `lightwave` integration links Home Assistant with your Lightwave WiFi link for controlling Lightwave lights, switches and TRVs.
 
 This integration uses the official API published by Lightwave on their website [https://api.lightwaverf.com/](https://api.lightwaverf.com/).
 To add your Lightwave devices into your Home Assistant installation, add the following to your `configuration.yaml` file:
@@ -44,7 +44,21 @@ Each `switch` or `light` requires an `id` and a `name`. The `id` takes the form 
 
 The first use of a light or switch will try to register with your Lightwave WiFi Link hub. If the hub has not been registered a message on your hub will be displayed asking you to pair the device. You have 12 seconds to push the button on your hub to accept this. Once done, you should be able to control your lights and switches via Home Assistant. This only needs to be done if the hub has not been registered.
 
-The Lightwave Home Assistant integration currently supports the following Lightwave devices:
+# TRVs
+Lightwave Thermostatic Radiator Values (TRV) are supported but require an additional proxy to capture the current TRV temperature.
+See [LWProxy](https://github.com/ColinRobbins/Homeassistant-Lightwave-TRV)
+```
+# Example TRV configuration.yaml for TRVs
+lightwave:
+  host: 192.168.1.2
+  trv_proxy_ip: 127.0.0.1       # Proxy address, do not change unless running on a different server
+  trv_proxy_port: 7878          # Do not change, unless a port clash
+  lights:
+    R99D1:
+      name: Bedroom Light
+  trv:
+    R1Dh:                       # The ID of the TRV.
+      name: Bedroom TRV
+      serial: E84902            # Serial number of the TRV - found in the Lightwave App, or web site
+```
 
-- Lightwave lights
-- Lightwave switches

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -42,14 +42,6 @@ host:
   description: IP address of your Lightwave hub
   required: true
   type: string
-trv_proxy_ip:
-  description: IP address of a proxy for TRV integration
-  required: false
-  type: string
-trv_proxy_port:
-  description: IP port address of a proxy for TRV integration
-  required: false
-  type: integer
 lights:
   description: List of lights you wish to configure
   required: false
@@ -69,18 +61,29 @@ switches:
       required: true
       type: string
 trv:
-  description: List of TRVs you wish to configure
-  required: false
-  type: map
-  keys: 
-    name: 
-      description: Name of the TRV
-      required: true
+    trv_proxy_ip:
+      description: IP address of a proxy for TRV integration. 
+      required: false
       type: string
-    serial: 
-      description: Serial Number of the TRV
-      required: true
-      type: string
+      default: "127.0.0.1"
+    trv_proxy_port:
+      description: IP port address of a proxy for TRV integration.
+      required: false
+      type: integer
+      default: 7878
+    trvs:
+      description: List of TRVs you wish to configure
+      required: false
+      type: map
+      keys: 
+        name: 
+          description: Name of the TRV
+          required: true
+          type: string
+        serial: 
+          description: Serial Number of the TRV
+          required: true
+          type: string
 {% endconfiguration %}
 
 
@@ -100,13 +103,14 @@ See [LWProxy](https://github.com/ColinRobbins/Homeassistant-Lightwave-TRV)
 # Example TRV configuration.yaml for TRVs
 lightwave:
   host: 192.168.1.2
-  trv_proxy_ip: 127.0.0.1       # Proxy address, do not change unless running on a different server
-  trv_proxy_port: 7878          # Do not change, unless a port clash
   lights:
     R99D1:
       name: Bedroom Light
   trv:
-    R1Dh:                       # The ID of the TRV.
-      name: Bedroom TRV
-      serial: E84902            # Serial number of the TRV - found in the Lightwave App, or web site
+      trv_proxy_ip: 127.0.0.1       # Proxy address, do not change unless running on a different server
+      trv_proxy_port: 7878          # Do not change, unless a port clash
+      trvs:
+        R1Dh:                       # The ID of the TRV.
+          name: Bedroom TRV
+          serial: E84902            # Serial number of the TRV - found in the Lightwave App, or web site
 ```

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -18,7 +18,7 @@ To add your Lightwave devices into your Home Assistant installation, add the fol
 ```yaml
 # Example configuration.yaml entry
 lightwave:
-  host: 192.168.1.2
+  host: IP_ADDRESS
   lights:
     R1D3:
       name: Wall lights
@@ -61,6 +61,10 @@ switches:
       required: true
       type: string
 trv:
+  description: PLEASE ADD A DESCRIPTION HERE :)
+  required: false
+  type: map
+  keys:
     trv_proxy_ip:
       description: IP address of a proxy for TRV integration. 
       required: false

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -45,8 +45,10 @@ Each `switch` or `light` requires an `id` and a `name`. The `id` takes the form 
 The first use of a light or switch will try to register with your Lightwave WiFi Link hub. If the hub has not been registered a message on your hub will be displayed asking you to pair the device. You have 12 seconds to push the button on your hub to accept this. Once done, you should be able to control your lights and switches via Home Assistant. This only needs to be done if the hub has not been registered.
 
 # TRVs
+
 Lightwave Thermostatic Radiator Values (TRV) are supported but require an additional proxy to capture the current TRV temperature.
 See [LWProxy](https://github.com/ColinRobbins/Homeassistant-Lightwave-TRV)
+
 ```yaml
 # Example TRV configuration.yaml for TRVs
 lightwave:
@@ -61,4 +63,3 @@ lightwave:
       name: Bedroom TRV
       serial: E84902            # Serial number of the TRV - found in the Lightwave App, or web site
 ```
-

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -49,19 +49,38 @@ trv_proxy_ip:
 trv_proxy_port:
   description: IP port address of a proxy for TRV integration
   required: false
-  type: number
+  type: integer
 lights:
   description: List of lights you wish to configure
   required: false
-  type: string
+  type: map
+  keys:
+    name:
+      description: Name of the Light
+      required: true
+      type: string
 switches:
   description: List of switches you wish to configure
   required: false
-  type: string
+  type: map
+  keys:
+    name:
+      description: Name of the Switch
+      required: true
+      type: string
 trv:
   description: List of TRVs you wish to configure
   required: false
-  type: string
+  type: map
+  keys: 
+    name: 
+      description: Name of the TRV
+      required: true
+      type: string
+    serial: 
+      description: Serial Number of the TRV
+      required: true
+      type: string
 {% endconfiguration %}
 
 

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -61,6 +61,8 @@ switches:
       required: true
       type: string
 trv:
+    description: TRV configuration
+    required: false
     trv_proxy_ip:
       description: IP address of a proxy for TRV integration. 
       required: false

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -91,7 +91,7 @@ trv:
 {% endconfiguration %}
 
 
-Where `192.168.1.2` is the IP address of your Lightwave hub.
+Where IP_ADDRESS is the IP address of your Lightwave hub.
 Each `switch` or `light` requires an `id` and a `name`. The `id` takes the form `R#D#` where `R#` is the room number and `D#` is the device number.
 
 `lights` and `switches` are optional but one of these must be present.
@@ -106,7 +106,7 @@ See [LWProxy](https://github.com/ColinRobbins/Homeassistant-Lightwave-TRV)
 ```yaml
 # Example TRV configuration.yaml for TRVs
 lightwave:
-  host: 192.168.1.2
+  host: IP_ADDRESS
   lights:
     R99D1:
       name: Bedroom Light

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -37,6 +37,34 @@ lightwave:
       name: Torch socket
 ```
 
+{% configuration %}
+host:
+  description: IP address of your Lightwave hub
+  required: true
+  type: string
+trv_proxy_ip:
+  description: IP address of a proxy for TRV integration
+  required: false
+  type: string
+trv_proxy_port:
+  description: IP port address of a proxy for TRV integration
+  required: false
+  type: number
+lights:
+  description: List of lights you wish to configure
+  required: false
+  type: string
+switches:
+  description: List of switches you wish to configure
+  required: false
+  type: string
+trv:
+  description: List of TRVs you wish to configure
+  required: false
+  type: string
+{% endconfiguration %}
+
+
 Where `192.168.1.2` is the IP address of your Lightwave hub.
 Each `switch` or `light` requires an `id` and a `name`. The `id` takes the form `R#D#` where `R#` is the room number and `D#` is the device number.
 

--- a/source/_integrations/somfy.markdown
+++ b/source/_integrations/somfy.markdown
@@ -47,7 +47,6 @@ It is possible to create your own developer account and configure Somfy via that
 somfy:
   client_id: CONSUMER_KEY
   client_secret: CONSUMER_SECRET
-  optimistic: False
 ```
 
 {% configuration %}
@@ -59,13 +58,7 @@ client_secret:
   description: Your Somfy consumer secret.
   required: true
   type: string
-optimistic:
-  description: Set optimistic mode.
-  required: false
-  type: boolean
 {% endconfiguration %}
-
-```optimistic``` mode should only be used when the integration is not able to gain information on whether a cover is open or closed.   It will attempt to track the status within HomeAssistant.  This mode should only be used if HomeAssistant is the only way you operate the blind.  If you also use the physcial remote control or the Somfy app, HomeAssistant will become out of sync.
 
 ### Potential duplicate with the Tahoma integration
 

--- a/source/_integrations/somfy.markdown
+++ b/source/_integrations/somfy.markdown
@@ -47,6 +47,7 @@ It is possible to create your own developer account and configure Somfy via that
 somfy:
   client_id: CONSUMER_KEY
   client_secret: CONSUMER_SECRET
+  optimistic: False
 ```
 
 {% configuration %}
@@ -58,7 +59,13 @@ client_secret:
   description: Your Somfy consumer secret.
   required: true
   type: string
+optimistic:
+  description: Set optimistic mode.
+  required: false
+  type: boolean
 {% endconfiguration %}
+
+```optimistic``` mode should only be used when the integration is not able to gain information on whether a cover is open or closed.   It will attempt to track the status within HomeAssistant.  This mode should only be used if HomeAssistant is the only way you operate the blind.  If you also use the physcial remote control or the Somfy app, HomeAssistant will become out of sync.
 
 ### Potential duplicate with the Tahoma integration
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
In the local `www` folders under the `http` integration, Linux symbolic links are not followed.
There is code in the integration to follow symbolic links, but no configuration in the code path to allow this.
This pull adds the relevant configuration option.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/42295
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: https://community.home-assistant.io/t/how-to-follow-symlink-in-www-folder/19646

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
