### PR TITLE
Update docs to reflect changes from no longer using `hass`

### DIFF
--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -16,7 +16,6 @@ The location of the folder differs between operating systems:
 | macOS          | `~/.homeassistant`         |
 | Linux          | `~/.homeassistant`         |
 
-If you want to use a different folder for configuration, use the configuration command line parameter: `ha --config path/to/config`.
 
 Inside your configuration folder is the file `configuration.yaml`. This is the main file that contains integrations to be loaded with their configurations. Throughout the documentation you will find snippets that you can add to your configuration file to enable functionality.
 

--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -16,7 +16,7 @@ The location of the folder differs between operating systems:
 | macOS          | `~/.homeassistant`         |
 | Linux          | `~/.homeassistant`         |
 
-If you want to use a different folder for configuration, use the configuration command line parameter: `hass --config path/to/config`.
+If you want to use a different folder for configuration, use the configuration command line parameter: `ha --config path/to/config`.
 
 Inside your configuration folder is the file `configuration.yaml`. This is the main file that contains integrations to be loaded with their configurations. Throughout the documentation you will find snippets that you can add to your configuration file to enable functionality.
 
@@ -24,7 +24,7 @@ If you run into trouble while configuring Home Assistant, have a look at the [co
 
 <div class='note tip'>
 
-  Test any changes to your configuration files from the command line with `hass --script check_config`. This script allows you to test changes without the need to restart Home Assistant. Remember to run this as the user you run Home Assistant as.
+  Test any changes to your configuration files from the command line with `ha core check`. This script allows you to test changes without the need to restart Home Assistant. Remember to run this as the user you run Home Assistant as.
 
 </div>
 

--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -185,14 +185,6 @@ That about wraps it up.
 
 If you have issues checkout `home-assistant.log` in the configuration directory as well as your indentations. If all else fails, head over to our [Discord chat server][discord] and ask away.
 
-## Debugging multiple configuration files
-
-If you have many configuration files, the `check_config` script allows you to see how Home Assistant interprets them:
-
-- Listing all loaded files: `ha core check --files`
-- Viewing a component's configuration: `ha core check --info light`
-- Or all components' configuration:  `ha core check --info all`
-
 You can get help from the command line using: `ha core check --help`
 
 ## Advanced Usage

--- a/source/_docs/configuration/splitting_configuration.markdown
+++ b/source/_docs/configuration/splitting_configuration.markdown
@@ -189,11 +189,11 @@ If you have issues checkout `home-assistant.log` in the configuration directory 
 
 If you have many configuration files, the `check_config` script allows you to see how Home Assistant interprets them:
 
-- Listing all loaded files: `hass --script check_config --files`
-- Viewing a component's configuration: `hass --script check_config --info light`
-- Or all components' configuration:  `hass --script check_config --info all`
+- Listing all loaded files: `ha core check --files`
+- Viewing a component's configuration: `ha core check --info light`
+- Or all components' configuration:  `ha core check --info all`
 
-You can get help from the command line using: `hass --script check_config --help`
+You can get help from the command line using: `ha core check --help`
 
 ## Advanced Usage
 

--- a/source/_docs/configuration/troubleshooting.markdown
+++ b/source/_docs/configuration/troubleshooting.markdown
@@ -20,7 +20,7 @@ If you have incorrect entries in your configuration files you can use the config
 One of the most common problems with Home Assistant is an invalid `configuration.yaml` or other configuration file.
 
 - With Home Assistant OS and Supervised you can use the [`ha` command](/hassio/commandline/#home-assistant): `ha core check`.
-  - You can test your configuration with Home Assistant Core using the command line with: `hass --script check_config`. If you need to provide the path for your configuration you can do this using the `-c` argument like this: `hass --script check_config -c /path/to/your/config/dir`.
+  - You can test your configuration with Home Assistant Core using the command line with: `ha core check`. If you need to provide the path for your configuration you can do this using the `--config` argument like this: `ha core check --config /path/to/your/config/dir`.
   - On Docker you can use `docker exec home-assistant python -m homeassistant --script check_config --config /config` - where `home-assistant` is the name of the container.
 - The configuration files, including `configuration.yaml` must be UTF-8 encoded. If you see error like `'utf-8' codec can't decode byte`, edit the offending configuration and re-save it as UTF-8.
 - You can verify your configuration's YAML structure using [this online YAML parser](http://yaml-online-parser.appspot.com/) or [YAML Lint](http://www.yamllint.com/).

--- a/source/_docs/installation/raspberry-pi.markdown
+++ b/source/_docs/installation/raspberry-pi.markdown
@@ -89,7 +89,7 @@ You can now reach your installation on your Raspberry Pi over the web interface 
 
 <div class='note'>
 
-When you run the `hass` command for the first time, it will download, install and cache the necessary libraries/dependencies. This procedure may take anywhere between 5 to 10 minutes. During that time, you may get "site cannot be reached" error when accessing the web interface. This will only happen for the first time, and subsequent restarts will be much faster.
+When you run the `ha` command for the first time, it will download, install and cache the necessary libraries/dependencies. This procedure may take anywhere between 5 to 10 minutes. During that time, you may get "site cannot be reached" error when accessing the web interface. This will only happen for the first time, and subsequent restarts will be much faster.
 
 </div>
 

--- a/source/_docs/installation/updating.markdown
+++ b/source/_docs/installation/updating.markdown
@@ -35,7 +35,7 @@ For a Raspberry Pi Docker container, simply pull the latest stable one:
 sudo docker pull homeassistant/raspberrypi3-homeassistant:stable
 ```
 
-After updating, you must start/restart Home Assistant for the changes to take effect. This means that you will have to restart `hass` itself.
+After updating, you must start/restart Home Assistant for the changes to take effect. This means that you will have to restart `ha` itself.
 Startup can take a considerable amount of time (i.e., minutes) depending on your device. This is because all requirements are updated as well.
 
 [BRUH automation](https://www.bruhautomation.io/) has created [a tutorial video](https://www.youtube.com/watch?v=tuG2rs1Cl2Y) explaining how to upgrade Home Assistant.

--- a/source/_docs/tools/hass.markdown
+++ b/source/_docs/tools/hass.markdown
@@ -3,7 +3,7 @@ title: "hass"
 description: "Description of hass."
 ---
 
-The command-line part of Home Assistant is `hass`.
+The command-line part of Home Assistant is `ha`.
 
 
 ```bash

--- a/source/_docs/z-wave/installation.markdown
+++ b/source/_docs/z-wave/installation.markdown
@@ -180,7 +180,7 @@ Or, if there is no result, try to find detailed USB connection info with:
 dmesg | grep USB
 ```
 
-If Home Assistant (`hass`) runs with another user (e.g., `homeassistant`) you need to give access to the stick with:
+If Home Assistant (`ha`) runs with another user (e.g., `homeassistant`) you need to give access to the stick with:
 
 ```bash
 sudo usermod -aG dialout homeassistant


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update commands in the documentation still referencing the old `hass` statement and options

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [X] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->
- Renamed occurences of `hass` to `ha` and verified command line arguments, changed them where appropriate
- Removed obsolete options

- Link to parent pull request in the codebase: 
N/A
- Link to parent pull request in the Brands repository: 
N/A
- This PR fixes or closes issue: 
N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
