### PR TITLE
Clarity edit for BLE tracker

### DIFF
--- a/source/_integrations/bluetooth_le_tracker.markdown
+++ b/source/_integrations/bluetooth_le_tracker.markdown
@@ -12,7 +12,11 @@ This tracker discovers new devices on boot and in regular intervals and tracks B
 
 Devices discovered are stored with 'BLE_' as the prefix for device mac addresses in `known_devices.yaml`.
 
+## Setup
+
 This platform requires pybluez to be installed, which is already the case if you're using Home Assistant OS, Supervised or Container. For Home Assistant Core installs see below on the required steps.
+
+## Configuration
 
 To use the Bluetooth tracker in your installation, add the following to your `configuration.yaml` file:
 
@@ -54,7 +58,7 @@ For additional configuration variables check the [Device tracker page](/integrat
 
 ## Home Assistant Core installs
 
-On Debian based Home Assistant Core installs, run
+On Debian based Home Assistant Core installations, run:
 
 ```bash
 sudo apt install bluetooth

--- a/source/_integrations/bluetooth_le_tracker.markdown
+++ b/source/_integrations/bluetooth_le_tracker.markdown
@@ -12,16 +12,7 @@ This tracker discovers new devices on boot and in regular intervals and tracks B
 
 Devices discovered are stored with 'BLE_' as the prefix for device mac addresses in `known_devices.yaml`.
 
-This platform requires pybluez to be installed. On Debian based installs, run
-
-```bash
-sudo apt install bluetooth
-```
-
-Before you get started with this platform, please note that:
-
- - This platform is incompatible with Windows
- - This platform requires access to the Bluetooth stack, see [Rootless Setup section](#rootless-setup) for further information
+This platform requires pybluez to be installed, which is already the case if you're using Home Assistant OS, Supervised or Container. For Home Assistant Core installs see below on the required steps.
 
 To use the Bluetooth tracker in your installation, add the following to your `configuration.yaml` file:
 
@@ -59,7 +50,22 @@ Some BTLE devices (e.g., fitness trackers) are only visible to the devices that 
 
 Enabling the battery tracking might slightly decrease the duration of the battery, but since this is only done at most once a day, this shouldn't be noticeable. Not all devices offer battery status information; if the information is not available, the integration will only try once at startup.
 
-## Rootless Setup
+For additional configuration variables check the [Device tracker page](/integrations/device_tracker/).
+
+## Home Assistant Core installs
+
+On Debian based Home Assistant Core installs, run
+
+```bash
+sudo apt install bluetooth
+```
+
+Before you get started with this platform, please note that:
+
+ - This platform is incompatible with Windows
+ - This platform requires access to the Bluetooth stack, see [Rootless Setup section](#rootless-setup) for further information
+
+### Rootless Setup on Core installs
 
 Normally accessing the Bluetooth stack is reserved for root, but running programs that are networked as root is a bad security wise. To allow non-root access to the Bluetooth stack we can give Python 3 and hcitool the missing capabilities to access the Bluetooth stack. Quite like setting the setuid bit (see [Stack Exchange](https://unix.stackexchange.com/questions/96106/bluetooth-le-scan-as-non-root) for more information).
 
@@ -70,5 +76,3 @@ sudo setcap 'cap_net_raw+ep' $(readlink -f $(which hcitool))
 ```
 
 A restart of Home Assistant is required.
-
-For additional configuration variables check the [Device tracker page](/integrations/device_tracker/).


### PR DESCRIPTION

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The wording at the start confuses everybody who _doesn't_ use the Core install. Given those are the exceptions, not the default, rewording the start and moving the Core steps to the end. If/when this is approved I'll do a similar edit to the BT tracker docs.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
