### PR TITLE
Integrate folders from network storage for media

### DIFF
--- a/source/more-info/local-media/setup-media.markdown
+++ b/source/more-info/local-media/setup-media.markdown
@@ -74,4 +74,43 @@ homeassistant:
     recording: /mnt/recordings
 ```
 
+## Using network shares as custom media folder
+
+This approach creates a local folder which is used as moutpoint for a folder on a network storage. 
+To trigger Homeassistant to mount the folder an automation is created which runs at startup and calls a shell command. 
+
+This example adds one shared network folder to  Home Assistant:
+
+```yaml
+# Example configuration.yaml
+homeassistant:
+  # check this - media_dirs might not be needed if default_config: is used
+  media_dirs:
+    media: /media
+    
+automations:
+  # this automation can easily be created in Settings->Automations
+- id: '1604432883902'
+  alias: Automount media from NAS
+  description: 'Automount media from NAS'
+  trigger:
+  - platform: homeassistant
+    event: start
+  condition: []
+  action:
+  - delay: 00:10
+  - service: shell_command.mount_smbmedia_folder
+    data: {}
+  mode: single
+
+shell_command:
+  mount_smbmedia_folder:
+    # 1. the mount point (/mnt/nasmp3) is created
+    # 2. the net share (//NAS/Volume/MP3) is mounted
+    # 3. a link to a folder in the media folder (/media/nasmp3) refers to the mounted directory
+    # ATTENTION - this approach exposes your user and password in your configuration file.
+    mkdir -p /mnt/nasmp3; mount -t cifs -o username=YOURUSER,password=YOURPASSWORD,domain=YOURDOMAIN //NAS/Volume/MP3 /mnt/nasmp3 ;ln -s /mnt/nasmp3 /media/nasmp3
+
+```
+
 [basic-configuration]: /docs/configuration/basic/#media_dirs


### PR DESCRIPTION
This is based on disussions in several threads in the forum. 
https://community.home-assistant.io/t/mount-remote-smb-share-on-hassio/116734/69
https://community.home-assistant.io/t/point-media-dirs-at-nas-share/227698/4
was the easiest functional version for me. 
Main drawback is that the password is used in the shell command, 
Are there better solutions?
Shall the links to the forum be added to the documentation?

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Mounting external sources for the media player is a feature which is often requested, since people usualy have already dedicated folders for their media.
Documentation was extended based on forum discussions and own tests.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->
Just extended the documentation, but I'm not sure if that kind of workaround is ok to be in the main documentation!?

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
