### PR TITLE
Emphasize that upc_connect works in Hungary too

### DIFF
--- a/source/_integrations/upc_connect.markdown
+++ b/source/_integrations/upc_connect.markdown
@@ -11,7 +11,7 @@ ha_domain: upc_connect
 ha_iot_class: Local Polling
 ---
 
-The `upc_connect` platform offers presence detection by looking at connected devices to a [Connect Box](https://www.upc.ch/en/internet/learn-about-internet/) from [Liberty Global](https://www.libertyglobal.com) (also known as UPC Cablecom in Switzerland) which is an Internet provider in Switzerland, Austria and the Netherlands (under Ziggo).
+The `upc_connect` platform offers presence detection by looking at connected devices to a [Connect Box](https://www.upc.ch/en/internet/learn-about-internet/) from [Liberty Global](https://www.libertyglobal.com) (also known as UPC Cablecom in Switzerland) which is an Internet provider in Switzerland, Austria, the Netherlands (under Ziggo) and Hungary (under Vodafone).
 
 <div class='note'>
 This integration works by logging into the router with a password. The router can only have one active session at any time, so if you want to access your router settings then stop Home Assistant first.
@@ -44,4 +44,4 @@ Also known to be working with the following devices:
  - Irish Virgin Media Super Hub 3.0
  - Unitymedia Connect Box (DE)
  - Ziggo Connectbox (NL)
- - Compal CH7465LG ED 3.0 - Connect box (UPC / Vodafone CZ)
+ - Compal CH7465LG ED 3.0 - Connect box (UPC / Vodafone CZ / Vodafone HU)


### PR DESCRIPTION
## Proposed change
The [upc_connect](https://www.home-assistant.io/integrations/upc_connect/) also works with Compal CH7465LG device in Hungary

## Additional information
Vodafone Hungary bought UPC Hungary


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
 - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
