### PR TITLE
Add a warning about ZHA and Sonoff ZBBridge

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -75,6 +75,11 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
   - [PiZiGate](https://zigate.fr/produit/pizigate-v1-0/)
   - [Wifi ZiGate](https://zigate.fr/produit/zigate-pack-wifi-v1-3/)
 
+<div class="note warning">
+<b>EZSP</b> protocol requires a stable connection to the serial port. With <em>ITEAD Sonoff ZBBridge</em> connecting over the WiFi network
+it is expected to see <code>NCP entered failed state. Requesting APP controller restart</code> in the logs. This is a normal part of operation and indicates there was a drop in communication between ZHA and SonOff bridge.
+</div>
+
 ### Experimental support for additional Zigbee radio modules
 
 - Texas Instruments based radios with Z-Stack Home 1.2.x (via the [zigpy-cc](https://github.com/zigpy/zigpy-cc) library for zigpy)

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -76,8 +76,10 @@ Some other Zigbee coordinator hardware may not support a firmware that is capabl
   - [Wifi ZiGate](https://zigate.fr/produit/zigate-pack-wifi-v1-3/)
 
 <div class="note warning">
-<b>EZSP</b> protocol requires a stable connection to the serial port. With <em>ITEAD Sonoff ZBBridge</em> connecting over the WiFi network
-it is expected to see <code>NCP entered failed state. Requesting APP controller restart</code> in the logs. This is a normal part of operation and indicates there was a drop in communication between ZHA and SonOff bridge.
+
+The **EZSP** protocol requires a stable connection to the serial port. With _ITEAD Sonoff ZBBridge_ connecting over the WiFi network
+it is expected to see `NCP entered failed state. Requesting APP controller restart` in the logs. This is a normal part of the operation and indicates there was a drop in communication between ZHA and SonOff bridge.
+
 </div>
 
 ### Experimental support for additional Zigbee radio modules


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Using Sonoff ZBBridge with ZHA relies on using serial connection over the wifi network. Sonoff ZBBridge uses EZSP protocol and if there's a drop in communication because of the wireless connection, than the protocol has to be restarted. Warn users about it, in a desperate attempt to stop them from opening issues about it. 


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.
git
## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
