### PR TITLE
Add object logging services for investigating memory leaks

### DIFF
--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -50,3 +50,25 @@ The `hpy` file can be viewed with any text editor. A visual representation can b
 from guppy import hpy
 hpy().pb()
 ```
+
+### Service `profiler.start_log_objects`
+
+Start logging the growth of objects in memory.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `scan_interval` | yes | The the frequency between logging objects. Defaults to 30.0
+
+Periodically log the growth of new objects in memory. This service's primary use case is finding memory leaks.
+
+### Service `profiler.stop_log_objects`
+
+Stop logging the growth of objects in memory.
+
+### Service `profiler.dump_log_objects`
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `type` | no | The type of object to dump to the log.
+
+When `start_log_objects` highlights the growth of a collection of objects in memory, this service can help investigate. The `repr` of each object that matches `type` will be logged.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add object logging services for investigating memory leaks.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/42951
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
