### PR TITLE
Update bluetooth_le_tracker.markdown

### DIFF
--- a/source/_integrations/bluetooth_le_tracker.markdown
+++ b/source/_integrations/bluetooth_le_tracker.markdown
@@ -65,8 +65,8 @@ Normally accessing the Bluetooth stack is reserved for root, but running program
 
 ```bash
 sudo apt-get install libcap2-bin
-sudo setcap 'cap_net_raw,cap_net_admin+eip' `readlink -f \`which python3\``
-sudo setcap 'cap_net_raw+ep' `readlink -f \`which hcitool\``
+sudo setcap 'cap_net_raw,cap_net_admin+eip' $(readlink -f $(which python3))
+sudo setcap 'cap_net_raw+ep' $(readlink -f $(which hcitool))
 ```
 
 A restart of Home Assistant is required.


### PR DESCRIPTION
Use POSIX supported `$()` instead of backticks for shell command.

## Proposed change
Instead of legacy backticks use $() in the documentation



## Type of change
- [X] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
