### PR TITLE
Add unsupported page for job conditions

### DIFF
--- a/source/more-info/unhealthy/setup.markdown
+++ b/source/more-info/unhealthy/setup.markdown
@@ -11,7 +11,7 @@ This happens when any of the setup tasks fails to complete, this can be due to t
 
 If the issue is related to DBUS, you will see an unsupported message about that as well; You can have a look [here][DBUS] on how to resolve that.
 
-The first thing you should try is to restart the Supervisor.
+If DBUS is not the problem, the first thing you should try is to restart the Supervisor.
 This can be done from the "System" tab in the Supervisor panel. On the card for "Supervisor", there is a button to restart the Supervisor.
 
 This can also be done with the CLI, by running the following command:
@@ -19,7 +19,6 @@ This can also be done with the CLI, by running the following command:
 ```bash
 ha supervisor restart
 ```
-
 
 If this does not help, you can try to reboot the host.
 If you are running Home Assistant Operating System, this can be done from the "System" tab in the Supervisor panel. On the card for "Host System", there is a button to reboot the host.

--- a/source/more-info/unsupported/job_conditions.markdown
+++ b/source/more-info/unsupported/job_conditions.markdown
@@ -1,0 +1,22 @@
+---
+title: "Job conditions ignored"
+description: "More information on why ignoring job conditions marks the installation as unsupported."
+---
+
+## The issue
+
+Ignoring job conditions can be useful in a development setting, but running with this is not supported and it will cause issues, these issues can break your system.
+
+## The solution
+
+Remove all ignored conditions by using the CLI.
+
+```bash
+ha jobs options --ignore_conditions []
+```
+
+Once you have removed all of them, reload th Supervisor.
+
+```bash
+ha supervisor reload
+```

--- a/source/more-info/unsupported/job_conditions.markdown
+++ b/source/more-info/unsupported/job_conditions.markdown
@@ -15,7 +15,7 @@ Remove all ignored conditions by using the CLI.
 ha jobs options --ignore_conditions []
 ```
 
-Once you have removed all of them, reload th Supervisor.
+Once you have removed all of them, reload the Supervisor.
 
 ```bash
 ha supervisor reload

--- a/source/more-info/unsupported/job_conditions.markdown
+++ b/source/more-info/unsupported/job_conditions.markdown
@@ -1,22 +1,24 @@
 ---
-title: "Job conditions ignored"
+title: "Ignored job conditions"
 description: "More information on why ignoring job conditions marks the installation as unsupported."
 ---
 
 ## The issue
 
-Ignoring job conditions can be useful in a development setting, but running with this is not supported and it will cause issues, these issues can break your system.
+You have turned on the setting to ignore job conditions. Home Assistant has a built-in protection mechanism that detects if the system is working as expected. Ignoring job conditions disables this protection.
+
+If the system is not working as expected, certain tasks can result in breaking the system.
 
 ## The solution
 
-Remove all ignored conditions by using the CLI.
+To solve this you need to re-enable the protection mechanism by removing all the ignored conditions by using the CLI:
 
 ```bash
 ha jobs reset
 ```
 
-When you have removed all of them, reload the Supervisor.
+When you have removed all of them, restart the Supervisor.
 
 ```bash
-ha supervisor reload
+ha supervisor restart
 ```

--- a/source/more-info/unsupported/job_conditions.markdown
+++ b/source/more-info/unsupported/job_conditions.markdown
@@ -15,7 +15,7 @@ Remove all ignored conditions by using the CLI.
 ha jobs options --ignore_conditions []
 ```
 
-Once you have removed all of them, reload the Supervisor.
+When you have removed all of them, reload the Supervisor.
 
 ```bash
 ha supervisor reload

--- a/source/more-info/unsupported/job_conditions.markdown
+++ b/source/more-info/unsupported/job_conditions.markdown
@@ -12,7 +12,7 @@ Ignoring job conditions can be useful in a development setting, but running with
 Remove all ignored conditions by using the CLI.
 
 ```bash
-ha jobs options --ignore_conditions []
+ha jobs reset
 ```
 
 When you have removed all of them, reload the Supervisor.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds a more-info page for `job_conditions` unsupported reason.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/frontend/pull/7790
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
