### PR TITLE
Rename LCN logic operation sensor states

### DIFF
--- a/source/_integrations/lcn.markdown
+++ b/source/_integrations/lcn.markdown
@@ -402,7 +402,7 @@ The [MOTOR_PORT](#ports) values specify which hardware relay or outputs configur
 | Constant | Values |
 | -------- | ------ |
 | LED_STATE | `on`, `off`, `blink`, `flicker` |
-| LOGICOP_STATE | `not`, `or`, `and` |
+| LOGICOP_STATE | `none`, `some`, `all` |
 | KEY_STATE | `hit`, `make`, `break`, `dontsend` |
 
 ### Keys:


### PR DESCRIPTION
## Proposed change
The LCN logic operation sensor states are renamed from (not, or, and) to (none, some, all). The renaming is more consistent with the LCN naming convention.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [home-assistant/core#43710](https://github.com/home-assistant/core/pull/43710)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
