### PR TITLE
Add link to Home Assistant Cloud Service

### DIFF
--- a/source/_integrations/xbox.markdown
+++ b/source/_integrations/xbox.markdown
@@ -16,7 +16,7 @@ ha_config_flow: true
 
 The Xbox integration allows you to control Xbox One (or newer) consoles from Home Assistant.
 
-Home Assistant authenticates with Xbox Live through OAuth2 using the [Home Assistant Cloud account linking service](https://www.home-assistant.io/integrations/cloud/). Set up the integration through **Configuration -> Integrations -> Xbox**. Ensure you login using the Microsoft account that is linked to your Xbox consoles.
+Home Assistant authenticates with Xbox Live through OAuth2 using the [Home Assistant Cloud account linking service](/integrations/cloud/). Set up the integration through **Configuration -> Integrations -> Xbox**. Ensure you login using the Microsoft account that is linked to your Xbox consoles.
 
 - [Media Player](#media-player)
   - [Service `play_media`](#service-play_media)

--- a/source/_integrations/xbox.markdown
+++ b/source/_integrations/xbox.markdown
@@ -16,7 +16,7 @@ ha_config_flow: true
 
 The Xbox integration allows you to control Xbox One (or newer) consoles from Home Assistant.
 
-Home Assistant authenticates with Xbox Live through OAuth2 using the Home Assistant Cloud account linking service. Set up the integration through **Configuration -> Integrations -> Xbox**. Ensure you login using the Microsoft account that is linked to your Xbox consoles.
+Home Assistant authenticates with Xbox Live through OAuth2 using the [Home Assistant Cloud account linking service](https://www.home-assistant.io/integrations/cloud/). Set up the integration through **Configuration -> Integrations -> Xbox**. Ensure you login using the Microsoft account that is linked to your Xbox consoles.
 
 - [Media Player](#media-player)
   - [Service `play_media`](#service-play_media)


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Several people have struggled with this integration because they did not have cloud service enabled. Added a link to the Cloud Service documentation to make it clear it needs to be enabled, and how to enable it.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: n/a
- Link to parent pull request in the Brands repository: n/a
- This PR fixes or closes issue: n/a

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
