### PR TITLE
Remove YAML documentation for Solar-log

### DIFF
--- a/source/_integrations/solarlog.markdown
+++ b/source/_integrations/solarlog.markdown
@@ -23,41 +23,9 @@ The open JSON interface is deactivated by default. To activate the open JSON int
 
 ## Configuration
 
-There are 2 options in configuring the `solarlog` integration:
-
-- Via the Home Assistant user interface where it will let you enter the name and host to connect to your Solar-Log device.
-- Via the Home Assistant `configuration.yaml` file.
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  platform: solarlog
-```
-
-{% configuration %}
-host:
-  description: The IP Address or host address of your Solar-Log device.
-  required: false
-  default: http://solar-log
-  type: string
-name:
-  description: Let you overwrite the name of the device in the frontend.
-  required: false
-  default: solarlog
-  type: string
-{% endconfiguration %}
-
-### Full configuration sample
-
-A full configuration entry would look like the sample below.
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: solarlog
-    name: solarlog
-    host: 192.168.1.123
-```
+This integration can be configured via the Home Assistant UI by navigating to
+**Configuration** -> **Integrations**.
+You will have to enter a name that is used as prefix for your sensors and a host to connect to your Solar-Log device.
 
 In case you would like to convert the values, for example, to Wh instead of the default kWh, you can use the [template platform](/integrations/template/).
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR removes YAML configuration documentation for the Solar-log integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#43484](https://github.com/home-assistant/core/pull/43484)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
