### PR TITLE
Add Colored Flash Example to deCONZ

### DIFF
--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -275,12 +275,16 @@ Note: Requires `on: true` to change color while the bulb is off. If `on:true` is
 {% raw %}
 
 ```yaml
-script:
-  hue_lamp_flash:
-    alias: Hue Lamp Flash
-    sequence:
+automation:
+  - alias: Flash Hue Bulb with Doorbell Motion
+    trigger:
+    - platform: state
+      entity_id: binary_sensor.doorbell_motion
+      to: 'on'
+    action:
     - service: deconz.configure
       data:
+        entity: light.hue_lamp
         field: /state
         data:
           'on': true
@@ -288,13 +292,13 @@ script:
           sat: 255
           bri: 255
           alert: breathe
-      entity_id: light.hue_lamp
-    - delay: '15'
+    - delay: 00:00:15
     - service: deconz.configure
       data:
+        entity: light.hue_lamp
+        field: /state
         data:
           'on': false
-      entity_id: light.hue_lamp
     mode: single
 ```
 

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -268,6 +268,37 @@ automation:
 ```
 
 {% endraw %}
+
+#### Colored Flashing - RGB Philips Hue bulb using deconz.configure
+Note: Requires `on: true` to change color while the bulb is off. If `on:true` is specified, the bulb remains on after flashing is complete. The previous color is not saved.
+
+{% raw %}
+
+```yaml
+script:
+  hue_lamp_flash:
+    alias: Hue Lamp Flash
+    sequence:
+    - service: deconz.configure
+      data:
+        field: /state
+        data:
+          'on': true
+          hue: 65535
+          sat: 255
+          bri: 255
+          alert: breathe
+      entity_id: light.hue_lamp
+    - delay: '15'
+    - service: deconz.configure
+      data:
+        data:
+          'on': false
+      entity_id: light.hue_lamp
+    mode: single
+```
+
+{% endraw %}
 ## Binary Sensor
 
 The following sensor types are supported:

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -270,13 +270,15 @@ automation:
 {% endraw %}
 
 #### Colored Flashing - RGB Philips Hue bulb using deconz.configure
-Note: Requires `on: true` to change color while the bulb is off. If `on:true` is specified, the bulb remains on after flashing is complete. The previous color is not saved.
+
+Note: Requires on: true to change color while the Philips Hue bulb is off. If on:true is specified, the bulb remains on after flashing is complete. The previous color is not saved or restored.
 
 {% raw %}
 
 ```yaml
 automation:
   - alias: Flash Hue Bulb with Doorbell Motion
+    mode: single
     trigger:
     - platform: state
       entity_id: binary_sensor.doorbell_motion
@@ -299,7 +301,6 @@ automation:
         field: /state
         data:
           'on': false
-    mode: single
 ```
 
 {% endraw %}

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -271,9 +271,7 @@ automation:
 
 #### Colored Flashing - RGB Philips Hue bulb using deconz.configure
 
-Note: Requires on: true to change color while the Philips Hue bulb is off. If on:true is specified, the bulb remains on after flashing is complete. The previous color is not saved or restored.
-
-{% raw %}
+Note: Requires `on: true` to change color while the Philips Hue bulb is off. If `on: true` is specified, the bulb remains on after flashing is complete. The previous color is not saved or restored. To color flash light groups, replace `/state` with `/action` and specify the light group as the entity.
 
 ```yaml
 automation:
@@ -303,7 +301,6 @@ automation:
           'on': false
 ```
 
-{% endraw %}
 ## Binary Sensor
 
 The following sensor types are supported:


### PR DESCRIPTION


## Proposed change
Update documentation with an example of colored flashing of hue bulbs via `deconz.configure` as a workaround since the `light.turn_on` service with `flash:long|short` and `color` does not work with deCONZ.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Additional discussion: https://community.home-assistant.io/t/update-deconz-integration-to-support-flash-with-color/246904

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
