### PR TITLE
Clarify Ruckus unleashed readme: "router" -> "access point"

### DIFF
--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -15,7 +15,7 @@ This platform allows you to connect to a [Ruckus Unleashed](https://support.ruck
 
 There is currently support for the following device types within Home Assistant:
 
-- **Presence Detection** - The platform will look at devices connected to the router and will create a `device_tracker` for each discovered device.
+- **Presence Detection** - The platform will look at devices connected to the access point and will create a `device_tracker` for each discovered device.
 
 ## Configuration
 

--- a/source/_integrations/ruckus_unleashed.markdown
+++ b/source/_integrations/ruckus_unleashed.markdown
@@ -11,7 +11,7 @@ ha_codeowners:
 ha_domain: ruckus_unleashed
 ---
 
-This platform allows you to connect to a [Ruckus Unleashed](https://support.ruckuswireless.com/product_families/19-ruckus-unleashed) router.
+This platform allows you to connect to a [Ruckus Unleashed](https://support.ruckuswireless.com/product_families/19-ruckus-unleashed) access point.
 
 There is currently support for the following device types within Home Assistant:
 


### PR DESCRIPTION
## Proposed change

A simple change to the readme to clarify that ruckus unleashed is for access points, not routers.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

'Unleashed' is a firmware for ruckus access points that allows people to run them without central management hardware (the 'director'). 

## Checklist

- [ x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
