### PR TITLE
Update Z-Wave documentation OpenZWave 1.6

### DIFF
--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -5,8 +5,8 @@ description: "Using Z-Wave with Home Assistant."
 
 Home Assistant currently offers two Z-Wave integrations. 
 
-1. [Z-Wave](https://www.home-assistant.io/integrations/zwave/) based on OpenZWave 1.4 (EOL)
-2. [OpenZWave (Beta)](https://www.home-assistant.io/integrations/ozw/) based on OpenZWave 1.6
+1. [Z-Wave](https://www.home-assistant.io/integrations/zwave/) based on "OpenZWave 1.4 (EOL)"
+2. [OpenZWave (Beta)](https://www.home-assistant.io/integrations/ozw/) based on "OpenZWave 1.6"
 
 <div class='note'>
   

--- a/source/_docs/z-wave.markdown
+++ b/source/_docs/z-wave.markdown
@@ -3,6 +3,17 @@ title: "Z-Wave"
 description: "Using Z-Wave with Home Assistant."
 ---
 
+Home Assistant currently offers two Z-Wave integrations. 
+
+1. [Z-Wave](https://www.home-assistant.io/integrations/zwave/) based on OpenZWave 1.4 (EOL)
+2. [OpenZWave (Beta)](https://www.home-assistant.io/integrations/ozw/) based on OpenZWave 1.6
+
+<div class='note'>
+  
+OpenZWave 1.4 is end-of-life. This means it is no longer maintained and your devices might not be supported. The [OpenZWave (Beta)](https://www.home-assistant.io/integrations/ozw/) integration will replace the [Z-Wave](https://www.home-assistant.io/integrations/zwave/) integration.
+ 
+ </div>
+
 [Z-Wave](https://www.z-wave.com/) integration for Home Assistant allows you to observe and control connected Z-Wave devices. Z-Wave support requires a [supported Z-Wave USB stick or module](/docs/z-wave/controllers/) to be plugged into the host.
 
 There is currently support for climate, covers, lights, locks, sensors, switches, and thermostats. All will be picked up automatically after configuring this platform.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Informing users that there are two z-wave integrations available. While also noting that OpenZWave 1.4 is EOL. And that the new integration is based on OpenZWave 1.6

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
