### PR TITLE
Update Shelly documentation

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -99,7 +99,9 @@ If the **BUTTON TYPE** of the switch connected to the device is set to `momentar
 | `LS`	             | `long_single` |
 
 <div class="note">
+
 Not all devices support all input events. You can check on [Shelly API Reference](https://shelly-api-docs.shelly.cloud/) website what types of Shelly input events your device supports.
+
 </div>
 
 ## Known issues and limitations

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -67,7 +67,7 @@ If the **BUTTON TYPE** of the switch connected to the device is set to `momentar
     platform: event
     event_type: shelly.click
     event_data:
-      device_id: shellyswitch25-AABBCCDD
+      device_id: shellyswitch25-AABBCC
       channel: 1
       click_type: single
   action:
@@ -79,7 +79,7 @@ If the **BUTTON TYPE** of the switch connected to the device is set to `momentar
     platform: event
     event_type: shelly.click
     event_data:
-      device_id: shellyswitch25-AABBCCDD
+      device_id: shellyswitch25-AABBCC
       channel: 2
       click_type: long
   action:

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -84,7 +84,7 @@ If the **BUTTON TYPE** of the switch connected to the device is set to `momentar
       click_type: long
   action:
     service: light.toggle
-    entity: light.lamp_living_room
+    <span class="x x-first x-last">entity_id</span>: light.lamp_living_room
 ```
 
 ### Possible values for `click_type`

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -59,6 +59,8 @@ Shelly device relays are added to the Home Assistant by default as `switch` enti
 
 If the **BUTTON TYPE** of the switch connected to the device is set to `momentary` or `detached switch`, integration fires events when the switch is used. You can use these events in your automations.
 
+### Automation examples
+
 ```yaml
 - alias: "Toggle living room light"
   trigger:
@@ -72,7 +74,7 @@ If the **BUTTON TYPE** of the switch connected to the device is set to `momentar
     service: light.toggle
     entity: light.living_room
 
-- alias: "Toggle lamp living room"
+- alias: "Toggle living room lamp"
   trigger:
     platform: event
     event_type: shelly.click

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -98,10 +98,13 @@ If the **BUTTON TYPE** of the switch connected to the device is set to `momentar
 | `SL`	             | `single_long` |
 | `LS`	             | `long_single` |
 
-You can check on [Shelly API Reference](https://shelly-api-docs.shelly.cloud/) website what types of Shelly input events your device supports.
+<div class="note">
+Not all devices support all input events. You can check on [Shelly API Reference](https://shelly-api-docs.shelly.cloud/) website what types of Shelly input events your device supports.
+</div>
 
 ## Known issues and limitations
 
 - Only supports firmware 1.8 and later
-- Support relays, lights (with brightness), sensors and rollers
-- Support for battery-powered devices is currently very limited
+- Support relays, lights, sensors and rollers
+- Support for RGB devices is limited
+- Support for battery-powered devices is limited

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -105,6 +105,5 @@ Not all devices support all input events. You can check on [Shelly API Reference
 ## Known issues and limitations
 
 - Only supports firmware 1.8 and later
-- Support relays, lights, sensors and rollers
 - Support for RGB devices is limited
 - Support for battery-powered devices is limited

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -67,7 +67,7 @@ If the **BUTTON TYPE** of the switch connected to the device is set to `momentar
     platform: event
     event_type: shelly.click
     event_data:
-      device_id: shellyswitch25-AABBCC
+      device: shellyswitch25-AABBCC
       channel: 1
       click_type: single
   action:
@@ -79,7 +79,7 @@ If the **BUTTON TYPE** of the switch connected to the device is set to `momentar
     platform: event
     event_type: shelly.click
     event_data:
-      device_id: shellyswitch25-AABBCC
+      device: shellyswitch25-AABBCC
       channel: 2
       click_type: long
   action:

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -72,7 +72,7 @@ If the **BUTTON TYPE** of the switch connected to the device is set to `momentar
       click_type: single
   action:
     service: light.toggle
-    entity: light.living_room
+    entity_id: light.living_room
 
 - alias: "Toggle living room lamp"
   trigger:

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -51,6 +51,53 @@ Names are set from the device web page:
 - Channel name for single-channel devices can be set in **Settings** >> **CHANNEL NAME**
 - Channel name for multi-channel devices can be set in **Settings** >> **CHANNEL NAME** after selecting the channel, by clicking on the channel name.
 
+## Appliance type
+
+Shelly device relays are added to the Home Assistant by default as `switch` entities. A relay can be added as a `light` entity if the device uses firmware version 1.9.0 or newer and the **Settings** >> **APPLIANCE TYPE** value is set to `light`.
+
+## Events
+
+If the **BUTTON TYPE** of the switch connected to the device is set to `momentary` or `detached switch`, integration fires events when the switch is used. You can use these events in your automations.
+
+```yaml
+- alias: "Toggle living room light"
+  trigger:
+    platform: event
+    event_type: shelly.click
+    event_data:
+      device_id: shellyswitch25-AABBCCDD
+      channel: 1
+      click_type: single
+  action:
+    service: light.toggle
+    entity: light.living_room
+
+- alias: "Toggle lamp living room"
+  trigger:
+    platform: event
+    event_type: shelly.click
+    event_data:
+      device_id: shellyswitch25-AABBCCDD
+      channel: 2
+      click_type: long
+  action:
+    service: light.toggle
+    entity: light.lamp_living_room
+```
+
+### Possible values for `click_type`
+
+| Shelly input event | Click Type    |
+| ------------------ | --------------|
+| `S`                | `single`      |
+| `SS`	             | `double`      |
+| `SSS`              | `triple`      |
+| `L`	               | `long`        |
+| `SL`	             | `single_long` |
+| `LS`	             | `long_single` |
+
+You can check on [Shelly API Reference](https://shelly-api-docs.shelly.cloud/) website what types of Shelly input events your device supports.
+
 ## Known issues and limitations
 
 - Only supports firmware 1.8 and later


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds information about `appliance type` and Shelly events and extends the list of issues and limitations.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/42508 https://github.com/home-assistant/core/pull/43479
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
