### PR TITLE
Updated notify page with working image link

### DIFF
--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -63,7 +63,7 @@ For services which have support for sending images.
 { "message": "Test plugin",
   "data": {
     "photo": {
-        "url": "http://www.gbsun.de/gbpics/berge/berge106.jpg"
+        "url": "https://raw.githubusercontent.com/home-assistant/home-assistant.io/current/source/images/default-social.png"
     }
   }
 }
@@ -78,7 +78,7 @@ action:
     message: "Test plugin"
     data:
       photo:
-        url: "http://www.gbsun.de/gbpics/berge/berge106.jpg"
+        url: "https://raw.githubusercontent.com/home-assistant/home-assistant.io/current/source/images/default-social.png"
 ```
 
 


### PR DESCRIPTION
## Proposed change
Fix the image link in the notify sample to a working internal image link.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
