### PR TITLE
Update Ubus documentation

### DIFF
--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -10,7 +10,7 @@ ha_domain: ubus
 
 This is a presence detection scanner for [OpenWrt](https://openwrt.org/) using [ubus](https://wiki.openwrt.org/doc/techref/ubus). It scans for changes in `hostapd.*`, which will detect and report changes in devices connected to the access point on the router.
 
-Before this scanner can be used you have to install the ubus RPC packages on OpenWRT (versions older than 18.06.x do not require the `uhttpd-mod-ubus` package):
+Before this scanner can be used you have to install the ubus RPC packages on OpenWrt (versions older than 18.06.x do not require the `uhttpd-mod-ubus` package):
 
 ```bash
 opkg update

--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -10,17 +10,14 @@ ha_domain: ubus
 
 This is a presence detection scanner for [OpenWrt](https://openwrt.org/) using [ubus](https://wiki.openwrt.org/doc/techref/ubus). It scans for changes in `hostapd.*`, which will detect and report changes in devices connected to the access point on the router.
 
-Before this scanner can be used you have to install the ubus RPC package on OpenWRT:
+Before this scanner can be used you have to install the ubus RPC packages on OpenWRT:
 
 ```bash
-opkg install rpcd-mod-file
+opkg update
+opkg install rpcd-mod-file uhttpd-mod-ubus
 ```
 
-For OpenWrt version 18.06.x the package uhttpd-mod-ubus should also be installed:
-
-```bash
-opkg install uhttpd-mod-ubus
-```
+Note: versions of OpenWrt older than 18.06.x do not require the `uhttpd-mod-ubus` package.
 
 And create on your OpenWrt device a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/user.json`.
 

--- a/source/_integrations/ubus.markdown
+++ b/source/_integrations/ubus.markdown
@@ -10,14 +10,12 @@ ha_domain: ubus
 
 This is a presence detection scanner for [OpenWrt](https://openwrt.org/) using [ubus](https://wiki.openwrt.org/doc/techref/ubus). It scans for changes in `hostapd.*`, which will detect and report changes in devices connected to the access point on the router.
 
-Before this scanner can be used you have to install the ubus RPC packages on OpenWRT:
+Before this scanner can be used you have to install the ubus RPC packages on OpenWRT (versions older than 18.06.x do not require the `uhttpd-mod-ubus` package):
 
 ```bash
 opkg update
 opkg install rpcd-mod-file uhttpd-mod-ubus
 ```
-
-Note: versions of OpenWrt older than 18.06.x do not require the `uhttpd-mod-ubus` package.
 
 And create on your OpenWrt device a read-only user to be used by setting up the ACL file `/usr/share/rpcd/acl.d/user.json`.
 


### PR DESCRIPTION
## Proposed change

Update the documentation for the Ubus device tracker to be more up-to-date. In the current version of the documentation it is not clear if `uhttpd-mod-ubus` needs to be installed for only OpenWRT version 18.06, or also for older or newer versions.

By now this information is outdated, OpenWRT 18.06 is 2 years old and no longer recommended. This PR updates the documentation with clear instructions for current versions of OpenWRT, while still keeping a note that older versions do not require this package.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
