### PR TITLE
Add support for effects, transition/brightness parameters to template light, min_mireds and max_mireds templates

### DIFF
--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -29,6 +29,7 @@ light:
         value_template: "{{ state_attr('sensor.theater_brightness', 'lux')|int > 0 }}"
         temperature_template: "{{states('input_number.temperature_input') | int}}"
         color_template: "({{states('input_number.h_input') | int}}, {{states('input_number.s_input') | int}})"
+        effect_list_template: "{{ state_attr('light.led_strip', 'effect_list') }}"
         turn_on:
           service: script.theater_lights_on
         turn_off:
@@ -56,6 +57,20 @@ light:
             data:
               value: "{{ s }}"
               entity_id: input_number.s_input
+          - service: light.turn_on
+            data_template:
+              entity_id:
+                - light.led_strip
+              transition: "{{ transition | float }}"
+              hs_color:
+                - "{{ hs[0] }}"
+                - "{{ hs[1] }}"
+        set_effect:
+          - service: light.turn_on
+            data_template:
+              entity_id:
+                - light.led_strip
+              effect: "{{ effect }}"
 ```
 
 {% endraw %}
@@ -99,6 +114,21 @@ light:
         required: false
         type: template
         default: optimistic
+      effect_list_template:
+        description: Defines a template to get the list of supported effects. Must render a list
+        required: false
+        type: template
+        default: optimistic
+      min_mireds_template:
+        description: Defines a template to get the min mireds value of the light.
+        required: false
+        type: template
+        default: optimistic
+      max_mireds_template:
+        description: Defines a template to get the max mireds value of the light.
+        required: false
+        type: template
+        default: optimistic
       icon_template:
         description: Defines a template for an icon or picture, e.g.,  showing a different icon for different states.
         required: false
@@ -132,6 +162,10 @@ light:
         description: Defines an action to run when the light is given a color command.
         required: false
         type: action
+      set_effect:
+        description: Defines an action to run when the light is given a effect command.
+        required: false
+        type: action
 {% endconfiguration %}
 
 ## Considerations
@@ -145,6 +179,8 @@ For example, you would replace
 with this equivalent that returns `true`/`false` and never gives an unknown
 result:
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
+Passing {% raw %}`transition`{% endraw %} and {% raw %}`brightness`{% endraw %} parameters along with {% raw %}`*_color`{% endraw %}, {% raw %}`color_temp`{% endraw %}, {% raw %}`white_value`{% endraw %} or {% raw %}`effect`{% endraw %} is supported.
+
 
 ## Examples
 

--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -179,7 +179,7 @@ For example, you would replace
 with this equivalent that returns `true`/`false` and never gives an unknown
 result:
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
-Passing {% raw %}`transition`{% endraw %} and {% raw %}`brightness`{% endraw %} parameters along with {% raw %}`*_color`{% endraw %}, {% raw %}`color_temp`{% endraw %}, {% raw %}`white_value`{% endraw %} or {% raw %}`effect`{% endraw %} is supported.
+Passing `transition` and `brightness` parameters along with `*_color`, `color_temp`, `white_value` or `effect` is supported.
 
 
 ## Examples

--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -185,7 +185,8 @@ For example, you would replace
 with this equivalent that returns `true`/`false` and never gives an unknown
 result:
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
-Passing `transition` and `brightness` parameters along with `*_color`, `color_temp`, `white_value` or `effect` is supported.
+Transition doesn't have its own script, it will instead be passed as a parameter to the `turn_on`, `turn_off`, `brightness`, `color_temp`, `effect`, `hs_color` or `white_value` scripts.
+Brightness in a `turn_on` call will be passed as a parameter to either of `color_temp`, `effect`, `hs_color` or `white_value` scripts if the corresponding parameter is also in the turn_on call. In this case the brightness script (`set_level`) will not be called.
 
 
 ## Examples

--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -116,13 +116,18 @@ light:
         type: template
         default: optimistic
       supports_transition_template:
-        description: Defines a template to get if light supports transition.
+        description: Defines a template to get if light supports transition. Should return boolean value (True/False). If this value is `True` transition parameter in a turn on or turn off call will be passed as a named parameter `transition` to either of the scripts.
         required: false
         type: template
         default: false
       effect_list_template:
         description: Defines a template to get the list of supported effects. Must render a list
-        required: false
+        required: inclusive
+        type: template
+        default: optimistic
+      effect_template:
+        description: Defines a template to get the effect of the light.
+        required: inclusive
         type: template
         default: optimistic
       min_mireds_template:
@@ -153,7 +158,7 @@ light:
         required: true
         type: action
       set_level:
-        description: Defines an action to run when the light is given a brightness command.
+        description: Defines an action to run when the light is given a brightness command. The script will only be called if the `turn_on` call only has brightness, and optionally transition.
         required: false
         type: action
       set_temperature:
@@ -170,7 +175,7 @@ light:
         type: action
       set_effect:
         description: Defines an action to run when the light is given a effect command.
-        required: false
+        required: inclusive
         type: action
 {% endconfiguration %}
 
@@ -185,9 +190,9 @@ For example, you would replace
 with this equivalent that returns `true`/`false` and never gives an unknown
 result:
 {% raw %}`{{ is_state('switch.source', 'on') }}`{% endraw %}
-Transition doesn't have its own script, it will instead be passed as a parameter to the `turn_on`, `turn_off`, `brightness`, `color_temp`, `effect`, `hs_color` or `white_value` scripts.
-Brightness in a `turn_on` call will be passed as a parameter to either of `color_temp`, `effect`, `hs_color` or `white_value` scripts if the corresponding parameter is also in the turn_on call. In this case the brightness script (`set_level`) will not be called.
-
+Transition doesn't have its own script, it will instead be passed as a named parameter `transition` to the `turn_on`, `turn_off`, `brightness`, `color_temp`, `effect`, `hs_color` or `white_value` scripts.
+Brightness will be passed as a named parameter `brightness` to either of `turn_on`, `color_temp`, `effect`, `hs_color` or `white_value` scripts if the corresponding parameter is also in the call. In this case the brightness script (`set_level`) will not be called.
+If only brightness is passed to `light.turn_on` service call then `set_level` script is called.
 
 ## Examples
 

--- a/source/_integrations/light.template.markdown
+++ b/source/_integrations/light.template.markdown
@@ -71,6 +71,7 @@ light:
               entity_id:
                 - light.led_strip
               effect: "{{ effect }}"
+        supports_transition_template: "{{ true }}"
 ```
 
 {% endraw %}
@@ -114,6 +115,11 @@ light:
         required: false
         type: template
         default: optimistic
+      supports_transition_template:
+        description: Defines a template to get if light supports transition.
+        required: false
+        type: template
+        default: false
       effect_list_template:
         description: Defines a template to get the list of supported effects. Must render a list
         required: false


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documetation update accordingly to https://github.com/home-assistant/core/pull/43850


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43850
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
