### PR TITLE
Add Rachio pause and resume service to docs

### DIFF
--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -139,6 +139,27 @@ Rachio allows for setting the moisture percentage of a zone or group of zones. A
 | `entity_id` | yes | String, list or group of zones to set moisture percentage.
 | `percent` | no | Integer of the desired moisture percentage. Accepts 0-100.
 
+### Service `rachio.pause_watering`
+
+Pause a currently running schedule.
+
+This service will not be available if only a Generation 1 controller is on the account, as these controllers do not support pause or resume.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `devices` | yes | Name of the controller(s) to pause. If not given, will pause all running controllers on the account.
+| `duration` | yes | Duration in minutes to pause. Accepts 1-60. Defaults to 60 minutes if not specified.
+
+### Service `rachio.resume_watering`
+
+Resume a currently paused schedule.
+
+This service will not be available if only a Generation 1 controller is on the account, as these controllers do not support pause or resume.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `devices` | yes | Name of the controller(s) to resume. If not given, will resume all paused controllers on the account.
+
 ## Examples
 
 In this section, you find some real-life examples of how to use this switch.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add docs for newly introduced Rachio pause and resume service.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43944
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
