### PR TITLE
Fix & improve documentation for Garadget integration variables

### DIFF
--- a/source/_integrations/garadget.markdown
+++ b/source/_integrations/garadget.markdown
@@ -37,29 +37,28 @@ covers:
   description: List of your doors.
   required: true
   type: list
-  covers:
-      keys:
-        device:
-          description: This is the device id from your Garadget portal.
-          required: true
-          type: string
-        username:
-          description: Your Garadget account username.
-          required: true
-          type: string
-        password:
-          description: Your Garadget account password.
-          required: true
-          type: string
-        access_token:
-          description: A generated `access_token` from your Garadget account.
-          required: true
-          type: string
-        name:
-          description: me to use in the frontend, will use name configured in Garadget otherwise.
-          required: false
-          default: Garadget
-          type: string
+  keys:
+    device:
+      description: This is the device id from your Garadget portal.
+      required: true
+      type: string
+    username:
+      description: Your Garadget account username.
+      required: true
+      type: string
+    password:
+      description: Your Garadget account password.
+      required: true
+      type: string
+    access_token:
+      description: A generated `access_token` from your Garadget account.
+      required: true
+      type: string
+    name:
+      description: me to use in the frontend, will use name configured in Garadget otherwise.
+      required: false
+      default: Garadget
+      type: string
 {% endconfiguration %}
 
 If provided, the **access_token** will be used, otherwise the **username** and **password** will be used to automatically generate an access token at start time.

--- a/source/_integrations/garadget.markdown
+++ b/source/_integrations/garadget.markdown
@@ -43,16 +43,16 @@ covers:
       required: true
       type: string
     username:
-      description: Your Garadget account username.
-      required: true
+      description: Your Garadget account username. Use with `password` to obtain the `access_token` automatically.
+      required: false
       type: string
     password:
-      description: Your Garadget account password.
-      required: true
+      description: Your Garadget account password. Use with `username` to obtain the `access_token` automatically.
+      required: false
       type: string
     access_token:
-      description: A generated `access_token` from your Garadget account.
-      required: true
+      description: A generated `access_token` from your Garadget account. To obtain an `access_token`, use the network tab of the developer tools for your web browser while logged into the Garadget website. When supplied, the `username` and `password` values are not required.
+      required: false
       type: string
     name:
       description: Name to use in the frontend, will use name configured in Garadget otherwise.
@@ -60,8 +60,6 @@ covers:
       default: Garadget
       type: string
 {% endconfiguration %}
-
-If provided, the **access_token** will be used, otherwise the **username** and **password** will be used to automatically generate an access token at start time.
 
 ## Example
 

--- a/source/_integrations/garadget.markdown
+++ b/source/_integrations/garadget.markdown
@@ -55,7 +55,7 @@ covers:
       required: true
       type: string
     name:
-      description: me to use in the frontend, will use name configured in Garadget otherwise.
+      description: Name to use in the frontend, will use name configured in Garadget otherwise.
       required: false
       default: Garadget
       type: string

--- a/source/_integrations/garadget.markdown
+++ b/source/_integrations/garadget.markdown
@@ -39,7 +39,7 @@ covers:
   type: list
   keys:
     device:
-      description: This is the device id from your Garadget portal.
+      description: This is the device id from your Garadget portal. It can be found in the Settings section of the Garadget website or mobile application.
       required: true
       type: string
     username:


### PR DESCRIPTION
## Proposed change
Fix & improve documentation for Garadget integration variables

A syntax issue was preventing a portion of the configuration variables from displaying correctly in the generated documentation, which I verified through a local build.

In addition to that, I made some minor improvements to documentation of the variables.

## Type of change
- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
