### PR TITLE
Add documentation for the Hyperion "off mode"

### DIFF
--- a/source/_integrations/hyperion.markdown
+++ b/source/_integrations/hyperion.markdown
@@ -42,6 +42,14 @@ relevant entry on the `Integrations` page.
 
 Options supported:
 - **priority**: The priority for color and effects, make sure this is lower then the streaming sources priority in hyperion itself (typically lower than 200 is appropriate).
+- **off_mode**: Whether to turn off the "LED Device" component (option=`component`) when
+  the light is turned off, or whether to set a black color at the priority
+  (option=`priority`) configured above. The former option might be preferred when Home
+  Assistant is the only client using Hyperion or when a hard stop of streamed data from
+  Hyperion is required (e.g. streaming from Hyperion to
+  [WLED](https://github.com/Aircoookie/WLED)). The latter might be preferred for
+  interoperability if multiple different clients are controlling the same Hyperion
+  instance at different priorities.
 
 ## Hyperion Instances
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Update documentation to reflect the new "off mode" option in the Hyperion integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/44073
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
