### PR TITLE
Updated Inovelli Scene Capable switch instructions

### DIFF
--- a/source/_docs/z-wave/device-specific.markdown
+++ b/source/_docs/z-wave/device-specific.markdown
@@ -177,7 +177,7 @@ To provide Central Scene support you need to **stop your Z-Wave network** and mo
 
 ### Inovelli Scene Capable On/Off and Dimmer Wall Switches
 
-For Inovelli switches, you'll need to update (or possibly add) the `COMMAND_CLASS_CENTRAL_SCENE` for each node in your `zwcfg` file with the following:
+For Inovelli switches, you'll need to update (or possibly add) the `COMMAND_CLASS_CENTRAL_SCENE` for each node in your `zwcfg_*.xml` file with the following:
 
 ```xml
       <CommandClass id="91" name="COMMAND_CLASS_CENTRAL_SCENE" version="1" request_flags="4" innif="true" scenecount="0">
@@ -188,18 +188,13 @@ For Inovelli switches, you'll need to update (or possibly add) the `COMMAND_CLAS
       </CommandClass>
 ```
 
-Once this is complete, you should see the follow `zwave.scene_activated` events:
+For Inovelli LZW30-SN and LZW31-SN switches with a third button for configuration, you'll need to add a third scene for that under the COMMAND_CLASS_CENTRAL_SCENE CommandClass:
 
-**Action**|**scene\_id**|**scene\_data**
-:-----:|:-----:|:-----:
-Double tap off|1|3
-Double tap on|2|3
-Triple tap off|1|4
-Triple tap on|2|4
-4x tap off|1|5
-4x tap on|2|5
-5x tap off|1|6
-5x tap on|2|6
+```xml
+        <Value type="int" genre="user" instance="1" index="3" label="Config Button Scene" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
+```
+
+Once this is complete, `zwave.scene_activated` events will fire according to which button press you perform. For information on what button press corresponds to what scene_id and scene_data in the event, see [Inovelli Knowledge Base > How To: Setting Up Scenes In Home Assistant](https://support.inovelli.com/portal/en/kb/articles/how-to-setting-up-scenes-in-home-assistant).
 
 ### Zooz Scene Capable On/Off and Dimmer Wall Switches (Zen21v3 & Zen22v2 - Firmware 3.0+, Zen26 & Zen27 - Firmware 2.0+, Zen30 Double Switch)
 


### PR DESCRIPTION
## Proposed change
Added Central Scene configuration instructions for Inovelli LZW30-SN and LZW31-SN switches that have a third "config" button, based on instructions found in the forums that I have also verified. ( https://community.home-assistant.io/t/how-can-i-get-inovelli-central-scene-support/170527/2 )

Removed the scene_activated event tables from this page and linked to the Inovelli documentation for setting up scenes in Home Assistant instead, as the existing table's scene_data values were incorrect. The Inovelli documentation contains the correct values.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
