### PR TITLE
Add 'type' to RFLink binary sensor configuration

### DIFF
--- a/source/_integrations/binary_sensor.rflink.markdown
+++ b/source/_integrations/binary_sensor.rflink.markdown
@@ -49,6 +49,11 @@ devices:
           description: Alternative RFLink ID's this device is known by.
           required: false
           type: list
+        type:
+          description: Sets the entities binary sensor `type`.
+          required: false
+          type: string
+          default: standard
         device_class:
           description: Sets the [class of the device](/integrations/binary_sensor/), changing the device state and icon that is displayed on the frontend.
           required: false
@@ -67,6 +72,13 @@ devices:
 ### Sensor state
 
 Initially, the state of a binary sensor is unknown. When a sensor update is received, the state is known and will be shown in the frontend.
+
+### Sensor type
+
+You can configure a binary sensor as `inverted` if the meaning of the `on`/`off` signals received are reversed from your needs.
+The `type` attribute accepts the values:
+* `standar`: for entities that follows the [binary_sensor specification](/integrations/binary_sensor/#device-class)
+* `inverted`: for entities with reversed `on`/`off` signals
 
 ### Device support
 
@@ -89,4 +101,8 @@ binary_sensor:
          name: PIR Living Room
          device_class: motion
          off_delay: 5
+       eurodomest_04fb6f_02:
+         name: Entrance door
+         type: inverted
+         device_class: door
 ```

--- a/source/_integrations/binary_sensor.rflink.markdown
+++ b/source/_integrations/binary_sensor.rflink.markdown
@@ -49,40 +49,39 @@ devices:
           description: Alternative RFLink ID's this device is known by.
           required: false
           type: list
-        type:
-          description: Sets the entities binary sensor `type`.
-          required: false
-          type: string
-          default: standard
         device_class:
           description: Sets the [class of the device](/integrations/binary_sensor/), changing the device state and icon that is displayed on the frontend.
           required: false
           type: string
         off_delay:
-          description: For sensors that only sends 'On' state updates, this variable sets a delay after which the sensor state will be updated back to 'Off'.
+          description: For sensors that only sends one kind of activation signal, this variable sets a delay after which the sensor state will be updated back to 'Off'.
           required: false
           type: integer
         force_update:
-          description: Sends update events even if the value has not changed. Useful for sensors that only sends `On`.
+          description: Sends update events even if its status does not change. Useful for sensors that only sends one kind of activation signal.
           required: false
           type: boolean
           default: false
+        inverted:
+          description: Inverts the sensor activation signal.
+          required: false
+          type: boolean
+          default: False
 {% endconfiguration %}
 
 ### Sensor state
 
 Initially, the state of a binary sensor is unknown. When a sensor update is received, the state is known and will be shown in the frontend.
 
-### Sensor type
-
-You can configure a binary sensor as `inverted` if the meaning of the `on`/`off` signals received are reversed from your needs.
-The `type` attribute accepts the values:
-* `standar`: for entities that follows the [binary_sensor specification](/integrations/binary_sensor/#device-class)
-* `inverted`: for entities with reversed `on`/`off` signals
-
 ### Device support
 
 See [device support](/integrations/rflink/#device-support)
+
+### Inverted sensors
+
+You can configure a binary sensor as `inverted` if the meaning of the *activation*/*deactivation* signals received are reversed from your needs.
+When the `inverted` attribute is configured to `True` the sensor state will be activated when an `off`/`alloff` signal is received, and deactivated for `on`/`allon` signals.
+Note that the `off_delay` attribute refers to the status change and has no relation to this attribute or the type of signal received.
 
 ### Additional configuration examples
 
@@ -103,6 +102,6 @@ binary_sensor:
          off_delay: 5
        eurodomest_04fb6f_02:
          name: Entrance door
-         type: inverted
+         inverted: True
          device_class: door
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds documentation of the new attribute added to the RFLink integration for binary sensors.

(comes from PR #15707)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
  - home-assistant/core#43459
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
