### PR TITLE
Update google_travel_time docs to reflect config flow support

### DIFF
--- a/source/_integrations/google_travel_time.markdown
+++ b/source/_integrations/google_travel_time.markdown
@@ -21,9 +21,7 @@ You need to register for an API key by following the instructions [here](https:/
 
 A quota can be set against the API to avoid exceeding the free credit amount. Set the 'Elements per day' to a limit of 645 or less. Details on how to configure a quota can be found [here](https://developers.google.com/maps/documentation/distance-matrix/usage-and-billing#set-caps)
 
-## Configuration
-
-To set up a `google_travel_time` sensor, go to the Integrations section in the Configuration tab of the Home Assistant UI, click the `+` button in the bottom right of the page, and search for `Google Travel Time`.
+{% include integrations/config_flow.md %}
 
 ## Dynamic Configuration
 

--- a/source/_integrations/google_travel_time.markdown
+++ b/source/_integrations/google_travel_time.markdown
@@ -35,6 +35,7 @@ Tracking can be setup to track entities of type `device_tracker`, `zone`, `senso
 
 Origin: device_tracker.mobile_phone
 Destination: zone.home
+
 #### Tracking entity to zone friendly name (e.g. "Eddies House")
 
 Origin: zone.home

--- a/source/_integrations/google_travel_time.markdown
+++ b/source/_integrations/google_travel_time.markdown
@@ -5,6 +5,7 @@ ha_category:
   - Transport
 ha_iot_class: Cloud Polling
 ha_release: 0.19
+ha_config_flow: true
 ha_domain: google_travel_time
 ha_platforms:
   - sensor
@@ -22,104 +23,21 @@ A quota can be set against the API to avoid exceeding the free credit amount. Se
 
 ## Configuration
 
-To enable the sensor, add the following lines to your `configuration.yaml` file:
-
-```yaml
-# Example entry for configuration.yaml
-sensor:
-  - platform: google_travel_time
-    api_key: XXXX_XXXXX_XXXXX
-    origin: Trondheim, Norway
-    destination: Paris, France
-```
-
-{% configuration %}
-api_key:
-  description: Your application's API key (get one by following the instructions above). This key identifies your application for purposes of quota management.
-  required: true
-  type: string
-origin:
-  description: "The starting point for calculating travel distance and time. You can supply one or more locations separated by the pipe character, in the form of an address, latitude/longitude coordinates, or a [Google place ID](https://developers.google.com/places/place-id). When specifying the location using a Google place ID, the ID must be prefixed with `place_id:`."
-  required: true
-  type: string
-destination:
-  description: One or more locations to use as the finishing point for calculating travel distance and time. The options for the destinations parameter are the same as for the origins parameter, described above.
-  required: true
-  type: string
-name:
-  description: A name to display on the sensor. The default is "Google Travel Time - [Travel Mode]" where [Travel Mode] is the mode set in options for the sensor (see option "mode" below).
-  required: false
-  type: string
-travel_mode:
-  description: "You can choose between: `driving`, `walking`, `bicycling` or `transit`. This method is now deprecated, use `mode` under `options`."
-  required: false
-  type: string
-options:
-  description: "A dictionary containing parameters to add to all requests to the Distance Matrix API. A full listing of available options can be found [here](https://developers.google.com/maps/documentation/distance-matrix/intro#RequestParameters)."
-  required: false
-  type: list
-  keys:
-    mode:
-      description: The travel mode used to calculate the directions/time. Can be `driving`, `bicycling`, `transit` or `walking`.
-      required: false
-      default: driving
-      type: string
-    language:
-      description: "You can choose from a lot of languages: `ar`, `bg`, `bn`, `ca`, `cs`, `da`, `de`, `el`, `en`, `es`, `eu`, `fa`, `fi`, `fr`, `gl`, `gu`, `hi`, `hr`, `hu`, `id`, `it`, `iw`, `ja`, `kn`, `ko`, `lt`, `lv`, `ml`, `mr`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `pt-PT`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `ta`, `te`, `th`, `tl`, `tr`, `uk`, `vi`, `zh-CN` and `zh-TW`."
-      required: false
-      type: string
-    departure_time:
-      description: Can be `now`, a Unix timestamp, or a 24 hour time string like `08:00:00`. If you provide a time string, it will be combined with the current date to get travel time for that moment.
-      required: exclusive
-      type: [time, string]
-    arrival_time:
-      description: See notes above for `departure_time`. `arrival_time` cannot be `now`, only a Unix timestamp or time string. You can not provide both `departure_time` and `arrival_time`. If you do provide both, `arrival_time` will be removed from the request.
-      required: exclusive
-      type: [time, string]
-    avoid:
-      description: "Indicate what Google should avoid when calculating the travel time, you can choose from: `tolls`, `highways`, `ferries`, `indoor`."
-      required: false
-      type: string
-    transit_mode:
-      description: "If you opted for `transit` at `travel_mode`, you can use this variable to specify which public transport you want to use: `bus`, `subway`, `train`, `tram` or `rail`."
-    transit_routing_preference:
-      description: "for the travel time calculation for public transport you can also specify the preference for: `less_walking` or `fewer_transfers`."
-      required: false
-      type: string
-    units:
-      description: "Set the unit for the sensor in metric or imperial, otherwise the default unit the same as the unit set in `unit_system:`."
-      required: false
-      type: string
-{% endconfiguration %}
+To set up a `google_travel_time` sensor, go to the Integrations section in the Configuration tab of the Home Assistant UI, click the `+` button in the bottom right of the page, and search for `Google Travel Time`.
 
 ## Dynamic Configuration
 
-Tracking can be setup to track entities of type `device_tracker`, `zone`, `sensor` and `person`. If an entity is placed in the origin or destination then every 5 minutes when the platform updates it will use the latest location of that entity.
+Tracking can be setup to track entities of type `device_tracker`, `zone`, `sensor` and `person`. If an entity is placed in the Origin or Destination then every 5 minutes when the platform updates it will use the latest location of that entity.
 
-```yaml
-# Example entry for configuration.yaml
-sensor:
-  # Tracking entity to entity
-  - platform: google_travel_time
-    name: Phone To Home
-    api_key: XXXX_XXXXX_XXXXX
-    origin: device_tracker.mobile_phone
-    destination: zone.home
+### Examples
+#### Tracking entity to entity
 
-  # Tracking entity to zone friendly name
-  - platform: google_travel_time
-    name: Home To Eddie's House
-    api_key: XXXX_XXXXX_XXXXX
-    origin: zone.home
-    destination: Eddies House    # Friendly name of a zone
+Origin: device_tracker.mobile_phone
+Destination: zone.home
+#### Tracking entity to zone friendly name (e.g. "Eddies House")
 
-  # Tracking entity in imperial unit
-  - platform: google_travel_time
-    api_key: XXXX_XXXXX_XXXXX
-    destination: zone.home
-    options:
-      units: imperial    # 'metric' for Metric, 'imperial' for Imperial
-```
+Origin: zone.home
+Destination: Eddies House
 
 ## Entity Tracking
 

--- a/source/_integrations/google_travel_time.markdown
+++ b/source/_integrations/google_travel_time.markdown
@@ -30,6 +30,7 @@ To set up a `google_travel_time` sensor, go to the Integrations section in the C
 Tracking can be setup to track entities of type `device_tracker`, `zone`, `sensor` and `person`. If an entity is placed in the Origin or Destination then every 5 minutes when the platform updates it will use the latest location of that entity.
 
 ### Examples
+
 #### Tracking entity to entity
 
 Origin: device_tracker.mobile_phone


### PR DESCRIPTION
## Proposed change
I added config flow support for `google_travel_time` in a parent PR, this docs update reflects those changes.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43509
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
