### PR TITLE
Add above,below,attribute to conditional card

### DIFF
--- a/source/_lovelace/conditional.markdown
+++ b/source/_lovelace/conditional.markdown
@@ -6,7 +6,7 @@ description: The Conditional card displays another card based on entity states.
 
 The Conditional card displays another card based on entity states.
 
-To add the Conditional card to your user interface, click the Lovelace menu (three dots at the top right of the screen) and then **Edit Dashboard**. Click the plus button in the bottom right corner and select **Conditional** from the card picker. All options for this card can be configured via the user interface.
+To add the Conditional card to your user interface, click the Lovelace menu (three dots at the top right of the screen) and then **Edit Dashboard**. Click the plus button in the bottom right corner and select **Conditional** from the card picker. Options `attribute`, `above`, `below` for this card, cannot be configured via the user interface.
 
 {% configuration %}
 type:
@@ -22,6 +22,10 @@ conditions:
       required: true
       description: Home Assistant entity ID.
       type: string
+    attribute:
+      required: false
+      description: Attribute of the entity to use instead of the state.
+      type: string
     state:
       required: false
       description: Entity state is equal to this value.*
@@ -30,13 +34,21 @@ conditions:
       required: false
       description: Entity state is unequal to this value.*
       type: string
+    above:
+      required: false
+      description: Entity state is above this value.*
+      type: any
+    below:
+      required: false
+      description: Entity state is below this value.*
+      type: any
 card:
   required: true
   description: Card to display if all conditions match.
   type: map
 {% endconfiguration %}
 
-*one is required (`state` or `state_not`)
+*one is required (`state` or `state_not` or `above` or `below`)
 
 Note: Conditions with more than one entity are treated as an 'and' condition. This means that for the card to show, *all* entities must meet the state requirements set.
 
@@ -49,6 +61,10 @@ conditions:
     state: "on"
   - entity: switch.decorative_lights
     state_not: "off"
+  - entity: sun.sun
+    attribute: "elevation"
+    above: 10
+    below: 80
 card:
   type: entities
   entities:


### PR DESCRIPTION
## Proposed change
Lovelace conditional card supports only 'equal' or 'not equal', so this patch adds also above, below conditions.
Also add support for attribute, inspired by filter card.
UI editor is not supported.

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/7688
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
