### PR TITLE
Fix "introduced in release number" for Kuler Sky

### DIFF
--- a/source/_integrations/kulersky.markdown
+++ b/source/_integrations/kulersky.markdown
@@ -4,7 +4,7 @@ description: Instructions for integrating Brightech Kuler Sky Bluetooth floor la
 ha_category:
   - Light
 ha_iot_class: Local Polling
-ha_release: '1.0.0'
+ha_release: '1.0'
 ha_domain: kulersky
 ha_codeowners:
   - '@emlove'


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
While checking new integrations for 1.0, I noticed that in the pull down on the left of the integration page 6 new integrations were listed under version 1.0, and one under 1.0.0. This PR fixes that. This should go in the 1.0 release.

![image](https://user-images.githubusercontent.com/33529490/101496056-93442c80-3969-11eb-8307-179383902a76.png)



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
