### PR TITLE
Update pi_hole.markdown

### DIFF
--- a/source/_integrations/pi_hole.markdown
+++ b/source/_integrations/pi_hole.markdown
@@ -99,9 +99,13 @@ pi_hole:
 
 ## Services
 
-The platform provides the following services to interact with your Pi-hole. Use switch entities when calling the services.
+The platform provides the following services to interact with your Pi-hole. If you're planning to use the switch-entity, remember to add your Pi-hole **API key**. Use the switch entitiy, when calling the service.
 
-_Note: Switch entity requires `api_key` to be configured._
+<div class='note'>
+
+The switch-entity wil **only** be created, if the `api_key` is defined in your configuration. If you accidentally initiated the Pi-hole integration without the `api_key`, make sure to remove the Pi-hole integration in "Configuration" > "Integrations", followed by adding `api_key` to the `pi_hole`-config in `configuration.yaml`. Restart Home Assistant, and you're good to go.
+
+</div>
 
 ### Service `pi_hole.disable`
 


### PR DESCRIPTION
## Proposed change
If Pi-hole is initiated without api_key, and the user tries to add it here after nothing happens. The user needs to remove the integration in "Configuration" > "Integrations", add the `api_key` and restart HA.

Adding about that that part.


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
