### PR TITLE
Airtouch4 integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,6 +18,7 @@ source/_integrations/aemet.markdown @noltari
 source/_integrations/agent_dvr.markdown @ispysoftware
 source/_integrations/airly.markdown @bieniu
 source/_integrations/airnow.markdown @asymworks
+source/_integrations/airtouch4.markdown @LonePurpleWolf
 source/_integrations/airvisual.markdown @bachya
 source/_integrations/alarmdecoder.markdown @ajschmidt8
 source/_integrations/alexa.markdown @home-assistant/cloud @ochlocracy

--- a/source/_integrations/airtouch4.markdown
+++ b/source/_integrations/airtouch4.markdown
@@ -1,0 +1,29 @@
+---
+title: AirTouch 4
+description: Instructions on how to integrate the AirTouch 4 A/C controller into Home Assistant.
+ha_category: Climate
+ha_release: 0.119
+ha_iot_class: Local Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@LonePurpleWolf'
+ha_domain: airtouch4
+---
+
+The AirTouch 4 integration allows you to control Ducted Air Conditioning Systems that are using the [AirTouch 4](https://www.airtouch.net.au/airtouch/airtouch-4/) Controller. Currently, this integration only supports AirTouch 4 controllers with the Individual Temperature Control (ITC) modules.
+
+## Configuration
+
+It is recommended that the wall-mounted AirTouch 4 Android tablet use a static IP, which you will then use to configure the AirTouch 4 in Home Assistant.
+
+Menu: **Configuration** -> **Integrations**.
+
+Click on the `+` sign to add an integration and click on **AirTouch 4**.
+Enter the IP address.
+After completing the configuration flow, the AirTouch 4 integration will dynamically add relevant entities for each controlled zones.
+
+## Entities
+
+### Climate
+
+The integration will create a climate entity for each zone that is temperature-controlled.

--- a/source/_integrations/airtouch4.markdown
+++ b/source/_integrations/airtouch4.markdown
@@ -2,7 +2,7 @@
 title: AirTouch 4
 description: Instructions on how to integrate the AirTouch 4 A/C controller into Home Assistant.
 ha_category: Climate
-ha_release: 0.119
+ha_release: 2021.9
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:

--- a/source/_integrations/airtouch4.markdown
+++ b/source/_integrations/airtouch4.markdown
@@ -12,15 +12,7 @@ ha_domain: airtouch4
 
 The AirTouch 4 integration allows you to control Ducted Air Conditioning Systems that are using the [AirTouch 4](https://www.airtouch.net.au/airtouch/airtouch-4/) Controller. Currently, this integration only supports AirTouch 4 controllers with the Individual Temperature Control (ITC) modules.
 
-## Configuration
-
-It is recommended that the wall-mounted AirTouch 4 Android tablet use a static IP, which you will then use to configure the AirTouch 4 in Home Assistant.
-
-Menu: **Configuration** -> **Integrations**.
-
-Click on the `+` sign to add an integration and click on **AirTouch 4**.
-Enter the IP address.
-After completing the configuration flow, the AirTouch 4 integration will dynamically add relevant entities for each controlled zones.
+{% include integrations/config_flow.md %}
 
 ## Entities
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documentation for AirTouch 4 Integration


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43513
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/2038
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
