### PR TITLE
Updated documentation for qbittorrent

### DIFF
--- a/source/_integrations/qbittorrent.markdown
+++ b/source/_integrations/qbittorrent.markdown
@@ -3,7 +3,9 @@ title: qBittorrent
 description: Instructions on how to integrate qBittorrent sensors within Home Assistant.
 ha_category:
   - Downloading
+  - Sensor
 ha_release: 0.84
+ha_config_flow: true
 ha_iot_class: Local Polling
 ha_domain: qbittorrent
 ---
@@ -15,6 +17,58 @@ The `qbittorrent` platform allows you to monitor your downloads with [qBittorren
 This sensor requires the qBittorrent Web UI enabled. The [official reference](https://github.com/qbittorrent/qBittorrent/wiki#webui-related) describes how to set up the Web UI.
 
 ## Configuration
+
+This integration can now be configured entirely via the UI. <br>
+The qBittorrent integration will add the following sensors.
+
+**Sensors**:
+
+- `sensor.qbittorrent_status`: The status of your qbittorrent server.
+- `sensor.qbittorrent_down_speed`: The current download speed [MB/s].
+- `sensor.qbittorrent_up_speed`: The current upload speed [MB/s].
+- `sensor.qbittorrent_active_torrents`: The current number of active torrents.
+- `sensor.qbittorrent_inactive_torrents`: The current number of inactive torrents.
+- `sensor.qbittorrent_paused_torrents`: The current number of paused torrents.
+- `sensor.qbittorrent_resumed_torrents`: The current number of resumed torrents after being paused.
+- `sensor.qbittorrent_seeding`: The current number of torrents which are seeding.
+- `sensor.qbittorrent_total_torrents`: The total number of torrents present in the client.
+- `sensor.qbittorrent_downloading`: The current number of started torrents (downloading).
+- `sensor.qbittorrent_completed_torrents`: The current number of completed torrents (seeding).
+
+## Services
+
+### Service `add_download`
+
+Adds a new torrent to download. This only works with a magnet link.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `magnet_link`    | no | The Magnet link you want to download.
+| `server_url` | yes | Only required when you have a multiple servers setup.
+| `download_path` | yes | Only required when you want to download to another path that differentiates from the default configured path within the server.
+
+### Service `remove_download`
+
+Removes a torrent from the client.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `torrent_hash`    | no | The unique identifier for the torrent you want to remove.
+| `server_url` | yes | Only required when you have a multiple servers setup.
+| `delete_permanent` | yes | Remove file from permanently disk, default False (True or False).
+
+## Deprecated Configuration
+
+This section contains instructions for deprecated `configuration.yaml` declaration.
+
+<div class='note warning'>
+This method of configuration will be removed in one of the next versions
+</div>
+
+<details>
+<summary>Click here for documentation for the deprecated configuration</summary>
+
+## Old configuration
 
 To enable this sensor, add the following lines to your `configuration.yaml`:
 

--- a/source/_integrations/qbittorrent.markdown
+++ b/source/_integrations/qbittorrent.markdown
@@ -23,7 +23,7 @@ The qBittorrent integration will add the following sensors.
 
 **Sensors**:
 
-- `sensor.qbittorrent_status`: The status of your qbittorrent server.
+- `sensor.qbittorrent_status`: The status of your qBittorrent server.
 - `sensor.qbittorrent_down_speed`: The current download speed [MB/s].
 - `sensor.qbittorrent_up_speed`: The current upload speed [MB/s].
 - `sensor.qbittorrent_active_torrents`: The current number of active torrents.

--- a/source/_integrations/qbittorrent.markdown
+++ b/source/_integrations/qbittorrent.markdown
@@ -7,6 +7,8 @@ ha_category:
 ha_release: 0.84
 ha_config_flow: true
 ha_iot_class: Local Polling
+ha_codeowners:
+  - '@geoffreylagaisse'
 ha_domain: qbittorrent
 ---
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
I've added the new sensors and service to the documentation for the qbittorrent integration.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/43661
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
