### PR TITLE
Add all installed apps in the androidtv sources list

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -76,6 +76,11 @@ get_sources:
   required: false
   default: true
   type: boolean
+source_provider:
+  description: Whether to populate the list of sources from running_apps or installed_apps
+  required: false
+  default: running_apps
+  type: string
 apps:
   description: A dictionary where the keys are app IDs and the values are app names that will be displayed in the UI; see example below. If a name is not provided, the app will never be shown in the sources list. ([These app names](https://github.com/JeffLIrion/python-androidtv/blob/748d6b71cad611c624ef7526d9928431167531a3/androidtv/constants.py#L290-L308) are configured in the backend package and do not need to be included in your configuration.)
   required: false


### PR DESCRIPTION
## Proposed change
Documents the option introduced in https://github.com/home-assistant/core/pull/43756

## Type of change

- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).

## Additional information

https://github.com/home-assistant/core/pull/43756

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards