### PR TITLE
Update Docs - webOS Required Port for segmented Networks

### DIFF
--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -239,3 +239,7 @@ automation:
         data:
           icon: "/home/homeassistant/images/doorbell.png"
 ```
+
+## Notes
+
+- If Home Assistant and your TV are not on the same subnet, you need to open Port 3000 with Protocol TCP from Home Assistant to your TV.

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -242,4 +242,4 @@ automation:
 
 ## Notes
 
-- If Home Assistant and your TV are not on the same network, you need to create a Firewall Rule, which allows a Connection on Port 3000 with Protocol TCP from Home Assistant to your TV.
+If Home Assistant and your TV are not on the same network, you need to create a firewall rule, which allows a connection on port 3000 with the TCP protocol from Home Assistant to your TV.

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -242,4 +242,4 @@ automation:
 
 ## Notes
 
-- If Home Assistant and your TV are not on the same subnet, you need to open Port 3000 with Protocol TCP from Home Assistant to your TV.
+- If Home Assistant and your TV are not on the same network, you need to create a Firewall Rule, which allows a Connection on Port 3000 with Protocol TCP from Home Assistant to your TV.


### PR DESCRIPTION
Verified with a LG OLED C9 TV in a segmented network.
I always appreciate knowing which Ports need to be opened. Hopefully others will to.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
