### PR TITLE
color_extractor update

### DIFF
--- a/source/_integrations/color_extractor.markdown
+++ b/source/_integrations/color_extractor.markdown
@@ -9,7 +9,7 @@ ha_codeowners:
   - '@GenericStudent'
 ---
 
-The `color_extractor` integration will extract the predominant color from a given image and apply that color to a target light.
+When provided with a single `entity_id`, the `color_extractor` integration will extract the predominant color from a given image and apply that color to a target light. When provided with a list of `entity_id`s, `color_extractor` will extract a palette of colors from the given image, and apply each color to a given light.
 Useful as part of an automation.
 
 ## Configuration
@@ -56,7 +56,6 @@ This service is very similar to the URL service above, except it processes a fil
 Example usage in an automation, taking the album art present on a Chromecast and supplying it to `light.shelf_leds` whenever it changes:
 
 {% raw %}
-
 ```yaml
 #automation.yaml
 - alias: Chromecast to Shelf Lights
@@ -71,9 +70,11 @@ Example usage in an automation, taking the album art present on a Chromecast and
         color_extract_url: '{{ states.media_player.chromecast.attributes.entity_picture }}'
         entity_id: light.shelf_leds
 ```
+{% endraw %}
 
 With a nicer transition period of 5 seconds and setting brightness to 100% each time (part of the [`light.turn_on`](/integrations/light#service-lightturn_on) service parameters):
 
+{% raw %}
 ```yaml
 #automation.yaml
 - alias: Nicer Chromecast to Shelf Lights
@@ -90,5 +91,38 @@ With a nicer transition period of 5 seconds and setting brightness to 100% each 
         brightness_pct: 100
         transition: 5
 ```
-
 {% endraw %}
+
+Example automation using the palette feature, taking the album art present on a Chromecast and apply the palette of colors to the given lights whenever it changes:
+
+{% raw %}
+```yaml
+#automation.yaml
+- alias: Chromecast to living room lights
+
+  trigger:
+    - platform: state
+      entity_id: media_player.chromecast
+
+  action:
+    - service: color_extractor.turn_on
+      data_template:
+        color_extract_url: '{{ states.media_player.chromecast.attributes.entity_picture }}'
+        entity_id:
+          - light.left_shelf
+          - light.right_shelf
+          - light.living_room_lamp
+```
+{% endraw %}
+
+In this automation, if the album art comprises of the following colors:
+ - red
+ - blue
+ - green
+
+then the following will happen:
+ - `left_shelf` light will be set to red
+ - `right_shelf` light will be set to blue
+ - `living_room_lamp` light will be set to green
+
+If a provided image doesn't have enough color range to satisfy the number of lights provided, `color_extractor` will only apply as many colors as we can extract.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Updating the docs to outline how multiple `entity_id` values (list of lights) can be passed in to utilise the color thief feature of palette extraction. This function will give the caller a palette of colors observed in an image (comapred with **just** the predominant color, which is color_extractors current functionality.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [X] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43974
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
