### PR TITLE
Problem with '' in the API

### DIFF
--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -93,7 +93,7 @@ sensor:
     password: YOUR_PASSWORD
     search: FROM <sender@email.com>, SUBJECT <subject here>
     # Or use X-GM-RAW search-term like this, to find unread emails from the last 7 days in your inbox
-    # search: "X-GM-RAW 'in: inbox newer_than:7d is:unread'"
+    # search: "X-GM-RAW \"in: inbox newer_than:7d is:unread\""
 
 # Example configuration.yaml entry for Office 365
 sensor:

--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -93,7 +93,7 @@ sensor:
     password: YOUR_PASSWORD
     search: FROM <sender@email.com>, SUBJECT <subject here>
     # Or use X-GM-RAW search-term like this, to find unread emails from the last 7 days in your inbox
-    # search: "X-GM-RAW \"in: inbox newer_than:7d is:unread\""
+    # search: 'X-GM-RAW "in: inbox newer_than:7d is:unread"'
 
 # Example configuration.yaml entry for Office 365
 sensor:


### PR DESCRIPTION
## Proposed change
Google don't like the ' in the XGM_RAW statement, so we need to use " instead. 

But I'm not sure, if we should to with \", not that the official documentation ask us to use `" ... 'something' ..."` instead of `'... "something"...'`  - So what do you think?


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
