### PR TITLE
Update examples

### DIFF
--- a/source/_docs/automation/examples.markdown
+++ b/source/_docs/automation/examples.markdown
@@ -18,18 +18,14 @@ automation:
       - platform: sun
         event: sunset
         offset: '-01:00:00'
-      - platform: state
-        entity_id: all
-        to: 'home'
     condition:
       # Prefix the first line of each condition configuration
       # with a '-'' to enter multiple
-      - condition: state
-        entity_id: all
-        state: 'home'
       - condition: time
         after: '16:00:00'
         before: '23:00:00'
+      - condition: template
+          value_template: '{{ states.person | selectattr(''state'',''=='',''home'') | list | count > 0 }}'
     action:
       # With a single service call, we don't need a '-' before service - though you can if you want to
       service: homeassistant.turn_on
@@ -38,9 +34,8 @@ automation:
 # Turn off lights when everybody leaves the house
   - alias: 'Rule 2 - Away Mode'
     trigger:
-      platform: state
-      entity_id: all
-      to: 'not_home'
+    - platform: template
+      value_template: '{{ states.person | selectattr(''state'',''=='',''home'') | list | count == 0 }}'
     action:
       service: light.turn_off
       entity_id: all
@@ -51,7 +46,7 @@ automation:
       platform: zone
       event: leave
       zone: zone.home
-      entity_id: device_tracker.paulus
+      entity_id: person.paulus
     condition:
       condition: time
       after: '20:00'


### PR DESCRIPTION
Removes `entity: all` under `states:` platform and replaces these with template platform and a value_template
Swap device_tracker for person

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #15595

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
