### PR TITLE
Add troubleshooting to share scenes in google home

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -278,6 +278,10 @@ Your fulfillment URL may be invalid or unreachable. Recheck the `Fulfillment URL
 When using NGINX, ensure that your `proxy_pass` line *does not* have a trailing `/`, as this will result in errors. Your line should look like:
 
     proxy_pass http://localhost:8123;
+    
+#### Scenes are not available to other household members
+
+As scenes are not linked to an area in Home Assistant they do not inherit a room in Google Home. This stops other users in your Google Home from accessing them. To fix this you can set a room for the scene using `entity_config`
 
 ### Unlink and relink
 


### PR DESCRIPTION
## Proposed change
Add troubleshooting step to Google Assistant integration docs page. When adding scenes by default they do not have a room and are therefore not available to other member of the Google Household



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
