### PR TITLE
Include station ID's in vasttrafik integration

### DIFF
--- a/source/_integrations/vasttrafik.markdown
+++ b/source/_integrations/vasttrafik.markdown
@@ -23,29 +23,6 @@ sensor:
     departures:
       - from: Musikvägen
 ```
-It is also possible to use the fullname of the station for the from/heading values, e.g. Musikvägen, Göteborg.
-
-In cases where the wrong station is being selected (see [34851](https://github.com/home-assistant/core/issues/34851)), it is possible to provide the station ID instead. To do this you first need to retrieve the station ID either via Västtrafik's [API-konsole](https://developer.vasttrafik.se/portal/#/api/Reseplaneraren/v2/landerss) or with curl.
-To retrieve the ID using curl:
-1. Login to the Västtrafik API and go to "Hantera nycklar" next to the application your created for Home Assistant.
-2. Make a copy of your AccessToken and execute the following curl command, replacing "<ACCESS_TOKEN>" and "<STATION_NAME>" as necessary:
-```shell
-curl -H "Authorization: Bearer <ACCESS_TOKEN>" "https://api.vasttrafik.se/bin/rest.exe/v2/location.name?input=<STATION_NAME>&format=json
-```
-3. In the output locate the key called "StopLocation", and under this key you will find a list of stops. Copy the ID for your desired stop and use it in your configuration.
-
-```yaml
-# Example configuration.yaml entry using station ID as departure and station name as destination
-sensor:
-  - platform: vasttrafik
-    key: YOUR_API_KEY
-    secret: YOUR_API_SECRET
-    departures:
-      - name: To the Iron Square \o/
-        from: 9021014004870000
-        heading: Järntorget
-        delay: 0
-```
 
 {% configuration %}
 key:
@@ -102,4 +79,34 @@ sensor:
           - 7
           - GRÖN
         delay: 10
+```
+
+## Solving incorrect selected station problems
+
+It is possible to use the full name of the station for the from/heading values, e.g., Musikvägen, Göteborg.
+
+In cases where the wrong station is being selected, it is possible to provide the station ID instead. To do this you first need to retrieve the station ID either via Västtrafik's [API-konsole](https://developer.vasttrafik.se/portal/#/api/Reseplaneraren/v2/landerss) or with `curl`.
+
+To retrieve the ID using curl:
+
+1. Login to the Västtrafik API and go to "Hantera nycklar" next to the application your created for Home Assistant.
+2. Make a copy of your AccessToken and execute the following curl command, replacing "<ACCESS_TOKEN>" and "<STATION_NAME>" as necessary:
+
+   ```shell
+   curl -H "Authorization: Bearer <ACCESS_TOKEN>" "https://api.vasttrafik.se/bin/rest.exe/v2/location.name?input=<STATION_NAME>&format=json
+   ```
+
+3. In the output locate the key called "StopLocation", and under this key you will find a list of stops. Copy the ID for your desired stop and use it in your configuration.
+
+```yaml
+# Example configuration.yaml entry using station ID as departure and station name as destination
+sensor:
+  - platform: vasttrafik
+    key: YOUR_API_KEY
+    secret: YOUR_API_SECRET
+    departures:
+      - name: To the Iron Square \o/
+        from: 9021014004870000
+        heading: Järntorget
+        delay: 0
 ```

--- a/source/_integrations/vasttrafik.markdown
+++ b/source/_integrations/vasttrafik.markdown
@@ -23,6 +23,27 @@ sensor:
     departures:
       - from: Musikvägen
 ```
+In cases where the wrong station is being selected (see [34851](https://github.com/home-assistant/core/issues/34851)), it is possible to provide the station ID instead. To do this you first need to retrieve the station ID either via Västtrafik's [API-konsole](https://developer.vasttrafik.se/portal/#/api/Reseplaneraren/v2/landerss) or with curl.
+To retrieve the ID using curl:
+1. Login to the Västtrafik API and go to "Hantera nycklar" next to the application your created for Home Assistant.
+2. Make a copy of your AccessToken and execute the following curl command, replacing "<Access_Token>" and "<STATION_NAME>" as necessary:
+```
+curl -H "Authorization: Bearer <Access_Token>" "https://api.vasttrafik.se/bin/rest.exe/v2/location.name?input=<STATION_NAME>&format=json
+```
+3. In the output locate the key called "StopLocation", and under this key you will find a list of stops. Copy the ID for your desired stop and use it in your configuration.
+
+```yaml
+# Example configuration.yaml entry using station ID as departure and station name as destination
+sensor:
+  - platform: vasttrafik
+    key: YOUR_API_KEY
+    secret: YOUR_API_SECRET
+    departures:
+      - name: To the Iron Square \o/
+        from: 9021014004870000
+        heading: Järntorget
+        delay: 0
+```
 
 {% configuration %}
 key:

--- a/source/_integrations/vasttrafik.markdown
+++ b/source/_integrations/vasttrafik.markdown
@@ -87,16 +87,16 @@ It is possible to use the full name of the station for the from/heading values, 
 
 In cases where the wrong station is being selected, it is possible to provide the station ID instead. To do this you first need to retrieve the station ID either via Västtrafik's [API-konsole](https://developer.vasttrafik.se/portal/#/api/Reseplaneraren/v2/landerss) or with `curl`.
 
-To retrieve the ID using curl:
+To retrieve the ID using `curl`:
 
-1. Login to the Västtrafik API and go to "Hantera nycklar" next to the application your created for Home Assistant.
-2. Make a copy of your AccessToken and execute the following curl command, replacing "<ACCESS_TOKEN>" and "<STATION_NAME>" as necessary:
+1. Login into the Västtrafik API and go to "Hantera nycklar" next to the application you created for Home Assistant.
+2. Make a copy of your AccessToken and execute the following `curl` command, replacing "<ACCESS_TOKEN>" and "<STATION_NAME>" as necessary:
 
    ```shell
    curl -H "Authorization: Bearer <ACCESS_TOKEN>" "https://api.vasttrafik.se/bin/rest.exe/v2/location.name?input=<STATION_NAME>&format=json
    ```
 
-3. In the output locate the key called "StopLocation", and under this key you will find a list of stops. Copy the ID for your desired stop and use it in your configuration.
+3. In the output locate the key called "StopLocation", and under this key, you will find a list of stops. Copy the ID for your desired stop and use it in your configuration.
 
 ```yaml
 # Example configuration.yaml entry using station ID as departure and station name as destination

--- a/source/_integrations/vasttrafik.markdown
+++ b/source/_integrations/vasttrafik.markdown
@@ -23,12 +23,14 @@ sensor:
     departures:
       - from: Musikvägen
 ```
+It is also possible to use the fullname of the station for the from/heading values, e.g. Musikvägen, Göteborg.
+
 In cases where the wrong station is being selected (see [34851](https://github.com/home-assistant/core/issues/34851)), it is possible to provide the station ID instead. To do this you first need to retrieve the station ID either via Västtrafik's [API-konsole](https://developer.vasttrafik.se/portal/#/api/Reseplaneraren/v2/landerss) or with curl.
 To retrieve the ID using curl:
 1. Login to the Västtrafik API and go to "Hantera nycklar" next to the application your created for Home Assistant.
-2. Make a copy of your AccessToken and execute the following curl command, replacing "<Access_Token>" and "<STATION_NAME>" as necessary:
+2. Make a copy of your AccessToken and execute the following curl command, replacing "<ACCESS_TOKEN>" and "<STATION_NAME>" as necessary:
 ```
-curl -H "Authorization: Bearer <Access_Token>" "https://api.vasttrafik.se/bin/rest.exe/v2/location.name?input=<STATION_NAME>&format=json
+curl -H "Authorization: Bearer <ACCESS_TOKEN>" "https://api.vasttrafik.se/bin/rest.exe/v2/location.name?input=<STATION_NAME>&format=json
 ```
 3. In the output locate the key called "StopLocation", and under this key you will find a list of stops. Copy the ID for your desired stop and use it in your configuration.
 
@@ -64,11 +66,11 @@ departures:
       required: false
       type: string
     from:
-      description: The start station.
+      description: The start station name or ID.
       required: true
       type: string
     heading:
-      description: Direction of the traveling.
+      description: The destination station name or ID.
       required: false
       type: string
     lines:

--- a/source/_integrations/vasttrafik.markdown
+++ b/source/_integrations/vasttrafik.markdown
@@ -29,7 +29,7 @@ In cases where the wrong station is being selected (see [34851](https://github.c
 To retrieve the ID using curl:
 1. Login to the Västtrafik API and go to "Hantera nycklar" next to the application your created for Home Assistant.
 2. Make a copy of your AccessToken and execute the following curl command, replacing "<ACCESS_TOKEN>" and "<STATION_NAME>" as necessary:
-```
+```shell
 curl -H "Authorization: Bearer <ACCESS_TOKEN>" "https://api.vasttrafik.se/bin/rest.exe/v2/location.name?input=<STATION_NAME>&format=json
 ```
 3. In the output locate the key called "StopLocation", and under this key you will find a list of stops. Copy the ID for your desired stop and use it in your configuration.


### PR DESCRIPTION
Update to include instructions on how to retrieve and use station ID's as the from/heading values. PR #43136

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Currently in the vasttrafik integration it is only possible to provide the departure/destination names in the configuration. When this is sent to the Västtrafik API it will respond with the station of the highest weight (most popular), which is not always the correct one. This change allows for the user to instead provide the station ID in the configuration, which ensures the correct station will be selected. This change still allows the user to provide the station name if they wish. In order to utilize this functionality the documentation for this integration needs to be updated so the user knows how to retrieve the station ID. This PR is for that.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [43136](https://github.com/home-assistant/core/pull/43136)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: [34851](https://github.com/home-assistant/core/issues/34851)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
