### PR TITLE
Update entity requirement in Button Card docs

### DIFF
--- a/source/_lovelace/button.markdown
+++ b/source/_lovelace/button.markdown
@@ -46,7 +46,7 @@ type:
   description: button
   type: string
 entity:
-  required: false
+  required: true
   description: The entity ID the card interacts with, for example, `light.living_room`.
   type: string
 name:


### PR DESCRIPTION
The Lovelace Button Card fails to render in the latest version (1.0.0b0) if `entity` is not specified.

**This might also need to be added to release notes as a breaking change.**

Based on the card editor UI this appears to now be required, but I couldn't find any references to it in PRs, issues, nor RC release notes.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update docs for Lovelace Button Card to show new `entity` requirement.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
- [x] Adjusted missing or incorrect information in the upcoming documentation (`next` branch).

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

Example:

```yaml
type: button
name: Netflix
icon: 'mdi:netflix'
icon_height: 64px
tap_action:
  action: call-service
  service: media_player.select_source
  service_data:
    entity_id: media_player.living_room_fire_tv
    source: com.netflix.ninja
hold_action:
  action: call-service
  service: androidtv.adb_command
  service_data:
    entity_id: media_player.living_room_fire_tv
    command: >-
      sendevent /dev/input/event5 4 4 786979 && sendevent /dev/input/event5 1
      172 1 && sendevent /dev/input/event5 0 0 0 && sendevent /dev/input/event5
      4 4 786979 && sendevent /dev/input/event5 1 172 0 && sendevent
      /dev/input/event5 0 0 0
```

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
