### PR TITLE
Add more-info about unhealthy setups

### DIFF
--- a/source/more-info/unhealthy/docker.markdown
+++ b/source/more-info/unhealthy/docker.markdown
@@ -1,9 +1,9 @@
 ---
 title: "The Docker environment is not working properly"
-description: "More information on why a misconfigured Docker environment mark the system as unhealthy."
+description: "More information on why a misconfigured Docker environment marks the system as unhealthy."
 ---
 
-Docker is at the core of most operations that the Supervisor does, it is important that this is configured properly and is working the way the Supervisor expect it to work.
+Docker is at the core of most operations that the Supervisor does, it is important that it is configured properly and is working the way the Supervisor expects.
 
 The Supervisor will be marked as unhealthy if any of these requirements are not met:
 

--- a/source/more-info/unhealthy/docker.markdown
+++ b/source/more-info/unhealthy/docker.markdown
@@ -1,0 +1,13 @@
+---
+title: "The Docker environment is not working properly"
+description: "More information on why a misconfigured Docker environment mark the system as unhealthy."
+---
+
+Docker is at the core of most operations that the Supervisor does, it is important that this is configured properly and is working the way the Supervisor expect it to work.
+
+The Supervisor will be marked as unhealthy if any of these requirements are not met:
+
+- [Running containers known to cause issues](/more-info/unsupported/container)
+- [Running an unsupported Docker version](/more-info/unsupported/docker_version)
+- [Running the Supervisor under LXC](/more-info/unsupported/lxc)
+- [Not running the Supervisor as privileged](/more-info/unsupported/privileged)

--- a/source/more-info/unhealthy/setup.markdown
+++ b/source/more-info/unhealthy/setup.markdown
@@ -1,23 +1,28 @@
 ---
 title: "Setup of the Supervisor failed"
-description: "More information on why failing the setup stage makes a installation as unhealthy."
+description: "More information on why failing the setup stage makes an installation as unhealthy."
 ---
 
 ## The issue
 
-This happens when any of the setup tasks fails to complete, this can be due to the host not being completly ready when the Supervisor starts or that [DBUS] is not properly working.
+This happens when any of the setup tasks fails to complete, this can be due to the host not being completely ready when the Supervisor starts or that [DBUS] is not properly working.
 
 ## The solution
 
-If the issue is related to DBUS, you will see an unsupported message about that as well, you can have a look here [DBUS] on how to resolve that.
+If the issue is related to DBUS, you will see an unsupported message about that as well; You can have a look [here][DBUS] on how to resolve that.
 
 The first thing you should try is to restart the Supervisor.
-This can be done from the "System" tab in the Supervisor panel, on the card for "Supervisor" there is a button to restart the Supervisor.
+This can be done from the "System" tab in the Supervisor panel. On the card for "Supervisor", there is a button to restart the Supervisor.
 
-This can also be done with the CLI with `ha supervisor restart`.
+This can also be done with the CLI, by running the following command:
+
+```bash
+ha supervisor restart
+```
+
 
 If this does not help, you can try to reboot the host.
-If you are running Home Assistant Operating System, this can be done from the "System" tab in the Supervisor panel, on the card for "Host System" there is a button to reboot the host.
+If you are running Home Assistant Operating System, this can be done from the "System" tab in the Supervisor panel. On the card for "Host System", there is a button to reboot the host.
 
 To help us make the setup more robust, please enable the sharing of diagnostics and crash logs on the "System" tab in the Supervisor panel.
 

--- a/source/more-info/unhealthy/setup.markdown
+++ b/source/more-info/unhealthy/setup.markdown
@@ -19,4 +19,6 @@ This can also be done with the CLI with `ha supervisor restart`.
 If this does not help, you can try to reboot the host.
 If you are running HAOS, this can be done from the "System" tab in the Supervisor panel, on the card for "Host System" there is a button to reboot the host.
 
+To help us make the setup more robust, please enable the sharing of diagnostics and crash logs on the "System" tab in the Supervisor panel.
+
 [DBUS]: /more-info/unsupported/dbus

--- a/source/more-info/unhealthy/setup.markdown
+++ b/source/more-info/unhealthy/setup.markdown
@@ -17,7 +17,7 @@ This can be done from the "System" tab in the Supervisor panel, on the card for 
 This can also be done with the CLI with `ha supervisor restart`.
 
 If this does not help, you can try to reboot the host.
-If you are running HAOS, this can be done from the "System" tab in the Supervisor panel, on the card for "Host System" there is a button to reboot the host.
+If you are running Home Assistant Operating System, this can be done from the "System" tab in the Supervisor panel, on the card for "Host System" there is a button to reboot the host.
 
 To help us make the setup more robust, please enable the sharing of diagnostics and crash logs on the "System" tab in the Supervisor panel.
 

--- a/source/more-info/unhealthy/setup.markdown
+++ b/source/more-info/unhealthy/setup.markdown
@@ -1,0 +1,22 @@
+---
+title: "Setup of the Supervisor failed"
+description: "More information on why failing the setup stage makes a installation as unhealthy."
+---
+
+## The issue
+
+This happens when any of the setup tasks fails to complete, this can be due to the host not being completly ready when the Supervisor starts or that [DBUS] is not properly working.
+
+## The solution
+
+If the issue is related to DBUS, you will see an unsupported message about that as well, you can have a look here [DBUS] on how to resolve that.
+
+The first thing you should try is to restart the Supervisor.
+This can be done from the "System" tab in the Supervisor panel, on the card for "Supervisor" there is a button to restart the Supervisor.
+
+This can also be done with the CLI with `ha supervisor restart`.
+
+If this does not help, you can try to reboot the host.
+If you are running HAOS, this can be done from the "System" tab in the Supervisor panel, on the card for "Host System" there is a button to reboot the host.
+
+[DBUS]: /more-info/unsupported/dbus

--- a/source/more-info/unhealthy/supervisor.markdown
+++ b/source/more-info/unhealthy/supervisor.markdown
@@ -1,14 +1,17 @@
 ---
 title: "Supervisor was not able to update"
-description: "More information on why a failed Supervisor update mark a system as unhealthy."
+description: "More information on why a failed Supervisor update marks a system as unhealthy."
 ---
 
 ## The issue
 
-This can happen if there was a network issue during the startup of the Supervisor
+This can happen when there was a network issue during the startup of the Supervisor.
 
 ## The solution
 
-Manually update the Supervisor. This can be done from the "System" tab in the Supervisor panel, on the card for "Supervisor" there is a button to update the Supervisor.
+Manually update the Supervisor. This can be done from the "System" tab in the Supervisor panel. On the card for "Supervisor", there is a button to update the Supervisor.
 
-This can also be done with the CLI with `ha supervisor update`.
+This can also be done with the CLI, by running the following command:
+```bash
+ha supervisor update
+```

--- a/source/more-info/unhealthy/supervisor.markdown
+++ b/source/more-info/unhealthy/supervisor.markdown
@@ -1,0 +1,14 @@
+---
+title: "Supervisor was not able to update"
+description: "More information on why a failed Supervisor update mark a system as unhealthy."
+---
+
+## The issue
+
+This can happen if there was a network issue during the startup of the Supervisor
+
+## The solution
+
+Manually update the Supervisor. This can be done from the "System" tab in the Supervisor panel, on the card for "Supervisor" there is a button to update the Supervisor.
+
+This can also be done with the CLI with `ha supervisor update`.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds more-info pages to help users with unhealthy setups.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/7781
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
