### PR TITLE
easy mDNS forwarding in Docker Compose

### DIFF
--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -147,3 +147,31 @@ If this is not possible, it's necessary to:
 
 - Enable mDNS forwarding between the subnets.
 - Enable source NAT to make requests from Home Assistant to the Chromecast appear to come from the same subnet as the Chromecast.
+
+#### Easy docker-compose for mDNS forwording
+```yaml
+version: '3'
+services:
+  home-assistant:
+    # your home assistant configuration
+    # without
+    # network_mode: host
+    # but with
+    ports:
+     - "8123:8123" # webgui
+    networks:
+     - default
+
+  mdns-repeater:
+    image: monstrenyatko/mdns-repeater
+    container_name: mdns-repeater
+    restart: unless-stopped
+    command: mdns-repeater-app -f <INTERFACENAME> homeassistant
+    network_mode: "host"
+
+networks:
+  default:
+    driver_opts:
+      com.docker.network.bridge.name: homeassistant
+```
+The `<INTERFACENAME>` for example `eth0` or `wlan0`.


### PR DESCRIPTION
Just a tiny extention to the readme for the chromecast module.
I strugeld to find a solution for my homeassistant within traefik as reverse proxy because that maks it nessesary to get rid of the
`network_mode: host` entry.
In the internet I found some forum entrys with the same problem but no solution.
This mDNS forwarding is a nice solution for the problem, that mDNS is just working in the same network, but docker is in its own network.

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.



- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
