### PR TITLE
Add support for multiple tags and devices in tag trigger

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -340,8 +340,6 @@ automation:
 Additionally, you can also only trigger if a card is scanned by a specific
 device/scanner by setting the `device_id`:
 
-{% raw %}
-
 ```yaml
 automation:
   trigger:
@@ -350,7 +348,17 @@ automation:
     device_id: 0e19cd3cf2b311ea88f469a7512c307d
 ```
 
-{% endraw %}
+Or trigger on multiple possible devices:
+
+```yaml
+automation:
+  trigger:
+    platform: tag
+    tag_id: A7-6B-90-5F
+    device_id:
+      - 0e19cd3cf2b311ea88f469a7512c307d
+      - d0609cb25f4a13922bb27d8f86e4c821
+```
 
 ### Template trigger
 

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -319,8 +319,6 @@ A very thorough explanation of this is available in the Wikipedia article about 
 Fires when a [tag](/integrations/tag) is scanned. For example, a NFC tag is
 scanned using the Home Assistant Companion mobile application.
 
-{% raw %}
-
 ```yaml
 automation:
   trigger:
@@ -328,7 +326,16 @@ automation:
     tag_id: A7-6B-90-5F
 ```
 
-{% endraw %}
+Or trigger on multiple possible tags:
+
+```yaml
+automation:
+  trigger:
+    platform: tag
+    tag_id:
+      - A7-6B-90-5F
+      - A7-6B-15-AC
+```
 
 Additionally, you can also only trigger if a card is scanned by a specific
 device/scanner by setting the `device_id`:

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -326,17 +326,6 @@ automation:
     tag_id: A7-6B-90-5F
 ```
 
-Or trigger on multiple possible tags:
-
-```yaml
-automation:
-  trigger:
-    platform: tag
-    tag_id:
-      - A7-6B-90-5F
-      - A7-6B-15-AC
-```
-
 Additionally, you can also only trigger if a card is scanned by a specific
 device/scanner by setting the `device_id`:
 
@@ -348,13 +337,15 @@ automation:
     device_id: 0e19cd3cf2b311ea88f469a7512c307d
 ```
 
-Or trigger on multiple possible devices:
+Or trigger on multiple possible devices for multiple tags:
 
 ```yaml
 automation:
   trigger:
     platform: tag
-    tag_id: A7-6B-90-5F
+    tag_id:
+      - A7-6B-90-5F
+      - A7-6B-15-AC
     device_id:
       - 0e19cd3cf2b311ea88f469a7512c307d
       - d0609cb25f4a13922bb27d8f86e4c821


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Currently, defining tags in automation triggers can be daunting if you want to respond to multiple specific tags or multiple devices (requires duplication of triggers).

This PR removes that by allowing to specify multiple tag IDs and multiple device IDs in a single trigger.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43098
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
