### PR TITLE
Updates pioneer integration with new alternative volume control method

### DIFF
--- a/source/_integrations/pioneer.markdown
+++ b/source/_integrations/pioneer.markdown
@@ -43,6 +43,16 @@ sources:
   required: false
   default: Empty list (i.e., no source selection will be possible)
   type: list
+alternative_volume_control:
+  description: Whether an alternative method to set volume to a specific amount should be used (enable this if you have problems with said functionality)
+  required: false
+  default: false
+  type: boolean
+max_volume:
+  description: Maximum volume reported by the receiver (can be used in conjunction with `alternative_volume_control` to fix volume issues)
+  required: false
+  default: 185
+  type: integer
 {% endconfiguration %}
 
 Notes:
@@ -142,3 +152,9 @@ sources:
   'Favorites': '45'
   'Game': '49'
 ```
+
+### Alternative volume control method
+
+Some older pioneer receivers do not support directly setting the volume to a specific amount via telnet. If you're experiencing such a problem you might enable the alternative volume control method, which will increase/decrease the volume gradually until the desired level is reached.
+
+You may also want to change the `max_volume` setting to the one reported by the receiver via telnet (not on the device's display), in order to accurately set the volume.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds documentation on new (optional) features for the pioneer integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/44075
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
