### PR TITLE
Add a tip on updating random templates

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -343,7 +343,9 @@ sensor:
 ### Updating templates using `random`
 
 If you use the `random` filter, you may want the template to select a different random element every now and then. If the template does not update automatically due to entity changes it can be updated periodically by using the `homeassistant.update_entity` service with a time pattern automation. For example, this will render a new random number every five minutes:
+
 {% raw %}
+
 ```yaml
 sensor:
   - platform: template
@@ -361,4 +363,5 @@ automation:
       - service: homeassistant.update_entity
         entity_id: sensor.random_number
 ```
+
 {% endraw %}

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -339,3 +339,26 @@ sensor:
 ```
 
 {% endraw %}
+
+### Updating templates using `random`
+
+If you use the `random` filter, you may want the template to select a different random element every now and then. If the template does not update automatically due to entity changes it can be updated periodically by using the `homeassistant.update_entity` service with a time pattern automation. For example, this will render a new random number every five minutes:
+{% raw %}
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      random_number:
+        friendly_name: "Random number"
+        value_template: "{{ range(0,100)|random }}"
+
+automation:
+  - alias: "Update random number template"
+    trigger:
+      - platform: time_pattern
+        minutes: "/5"
+    action:
+      - service: homeassistant.update_entity
+        entity_id: sensor.random_number
+```
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add a note on updating `random` templates now that the "Working without entities" sections are removed due to `now()` causing automatic updates.

Suggested by @frenck in https://github.com/home-assistant/home-assistant.io/pull/15360#discussion_r510827475

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
