### PR TITLE
Added KP105 smart plug as supported Kasa device

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -37,6 +37,7 @@ Plugs are type `switch` when autodiscovery has been disabled.
 - HS103
 - HS105
 - HS110 (This device is capable of reporting energy usage data to template sensors)
+- KP105
 
 ### Strip (Multi-Plug)
 


### PR DESCRIPTION
Added KP105 smart plug to list of supported Kasa devices. I have tested the device with my local setup - it’s working perfectly and I think that information is helpful for other users. 