### PR TITLE
Updated the installation icon link

### DIFF
--- a/source/docs/index.markdown
+++ b/source/docs/index.markdown
@@ -6,7 +6,7 @@ description: "Documentation for Home Assistant"
 The documentation covers beginner to advanced topics around the installation, setup, configuration, and usage of Home Assistant.
 
 <div class="text-center hass-option-cards" markdown="0">
-  <a class='option-card' href='/hassio/'>
+  <a class='option-card' href='/docs/installation/'>
     <div class='img-container'>
       <img src='https://brands.home-assistant.io/homeassistant/icon.png' />
     </div>


### PR DESCRIPTION
i have changed the link on this icon because it is sending to the "os" version of home-assistant so it can be confusing people using the menu on the right that is speaking about all the versions :)