### PR TITLE
alarm_control_panel.alarm_trigger new delay param

### DIFF
--- a/source/_integrations/manual.markdown
+++ b/source/_integrations/manual.markdown
@@ -149,7 +149,7 @@ In the rest of this section, you find some real-life examples on how to use this
 
 ### Sensors
 
-Using sensors to trigger the alarm.
+Using sensors to trigger the alarm. In this example we will also show that you can override the delay time which is set in the configuration.yaml so doors will have 30 seconds delay even if the windows sensors will trigger it immediately.
 
 ```yaml
 automation:
@@ -164,9 +164,6 @@ automation:
     - platform: state
       entity_id: sensor.door
       to: 'open'
-    - platform: state
-      entity_id: sensor.window
-      to: 'open'
   condition:
     - condition: state
       entity_id: alarm_control_panel.ha_alarm
@@ -174,6 +171,8 @@ automation:
   action:
     service: alarm_control_panel.alarm_trigger
     entity_id: alarm_control_panel.ha_alarm
+    data:
+      delay: 30
 ```
 
 Sending a notification when the alarm is triggered.


### PR DESCRIPTION
This change document the change in PR: https://github.com/home-assistant/core/pull/41657/files .

## Proposed change
This change document the change in https://github.com/home-assistant/core/pull/41657 . We will now support delay param in alarm_control_panel.alarm_trigger service so users can have different delay for windows and doors for example.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
https://github.com/home-assistant/core/pull/41657

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
