### PR TITLE
Clarify Flux brightness parameter behavior

### DIFF
--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -64,11 +64,11 @@ stop_colortemp:
   default: 1900
   type: integer
 brightness:
-  description: The brightness of the lights.
+  description: Constant brightness of the lights. Besides color temperature, brightness is also adjusted unless a value is specified here.
   required: false
   type: integer
 disable_brightness_adjust:
-  description: If true, brightness will not be adjusted besides color temperature.
+  description: If true, brightness will not be adjusted, only color temperature.
   required: false
   type: boolean
   default: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The existing documentation on the `brightness` parameter is not clear enough, so I clarified when the brightness is adjusted by the integration ([current implementation](https://github.com/home-assistant/core/blob/6eeb9c0e49a1453c8c9c22975be76826485248bc/homeassistant/components/flux/switch.py#L302))


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
