### PR TITLE
Add details on new config options for retry attempt for tplink integration

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -77,6 +77,16 @@ discovery:
   required: false
   type: boolean
   default: true
+retry_max_attempts:
+  description: Maximum number of retry attempts to contact unavailable devices.
+  required: false
+  type: integer
+  default: 300
+retry_delay:
+  description: Number of seconds between retry attempts.
+  required: false
+  type: integer
+  default: 2
 light:
   description: List of light devices.
   required: false
@@ -121,6 +131,8 @@ dimmer:
 # Example configuration.yaml entry with manually specified addresses
 tplink:
   discovery: false
+  retry_max_attempts: 5
+  retry_delay: 1
   light:
     - host: 192.168.200.1
     - host: 192.168.200.2


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR is to add documentation to support new configuration options being proposed for allowing users to specify the max retry attempt and delay for the tplink integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43265
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
