### PR TITLE
Update TP-Link Smart Plug Energy Sensor Data templates

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -150,24 +150,24 @@ sensor:
   - platform: template
     sensors:
       my_tp_switch_amps:
-        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Current"
-        value_template: '{{ states.switch.my_tp_switch.attributes["current_a"] | float }}'
+        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Current"
+        value_template: "{{ state_attr('switch.my_tp_switch','current_a') | float }}"
         unit_of_measurement: 'A'
       my_tp_switch_watts:
-        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Current Consumption"
-        value_template: '{{ states.switch.my_tp_switch.attributes["current_power_w"] | float }}'
+        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Current Consumption"
+        value_template: "{{ state_attr('switch.my_tp_switch','current_power_w') | float }}"
         unit_of_measurement: 'W'
       my_tp_switch_total_kwh:
-        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Total Consumption"
-        value_template: '{{ states.switch.my_tp_switch.attributes["total_energy_kwh"] | float }}'
+        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Total Consumption"
+        value_template: "{{ state_attr('switch.my_tp_switch','total_energy_kwh') | float }}"
         unit_of_measurement: 'kWh'
       my_tp_switch_volts:
-        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Voltage"
-        value_template: '{{ states.switch.my_tp_switch.attributes["voltage"] | float }}'
+        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Voltage"
+        value_template: "{{ state_attr('switch.my_tp_switch','voltage') | float }}"
         unit_of_measurement: 'V'
       my_tp_switch_today_kwh:
-        friendly_name_template: "{{ states.switch.my_tp_switch.name}} Today's Consumption"
-        value_template: '{{ states.switch.my_tp_switch.attributes["today_energy_kwh"] | float }}'
+        friendly_name_template: "{{ state_attr('switch.my_tp_switch','friendly_name') }} Today's Consumption"
+        value_template: "{{ state_attr('switch.my_tp_switch','today_energy_kwh') | float }}"
         unit_of_measurement: 'kWh'
 ```
 {% endraw %}


### PR DESCRIPTION
I noticed that these example templates use the templating method that is not recommended on the Templating page (https://www.home-assistant.io/docs/configuration/templating/) so have updated them to follow that convention. Apologies in advance if there was a specific reason this hasn't been done already!

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This is to change the method in which the example templates are written to follow best practice.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
