### PR TITLE
Add support for LED indexes in blinksticklight

### DIFF
--- a/source/_integrations/blinksticklight.markdown
+++ b/source/_integrations/blinksticklight.markdown
@@ -29,12 +29,33 @@ light:
     serial: BS000795-1.1
 ```
 
+To add multiple LEDs from a multi-LED Blinkstick to your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+light:
+  - platform: blinksticklight
+    serial: BS000795-1.1
+    index: 0
+  - platform: blinksticklight
+    serial: BS000795-1.1
+    index: 1
+  - platform: blinksticklight
+    serial: BS000795-1.1
+    index: 2
+```
+
 {% configuration %}
 serial:
   description: The serial number of your stick.
   required: true
   default: 640
   type: string
+index:
+  description: Index of the LED.
+  required: false
+  type: integer
+  default: 0
 name:
   description: Name of the stick.
   required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I've updated the `blinksticklight` component to support controlling specific LEDs on Blinkstick devices with more than one LED (such as the Blinkstick Square). This PR updates the documentation for the `blinksticklight` component to explain this change.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43617

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
