### PR TITLE
Add summary template example to 17track

### DIFF
--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -50,3 +50,21 @@ show_delivered:
   type: boolean
   default: false
 {% endconfiguration %}
+
+## Examples
+
+### Lovelace summary card
+
+Use the following templated Markdown card to list all packages in transit along their status:
+
+```yaml
+type: markdown
+title: Packages in transit
+content: >-
+  {% for package in
+  states.sensor.seventeentrack_packages_in_transit.attributes.packages %}
+
+  **{{ package.friendly_name }}:** {{ package.info_text }}
+
+  {% endfor %}
+```

--- a/source/_integrations/seventeentrack.markdown
+++ b/source/_integrations/seventeentrack.markdown
@@ -57,6 +57,7 @@ show_delivered:
 
 Use the following templated Markdown card to list all packages in transit along their status:
 
+{% raw %}
 ```yaml
 type: markdown
 title: Packages in transit
@@ -68,3 +69,4 @@ content: >-
 
   {% endfor %}
 ```
+{% endraw %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add an example Lovelace snippet that uses a templated Markdown card to list a summary of packages in transit.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
