### PR TITLE
Update Nest config snippet to reference Subscription Name, not Subscription ID

### DIFF
--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -100,8 +100,7 @@ project_id:
   required: false
   type: string
 subscriber_id:
-  description: Full path for the Pub/sub Subscription ID used to receive events. This is required to use the SDM API.
-  Enter this exactly as it appers under "Subscription name" in the [Pub/Sub console](https://console.cloud.google.com/cloudpubsub/subscription/list).
+  description: Full path for the Pub/sub Subscription ID used to receive events. This is required to use the SDM API. Enter this exactly as it appers under "Subscription name" in the [Pub/Sub console](https://console.cloud.google.com/cloudpubsub/subscription/list).
   type: string
   required: false
 {% endconfiguration %}

--- a/source/_integrations/nest.markdown
+++ b/source/_integrations/nest.markdown
@@ -80,8 +80,10 @@ When you get to the steps about configuring events make sure to follow guide und
 nest:
   client_id: CLIENT_ID
   client_secret: CLIENT_SECRET
-  project_id: PROJECT_ID    # ("Project ID" in the Device Access Console)
-  subscriber_id: projects/.../subscriptions/SUBSCRIBER_ID # ("Subscription ID" in Google Cloud Console. Replace with full path.)
+  # "Project ID" in the Device Access Console
+  project_id: PROJECT_ID
+  # Provide the full path exactly as shown under "Subscription name" in Google Cloud Console
+  subscriber_id: projects/project-label-22ee1/subscriptions/SUBSCRIBER_ID
 ```
 
 {% configuration %}
@@ -99,6 +101,7 @@ project_id:
   type: string
 subscriber_id:
   description: Full path for the Pub/sub Subscription ID used to receive events. This is required to use the SDM API.
+  Enter this exactly as it appers under "Subscription name" in the [Pub/Sub console](https://console.cloud.google.com/cloudpubsub/subscription/list).
   type: string
   required: false
 {% endconfiguration %}


### PR DESCRIPTION
The current sample yaml for the Nest SDM API asks users to supply subscriber_id as per "Subscription ID in Google Cloud Console".

This is potentially ambiguous - should they provide the Subscription ID, or just replace the last part of the dummy value with it? Users could incorporate "Subscription ID" as show in the console and craft the full path by hand, but they would also need to fill in the missing project ID (represented in the example yaml as '...'). To add to the confusion, the GCP project ID they would need to supply midway through this full path is different to the Device Access Console project_id they have just provided in the previous yaml parameter.

We can simplify this significantly by removing references to "Subscription ID" and just telling users to use the value under "Subscription name" in the same table - this is the fully qualified path which HA really wants. 

Screenshot here for clarity: https://i.imgur.com/on39AtX.png

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
