### PR TITLE
Updated note on Aeotec Z-Stick & Raspberry Pi 4 support

### DIFF
--- a/source/_docs/z-wave/controllers.markdown
+++ b/source/_docs/z-wave/controllers.markdown
@@ -9,7 +9,7 @@ You need to have a compatible Z-Wave stick or module installed. This needs to be
 
 <div class='note'>
   
-There have [been reports](https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=245031#p1502030) of the Aeotec stick not working on the Raspberry Pi 4.
+There are [known compatability issues](https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=245031#p1502030) with older hardware versions of the Aeotec stick not working on the Raspberry Pi 4. Aeotec has released a 2020 hardware revision ZW090-A with Pi 4 compatibility. Both hardware revisions are still being sold, make informed purchasing decisions if using paired with a Pi 4.
 
 </div>
 


### PR DESCRIPTION
## Proposed change

Modified documentation note on Aeotec Z-Stick & Raspberry Pi 4 support. Older hardware does not conform to USB power specifications. Aeotec has released a 2020 hardware revision to correct the issue.



## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Checklist


- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
