### PR TITLE
Update emulated_hue.markdown

### DIFF
--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -156,6 +156,13 @@ You can verify that the `emulated_hue` integration has been loaded and is respon
 
 Verify that the URLs above are using port 80, rather than port 8300 (i.e., `http://<HA IP Address>:80/description.xml`). Both Google Home and Amazon Alexa/Echo (as of the 2019-08 firmware) require port 80.
 
+In builds 0.115 and forward `input_boolean` entities may no longer be discovered respond as expected by Alexa. To work around this issue add 
+
+```yaml
+  lights_all_dimmable: true
+```
+to the `emulated_hue` configuration.
+
 ### Platform specific instructions
 
 #### Home Assistant Core

--- a/source/_integrations/emulated_hue.markdown
+++ b/source/_integrations/emulated_hue.markdown
@@ -156,7 +156,7 @@ You can verify that the `emulated_hue` integration has been loaded and is respon
 
 Verify that the URLs above are using port 80, rather than port 8300 (i.e., `http://<HA IP Address>:80/description.xml`). Both Google Home and Amazon Alexa/Echo (as of the 2019-08 firmware) require port 80.
 
-In builds 0.115 and forward `input_boolean` entities may no longer be discovered respond as expected by Alexa. To work around this issue add 
+`input_boolean` entities may sometimes have trouble being discovered/responding as expected by Alexa. To work around this issue add 
 
 ```yaml
   lights_all_dimmable: true


### PR DESCRIPTION
Emulated_hue discovery for input_boolean stopped working for at least some scenarios in 0.115 and still does not work in 0.118. This workaround description will unblock users of the emulated hue component for input_boolean entities.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
