### PR TITLE
Add MQTT Scenes Docs

### DIFF
--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -117,18 +117,16 @@ switch:
     retain: true
 ```
 
-### Use with Zigbee2MQTT Scenes
+### Use with a JSON Payload
 
-Assuming you have [Zigbee2MQTT Scenes](https://www.zigbee2mqtt.io/information/scenes.html) configured, you can use the following configuration as an example:
+The example below shows a configuration using a JSON payload.
 
-{% raw %}
 ```yaml
 # Example configuration.yaml entry
 scene:
   - platform: mqtt
     name: Living Room Blue Scene
     unique_id: living_room_blue_scene
-    command_topic: zigbee2mqtt/living_room_group/set
-    payload_on: '{"scene_recall": 1}'
+    command_topic: "home/living_room/set"
+    payload_on: '{"activate_scene": "Blue Scene"}'
 ```
-{% endraw %}

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -1,0 +1,134 @@
+---
+title: "MQTT Scene"
+description: "Instructions on how to integrate MQTT scenes into Home Assistant."
+ha_category:
+  - Scene
+ha_release: 0.118
+ha_iot_class: Configurable
+ha_domain: mqtt
+---
+
+The `mqtt` scene platform lets you control your MQTT enabled scenes.
+
+## Configuration
+
+To enable a MQTT scene in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+scene:
+  - platform: mqtt
+    command_topic: zigbee2mqtt/living_room_group/set
+```
+
+{% configuration %}
+availability:
+  description: A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with `availability_topic`.
+  required: false
+  type: list
+  keys:
+    payload_available:
+      description: The payload that represents the available state.
+      required: false
+      type: string
+      default: online
+    payload_not_available:
+      description: The payload that represents the unavailable state.
+      required: false
+      type: string
+      default: offline
+    topic:
+      description: An MQTT topic subscribed to receive availability (online/offline) updates.
+      required: true
+      type: string
+availability_topic:
+  description: The MQTT topic subscribed to receive availability (online/offline) updates. Must not be used together with `availability`.
+  required: false
+  type: string
+command_topic:
+  description: The MQTT topic to publish commands to change the switch state.
+  required: false
+  type: string
+icon:
+  description: Icon for the switch.
+  required: false
+  type: icon
+name:
+  description: The name to use when displaying this switch.
+  required: false
+  type: string
+  default: MQTT Switch
+payload_available:
+  description: The payload that represents the available state.
+  required: false
+  type: string
+  default: online
+payload_not_available:
+  description: The payload that represents the unavailable state.
+  required: false
+  type: string
+  default: offline
+payload_on:
+  description: The payload that represents `on` state. If specified, will be used for both comparing to the value in the `state_topic` (see `value_template` and `state_on`  for details) and sending as `on` command to the `command_topic`.
+  required: false
+  type: string
+  default: "ON"
+qos:
+  description: The maximum QoS level of the state topic. Default is 0 and will also be used to publishing messages.
+  required: false
+  type: integer
+  default: 0
+retain:
+  description: If the published message should have the retain flag on or not.
+  required: false
+  type: boolean
+  default: false
+unique_id:
+  description: An ID that uniquely identifies this switch device. If two switches have the same unique ID, Home Assistant will raise an exception.
+  required: false
+  type: string
+{% endconfiguration %}
+
+<div class='note warning'>
+
+Make sure that your topic matches exactly. `some-topic/` and `some-topic` are different topics.
+
+</div>
+
+## Examples
+
+In this section, you will find some real-life examples of how to use this sensor.
+
+### Full configuration
+
+The example below shows a full configuration for a switch.
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: mqtt
+    unique_id: living_room_party_scene
+    name: "Living Room Party Scene"
+    command_topic: "home/living_room/party_scene/set"
+    availability:
+      - topic: "home/living_room/party_scene/available"
+    payload_on: "ON"
+    qos: 0
+    retain: true
+```
+
+### Use with Zigbee2MQTT Scenes
+
+Assuming you have [Zigbee2MQTT Scenes](https://www.zigbee2mqtt.io/information/scenes.html) configured, you can use the following configuration as an example:
+
+{% raw %}
+```yaml
+# Example configuration.yaml entry
+scene:
+  - platform: mqtt
+    name: Living Room Blue Scene
+    unique_id: living_room_blue_scene
+    command_topic: zigbee2mqtt/living_room_group/set
+    payload_on: '{"scene_recall": 1}'
+```
+{% endraw %}

--- a/source/_integrations/scene.mqtt.markdown
+++ b/source/_integrations/scene.mqtt.markdown
@@ -3,7 +3,7 @@ title: "MQTT Scene"
 description: "Instructions on how to integrate MQTT scenes into Home Assistant."
 ha_category:
   - Scene
-ha_release: 0.118
+ha_release: 0.119
 ha_iot_class: Configurable
 ha_domain: mqtt
 ---


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adding documentation for MQTT Scenes - See https://github.com/home-assistant/core/pull/42639

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/42639
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
