### PR TITLE
Changed url's that point to .gz files to point to .xz instead

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -102,20 +102,20 @@ If you would like to test next release before anyone else, you can install the b
 
 [balenaEtcher]: https://www.balena.io/etcher
 [hassos-network]: https://github.com/home-assistant/operating-system/blob/dev/Documentation/network.md
-[pi3-32]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_rpi3-5.8.img.gz
-[pi3-64]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_rpi3-64-5.8.img.gz
-[pi4-32]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_rpi4-5.8.img.gz
-[pi4-64]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_rpi4-64-5.8.img.gz
-[tinker]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_tinker-5.8.img.gz
-[odroid-c2]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_odroid-c2-5.8.img.gz
-[odroid-c4]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_odroid-c4-5.8.img.gz
-[odroid-n2]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_odroid-n2-5.8.img.gz
-[odroid-xu4]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_odroid-xu4-5.8.img.gz
-[intel-nuc]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_intel-nuc-5.8.img.gz
-[vmdk]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_ova-5.8.vmdk.gz
-[vhdx]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_ova-5.8.vhdx.gz
-[vdi]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_ova-5.8.vdi.gz
-[qcow2]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_ova-5.8.qcow2.gz
+[pi3-32]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_rpi3-5.8.img.xz
+[pi3-64]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_rpi3-64-5.8.img.xz
+[pi4-32]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_rpi4-5.8.img.xz
+[pi4-64]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_rpi4-64-5.8.img.xz
+[tinker]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_tinker-5.8.img.xz
+[odroid-c2]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_odroid-c2-5.8.img.xz
+[odroid-c4]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_odroid-c4-5.8.img.xz
+[odroid-n2]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_odroid-n2-5.8.img.xz
+[odroid-xu4]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_odroid-xu4-5.8.img.xz
+[intel-nuc]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_intel-nuc-5.8.img.xz
+[vmdk]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_ova-5.8.vmdk.xz
+[vhdx]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_ova-5.8.vhdx.xz
+[vdi]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_ova-5.8.vdi.xz
+[qcow2]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_ova-5.8.qcow2.xz
 [Virtual Appliance]: https://github.com/home-assistant/operating-system/releases/download/5.8/hassos_ova-5.8.ova
 [local]: http://homeassistant.local:8123
 [samba]: /addons/samba/


### PR DESCRIPTION
## Proposed change

This file is probably auto-generated, but at least I can raise the issue this way. The url's are pointing to .gz files that don't exist. Is there a better way to report something like this?


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
