### PR TITLE
Remove duplicate logger in Nest documentation

### DIFF
--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -139,7 +139,6 @@ logger:
     google_nest_sdm.event: debug
     google.cloud.pubsub_v1: debug
     google.cloud.pubsub_v1.subscriber._protocol.streaming_pull_manager: debug
-    google.cloud.pubsub_v1.subscriber._protocol.streaming_pull_manager: debug
 
 ```
 


### PR DESCRIPTION
## Proposed change
This line is already defined on the line above, no need to define it twice.


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
