### PR TITLE
Fix incorrect parameter name: proxy_ip

### DIFF
--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -65,12 +65,12 @@ trv:
   required: false
   type: map
   keys:
-    trv_proxy_ip:
+    proxy_ip:
       description: IP address of a proxy for TRV integration. 
       required: false
       type: string
       default: "127.0.0.1"
-    trv_proxy_port:
+    proxy_port:
       description: IP port address of a proxy for TRV integration.
       required: false
       type: integer
@@ -111,8 +111,8 @@ lightwave:
     R99D1:
       name: Bedroom Light
   trv:
-      trv_proxy_ip: 127.0.0.1       # Proxy address, do not change unless running on a different server
-      trv_proxy_port: 7878          # Do not change, unless a port clash
+      proxy_ip: 127.0.0.1       # Proxy address, do not change unless running on a different server
+      proxy_port: 7878          # Do not change, unless a port clash
       trvs:
         R1Dh:                       # The ID of the TRV.
           name: Bedroom TRV


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The parameter `tcp_proxy_ip` should be `proxy_ip` in `trv` configuration

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: https://github.com/ColinRobbins/Homeassistant-Lightwave-TRV/issues/1

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
