### PR TITLE
Revert "Update opensky.markdown"

### DIFF
--- a/source/_integrations/opensky.markdown
+++ b/source/_integrations/opensky.markdown
@@ -37,8 +37,6 @@ Both events have three attributes:
 
 - **sensor**: Name of `opensky` sensor that fired the event.
 - **callsign**: Callsign of the flight.
-- **latitude**: Latitude of the flight.
-- **longitude**: Longitude of the flight.
 - **altitude**: Altitude of the flight in meters.
 
 To receive notifications of the entering flights using the [Home Assistant Companion App](https://companion.home-assistant.io/), add the following lines to your `configuration.yaml` file:


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#15628

As it has been reverted upstream: <https://github.com/home-assistant/core/pull/43185>