### PR TITLE
Tuya climate override temperature precision

### DIFF
--- a/source/_integrations/tuya.markdown
+++ b/source/_integrations/tuya.markdown
@@ -102,6 +102,8 @@ but all selected devices must be of the same type.
 
 - **Min color temperature**: set minimum `color temperature` expressed in `kelvin` accepted by the light.
 
+- **Temperature precision**: override default temperature precision.
+
 - **Max color temperature**: set maximum `color temperature` expressed in `kelvin` accepted by the light.
 
 - **Max color temperature reported**: set the maximum `color temperature` value reported by the light.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Tuya platform has some issues in temperature rounding for some devices.
For example, my BTH-002-GCLW thermostat is rounded to unit (18, 19, 20) even if it should show in HA halves rounding (19.5, 20, 20.5).
I'm not the only one with this issue [as stated in this long thread](https://community.home-assistant.io/t/smart-life-tuya-show-wrong-temperature/89093/147).
So I decided to fix not only for myself, but I'm happy to contribute to this awesome project.
I simply added an option that let me override the default behavior.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43970

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
