### PR TITLE
Add USB documentation for Plugwise integration

### DIFF
--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -25,7 +25,7 @@ Platforms available - depending on your Smile and setup include:
  - `climate` (for the Anna and Lisa products, or a single Tom)
  - `sensor` (for all relevant products including the Smile P1)
  - `binary_sensor` (for domestic hot water and secondary heater)
- - `switch` (for Plugs connected to Adam or Stealths and Circles either connected to a Stretch or through the USB-stick)
+ - `switch` (for Plugs connected to Adam or Stealths and Circles either connected to a Stretch or to a Stick)
 
 For Smile connectivity, the Smile-ID can be found on the bottom of your Smile or Stretch, it should consist of 6 characters. To find your IP address use the Plugwise App: 
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -143,13 +143,13 @@ script:
           preset_mode: asleep
 ```
 
-#### Manually add a device using the USB stick
+#### Manually add a device using the Stick
 
 Service: `plugwise.device_add`
 
 Mandatory option `mac` holding the full 16 character MAC address of the device.
 
-#### Manually remove a device using the USB stick
+#### Manually remove a device using the Stick
 
 Service: `plugwise.device_remove`
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -16,7 +16,7 @@ ha_config_flow: true
 ha_domain: plugwise
 ---
 
-This enables [Plugwise](https://www.plugwise.com) components with a central Smile gateway or USB-stick and components to be integrated. For USB you will need to know which port your stick is connected to. For the networked Plugwise Smile you will need its password and IP address.
+This enables [Plugwise](https://www.plugwise.com) components with a Smile gateway or Stick and the various connected devices to be integrated. For the Stick you will need to know which port it is connected to, for the networked Smile you will need its IP address and Smile ID.
 
 This integration supports [Anna](https://www.plugwise.com/en_US/products/anna), [Adam (zonecontrol)](https://www.plugwise.com/en_US/zonecontrol), [P1](https://www.plugwise.com/en_US/products/smile-p1) Smile products and other Plugwise products through the [Stretch](https://www.plugwise.com/nl_NL/het-systeem) product or using the USB-stick. See below list for more details.
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -3,29 +3,31 @@ title: Plugwise
 description: Plugwise Smile platform integration.
 ha_category:
   - Climate
+  - Binary Sensor
   - Sensor
   - Switch
-  - Water Heater
 ha_iot_class: Local Polling
 ha_release: 0.98
 ha_codeowners:
   - '@CoMPaTech'
   - '@bouwew'
+  - '@brefra'
 ha_config_flow: true
 ha_domain: plugwise
 ---
 
-This enables [Plugwise](https://www.plugwise.com) components with a central Smile gateway to be integrated. This integration talks locally to your **Smile** interface, and you will need its password and IP address.
-The platform supports [Anna](https://www.plugwise.com/en_US/products/anna), [Adam (zonecontrol)](https://www.plugwise.com/en_US/zonecontrol), [P1](https://www.plugwise.com/en_US/products/smile-p1) Smile products and the [Stretch](https://www.plugwise.com/nl_NL/het-systeem) product. See below list for more details.
+This enables [Plugwise](https://www.plugwise.com) components with a central Smile gateway or USB-stick and components to be integrated. For USB you will need to know which port your stick is connected to. For the networked Plugwise Smile you will need its password and IP address.
+
+This integration supports [Anna](https://www.plugwise.com/en_US/products/anna), [Adam (zonecontrol)](https://www.plugwise.com/en_US/zonecontrol), [P1](https://www.plugwise.com/en_US/products/smile-p1) Smile products and other Plugwise products through the [Stretch](https://www.plugwise.com/nl_NL/het-systeem) product or using the USB-stick. See below list for more details.
 
 Platforms available - depending on your Smile and setup include:
 
  - `climate` (for the Anna and Lisa products, or a single Tom)
  - `sensor` (for all relevant products including the Smile P1)
  - `binary_sensor` (for domestic hot water and secondary heater)
- - `switch` (for Plugs connected to Adam or Stealths and Circles connected to a Stretch)
+ - `switch` (for Plugs connected to Adam or Stealths and Circles either connected to a Stretch or through the USB-stick)
 
-The password can be found on the bottom of your Smile or Stretch, it should consist of 6 characters. To find your IP address use the Plugwise App: 
+For Smile connectivity, the password can be found on the bottom of your Smile or Stretch, it should consist of 6 characters. To find your IP address use the Plugwise App: 
 
  - Open the Plugwise App and choose the 'Settings'-icon (&#9776;) and choose 'HTML-interface'. 
  - Go to the (lower) 'Settings'-icon (&#9776;) and choose 'Preferences'. 
@@ -33,13 +35,17 @@ The password can be found on the bottom of your Smile or Stretch, it should cons
 
 ## Entities
 
-This integration will show all Plugwise entities present in your Plugwise configuration. In addition, you will see a 'Smile' entity representing your central Plugwise gateway (i.e., the Smile, Smile P1 or Adam).
+This integration will show all Plugwise entities present in your Plugwise configuration. For Smiles, you will see a 'Smile' entity added representing your central Plugwise gateway (i.e., Anna, Smile P1 or Adam).
 
 For example, if you have an Adam setup with a Lisa named 'Living' and a Tom named 'Bathroom', these will show up as individual entities. When there are more (than one) Plugwise thermostats present, an "Auxiliary Device" will be added, representing the active heating/cooling device present in your climate system. If you have Plugs (as in, pluggable switches connecting to an Adam) those will be discovered as switches. Various other measures of your setup will be available as sensors or binary sensors.
 
 Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna or Smile will be assigned to your gateway entity. Auxiliary Heater(/Cooler) measurements such as 'boiler_temperature' will be assigned to the Auxiliary entity.
 
 ## Configuration
+
+From the Home Assistant front page, go to **Configuration** and then select **Integrations** from the list. If you have a Smile it most probably is visible as a discovered device for you to click to configure. Otherwise use the plus button in the bottom right to add a new integration, just search for **Plugwise** and choose Networked or USB approprately on the first question.
+
+### Smile (Networked component)
 
 The Plugwise Smile(s) present in your network will be automatically detected via Zeroconf discovery and will be shown on the Integrations-page. To set up an integration, click the "CONFIGURATION" button on the discovered integration and you will be presented with a dialog requesting your Smile password. After you click submit, you will have the opportunity to select the area(s) where individual Smile appliances are located. The username `smile` is shown as a default, when configuring your Stretch change this to `stretch` accordingly.
 
@@ -50,6 +56,14 @@ After adding the Plugwise integration(s), the default Smile-data refresh-interva
 <div class='note warning'>
 When you have an Anna and an Adam, make sure to only configure the Adam integration. You can press the "IGNORE" button on the Anna integration to remove this integration. In case you need to rediscover the Adam integration, make sure to click the "STOP IGNORING" button on the Plugwise integration first, available via "show ignored integrations".
 </div>
+
+### Stick (USB)
+
+In the setup wizard at the 'USB Device Path', it will list all detected serial ports available to Home Assistant. You need to pick the serial port of the connected Plugwise USB-Stick. If required, the selection list contains the possibility to manually enter the device path.
+
+When you press `Submit` and the integration will try to initialize the USB-Stick at the supplied device path. If the connection to the USB-stick is initialized successfully, it will automatically do a discovery of all linked Plugwise nodes stored at the Circle+ device. An error will be displayed in the wizard if Home Assistant can't access the USB-stick or the connection fails.
+
+The integration will automatically save the connection by the serial path (e.g., `/dev/serial/by-id/*`) to keep the connection consistent between system restarts.
 
 ### Services
 
@@ -129,9 +143,21 @@ script:
           preset_mode: asleep
 ```
 
+#### Manually add a device using the USB stick
+
+Service: `plugwise.device_add`
+
+Mandatory option `mac` holding the full 16 character MAC address of the device.
+
+#### Manually remove a device using the USB stick
+
+Service: `plugwise.device_remove`
+
+Mandatory option `mac` holding the full 16 character MAC address of the device.
+
 ### Supported devices
 
-The current implementation of the Python module (Plugwise-Smile) includes:
+The current implementation of the [Python module](https://pypi.org/projects/plugwise) from [`python-plugwise`](https://github.com/plugwise/python/plugwise) includes:
 
 Adam (zone_control):
 
@@ -156,3 +182,5 @@ Stretch (power switches):
 
  - v3.x
  - v2.x
+
+USB-stick

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -18,7 +18,7 @@ ha_domain: plugwise
 
 This enables [Plugwise](https://www.plugwise.com) components with a Smile gateway or Stick and the various connected devices to be integrated. For the Stick you will need to know which port it is connected to, for the networked Smile you will need its IP address and Smile ID.
 
-This integration supports [Anna](https://www.plugwise.com/en_US/products/anna), [Adam (zonecontrol)](https://www.plugwise.com/en_US/zonecontrol), [P1](https://www.plugwise.com/en_US/products/smile-p1) Smile products and other Plugwise products through the [Stretch](https://www.plugwise.com/nl_NL/het-systeem) product or using the USB-stick. See below list for more details.
+This integration supports [Anna](https://www.plugwise.com/en_US/products/anna), [Adam (zonecontrol)](https://www.plugwise.com/en_US/zonecontrol), [P1](https://www.plugwise.com/en_US/products/smile-p1) Smile products and various legacy products (Circle, Stealth, etc.) through the [Stretch](https://www.plugwise.com/nl_NL/het-systeem) or Stick. See below list for more details.
 
 Platforms available - depending on your Smile and setup include:
 
@@ -27,7 +27,7 @@ Platforms available - depending on your Smile and setup include:
  - `binary_sensor` (for domestic hot water and secondary heater)
  - `switch` (for Plugs connected to Adam or Stealths and Circles either connected to a Stretch or through the USB-stick)
 
-For Smile connectivity, the password can be found on the bottom of your Smile or Stretch, it should consist of 6 characters. To find your IP address use the Plugwise App: 
+For Smile connectivity, the Smile-ID can be found on the bottom of your Smile or Stretch, it should consist of 6 characters. To find your IP address use the Plugwise App: 
 
  - Open the Plugwise App and choose the 'Settings'-icon (&#9776;) and choose 'HTML-interface'. 
  - Go to the (lower) 'Settings'-icon (&#9776;) and choose 'Preferences'. 
@@ -59,9 +59,9 @@ When you have an Anna and an Adam, make sure to only configure the Adam integrat
 
 ### Stick (USB)
 
-In the setup wizard at the 'USB Device Path', it will list all detected serial ports available to Home Assistant. You need to pick the serial port of the connected Plugwise USB-Stick. If required, the selection list contains the possibility to manually enter the device path.
+In the setup wizard at the 'USB Device Path', it will list all detected serial ports available to Home Assistant. You need to pick the serial port of the connected Plugwise Stick. If required, the selection list contains the possibility to manually enter the device path.
 
-When you press `Submit` and the integration will try to initialize the USB-Stick at the supplied device path. If the connection to the USB-stick is initialized successfully, it will automatically do a discovery of all linked Plugwise nodes stored at the Circle+ device. An error will be displayed in the wizard if Home Assistant can't access the USB-stick or the connection fails.
+When you press `Submit` and the integration will try to initialize the Stick at the supplied device path. If the connection to the USB-stick is initialized successfully, it will automatically do a discovery of all linked Plugwise nodes stored at the Circle+ device. An error will be displayed in the wizard if Home Assistant can't access the USB-stick or the connection fails.
 
 The integration will automatically save the connection by the serial path (e.g., `/dev/serial/by-id/*`) to keep the connection consistent between system restarts.
 
@@ -183,4 +183,4 @@ Stretch (power switches):
  - v3.x
  - v2.x
 
-USB-stick
+Stick

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -171,4 +171,7 @@ Stretch (power switches):
  - v3.x
  - v2.x
 
-Stick
+Stick:
+
+ - Circle(+)
+ - Stealth(+)

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -143,18 +143,6 @@ script:
           preset_mode: asleep
 ```
 
-#### Manually add a device using the Stick
-
-Service: `plugwise.device_add`
-
-Mandatory option `mac` holding the full 16 character MAC address of the device.
-
-#### Manually remove a device using the Stick
-
-Service: `plugwise.device_remove`
-
-Mandatory option `mac` holding the full 16 character MAC address of the device.
-
 ### Supported devices
 
 The current implementation of the [Python module](https://pypi.org/projects/plugwise) from [`python-plugwise`](https://github.com/plugwise/python-plugwise) includes:

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -43,7 +43,7 @@ Centralized measurements such as 'power' for a P1, 'outdoor_temperature' on Anna
 
 ## Configuration
 
-From the Home Assistant front page, go to **Configuration** and then select **Integrations** from the list. If you have a Smile it most probably is visible as a discovered device for you to click to configure. Otherwise use the plus button in the bottom right to add a new integration, just search for **Plugwise** and choose Networked or USB approprately on the first question.
+From the Home Assistant front page, go to **Configuration** and then select **Integrations** from the list. If you have a Smile it most probably is visible as a discovered device for you to click to configure. Otherwise use the plus button in the bottom right to add a new integration, just search for **Plugwise** and choose Networked or USB appropriately on the first question.
 
 ### Smile (Networked component)
 

--- a/source/_integrations/plugwise.markdown
+++ b/source/_integrations/plugwise.markdown
@@ -157,7 +157,7 @@ Mandatory option `mac` holding the full 16 character MAC address of the device.
 
 ### Supported devices
 
-The current implementation of the [Python module](https://pypi.org/projects/plugwise) from [`python-plugwise`](https://github.com/plugwise/python/plugwise) includes:
+The current implementation of the [Python module](https://pypi.org/projects/plugwise) from [`python-plugwise`](https://github.com/plugwise/python-plugwise) includes:
 
 Adam (zone_control):
 


### PR DESCRIPTION
## Proposed change
Replacing #13466. This adds documentation for adding in USB-switch-platform within the existing Plugwise integration. Includes minor rewording towards the networked components to distinguish between the devices types. (USB switches `sensors` will follow in additional PR to core).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: #13466

## Checklist

- [ x This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
