### PR TITLE
Update Transmission docs with event ID info

### DIFF
--- a/source/_integrations/transmission.markdown
+++ b/source/_integrations/transmission.markdown
@@ -18,7 +18,7 @@ The Transmission integration allows you to monitor your [Transmission](https://w
 
 ## Setup
 
-Your Transmission client must first be configured to allow remote access. In your Transmission client navigate to **Preferences** -> **Remote** tab and then click the **Allow remote access** checkbox. 
+Your Transmission client must first be configured to allow remote access. In your Transmission client navigate to **Preferences** -> **Remote** tab and then click the **Allow remote access** checkbox.
 
 ## Configuration
 
@@ -80,7 +80,7 @@ The Transmission integration will add the following sensors and switches.
 
 ## Event Automation
 
-The Transmission integration is continuously monitoring the status of torrents in the target client. Once a torrent is started or completed, an event is triggered on the Home Assistant Bus, which allows to implement any kind of automation.
+The Transmission integration is continuously monitoring the status of torrents in the target client. Once a torrent is started or completed, an event is triggered on the Home Assistant Bus containing the torrent name and ID, which can be used with automations.
 
 Possible events are:
 
@@ -90,20 +90,24 @@ Possible events are:
 
 Inside of the event, there is the name of the torrent that is started or completed, as it is seen in the Transmission User Interface.
 
-Example of configuration of an automation with completed torrents:
+Example of an automation that notifies on successful download and removes the torrent from the client:
 
 {% raw %}
 
 ```yaml
-- alias: Completed Torrent
+- alias: Notify and remove completed torrent
   trigger:
     platform: event
     event_type: transmission_downloaded_torrent
   action:
-    service: notify.telegram_notifier
-    data:
-      title: "Torrent completed!"
-      message: "{{trigger.event.data.name}}"
+    - service: notify.telegram_notifier
+      data:
+        title: "Torrent completed!"
+        message: "{{trigger.event.data.name}}"
+    - service: transmission.remove_torrent
+      data:
+        name: "Transmission"
+        id: "{{trigger.event.data.id}}"
 ```
 
 {% endraw %}


### PR DESCRIPTION
## Proposed change

Mentions new "ID" added to the Transmission events in https://github.com/home-assistant/core/pull/44187 and includes this in the automation example.

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/44187
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes feature request: https://community.home-assistant.io/t/transmission-add-torrent-id-to-event-data/254822

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
