### PR TITLE
Add docs for the new Kuler Sky integration

### DIFF
--- a/source/_integrations/kulersky.markdown
+++ b/source/_integrations/kulersky.markdown
@@ -1,0 +1,46 @@
+---
+title: Kuler Sky
+description: Instructions for integrating Brightech Kuler Sky Bluetooth floor lamps with Home Assistant.
+ha_category:
+  - Light
+ha_iot_class: Local Polling
+ha_release: '0.118'
+ha_domain: kulersky
+ha_codeowners:
+  - '@emlove'
+ha_config_flow: true
+---
+
+This integration connects Brightech Kuler Sky floor lamps to Home Assistant.
+
+## Configuration
+
+This integration can be configured using the integrations page in Home Assistant.
+
+Menu: **Configuration** -> **Integrations**.
+
+Click on the `+` sign to add an integration and search for **Kuler Sky**.
+
+The integration will scan for nearby Bluetooth devices, and ask you to select your lamp.
+
+## Additional information for Home Assistant Core on Python environments
+
+This integration requires `pybluez` to be installed. On Debian based installs, run:
+
+```bash
+sudo apt install bluetooth
+```
+
+Before you get started with this integration, please note that:
+
+- Requires access to the Bluetooth stack, see [Rootless Setup section](#rootless-setup) for further information
+
+## Rootless Setup
+
+Normally accessing the Bluetooth stack is reserved for `root`, but running programs that are networked as `root` is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 and `hcitool` the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](https://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
+
+```bash
+sudo apt-get install libcap2-bin
+sudo setcap 'cap_net_raw,cap_net_admin+eip' `readlink -f \`which python3\``
+sudo setcap 'cap_net_raw+ep' `readlink -f \`which hcitool\``
+```

--- a/source/_integrations/kulersky.markdown
+++ b/source/_integrations/kulersky.markdown
@@ -4,7 +4,7 @@ description: Instructions for integrating Brightech Kuler Sky Bluetooth floor la
 ha_category:
   - Light
 ha_iot_class: Local Polling
-ha_release: '0.118'
+ha_release: '1.0.0'
 ha_domain: kulersky
 ha_codeowners:
   - '@emlove'


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds docs for the new Kuler Sky integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/42372
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/1973
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
