### PR TITLE
edl21: Add APATOR Norax 3D as tested smart meter and example ser2net configuration file

### DIFF
--- a/source/_integrations/edl21.markdown
+++ b/source/_integrations/edl21.markdown
@@ -21,6 +21,7 @@ Compatible transceivers:
 
 Tested smart meters:
 
+- APATOR Norax 3D (enable InF Mode as described in manual to retrieve full data)
 - Iskraemeco MT175 (ISKRA MT175-D2A51-V22-K0t)
 
 ## Configuration

--- a/source/_integrations/edl21.markdown
+++ b/source/_integrations/edl21.markdown
@@ -51,6 +51,4 @@ To use this integration with a remote transceiver you could use [ser2net](https:
 
 Example `ser2net.conf` configuration file:
 
-```
-2001:raw:0:/dev/ttyUSB0:9600 8DATABITS NONE 1STOPBIT
-```
+> 2001:raw:0:/dev/ttyUSB0:9600 8DATABITS NONE 1STOPBIT

--- a/source/_integrations/edl21.markdown
+++ b/source/_integrations/edl21.markdown
@@ -44,3 +44,13 @@ serial_port:
   required: true
   type: string
 {% endconfiguration %}
+
+### ser2net
+
+To use this integration with a remote transceiver you could use [ser2net](https://linux.die.net/man/8/ser2net).
+
+Example `ser2net.conf` configuration file:
+
+```
+2001:raw:0:/dev/ttyUSB0:9600 8DATABITS NONE 1STOPBIT
+```


### PR DESCRIPTION
## Proposed change
Add APATOR Norax 3D as tested smart meter and example ser2net configuration file.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43603
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
