### PR TITLE
Added "OS" in the title

### DIFF
--- a/source/hassio/index.markdown
+++ b/source/hassio/index.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Home Assistant"
+title: "Home Assistant OS"
 description: "Manage your Home Assistant and custom add-ons."
 ---
 


### PR DESCRIPTION
This page title is not clear so i have added the "OS" specification because the links on this page are speaking about the os installation version