### PR TITLE
Add a section about general Chromecast use cases

### DIFF
--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -103,6 +103,66 @@ To cast media directly from a configured Plex server, set the fields [as documen
       media_content_type: movie
       media_content_id: 'plex://{"library_name": "Movies", "title": "Groundhog Day"}'
 ```
+### Play (almost) any kind of media
+
+Chromecasts can play many kinds of modern [media (image/audio/video) formats](https://developers.google.com/cast/docs/media). As a rule of thumb, if a Chrome browser can play a media file a Chromecast will be able to handle that too.
+
+The media needs to be accessible via HTTP(S). Chromecast devices does not support other protocols like DLNA or playback from an SMB file share.
+
+You can play MP3 streams like netradios, FLAC files or videos from your local network with the `media_player.play_media` service, as long as the media is accessible via HTTP(S). You need to set the `media_content_id` to the media URL and `media_content_type` to a matching content type.
+
+```yaml
+# Play a video file from the local network:
+service: media_player.play_media
+data:
+  entity_id: media_player.chromecast
+  media_content_type: 'video'
+  media_content_id: 'http://192.168.0.100/movies/sample-video.mkv'
+```
+
+```yaml
+# Show a jpeg image:
+service: media_player.play_media
+data:
+  entity_id: media_player.chromecast
+  media_content_type: 'image/jpeg'
+  media_content_id: 'http://via.placeholder.com/1024x600.jpg/0B6B94/FFFFFF/?text=Hello,%20Home%20Assistant!'
+```
+
+Extra media metadata (for example title, subtitle, artist or album name) can be passed in to the service and that will be shown on the Chromecast display.
+For the possible metadata types and values check [google cast docs > MediaInformation > metadata field](https://developers.google.com/cast/docs/reference/messages#MediaInformation).
+
+```yaml
+# Play a movie from the internet, with extra metadata provided:
+service: media_player.play_media
+data:
+  entity_id: media_player.chromecast
+  media_content_type: 'video/mp4'
+  media_content_id: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4'
+  extra: 
+    metadata: 
+      metadataType: 1
+      title: 'Big Buck Bunny'
+      subtitle: 'By Blender Foundation, Licensed under the Creative Commons Attribution license'
+      images:
+        - url: 'https://peach.blender.org/wp-content/uploads/watchtrailer.gif'
+```
+
+```yaml
+# Play a netradio, with extra metadata provided:
+service: media_player.play_media
+data:
+  entity_id: media_player.chromecast
+  media_content_type: 'audio/mp3'
+  media_content_id: 'http://stream.tilos.hu:8000/tilos' 
+  extra: 
+    metadata: 
+      metadataType: 3
+      title: 'Radio TILOS'
+      artist: 'LIVE'
+      images:
+        - url: 'https://tilos.hu/images/kockalogo.png'
+```
 
 ## Advanced use
 

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -130,7 +130,7 @@ data:
 ```
 
 Extra media metadata (for example title, subtitle, artist or album name) can be passed in to the service and that will be shown on the Chromecast display.
-For the possible metadata types and values check [google cast docs > MediaInformation > metadata field](https://developers.google.com/cast/docs/reference/messages#MediaInformation).
+For the possible metadata types and values check [Google cast documentation > MediaInformation > metadata field](https://developers.google.com/cast/docs/reference/messages#MediaInformation).
 
 ```yaml
 # Play a movie from the internet, with extra metadata provided:

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -103,6 +103,7 @@ To cast media directly from a configured Plex server, set the fields [as documen
       media_content_type: movie
       media_content_id: 'plex://{"library_name": "Movies", "title": "Groundhog Day"}'
 ```
+
 ### Play (almost) any kind of media
 
 Chromecasts can play many kinds of modern [media (image/audio/video) formats](https://developers.google.com/cast/docs/media). As a rule of thumb, if a Chrome browser can play a media file a Chromecast will be able to handle that too.

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -108,9 +108,9 @@ To cast media directly from a configured Plex server, set the fields [as documen
 
 Chromecasts can play many kinds of modern [media (image/audio/video) formats](https://developers.google.com/cast/docs/media). As a rule of thumb, if a Chrome browser can play a media file a Chromecast will be able to handle that too.
 
-The media needs to be accessible via HTTP(S). Chromecast devices does not support other protocols like DLNA or playback from an SMB file share.
+The media needs to be accessible via HTTP(S). Chromecast devices do not support other protocols like DLNA or playback from an SMB file share.
 
-You can play MP3 streams like netradios, FLAC files or videos from your local network with the `media_player.play_media` service, as long as the media is accessible via HTTP(S). You need to set the `media_content_id` to the media URL and `media_content_type` to a matching content type.
+You can play MP3 streams like net radios, FLAC files or videos from your local network with the `media_player.play_media` service, as long as the media is accessible via HTTP(S). You need to set the `media_content_id` to the media URL and `media_content_type` to a matching content type.
 
 ```yaml
 # Play a video file from the local network:

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -130,7 +130,7 @@ data:
   media_content_id: 'http://via.placeholder.com/1024x600.jpg/0B6B94/FFFFFF/?text=Hello,%20Home%20Assistant!'
 ```
 
-Extra media metadata (for example title, subtitle, artist or album name) can be passed in to the service and that will be shown on the Chromecast display.
+Extra media metadata (for example title, subtitle, artist or album name) can be passed into the service and that will be shown on the Chromecast display.
 For the possible metadata types and values check [Google cast documentation > MediaInformation > metadata field](https://developers.google.com/cast/docs/reference/messages#MediaInformation).
 
 ```yaml


### PR DESCRIPTION
Provide examples about audio / video playback with extra metadata.

## Proposed change
Chromecast's DefaultMediaPlayer app is able to handle media metadata, like titles for movies/songs, album names, etc. The media_player.play_media service is able to handle this, via the 'extra' field, but I've not seen that reflected in the documentation.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
