### PR TITLE
Deprecate ptvsd integration

### DIFF
--- a/source/_integrations/ptvsd.markdown
+++ b/source/_integrations/ptvsd.markdown
@@ -9,6 +9,13 @@ ha_codeowners:
 ha_domain: ptvsd
 ---
 
+<div class="note warning">
+
+The PTVSD integration has been deprecated and will be removed in Home Assistant 0.120.0.
+A full-featured replacement is available, by using the [`debugpy` integration](/integrations/debugpy).
+
+</div>
+
 The `ptvsd` integration allows you to use the Visual Studio Code PTVSD debugger with Home Assistant.
 
 This is useful in testing changes on a local development install, or connecting to a production server to debug issues.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The ptvsd integration is been marked as deprecated and will be removed in Home Assistant Core 0.120.
A full-featured replacement is available with the debugpy integration, which is now considered stable.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/42351
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
