### PR TITLE
Nest SDM: subscription_id should be subscriber_id

### DIFF
--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -41,13 +41,13 @@ Quick Start Guide:
 - Register in the Device Access Console to get a `project_id`.
 - Authorize your Google Account and create OAuth credentials to get a `client_id` and `client_secret`.
 - Enable pubsub events in the Device Access Console (creates a topic).
-- Create a pull subscription to get a `subscription_id`.
+- Create a pull subscription to get a `subscriber_id` ("Subscription ID" in Google Cloud Console).
 
 Additionally, Home Assistant must be configured with a URL (e.g., external exposed [`http`](/integrations/http/), Nabu Casa, etc). When setting up the OAuth credentials, make sure the Home Assistant URL is in the list of *Authorized redirect URIs*, so the redirect back to Home Assistant can get an OAuth authorization code.
 
 Follow all of the instructions in [Device Access: Quick Start Guide](https://developers.google.com/nest/device-access/get-started) carefully as it is easy to make a configuration mistake that is difficult to debug. It is recommended to exercise the entire guide, including the command to test out the API, to make sure that it is working before configuring Home Assistant.
 
-It may be easiest to create a [Pub/Sub subscription](https://console.cloud.google.com/cloudpubsub/subscription/list) from the Google Cloud console. Make sure to use the *topic name* from the device access console and a unique subscription name. Note the message retention is how long messages will queue while offline, so keep that short (e.g., under an hour) to avoid a potentially large backlog of updates.
+It may be easiest to create a [Pub/Sub subscription](https://console.cloud.google.com/cloudpubsub/subscription/list) from the Google Cloud console. Make sure to use the *topic name* from the device access console and a unique subscription ID. Note the message retention is how long messages will queue while offline, so keep that short (e.g., under an hour) to avoid a potentially large backlog of updates.
 
 ## Works With Nest: Developer Account Setup (Legacy)
 
@@ -83,7 +83,7 @@ nest:
   client_secret: CLIENT_SECRET
   # Fields required by Device Access (SDM) API.  Otherwise, use legacy API.
   project_id: PROJECT_ID
-  subscriber_id: SUBSCRIBER_ID
+  subscriber_id: SUBSCRIBER_ID # ("Subscription ID" in Google Cloud Console)
 ```
 
 ```yaml
@@ -106,11 +106,11 @@ client_secret:
   required: true
   type: string
 project_id:
-  description: Your Device Access project_id. This enables the SDM API.
+  description: Your Device Access Project ID. This enables the SDM API.
   required: false
   type: string
-subscription_id:
-  description: Your Pub/sub subscription_id used to receive events. This is required to use the SDM API.
+subscriber_id:
+  description: Your Pub/sub Subscription ID used to receive events. This is required to use the SDM API.
   type: string
   required: false
 structure:


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I had some trouble setting up the new Nest integration because the configuration property is `subscriber_id` but the Nest site and Google Cloud Console say "Subscription ID" and in most places (but not all) the documentation said `subscription_id`. Hopefully this makes it clearer what the user is supposed to put in the configuration file.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

**Note**: This needs to target rc or next, not current, because the documentation being updated does not yet exist in current.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
